### PR TITLE
Mask sensitive values in dotted config keys (Spark, Hadoop) in render templates #67459

### DIFF
--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -681,3 +681,25 @@ def test_serialize_template_field_masks_nested_sensitive_keys_on_truncation(monk
     assert "Truncated. You can change this behaviour" in result
     assert nested_value not in result
     assert "***" in result
+
+
+@pytest.mark.enable_redact
+def test_serialize_template_field_masks_dotted_sensitive_keys_on_truncation(monkeypatch):
+    """Dotted/dashed config keys must match underscore-style sensitive fields after normalization."""
+    monkeypatch.setenv("AIRFLOW__CORE__MAX_TEMPLATED_FIELD_LENGTH", "1500")
+
+    access_key_value = "AKIA-REGRESSION-FIXTURE-ACCESS-KEY"
+    token_value = "REGRESSION-FIXTURE-JWT-TOKEN-VALUE"
+    payload = {
+        "spark.hadoop.fs.s3a.bucket.spark.access.key": access_key_value,
+        "spark.sql.catalog.kometa.token": token_value,
+        "zpadding": "z" * 2000,
+    }
+
+    result = serialize_template_field(payload, "conf")
+
+    assert isinstance(result, str)
+    assert "Truncated. You can change this behaviour" in result
+    assert access_key_value not in result
+    assert token_value not in result
+    assert "***" in result

--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -569,7 +569,9 @@ class SecretsMasker(logging.Filter):
         """
         if isinstance(name, str) and self.hide_sensitive_var_conn_fields:
             name = name.strip().lower()
-            return any(s in name for s in self.sensitive_variables_fields)
+            # Normalize separators so dotted/dashed keys (Spark, Hadoop) match underscore-style fields.
+            normalized = re.sub(r"\W+", "_", name)
+            return any(s in name or s in normalized for s in self.sensitive_variables_fields)
         return False
 
     def add_mask(self, secret: JsonValue, name: str | None = None):

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -834,6 +834,15 @@ class TestShouldHideValueForKey:
             ("custom_auth_header", True),
             ("service_key", True),
             ("my_service_key", True),
+            # Dotted/dashed config keys (Spark, Hadoop, K8s annotations, etc.) must
+            # match the underscore-style sensitive fields after normalization.
+            ("spark.hadoop.fs.s3a.bucket.spark.access.key", True),
+            ("spark.hadoop.fs.s3a.bucket.spark.secret.key", True),
+            ("spark.sql.catalog.kometa.token", True),
+            ("my-access-key", True),
+            ("auth.example.com/token", True),
+            ("spark.executor.memory", False),
+            ("spark.driver.cores", False),
         ],
     )
     def test_hiding_defaults(self, key, expected_result):


### PR DESCRIPTION
The secrets masker matches sensitive field names by substring, but its default fields use underscores (`access_key`, `api_key`) while Spark/Hadoop configs use dots (`spark.access.key`). Normalize separators so dotted keys also match.

closes: #67459

