### PR TITLE
Lazy load neo4j driver imports

### DIFF
--- a/providers/neo4j/src/airflow/providers/neo4j/hooks/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/hooks/neo4j.py
@@ -22,14 +22,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
-from neo4j import Driver, GraphDatabase
-
 try:
     from airflow.sdk.bases.hook import BaseHook
 except ImportError:
     from airflow.hooks.base import BaseHook  # type: ignore[attr-defined,no-redef]
 
 if TYPE_CHECKING:
+    from neo4j import Driver
+
     from airflow.models import Connection
 
 # Default Neo4j port
@@ -77,6 +77,8 @@ class Neo4jHook(BaseHook):
         :param uri: URI string for connection.
         :return: Neo4j Driver instance.
         """
+        from neo4j import GraphDatabase
+
         parsed_uri = urlsplit(uri)
         kwargs: dict[str, Any] = {}
         if parsed_uri.scheme in ["bolt", "neo4j"]:

--- a/providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py
@@ -54,7 +54,7 @@ class TestNeo4jHookConn:
 
             assert uri == expected_uri
 
-    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
+    @mock.patch("neo4j.GraphDatabase")
     def test_run_with_schema(self, mock_graph_database):
         connection = Connection(
             conn_type="neo4j", login="login", password="password", host="host", schema="schema"
@@ -79,7 +79,7 @@ class TestNeo4jHookConn:
             session = mock_graph_database.driver.return_value.session.return_value.__enter__.return_value
             assert op_result == session.run.return_value.data.return_value
 
-    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
+    @mock.patch("neo4j.GraphDatabase")
     def test_run_with_schema_and_params(self, mock_graph_database):
         connection = Connection(
             conn_type="neo4j", login="login", password="password", host="host", schema="schema"
@@ -105,7 +105,7 @@ class TestNeo4jHookConn:
             session = mock_graph_database.driver.return_value.session.return_value.__enter__.return_value
             assert op_result == session.run.return_value.data.return_value
 
-    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
+    @mock.patch("neo4j.GraphDatabase")
     def test_run_without_schema(self, mock_graph_database):
         connection = Connection(
             conn_type="neo4j", login="login", password="password", host="host", schema=None
@@ -130,7 +130,7 @@ class TestNeo4jHookConn:
             session = mock_graph_database.driver.return_value.session.return_value.__enter__.return_value
             assert op_result == session.run.return_value.data.return_value
 
-    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase")
+    @mock.patch("neo4j.GraphDatabase")
     def test_run_without_schema_and_params(self, mock_graph_database):
         connection = Connection(
             conn_type="neo4j", login="login", password="password", host="host", schema=None
@@ -171,7 +171,7 @@ class TestNeo4jHookConn:
             ({"certs_trusted_ca": True, "neo4j_scheme": True, "encrypted": False}, False, None),
         ],
     )
-    @mock.patch("airflow.providers.neo4j.hooks.neo4j.GraphDatabase.driver")
+    @mock.patch("neo4j.GraphDatabase.driver")
     def test_encrypted_provided(
         self, mock_graph_database, conn_extra, should_provide_encrypted, expected_encrypted
     ):


### PR DESCRIPTION
Lazy-load `neo4j` SDK imports to reduce memory footprint and import time of `airflow.providers.neo4j.hooks.neo4j`, following the same pattern as #62365 (snowflake) and #67519 (elasticsearch).

### Hook changes
- Removed the top-level `from neo4j import Driver, GraphDatabase`.
- `Driver` is only used as a type annotation, so it now lives under `if TYPE_CHECKING:`.
- `GraphDatabase.driver(...)` is only invoked inside `_create_driver`, so the import is moved into that method body.

### Test changes
- Updated five `mock.patch` targets in `test_neo4j.py` from `airflow.providers.neo4j.hooks.neo4j.GraphDatabase` to `neo4j.GraphDatabase` (and `...GraphDatabase.driver` for the parametrized test), since `GraphDatabase` is no longer a module-level symbol in the hook module.

### Validation
Local smoke check (Windows host; full unit suite requires the Linux-only `fcntl` import that Airflow's test conftest pulls in transitively):

- Importing `Neo4jHook` no longer loads the `neo4j` package into `sys.modules`.
- `Driver` and `GraphDatabase` are no longer attributes of the hook module.
- `neo4j.GraphDatabase` and `neo4j.GraphDatabase.driver` resolve as `mock.patch` targets.

The unit tests in `providers/neo4j/tests/unit/neo4j/hooks/test_neo4j.py` should now pass against the moved import; CI will be the source of truth here.

* related: #67515

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude (Opus) was used for the mechanical edits and the announcement comment on #67515. Reviewed by hand against the pattern in #62365 and #67519.