### PR TITLE
Correct README.rst common compat version reference inconsistency

### DIFF
--- a/providers/celery/README.rst
+++ b/providers/celery/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.14.3``
+``apache-airflow-providers-common-compat``  ``>=1.15.0``
 ``celery[redis]``                           ``>=5.5.0,<6``
 ``flower``                                  ``>=1.0.0``
 ==========================================  ==================

--- a/providers/cncf/kubernetes/README.rst
+++ b/providers/cncf/kubernetes/README.rst
@@ -55,7 +55,7 @@ PIP package                                 Version required
 ==========================================  ======================================
 ``aiofiles``                                ``>=23.2.0``
 ``apache-airflow``                          ``>=2.11.0``
-``apache-airflow-providers-common-compat``  ``>=1.14.3``
+``apache-airflow-providers-common-compat``  ``>=1.15.0``
 ``asgiref``                                 ``>=3.5.2; python_version < "3.14"``
 ``asgiref``                                 ``>=3.11.1; python_version >= "3.14"``
 ``cryptography``                            ``>=44.0.3``

--- a/providers/edge3/README.rst
+++ b/providers/edge3/README.rst
@@ -66,7 +66,7 @@ Requirements
 PIP package                                 Version required
 ==========================================  ===================
 ``apache-airflow``                          ``>=3.0.0,!=3.1.0``
-``apache-airflow-providers-common-compat``  ``>=1.14.3``
+``apache-airflow-providers-common-compat``  ``>=1.15.0``
 ``pydantic``                                ``>=2.11.0``
 ``retryhttp``                               ``>=1.4.0``
 ``aiofiles``                                ``>=23.2.0``

--- a/providers/git/README.rst
+++ b/providers/git/README.rst
@@ -54,7 +54,7 @@ Requirements
 PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=3.0.0``
-``apache-airflow-providers-common-compat``  ``>=1.12.0``
+``apache-airflow-providers-common-compat``  ``>=1.15.0``
 ``GitPython``                               ``>=3.1.44``
 ==========================================  ==================
 

--- a/providers/openlineage/README.rst
+++ b/providers/openlineage/README.rst
@@ -56,7 +56,7 @@ PIP package                                 Version required
 ==========================================  ==================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``apache-airflow-providers-common-compat``  ``>=1.14.3``
+``apache-airflow-providers-common-compat``  ``>=1.15.0``
 ``attrs``                                   ``>=22.2``
 ``openlineage-integration-common``          ``>=1.47.0``
 ``openlineage-python``                      ``>=1.47.0``


### PR DESCRIPTION
I just noticed while testing 3.2.2rc2 that the last providers release wave contained an inconsitency, the generated README.rst files were not bumped towards common-compat provider. Pyproject.toml was correct and consistent but for 5 providers the version number in README was not correctly bumped.

This PR fixes the problem

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
