### PR TITLE
CI: drive milestone auto-tag skip from live labels + issue events

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -1139,9 +1139,45 @@ def _has_bug_fix_indicators(title: str, labels: list[str]) -> bool:
     return False
 
 
-def _should_skip_milestone_tagging(labels: list[str]) -> bool:
-    """Check if the PR should be skipped from milestone auto-tagging."""
-    return bool(set(labels) & MILESTONE_SKIP_LABELS)
+def _all_backport_labels_removed(snapshot_labels: list[str], current_labels: list[str]) -> set[str]:
+    """Return removed ``backport-to-*`` labels when none remain on the PR.
+
+    Returns the set of ``backport-to-*`` labels present in ``snapshot_labels``
+    but absent from ``current_labels``, but only when ``current_labels``
+    contains no ``backport-to-*`` label at all. A non-empty result means a
+    maintainer fully unbackported the PR during the workflow's race window
+    (between the ``get-pr-info`` snapshot and the ``set-milestone`` step).
+    That is an explicit "don't auto-tag" signal that should override other
+    auto-tagging conditions (e.g. merge to a version branch).
+
+    Returning an empty set when *some* backport label still remains
+    preserves the label-replacement case: a maintainer swapping
+    ``backport-to-v3-1-test`` for ``backport-to-v3-2-test`` is a fix, not a
+    cancel, so the milestone should follow the new label.
+    """
+    snapshot_backports = {label for label in snapshot_labels if label.startswith("backport-to-")}
+    current_backports = {label for label in current_labels if label.startswith("backport-to-")}
+    if current_backports:
+        return set()
+    return snapshot_backports
+
+
+def _should_skip_milestone_tagging(labels: list[str], snapshot_labels: list[str] | None = None) -> bool:
+    """Check if the PR should be skipped from milestone auto-tagging.
+
+    Skip when either:
+
+    - any ``MILESTONE_SKIP_LABELS`` label is present on the PR right now, or
+    - ``snapshot_labels`` is supplied and every ``backport-to-*`` label that
+      was on the snapshot has been removed (with no replacement backport
+      label) since. The full removal is treated as an explicit "don't
+      auto-tag this PR" signal from the maintainer.
+    """
+    if set(labels) & MILESTONE_SKIP_LABELS:
+        return True
+    if snapshot_labels is not None and _all_backport_labels_removed(snapshot_labels, labels):
+        return True
+    return False
 
 
 def _get_backport_version_from_labels(labels: list[str]) -> tuple[int, int] | None:
@@ -1300,6 +1336,18 @@ def set_milestone(
         console_print("[info]Labels changed since workflow snapshot; re-evaluating.[/]")
         console_print(f"[info]Snapshot labels: {sorted(labels)}[/]")
         console_print(f"[info]Current labels:  {sorted(current_labels)}[/]")
+
+        # Treat a maintainer-removed backport label (with no replacement
+        # backport remaining) as an explicit "don't auto-tag" signal: it
+        # overrides any other auto-tagging condition (e.g. merge to a
+        # version branch) that might otherwise apply.
+        removed_backports = _all_backport_labels_removed(labels, current_labels)
+        if removed_backports:
+            console_print(
+                f"[info]Skipping milestone tagging - backport labels removed during workflow "
+                f"window, treated as explicit maintainer signal: {sorted(removed_backports)}[/]"
+            )
+            return
 
         if _should_skip_milestone_tagging(current_labels):
             console_print(

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -1180,6 +1180,61 @@ def _should_skip_milestone_tagging(labels: list[str], snapshot_labels: list[str]
     return False
 
 
+def _get_latest_backport_unlabel_actor(issue: Issue, removed_backports: set[str]) -> str | None:
+    """Return the login of the user who most recently unlabeled a removed backport label.
+
+    Scans the issue's events for ``unlabeled`` events whose label matches one
+    of ``removed_backports`` and returns the actor login of the most recent
+    such event. Returns ``None`` when the events cannot be fetched or no
+    matching event is found.
+
+    Used to attribute the unbackport action to a specific user so the skip
+    log line can name them, and so we can defer to the regular evaluation
+    when the unlabel was performed by a non-maintainer (see
+    :func:`_actor_has_write_access`).
+    """
+    try:
+        events = issue.get_events()
+    except Exception as e:
+        console_print(f"[warning]Could not fetch issue events for attribution: {e}[/]")
+        return None
+
+    latest_actor: str | None = None
+    latest_when = None
+    for event in events:
+        if getattr(event, "event", None) != "unlabeled":
+            continue
+        label = getattr(event, "label", None)
+        if not label or getattr(label, "name", None) not in removed_backports:
+            continue
+        actor = getattr(event, "actor", None)
+        actor_login = getattr(actor, "login", None)
+        when = getattr(event, "created_at", None)
+        if when is None or actor_login is None:
+            continue
+        if latest_when is None or when > latest_when:
+            latest_when = when
+            latest_actor = actor_login
+    return latest_actor
+
+
+def _actor_has_write_access(repo: Repository, login: str) -> bool | None:
+    """Check whether ``login`` has write/admin access on ``repo``.
+
+    Returns ``True`` for ``write``/``admin``, ``False`` for everything else
+    that the API resolves, and ``None`` when the lookup itself fails (rate
+    limit, network error, unknown user). The tri-state lets the caller
+    distinguish "positively a non-maintainer" from "unknown" so that an API
+    blip never silently disables the skip.
+    """
+    try:
+        permission = repo.get_collaborator_permission(login)
+    except Exception as e:
+        console_print(f"[warning]Could not check repository permission for @{login}: {e}[/]")
+        return None
+    return permission in ("admin", "write")
+
+
 def _get_backport_version_from_labels(labels: list[str]) -> tuple[int, int] | None:
     """Find the first backport label and extract version from it."""
     for label in labels:
@@ -1340,14 +1395,34 @@ def set_milestone(
         # Treat a maintainer-removed backport label (with no replacement
         # backport remaining) as an explicit "don't auto-tag" signal: it
         # overrides any other auto-tagging condition (e.g. merge to a
-        # version branch) that might otherwise apply.
+        # version branch) that might otherwise apply. Cross-check the
+        # issue events to attribute the unlabel action; if the actor is
+        # positively identified as lacking write access (e.g. a bot or
+        # external contributor), fall through to normal evaluation rather
+        # than treating the change as a maintainer signal.
         removed_backports = _all_backport_labels_removed(labels, current_labels)
         if removed_backports:
-            console_print(
-                f"[info]Skipping milestone tagging - backport labels removed during workflow "
-                f"window, treated as explicit maintainer signal: {sorted(removed_backports)}[/]"
-            )
-            return
+            actor_login = _get_latest_backport_unlabel_actor(issue, removed_backports)
+            is_maintainer = _actor_has_write_access(repo, actor_login) if actor_login is not None else None
+            if is_maintainer is False:
+                console_print(
+                    f"[warning]Backport labels {sorted(removed_backports)} were removed by "
+                    f"@{actor_login}, who lacks write access. Ignoring removal signal and "
+                    f"continuing with normal evaluation.[/]"
+                )
+            else:
+                if actor_login and is_maintainer:
+                    attribution = f" by maintainer @{actor_login}"
+                elif actor_login:
+                    attribution = f" by @{actor_login}, permission unknown"
+                else:
+                    attribution = ", actor unknown"
+                console_print(
+                    f"[info]Skipping milestone tagging - backport labels removed during workflow "
+                    f"window{attribution}, treated as explicit maintainer signal: "
+                    f"{sorted(removed_backports)}[/]"
+                )
+                return
 
         if _should_skip_milestone_tagging(current_labels):
             console_print(

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -64,6 +64,7 @@ from airflow_breeze.utils.run_utils import run_command
 
 if TYPE_CHECKING:
     from github import Github
+    from github.IssueEvent import IssueEvent
     from github.Repository import Issue, Milestone, Repository
 
 
@@ -1014,46 +1015,37 @@ def upgrade(
 #
 # Skip-decision pipeline
 # ----------------------
-# :func:`_should_skip_milestone_tagging` is the single interface that decides
-# whether milestone auto-tagging should be skipped for a PR. The full pipeline
-# the ``set_milestone`` command runs is:
+# After fetching the PR (so the ``Issue`` is in scope), the ``set-milestone``
+# command runs these three checks IN ORDER and stops on the first one that
+# returns "skip":
 #
-# 1. **Static skip on snapshot labels.** Before any GitHub API call, ask
-#    ``_should_skip_milestone_tagging(snapshot_labels)``. This handles the
-#    ``MILESTONE_SKIP_LABELS`` set (e.g. ``area:CI``) cheaply.
-# 2. **Milestone-already-set guard.** Fetch the issue; if it already has a
-#    milestone, leave it alone.
-# 3. **Race-window re-evaluation.** Re-read live labels from the freshly
-#    fetched issue. If they differ from ``snapshot_labels``, gather the
-#    GitHub-events attribution for any fully-removed ``backport-to-*``
-#    labels and ask ``_should_skip_milestone_tagging`` again with the
-#    snapshot, current labels, and actor info. The function applies these
-#    checks in order:
+# 1. **Milestone-already-set guard** (in ``set_milestone``): if
+#    ``issue.milestone`` is non-null, leave the existing milestone alone and
+#    exit.
+# 2. **GitHub events evaluation** (:func:`_should_skip_milestone_tagging`):
+#    if any ``unlabeled`` event in ``issue.get_events()`` removed a
+#    ``backport-to-*`` label AND no ``backport-to-*`` label remains on the
+#    PR, treat the removal as an explicit "don't auto-tag" signal and skip.
+#    GitHub repo settings restrict label changes to committers/triagers, so
+#    the actor's permission is NOT re-verified here — the change is
+#    implicitly authorised.
+# 3. **Static skip labels** (:func:`_should_skip_milestone_tagging`): if any
+#    ``MILESTONE_SKIP_LABELS`` label is currently on the PR, skip.
 #
-#    a. ``MILESTONE_SKIP_LABELS`` present on current labels → skip.
-#    b. Every ``backport-to-*`` label from ``snapshot_labels`` is now
-#       absent (no replacement backport remains) AND the unlabel actor is
-#       not positively identified as lacking write access → skip; treat
-#       the removal as an explicit "don't auto-tag" maintainer signal.
-#    c. Same removal pattern but the unlabel actor is positively a
-#       non-maintainer (bot / external contributor) → do **not** skip;
-#       a warning is logged and normal evaluation continues.
-#    d. Otherwise → do not skip.
+# The events check is intentionally ordered before the static-label check so
+# that an explicit maintainer "unbackport" overrides every other condition,
+# including the merge-to-version-branch heuristic that
+# :func:`_determine_milestone_version` would otherwise apply.
 #
 # Inputs the decision uses
 # ------------------------
-# - ``labels`` — the labels currently on the PR (or the snapshot, when the
-#   function is called as a cheap pre-flight check before any API call).
-# - ``snapshot_labels`` — the labels captured by the workflow's
-#   ``get-pr-info`` job, used to detect race-window changes.
-# - ``unlabel_actor_login`` — GitHub login of the user who most recently
-#   removed a ``backport-to-*`` label, resolved via
-#   :func:`_get_latest_backport_unlabel_actor`.
-# - ``unlabel_actor_has_write_access`` — tri-state result from
-#   :func:`_actor_has_write_access` (``True`` write/admin, ``False`` other,
-#   ``None`` lookup failed). ``False`` is the only value that defers the
-#   skip; ``True`` / ``None`` both treat the removal as a maintainer signal
-#   so transient API failures never silently disable the skip.
+# - ``labels`` — the labels currently on the PR (live from ``issue.labels``,
+#   fetched fresh by the caller; the workflow's ``--pr-labels`` snapshot is
+#   no longer consulted for the decision).
+# - ``events`` — the issue events stream from ``issue.get_events()``,
+#   fetched fresh by the caller. Pass ``None`` to disable the events check
+#   (e.g. when the events fetch failed and only the static check should
+#   run).
 #
 # All milestone helpers log via :func:`console_print` with the workflow's
 # Rich console; callers do not need to add their own skip-related log lines.
@@ -1191,166 +1183,85 @@ def _has_bug_fix_indicators(title: str, labels: list[str]) -> bool:
     return False
 
 
-def _all_backport_labels_removed(snapshot_labels: list[str], current_labels: list[str]) -> set[str]:
-    """Return removed ``backport-to-*`` labels when none remain on the PR.
+def _get_removed_backport_labels_from_events(events: Iterable[IssueEvent]) -> set[str]:
+    """Return ``backport-to-*`` labels that appear in any ``unlabeled`` event.
 
-    Returns the set of ``backport-to-*`` labels present in ``snapshot_labels``
-    but absent from ``current_labels``, but only when ``current_labels``
-    contains no ``backport-to-*`` label at all. A non-empty result means a
-    maintainer fully unbackported the PR during the workflow's race window
-    (between the ``get-pr-info`` snapshot and the ``set-milestone`` step).
-    That is an explicit "don't auto-tag" signal that should override other
-    auto-tagging conditions (e.g. merge to a version branch).
+    Scans the issue events stream for ``unlabeled`` events on ``backport-to-*``
+    labels and returns the set of label names that were removed at any point
+    in the PR's lifecycle. The actor is intentionally NOT checked: GitHub
+    repo settings restrict label changes to users with write or triage
+    access, so any ``unlabeled`` event is implicitly authorised.
 
-    Returning an empty set when *some* backport label still remains
-    preserves the label-replacement case: a maintainer swapping
-    ``backport-to-v3-1-test`` for ``backport-to-v3-2-test`` is a fix, not a
-    cancel, so the milestone should follow the new label.
+    Combined with the live ``backport-to-*`` labels still on the PR, this is
+    enough to distinguish:
+
+    - Full removal (event present, no current backport) → skip signal.
+    - Replacement (event present, different current backport) → no skip;
+      the caller's regular evaluation picks up the new label.
+    - No removal (no event) → no skip.
     """
-    snapshot_backports = {label for label in snapshot_labels if label.startswith("backport-to-")}
-    current_backports = {label for label in current_labels if label.startswith("backport-to-")}
-    if current_backports:
-        return set()
-    return snapshot_backports
+    return {
+        event.label.name
+        for event in events
+        if getattr(event, "event", None) == "unlabeled"
+        and getattr(getattr(event, "label", None), "name", "").startswith("backport-to-")
+    }
 
 
 def _should_skip_milestone_tagging(
     labels: list[str],
-    snapshot_labels: list[str] | None = None,
-    *,
-    unlabel_actor_login: str | None = None,
-    unlabel_actor_has_write_access: bool | None = None,
+    events: Iterable[IssueEvent] | None = None,
 ) -> bool:
     """Decide whether milestone auto-tagging should be skipped for the PR.
 
-    Single decision point for the ``set-milestone`` command. Applies the
-    following checks IN ORDER and short-circuits on the first hit. Each
-    skip / defer outcome logs its own reason via ``console_print``; callers
-    only need to react to the boolean return.
+    Single decision point for the ``set-milestone`` command, covering
+    checks 2 and 3 of the pipeline documented in the module-level comment
+    above. Check 1 (milestone-already-set guard) is handled separately in
+    :func:`set_milestone` because it operates on ``issue.milestone`` rather
+    than labels. Applies the checks IN ORDER and short-circuits on the
+    first hit; each skip outcome emits its own ``console_print`` info log
+    so callers only need to react to the boolean return.
 
-    1. ``MILESTONE_SKIP_LABELS`` present on ``labels`` → **skip** (info
-       log). This is independent of the snapshot and is cheap enough to
-       use as a pre-flight check before any GitHub API call.
-    2. ``snapshot_labels`` supplied AND every ``backport-to-*`` label that
-       was on the snapshot is now absent from ``labels`` (no replacement
-       backport remains) — i.e. a maintainer fully unbackported the PR
-       during the workflow's race window. The GitHub-events inputs then
-       decide attribution:
+    1. **GitHub events evaluation** (when ``events`` is supplied). If any
+       ``unlabeled`` event in ``events`` removed a ``backport-to-*`` label
+       AND ``labels`` contains no ``backport-to-*`` label now, treat the
+       removal as an explicit "don't auto-tag" signal and skip. Pure label
+       replacement (e.g. ``backport-to-v3-1-test`` swapped for
+       ``backport-to-v3-2-test``) leaves a backport on the PR and does NOT
+       trigger the skip — the caller's regular evaluation picks up the new
+       label. The unlabel actor's permission is NOT re-verified: GitHub
+       repo settings already restrict label changes to committers/triagers.
+    2. **Static skip labels.** If any ``MILESTONE_SKIP_LABELS`` label is
+       in ``labels``, skip.
+    3. Otherwise, do not skip.
 
-       - ``unlabel_actor_has_write_access`` is ``False`` (positively
-         identified as a non-maintainer such as a bot or external
-         contributor) → **do not skip**; a warning is logged and the
-         caller falls through to normal evaluation. This is the only
-         value that defers; ``True`` / ``None`` both treat the removal
-         as a maintainer signal so transient permission-API failures
-         never silently disable the skip.
-       - Otherwise (write/admin actor, unknown actor, or unknown
-         permission) → **skip** with attribution in the info log.
-    3. Otherwise → **do not skip**.
+    The events check is ordered first so that an explicit unbackport
+    overrides every other condition, including the merge-to-version-branch
+    heuristic that :func:`_determine_milestone_version` would otherwise
+    apply.
 
-    Partial replacement (snapshot had ``backport-to-v3-1-test``, current
-    has ``backport-to-v3-2-test``) is intentionally NOT a skip signal:
-    :func:`_all_backport_labels_removed` returns an empty set in that
-    case, so the caller's regular re-evaluation picks up the new label.
-
-    :param labels: Labels currently on the PR (or the snapshot, when used
-        as a pre-flight check before any API call).
-    :param snapshot_labels: Labels captured by the workflow's
-        ``get-pr-info`` job, used to detect race-window changes. Pass
-        ``None`` to disable race-window checks (e.g. the pre-flight call).
-    :param unlabel_actor_login: GitHub login of the user who most recently
-        removed a ``backport-to-*`` label, from
-        :func:`_get_latest_backport_unlabel_actor`. Only used when the
-        snapshot/current diff triggers check 2.
-    :param unlabel_actor_has_write_access: Tri-state from
-        :func:`_actor_has_write_access`. Only used when check 2 fires.
+    :param labels: Labels currently on the PR (live, from ``issue.labels``).
+    :param events: Issue events stream (live, from ``issue.get_events()``).
+        Pass ``None`` to disable the events check — e.g. when the events
+        fetch failed and only the static skip-label check should run.
     """
+    if events is not None:
+        removed_backports = _get_removed_backport_labels_from_events(events)
+        current_backports = {label for label in labels if label.startswith("backport-to-")}
+        if removed_backports and not current_backports:
+            console_print(
+                f"[info]Skipping milestone tagging - backport labels were removed during the "
+                f"PR lifecycle and no replacement remains, treated as explicit "
+                f"maintainer/triager signal: {sorted(removed_backports)}[/]"
+            )
+            return True
+
     skip_labels_present = set(labels) & MILESTONE_SKIP_LABELS
     if skip_labels_present:
         console_print(f"[info]Skipping milestone tagging - PR has skip label(s): {skip_labels_present}[/]")
         return True
 
-    if snapshot_labels is None:
-        return False
-
-    removed = _all_backport_labels_removed(snapshot_labels, labels)
-    if not removed:
-        return False
-
-    if unlabel_actor_has_write_access is False:
-        console_print(
-            f"[warning]Backport labels {sorted(removed)} were removed by "
-            f"@{unlabel_actor_login}, who lacks write access. Ignoring removal signal and "
-            f"continuing with normal evaluation.[/]"
-        )
-        return False
-
-    if unlabel_actor_login and unlabel_actor_has_write_access:
-        attribution = f" by maintainer @{unlabel_actor_login}"
-    elif unlabel_actor_login:
-        attribution = f" by @{unlabel_actor_login}, permission unknown"
-    else:
-        attribution = ", actor unknown"
-    console_print(
-        f"[info]Skipping milestone tagging - backport labels removed during workflow "
-        f"window{attribution}, treated as explicit maintainer signal: {sorted(removed)}[/]"
-    )
-    return True
-
-
-def _get_latest_backport_unlabel_actor(issue: Issue, removed_backports: set[str]) -> str | None:
-    """Return the login of the user who most recently unlabeled a removed backport label.
-
-    Scans the issue's events for ``unlabeled`` events whose label matches one
-    of ``removed_backports`` and returns the actor login of the most recent
-    such event. Returns ``None`` when the events cannot be fetched or no
-    matching event is found.
-
-    Used to attribute the unbackport action to a specific user so the skip
-    log line can name them, and so we can defer to the regular evaluation
-    when the unlabel was performed by a non-maintainer (see
-    :func:`_actor_has_write_access`).
-    """
-    try:
-        events = issue.get_events()
-    except Exception as e:
-        console_print(f"[warning]Could not fetch issue events for attribution: {e}[/]")
-        return None
-
-    latest_actor: str | None = None
-    latest_when = None
-    for event in events:
-        if getattr(event, "event", None) != "unlabeled":
-            continue
-        label = getattr(event, "label", None)
-        if not label or getattr(label, "name", None) not in removed_backports:
-            continue
-        actor = getattr(event, "actor", None)
-        actor_login = getattr(actor, "login", None)
-        when = getattr(event, "created_at", None)
-        if when is None or actor_login is None:
-            continue
-        if latest_when is None or when > latest_when:
-            latest_when = when
-            latest_actor = actor_login
-    return latest_actor
-
-
-def _actor_has_write_access(repo: Repository, login: str) -> bool | None:
-    """Check whether ``login`` has write/admin access on ``repo``.
-
-    Returns ``True`` for ``write``/``admin``, ``False`` for everything else
-    that the API resolves, and ``None`` when the lookup itself fails (rate
-    limit, network error, unknown user). The tri-state lets the caller
-    distinguish "positively a non-maintainer" from "unknown" so that an API
-    blip never silently disables the skip.
-    """
-    try:
-        permission = repo.get_collaborator_permission(login)
-    except Exception as e:
-        console_print(f"[warning]Could not check repository permission for @{login}: {e}[/]")
-        return None
-    return permission in ("admin", "write")
+    return False
 
 
 def _get_backport_version_from_labels(labels: list[str]) -> tuple[int, int] | None:
@@ -1449,27 +1360,18 @@ def set_milestone(
     console_print(f"[info]Base branch: {base_branch}[/]")
     console_print(f"[info]Merged by: {merged_by}[/]")
 
-    # Parse labels from JSON
+    # The workflow's ``--pr-labels`` snapshot is logged for diagnostic visibility
+    # but is no longer used in the decision: live labels and live events are
+    # fetched fresh below. See the milestone-helpers module-level comment for
+    # the full skip-decision pipeline.
     try:
-        labels = json.loads(pr_labels)
+        snapshot_labels = json.loads(pr_labels)
     except json.JSONDecodeError:
         console_print(f"[warning]Could not parse labels JSON: {pr_labels}[/]")
-        labels = []
+        snapshot_labels = []
+    console_print(f"[info]Workflow snapshot labels (diagnostic only): {snapshot_labels}[/]")
 
-    console_print(f"[info]Labels: {labels}[/]")
-
-    # Cheap pre-flight: skip on static MILESTONE_SKIP_LABELS before any API call.
-    # (See the milestone-helpers module-level note for the full decision pipeline.)
-    if _should_skip_milestone_tagging(labels):
-        return
-
-    # Determine which milestone to use
-    version, reason = _determine_milestone_version(labels, pr_title, base_branch)
-    if version is None:
-        console_print(f"[info]No milestone to set: {reason}[/]")
-        return
-
-    # Initialize GitHub client and get repository
+    # Initialize GitHub client and get repository.
     try:
         gh = _get_github_client(github_token)
         repo: Repository = gh.get_repo(github_repository)
@@ -1477,7 +1379,7 @@ def set_milestone(
         console_print(f"[error]Failed to connect to GitHub: {e}[/]")
         return
 
-    # Double check whether the PR already has a milestone set - if so, we don't want to override it
+    # Step 1: milestone-already-set guard — don't override an existing milestone.
     try:
         issue: Issue = repo.get_issue(pr_number)
         if issue.milestone is not None:
@@ -1492,53 +1394,34 @@ def set_milestone(
         console_print(f"[error]Failed to check existing milestone: {e}[/]")
         return
 
-    # Re-read labels from the freshly-fetched issue to close the race between
-    # the workflow's initial label snapshot (taken by the get-pr-info job a
-    # couple of minutes ago) and the actual milestone-set step. Maintainers
-    # sometimes add and remove a backport label inside that window; honour
-    # the latest state, not the stale snapshot.
+    # Pull live labels and events. Both feed the skip-decision function below
+    # (events → check 2, labels → check 3) and ``labels`` also feeds
+    # ``_determine_milestone_version`` once the skip pipeline lets the PR
+    # through.
     try:
-        current_labels = [label.name for label in issue.labels]
+        labels = [label.name for label in issue.labels]
     except Exception as e:
-        console_print(f"[warning]Could not re-read PR labels; falling back to snapshot decision: {e}[/]")
-        current_labels = labels
+        console_print(f"[warning]Could not read live PR labels; falling back to snapshot: {e}[/]")
+        labels = snapshot_labels
+    console_print(f"[info]Live labels: {sorted(labels)}[/]")
 
-    if set(current_labels) != set(labels):
-        console_print("[info]Labels changed since workflow snapshot; re-evaluating.[/]")
-        console_print(f"[info]Snapshot labels: {sorted(labels)}[/]")
-        console_print(f"[info]Current labels:  {sorted(current_labels)}[/]")
+    events: list | None
+    try:
+        events = list(issue.get_events())
+    except Exception as e:
+        console_print(f"[warning]Could not fetch issue events; skipping events check: {e}[/]")
+        events = None
 
-        # Resolve the GitHub-events attribution for any fully-removed
-        # ``backport-to-*`` labels so the unified skip-decision function
-        # can defer to non-maintainer removals (e.g. by a bot) while still
-        # treating maintainer removals as a "don't auto-tag" signal that
-        # overrides the merge-to-version-branch heuristic.
-        removed_backports = _all_backport_labels_removed(labels, current_labels)
-        actor_login: str | None = None
-        actor_has_write_access: bool | None = None
-        if removed_backports:
-            actor_login = _get_latest_backport_unlabel_actor(issue, removed_backports)
-            if actor_login is not None:
-                actor_has_write_access = _actor_has_write_access(repo, actor_login)
+    # Steps 2 and 3 of the pipeline: events-based unbackport signal, then
+    # static skip labels. The function logs its own reason when it returns True.
+    if _should_skip_milestone_tagging(labels, events=events):
+        return
 
-        if _should_skip_milestone_tagging(
-            current_labels,
-            snapshot_labels=labels,
-            unlabel_actor_login=actor_login,
-            unlabel_actor_has_write_access=actor_has_write_access,
-        ):
-            return
-
-        new_version, new_reason = _determine_milestone_version(current_labels, pr_title, base_branch)
-        if (new_version, new_reason) != (version, reason):
-            console_print(
-                f"[info]Determination changed after re-read: was ({version}, {reason!r}); "
-                f"now ({new_version}, {new_reason!r}). Using current labels.[/]"
-            )
-            version, reason = new_version, new_reason
-            if version is None:
-                console_print(f"[info]No milestone to set after re-evaluation: {reason}[/]")
-                return
+    # Determine which milestone to use from the live labels.
+    version, reason = _determine_milestone_version(labels, pr_title, base_branch)
+    if version is None:
+        console_print(f"[info]No milestone to set: {reason}[/]")
+        return
 
     major, minor = version
     milestone_prefix = _get_milestone_prefix(major, minor)

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -1008,6 +1008,58 @@ def upgrade(
         console_print("[info]PR creation skipped. Changes are committed locally.[/]")
 
 
+# ---------------------------------------------------------------------------
+# Milestone auto-tagging helpers (used by the ``set-milestone`` command and the
+# ``milestone-tag-assistant.yml`` workflow).
+#
+# Skip-decision pipeline
+# ----------------------
+# :func:`_should_skip_milestone_tagging` is the single interface that decides
+# whether milestone auto-tagging should be skipped for a PR. The full pipeline
+# the ``set_milestone`` command runs is:
+#
+# 1. **Static skip on snapshot labels.** Before any GitHub API call, ask
+#    ``_should_skip_milestone_tagging(snapshot_labels)``. This handles the
+#    ``MILESTONE_SKIP_LABELS`` set (e.g. ``area:CI``) cheaply.
+# 2. **Milestone-already-set guard.** Fetch the issue; if it already has a
+#    milestone, leave it alone.
+# 3. **Race-window re-evaluation.** Re-read live labels from the freshly
+#    fetched issue. If they differ from ``snapshot_labels``, gather the
+#    GitHub-events attribution for any fully-removed ``backport-to-*``
+#    labels and ask ``_should_skip_milestone_tagging`` again with the
+#    snapshot, current labels, and actor info. The function applies these
+#    checks in order:
+#
+#    a. ``MILESTONE_SKIP_LABELS`` present on current labels → skip.
+#    b. Every ``backport-to-*`` label from ``snapshot_labels`` is now
+#       absent (no replacement backport remains) AND the unlabel actor is
+#       not positively identified as lacking write access → skip; treat
+#       the removal as an explicit "don't auto-tag" maintainer signal.
+#    c. Same removal pattern but the unlabel actor is positively a
+#       non-maintainer (bot / external contributor) → do **not** skip;
+#       a warning is logged and normal evaluation continues.
+#    d. Otherwise → do not skip.
+#
+# Inputs the decision uses
+# ------------------------
+# - ``labels`` — the labels currently on the PR (or the snapshot, when the
+#   function is called as a cheap pre-flight check before any API call).
+# - ``snapshot_labels`` — the labels captured by the workflow's
+#   ``get-pr-info`` job, used to detect race-window changes.
+# - ``unlabel_actor_login`` — GitHub login of the user who most recently
+#   removed a ``backport-to-*`` label, resolved via
+#   :func:`_get_latest_backport_unlabel_actor`.
+# - ``unlabel_actor_has_write_access`` — tri-state result from
+#   :func:`_actor_has_write_access` (``True`` write/admin, ``False`` other,
+#   ``None`` lookup failed). ``False`` is the only value that defers the
+#   skip; ``True`` / ``None`` both treat the removal as a maintainer signal
+#   so transient API failures never silently disable the skip.
+#
+# All milestone helpers log via :func:`console_print` with the workflow's
+# Rich console; callers do not need to add their own skip-related log lines.
+# ---------------------------------------------------------------------------
+
+
 VERSION_BRANCH_PATTERN = re.compile(r"^v(\d+)-(\d+)-test$")
 BACKPORT_LABEL_PATTERN = re.compile(r"^backport-to-v(\d+)-(\d+)-test$")
 
@@ -1162,22 +1214,88 @@ def _all_backport_labels_removed(snapshot_labels: list[str], current_labels: lis
     return snapshot_backports
 
 
-def _should_skip_milestone_tagging(labels: list[str], snapshot_labels: list[str] | None = None) -> bool:
-    """Check if the PR should be skipped from milestone auto-tagging.
+def _should_skip_milestone_tagging(
+    labels: list[str],
+    snapshot_labels: list[str] | None = None,
+    *,
+    unlabel_actor_login: str | None = None,
+    unlabel_actor_has_write_access: bool | None = None,
+) -> bool:
+    """Decide whether milestone auto-tagging should be skipped for the PR.
 
-    Skip when either:
+    Single decision point for the ``set-milestone`` command. Applies the
+    following checks IN ORDER and short-circuits on the first hit. Each
+    skip / defer outcome logs its own reason via ``console_print``; callers
+    only need to react to the boolean return.
 
-    - any ``MILESTONE_SKIP_LABELS`` label is present on the PR right now, or
-    - ``snapshot_labels`` is supplied and every ``backport-to-*`` label that
-      was on the snapshot has been removed (with no replacement backport
-      label) since. The full removal is treated as an explicit "don't
-      auto-tag this PR" signal from the maintainer.
+    1. ``MILESTONE_SKIP_LABELS`` present on ``labels`` → **skip** (info
+       log). This is independent of the snapshot and is cheap enough to
+       use as a pre-flight check before any GitHub API call.
+    2. ``snapshot_labels`` supplied AND every ``backport-to-*`` label that
+       was on the snapshot is now absent from ``labels`` (no replacement
+       backport remains) — i.e. a maintainer fully unbackported the PR
+       during the workflow's race window. The GitHub-events inputs then
+       decide attribution:
+
+       - ``unlabel_actor_has_write_access`` is ``False`` (positively
+         identified as a non-maintainer such as a bot or external
+         contributor) → **do not skip**; a warning is logged and the
+         caller falls through to normal evaluation. This is the only
+         value that defers; ``True`` / ``None`` both treat the removal
+         as a maintainer signal so transient permission-API failures
+         never silently disable the skip.
+       - Otherwise (write/admin actor, unknown actor, or unknown
+         permission) → **skip** with attribution in the info log.
+    3. Otherwise → **do not skip**.
+
+    Partial replacement (snapshot had ``backport-to-v3-1-test``, current
+    has ``backport-to-v3-2-test``) is intentionally NOT a skip signal:
+    :func:`_all_backport_labels_removed` returns an empty set in that
+    case, so the caller's regular re-evaluation picks up the new label.
+
+    :param labels: Labels currently on the PR (or the snapshot, when used
+        as a pre-flight check before any API call).
+    :param snapshot_labels: Labels captured by the workflow's
+        ``get-pr-info`` job, used to detect race-window changes. Pass
+        ``None`` to disable race-window checks (e.g. the pre-flight call).
+    :param unlabel_actor_login: GitHub login of the user who most recently
+        removed a ``backport-to-*`` label, from
+        :func:`_get_latest_backport_unlabel_actor`. Only used when the
+        snapshot/current diff triggers check 2.
+    :param unlabel_actor_has_write_access: Tri-state from
+        :func:`_actor_has_write_access`. Only used when check 2 fires.
     """
-    if set(labels) & MILESTONE_SKIP_LABELS:
+    skip_labels_present = set(labels) & MILESTONE_SKIP_LABELS
+    if skip_labels_present:
+        console_print(f"[info]Skipping milestone tagging - PR has skip label(s): {skip_labels_present}[/]")
         return True
-    if snapshot_labels is not None and _all_backport_labels_removed(snapshot_labels, labels):
-        return True
-    return False
+
+    if snapshot_labels is None:
+        return False
+
+    removed = _all_backport_labels_removed(snapshot_labels, labels)
+    if not removed:
+        return False
+
+    if unlabel_actor_has_write_access is False:
+        console_print(
+            f"[warning]Backport labels {sorted(removed)} were removed by "
+            f"@{unlabel_actor_login}, who lacks write access. Ignoring removal signal and "
+            f"continuing with normal evaluation.[/]"
+        )
+        return False
+
+    if unlabel_actor_login and unlabel_actor_has_write_access:
+        attribution = f" by maintainer @{unlabel_actor_login}"
+    elif unlabel_actor_login:
+        attribution = f" by @{unlabel_actor_login}, permission unknown"
+    else:
+        attribution = ", actor unknown"
+    console_print(
+        f"[info]Skipping milestone tagging - backport labels removed during workflow "
+        f"window{attribution}, treated as explicit maintainer signal: {sorted(removed)}[/]"
+    )
+    return True
 
 
 def _get_latest_backport_unlabel_actor(issue: Issue, removed_backports: set[str]) -> str | None:
@@ -1340,11 +1458,9 @@ def set_milestone(
 
     console_print(f"[info]Labels: {labels}[/]")
 
-    # Check if we should skip
+    # Cheap pre-flight: skip on static MILESTONE_SKIP_LABELS before any API call.
+    # (See the milestone-helpers module-level note for the full decision pipeline.)
     if _should_skip_milestone_tagging(labels):
-        console_print(
-            f"[info]Skipping milestone tagging - PR has skip label(s): {set(labels) & MILESTONE_SKIP_LABELS}[/]"
-        )
         return
 
     # Determine which milestone to use
@@ -1392,43 +1508,25 @@ def set_milestone(
         console_print(f"[info]Snapshot labels: {sorted(labels)}[/]")
         console_print(f"[info]Current labels:  {sorted(current_labels)}[/]")
 
-        # Treat a maintainer-removed backport label (with no replacement
-        # backport remaining) as an explicit "don't auto-tag" signal: it
-        # overrides any other auto-tagging condition (e.g. merge to a
-        # version branch) that might otherwise apply. Cross-check the
-        # issue events to attribute the unlabel action; if the actor is
-        # positively identified as lacking write access (e.g. a bot or
-        # external contributor), fall through to normal evaluation rather
-        # than treating the change as a maintainer signal.
+        # Resolve the GitHub-events attribution for any fully-removed
+        # ``backport-to-*`` labels so the unified skip-decision function
+        # can defer to non-maintainer removals (e.g. by a bot) while still
+        # treating maintainer removals as a "don't auto-tag" signal that
+        # overrides the merge-to-version-branch heuristic.
         removed_backports = _all_backport_labels_removed(labels, current_labels)
+        actor_login: str | None = None
+        actor_has_write_access: bool | None = None
         if removed_backports:
             actor_login = _get_latest_backport_unlabel_actor(issue, removed_backports)
-            is_maintainer = _actor_has_write_access(repo, actor_login) if actor_login is not None else None
-            if is_maintainer is False:
-                console_print(
-                    f"[warning]Backport labels {sorted(removed_backports)} were removed by "
-                    f"@{actor_login}, who lacks write access. Ignoring removal signal and "
-                    f"continuing with normal evaluation.[/]"
-                )
-            else:
-                if actor_login and is_maintainer:
-                    attribution = f" by maintainer @{actor_login}"
-                elif actor_login:
-                    attribution = f" by @{actor_login}, permission unknown"
-                else:
-                    attribution = ", actor unknown"
-                console_print(
-                    f"[info]Skipping milestone tagging - backport labels removed during workflow "
-                    f"window{attribution}, treated as explicit maintainer signal: "
-                    f"{sorted(removed_backports)}[/]"
-                )
-                return
+            if actor_login is not None:
+                actor_has_write_access = _actor_has_write_access(repo, actor_login)
 
-        if _should_skip_milestone_tagging(current_labels):
-            console_print(
-                f"[info]Skipping milestone tagging - PR now has skip label(s): "
-                f"{set(current_labels) & MILESTONE_SKIP_LABELS}[/]"
-            )
+        if _should_skip_milestone_tagging(
+            current_labels,
+            snapshot_labels=labels,
+            unlabel_actor_login=actor_login,
+            unlabel_actor_has_write_access=actor_has_write_access,
+        ):
             return
 
         new_version, new_reason = _determine_milestone_version(current_labels, pr_title, base_branch)

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -1382,16 +1382,17 @@ def set_milestone(
     # Step 1: milestone-already-set guard — don't override an existing milestone.
     try:
         issue: Issue = repo.get_issue(pr_number)
-        if issue.milestone is not None:
-            console_print(
-                f"[info]PR #{pr_number} already has milestone '{issue.milestone.title}' set. Skipping.[/]"
-            )
-            return
     except UnknownObjectException:
         console_print(f"[error]PR #{pr_number} not found when checking existing milestone[/]")
         return
     except Exception as e:
         console_print(f"[error]Failed to check existing milestone: {e}[/]")
+        return
+
+    if issue.milestone is not None:
+        console_print(
+            f"[info]PR #{pr_number} already has milestone '{issue.milestone.title}' set. Skipping.[/]"
+        )
         return
 
     # Pull live labels and events. Both feed the skip-decision function below

--- a/dev/breeze/tests/test_set_milestone.py
+++ b/dev/breeze/tests/test_set_milestone.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow_breeze.commands.ci_commands import (
+    _all_backport_labels_removed,
     _determine_milestone_version,
     _find_latest_milestone,
     _find_matching_milestone,
@@ -161,6 +162,68 @@ class TestShouldSkipMilestoneTagging:
 
     def test_no_skip_without_skip_labels(self):
         assert not _should_skip_milestone_tagging(["kind:feature", "area:scheduler"])
+
+    def test_skip_when_all_backport_labels_removed_during_race_window(self):
+        # Snapshot had a backport label, current has none — explicit maintainer signal.
+        assert _should_skip_milestone_tagging(
+            ["kind:bug"], snapshot_labels=["backport-to-v3-1-test", "kind:bug"]
+        )
+
+    def test_no_skip_when_backport_label_unchanged(self):
+        assert not _should_skip_milestone_tagging(
+            ["backport-to-v3-1-test", "kind:bug"],
+            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
+        )
+
+    def test_no_skip_when_backport_label_added(self):
+        # Adding a backport label is not a skip signal — the regular evaluation handles it.
+        assert not _should_skip_milestone_tagging(
+            ["backport-to-v3-1-test", "kind:bug"], snapshot_labels=["kind:bug"]
+        )
+
+    def test_no_skip_when_backport_label_replaced(self):
+        # Swapping one backport label for another is a fix, not a cancel — current
+        # state still has a backport, so the normal evaluation should run.
+        assert not _should_skip_milestone_tagging(
+            ["backport-to-v3-2-test", "kind:bug"],
+            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
+        )
+
+    def test_no_skip_when_non_backport_label_removed(self):
+        # Removing a non-backport label is irrelevant; tagging proceeds.
+        assert not _should_skip_milestone_tagging(
+            ["kind:bug"], snapshot_labels=["kind:bug", "kind:documentation"]
+        )
+
+
+class TestAllBackportLabelsRemoved:
+    """Test cases for _all_backport_labels_removed."""
+
+    def test_no_change(self):
+        labels = ["backport-to-v3-1-test", "kind:bug"]
+        assert _all_backport_labels_removed(labels, labels) == set()
+
+    def test_single_backport_fully_removed(self):
+        assert _all_backport_labels_removed(["backport-to-v3-1-test", "kind:bug"], ["kind:bug"]) == {
+            "backport-to-v3-1-test"
+        }
+
+    def test_multiple_backports_fully_removed(self):
+        assert _all_backport_labels_removed(["backport-to-v3-1-test", "backport-to-v3-2-test"], []) == {
+            "backport-to-v3-1-test",
+            "backport-to-v3-2-test",
+        }
+
+    def test_backport_replaced_returns_empty(self):
+        # When a replacement backport remains, the helper reports nothing —
+        # the regular re-evaluation should handle the new version.
+        assert _all_backport_labels_removed(["backport-to-v3-1-test"], ["backport-to-v3-2-test"]) == set()
+
+    def test_backport_added_not_reported(self):
+        assert _all_backport_labels_removed([], ["backport-to-v3-1-test"]) == set()
+
+    def test_non_backport_removal_not_reported(self):
+        assert _all_backport_labels_removed(["kind:bug"], []) == set()
 
 
 class TestGetBackportVersionFromLabels:
@@ -621,11 +684,60 @@ However, **no open milestone was found** matching: {expected_search_criteria}
         )
 
         # Snapshot still has the backport label, but the fresh issue.labels does not.
-        # The action must re-read, notice the change, and skip the milestone-set.
+        # The action must re-read, notice the change, and skip the milestone-set —
+        # treating the maintainer's removal as an explicit "don't auto-tag" signal.
         mock_issue.edit.assert_not_called()
         mock_issue.create_comment.assert_not_called()
         assert "Labels changed since workflow snapshot" in result.output
-        assert "No milestone to set after re-evaluation" in result.output
+        assert "backport labels removed during workflow window" in result.output
+        assert "backport-to-v3-2-test" in result.output
+        assert result.exit_code == 0
+
+    @patch("airflow_breeze.commands.ci_commands._get_github_client")
+    def test_backport_label_removed_on_version_branch_should_skip(
+        self, mock_get_client, cli_runner, mock_github_setup
+    ):
+        """A backport label removed during the race window must take precedence
+        over the merge-to-version-branch heuristic. Without this, a PR merged to
+        a version branch would still get that branch's milestone even after a
+        maintainer explicitly removed a different backport label, because the
+        version-branch rule alone keeps producing a milestone.
+        """
+        from airflow_breeze.commands.ci_commands import ci_group
+
+        mock_gh, mock_repo, mock_issue = mock_github_setup
+        mock_issue.milestone = None
+        # Snapshot had backport-to-v3-2-test on a PR merged to v3-1-test; the
+        # maintainer removed the v3-2-test backport label inside the race window.
+        mock_issue.labels = [_label("kind:bug")]
+        mock_get_client.return_value = mock_gh
+
+        result = cli_runner.invoke(
+            ci_group,
+            [
+                "set-milestone",
+                "--pr-number",
+                "12345",
+                "--pr-title",
+                "Fix: scheduler issue",
+                "--pr-labels",
+                json.dumps(["backport-to-v3-2-test", "kind:bug"]),
+                "--base-branch",
+                "v3-1-test",
+                "--merged-by",
+                "testuser",
+                "--github-token",
+                "fake-token",
+                "--github-repository",
+                "apache/airflow",
+            ],
+        )
+
+        mock_issue.edit.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+        assert "Labels changed since workflow snapshot" in result.output
+        assert "backport labels removed during workflow window" in result.output
+        assert "backport-to-v3-2-test" in result.output
         assert result.exit_code == 0
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")

--- a/dev/breeze/tests/test_set_milestone.py
+++ b/dev/breeze/tests/test_set_milestone.py
@@ -218,6 +218,43 @@ class TestShouldSkipMilestoneTagging:
             ["kind:bug"], snapshot_labels=["kind:bug", "kind:documentation"]
         )
 
+    def test_skip_when_backport_removed_by_maintainer(self):
+        # Removal attributed to a write-access user → skip (check 2b).
+        assert _should_skip_milestone_tagging(
+            ["kind:bug"],
+            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
+            unlabel_actor_login="alice",
+            unlabel_actor_has_write_access=True,
+        )
+
+    def test_skip_when_backport_removed_actor_permission_unknown(self):
+        # Permission lookup failed (None) → still skip (safe default).
+        assert _should_skip_milestone_tagging(
+            ["kind:bug"],
+            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
+            unlabel_actor_login="alice",
+            unlabel_actor_has_write_access=None,
+        )
+
+    def test_no_skip_when_backport_removed_by_non_maintainer(self):
+        # Removal positively attributed to a non-maintainer (bot) → defer.
+        assert not _should_skip_milestone_tagging(
+            ["kind:bug"],
+            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
+            unlabel_actor_login="some-bot",
+            unlabel_actor_has_write_access=False,
+        )
+
+    def test_skip_label_check_takes_precedence_over_backport_removal(self):
+        # Check 1 (static skip labels) wins over check 2 — even when a
+        # non-maintainer was the unlabeler, the area:CI label still skips.
+        assert _should_skip_milestone_tagging(
+            ["area:CI"],
+            snapshot_labels=["backport-to-v3-1-test"],
+            unlabel_actor_login="some-bot",
+            unlabel_actor_has_write_access=False,
+        )
+
 
 class TestGetLatestBackportUnlabelActor:
     """Test cases for _get_latest_backport_unlabel_actor."""

--- a/dev/breeze/tests/test_set_milestone.py
+++ b/dev/breeze/tests/test_set_milestone.py
@@ -24,17 +24,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow_breeze.commands.ci_commands import (
-    _actor_has_write_access,
-    _all_backport_labels_removed,
     _determine_milestone_version,
     _find_latest_milestone,
     _find_matching_milestone,
     _get_backport_version_from_labels,
-    _get_latest_backport_unlabel_actor,
     _get_mention,
     _get_milestone_not_found_comment,
     _get_milestone_notification_comment,
     _get_milestone_prefix,
+    _get_removed_backport_labels_from_events,
     _has_bug_fix_indicators,
     _parse_milestone_version,
     _parse_version_from_backport_label,
@@ -180,171 +178,87 @@ class TestShouldSkipMilestoneTagging:
             ["area:CI"],
         ],
     )
-    def test_skip_with_skip_labels(self, labels):
-        assert _should_skip_milestone_tagging(labels)
+    def test_skip_with_static_skip_labels(self, labels):
+        assert _should_skip_milestone_tagging(labels, events=[])
 
-    def test_no_skip_without_skip_labels(self):
-        assert not _should_skip_milestone_tagging(["kind:feature", "area:scheduler"])
+    def test_no_skip_without_static_skip_labels(self):
+        assert not _should_skip_milestone_tagging(["kind:feature", "area:scheduler"], events=[])
 
-    def test_skip_when_all_backport_labels_removed_during_race_window(self):
-        # Snapshot had a backport label, current has none — explicit maintainer signal.
-        assert _should_skip_milestone_tagging(
-            ["kind:bug"], snapshot_labels=["backport-to-v3-1-test", "kind:bug"]
-        )
+    def test_skip_when_backport_unlabeled_with_no_replacement(self):
+        # Events show backport removal, no backport on PR now → skip (check 2).
+        events = [
+            _unlabel_event(
+                "backport-to-v3-1-test", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+            )
+        ]
+        assert _should_skip_milestone_tagging(["kind:bug"], events=events)
 
-    def test_no_skip_when_backport_label_unchanged(self):
-        assert not _should_skip_milestone_tagging(
-            ["backport-to-v3-1-test", "kind:bug"],
-            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
-        )
+    def test_no_skip_when_backport_replaced(self):
+        # Events show backport-to-v3-1 removal but v3-2 remains on the PR → no skip.
+        # The caller's regular evaluation will pick up the new label.
+        events = [
+            _unlabel_event(
+                "backport-to-v3-1-test", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+            )
+        ]
+        assert not _should_skip_milestone_tagging(["backport-to-v3-2-test", "kind:bug"], events=events)
 
-    def test_no_skip_when_backport_label_added(self):
-        # Adding a backport label is not a skip signal — the regular evaluation handles it.
-        assert not _should_skip_milestone_tagging(
-            ["backport-to-v3-1-test", "kind:bug"], snapshot_labels=["kind:bug"]
-        )
+    def test_no_skip_when_no_removal_event(self):
+        # No unlabeled events at all — current backport label drives the decision elsewhere.
+        assert not _should_skip_milestone_tagging(["backport-to-v3-1-test", "kind:bug"], events=[])
 
-    def test_no_skip_when_backport_label_replaced(self):
-        # Swapping one backport label for another is a fix, not a cancel — current
-        # state still has a backport, so the normal evaluation should run.
-        assert not _should_skip_milestone_tagging(
-            ["backport-to-v3-2-test", "kind:bug"],
-            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
-        )
+    def test_no_skip_when_unrelated_label_removed(self):
+        events = [
+            _unlabel_event("kind:documentation", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc))
+        ]
+        assert not _should_skip_milestone_tagging(["kind:bug"], events=events)
 
-    def test_no_skip_when_non_backport_label_removed(self):
-        # Removing a non-backport label is irrelevant; tagging proceeds.
-        assert not _should_skip_milestone_tagging(
-            ["kind:bug"], snapshot_labels=["kind:bug", "kind:documentation"]
-        )
+    def test_events_check_takes_precedence_over_static_labels(self):
+        # Both check 2 (events) and check 3 (static label) would fire here;
+        # the function returns True on the first one — events — and never logs
+        # the static-label reason.
+        events = [
+            _unlabel_event(
+                "backport-to-v3-1-test", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+            )
+        ]
+        assert _should_skip_milestone_tagging(["area:CI"], events=events)
 
-    def test_skip_when_backport_removed_by_maintainer(self):
-        # Removal attributed to a write-access user → skip (check 2b).
-        assert _should_skip_milestone_tagging(
-            ["kind:bug"],
-            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
-            unlabel_actor_login="alice",
-            unlabel_actor_has_write_access=True,
-        )
-
-    def test_skip_when_backport_removed_actor_permission_unknown(self):
-        # Permission lookup failed (None) → still skip (safe default).
-        assert _should_skip_milestone_tagging(
-            ["kind:bug"],
-            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
-            unlabel_actor_login="alice",
-            unlabel_actor_has_write_access=None,
-        )
-
-    def test_no_skip_when_backport_removed_by_non_maintainer(self):
-        # Removal positively attributed to a non-maintainer (bot) → defer.
-        assert not _should_skip_milestone_tagging(
-            ["kind:bug"],
-            snapshot_labels=["backport-to-v3-1-test", "kind:bug"],
-            unlabel_actor_login="some-bot",
-            unlabel_actor_has_write_access=False,
-        )
-
-    def test_skip_label_check_takes_precedence_over_backport_removal(self):
-        # Check 1 (static skip labels) wins over check 2 — even when a
-        # non-maintainer was the unlabeler, the area:CI label still skips.
-        assert _should_skip_milestone_tagging(
-            ["area:CI"],
-            snapshot_labels=["backport-to-v3-1-test"],
-            unlabel_actor_login="some-bot",
-            unlabel_actor_has_write_access=False,
-        )
+    def test_events_none_disables_events_check(self):
+        # When events is None (fetch failed), only the static label check runs.
+        assert not _should_skip_milestone_tagging(["kind:bug"], events=None)
+        assert _should_skip_milestone_tagging(["area:CI"], events=None)
 
 
-class TestGetLatestBackportUnlabelActor:
-    """Test cases for _get_latest_backport_unlabel_actor."""
+class TestGetRemovedBackportLabelsFromEvents:
+    """Test cases for _get_removed_backport_labels_from_events."""
 
-    def test_returns_latest_actor_for_matching_unlabel(self):
-        issue = MagicMock()
-        issue.get_events.return_value = [
+    def test_returns_all_unlabel_events_for_backports(self):
+        events = [
             _unlabel_event(
                 "backport-to-v3-1-test", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
             ),
-            _unlabel_event("backport-to-v3-1-test", "bob", datetime(2026, 5, 23, 14, 0, tzinfo=timezone.utc)),
-            _unlabel_event(
-                "backport-to-v3-1-test", "carol", datetime(2026, 5, 23, 13, 0, tzinfo=timezone.utc)
-            ),
+            _unlabel_event("backport-to-v3-2-test", "bob", datetime(2026, 5, 23, 14, 0, tzinfo=timezone.utc)),
         ]
-        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) == "bob"
-
-    def test_ignores_unrelated_label_events(self):
-        issue = MagicMock()
-        issue.get_events.return_value = [
-            _unlabel_event("kind:documentation", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)),
-        ]
-        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) is None
-
-    def test_ignores_non_unlabeled_events(self):
-        issue = MagicMock()
-        labeled_event = MagicMock()
-        labeled_event.event = "labeled"
-        labeled_event.label = _label("backport-to-v3-1-test")
-        labeled_event.actor = MagicMock()
-        labeled_event.actor.login = "alice"
-        labeled_event.created_at = datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
-        issue.get_events.return_value = [labeled_event]
-        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) is None
-
-    def test_returns_none_when_events_fetch_raises(self):
-        issue = MagicMock()
-        issue.get_events.side_effect = RuntimeError("rate limited")
-        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) is None
-
-
-class TestActorHasWriteAccess:
-    """Test cases for _actor_has_write_access."""
-
-    @pytest.mark.parametrize("permission", ["admin", "write"])
-    def test_returns_true_for_write_or_admin(self, permission):
-        repo = MagicMock()
-        repo.get_collaborator_permission.return_value = permission
-        assert _actor_has_write_access(repo, "alice") is True
-
-    @pytest.mark.parametrize("permission", ["read", "none", "triage"])
-    def test_returns_false_for_other_permissions(self, permission):
-        repo = MagicMock()
-        repo.get_collaborator_permission.return_value = permission
-        assert _actor_has_write_access(repo, "bot-user") is False
-
-    def test_returns_none_when_lookup_raises(self):
-        repo = MagicMock()
-        repo.get_collaborator_permission.side_effect = RuntimeError("rate limited")
-        assert _actor_has_write_access(repo, "alice") is None
-
-
-class TestAllBackportLabelsRemoved:
-    """Test cases for _all_backport_labels_removed."""
-
-    def test_no_change(self):
-        labels = ["backport-to-v3-1-test", "kind:bug"]
-        assert _all_backport_labels_removed(labels, labels) == set()
-
-    def test_single_backport_fully_removed(self):
-        assert _all_backport_labels_removed(["backport-to-v3-1-test", "kind:bug"], ["kind:bug"]) == {
-            "backport-to-v3-1-test"
-        }
-
-    def test_multiple_backports_fully_removed(self):
-        assert _all_backport_labels_removed(["backport-to-v3-1-test", "backport-to-v3-2-test"], []) == {
+        assert _get_removed_backport_labels_from_events(events) == {
             "backport-to-v3-1-test",
             "backport-to-v3-2-test",
         }
 
-    def test_backport_replaced_returns_empty(self):
-        # When a replacement backport remains, the helper reports nothing —
-        # the regular re-evaluation should handle the new version.
-        assert _all_backport_labels_removed(["backport-to-v3-1-test"], ["backport-to-v3-2-test"]) == set()
+    def test_ignores_unrelated_label_unlabel_events(self):
+        events = [
+            _unlabel_event("kind:documentation", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc))
+        ]
+        assert _get_removed_backport_labels_from_events(events) == set()
 
-    def test_backport_added_not_reported(self):
-        assert _all_backport_labels_removed([], ["backport-to-v3-1-test"]) == set()
+    def test_ignores_non_unlabeled_events(self):
+        labeled = MagicMock()
+        labeled.event = "labeled"
+        labeled.label = _label("backport-to-v3-1-test")
+        assert _get_removed_backport_labels_from_events([labeled]) == set()
 
-    def test_non_backport_removal_not_reported(self):
-        assert _all_backport_labels_removed(["kind:bug"], []) == set()
+    def test_empty_events(self):
+        assert _get_removed_backport_labels_from_events([]) == set()
 
 
 class TestGetBackportVersionFromLabels:
@@ -510,9 +424,17 @@ class TestSetMilestoneCommand:
         ],
     )
     @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_skip_label_should_skip(self, mock_get_client, base_branch, skip_label, cli_runner):
+    def test_skip_label_should_skip(
+        self, mock_get_client, base_branch, skip_label, cli_runner, mock_github_setup
+    ):
         """When PR has a skip label, milestone tagging should be skipped."""
         from airflow_breeze.commands.ci_commands import ci_group
+
+        mock_gh, mock_repo, mock_issue = mock_github_setup
+        mock_issue.milestone = None
+        mock_issue.labels = [_label(skip_label)]
+        mock_issue.get_events.return_value = []
+        mock_get_client.return_value = mock_gh
 
         result = cli_runner.invoke(
             ci_group,
@@ -533,13 +455,23 @@ class TestSetMilestoneCommand:
             ],
         )
 
-        mock_get_client.assert_not_called()
-        assert "Skipping milestone tagging" in result.output
+        mock_issue.edit.assert_not_called()
+        plain = _plain_output(result.output)
+        assert "Skipping milestone tagging" in plain
+        assert skip_label in plain
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_main_branch_without_backport_label_should_skip(self, mock_get_client, cli_runner):
+    def test_main_branch_without_backport_label_should_skip(
+        self, mock_get_client, cli_runner, mock_github_setup
+    ):
         """When PR is merged to main without backport label, milestone tagging should be skipped."""
         from airflow_breeze.commands.ci_commands import ci_group
+
+        mock_gh, mock_repo, mock_issue = mock_github_setup
+        mock_issue.milestone = None
+        mock_issue.labels = [_label("kind:feature")]
+        mock_issue.get_events.return_value = []
+        mock_get_client.return_value = mock_gh
 
         result = cli_runner.invoke(
             ci_group,
@@ -560,7 +492,7 @@ class TestSetMilestoneCommand:
             ],
         )
 
-        mock_get_client.assert_not_called()
+        mock_issue.edit.assert_not_called()
         assert "No milestone to set" in result.output
 
     @pytest.mark.parametrize(
@@ -768,19 +700,26 @@ However, **no open milestone was found** matching: {expected_search_criteria}
         assert "No open milestone found" in result.output
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_backport_label_removed_after_snapshot_should_skip(
+    def test_backport_unlabeled_with_no_replacement_should_skip(
         self, mock_get_client, cli_runner, mock_github_setup
     ):
-        """If a backport label is removed between the workflow snapshot and the action,
-        the action must re-read labels from the issue and honour the current state —
-        skip milestone-set when the only signal that triggered it (the backport label)
-        is gone. Regression test for PR #67301 race.
+        """If an ``unlabeled`` event for a ``backport-to-*`` label exists on the
+        PR and no ``backport-to-*`` label remains, the action must skip the
+        milestone-set. Regression test for PR #67301 race; the events stream
+        is now the single source of truth for the unbackport signal.
         """
         from airflow_breeze.commands.ci_commands import ci_group
 
         mock_gh, mock_repo, mock_issue = mock_github_setup
         mock_issue.milestone = None
         mock_issue.labels = [_label("kind:documentation")]
+        mock_issue.get_events.return_value = [
+            _unlabel_event(
+                "backport-to-v3-2-test",
+                "shahar1",
+                datetime(2026, 5, 23, 20, 32, 17, tzinfo=timezone.utc),
+            ),
+        ]
         mock_get_client.return_value = mock_gh
 
         result = cli_runner.invoke(
@@ -804,33 +743,35 @@ However, **no open milestone was found** matching: {expected_search_criteria}
             ],
         )
 
-        # Snapshot still has the backport label, but the fresh issue.labels does not.
-        # The action must re-read, notice the change, and skip the milestone-set —
-        # treating the maintainer's removal as an explicit "don't auto-tag" signal.
         mock_issue.edit.assert_not_called()
         mock_issue.create_comment.assert_not_called()
-        assert "Labels changed since workflow snapshot" in result.output
-        assert "backport labels removed during workflow window" in result.output
-        assert "backport-to-v3-2-test" in result.output
+        plain = _plain_output(result.output)
+        assert "Skipping milestone tagging" in plain
+        assert "backport labels were removed during the PR lifecycle" in plain
+        assert "backport-to-v3-2-test" in plain
         assert result.exit_code == 0
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_backport_label_removed_on_version_branch_should_skip(
+    def test_backport_unlabeled_on_version_branch_should_skip(
         self, mock_get_client, cli_runner, mock_github_setup
     ):
-        """A backport label removed during the race window must take precedence
-        over the merge-to-version-branch heuristic. Without this, a PR merged to
-        a version branch would still get that branch's milestone even after a
-        maintainer explicitly removed a different backport label, because the
-        version-branch rule alone keeps producing a milestone.
+        """A backport-label removal recorded in the issue events must take
+        precedence over the merge-to-version-branch heuristic. Without this, a
+        PR merged to a version branch would still get that branch's milestone
+        even after a maintainer/triager explicitly removed the backport label.
         """
         from airflow_breeze.commands.ci_commands import ci_group
 
         mock_gh, mock_repo, mock_issue = mock_github_setup
         mock_issue.milestone = None
-        # Snapshot had backport-to-v3-2-test on a PR merged to v3-1-test; the
-        # maintainer removed the v3-2-test backport label inside the race window.
         mock_issue.labels = [_label("kind:bug")]
+        mock_issue.get_events.return_value = [
+            _unlabel_event(
+                "backport-to-v3-2-test",
+                "testuser",
+                datetime(2026, 5, 23, 20, 32, 17, tzinfo=timezone.utc),
+            ),
+        ]
         mock_get_client.return_value = mock_gh
 
         result = cli_runner.invoke(
@@ -856,132 +797,30 @@ However, **no open milestone was found** matching: {expected_search_criteria}
 
         mock_issue.edit.assert_not_called()
         mock_issue.create_comment.assert_not_called()
-        assert "Labels changed since workflow snapshot" in result.output
-        assert "backport labels removed during workflow window" in result.output
-        assert "backport-to-v3-2-test" in result.output
-        assert result.exit_code == 0
-
-    @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_skip_log_attributes_maintainer_who_unlabeled(
-        self, mock_get_client, cli_runner, mock_github_setup
-    ):
-        """When the issue-events scan identifies a write-access user as the
-        actor of the ``unlabeled`` event for the removed backport label, that
-        login must appear in the skip log line so reviewers can audit who
-        cancelled the auto-tag.
-        """
-        from airflow_breeze.commands.ci_commands import ci_group
-
-        mock_gh, mock_repo, mock_issue = mock_github_setup
-        mock_issue.milestone = None
-        mock_issue.labels = [_label("kind:documentation")]
-        mock_issue.get_events.return_value = [
-            _unlabel_event(
-                "backport-to-v3-2-test",
-                "shahar1",
-                datetime(2026, 5, 23, 20, 32, 17, tzinfo=timezone.utc),
-            ),
-        ]
-        mock_repo.get_collaborator_permission.return_value = "write"
-        mock_get_client.return_value = mock_gh
-
-        result = cli_runner.invoke(
-            ci_group,
-            [
-                "set-milestone",
-                "--pr-number",
-                "67301",
-                "--pr-title",
-                "fix: typo",
-                "--pr-labels",
-                json.dumps(["backport-to-v3-2-test", "kind:documentation"]),
-                "--base-branch",
-                "main",
-                "--merged-by",
-                "shahar1",
-                "--github-token",
-                "fake-token",
-                "--github-repository",
-                "apache/airflow",
-            ],
-        )
-
-        mock_issue.edit.assert_not_called()
-        mock_issue.create_comment.assert_not_called()
-        mock_repo.get_collaborator_permission.assert_called_once_with("shahar1")
         plain = _plain_output(result.output)
-        assert "by maintainer @shahar1" in plain
-        assert "backport labels removed during workflow window" in plain
+        assert "Skipping milestone tagging" in plain
+        assert "backport labels were removed during the PR lifecycle" in plain
+        assert "backport-to-v3-2-test" in plain
         assert result.exit_code == 0
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_backport_removal_by_non_maintainer_should_fall_through(
-        self, mock_get_client, cli_runner, mock_github_setup
-    ):
-        """If the issue-events scan identifies a user without write access
-        (e.g. a bot or external contributor) as the ``unlabeled`` actor, the
-        removal must NOT be treated as a maintainer signal. The action falls
-        back to normal evaluation. On main with no current backport that
-        means "no milestone to set" — still no edit, but for a different,
-        non-attributed reason.
+    def test_backport_label_replaced_should_use_current(self, mock_get_client, cli_runner, mock_github_setup):
+        """When the events show one backport label removed but another
+        ``backport-to-*`` remains on the PR (e.g. someone swapped the version
+        target), the action must use the current label, not skip.
         """
         from airflow_breeze.commands.ci_commands import ci_group
 
         mock_gh, mock_repo, mock_issue = mock_github_setup
         mock_issue.milestone = None
-        mock_issue.labels = [_label("kind:documentation")]
-        mock_issue.get_events.return_value = [
-            _unlabel_event(
-                "backport-to-v3-2-test",
-                "some-bot",
-                datetime(2026, 5, 23, 20, 32, 17, tzinfo=timezone.utc),
-            ),
-        ]
-        mock_repo.get_collaborator_permission.return_value = "read"
-        mock_get_client.return_value = mock_gh
-
-        result = cli_runner.invoke(
-            ci_group,
-            [
-                "set-milestone",
-                "--pr-number",
-                "67301",
-                "--pr-title",
-                "fix: typo",
-                "--pr-labels",
-                json.dumps(["backport-to-v3-2-test", "kind:documentation"]),
-                "--base-branch",
-                "main",
-                "--merged-by",
-                "shahar1",
-                "--github-token",
-                "fake-token",
-                "--github-repository",
-                "apache/airflow",
-            ],
-        )
-
-        mock_issue.edit.assert_not_called()
-        plain = _plain_output(result.output)
-        assert "Ignoring removal signal" in plain
-        assert "@some-bot" in plain
-        assert "No milestone to set after re-evaluation" in plain
-        assert result.exit_code == 0
-
-    @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_backport_label_changed_after_snapshot_should_use_current(
-        self, mock_get_client, cli_runner, mock_github_setup
-    ):
-        """If the backport label is replaced with a different version between
-        snapshot and action (e.g. someone fixes the version target), the action
-        must re-determine the version using the current label, not the stale one.
-        """
-        from airflow_breeze.commands.ci_commands import ci_group
-
-        mock_gh, mock_repo, mock_issue = mock_github_setup
-        mock_issue.milestone = None
-        # Fresh state: now targets v3-2-test, not v3-1-test.
         mock_issue.labels = [_label("backport-to-v3-2-test"), _label("kind:bug")]
+        mock_issue.get_events.return_value = [
+            _unlabel_event(
+                "backport-to-v3-1-test",
+                "testuser",
+                datetime(2026, 5, 23, 20, 30, 0, tzinfo=timezone.utc),
+            ),
+        ]
         mock_milestone = MagicMock()
         mock_milestone.title = "Airflow 3.2.3"
         mock_milestone.number = 140
@@ -1013,23 +852,24 @@ However, **no open milestone was found** matching: {expected_search_criteria}
         )
 
         mock_issue.edit.assert_called_once_with(milestone=mock_milestone)
-        assert "Labels changed since workflow snapshot" in result.output
-        assert "Determination changed after re-read" in result.output
         assert "Airflow 3.2.3" in captured_comments[0]
         assert "backport label targeting v3-2-test" in captured_comments[0]
         assert result.exit_code == 0
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")
-    def test_skip_label_added_after_snapshot_should_skip(
+    def test_skip_label_present_on_live_labels_should_skip(
         self, mock_get_client, cli_runner, mock_github_setup
     ):
-        """A skip label added after the snapshot must also halt the action."""
+        """A skip label present on the live labels (regardless of what the
+        workflow snapshot had) must halt the action via check 3 of the
+        pipeline.
+        """
         from airflow_breeze.commands.ci_commands import ci_group
 
         mock_gh, mock_repo, mock_issue = mock_github_setup
         mock_issue.milestone = None
-        # Snapshot had no skip label; fresh state added area:CI.
         mock_issue.labels = [_label("backport-to-v3-1-test"), _label("area:CI")]
+        mock_issue.get_events.return_value = []
         mock_get_client.return_value = mock_gh
 
         result = cli_runner.invoke(

--- a/dev/breeze/tests/test_set_milestone.py
+++ b/dev/breeze/tests/test_set_milestone.py
@@ -17,16 +17,20 @@
 from __future__ import annotations
 
 import json
+import re
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from airflow_breeze.commands.ci_commands import (
+    _actor_has_write_access,
     _all_backport_labels_removed,
     _determine_milestone_version,
     _find_latest_milestone,
     _find_matching_milestone,
     _get_backport_version_from_labels,
+    _get_latest_backport_unlabel_actor,
     _get_mention,
     _get_milestone_not_found_comment,
     _get_milestone_notification_comment,
@@ -38,12 +42,31 @@ from airflow_breeze.commands.ci_commands import (
     _should_skip_milestone_tagging,
 )
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain_output(output: str) -> str:
+    """Strip ANSI color codes and collapse whitespace so wrap-tolerant substring
+    asserts don't trip over Rich's color escapes or soft line wraps."""
+    return " ".join(_ANSI_ESCAPE_RE.sub("", output).split())
+
 
 def _label(name: str) -> MagicMock:
     """Build a mock that quacks like a PyGithub ``Label`` for ``issue.labels``."""
     m = MagicMock()
     m.name = name
     return m
+
+
+def _unlabel_event(label_name: str, actor_login: str, when: datetime) -> MagicMock:
+    """Build a mock that quacks like a PyGithub IssueEvent for an ``unlabeled`` event."""
+    event = MagicMock()
+    event.event = "unlabeled"
+    event.label = _label(label_name)
+    event.actor = MagicMock()
+    event.actor.login = actor_login
+    event.created_at = when
+    return event
 
 
 class TestParseVersionFromBranch:
@@ -194,6 +217,67 @@ class TestShouldSkipMilestoneTagging:
         assert not _should_skip_milestone_tagging(
             ["kind:bug"], snapshot_labels=["kind:bug", "kind:documentation"]
         )
+
+
+class TestGetLatestBackportUnlabelActor:
+    """Test cases for _get_latest_backport_unlabel_actor."""
+
+    def test_returns_latest_actor_for_matching_unlabel(self):
+        issue = MagicMock()
+        issue.get_events.return_value = [
+            _unlabel_event(
+                "backport-to-v3-1-test", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+            ),
+            _unlabel_event("backport-to-v3-1-test", "bob", datetime(2026, 5, 23, 14, 0, tzinfo=timezone.utc)),
+            _unlabel_event(
+                "backport-to-v3-1-test", "carol", datetime(2026, 5, 23, 13, 0, tzinfo=timezone.utc)
+            ),
+        ]
+        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) == "bob"
+
+    def test_ignores_unrelated_label_events(self):
+        issue = MagicMock()
+        issue.get_events.return_value = [
+            _unlabel_event("kind:documentation", "alice", datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)),
+        ]
+        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) is None
+
+    def test_ignores_non_unlabeled_events(self):
+        issue = MagicMock()
+        labeled_event = MagicMock()
+        labeled_event.event = "labeled"
+        labeled_event.label = _label("backport-to-v3-1-test")
+        labeled_event.actor = MagicMock()
+        labeled_event.actor.login = "alice"
+        labeled_event.created_at = datetime(2026, 5, 23, 12, 0, tzinfo=timezone.utc)
+        issue.get_events.return_value = [labeled_event]
+        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) is None
+
+    def test_returns_none_when_events_fetch_raises(self):
+        issue = MagicMock()
+        issue.get_events.side_effect = RuntimeError("rate limited")
+        assert _get_latest_backport_unlabel_actor(issue, {"backport-to-v3-1-test"}) is None
+
+
+class TestActorHasWriteAccess:
+    """Test cases for _actor_has_write_access."""
+
+    @pytest.mark.parametrize("permission", ["admin", "write"])
+    def test_returns_true_for_write_or_admin(self, permission):
+        repo = MagicMock()
+        repo.get_collaborator_permission.return_value = permission
+        assert _actor_has_write_access(repo, "alice") is True
+
+    @pytest.mark.parametrize("permission", ["read", "none", "triage"])
+    def test_returns_false_for_other_permissions(self, permission):
+        repo = MagicMock()
+        repo.get_collaborator_permission.return_value = permission
+        assert _actor_has_write_access(repo, "bot-user") is False
+
+    def test_returns_none_when_lookup_raises(self):
+        repo = MagicMock()
+        repo.get_collaborator_permission.side_effect = RuntimeError("rate limited")
+        assert _actor_has_write_access(repo, "alice") is None
 
 
 class TestAllBackportLabelsRemoved:
@@ -738,6 +822,113 @@ However, **no open milestone was found** matching: {expected_search_criteria}
         assert "Labels changed since workflow snapshot" in result.output
         assert "backport labels removed during workflow window" in result.output
         assert "backport-to-v3-2-test" in result.output
+        assert result.exit_code == 0
+
+    @patch("airflow_breeze.commands.ci_commands._get_github_client")
+    def test_skip_log_attributes_maintainer_who_unlabeled(
+        self, mock_get_client, cli_runner, mock_github_setup
+    ):
+        """When the issue-events scan identifies a write-access user as the
+        actor of the ``unlabeled`` event for the removed backport label, that
+        login must appear in the skip log line so reviewers can audit who
+        cancelled the auto-tag.
+        """
+        from airflow_breeze.commands.ci_commands import ci_group
+
+        mock_gh, mock_repo, mock_issue = mock_github_setup
+        mock_issue.milestone = None
+        mock_issue.labels = [_label("kind:documentation")]
+        mock_issue.get_events.return_value = [
+            _unlabel_event(
+                "backport-to-v3-2-test",
+                "shahar1",
+                datetime(2026, 5, 23, 20, 32, 17, tzinfo=timezone.utc),
+            ),
+        ]
+        mock_repo.get_collaborator_permission.return_value = "write"
+        mock_get_client.return_value = mock_gh
+
+        result = cli_runner.invoke(
+            ci_group,
+            [
+                "set-milestone",
+                "--pr-number",
+                "67301",
+                "--pr-title",
+                "fix: typo",
+                "--pr-labels",
+                json.dumps(["backport-to-v3-2-test", "kind:documentation"]),
+                "--base-branch",
+                "main",
+                "--merged-by",
+                "shahar1",
+                "--github-token",
+                "fake-token",
+                "--github-repository",
+                "apache/airflow",
+            ],
+        )
+
+        mock_issue.edit.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+        mock_repo.get_collaborator_permission.assert_called_once_with("shahar1")
+        plain = _plain_output(result.output)
+        assert "by maintainer @shahar1" in plain
+        assert "backport labels removed during workflow window" in plain
+        assert result.exit_code == 0
+
+    @patch("airflow_breeze.commands.ci_commands._get_github_client")
+    def test_backport_removal_by_non_maintainer_should_fall_through(
+        self, mock_get_client, cli_runner, mock_github_setup
+    ):
+        """If the issue-events scan identifies a user without write access
+        (e.g. a bot or external contributor) as the ``unlabeled`` actor, the
+        removal must NOT be treated as a maintainer signal. The action falls
+        back to normal evaluation. On main with no current backport that
+        means "no milestone to set" — still no edit, but for a different,
+        non-attributed reason.
+        """
+        from airflow_breeze.commands.ci_commands import ci_group
+
+        mock_gh, mock_repo, mock_issue = mock_github_setup
+        mock_issue.milestone = None
+        mock_issue.labels = [_label("kind:documentation")]
+        mock_issue.get_events.return_value = [
+            _unlabel_event(
+                "backport-to-v3-2-test",
+                "some-bot",
+                datetime(2026, 5, 23, 20, 32, 17, tzinfo=timezone.utc),
+            ),
+        ]
+        mock_repo.get_collaborator_permission.return_value = "read"
+        mock_get_client.return_value = mock_gh
+
+        result = cli_runner.invoke(
+            ci_group,
+            [
+                "set-milestone",
+                "--pr-number",
+                "67301",
+                "--pr-title",
+                "fix: typo",
+                "--pr-labels",
+                json.dumps(["backport-to-v3-2-test", "kind:documentation"]),
+                "--base-branch",
+                "main",
+                "--merged-by",
+                "shahar1",
+                "--github-token",
+                "fake-token",
+                "--github-repository",
+                "apache/airflow",
+            ],
+        )
+
+        mock_issue.edit.assert_not_called()
+        plain = _plain_output(result.output)
+        assert "Ignoring removal signal" in plain
+        assert "@some-bot" in plain
+        assert "No milestone to set after re-evaluation" in plain
         assert result.exit_code == 0
 
     @patch("airflow_breeze.commands.ci_commands._get_github_client")

--- a/dev/breeze/tests/test_set_milestone.py
+++ b/dev/breeze/tests/test_set_milestone.py
@@ -67,6 +67,22 @@ def _unlabel_event(label_name: str, actor_login: str, when: datetime) -> MagicMo
     return event
 
 
+def _issue_event(
+    event_name: str,
+    actor_login: str,
+    when: str,
+    label_name: str | None = None,
+) -> MagicMock:
+    """Build a mock shaped like a PyGithub ``IssueEvent`` for any event kind."""
+    event = MagicMock()
+    event.event = event_name
+    event.label = _label(label_name) if label_name else None
+    event.actor = MagicMock()
+    event.actor.login = actor_login
+    event.created_at = when
+    return event
+
+
 class TestParseVersionFromBranch:
     """Test cases for _parse_version_from_branch."""
 
@@ -897,4 +913,78 @@ However, **no open milestone was found** matching: {expected_search_criteria}
         mock_issue.create_comment.assert_not_called()
         assert "Skipping milestone tagging" in result.output
         assert "area:CI" in result.output
+        assert result.exit_code == 0
+
+    @patch("airflow_breeze.commands.ci_commands._get_github_client")
+    def test_pr_67301_real_events_should_skip(self, mock_get_client, cli_runner, mock_github_setup):
+        """End-to-end regression test against the real ``issue.get_events()``
+        stream from PR #67301 (the incident that motivated this change).
+
+        The events below are the actual events captured from
+        ``GET /repos/apache/airflow/issues/67301/events``, trimmed to those
+        that existed BEFORE the offending ``github-actions[bot] milestoned``
+        event — that ``milestoned`` event is exactly what the new
+        live-labels + events pipeline must prevent, so it is intentionally
+        omitted from this fixture. With the fix in place, ``set-milestone``
+        must notice shahar1's ``unlabeled backport-to-v3-2-test`` 92 seconds
+        earlier and skip.
+        """
+        from airflow_breeze.commands.ci_commands import ci_group
+
+        pr_67301_events = [
+            _issue_event("labeled", "boring-cyborg[bot]", "2026-05-21T19:42:28Z", "area:providers"),
+            _issue_event("labeled", "boring-cyborg[bot]", "2026-05-21T19:42:28Z", "kind:documentation"),
+            _issue_event("labeled", "boring-cyborg[bot]", "2026-05-21T19:42:28Z", "provider:standard"),
+            _issue_event("merged", "shahar1", "2026-05-21T20:31:18Z"),
+            _issue_event("closed", "shahar1", "2026-05-21T20:31:18Z"),
+            _issue_event("labeled", "shahar1", "2026-05-21T20:31:28Z", "backport-to-v3-2-test"),
+            _issue_event("unlabeled", "shahar1", "2026-05-21T20:32:17Z", "backport-to-v3-2-test"),
+        ]
+        # Live ``issue.labels`` at the moment set-milestone would have run:
+        # backport-to-v3-2-test had just been removed, leaving these three.
+        live_labels = ["area:providers", "kind:documentation", "provider:standard"]
+
+        mock_gh, mock_repo, mock_issue = mock_github_setup
+        mock_issue.milestone = None
+        mock_issue.labels = [_label(name) for name in live_labels]
+        mock_issue.get_events.return_value = pr_67301_events
+        mock_get_client.return_value = mock_gh
+
+        result = cli_runner.invoke(
+            ci_group,
+            [
+                "set-milestone",
+                "--pr-number",
+                "67301",
+                "--pr-title",
+                'fix: typo "@tash.bash" -> "@task.bash',
+                "--pr-labels",
+                # The workflow's stale snapshot from get-pr-info still saw the
+                # backport label; the new pipeline ignores this in favour of
+                # live state.
+                json.dumps(
+                    [
+                        "area:providers",
+                        "kind:documentation",
+                        "provider:standard",
+                        "backport-to-v3-2-test",
+                    ]
+                ),
+                "--base-branch",
+                "main",
+                "--merged-by",
+                "shahar1",
+                "--github-token",
+                "fake-token",
+                "--github-repository",
+                "apache/airflow",
+            ],
+        )
+
+        mock_issue.edit.assert_not_called()
+        mock_issue.create_comment.assert_not_called()
+        plain = _plain_output(result.output)
+        assert "Skipping milestone tagging" in plain
+        assert "backport labels were removed during the PR lifecycle" in plain
+        assert "backport-to-v3-2-test" in plain
         assert result.exit_code == 0


### PR DESCRIPTION
- related: #67337 (review comment https://github.com/apache/airflow/pull/67337#discussion_r3292879342)

## Why

Follow-up of https://github.com/apache/airflow/pull/67337#discussion_r3292879342.
We should make `milestone-tag-assistant` more accurate by interpreting the GitHub events of corresponding PR.

## How

- Drop the workflow-snapshot vs current-labels diff. The `--pr-labels` snapshot is parsed only for a diagnostic log line; the decision now uses live `issue.labels` and `issue.get_events()` exclusively.
- Consolidate the skip decision into `_should_skip_milestone_tagging(labels, events=...)`. Pipeline, documented in a section-level comment block above the milestone helpers and in the function's own docstring:
  1. **Milestone-already-set guard** (in `set_milestone`) — leave existing milestones alone.
  2. **GitHub events evaluation** — if any `unlabeled` event removed a `backport-to-*` label AND no `backport-to-*` label remains on the PR, skip. No permission check on the actor: GitHub repo settings already restrict label changes to committers/triagers, so the change is implicitly authorised.
  3. **Static skip labels** — skip on `MILESTONE_SKIP_LABELS`.
- Events check runs before the static-label check so an explicit unbackport overrides every other condition, including the merge-to-version-branch heuristic.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
