### PR TITLE
Fix next-execution table crash without next run

### DIFF
--- a/airflow-core/newsfragments/67565.bugfix.rst
+++ b/airflow-core/newsfragments/67565.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``airflow dags next-execution --table`` when no following schedule exists.

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -438,13 +438,27 @@ def dag_next_execution(args) -> None:
             if dagrun_info is None:
                 break
 
+    def print_no_following_schedule_warning() -> None:
+        print(
+            "[WARN] No following schedule can be found. "
+            "This DAG may have schedule interval '@once' or `None`.",
+            file=sys.stderr,
+        )
+
     if args.table:
         if last_parsed_dag.timetable_partitioned:
             columns = ["partition_key", "partition_date", "run_after"]
         else:
             columns = ["logical_date", "data_interval.start", "data_interval.end", "run_after"]
         getters = [(c, operator.attrgetter(c)) for c in columns]
-        AirflowConsole().print_as_table([{n: f(o) for n, f in getters} for o in iter_next_dagrun_info()])
+        rows = []
+        for info in iter_next_dagrun_info():
+            if info is None:
+                print_no_following_schedule_warning()
+                rows.append({n: None for n, _ in getters})
+            else:
+                rows.append({n: f(info) for n, f in getters})
+        AirflowConsole().print_as_table(rows)
         return
 
     if args.field:
@@ -456,11 +470,7 @@ def dag_next_execution(args) -> None:
 
     for info in iter_next_dagrun_info():
         if info is None:
-            print(
-                "[WARN] No following schedule can be found. "
-                "This DAG may have schedule interval '@once' or `None`.",
-                file=sys.stderr,
-            )
+            print_no_following_schedule_warning()
             print(None)
         else:
             value = getter(info)

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -274,6 +274,35 @@ class TestCliDags:
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)
 
+    def test_next_execution_table_no_following_schedule(self, tmp_path, stdout_capture, stderr_capture):
+        dag_id = "no_schedule_next_execution_table"
+        file_content = os.linesep.join(
+            [
+                "from airflow import DAG",
+                "from airflow.providers.standard.operators.empty import EmptyOperator",
+                "from pendulum import today",
+                f"dag = DAG('{dag_id}', start_date=today(tz='UTC'), schedule=None)",
+                "task = EmptyOperator(task_id='empty_task', dag=dag)",
+            ]
+        )
+        dag_file = tmp_path / f"{dag_id}.py"
+        dag_file.write_text(file_content)
+
+        with time_machine.travel(DEFAULT_DATE):
+            clear_db_dags()
+            parse_and_sync_to_db(tmp_path, include_examples=False)
+
+        args = self.parser.parse_args(["dags", "next-execution", dag_id, "--table"])
+        with stdout_capture as temp_stdout, stderr_capture as temp_stderr:
+            dag_command.dag_next_execution(args)
+
+        assert "logical_date" in temp_stdout.getvalue()
+        assert "None" in temp_stdout.getvalue()
+        assert "No following schedule can be found" in temp_stderr.getvalue()
+
+        clear_db_dags()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
+
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_report(self, stdout_capture):
         args = self.parser.parse_args(["dags", "report", "--output", "json"])


### PR DESCRIPTION
Fixes `airflow dags next-execution --table` when the next Dag run iterator returns `None`.

The table branch now handles the no-following-schedule sentinel before applying attribute getters, matching the warning behavior of the non-table output and rendering a row of `None` values instead of crashing.

closes: #67394

Tests:
- `python -m ruff format --check airflow-core/src/airflow/cli/commands/dag_command.py airflow-core/tests/unit/cli/commands/test_dag_command.py`
- `python -m ruff check airflow-core/src/airflow/cli/commands/dag_command.py airflow-core/tests/unit/cli/commands/test_dag_command.py`
- `python -m pytest airflow-core/tests/unit/cli/commands/test_dag_command.py::TestCliDags::test_next_execution_table_no_following_schedule -q` blocked locally: Windows checkout does not materialize Airflow shared-library symlinks/workspace the same way Breeze does.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Codex

Generated-by: Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)