### PR TITLE
Fix callback state not updating from executor events due to UUID type mismatch

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -32,6 +32,7 @@ from datetime import date, datetime, timedelta
 from functools import lru_cache, partial
 from itertools import groupby
 from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID
 
 from sqlalchemy import (
     CTE,
@@ -1270,7 +1271,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # Handle callback state events
         for callback_id in callback_keys_with_events:
             state, info = event_buffer.pop(callback_id)
-            callback = session.get(Callback, str(callback_id))
+            callback = session.get(Callback, UUID(str(callback_id)))
             if not callback:
                 # This should not normally happen - we just received an event for this callback.
                 # Only possible if callback was deleted mid-execution (e.g., cascade delete from DagRun deletion).

--- a/airflow-core/tests/unit/models/test_callback.py
+++ b/airflow-core/tests/unit/models/test_callback.py
@@ -243,9 +243,11 @@ class TestExecutorCallback:
         from uuid import UUID
 
         callback = ExecutorCallback(TEST_SYNC_CALLBACK, fetch_method=CallbackFetchMethod.IMPORT_PATH)
-        callback_id_str = str(callback.id)
         session.add(callback)
         session.commit()
+        # ``id`` is filled by the ``uuid6.uuid7`` default at flush time, so it
+        # is only safe to stringify *after* the commit.
+        callback_id_str = str(callback.id)
 
         assert session.get(Callback, UUID(callback_id_str)) is not None
 

--- a/airflow-core/tests/unit/models/test_callback.py
+++ b/airflow-core/tests/unit/models/test_callback.py
@@ -237,6 +237,18 @@ class TestExecutorCallback:
         callback.queue()
         assert callback.state == CallbackState.QUEUED
 
+    def test_session_get_requires_uuid_not_str(self, session):
+        """Filtering the UUID id column with a plain str breaks on SQLite, so
+        callers must wrap with ``UUID(...)`` before querying."""
+        from uuid import UUID
+
+        callback = ExecutorCallback(TEST_SYNC_CALLBACK, fetch_method=CallbackFetchMethod.IMPORT_PATH)
+        callback_id_str = str(callback.id)
+        session.add(callback)
+        session.commit()
+
+        assert session.get(Callback, UUID(callback_id_str)) is not None
+
 
 class TestDagProcessorCallback:
     def test_polymorphic_serde(self, session):


### PR DESCRIPTION
failing test: https://github.com/apache/airflow/actions/runs/26440894620/job/77843758833?pr=66141

When filtering a UUID-typed column on the existing `Callback` table with a plain string, the following error is raised. This error does not surface on PostgreSQL, but it does on SQLite and MySQL.
```
FAILED airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_process_executor_events_failed_event_captures_output[queued] - sqlalchemy.exc.StatementError: (builtins.AttributeError) 'str' object has no attribute 'hex'
[SQL: SELECT callback.id AS callback_id, callback.type AS callback_type, callback.fetch_method AS callback_fetch_method, callback.data AS callback_data, callback.bundle_name AS callback_bundle_name, callback.state AS callback_state, callback.output AS callback_output, callback.priority_weight AS callback_priority_weight, callback.created_at AS callback_created_at, callback.trigger_id AS callback_trigger_id 
FROM callback 
WHERE callback.id = %s]
[parameters: [{'pk_1': '019e63b5-0c8e-7749-b423-236d64f5a623'}]]
```
The fix wraps the lookup value in UUID(...) instead of passing the raw string.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
