### PR TITLE
[v3-2-test] Fix Callback.handle_event crash on OTel metrics with dict tag values (#67527)

### DIFF
--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
@@ -160,6 +161,19 @@ class Callback(Base, BaseWorkload):
         if "kwargs" in tags:
             # Remove the context (if exists) to keep the tags simple
             tags["kwargs"] = {k: v for k, v in tags["kwargs"].items() if k != "context"}
+
+        # Metric backends (statsd, OpenTelemetry) require tag values to be primitives.
+        # OTel's aggregation key is built via ``frozenset(attributes.items())``, which
+        # raises ``TypeError: unhashable type: 'dict'`` if a value is a dict/list. The
+        # callback's ``result`` (passed in from a user callback) and ``kwargs`` are both
+        # frequently dicts, so coerce any non-primitive tag value to a JSON string before
+        # returning. Using ``default=str`` so values like ``datetime`` fall back cleanly.
+        tags = {
+            k: v
+            if isinstance(v, (str, int, float, bool)) or v is None
+            else json.dumps(v, default=str, sort_keys=True)
+            for k, v in tags.items()
+        }
 
         prefix = self.data.get("prefix", "")
         name = f"{prefix}.callback_{status}" if prefix else f"callback_{status}"

--- a/airflow-core/tests/unit/models/test_callback.py
+++ b/airflow-core/tests/unit/models/test_callback.py
@@ -112,9 +112,35 @@ class TestCallback:
         assert metric_info["tags"] == {
             "result": "0",
             "path": TEST_ASYNC_CALLBACK.path,
-            "kwargs": {"email": "test@example.com"},
+            "kwargs": '{"email": "test@example.com"}',
             "dag_id": TEST_DAG_ID,
         }
+
+    def test_get_metric_info_dict_values_are_stringified(self):
+        """
+        Regression for ``TypeError: unhashable type: 'dict'`` raised by OpenTelemetry's
+        ``_view_instrument_match`` when callback metric tags contain dict/list values.
+
+        OTel builds its aggregation key as ``frozenset(attributes.items())``; any tag
+        value that isn't hashable (dict, list, set) crashes the triggerer when a
+        callback completes — e.g., deadline async callbacks whose ``result`` is a dict.
+        """
+        callback = TriggererCallback(TEST_ASYNC_CALLBACK, prefix="deadline_alerts", dag_id=TEST_DAG_ID)
+        callback.data["kwargs"] = {"context": {"dag_id": TEST_DAG_ID}, "nested": {"a": 1}}
+
+        # ``result`` is a dict — exactly the case that surfaced in the deadline DAG.
+        metric_info = callback.get_metric_info(CallbackState.SUCCESS, {"output": [1, 2], "code": 0})
+
+        # Every tag value must be a primitive (str/int/float/bool/None) so OTel can hash it.
+        for k, v in metric_info["tags"].items():
+            assert isinstance(v, (str, int, float, bool)) or v is None, (
+                f"Tag {k!r}={v!r} is type {type(v).__name__}; must be primitive for OTel."
+            )
+        # ``frozenset(attributes.items())`` must not raise.
+        frozenset(metric_info["tags"].items())
+        # Stringified tag values must be sorted so equivalent kwargs in different
+        # insertion order collapse to one metric series (no needless cardinality split).
+        assert metric_info["tags"]["result"] == '{"code": 0, "output": [1, 2]}'
 
 
 class TestTriggererCallback:


### PR DESCRIPTION
Manual backport of #67527 to \`v3-2-test\` for 3.2.3.

The auto-backport bot can't cherry-pick this one — \`main\` and \`v3-2-test\` diverged in the imports block of \`airflow-core/src/airflow/models/callback.py\` (\`main\` has \`from dataclasses import dataclass\`, \`v3-2-test\` still has \`import inspect; from collections.abc import Callable\`), so the cherry-pick conflicts. Conflict resolved by keeping the v3-2-test imports and adding the new \`import json\` the fix needs. The \`Stats.incr\` call site (v3-2-test) vs \`stats.incr\` (main) needed no change — \`handle_event\` carries the v3-2-test form unmodified.

## Why this needs backporting

\`Callback.handle_event\` crashes the triggerer when OpenTelemetry metrics are enabled and a deadline async callback completes with a dict-typed \`result\` (or dict-typed \`kwargs\`). OTel builds its aggregation key as \`frozenset(attributes.items())\`, which raises \`TypeError: unhashable type: 'dict'\`. Statsd accepts non-primitive tag values silently, so OSS deployments on default metrics don't see it — Astronomer Astro and any deployment with \`[metrics] otel_*\` configured hit it consistently. Reported by the Astro Runtime team while exercising 3.2.2rc2-based images.

## What's in the cherry-pick

- \`Callback.get_metric_info\` coerces non-primitive tag values (dict/list/set) to JSON strings before returning. Primitives (\`str | int | float | bool | None\`) pass through unchanged. \`json.dumps(..., default=str, sort_keys=True)\` so \`datetime\` values fall back cleanly and equivalent dicts in different insertion order don't split metric cardinality.
- New regression test \`test_get_metric_info_dict_values_are_stringified\` asserts every tag value is a primitive and that \`frozenset(tags.items())\` does not raise.
- Updates the existing \`test_get_metric_info\` to expect the JSON-stringified \`kwargs\` shape.

## Review feedback already addressed in #67527

- \`sort_keys=True\` per @uranusjr's suggestion
- Cross-ref comment removed from the existing test per @amoghrajesh's suggestion