### PR TITLE
Add community escalation process doc with private@ appeal channel

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,3 +22,9 @@
 The Apache Airflow project follows the [Apache Software Foundation code of conduct](https://www.apache.org/foundation/policies/conduct.html).
 
 If you observe behavior that violates those rules please follow the [ASF reporting guidelines](https://www.apache.org/foundation/policies/conduct#reporting-guidelines).
+
+For how the Airflow community responds to repeated Code of Conduct
+breaches, spamming, or other sustained disruptive behaviour — and how
+affected contributors can appeal a decision via
+`private@airflow.apache.org` — see the
+[Community escalation process](COMMUNITY_ESCALATION.md).

--- a/COMMUNITY_ESCALATION.md
+++ b/COMMUNITY_ESCALATION.md
@@ -1,0 +1,146 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+# Community escalation process
+
+This document describes how the Apache Airflow community responds when a
+contributor's behaviour repeatedly imposes an unreasonable burden on
+maintainers or the wider community — for example, [Code of Conduct](CODE_OF_CONDUCT.md)
+breaches, spamming project channels, abusing project resources, or
+sustained disruption that the normal review and mentoring process
+cannot resolve.
+
+It complements the [Code of Conduct](CODE_OF_CONDUCT.md), which sets
+the standards of behaviour expected from everyone interacting with the
+project. The Code of Conduct says **what** is expected; this document
+describes **what happens** when those expectations are repeatedly
+ignored, and how affected contributors can appeal a decision.
+
+## Scope
+
+Behaviours that may lead to escalation include (but are not limited to):
+
+* **Code of Conduct violations** — harassment, personal attacks,
+  discriminatory behaviour, or any other conduct that breaches the
+  [ASF Code of Conduct](https://www.apache.org/foundation/policies/conduct).
+* **Spamming the project** — opening low-quality or duplicate issues
+  and PRs in bulk, mass-pinging maintainers, or posting promotional,
+  off-topic, or unsolicited content on GitHub, the mailing lists,
+  Slack, the CWiki, or any other project channel.
+* **Repeatedly disregarding maintainer feedback** — for example,
+  reopening the same PR after closure with no substantive change, or
+  continuing to bypass project quality criteria after being asked to
+  stop. The general PR quality bar is described in
+  [Pull request quality criteria](contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
+* **Submitting unvetted Gen-AI-generated content** — the specific
+  expectations around generative-AI-assisted contributions are
+  described in
+  [Gen-AI Assisted contributions](contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions);
+  the escalation steps that follow when those expectations are
+  ignored are the ones described here.
+* **Conduct that violates GitHub's Terms of Service** — for example,
+  evading prior blocks, automated abuse, or coordinated harassment.
+* **Being generally and persistently disruptive to the community** in
+  ways that are not covered by the categories above but that
+  similarly burden maintainers or other contributors.
+
+This document is **not** about ordinary disagreements, slow PRs, or
+contributions that simply need more work — those are handled through
+normal review and mentoring (see
+[How to communicate](contributing-docs/02_how_to_communicate.rst) and
+[Pull request guidelines](contributing-docs/05_pull_requests.rst)).
+
+## Escalation steps
+
+The community applies the minimum necessary measure at each step. The
+goal is to protect maintainer time and the health of the project, not
+to punish contributors. A contributor who acknowledges feedback and
+changes their behaviour is welcomed to continue contributing at any
+point in this sequence.
+
+1. **Direct feedback by maintainers.** A maintainer points out the
+   problem on the PR, issue, mailing list thread, or Slack message
+   and links to the relevant guideline (Code of Conduct, Gen-AI
+   guidelines, PR quality criteria, communication guidelines, etc.).
+
+2. **Closing PRs or locking threads.** If the behaviour persists,
+   maintainers may close one or more of the contributor's open PRs
+   or lock conversations that have become unproductive. When a
+   contributor accumulates multiple PRs flagged for the same problem,
+   maintainers may close all of that contributor's open PRs at once
+   to avoid repeated review burden. Each closure or lock is
+   accompanied by a comment pointing to the violated guideline so the
+   contributor knows what to fix.
+
+3. **PMC-level blocking from the project.** If the behaviour continues
+   after the previous steps, PMC members may decide to block the
+   contributor from making further contributions to the Apache
+   Airflow project. Such a block is a last-resort measure to protect
+   the project from sustained harm and to avoid overburdening
+   maintainers. The decision is taken as a
+   [LAZY CONSENSUS](https://community.apache.org/committers/lazyConsensus.html)
+   among PMC members on the private PMC list, so that it is
+   collectively agreed, not vetoed, and recorded in the Apache
+   Software Foundation's archives.
+
+4. **ASF Infrastructure / cross-project block.** In extreme cases —
+   for example, behaviour that affects multiple ASF projects or
+   evasion of an Airflow-level block — the PMC may request the ASF
+   Infrastructure team to block the contributor at the organisation
+   level, across all ASF projects.
+
+5. **Reporting to GitHub.** If a contributor is evidently spamming
+   the project, evading prior blocks, or otherwise breaching
+   [GitHub's Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service),
+   maintainers may report the account to GitHub. GitHub may then
+   take its own action, which can include suspending or deleting the
+   account.
+
+A separate, parallel path applies specifically to Code of Conduct
+violations: anyone observing such behaviour can — and is encouraged to
+— also follow the
+[ASF reporting guidelines](https://www.apache.org/foundation/policies/conduct#reporting-guidelines)
+directly, independently of the steps above.
+
+## Appeals — `private@airflow.apache.org`
+
+Any contributor affected by a decision taken under this process may
+appeal it by emailing the Apache Airflow PMC at:
+
+> **private@airflow.apache.org**
+
+This is the appropriate appeal channel for **all** escalation decisions
+described in this document — including PR closures, project-level
+blocks, and infrastructure-level block requests.
+
+When sending an appeal, please:
+
+* Identify the decision being appealed (link to the PR, issue, thread,
+  or block notice where possible).
+* Describe the grounds for the appeal — what the decision got wrong,
+  what additional context the PMC should consider, or what has
+  changed since the decision was taken.
+
+Appeals are reviewed by the PMC on the private list and the outcome is
+communicated back to the contributor. The PMC may uphold the original
+decision, modify it, or reverse it.
+
+For Code of Conduct matters, contributors also retain the separate
+right to escalate to the ASF Conduct Committee as described in the
+[ASF Code of Conduct](https://www.apache.org/foundation/policies/conduct).

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Use Airflow to author workflows (Dags) that orchestrate tasks. The Airflow sched
 - [Base OS support for reference Airflow images](#base-os-support-for-reference-airflow-images)
 - [Approach to dependencies of Airflow](#approach-to-dependencies-of-airflow)
 - [Contributing](#contributing)
+- [Community standards](#community-standards)
 - [Agent-assisted contribution (apache-steward)](#agent-assisted-contribution-apache-steward)
 - [Voting Policy](#voting-policy)
 - [Who uses Apache Airflow?](#who-uses-apache-airflow)
@@ -431,6 +432,22 @@ If you can't wait to contribute, and want to get started asap, check out the [co
 Official Docker (container) images for Apache Airflow are described in [images](https://github.com/apache/airflow/blob/main/dev/breeze/doc/ci/02_images.md).
 
 <!-- END Contributing, please keep comment here to allow auto update of PyPI readme.md -->
+
+## Community standards
+
+Everyone interacting with the Apache Airflow project — on GitHub, the
+mailing lists, Slack, the CWiki, or anywhere else — is expected to
+follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+When repeated Code of Conduct breaches, spamming, abuse of project
+resources, or other sustained disruptive behaviour cannot be resolved
+through normal review and mentoring, the project applies the
+[Community escalation process](COMMUNITY_ESCALATION.md). It describes
+the steps maintainers and the PMC may take — from direct feedback,
+through closing PRs, up to PMC-level or ASF-Infrastructure-level
+blocks and reporting accounts to GitHub — and how affected
+contributors can appeal a decision by emailing the PMC at
+`private@airflow.apache.org`.
 
 ## Agent-assisted contribution (apache-steward)
 

--- a/contributing-docs/02_how_to_communicate.rst
+++ b/contributing-docs/02_how_to_communicate.rst
@@ -26,6 +26,11 @@ This means that communication plays a big role in it, and this chapter is all ab
 
 In our communication, everyone is expected to follow the `ASF Code of Conduct <https://www.apache.org/foundation/policies/conduct>`_.
 
+When repeated Code of Conduct breaches, spamming of project channels, or other sustained disruptive
+behaviour cannot be resolved through normal review and mentoring, the project applies the
+`Community escalation process <../COMMUNITY_ESCALATION.md>`_. Affected contributors can appeal
+any decision taken under that process by emailing the PMC at ``private@airflow.apache.org``.
+
 .. contents:: Table of Contents
    :depth: 2
    :local:

--- a/contributing-docs/05_pull_requests.rst
+++ b/contributing-docs/05_pull_requests.rst
@@ -213,6 +213,12 @@ maliciously, or inject harmful code), **all open PRs by the same author** will b
 and labeled ``suspicious changes detected``. A comment is posted on each PR explaining that
 the closure was triggered by suspicious changes found in the flagged PR.
 
+If a contributor believes any closure described above was applied in error, the appeal channel
+is the PMC private list — see the
+`Community escalation process <../COMMUNITY_ESCALATION.md>`_ for how to email
+``private@airflow.apache.org``. That document also covers the further steps the project may
+take when the same behaviour persists across PRs.
+
 Gen-AI Assisted contributions
 -----------------------------
 
@@ -242,24 +248,15 @@ adhere to the following guidelines:
   unrelated changes should be removed from the PR before it is submitted for review. Relying on
   maintainers to spot such unrelated changes is unfair and adds extra burden on them.
 
-When a contributor does not follow these guidelines, maintainers might decide to close the PR
-(and all the PRs of that contributor) without reviewing them - to avoid extra burden on the
-maintainers and to protect the project from potential risks of merging unvetted code by a tired
-maintainer. This should be accompanied by a comment explaining the reason for closing the PR
-and pointing to this section of the documentation.
-
-If the contributor repeatedly ignores these guidelines, PMC members might decide to block the contributor
-from making further contributions to the project, this is a last resort measure to protect the project
-from potential risks of unvetted code and to avoid overburdening the maintainers. Such blocking is
-accompanied with a LAZY CONSENSUS vote amongst the PMC members to make sure that the decision is
-agreed upon and not vetoed by any of the PMC members and it is kept in the records of the
-Apache Software Foundation. In extreme cases the PMC might request the ASF Infrastructure team
-to block the contributor at the Organization level - for all ASF projects.
-
-If the contributor is evidently spamming the project with the content that is violating GitHub terms and
-condition, maintainers might decide to report such behaviour to GitHub for further actions, which often
-results in deletion of the user account by GitHub or blocking the user from making further contributions at
-GitHub level.
+When a contributor does not follow these guidelines, maintainers may close the PR (or all of
+that contributor's open PRs) with a comment pointing to this section of the documentation, so
+that maintainer review time is not spent on unvetted Gen-AI-generated code. Repeated disregard
+of the Gen-AI guidelines is treated the same way as any other sustained disruptive behaviour
+toward the project: it is handled under the project-wide
+`Community escalation process <../COMMUNITY_ESCALATION.md>`_, which describes the further
+steps that may follow (PMC-level blocking, ASF-Infrastructure-level blocking, reporting the
+account to GitHub) and how a contributor can appeal any such decision by emailing the PMC at
+``private@airflow.apache.org``.
 
 Requirement to resolve all conversations
 ----------------------------------------

--- a/contributing-docs/README.rst
+++ b/contributing-docs/README.rst
@@ -64,6 +64,14 @@ To learn about various roles and communication channels in the Airflow project:
 * `How to communicate <02_how_to_communicate.rst>`__
   describes how to communicate with the community and how to get help.
 
+* `Code of Conduct <../CODE_OF_CONDUCT.md>`__ states the behaviour
+  the project expects from everyone, and the
+  `Community escalation process <../COMMUNITY_ESCALATION.md>`__
+  describes what happens when Code of Conduct breaches, spamming, or
+  other sustained disruptive behaviour cannot be resolved through
+  normal review and mentoring — and how to appeal a decision via
+  ``private@airflow.apache.org``.
+
 * `How to contribute <04_how_to_contribute.rst>`__ describes the various ways of how you can contribute to Airflow.
 
 To learn how to setup your environment for development and how to develop and test code:


### PR DESCRIPTION
## Summary

- Extracts the generic escalation language (close PRs, PMC LAZY-CONSENSUS block, ASF-Infrastructure block, report to GitHub) from `contributing-docs/05_pull_requests.rst`'s Gen-AI section into a standalone `COMMUNITY_ESCALATION.md` at the repo root, next to `CODE_OF_CONDUCT.md`.
- Broadens the scope from Gen-AI-specific misuse to all sustained disruptive behaviour: Code of Conduct breaches, spamming, repeated disregard of maintainer feedback, GitHub ToS violations, and unvetted Gen-AI content.
- Names `private@airflow.apache.org` as the appeal channel for any decision taken under the process.
- References the new doc from the README (new "Community standards" section + TOC entry), `CODE_OF_CONDUCT.md`, `contributing-docs/README.rst`, `contributing-docs/02_how_to_communicate.rst`, and `contributing-docs/05_pull_requests.rst` (Gen-AI section + PR-quality-criteria appeal pointer).
- No guideline content removed — the Gen-AI guidelines themselves stay in place; only the duplicated escalation steps are now factored out.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)