### PR TITLE
UI: Rewrite modulepreload hrefs to the api-server static path

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -35,15 +35,19 @@ const loadMonacoModules = async () => {
     import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
   ]).then(([api]) => api);
 
-  // Resolve the workers as plain URLs (not Vite `?worker` constructors). In dev mode
-  // the SPA shell is served by the airflow api-server while Vite serves assets on a
-  // different origin, and `new Worker(crossOriginUrl, { type: "module" })` is rejected
-  // by the browser. Wrapping the cross-origin URL in a same-origin Blob shim that just
-  // re-imports it sidesteps the restriction (CORS still permits the inner import). In
-  // production the worker is same-origin and the shim is harmless.
+  // Resolve the bundled worker URLs (`?worker&url` runs the worker through Vite's worker
+  // pipeline — bundling all dependencies — and returns the resulting URL as a string,
+  // unlike `?url` which would treat the file as a raw asset and either inline its source
+  // as a data URL (assetsInlineLimit) or copy it without bundling its imports, leaving
+  // unresolved bare specifiers at runtime). In dev mode the SPA shell is served by the
+  // airflow api-server while Vite serves assets on a different origin, and
+  // `new Worker(crossOriginUrl, { type: "module" })` is rejected by the browser.
+  // Wrapping the cross-origin URL in a same-origin Blob shim that just re-imports it
+  // sidesteps the restriction (CORS still permits the inner import). In production the
+  // worker is same-origin and the shim is harmless.
   const workerUrls = Promise.all([
-    import("monaco-editor/esm/vs/editor/editor.worker.js?url").then((module) => module.default),
-    import("monaco-editor/esm/vs/language/json/json.worker.js?url").then((module) => module.default),
+    import("monaco-editor/esm/vs/editor/editor.worker.js?worker&url").then((module) => module.default),
+    import("monaco-editor/esm/vs/language/json/json.worker.js?worker&url").then((module) => module.default),
   ]);
 
   const languageContributions = Promise.all([

--- a/airflow-core/src/airflow/ui/vite.config.ts
+++ b/airflow-core/src/airflow/ui/vite.config.ts
@@ -37,7 +37,10 @@ export default defineConfig({
     {
       name: "transform-url-src",
       transformIndexHtml: (html) =>
-        html.replace(`src="./assets/`, `src="./static/assets/`).replace(`href="/`, `href="./`),
+        html
+          .replaceAll(`src="./assets/`, `src="./static/assets/`)
+          .replaceAll(`href="./assets/`, `href="./static/assets/`)
+          .replaceAll(`href="/`, `href="./`),
     },
     // Keep Monaco's codicon CSS as a real CSS file (rather than inlined into JS).
     // The codicon stylesheet references `codicon.ttf` with a CSS-relative URL — when


### PR DESCRIPTION
Vite emits both `<script src="./assets/...">` and `<link rel="modulepreload" href="./assets/...">` for chunks in the built `index.html`. The `transform-url-src` plugin in `vite.config.ts` only rewrites `src="./assets/"` to `src="./static/assets/"` — the modulepreload `href`s are left untouched.

Behind the api-server's `/static/` mount those preload requests hit the SPA HTML fallback, and the browser fails them with:

```
Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/html".
```

The chunks themselves still load via `<script src>` (whose path *is* rewritten), so the app keeps working. What's lost is the modulepreload optimization (those chunks aren't parallel-fetched ahead of import-graph discovery), plus each page load wastes three round-trips that return the full SPA HTML and floods the console.

### Fix

Apply the same `static/` rewrite to `href="./assets/"` and switch all three rewrites to `replaceAll` so multiple matches (one per chunk) are handled — `replace` with a string only touches the first occurrence.

Verified the rebuilt `dist/index.html` now points all `<link rel="modulepreload">` at `./static/assets/...`.

> Note: this PR's branch is stacked on top of #67546 (the Monaco worker bundling fix); the modulepreload change is the second commit. Once #67546 merges, GitHub will collapse the diff to just the `vite.config.ts` change.

---
<img width="1911" height="967" alt="Screenshot 2026-05-26 at 13 41 25" src="https://github.com/user-attachments/assets/3abafb75-29f1-46a4-85e1-24d7cea5a2f3" />


##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)