### PR TITLE
Add advisory rudolint Dockerfile check

### DIFF
--- a/.github/workflows/rudolint.yml
+++ b/.github/workflows/rudolint.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+name: Rudolint
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+      - ".github/workflows/rudolint.yml"
+      - ".rudolint.yaml"
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+  push:
+    branches: ["main", "v*-*-test"]
+    paths:
+      - ".github/workflows/rudolint.yml"
+      - ".rudolint.yaml"
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+
+permissions:
+  contents: read
+
+jobs:
+  rudolint:
+    name: "Rudolint Dockerfiles"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: "Run rudolint"
+        uses: kubeply/rudolint@v1
+        with:
+          config: .rudolint.yaml
+          failure-threshold: error

--- a/.rudolint.yaml
+++ b/.rudolint.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+ignore:
+  - DL3005
+  - DL3006
+  - DL3008
+  - DL3013
+  - RUD1001
+  - SC1091


### PR DESCRIPTION
## What

This adds an advisory Rudolint workflow for Dockerfiles using the published `kubeply/rudolint` GitHub Action. The job is intentionally non-blocking so maintainers can evaluate the BuildKit-focused signal before deciding whether to enforce anything.

The workflow runs Rudolint's default profile, which includes BuildKit/buildx-aware diagnostics such as target-platform-aware downloads, cache mount opportunities, explicit syntax directives, and secret mount recommendations. `failure-threshold: error` keeps those warning/info findings visible in CI logs without failing the job.

The accompanying `.rudolint.yaml` mirrors Airflow's existing Hadolint ignores and suppresses legacy Hadolint comment migration noise, so the initial output focuses on BuildKit-specific findings.

## Why

This follows up on #67553. Airflow already has Hadolint coverage; this PR only adds an optional signal for modern BuildKit patterns such as cache mounts, secret mounts, syntax directives, and target-platform-aware downloads.

The local rudolint run reports 13 advisory findings across 5 files and exits successfully.

<img width="895" height="437" alt="CleanShot 2026-05-26 at 18 13 48" src="https://github.com/user-attachments/assets/7efe8f9c-6c6a-4eaf-91a3-2ea6f7faa5c2" />


linked to #67553
