### PR TITLE
Lazy load Elasticsearch hook client import

### DIFF
--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -24,14 +24,13 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 from urllib import parse
 
-from elasticsearch import Elasticsearch
-
 from airflow.providers.common.compat.sdk import BaseHook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 from airflow.providers.elasticsearch._compat import apply_compat_with
 
 if TYPE_CHECKING:
     from elastic_transport import ObjectApiResponse
+    from elasticsearch import Elasticsearch
 
     from airflow.models.connection import Connection as AirflowConnection
 
@@ -171,6 +170,8 @@ class ESConnection:
         kwargs.pop("field_multi_value_leniency", None)
         netloc = f"{host}:{port}"
         self.url = parse.urlunparse((scheme, netloc, "/", None, None, None))
+        from elasticsearch import Elasticsearch
+
         if user and password:
             self.es = apply_compat_with(Elasticsearch(self.url, basic_auth=(user, password), **kwargs))
         else:
@@ -284,6 +285,8 @@ class ElasticsearchPythonHook(BaseHook):
 
     def _get_elastic_connection(self):
         """Return the Elasticsearch client."""
+        from elasticsearch import Elasticsearch
+
         client = apply_compat_with(Elasticsearch(self.hosts, **self.es_conn_args))
 
         return client

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -170,6 +170,7 @@ class ESConnection:
         kwargs.pop("field_multi_value_leniency", None)
         netloc = f"{host}:{port}"
         self.url = parse.urlunparse((scheme, netloc, "/", None, None, None))
+
         from elasticsearch import Elasticsearch
 
         if user and password:

--- a/providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py
@@ -303,7 +303,7 @@ class TestElasticsearchSQLHook:
         assert call_kw["sql"] == sql
         assert call_kw["sql_parameters"] == parameters
 
-    @mock.patch("airflow.providers.elasticsearch.hooks.elasticsearch.Elasticsearch")
+    @mock.patch("elasticsearch.Elasticsearch")
     def test_execute_sql_query(self, mock_es):
         mock_es_sql_client = MagicMock()
         mock_es_sql_client.query.return_value = RESPONSE_WITHOUT_CURSOR


### PR DESCRIPTION
## Why

This is a focused provider-specific PR for the broader provider lazy-loading effort discussed in the issue. The Elasticsearch provider currently imports the Elasticsearch Python client at module import time in `hooks/elasticsearch.py`. That means importing the provider hook also imports the external `elasticsearch` client package immediately, even when a DAG only needs to parse the hook module and does not actually create an Elasticsearch client. This PR makes that import lazy so the Elasticsearch client package is imported only when a connection/client is actually created.

## What changed

Removed the module-level `from elasticsearch import Elasticsearch` import from the Elasticsearch hook module, added a type-only import under `TYPE_CHECKING`, and moved the runtime import into the places where the client is actually created: `ESConnection.__init__` and `ElasticsearchPythonHook._get_elastic_connection`. Also updated the affected unit test mock to patch `elasticsearch.Elasticsearch` directly now that the provider module no longer exposes `Elasticsearch` as a module-level import.

## Scope

This PR only targets the Elasticsearch provider to keep the change small and reviewable. If this direction looks good, similar provider-specific lazy-loading PRs can be opened separately for other providers.

## Tests

Ran `uv run pytest providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py -q` and got `26 passed, 1 warning`.

Ran `uv run pytest providers/elasticsearch/tests/unit/elasticsearch -q` and got `131 passed, 1 warning`.

Ran `uv run prek run --files providers/elasticsearch/src/airflow/providers/elasticsearch/hooks/elasticsearch.py providers/elasticsearch/tests/unit/elasticsearch/hooks/test_elasticsearch.py` and all checks passed.