### PR TITLE
UI: Fix Monaco workers crashing in production mode

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -35,15 +35,19 @@ const loadMonacoModules = async () => {
     import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
   ]).then(([api]) => api);
 
-  // Resolve the workers as plain URLs (not Vite `?worker` constructors). In dev mode
-  // the SPA shell is served by the airflow api-server while Vite serves assets on a
-  // different origin, and `new Worker(crossOriginUrl, { type: "module" })` is rejected
-  // by the browser. Wrapping the cross-origin URL in a same-origin Blob shim that just
-  // re-imports it sidesteps the restriction (CORS still permits the inner import). In
-  // production the worker is same-origin and the shim is harmless.
+  // Resolve the bundled worker URLs (`?worker&url` runs the worker through Vite's worker
+  // pipeline — bundling all dependencies — and returns the resulting URL as a string,
+  // unlike `?url` which would treat the file as a raw asset and either inline its source
+  // as a data URL (assetsInlineLimit) or copy it without bundling its imports, leaving
+  // unresolved bare specifiers at runtime). In dev mode the SPA shell is served by the
+  // airflow api-server while Vite serves assets on a different origin, and
+  // `new Worker(crossOriginUrl, { type: "module" })` is rejected by the browser.
+  // Wrapping the cross-origin URL in a same-origin Blob shim that just re-imports it
+  // sidesteps the restriction (CORS still permits the inner import). In production the
+  // worker is same-origin and the shim is harmless.
   const workerUrls = Promise.all([
-    import("monaco-editor/esm/vs/editor/editor.worker.js?url").then((module) => module.default),
-    import("monaco-editor/esm/vs/language/json/json.worker.js?url").then((module) => module.default),
+    import("monaco-editor/esm/vs/editor/editor.worker.js?worker&url").then((module) => module.default),
+    import("monaco-editor/esm/vs/language/json/json.worker.js?worker&url").then((module) => module.default),
   ]);
 
   const languageContributions = Promise.all([


### PR DESCRIPTION
Follow-up to #67352. In production builds, the Monaco editor was unable to spawn its web workers — Chrome logged `Could not create web worker(s). Falling back to loading web worker code in main thread.` plus MIME-type errors for `editor/editor.worker.js`, and the JSON editor in XComs / Audit Log was running everything (syntax service, folding) on the UI thread.

### Root cause

#67352 switched the worker imports from `?worker` to `?url` so a Blob shim could re-import them same-origin. `?url`, however, does **not** run Vite's worker pipeline:

- For `editor.worker.js` (the entry source is ~1 KB), `?url` inlines the **raw** module as a base64 data URL via `build.assetsInlineLimit`. The inlined module still contains bare-specifier imports (`vs/editor/...`) that cannot be resolved inside a module Worker.
- For `json.worker.js` it copies a partly-bundled file whose top-level `import '../../editor/editor.worker.js'` resolves to a path that does not exist in the build output.

In both cases the Worker fails to evaluate, Monaco's fallback path kicks in, and the unhashed `editor/editor.worker.js` URL Monaco tries next hits the SPA HTML fallback (the MIME error).

### Fix

Switch the imports to `?worker&url`. Vite's worker plugin runs the file through the full worker pipeline (bundling all dependencies into a self-contained IIFE), and the `&url` suffix returns the bundled file's URL as a string instead of a Worker constructor — which is what the Blob shim needs.

Verified the rebuilt `dist/` now contains self-contained workers (`editor.worker-<hash>.js` ≈ 260 KB, `json.worker-<hash>.js` ≈ 390 KB, zero top-level imports), with small URL-wrapper modules pointing at them.

---

## Prod:
https://github.com/user-attachments/assets/e5767f35-6de9-4f5e-b817-cd577fe1680b

## Dev:

https://github.com/user-attachments/assets/34af899d-eca8-4e5b-a53d-74f5c7ec732b






##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)