### PR TITLE
Decorate custom state refs with an envelope for UI clarity

### DIFF
--- a/shared/state/src/airflow_shared/state/__init__.py
+++ b/shared/state/src/airflow_shared/state/__init__.py
@@ -216,6 +216,11 @@ class BaseStateBackend(ABC):
         stored in the DB — typically a reference path (e.g. an S3 key) rather than the
         actual value. Default: return ``value`` unchanged.
 
+        **Important:** return only the raw reference string. The worker framework automatically
+        wraps it in ``{"__airflow_state_ref__": "<ref>"}`` before writing to the DB, and strips
+        that wrapper before passing ``stored`` to ``deserialize_task_state_from_ref()``. Do not
+        wrap the reference yourself.
+
         The returned reference must be deterministic — given the same ``ti_id`` and ``key`` it
         must always return the same string. Do not use timestamps or random UUIDs as part of
         the reference, otherwise ``delete()``/``clear()`` cannot reconstruct it and the external
@@ -240,6 +245,11 @@ class BaseStateBackend(ABC):
         Called by ``AssetStateAccessor.set()`` on the worker. The return value is what gets
         stored in the DB — typically a reference path rather than the actual value.
         Default: return ``value`` unchanged.
+
+        **Important:** return only the raw reference string. The worker framework automatically
+        wraps it in ``{"__airflow_state_ref__": "<ref>"}`` before writing to the DB, and strips
+        that wrapper before passing ``stored`` to ``deserialize_asset_state_from_ref()``. Do not
+        wrap the reference yourself.
 
         ``asset_ref`` is either the asset name or URI, depending on how the accessor was
         constructed. It may be a URI string if the task inlet was declared as ``AssetUriRef``.

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -121,6 +121,17 @@ log = structlog.get_logger(logger_name="task")
 #: Example: ``context["task_state"].set("job_id", job_id, retention=NEVER_EXPIRE)``
 NEVER_EXPIRE: timedelta = timedelta.max
 
+_EXTERNAL_STATE_REF_KEY = "__airflow_state_ref__"
+
+
+def _wrap_external_ref(ref: str) -> dict[str, str]:
+    return {_EXTERNAL_STATE_REF_KEY: ref}
+
+
+def _unwrap_external_ref(stored: dict) -> str | None:
+    return stored.get(_EXTERNAL_STATE_REF_KEY)
+
+
 T = TypeVar("T")
 
 
@@ -513,12 +524,16 @@ class TaskStateAccessor:
         if isinstance(resp, TaskStateResult):
             stored = resp.value
             backend = _get_worker_state_backend()
-            if backend is not None and isinstance(stored, dict) and stored.get("__type") == "ExternalState":
+            if backend is not None and isinstance(stored, dict) and (ref := _unwrap_external_ref(stored)):
                 # unwrap the marker to get the ref, and retrieve the actual value from the backend using the ref
-                ref = stored["__var"]
-                if TYPE_CHECKING:
-                    assert isinstance(ref, str)
                 return backend.deserialize_task_state_from_ref(ref)
+            if backend is not None:
+                log.warning(
+                    "Task state key %r was not written through the configured state backend — returning raw "
+                    "stored value. To use the backend, ensure the task that wrote this key had the same "
+                    "backend configured.",
+                    key,
+                )
             return stored
         return None
 
@@ -547,12 +562,12 @@ class TaskStateAccessor:
 
         # if custom backend is configured, store the value on the custom backend, and return the reference
         # to the stored value to store in the DB
-        stored: JsonValue = value
         backend = _get_worker_state_backend()
+        stored: JsonValue = value
         if backend is not None:
-            # decorate the value with a marker to indicate that it's stored externally, and include the ref to the external storage
-            ref = backend.serialize_task_state_to_ref(value=value, key=key, ti_id=str(self._ti_id))
-            stored = {"__type": "ExternalState", "__var": ref}
+            ref: str = backend.serialize_task_state_to_ref(value=value, key=key, ti_id=str(self._ti_id))
+            # wrap the value with a marker to indicate that it's stored externally, and include the ref to the external storage
+            stored = _wrap_external_ref(ref)  # type: ignore[assignment]
 
         SUPERVISOR_COMMS.send(SetTaskState(ti_id=self._ti_id, key=key, value=stored, expires_at=expires_at))
 
@@ -647,12 +662,17 @@ class AssetStateAccessor:
         if isinstance(resp, AssetStateResult):
             stored = resp.value
             backend = _get_worker_state_backend()
-            if backend is not None and isinstance(stored, dict) and stored.get("__type") == "ExternalState":
+            if backend is not None and isinstance(stored, dict) and (ref := _unwrap_external_ref(stored)):
                 # unwrap the marker to get the ref, and retrieve the actual value from the backend using the ref
-                ref = stored["__var"]
-                if TYPE_CHECKING:
-                    assert isinstance(ref, str)
                 return backend.deserialize_asset_state_from_ref(ref)
+            if backend is not None:
+                log.warning(
+                    "Asset state key %r for asset %r was not written through the configured state backend — "
+                    "returning raw stored value. To use the backend, ensure the task that wrote this key had "
+                    "the same backend configured.",
+                    key,
+                    self._name or self._uri,
+                )
             return stored
         return None
 
@@ -661,13 +681,14 @@ class AssetStateAccessor:
         from airflow.sdk.execution_time.comms import SetAssetStateByName, SetAssetStateByUri, ToSupervisor
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
+        # if custom backend is configured, store the value on the custom backend, and return the reference
+        # to the stored value to store in the DB
         backend = _get_worker_state_backend()
         asset_ref = self._name or self._uri or ""
         stored: JsonValue = value
         if backend is not None:
-            # decorate the value with a marker to indicate that it's stored externally, and include the ref to the external storage
             ref = backend.serialize_asset_state_to_ref(value=value, key=key, asset_ref=asset_ref)
-            stored = {"__type": "ExternalState", "__var": ref}
+            stored = _wrap_external_ref(ref)  # type: ignore[assignment]
 
         msg: ToSupervisor
         if self._name:

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -512,14 +512,13 @@ class TaskStateAccessor:
             raise AirflowRuntimeError(resp)
         if isinstance(resp, TaskStateResult):
             stored = resp.value
-            # if custom backend is configured, the stored value in DB is a reference, fetch the actual value from
-            # custom backend using the reference
             backend = _get_worker_state_backend()
-            if backend is not None:
-                # serialize_task_state_to_ref always returns str by contract; stored contains the ref.
+            if backend is not None and isinstance(stored, dict) and stored.get("__type") == "ExternalState":
+                # unwrap the marker to get the ref, and retrieve the actual value from the backend using the ref
+                ref = stored["__var"]
                 if TYPE_CHECKING:
-                    assert isinstance(stored, str)
-                return backend.deserialize_task_state_from_ref(stored)
+                    assert isinstance(ref, str)
+                return backend.deserialize_task_state_from_ref(ref)
             return stored
         return None
 
@@ -548,12 +547,12 @@ class TaskStateAccessor:
 
         # if custom backend is configured, store the value on the custom backend, and return the reference
         # to the stored value to store in the DB
+        stored: JsonValue = value
         backend = _get_worker_state_backend()
-        stored = (
-            backend.serialize_task_state_to_ref(value=value, key=key, ti_id=str(self._ti_id))
-            if backend
-            else value
-        )
+        if backend is not None:
+            # decorate the value with a marker to indicate that it's stored externally, and include the ref to the external storage
+            ref = backend.serialize_task_state_to_ref(value=value, key=key, ti_id=str(self._ti_id))
+            stored = {"__type": "ExternalState", "__var": ref}
 
         SUPERVISOR_COMMS.send(SetTaskState(ti_id=self._ti_id, key=key, value=stored, expires_at=expires_at))
 
@@ -648,11 +647,12 @@ class AssetStateAccessor:
         if isinstance(resp, AssetStateResult):
             stored = resp.value
             backend = _get_worker_state_backend()
-            if backend is not None:
-                # serialize_asset_state_to_ref always returns str by contract; stored contains the ref.
+            if backend is not None and isinstance(stored, dict) and stored.get("__type") == "ExternalState":
+                # unwrap the marker to get the ref, and retrieve the actual value from the backend using the ref
+                ref = stored["__var"]
                 if TYPE_CHECKING:
-                    assert isinstance(stored, str)
-                return backend.deserialize_asset_state_from_ref(stored)
+                    assert isinstance(ref, str)
+                return backend.deserialize_asset_state_from_ref(ref)
             return stored
         return None
 
@@ -661,15 +661,13 @@ class AssetStateAccessor:
         from airflow.sdk.execution_time.comms import SetAssetStateByName, SetAssetStateByUri, ToSupervisor
         from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
-        # if custom backend is configured, store the value on the custom backend, and return the reference
-        # to the stored value to store in the DB
         backend = _get_worker_state_backend()
         asset_ref = self._name or self._uri or ""
-        stored = (
-            backend.serialize_asset_state_to_ref(value=value, key=key, asset_ref=asset_ref)
-            if backend
-            else value
-        )
+        stored: JsonValue = value
+        if backend is not None:
+            # decorate the value with a marker to indicate that it's stored externally, and include the ref to the external storage
+            ref = backend.serialize_asset_state_to_ref(value=value, key=key, asset_ref=asset_ref)
+            stored = {"__type": "ExternalState", "__var": ref}
 
         msg: ToSupervisor
         if self._name:

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -124,7 +124,7 @@ NEVER_EXPIRE: timedelta = timedelta.max
 _EXTERNAL_STATE_REF_KEY = "__airflow_state_ref__"
 
 
-def _wrap_external_ref(ref: str) -> dict[str, str]:
+def _wrap_external_ref(ref: str) -> dict[str, JsonValue]:
     return {_EXTERNAL_STATE_REF_KEY: ref}
 
 
@@ -567,7 +567,7 @@ class TaskStateAccessor:
         if backend is not None:
             ref: str = backend.serialize_task_state_to_ref(value=value, key=key, ti_id=str(self._ti_id))
             # wrap the value with a marker to indicate that it's stored externally, and include the ref to the external storage
-            stored = _wrap_external_ref(ref)  # type: ignore[assignment]
+            stored = _wrap_external_ref(ref)
 
         SUPERVISOR_COMMS.send(SetTaskState(ti_id=self._ti_id, key=key, value=stored, expires_at=expires_at))
 
@@ -688,7 +688,7 @@ class AssetStateAccessor:
         stored: JsonValue = value
         if backend is not None:
             ref = backend.serialize_asset_state_to_ref(value=value, key=key, asset_ref=asset_ref)
-            stored = _wrap_external_ref(ref)  # type: ignore[assignment]
+            stored = _wrap_external_ref(ref)
 
         msg: ToSupervisor
         if self._name:

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -1225,6 +1225,43 @@ class TestTaskStateAccessor:
 
         mock_supervisor_comms.send.assert_not_called()
 
+    def test_set_with_custom_backend_decorates_value_with_marker(self, mock_supervisor_comms):
+        """Custom backend ref is wrapped in ExternalState envelope before going to DB."""
+        mock_supervisor_comms.send.return_value = OKResponse(ok=True)
+
+        backend = MagicMock(spec=BaseStateBackend)
+        backend.serialize_task_state_to_ref.return_value = "s3://bucket/ti_123/job_id"
+
+        with (
+            patch("airflow.sdk.execution_time.context._get_worker_state_backend", return_value=backend),
+            conf_vars({("state_store", "default_retention_days"): "0"}),
+        ):
+            TaskStateAccessor(ti_id=self.TI_ID, scope=self.SCOPE).set("job_id", "spark_001")
+
+        mock_supervisor_comms.send.assert_called_once_with(
+            SetTaskState(
+                ti_id=self.TI_ID,
+                key="job_id",
+                value={"__type": "ExternalState", "__var": "s3://bucket/ti_123/job_id"},
+                expires_at=None,
+            )
+        )
+
+    def test_get_with_custom_backend_removes_decoration_marker(self, mock_supervisor_comms):
+        """ExternalState envelope is detected and the ref is passed to deserialize."""
+        mock_supervisor_comms.send.return_value = TaskStateResult(
+            value={"__type": "ExternalState", "__var": "s3://bucket/ti_123/job_id"}
+        )
+
+        backend = MagicMock(spec=BaseStateBackend)
+        backend.deserialize_task_state_from_ref.return_value = {"rows": 123}
+
+        with patch("airflow.sdk.execution_time.context._get_worker_state_backend", return_value=backend):
+            result = TaskStateAccessor(ti_id=self.TI_ID, scope=self.SCOPE).get("job_id")
+
+        assert result == {"rows": 123}
+        backend.deserialize_task_state_from_ref.assert_called_once_with("s3://bucket/ti_123/job_id")
+
 
 class TestAssetStateAccessor:
     ASSET_NAME = "debug_watcher_asset"
@@ -1316,6 +1353,41 @@ class TestAssetStateAccessor:
         AssetStateAccessor(uri=self.ASSET_URI).clear()
 
         mock_supervisor_comms.send.assert_called_once_with(ClearAssetStateByUri(uri=self.ASSET_URI))
+
+    def test_set_with_custom_backend_decorates_value_with_marker(self, mock_supervisor_comms):
+        """Custom backend ref is wrapped in ExternalState envelope before going to DB."""
+        mock_supervisor_comms.send.return_value = OKResponse(ok=True)
+
+        backend = MagicMock(spec=BaseStateBackend)
+        backend.serialize_asset_state_to_ref.return_value = "s3://bucket/assets/orders/watermark"
+
+        with patch("airflow.sdk.execution_time.context._get_worker_state_backend", return_value=backend):
+            AssetStateAccessor(name=self.ASSET_NAME).set("watermark", "2026-05-01")
+
+        mock_supervisor_comms.send.assert_called_once_with(
+            SetAssetStateByName(
+                name=self.ASSET_NAME,
+                key="watermark",
+                value={"__type": "ExternalState", "__var": "s3://bucket/assets/orders/watermark"},
+            )
+        )
+
+    def test_get_with_custom_backend_removes_decoration_marker(self, mock_supervisor_comms):
+        """ExternalState envelope is detected and the ref is passed to deserialize."""
+        mock_supervisor_comms.send.return_value = AssetStateResult(
+            value={"__type": "ExternalState", "__var": "s3://bucket/assets/orders/watermark"}
+        )
+
+        backend = MagicMock(spec=BaseStateBackend)
+        backend.deserialize_asset_state_from_ref.return_value = "2026-05-01"
+
+        with patch("airflow.sdk.execution_time.context._get_worker_state_backend", return_value=backend):
+            result = AssetStateAccessor(name=self.ASSET_NAME).get("watermark")
+
+        assert result == "2026-05-01"
+        backend.deserialize_asset_state_from_ref.assert_called_once_with(
+            "s3://bucket/assets/orders/watermark"
+        )
 
 
 class TestAssetStateAccessors:

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -96,6 +96,7 @@ from airflow.sdk.execution_time.context import (
     _convert_variable_result_to_variable,
     _get_connection,
     _process_connection_result_conn,
+    _wrap_external_ref,
     context_to_airflow_vars,
     set_current_context,
 )
@@ -1226,7 +1227,7 @@ class TestTaskStateAccessor:
         mock_supervisor_comms.send.assert_not_called()
 
     def test_set_with_custom_backend_decorates_value_with_marker(self, mock_supervisor_comms):
-        """Custom backend ref is wrapped in ExternalState envelope before going to DB."""
+        """Custom backend ref is wrapped in external state marker before going to DB."""
         mock_supervisor_comms.send.return_value = OKResponse(ok=True)
 
         backend = MagicMock(spec=BaseStateBackend)
@@ -1242,15 +1243,15 @@ class TestTaskStateAccessor:
             SetTaskState(
                 ti_id=self.TI_ID,
                 key="job_id",
-                value={"__type": "ExternalState", "__var": "s3://bucket/ti_123/job_id"},
+                value=_wrap_external_ref("s3://bucket/ti_123/job_id"),
                 expires_at=None,
             )
         )
 
     def test_get_with_custom_backend_removes_decoration_marker(self, mock_supervisor_comms):
-        """ExternalState envelope is detected and the ref is passed to deserialize."""
+        """External state marker is detected and the ref is passed to deserialize."""
         mock_supervisor_comms.send.return_value = TaskStateResult(
-            value={"__type": "ExternalState", "__var": "s3://bucket/ti_123/job_id"}
+            value=_wrap_external_ref("s3://bucket/ti_123/job_id")
         )
 
         backend = MagicMock(spec=BaseStateBackend)
@@ -1355,7 +1356,7 @@ class TestAssetStateAccessor:
         mock_supervisor_comms.send.assert_called_once_with(ClearAssetStateByUri(uri=self.ASSET_URI))
 
     def test_set_with_custom_backend_decorates_value_with_marker(self, mock_supervisor_comms):
-        """Custom backend ref is wrapped in ExternalState envelope before going to DB."""
+        """Custom backend ref is wrapped in external state marker before going to DB."""
         mock_supervisor_comms.send.return_value = OKResponse(ok=True)
 
         backend = MagicMock(spec=BaseStateBackend)
@@ -1368,14 +1369,14 @@ class TestAssetStateAccessor:
             SetAssetStateByName(
                 name=self.ASSET_NAME,
                 key="watermark",
-                value={"__type": "ExternalState", "__var": "s3://bucket/assets/orders/watermark"},
+                value=_wrap_external_ref("s3://bucket/assets/orders/watermark"),
             )
         )
 
     def test_get_with_custom_backend_removes_decoration_marker(self, mock_supervisor_comms):
-        """ExternalState envelope is detected and the ref is passed to deserialize."""
+        """External state marker is detected and the ref is passed to deserialize."""
         mock_supervisor_comms.send.return_value = AssetStateResult(
-            value={"__type": "ExternalState", "__var": "s3://bucket/assets/orders/watermark"}
+            value=_wrap_external_ref("s3://bucket/assets/orders/watermark")
         )
 
         backend = MagicMock(spec=BaseStateBackend)
@@ -1568,7 +1569,7 @@ class TestTaskStateAccessorWithCustomBackend:
             SetTaskState(
                 ti_id=self.TI_ID,
                 key="job_id",
-                value={"__var": expected_ref, "__type": "ExternalState"},
+                value=_wrap_external_ref(expected_ref),
                 expires_at=frozen_dt + timedelta(days=30),
             )
         )
@@ -1578,7 +1579,7 @@ class TestTaskStateAccessorWithCustomBackend:
 
     def test_get_resolves_reference_to_actual_value(self, mock_supervisor_comms, backend):
         """get() fetches mem:// reference from DB, resolves it to actual value via backend."""
-        ref = {"__var": f"mem://{self.TI_ID}/job_id", "__type": "ExternalState"}
+        ref = _wrap_external_ref(f"mem://{self.TI_ID}/job_id")
         backend._actual_key_value_store["job_id"] = "app_001"
         mock_supervisor_comms.send.return_value = TaskStateResult(value=ref)
 
@@ -1635,7 +1636,7 @@ class TestAssetStateAccessorWithCustomBackend:
             SetAssetStateByName(
                 name=self.ASSET_NAME,
                 key="watermark",
-                value={"__var": expected_ref, "__type": "ExternalState"},
+                value=_wrap_external_ref(expected_ref),
             )
         )
         # actual value is stored on the backend, reference is stored for DB
@@ -1644,7 +1645,7 @@ class TestAssetStateAccessorWithCustomBackend:
 
     def test_get_resolves_reference_to_actual_value(self, mock_supervisor_comms, backend):
         """get() fetches mem:// reference from DB, resolves it to actual value via backend."""
-        ref = {"__var": f"mem://{self.ASSET_NAME}/watermark", "__type": "ExternalState"}
+        ref = _wrap_external_ref(f"mem://{self.ASSET_NAME}/watermark")
         backend._actual_key_value_store["watermark"] = "2026-05-01"
         mock_supervisor_comms.send.return_value = AssetStateResult(value=ref)
 

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -1566,7 +1566,10 @@ class TestTaskStateAccessorWithCustomBackend:
         # comms message has the mem:// reference, not the actual value
         mock_supervisor_comms.send.assert_called_once_with(
             SetTaskState(
-                ti_id=self.TI_ID, key="job_id", value=expected_ref, expires_at=frozen_dt + timedelta(days=30)
+                ti_id=self.TI_ID,
+                key="job_id",
+                value={"__var": expected_ref, "__type": "ExternalState"},
+                expires_at=frozen_dt + timedelta(days=30),
             )
         )
         # actual value is stored on the backend, reference is stored for DB
@@ -1575,7 +1578,7 @@ class TestTaskStateAccessorWithCustomBackend:
 
     def test_get_resolves_reference_to_actual_value(self, mock_supervisor_comms, backend):
         """get() fetches mem:// reference from DB, resolves it to actual value via backend."""
-        ref = f"mem://{self.TI_ID}/job_id"
+        ref = {"__var": f"mem://{self.TI_ID}/job_id", "__type": "ExternalState"}
         backend._actual_key_value_store["job_id"] = "app_001"
         mock_supervisor_comms.send.return_value = TaskStateResult(value=ref)
 
@@ -1629,7 +1632,11 @@ class TestAssetStateAccessorWithCustomBackend:
         expected_ref = f"mem://{self.ASSET_NAME}/watermark"
         # comms message has the mem:// reference, not the actual value
         mock_supervisor_comms.send.assert_called_once_with(
-            SetAssetStateByName(name=self.ASSET_NAME, key="watermark", value=expected_ref)
+            SetAssetStateByName(
+                name=self.ASSET_NAME,
+                key="watermark",
+                value={"__var": expected_ref, "__type": "ExternalState"},
+            )
         )
         # actual value is stored on the backend, reference is stored for DB
         assert backend._actual_key_value_store["watermark"] == "2026-05-01"
@@ -1637,7 +1644,7 @@ class TestAssetStateAccessorWithCustomBackend:
 
     def test_get_resolves_reference_to_actual_value(self, mock_supervisor_comms, backend):
         """get() fetches mem:// reference from DB, resolves it to actual value via backend."""
-        ref = f"mem://{self.ASSET_NAME}/watermark"
+        ref = {"__var": f"mem://{self.ASSET_NAME}/watermark", "__type": "ExternalState"}
         backend._actual_key_value_store["watermark"] = "2026-05-01"
         mock_supervisor_comms.send.return_value = AssetStateResult(value=ref)
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -153,6 +153,7 @@ from airflow.sdk.execution_time.context import (
     TaskStateAccessor,
     TriggeringAssetEventsAccessor,
     VariableAccessor,
+    _wrap_external_ref,
 )
 from airflow.sdk.execution_time.task_runner import (
     RuntimeTaskInstance,
@@ -5596,7 +5597,7 @@ class TestTaskInstanceStateOperations:
             SetAssetStateByName(
                 name="my_asset",
                 key="watermark",
-                value={"__var": "mem://my_asset/watermark", "__type": "ExternalState"},
+                value=_wrap_external_ref("mem://my_asset/watermark"),
             )
         )
 
@@ -5631,7 +5632,7 @@ class TestTaskInstanceStateOperations:
             SetTaskState(
                 ti_id=runtime_ti.id,
                 key="job_id",
-                value={"__var": ref, "__type": "ExternalState"},
+                value=_wrap_external_ref(ref),
                 expires_at=frozen_dt + timedelta(days=30),
             )
         )

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5593,7 +5593,11 @@ class TestTaskInstanceStateOperations:
             value="2026-05-01", key="watermark", asset_ref="my_asset"
         )
         mock_supervisor_comms.send.assert_any_call(
-            SetAssetStateByName(name="my_asset", key="watermark", value="mem://my_asset/watermark")
+            SetAssetStateByName(
+                name="my_asset",
+                key="watermark",
+                value={"__var": "mem://my_asset/watermark", "__type": "ExternalState"},
+            )
         )
 
     def test_task_state_set_sends_reference_via_custom_backend(
@@ -5625,7 +5629,10 @@ class TestTaskInstanceStateOperations:
         )
         mock_supervisor_comms.send.assert_any_call(
             SetTaskState(
-                ti_id=runtime_ti.id, key="job_id", value=ref, expires_at=frozen_dt + timedelta(days=30)
+                ti_id=runtime_ti.id,
+                key="job_id",
+                value={"__var": ref, "__type": "ExternalState"},
+                expires_at=frozen_dt + timedelta(days=30),
             )
         )
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - claude sonnet 4.6
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What problem are we solving?

When a custom worker backend (e.g. S3, GCS) stores a state value externally and writes a reference string back to the DB, the UI has no way to tell whether a value like `s3://bucket/ti_123/job_id` is:

- The user's actual state value (a plain string they stored), or
- An opaque reference to externally-stored data

Without this distinction, the UI would show the raw path as if it were the value, which can be confusing and misleading.

### Current behaviour

Custom backends return a reference string from `serialize_task_state_to_ref()`, which is stored verbatim in the DB. The DB value column contains either a plain JSON value or a reference string with no structural difference between the two — the UI cannot differentiate them.

### Proposed change

When a custom worker backend is configured, the framework now automatically wraps the reference returned by `serialize_task_state_to_ref()` in a typed envelope before storing:

```json
{"__airflow_state_ref__": "s3://bucket/ti_123/job_id"}
```

On read, the framework detects the envelope, extracts the ref, and passes it to `deserialize_task_state_from_ref()` and the backend never sees the envelope. If a stored value does not carry the marker (e.g. a corrupt row), the raw value is returned and a warning is logged.

The default path (no custom backend) is unaffected, plain JSON values are stored and returned as before.


### UI Impact

UI PR for reference https://github.com/apache/airflow/pull/67292/

The UI reads state values directly from the DB and displays them as-is. With this change, when a custom backend is in use, the UI will show `{"__airflow_state_ref__": "..."}` instead of a raw reference string, making it visually clear that the value is a pointer to externally-stored data rather than the actual state value.


### Testing

Created a custom worker side backend based on file system:

```python
from __future__ import annotations

import json
from pathlib import Path
from typing import TYPE_CHECKING

from airflow.sdk.state import BaseStateBackend

if TYPE_CHECKING:
    from datetime import datetime

    from pydantic import JsonValue
    from sqlalchemy.ext.asyncio import AsyncSession
    from sqlalchemy.orm import Session

    from airflow_shared.state import StateScope

BASE_DIR = Path("/tmp/airflow_state")


class FileStateBackend(BaseStateBackend):
    """Stores task/asset state values as local JSON files; returns the path as the ref."""
    def serialize_task_state_to_ref(self, *, value: JsonValue, key: str, ti_id: str) -> str:
        path = BASE_DIR / f"ti_{ti_id}" / f"{key}.json"
        path.parent.mkdir(parents=True, exist_ok=True)
        path.write_text(json.dumps(value))
        return str(path)

    def deserialize_task_state_from_ref(self, stored: str) -> JsonValue:
        return json.loads(Path(stored).read_text())

    def serialize_asset_state_to_ref(self, *, value: JsonValue, key: str, asset_ref: str) -> str:
        safe = asset_ref.replace("/", "_").replace(":", "")
        path = BASE_DIR / "assets" / safe / f"{key}.json"
        path.parent.mkdir(parents=True, exist_ok=True)
        path.write_text(json.dumps(value))
        return str(path)

    def deserialize_asset_state_from_ref(self, stored: str) -> JsonValue:
        return json.loads(Path(stored).read_text())


    def get(self, scope: StateScope, key: str, *, session: Session | None = None) -> str | None:
        raise NotImplementedError(
            "FileStateBackend is a worker-side backend; server uses MetastoreStateBackend"
        )

    def set(
        self,
        scope: StateScope,
        key: str,
        value: str,
        *,
        expires_at: datetime | None = None,
        session: Session | None = None,
    ) -> None:
        raise NotImplementedError

    def delete(self, scope: StateScope, key: str, *, session: Session | None = None) -> None:
        raise NotImplementedError

    def clear(
        self, scope: StateScope, *, all_map_indices: bool = False, session: Session | None = None
    ) -> None:
        raise NotImplementedError

    async def aget(self, scope: StateScope, key: str, *, session: AsyncSession | None = None) -> str | None:
        raise NotImplementedError

    async def aset(
        self,
        scope: StateScope,
        key: str,
        value: str,
        *,
        expires_at: datetime | None = None,
        session: AsyncSession | None = None,
    ) -> None:
        raise NotImplementedError

    async def adelete(self, scope: StateScope, key: str, *, session: AsyncSession | None = None) -> None:
        raise NotImplementedError

    async def aclear(
        self, scope: StateScope, *, all_map_indices: bool = False, session: AsyncSession | None = None
    ) -> None:
        raise NotImplementedError

```

Ran breeze with: `export AIRFLOW__WORKERS__STATE_BACKEND=file_state_backend.FileStateBackend`

DAG:
```python
@dag(schedule=None, start_date=datetime(2026, 4, 23), catchup=True)
def simple_task_state():

    @task
    def my_task(**context: Context):
        task_state = context["task_state"]

        task_state.set("job_id", "12345")
        task_state.set("secret-dict", {"key": "value"})
        task_state.set("int_value", 42)

        print("Fetching task states I stored earlier")

        print("job_id:", task_state.get("job_id"), type(task_state.get("job_id")))
        print("secret-dict:", task_state.get("secret-dict"), type(task_state.get("secret-dict")))
        print("int_value:", task_state.get("int_value"), type(task_state.get("int_value")))

    my_task()

```

The task is agnostic to the envelope.

<img width="1717" height="608" alt="image" src="https://github.com/user-attachments/assets/2a378739-f63a-4fbb-9649-3a67f81d4703" />



File system is updated with the custom backend generated files:

```shell
[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$ pwd
/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14
[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$ ll
bash: ll: command not found
[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$ ls -l
total 12
-rw-r--r-- 1 root root  2 May 27 06:30 int_value.json
-rw-r--r-- 1 root root  7 May 27 06:30 job_id.json
-rw-r--r-- 1 root root 16 May 27 06:30 secret-dict.json
[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$ cat int_value.json
42[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$ cat job_id.json
"12345"[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$ cat secret-dict.json
{"key": "value"}[Breeze:3.10.20] root@78d3c819fefd:/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14$
```


Core API will return the external reference for UI to build upon, the extra encoding like `{\"__airflow_state_ref__\": \"/tmp/airflow_state/ti_019e6821-0661-7bdc-ad37-8dad5ac1fa14/int_value.json\"}` will be fixed by: https://github.com/apache/airflow/pull/67547

<img width="2102" height="1140" alt="image" src="https://github.com/user-attachments/assets/62c17cb9-cd56-4b1e-9822-3e4a7bded24e" />




---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
