### PR TITLE
i18n(ko): add missing translation for Rendered Map Index

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -283,6 +283,7 @@
     "priorityWeight": "우선순위 가중치",
     "queue": "큐",
     "queuedWhen": "대기열에 추가된 시간",
+    "renderedMapIndex": "렌더링된 맵 인덱스",
     "scheduledWhen": "예정된 시간",
     "triggerer": {
       "assigned": "할당된 트리거",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Description

This PR adds the missing Korean translation for the `renderedMapIndex` filter key in `ko/common.json` to fix the untranslated `TODO: translate` placeholder displayed in the UI filter bar.

### Screenshots

| Before | After |
| :---: | :---: |
| <img width="2546" height="2394" alt="before" src="https://github.com/user-attachments/assets/9fd13ae3-4cb3-4a5f-aada-3a610e829578" /> | <img width="2546" height="2394" alt="after" src="https://github.com/user-attachments/assets/4b6a5fc1-f737-42c7-85b7-2846a86d5d81" /> |

- Checked translation completeness using `breeze ui check-translation-completeness --language ko`
  <img width="1992" height="1114" alt="breeze translation check" src="https://github.com/user-attachments/assets/3116e140-48c6-4818-9a77-4f5d4dd3f0a9" />

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

Please review this translation.
/cc @choo121600 @onestn @noeunkim

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
