### PR TITLE
[RFC] Feat(ui): Add Portuguese (Brazil) pt-BR translation + CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@ airflow-core/src/airflow/ui/public/i18n/locales/ko/ @choo121600 # + @onestn @noe
 airflow-core/src/airflow/ui/public/i18n/locales/nl/ @BasPH # + @DjVinnii
 airflow-core/src/airflow/ui/public/i18n/locales/pl/ @potiuk @mobuchowski # + @kacpermuda
 airflow-core/src/airflow/ui/public/i18n/locales/pt/ @potiuk  # + @aoelvp94 @victoru2
-airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/ @potiuk # + @andreahlert
+airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/ @potiuk @jscheffl # + @andreahlert
 airflow-core/src/airflow/ui/public/i18n/locales/ru/ @jscheffl # + @puzzle-rpa-team @renat-sagut
 airflow-core/src/airflow/ui/public/i18n/locales/th/ @potiuk # + @zkan @blackbass64 @lifnaja @Aphinan-Th @chonla @Srabasti
 airflow-core/src/airflow/ui/public/i18n/locales/tr/ @bugraoz93 # +@hasancatalgol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,7 @@ airflow-core/src/airflow/ui/public/i18n/locales/ko/ @choo121600 # + @onestn @noe
 airflow-core/src/airflow/ui/public/i18n/locales/nl/ @BasPH # + @DjVinnii
 airflow-core/src/airflow/ui/public/i18n/locales/pl/ @potiuk @mobuchowski # + @kacpermuda
 airflow-core/src/airflow/ui/public/i18n/locales/pt/ @potiuk  # + @aoelvp94 @victoru2
+airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/ @potiuk # + @andreahlert
 airflow-core/src/airflow/ui/public/i18n/locales/ru/ @jscheffl # + @puzzle-rpa-team @renat-sagut
 airflow-core/src/airflow/ui/public/i18n/locales/th/ @potiuk # + @zkan @blackbass64 @lifnaja @Aphinan-Th @chonla @Srabasti
 airflow-core/src/airflow/ui/public/i18n/locales/tr/ @bugraoz93 # +@hasancatalgol

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -444,6 +444,9 @@ labelPRBasedOnFilePath:
   translation:pt:
     - airflow-core/src/airflow/ui/public/i18n/locales/pt/*
 
+  translation:pt-BR:
+    - airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/*
+
   translation:ru:
     - airflow-core/src/airflow/ui/public/i18n/locales/ru/*
 

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -1,0 +1,180 @@
+{
+  "columns": {
+    "description": "Descrição",
+    "key": "Chave",
+    "name": "Nome",
+    "value": "Valor"
+  },
+  "config": {
+    "columns": {
+      "section": "Secção"
+    },
+    "title": "Configuração do Airflow"
+  },
+  "connections": {
+    "add": "Adicionar Conexão",
+    "columns": {
+      "connectionId": "ID da Conexão",
+      "connectionType": "Tipo de Conexão",
+      "host": "Host",
+      "port": "Porta"
+    },
+    "connection_many": "Conexões",
+    "connection_one": "Conexão",
+    "connection_other": "Conexões",
+    "connection_zero": "Nenhuma conexão",
+    "delete": {
+      "deleteConnection_many": "Excluir {{count}} conexões",
+      "deleteConnection_one": "Excluir 1 conexão",
+      "deleteConnection_other": "Excluir {{count}} conexões",
+      "deleteConnection_zero": "Nenhuma conexão para excluir",
+      "firstConfirmMessage_many": "Você está prestes a excluir as seguintes conexões:",
+      "firstConfirmMessage_one": "Você está prestes a excluir a seguinte conexão:",
+      "firstConfirmMessage_other": "Você está prestes a excluir as seguintes conexões:",
+      "firstConfirmMessage_zero": "Nenhuma conexão para excluir",
+      "title": "Excluir Conexão"
+    },
+    "edit": "Editar Conexão",
+    "form": {
+      "connectionIdRequired": "ID da Conexão é obrigatório",
+      "connectionIdRequirement": "ID da Conexão não pode conter somente espaços",
+      "connectionTypeRequired": "Tipo de Conexão é obrigatório",
+      "extraFields": "Campos Extra",
+      "extraFieldsJson": "Campos Extra JSON",
+      "helperText": "Tipo de conexão faltando? Certifique-se de ter instalado o pacote do provider correspondente ao Airflow.",
+      "helperTextForRedactedFields": "Os campos redigidos ('***') permanecerão inalterados se não forem modificados.",
+      "selectConnectionType": "Selecionar Tipo de Conexão",
+      "standardFields": "Campos Padrão"
+    },
+    "nothingFound": {
+      "description": "Conexões definidas via variáveis de ambiente ou gerenciadores de segredos não estão listadas aqui.",
+      "documentationLink": "Saiba mais na documentação do Airflow.",
+      "learnMore": "Estas são resolvidas em tempo de execução e não são visíveis na interface do usuário.",
+      "title": "Nenhuma conexão encontrada!"
+    },
+    "searchPlaceholder": "Pesquisar Conexões",
+    "test": "Testar Conexão",
+    "testDisabled": "A funcionalidade de teste de conexão está desativada. Por favor, contate um administrador para ativá-la.",
+    "typeMeta": {
+      "error": "Falha ao recuperar Meta do Tipo de Conexão",
+      "standardFields": {
+        "description": "Descrição",
+        "host": "Host",
+        "login": "Login",
+        "password": "Senha",
+        "port": "Porta",
+        "url_schema": "Esquema"
+      }
+    }
+  },
+  "deleteActions": {
+    "button": "Excluir",
+    "modal": {
+      "confirmButton": "Sim, Excluir",
+      "secondConfirmMessage": "Esta ação é permanente e não pode ser desfeita.",
+      "thirdConfirmMessage": "Tem certeza que deseja prosseguir?"
+    },
+    "selected": "Selecionado",
+    "tooltip": "Excluir conexões selecionadas"
+  },
+  "formActions": {
+    "save": "Salvar"
+  },
+  "plugins": {
+    "columns": {
+      "source": "Origem"
+    },
+    "importError_many": "Erros de Importação de Plugins",
+    "importError_one": "Erro de Importação de Plugin",
+    "importError_other": "Erros de Importação de Plugins",
+    "importError_zero": "Nenhum erro de importação de plugin",
+    "searchPlaceholder": "Pesquisar por arquivo"
+  },
+  "pools": {
+    "add": "Adicionar Pool",
+    "deferredSlotsIncluded": "Slots Deferidos Incluídos",
+    "delete": {
+      "title": "Excluir Pool",
+      "warning": "Isso removerá todas as metadados relacionados ao pool e pode afetar as tarefas usando este pool."
+    },
+    "edit": "Editar Pool",
+    "form": {
+      "checkbox": "Marcar para incluir tarefas deferidas ao calcular slots abertos do pool",
+      "description": "Descrição",
+      "includeDeferred": "Incluir Deferidos",
+      "nameMaxLength": "Nome pode conter um máximo de 256 caracteres",
+      "nameRequired": "Nome é obrigatório",
+      "slots": "Slots"
+    },
+    "noPoolsFound": "Nenhum pool encontrado",
+    "pool_many": "Pools",
+    "pool_one": "Pool",
+    "pool_other": "Pools",
+    "pool_zero": "Nenhum pool",
+    "searchPlaceholder": "Pesquisar Pools",
+    "sort": {
+      "asc": "Nome (A-Z)",
+      "desc": "Nome (Z-A)",
+      "placeholder": "Ordenar por"
+    }
+  },
+  "providers": {
+    "columns": {
+      "packageName": "Nome do Pacote",
+      "version": "Versão"
+    }
+  },
+  "variables": {
+    "add": "Adicionar Variável",
+    "columns": {
+      "isEncrypted": "Está Encriptado"
+    },
+    "delete": {
+      "deleteVariable_many": "Excluir {{count}} Variáveis",
+      "deleteVariable_one": "Excluir 1 Variável",
+      "deleteVariable_other": "Excluir {{count}} Variáveis",
+      "deleteVariable_zero": "Nenhuma variável para excluir",
+      "firstConfirmMessage_many": "Você está prestes a excluir as seguintes variáveis:",
+      "firstConfirmMessage_one": "Você está prestes a excluir a seguinte variável:",
+      "firstConfirmMessage_other": "Você está prestes a excluir as seguintes variáveis:",
+      "firstConfirmMessage_zero": "Nenhuma variável para excluir",
+      "title": "Excluir Variável",
+      "tooltip": "Excluir variáveis selecionadas"
+    },
+    "edit": "Editar Variável",
+    "form": {
+      "invalidJson": "JSON Inválido",
+      "keyMaxLength": "Chave pode conter um máximo de 250 caracteres",
+      "keyRequired": "Chave é obrigatória",
+      "valueRequired": "Valor é obrigatório"
+    },
+    "import": {
+      "button": "Importar",
+      "conflictResolution": "Selecionar Resolução de Conflito de Variável",
+      "errorParsingJsonFile": "Erro ao Analisar Arquivo JSON: Upload um arquivo JSON contendo variáveis (exemplo: {\"key\": \"value\", ...}).",
+      "options": {
+        "fail": {
+          "description": "Falha na importação se forem detetadas variáveis que já existem.",
+          "title": "Falha"
+        },
+        "overwrite": {
+          "description": "Sobreescreve a variável em caso de conflito.",
+          "title": "Sobreescrever"
+        },
+        "skip": {
+          "description": "Ignora a importação de variáveis que já existem.",
+          "title": "Ignorar"
+        }
+      },
+      "title": "Importar Variáveis",
+      "upload": "Upload um Arquivo JSON",
+      "uploadPlaceholder": "Upload um arquivo JSON contendo variáveis (exemplo: {\"key\": \"value\", ...})"
+    },
+    "noRowsMessage": "Nenhuma variável encontrada",
+    "searchPlaceholder": "Pesquisar Chaves",
+    "variable_many": "Variáveis",
+    "variable_one": "Variável",
+    "variable_other": "Variáveis",
+    "variable_zero": "Nenhuma variável"
+  }
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -3,6 +3,7 @@
     "description": "Descrição",
     "key": "Chave",
     "name": "Nome",
+    "team": "Equipe",
     "value": "Valor"
   },
   "config": {
@@ -55,6 +56,12 @@
     "searchPlaceholder": "Pesquisar Conexões",
     "test": "Testar Conexão",
     "testDisabled": "A funcionalidade de teste de conexão está desativada. Por favor, contate um administrador para ativá-la.",
+    "testError": {
+      "title": "Falha no teste da conexão"
+    },
+    "testSuccess": {
+      "title": "Conexão testada com sucesso"
+    },
     "typeMeta": {
       "error": "Falha ao recuperar Meta do Tipo de Conexão",
       "standardFields": {
@@ -79,6 +86,23 @@
   },
   "formActions": {
     "save": "Salvar"
+  },
+  "jobs": {
+    "columns": {
+      "executorClass": "Classe do executor",
+      "hostname": "Nome do host",
+      "id": "ID",
+      "jobType": "Tipo de job",
+      "latestHeartbeat": "Último heartbeat",
+      "unixname": "Nome Unix"
+    },
+    "filters": {
+      "allStates": "Todos os estados",
+      "allTypes": "Todos os tipos",
+      "dagProcessorJob": "DagProcessorJob",
+      "schedulerJob": "SchedulerJob",
+      "triggererJob": "TriggererJob"
+    }
   },
   "plugins": {
     "columns": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -20,19 +20,13 @@
       "host": "Host",
       "port": "Porta"
     },
-    "connection_many": "Conexões",
     "connection_one": "Conexão",
     "connection_other": "Conexões",
-    "connection_zero": "Nenhuma conexão",
     "delete": {
-      "deleteConnection_many": "Excluir {{count}} conexões",
       "deleteConnection_one": "Excluir 1 conexão",
       "deleteConnection_other": "Excluir {{count}} conexões",
-      "deleteConnection_zero": "Nenhuma conexão para excluir",
-      "firstConfirmMessage_many": "Você está prestes a excluir as seguintes conexões:",
       "firstConfirmMessage_one": "Você está prestes a excluir a seguinte conexão:",
       "firstConfirmMessage_other": "Você está prestes a excluir as seguintes conexões:",
-      "firstConfirmMessage_zero": "Nenhuma conexão para excluir",
       "title": "Excluir Conexão"
     },
     "edit": "Editar Conexão",
@@ -108,10 +102,8 @@
     "columns": {
       "source": "Origem"
     },
-    "importError_many": "Erros de Importação de Plugins",
     "importError_one": "Erro de Importação de Plugin",
     "importError_other": "Erros de Importação de Plugins",
-    "importError_zero": "Nenhum erro de importação de plugin",
     "searchPlaceholder": "Pesquisar por arquivo"
   },
   "pools": {
@@ -128,13 +120,12 @@
       "includeDeferred": "Incluir Deferidos",
       "nameMaxLength": "Nome pode conter um máximo de 256 caracteres",
       "nameRequired": "Nome é obrigatório",
-      "slots": "Slots"
+      "slots": "Slots",
+      "slotsHelperText": "Use -1 para slots ilimitados."
     },
     "noPoolsFound": "Nenhum pool encontrado",
-    "pool_many": "Pools",
     "pool_one": "Pool",
     "pool_other": "Pools",
-    "pool_zero": "Nenhum pool",
     "searchPlaceholder": "Pesquisar Pools",
     "sort": {
       "asc": "Nome (A-Z)",
@@ -154,14 +145,10 @@
       "isEncrypted": "Está Encriptado"
     },
     "delete": {
-      "deleteVariable_many": "Excluir {{count}} Variáveis",
       "deleteVariable_one": "Excluir 1 Variável",
       "deleteVariable_other": "Excluir {{count}} Variáveis",
-      "deleteVariable_zero": "Nenhuma variável para excluir",
-      "firstConfirmMessage_many": "Você está prestes a excluir as seguintes variáveis:",
       "firstConfirmMessage_one": "Você está prestes a excluir a seguinte variável:",
       "firstConfirmMessage_other": "Você está prestes a excluir as seguintes variáveis:",
-      "firstConfirmMessage_zero": "Nenhuma variável para excluir",
       "title": "Excluir Variável",
       "tooltip": "Excluir variáveis selecionadas"
     },
@@ -196,9 +183,7 @@
     },
     "noRowsMessage": "Nenhuma variável encontrada",
     "searchPlaceholder": "Pesquisar Chaves",
-    "variable_many": "Variáveis",
     "variable_one": "Variável",
-    "variable_other": "Variáveis",
-    "variable_zero": "Nenhuma variável"
+    "variable_other": "Variáveis"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -8,7 +8,7 @@
   },
   "config": {
     "columns": {
-      "section": "Secção"
+      "section": "Seção"
     },
     "title": "Configuração do Airflow"
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -165,7 +165,7 @@
       "errorParsingJsonFile": "Erro ao Analisar Arquivo JSON: Upload um arquivo JSON contendo variáveis (exemplo: {\"key\": \"value\", ...}).",
       "options": {
         "fail": {
-          "description": "Falha na importação se forem detetadas variáveis que já existem.",
+          "description": "Falha na importação se forem detectadas variáveis que já existem.",
           "title": "Falha"
         },
         "overwrite": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -43,7 +43,7 @@
     },
     "nothingFound": {
       "description": "Conexões definidas via variáveis de ambiente ou gerenciadores de segredos não estão listadas aqui.",
-      "documentationLink": "Saiba mais na documentação do Airflow.",
+      "documentationLink": "Consulte a documentação do Airflow para saber mais.",
       "learnMore": "Estas são resolvidas em tempo de execução e não são visíveis na interface do usuário.",
       "title": "Nenhuma conexão encontrada!"
     },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -35,7 +35,7 @@
       "connectionIdRequirement": "ID da Conexão não pode conter somente espaços",
       "connectionTypeRequired": "Tipo de Conexão é obrigatório",
       "extraFields": "Campos Extras",
-      "extraFieldsJson": "Campos Extra JSON",
+      "extraFieldsJson": "Campos Extras JSON",
       "helperText": "Tipo de conexão faltando? Certifique-se de ter instalado o pacote do provider correspondente ao Airflow.",
       "helperTextForRedactedFields": "Os campos redigidos ('***') permanecerão inalterados se não forem modificados.",
       "selectConnectionType": "Selecionar Tipo de Conexão",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -155,7 +155,7 @@
     "edit": "Editar Variável",
     "form": {
       "invalidJson": "JSON Inválido",
-      "keyMaxLength": "Chave pode conter um máximo de 250 caracteres",
+      "keyMaxLength": "Chave pode conter no máximo 250 caracteres",
       "keyRequired": "Chave é obrigatória",
       "valueRequired": "Valor é obrigatório"
     },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -57,7 +57,7 @@
       "title": "Conexão testada com sucesso"
     },
     "typeMeta": {
-      "error": "Falha ao recuperar Meta do Tipo de Conexão",
+      "error": "Erro ao recuperar os metadados do tipo de conexão",
       "standardFields": {
         "description": "Descrição",
         "host": "Host",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/admin.json
@@ -34,7 +34,7 @@
       "connectionIdRequired": "ID da Conexão é obrigatório",
       "connectionIdRequirement": "ID da Conexão não pode conter somente espaços",
       "connectionTypeRequired": "Tipo de Conexão é obrigatório",
-      "extraFields": "Campos Extra",
+      "extraFields": "Campos Extras",
       "extraFieldsJson": "Campos Extra JSON",
       "helperText": "Tipo de conexão faltando? Certifique-se de ter instalado o pacote do provider correspondente ao Airflow.",
       "helperTextForRedactedFields": "Os campos redigidos ('***') permanecerão inalterados se não forem modificados.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
@@ -1,0 +1,30 @@
+{
+  "consumingDags": "Consumindo Dags",
+  "createEvent": {
+    "button": "Criar Evento",
+    "manual": {
+      "description": "Manualmente criar um Evento de Asset",
+      "extra": "Evento de Asset Extra",
+      "label": "Manual"
+    },
+    "materialize": {
+      "description": "Ativar o Dag acima deste Asset",
+      "descriptionWithDag": "Ativar o Dag acima deste Asset: {{dagName}}",
+      "label": "Materializar",
+      "unpauseDag": "Despausar {{dagName}} ao ativar"
+    },
+    "success": {
+      "manualDescription": "Criação de evento de Asset manual foi bem-sucedida.",
+      "manualTitle": "Evento de Asset Criado",
+      "materializeDescription": "Dag acima {{dagId}} foi ativado com sucesso.",
+      "materializeTitle": "Materializando Asset"
+    },
+    "title": "Criar Evento de Asset para {{name}}"
+  },
+  "group": "Grupo",
+  "lastAssetEvent": "Último Evento de Asset",
+  "name": "Nome",
+  "producingTasks": "Produzindo Tarefas",
+  "scheduledDags": "Dags Programados",
+  "searchPlaceholder": "Pesquisar Assets"
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
@@ -2,8 +2,6 @@
   "additional_data": "Dados adicionais",
   "asset_many": "Asset",
   "asset_one": "Asset",
-  "asset_other": "Asset",
-  "asset_zero": "Asset",
   "consumingDags": "Consumindo Dags",
   "consumingTasks": "Tarefas consumidoras",
   "createEvent": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
@@ -1,5 +1,11 @@
 {
+  "additional_data": "Dados adicionais",
+  "asset_many": "Asset",
+  "asset_one": "Asset",
+  "asset_other": "Asset",
+  "asset_zero": "Asset",
   "consumingDags": "Consumindo Dags",
+  "consumingTasks": "Tarefas consumidoras",
   "createEvent": {
     "button": "Criar Evento",
     "manual": {
@@ -21,10 +27,13 @@
     },
     "title": "Criar Evento de Asset para {{name}}"
   },
+  "extra": "Extra",
   "group": "Grupo",
   "lastAssetEvent": "Último Evento de Asset",
   "name": "Nome",
   "producingTasks": "Produzindo Tarefas",
   "scheduledDags": "Dags Programados",
-  "searchPlaceholder": "Pesquisar Assets"
+  "scheduling": "Agendamento",
+  "searchPlaceholder": "Pesquisar Assets",
+  "taskDependencies": "Dependências de tarefa"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/assets.json
@@ -1,7 +1,7 @@
 {
   "additional_data": "Dados adicionais",
-  "asset_many": "Asset",
-  "asset_one": "Asset",
+  "asset_many": "Ativos",
+  "asset_one": "Ativo",
   "consumingDags": "Consumindo Dags",
   "consumingTasks": "Tarefas consumidoras",
   "createEvent": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/browse.json
@@ -1,0 +1,22 @@
+{
+  "auditLog": {
+    "columns": {
+      "event": "Evento",
+      "extra": "Extra",
+      "user": "Usuário",
+      "when": "Quando"
+    },
+    "filters": {
+      "eventType": "Tipo de Evento"
+    },
+    "title": "Log de Auditoria"
+  },
+  "xcom": {
+    "columns": {
+      "dag": "Dag",
+      "key": "Chave",
+      "value": "Valor"
+    },
+    "title": "XCom"
+  }
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/browse.json
@@ -12,11 +12,35 @@
     "title": "Log de Auditoria"
   },
   "xcom": {
+    "add": {
+      "error": "Falha ao adicionar XCom",
+      "errorTitle": "Erro",
+      "success": "XCom adicionado com sucesso",
+      "successTitle": "XCom adicionado",
+      "title": "Adicionar XCom"
+    },
     "columns": {
       "dag": "Dag",
       "key": "Chave",
       "value": "Valor"
     },
-    "title": "XCom"
+    "delete": {
+      "error": "Falha ao excluir XCom",
+      "errorTitle": "Erro",
+      "success": "XCom excluído com sucesso",
+      "successTitle": "XCom excluído",
+      "title": "Excluir XCom",
+      "warning": "Tem certeza de que deseja excluir este XCom? Esta ação não pode ser desfeita."
+    },
+    "edit": {
+      "error": "Falha ao atualizar XCom",
+      "errorTitle": "Erro",
+      "success": "XCom atualizado com sucesso",
+      "successTitle": "XCom atualizado",
+      "title": "Editar XCom"
+    },
+    "key": "Chave",
+    "title": "XCom",
+    "value": "Valor"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -1,0 +1,347 @@
+{
+  "admin": {
+    "Config": "Configuração",
+    "Connections": "Conexões",
+    "Plugins": "Plugins",
+    "Pools": "Pools",
+    "Providers": "Providers",
+    "Variables": "Variáveis"
+  },
+  "allOperators": "Todos os Operadores",
+  "appearance": {
+    "appearance": "Aparência",
+    "darkMode": "Modo Escuro",
+    "lightMode": "Modo Claro",
+    "systemMode": "Seguir Configuração do Sistema"
+  },
+  "asset_many": "Assets",
+  "asset_one": "Asset",
+  "asset_other": "Assets",
+  "asset_zero": "Nenhum asset",
+  "assetEvent_many": "Eventos de Asset",
+  "assetEvent_one": "Evento de Asset",
+  "assetEvent_other": "Eventos de Asset",
+  "assetEvent_zero": "Nenhum evento de asset",
+  "backfill_many": "Backfills",
+  "backfill_one": "Backfill",
+  "backfill_other": "Backfills",
+  "backfill_zero": "Nenhum backfill",
+  "browse": {
+    "auditLog": "Log de Auditoria",
+    "requiredActions": "Ações Necessárias",
+    "xcoms": "XComs"
+  },
+  "collapseAllExtra": "Recolher todos os extra json",
+  "collapseDetailsPanel": "Recolher Painel de Detalhes",
+  "createdAssetEvent_many": "Eventos de Asset Criados",
+  "createdAssetEvent_one": "Evento de Asset Criado",
+  "createdAssetEvent_other": "Eventos de Asset Criados",
+  "createdAssetEvent_zero": "Nenhum evento de asset criado",
+  "dag_many": "Dags",
+  "dag_one": "Dag",
+  "dag_other": "Dags",
+  "dag_zero": "Nenhum Dag",
+  "dagDetails": {
+    "catchup": "Catchup",
+    "dagRunTimeout": "Tempo Limite da Execução do Dag",
+    "defaultArgs": "Argumentos Padrão",
+    "description": "Descrição",
+    "documentation": "Documentação do Dag",
+    "fileLocation": "Local do Arquivo",
+    "hasTaskConcurrencyLimits": "Tem Limite de Concorrência de Tarefas",
+    "lastExpired": "Último Expirado",
+    "lastParseDuration": "Duração do Último Parse",
+    "lastParsed": "Último Parseado",
+    "latestDagVersion": "Última Versão do Dag",
+    "latestRun": "Última Execução",
+    "maxActiveRuns": "Máximo de Execuções Ativas",
+    "maxActiveTasks": "Máximo de Tarefas Ativas",
+    "maxConsecutiveFailedDagRuns": "Máximo de Execuções Consecutivas Falhadas",
+    "nextRun": "Próxima Execução",
+    "owner": "Proprietário",
+    "params": "Parâmetros",
+    "schedule": "Agendamento",
+    "tags": "Etiquetas"
+  },
+  "dagId": "ID do Dag",
+  "dagRun": {
+    "conf": "Conf",
+    "dagVersions": "Versão(s) do Dag",
+    "dataIntervalEnd": "Fim do Intervalo de Dados",
+    "dataIntervalStart": "Início do Intervalo de Dados",
+    "lastSchedulingDecision": "Última Decisão de Agendamento",
+    "queuedAt": "Enfileirado Em",
+    "runAfter": "Executar Depois",
+    "runType": "Tipo de Execução",
+    "sourceAssetEvent": "Evento de Asset de Origem",
+    "triggeredBy": "Acionado por",
+    "triggeringUser": "Nome do Usuário que Disparou"
+  },
+  "dagRun_many": "Execuções do Dag",
+  "dagRun_one": "Execução do Dag",
+  "dagRun_other": "Execuções do Dag",
+  "dagRun_zero": "Nenhuma execução do Dag",
+  "dagRunId": "ID da Execução do Dag",
+  "dagWarnings": "Avisos/Erros do Dag",
+  "defaultToGraphView": "Padrão para visualização gráfica",
+  "defaultToGridView": "Padrão para visualização em grade",
+  "direction": "Direção",
+  "docs": {
+    "documentation": "Documentação",
+    "githubRepo": "Repositório GitHub",
+    "restApiReference": "Referência da API REST"
+  },
+  "download": {
+    "download": "Baixar",
+    "hotkey": "d",
+    "tooltip": "Pressione {{hotkey}} para baixar os logs"
+  },
+  "duration": "Duração",
+  "endDate": "Data Final",
+  "error": {
+    "back": "Voltar",
+    "defaultMessage": "Ocorreu um erro inesperado",
+    "home": "Início",
+    "notFound": "Página Não Encontrada",
+    "title": "Erro"
+  },
+  "expand": {
+    "collapse": "Recolher",
+    "expand": "Expandir",
+    "hotkey": "Pressione {{hotkey}} para expandir ou recolher",
+    "tooltip": "Pressione {{hotkey}} para expandir ou recolher a secção"
+  },
+  "expandAllExtra": "Expandir todos os extra json",
+  "expression": {
+    "all": "Todos",
+    "and": "E",
+    "any": "Qualquer",
+    "or": "OU"
+  },
+  "filter": "Filtro",
+  "filters": {
+    "durationFrom": "Duração De",
+    "durationTo": "Duração Até",
+    "logicalDateFrom": "Data Lógica De",
+    "logicalDateTo": "Data Lógica Para",
+    "runAfterFrom": "Executar Depois De",
+    "runAfterTo": "Executar Depois Para"
+  },
+  "logicalDate": "Data Lógica",
+  "logout": "Sair",
+  "logoutConfirmation": "Você está prestes a sair do aplicativo.",
+  "mapIndex": "Índice do Mapa",
+  "modal": {
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "delete": {
+      "button": "Excluir",
+      "confirmation": "Tem certeza que deseja excluir {{resourceName}}? Esta ação não pode ser desfeita."
+    }
+  },
+  "nav": {
+    "admin": "Administração",
+    "assets": "Assets",
+    "browse": "Navegar",
+    "dags": "Dags",
+    "docs": "Documentação",
+    "home": "Início",
+    "legacyFabViews": "Visualizações Legacy FAB",
+    "plugins": "Plugins",
+    "security": "Segurança"
+  },
+  "noItemsFound": "Nenhum {{modelName}} encontrado",
+  "note": {
+    "add": "Adicionar uma nota",
+    "dagRun": "Nota da Execução do Dag",
+    "label": "Nota",
+    "placeholder": "Adicionar uma nota...",
+    "taskInstance": "Nota da Instância de Tarefa"
+  },
+  "pools": {
+    "deferred": "Deferido",
+    "open": "Aberto",
+    "pools_many": "pools",
+    "pools_one": "pool",
+    "pools_other": "pools",
+    "pools_zero": "nenhum pool",
+    "queued": "Enfileirado",
+    "running": "Executando",
+    "scheduled": "Agendado"
+  },
+  "reset": "Resetar",
+  "runId": "ID da Execução",
+  "runTypes": {
+    "asset_triggered": "Asset Acionado",
+    "backfill": "Backfill",
+    "manual": "Manual",
+    "scheduled": "Agendado"
+  },
+  "scroll": {
+    "direction": {
+      "bottom": "Inferior",
+      "top": "Superior"
+    },
+    "tooltip": "Pressione {{hotkey}} para rolar para {{direction}}"
+  },
+  "security": {
+    "actions": "Ações",
+    "permissions": "Permissões",
+    "resources": "Recursos",
+    "roles": "Funções",
+    "users": "Usuários"
+  },
+  "selectLanguage": "Selecionar Idioma",
+  "showDetailsPanel": "Mostrar Painel de Detalhes",
+  "source": {
+    "hide": "Ocultar",
+    "hotkey": "Pressione {{hotkey}} para ocultar/mostrar",
+    "show": "Mostrar"
+  },
+  "sourceAssetEvent_many": "Eventos de Asset de Origem",
+  "sourceAssetEvent_one": "Evento de Asset de Origem",
+  "sourceAssetEvent_other": "Eventos de Asset de Origem",
+  "sourceAssetEvent_zero": "Nenhum evento de asset de origem",
+  "startDate": "Data Inicial",
+  "state": "Estado",
+  "states": {
+    "deferred": "Deferido",
+    "failed": "Falha",
+    "no_status": "Sem Status",
+    "none": "Sem Status",
+    "planned": "Planejado",
+    "queued": "Enfileirado",
+    "removed": "Removido",
+    "restarting": "Reiniciando",
+    "running": "Executando",
+    "scheduled": "Agendado",
+    "skipped": "Pulado",
+    "success": "Sucesso",
+    "up_for_reschedule": "Pronto para reagendar",
+    "up_for_retry": "Pronto para tentar novamente",
+    "upstream_failed": "Falha no upstream"
+  },
+  "table": {
+    "completedAt": "Concluído em",
+    "createdAt": "Criado em",
+    "filterByTag": "Filtrar Dags por tag",
+    "filterColumns": "Filtrar colunas da tabela",
+    "filterReset_many": "Resetar filtros",
+    "filterReset_one": "Resetar filtro",
+    "filterReset_other": "Resetar filtros",
+    "filterReset_zero": "Nenhum filtro para resetar",
+    "from": "De",
+    "maxActiveRuns": "Máximo de Execuções Ativas",
+    "noTagsFound": "Nenhuma tag encontrada",
+    "tagMode": {
+      "all": "Todos",
+      "any": "Qualquer"
+    },
+    "tagPlaceholder": "Filtrar por tag",
+    "to": "Para"
+  },
+  "task": {
+    "documentation": "Documentação da Tarefa",
+    "lastInstance": "Última Instância",
+    "operator": "Operador",
+    "triggerRule": "Regra de Trigger"
+  },
+  "task_many": "Tarefas",
+  "task_one": "Tarefa",
+  "task_other": "Tarefas",
+  "task_zero": "Nenhuma tarefa",
+  "taskGroup": "Grupo de Tarefas",
+  "taskId": "ID da Tarefa",
+  "taskInstance": {
+    "dagVersion": "Versão do Dag",
+    "executor": "Executor",
+    "executorConfig": "Configuração do Executor",
+    "hostname": "Hostname",
+    "maxTries": "Máximo de Tentativas",
+    "pid": "PID",
+    "pool": "Pool",
+    "poolSlots": "Slots do Pool",
+    "priorityWeight": "Prioridade",
+    "queue": "Fila",
+    "queuedWhen": "Enfileirado em",
+    "scheduledWhen": "Agendado em",
+    "triggerer": {
+      "assigned": "Triggerer atribuído",
+      "class": "Classe do Trigger",
+      "createdAt": "Tempo de criação do Trigger",
+      "id": "ID do Trigger",
+      "latestHeartbeat": "Último heartbeat do Trigger",
+      "title": "Informações do Trigger"
+    },
+    "unixname": "Nome do Unix"
+  },
+  "taskInstance_many": "Instâncias de Tarefa",
+  "taskInstance_one": "Instância de Tarefa",
+  "taskInstance_other": "Instâncias de Tarefa",
+  "taskInstance_zero": "Nenhuma instância de tarefa",
+  "timeRange": {
+    "last12Hours": "Últimas 12 Horas",
+    "last24Hours": "Últimas 24 Horas",
+    "lastHour": "Última Hora",
+    "pastWeek": "Semana Passada"
+  },
+  "timestamp": {
+    "hide": "Ocultar",
+    "hotkey": "Pressione {{hotkey}} para ocultar/mostrar",
+    "show": "Mostrar"
+  },
+  "timezone": "Fuso Horário",
+  "timezoneModal": {
+    "current-timezone": "Hora atual em",
+    "placeholder": "Selecionar um fuso horário",
+    "title": "Selecionar Fuso Horário",
+    "utc": "UTC (Tempo Universal Coordenado)"
+  },
+  "toaster": {
+    "bulkDelete": {
+      "error": "Exclusão em Massa de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}",
+        "title": "Exclusão em Massa de {{resourceName}} Submetida"
+      }
+    },
+    "create": {
+      "error": "Criação de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{resourceName}} foi criado com sucesso.",
+        "title": "Criação de {{resourceName}} Submetida"
+      }
+    },
+    "delete": {
+      "error": "Exclusão de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{resourceName}} foi excluído com sucesso.",
+        "title": "Exclusão de {{resourceName}} Submetida"
+      }
+    },
+    "import": {
+      "error": "Importação de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{count}} {{resourceName}} foram importados com sucesso.",
+        "title": "Importação de {{resourceName}} Submetida"
+      }
+    },
+    "update": {
+      "error": "Atualização de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{resourceName}} foi atualizado com sucesso.",
+        "title": "Atualização de {{resourceName}} Submetida"
+      }
+    }
+  },
+  "total": "Total {{state}}",
+  "triggered": "Acionado",
+  "tryNumber": "Número de Tentativas",
+  "user": "Usuário",
+  "wrap": {
+    "hotkey": "Pressione {{hotkey}} para expandir ou recolher",
+    "tooltip": "Pressione {{hotkey}} para expandir ou recolher a secção",
+    "unwrap": "Expandir",
+    "wrap": "Recolher"
+  }
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -14,18 +14,12 @@
     "lightMode": "Modo Claro",
     "systemMode": "Seguir Configuração do Sistema"
   },
-  "asset_many": "Assets",
   "asset_one": "Asset",
   "asset_other": "Assets",
-  "asset_zero": "Nenhum asset",
-  "assetEvent_many": "Eventos de Asset",
   "assetEvent_one": "Evento de Asset",
   "assetEvent_other": "Eventos de Asset",
-  "assetEvent_zero": "Nenhum evento de asset",
-  "backfill_many": "Backfills",
   "backfill_one": "Backfill",
   "backfill_other": "Backfills",
-  "backfill_zero": "Nenhum backfill",
   "browse": {
     "auditLog": "Log de Auditoria",
     "jobs": "Jobs",
@@ -34,14 +28,10 @@
   },
   "collapseAllExtra": "Recolher todos os extra json",
   "collapseDetailsPanel": "Recolher Painel de Detalhes",
-  "createdAssetEvent_many": "Eventos de Asset Criados",
   "createdAssetEvent_one": "Evento de Asset Criado",
   "createdAssetEvent_other": "Eventos de Asset Criados",
-  "createdAssetEvent_zero": "Nenhum evento de asset criado",
-  "dag_many": "Dags",
   "dag_one": "Dag",
   "dag_other": "Dags",
-  "dag_zero": "Nenhum Dag",
   "dagDetails": {
     "catchup": "Catchup",
     "dagRunTimeout": "Tempo Limite da Execução do Dag",
@@ -80,10 +70,8 @@
     "triggeredBy": "Acionado por",
     "triggeringUser": "Nome do Usuário que Disparou"
   },
-  "dagRun_many": "Execuções do Dag",
   "dagRun_one": "Execução do Dag",
   "dagRun_other": "Execuções do Dag",
-  "dagRun_zero": "Nenhuma execução do Dag",
   "dagRunId": "ID da Execução do Dag",
   "dagWarnings": "Avisos/Erros do Dag",
   "defaultToGraphView": "Padrão para visualização gráfica",
@@ -173,24 +161,18 @@
     "placeholder": "Adicionar uma nota...",
     "taskInstance": "Nota da Instância de Tarefa"
   },
-  "partitionedDagRun_many": "Execuções particionadas do DAG",
   "partitionedDagRun_one": "Execução particionada do DAG",
   "partitionedDagRun_other": "Execuções particionadas do DAG",
-  "partitionedDagRun_zero": "Nenhuma execução particionada do DAG",
   "partitionedDagRunDetail": {
     "receivedAssetEvents": "Eventos de asset recebidos"
   },
-  "pendingDagRun_many": "{{count}} execuções do DAG pendentes",
   "pendingDagRun_one": "{{count}} execução do DAG pendente",
   "pendingDagRun_other": "{{count}} execuções do DAG pendentes",
-  "pendingDagRun_zero": "Nenhuma execução do DAG pendente",
   "pools": {
     "deferred": "Deferido",
     "open": "Aberto",
-    "pools_many": "pools",
     "pools_one": "pool",
     "pools_other": "pools",
-    "pools_zero": "nenhum pool",
     "queued": "Enfileirado",
     "running": "Executando",
     "scheduled": "Agendado"
@@ -201,7 +183,8 @@
     "asset_triggered": "Asset Acionado",
     "backfill": "Backfill",
     "manual": "Manual",
-    "scheduled": "Agendado"
+    "scheduled": "Agendado",
+    "asset_materialization": "Materialização de Asset"
   },
   "scroll": {
     "direction": {
@@ -225,10 +208,8 @@
     "hotkey": "Pressione {{hotkey}} para ocultar/mostrar",
     "show": "Mostrar"
   },
-  "sourceAssetEvent_many": "Eventos de Asset de Origem",
   "sourceAssetEvent_one": "Evento de Asset de Origem",
   "sourceAssetEvent_other": "Eventos de Asset de Origem",
-  "sourceAssetEvent_zero": "Nenhum evento de asset de origem",
   "startDate": "Data Inicial",
   "state": "Estado",
   "states": {
@@ -254,10 +235,8 @@
     "createdAt": "Criado em",
     "filterByTag": "Filtrar Dags por tag",
     "filterColumns": "Filtrar colunas da tabela",
-    "filterReset_many": "Resetar filtros",
     "filterReset_one": "Resetar filtro",
     "filterReset_other": "Resetar filtros",
-    "filterReset_zero": "Nenhum filtro para resetar",
     "from": "De",
     "maxActiveRuns": "Máximo de Execuções Ativas",
     "noTagsFound": "Nenhuma tag encontrada",
@@ -274,10 +253,8 @@
     "operator": "Operador",
     "triggerRule": "Regra de Trigger"
   },
-  "task_many": "Tarefas",
   "task_one": "Tarefa",
   "task_other": "Tarefas",
-  "task_zero": "Nenhuma tarefa",
   "taskGroup": "Grupo de Tarefas",
   "taskId": "ID da Tarefa",
   "taskInstance": {
@@ -303,10 +280,8 @@
     },
     "unixname": "Nome do Unix"
   },
-  "taskInstance_many": "Instâncias de Tarefa",
   "taskInstance_one": "Instância de Tarefa",
   "taskInstance_other": "Instâncias de Tarefa",
-  "taskInstance_zero": "Nenhuma instância de tarefa",
   "timeRange": {
     "last12Hours": "Últimas 12 Horas",
     "last24Hours": "Últimas 24 Horas",
@@ -360,6 +335,10 @@
         "description": "{{resourceName}} foi atualizado com sucesso.",
         "title": "Atualização de {{resourceName}} Submetida"
       }
+    },
+    "forbidden": {
+      "title": "Acesso Negado",
+      "description": "Você não tem permissão para realizar esta ação."
     }
   },
   "total": "Total {{state}}",
@@ -371,5 +350,18 @@
     "tooltip": "Pressione {{hotkey}} para expandir ou recolher a secção",
     "unwrap": "Expandir",
     "wrap": "Recolher"
+  },
+  "generateToken": "Gerar Token",
+  "tokenGeneration": {
+    "title": "Gerar Token",
+    "apiToken": "Token de API",
+    "cliToken": "Token CLI",
+    "generate": "Gerar",
+    "selectType": "Selecione o tipo de token a ser gerado.",
+    "tokenGenerated": "Seu token foi gerado.",
+    "tokenShownOnce": "Este token será exibido apenas uma vez. Copie-o agora.",
+    "tokenExpiresIn": "Este token expira em {{duration}}.",
+    "errorTitle": "Falha na Geração do Token",
+    "errorDescription": "Ocorreu um erro ao gerar o token. Por favor, tente novamente."
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -28,6 +28,7 @@
   "backfill_zero": "Nenhum backfill",
   "browse": {
     "auditLog": "Log de Auditoria",
+    "jobs": "Jobs",
     "requiredActions": "Ações Necessárias",
     "xcoms": "XComs"
   },
@@ -70,6 +71,8 @@
     "dataIntervalEnd": "Fim do Intervalo de Dados",
     "dataIntervalStart": "Início do Intervalo de Dados",
     "lastSchedulingDecision": "Última Decisão de Agendamento",
+    "mappedPartitionKey": "Chave de partição mapeada",
+    "partitionKey": "Chave de partição",
     "queuedAt": "Enfileirado Em",
     "runAfter": "Executar Depois",
     "runType": "Tipo de Execução",
@@ -85,6 +88,11 @@
   "dagWarnings": "Avisos/Erros do Dag",
   "defaultToGraphView": "Padrão para visualização gráfica",
   "defaultToGridView": "Padrão para visualização em grade",
+  "delete": "Excluir",
+  "diff": "Diff",
+  "diffCompareWith": "Comparar com",
+  "diffExit": "Sair do diff",
+  "diffSelectVersionToCompare": "Selecionar versão para comparar",
   "direction": "Direção",
   "docs": {
     "documentation": "Documentação",
@@ -97,11 +105,13 @@
     "tooltip": "Pressione {{hotkey}} para baixar os logs"
   },
   "duration": "Duração",
+  "edit": "Editar",
   "endDate": "Data Final",
   "error": {
     "back": "Voltar",
     "defaultMessage": "Ocorreu um erro inesperado",
     "home": "Início",
+    "invalidUrl": "Página não encontrada. Verifique a URL e tente novamente.",
     "notFound": "Página Não Encontrada",
     "title": "Erro"
   },
@@ -122,22 +132,27 @@
   "filters": {
     "durationFrom": "Duração De",
     "durationTo": "Duração Até",
+    "endTime": "Hora de término",
     "logicalDateFrom": "Data Lógica De",
     "logicalDateTo": "Data Lógica Para",
     "runAfterFrom": "Executar Depois De",
-    "runAfterTo": "Executar Depois Para"
+    "runAfterTo": "Executar Depois Para",
+    "selectDateRange": "Selecionar intervalo de datas",
+    "startTime": "Hora de início"
   },
   "logicalDate": "Data Lógica",
   "logout": "Sair",
   "logoutConfirmation": "Você está prestes a sair do aplicativo.",
   "mapIndex": "Índice do Mapa",
   "modal": {
+    "add": "Adicionar",
     "cancel": "Cancelar",
     "confirm": "Confirmar",
     "delete": {
       "button": "Excluir",
       "confirmation": "Tem certeza que deseja excluir {{resourceName}}? Esta ação não pode ser desfeita."
-    }
+    },
+    "save": "Salvar"
   },
   "nav": {
     "admin": "Administração",
@@ -158,6 +173,17 @@
     "placeholder": "Adicionar uma nota...",
     "taskInstance": "Nota da Instância de Tarefa"
   },
+  "partitionedDagRun_many": "Execuções particionadas do DAG",
+  "partitionedDagRun_one": "Execução particionada do DAG",
+  "partitionedDagRun_other": "Execuções particionadas do DAG",
+  "partitionedDagRun_zero": "Nenhuma execução particionada do DAG",
+  "partitionedDagRunDetail": {
+    "receivedAssetEvents": "Eventos de asset recebidos"
+  },
+  "pendingDagRun_many": "{{count}} execuções do DAG pendentes",
+  "pendingDagRun_one": "{{count}} execução do DAG pendente",
+  "pendingDagRun_other": "{{count}} execuções do DAG pendentes",
+  "pendingDagRun_zero": "Nenhuma execução do DAG pendente",
   "pools": {
     "deferred": "Deferido",
     "open": "Aberto",
@@ -193,6 +219,7 @@
   },
   "selectLanguage": "Selecionar Idioma",
   "showDetailsPanel": "Mostrar Painel de Detalhes",
+  "signedInAs": "Conectado como",
   "source": {
     "hide": "Ocultar",
     "hotkey": "Pressione {{hotkey}} para ocultar/mostrar",
@@ -209,6 +236,7 @@
     "failed": "Falha",
     "no_status": "Sem Status",
     "none": "Sem Status",
+    "open": "Aberto",
     "planned": "Planejado",
     "queued": "Enfileirado",
     "removed": "Removido",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -68,7 +68,12 @@
     "runType": "Tipo de Execução",
     "sourceAssetEvent": "Evento de Asset de Origem",
     "triggeredBy": "Acionado por",
-    "triggeringUser": "Nome do Usuário que Disparou"
+    "triggeringUser": "Nome do Usuário que Disparou",
+    "durationStats": {
+      "mean": "Média",
+      "mode": "Moda"
+    },
+    "expectedDuration": "Duração Esperada"
   },
   "dagRun_one": "Execução do Dag",
   "dagRun_other": "Execuções do Dag",
@@ -126,7 +131,8 @@
     "runAfterFrom": "Executar Depois De",
     "runAfterTo": "Executar Depois Para",
     "selectDateRange": "Selecionar intervalo de datas",
-    "startTime": "Hora de início"
+    "startTime": "Hora de início",
+    "searchAsset": "Buscar Asset"
   },
   "generateToken": "Gerar Token",
   "logicalDate": "Data Lógica",
@@ -270,7 +276,8 @@
       "latestHeartbeat": "Último heartbeat do Trigger",
       "title": "Informações do Trigger"
     },
-    "unixname": "Nome do Unix"
+    "unixname": "Nome do Unix",
+    "renderedMapIndex": "Índice de Mapa Renderizado"
   },
   "taskInstance_one": "Instância de Tarefa",
   "taskInstance_other": "Instâncias de Tarefa",
@@ -297,8 +304,6 @@
       "error": "Limpeza em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}",
-        "description_one": "{{count}} {{resourceName}} foi limpo com sucesso. Chave: {{keys}}",
-        "description_other": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}",
         "title": "Limpeza em Massa de {{resourceName}} Submetida"
       }
     },
@@ -306,8 +311,6 @@
       "error": "Exclusão em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}",
-        "description_one": "{{count}} {{resourceName}} foi excluído com sucesso. Chave: {{keys}}",
-        "description_other": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}",
         "title": "Exclusão em Massa de {{resourceName}} Submetida"
       }
     },
@@ -315,8 +318,6 @@
       "error": "Atualização em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}",
-        "description_one": "{{count}} {{resourceName}} foi atualizado com sucesso. Chave: {{keys}}",
-        "description_other": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}",
         "title": "Atualização em Massa de {{resourceName}} Submetida"
       }
     },
@@ -334,16 +335,10 @@
         "title": "Exclusão de {{resourceName}} Submetida"
       }
     },
-    "forbidden": {
-      "description": "Você não tem permissão para realizar esta ação.",
-      "title": "Acesso Negado"
-    },
     "import": {
       "error": "Importação de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram importados com sucesso.",
-        "description_one": "{{count}} {{resourceName}} foi importado com sucesso.",
-        "description_other": "{{count}} {{resourceName}} foram importados com sucesso.",
         "title": "Importação de {{resourceName}} Submetida"
       }
     },
@@ -376,5 +371,25 @@
     "tooltip": "Pressione {{hotkey}} para expandir ou recolher a secção",
     "unwrap": "Expandir",
     "wrap": "Recolher"
+  },
+  "consumingAsset": "Asset Consumidor",
+  "errors": {
+    "forbidden": {
+      "description": "Você não tem permissão para realizar esta ação.",
+      "title": "Acesso Negado"
+    }
+  },
+  "search": {
+    "advanced": {
+      "description": "Corresponder em qualquer parte do valor (busca por substring). Mais lento em deployments grandes porque não consegue usar índice de banco de dados.",
+      "title": "Corresponder em qualquer parte"
+    }
+  },
+  "selected": "Selecionado",
+  "taskGroup_one": "Grupo de Tarefas",
+  "taskGroup_other": "Grupos de Tarefas",
+  "validation": {
+    "mustBeAtLeast": "Deve ser no mínimo {{min}}.",
+    "mustBeValidNumber": "Deve ser um número válido."
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -292,11 +292,31 @@
     "utc": "UTC (Tempo Universal Coordenado)"
   },
   "toaster": {
+    "bulkClear": {
+      "error": "Limpeza em Massa de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}",
+        "title": "Limpeza em Massa de {{resourceName}} Submetida",
+        "description_one": "{{count}} {{resourceName}} foi limpo com sucesso. Chave: {{keys}}",
+        "description_other": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}"
+      }
+    },
     "bulkDelete": {
       "error": "Exclusão em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}",
-        "title": "Exclusão em Massa de {{resourceName}} Submetida"
+        "title": "Exclusão em Massa de {{resourceName}} Submetida",
+        "description_one": "{{count}} {{resourceName}} foi excluído com sucesso. Chave: {{keys}}",
+        "description_other": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}"
+      }
+    },
+    "bulkUpdate": {
+      "error": "Atualização em Massa de {{resourceName}} Falhou",
+      "success": {
+        "description": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}",
+        "title": "Atualização em Massa de {{resourceName}} Submetida",
+        "description_one": "{{count}} {{resourceName}} foi atualizado com sucesso. Chave: {{keys}}",
+        "description_other": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}"
       }
     },
     "create": {
@@ -317,7 +337,9 @@
       "error": "Importação de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram importados com sucesso.",
-        "title": "Importação de {{resourceName}} Submetida"
+        "title": "Importação de {{resourceName}} Submetida",
+        "description_one": "{{count}} {{resourceName}} foi importado com sucesso.",
+        "description_other": "{{count}} {{resourceName}} foram importados com sucesso."
       }
     },
     "update": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -168,15 +168,6 @@
   },
   "pendingDagRun_one": "{{count}} execução do DAG pendente",
   "pendingDagRun_other": "{{count}} execuções do DAG pendentes",
-  "pools": {
-    "deferred": "Deferido",
-    "open": "Aberto",
-    "pools_one": "pool",
-    "pools_other": "pools",
-    "queued": "Enfileirado",
-    "running": "Executando",
-    "scheduled": "Agendado"
-  },
   "reset": "Resetar",
   "runId": "ID da Execução",
   "runTypes": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/common.json
@@ -128,6 +128,7 @@
     "selectDateRange": "Selecionar intervalo de datas",
     "startTime": "Hora de início"
   },
+  "generateToken": "Gerar Token",
   "logicalDate": "Data Lógica",
   "logout": "Sair",
   "logoutConfirmation": "Você está prestes a sair do aplicativo.",
@@ -171,11 +172,11 @@
   "reset": "Resetar",
   "runId": "ID da Execução",
   "runTypes": {
+    "asset_materialization": "Materialização de Asset",
     "asset_triggered": "Asset Acionado",
     "backfill": "Backfill",
     "manual": "Manual",
-    "scheduled": "Agendado",
-    "asset_materialization": "Materialização de Asset"
+    "scheduled": "Agendado"
   },
   "scroll": {
     "direction": {
@@ -296,27 +297,27 @@
       "error": "Limpeza em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}",
-        "title": "Limpeza em Massa de {{resourceName}} Submetida",
         "description_one": "{{count}} {{resourceName}} foi limpo com sucesso. Chave: {{keys}}",
-        "description_other": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}"
+        "description_other": "{{count}} {{resourceName}} foram limpos com sucesso. Chaves: {{keys}}",
+        "title": "Limpeza em Massa de {{resourceName}} Submetida"
       }
     },
     "bulkDelete": {
       "error": "Exclusão em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}",
-        "title": "Exclusão em Massa de {{resourceName}} Submetida",
         "description_one": "{{count}} {{resourceName}} foi excluído com sucesso. Chave: {{keys}}",
-        "description_other": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}"
+        "description_other": "{{count}} {{resourceName}} foram excluídos com sucesso. Chaves: {{keys}}",
+        "title": "Exclusão em Massa de {{resourceName}} Submetida"
       }
     },
     "bulkUpdate": {
       "error": "Atualização em Massa de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}",
-        "title": "Atualização em Massa de {{resourceName}} Submetida",
         "description_one": "{{count}} {{resourceName}} foi atualizado com sucesso. Chave: {{keys}}",
-        "description_other": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}"
+        "description_other": "{{count}} {{resourceName}} foram atualizados com sucesso. Chaves: {{keys}}",
+        "title": "Atualização em Massa de {{resourceName}} Submetida"
       }
     },
     "create": {
@@ -333,13 +334,17 @@
         "title": "Exclusão de {{resourceName}} Submetida"
       }
     },
+    "forbidden": {
+      "description": "Você não tem permissão para realizar esta ação.",
+      "title": "Acesso Negado"
+    },
     "import": {
       "error": "Importação de {{resourceName}} Falhou",
       "success": {
         "description": "{{count}} {{resourceName}} foram importados com sucesso.",
-        "title": "Importação de {{resourceName}} Submetida",
         "description_one": "{{count}} {{resourceName}} foi importado com sucesso.",
-        "description_other": "{{count}} {{resourceName}} foram importados com sucesso."
+        "description_other": "{{count}} {{resourceName}} foram importados com sucesso.",
+        "title": "Importação de {{resourceName}} Submetida"
       }
     },
     "update": {
@@ -348,11 +353,19 @@
         "description": "{{resourceName}} foi atualizado com sucesso.",
         "title": "Atualização de {{resourceName}} Submetida"
       }
-    },
-    "forbidden": {
-      "title": "Acesso Negado",
-      "description": "Você não tem permissão para realizar esta ação."
     }
+  },
+  "tokenGeneration": {
+    "apiToken": "Token de API",
+    "cliToken": "Token CLI",
+    "errorDescription": "Ocorreu um erro ao gerar o token. Por favor, tente novamente.",
+    "errorTitle": "Falha na Geração do Token",
+    "generate": "Gerar",
+    "selectType": "Selecione o tipo de token a ser gerado.",
+    "title": "Gerar Token",
+    "tokenExpiresIn": "Este token expira em {{duration}}.",
+    "tokenGenerated": "Seu token foi gerado.",
+    "tokenShownOnce": "Este token será exibido apenas uma vez. Copie-o agora."
   },
   "total": "Total {{state}}",
   "triggered": "Acionado",
@@ -363,18 +376,5 @@
     "tooltip": "Pressione {{hotkey}} para expandir ou recolher a secção",
     "unwrap": "Expandir",
     "wrap": "Recolher"
-  },
-  "generateToken": "Gerar Token",
-  "tokenGeneration": {
-    "title": "Gerar Token",
-    "apiToken": "Token de API",
-    "cliToken": "Token CLI",
-    "generate": "Gerar",
-    "selectType": "Selecione o tipo de token a ser gerado.",
-    "tokenGenerated": "Seu token foi gerado.",
-    "tokenShownOnce": "Este token será exibido apenas uma vez. Copie-o agora.",
-    "tokenExpiresIn": "Este token expira em {{duration}}.",
-    "errorTitle": "Falha na Geração do Token",
-    "errorDescription": "Ocorreu um erro ao gerar o token. Por favor, tente novamente."
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -1,0 +1,160 @@
+{
+  "backfill": {
+    "affected_many": "{{count}} execuções serão acionadas.",
+    "affected_one": "1 execução será acionada.",
+    "affected_other": "{{count}} execuções serão acionadas.",
+    "affected_zero": "Nenhuma execução será acionada.",
+    "affectedNone": "Nenhuma execução correspondente aos critérios selecionados.",
+    "allRuns": "Todas as Execuções",
+    "backwards": "Executar para trás",
+    "dateRange": "Intervalo de Data",
+    "errorStartDateBeforeEndDate": "A Data Inicial deve ser antes da Data Final",
+    "maxRuns": "Máximo de Execuções Ativas",
+    "missingAndErroredRuns": "Execuções Faltando e com Erro",
+    "missingRuns": "Execuções Faltando",
+    "reprocessBehavior": "Comportamento de Reprocessamento",
+    "run": "Executar Backfill",
+    "selectDescription": "Executar este Dag para um intervalo de datas",
+    "selectLabel": "Backfill",
+    "title": "Executar Backfill",
+    "toaster": {
+      "success": {
+        "description": "Backfill jobs foram acionados com sucesso.",
+        "title": "Backfill gerado"
+      }
+    },
+    "tooltip": "Backfill requer um agendamento",
+    "unpause": "Despausar {{dag_display_name}} ao acionar",
+    "validation": {
+      "datesRequired": "Ambas as datas de início e fim do intervalo devem ser fornecidas.",
+      "startBeforeEnd": "A Data Inicial do Intervalo deve ser menor ou igual à Data Final do Intervalo."
+    }
+  },
+  "banner": {
+    "backfillInProgress": "Backfill em progresso",
+    "cancel": "Cancelar backfill",
+    "pause": "Pausar backfill",
+    "unpause": "Despausar backfill"
+  },
+  "clipboard": {
+    "copy": "Copiar"
+  },
+  "close": "Fechar",
+  "configForm": {
+    "advancedOptions": "Opções Avançadas",
+    "configJson": "Configuração JSON",
+    "invalidJson": "Formato JSON inválido: {{errorMessage}}"
+  },
+  "dagWarnings": {
+    "error_many": "{{count}} Erros",
+    "error_one": "1 Erro",
+    "error_other": "{{count}} Erros",
+    "error_zero": "Nenhum erro",
+    "errorAndWarning": "1 Erro e {{warningText}}",
+    "warning_many": "{{count}} Avisos",
+    "warning_one": "1 Aviso",
+    "warning_other": "{{count}} Avisos",
+    "warning_zero": "Nenhum aviso"
+  },
+  "durationChart": {
+    "duration": "Duração (segundos)",
+    "lastDagRun_many": "Últimas {{count}} Execuções do Dag",
+    "lastDagRun_one": "Última Execução do Dag",
+    "lastDagRun_other": "Últimas {{count}} Execuções do Dag",
+    "lastDagRun_zero": "Nenhuma execução do Dag",
+    "lastTaskInstance_many": "Últimas {{count}} Instâncias de Tarefa",
+    "lastTaskInstance_one": "Última Instância de Tarefa",
+    "lastTaskInstance_other": "Últimas {{count}} Instâncias de Tarefa",
+    "lastTaskInstance_zero": "Nenhuma instância de tarefa",
+    "queuedDuration": "Duração da Fila",
+    "runAfter": "Executar Depois",
+    "runDuration": "Duração da Execução"
+  },
+  "fileUpload": {
+    "files_many": "{{count}} arquivos",
+    "files_one": "1 arquivo",
+    "files_other": "{{count}} arquivos",
+    "files_zero": "Nenhum arquivo"
+  },
+  "flexibleForm": {
+    "placeholder": "Selecionar Valor",
+    "placeholderArray": "Digite cada string em uma nova linha",
+    "placeholderExamples": "Comece a digitar para ver opções",
+    "placeholderMulti": "Selecione um ou vários valores",
+    "validationErrorArrayNotArray": "O valor deve ser um array.",
+    "validationErrorArrayNotNumbers": "Todos os elementos do array devem ser números.",
+    "validationErrorArrayNotObject": "Todos os elementos do array devem ser objetos.",
+    "validationErrorRequired": "Este campo é obrigatório"
+  },
+  "graph": {
+    "directionDown": "Superior para Inferior",
+    "directionLeft": "Direita para Esquerda",
+    "directionRight": "Esquerda para Direita",
+    "directionUp": "Inferior para Superior",
+    "downloadImage": "Baixar imagem do gráfico",
+    "downloadImageError": "Falha ao baixar a imagem do gráfico.",
+    "downloadImageErrorTitle": "Download Falhou",
+    "otherDagRuns": "+Outras Execuções do Dag",
+    "taskCount_many": "{{count}} Tarefas",
+    "taskCount_one": "{{count}} Tarefa",
+    "taskCount_other": "{{count}} Tarefas",
+    "taskCount_zero": "Nenhuma tarefa",
+    "taskGroup": "Grupo de Tarefas"
+  },
+  "limitedList": "+{{count}} mais",
+  "limitedList.allItems": "Todos os {{count}} itens:",
+  "limitedList.allTags_many": "Todas as etiquetas ({{count}})",
+  "limitedList.allTags_one": "Todas as etiquetas (1)",
+  "limitedList.allTags_other": "Todas as etiquetas ({{count}})",
+  "limitedList.allTags_zero": "Todas as etiquetas (0)",
+  "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os Dags",
+  "limitedList.clickToOpenFull": "Clique em \"+{{count}} mais\" para ver a lista completa",
+  "limitedList.copyPasteText": "Você pode copiar e colar o texto acima",
+  "limitedList.showingItems_many": "Mostrando {{count}} itens",
+  "limitedList.showingItems_one": "Mostrando 1 item",
+  "limitedList.showingItems_other": "Mostrando {{count}} itens",
+  "limitedList.showingItems_zero": "Mostrando 0 itens",
+  "logs": {
+    "file": "Arquivo",
+    "location": "linha {{line}} em {{name}}"
+  },
+  "reparseDag": "Reparse Dag",
+  "sortedAscending": "Ordenado em ordem crescente",
+  "sortedDescending": "Ordenado em ordem decrescente",
+  "sortedUnsorted": "Não ordenado",
+  "taskTries": "Tentativas de Tarefa",
+  "toggleCardView": "Mostrar visualização de cartão",
+  "toggleTableView": "Mostrar visualização de tabela",
+  "triggerDag": {
+    "button": "Acionar",
+    "loading": "Carregando informações do Dag...",
+    "loadingFailed": "Falha ao carregar informações do Dag. Por favor, tente novamente.",
+    "runIdHelp": "Opcional - será gerado se não for fornecido",
+    "selectDescription": "Acionar uma única execução deste Dag",
+    "selectLabel": "Execução Única",
+    "title": "Acionar Dag",
+    "toaster": {
+      "success": {
+        "description": "A execução do Dag foi acionada com sucesso.",
+        "title": "Execução do Dag acionada"
+      }
+    },
+    "unpause": "Despausar {{dagDisplayName}} ao acionar"
+  },
+  "trimText": {
+    "details": "Detalhes",
+    "empty": "Vazio",
+    "noContent": "Nenhum conteúdo disponível."
+  },
+  "versionDetails": {
+    "bundleLink": "Link do Bundle",
+    "bundleName": "Nome do Bundle",
+    "bundleVersion": "Versão do Bundle",
+    "createdAt": "Criado em",
+    "versionId": "ID da Versão"
+  },
+  "versionSelect": {
+    "dagVersion": "Versão do Dag",
+    "versionCode": "v{{versionCode}}"
+  }
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -12,6 +12,7 @@
     "maxRuns": "Máximo de Execuções Ativas",
     "missingAndErroredRuns": "Execuções Faltando e com Erro",
     "missingRuns": "Execuções Faltando",
+    "permissionDenied": "Dry run falhou: o usuário não tem permissão para criar backfills.",
     "reprocessBehavior": "Comportamento de Reprocessamento",
     "run": "Executar Backfill",
     "selectDescription": "Executar este Dag para um intervalo de datas",
@@ -55,6 +56,13 @@
     "warning_one": "1 Aviso",
     "warning_other": "{{count}} Avisos",
     "warning_zero": "Nenhum aviso"
+  },
+  "dateRangeFilter": {
+    "validation": {
+      "invalidDateFormat": "Formato de data inválido.",
+      "invalidTimeFormat": "Formato de hora inválido.",
+      "startBeforeEnd": "A data/hora de início deve ser anterior à data/hora de término"
+    }
   },
   "durationChart": {
     "duration": "Duração (segundos)",
@@ -123,22 +131,40 @@
   "sortedDescending": "Ordenado em ordem decrescente",
   "sortedUnsorted": "Não ordenado",
   "taskTries": "Tentativas de Tarefa",
+  "taskTryPlaceholder": "Tentativa da tarefa",
+  "team": {
+    "selector": {
+      "helperText": "Opcional. Restrinja o uso a uma equipe específica.",
+      "label": "Equipe",
+      "placeHolder": "Selecionar uma equipe"
+    }
+  },
   "toggleCardView": "Mostrar visualização de cartão",
   "toggleTableView": "Mostrar visualização de tabela",
   "triggerDag": {
     "button": "Acionar",
+    "dataInterval": "Intervalo de dados",
+    "dataIntervalAuto": "Inferido da data lógica e do cronograma",
+    "dataIntervalManual": "Especificar manualmente",
+    "intervalEnd": "Fim",
+    "intervalStart": "Início",
     "loading": "Carregando informações do Dag...",
     "loadingFailed": "Falha ao carregar informações do Dag. Por favor, tente novamente.",
+    "manualRunDenied": "Execuções manuais não são permitidas para este DAG",
     "runIdHelp": "Opcional - será gerado se não for fornecido",
     "selectDescription": "Acionar uma única execução deste Dag",
     "selectLabel": "Execução Única",
     "title": "Acionar Dag",
     "toaster": {
+      "error": {
+        "title": "Falha ao acionar o DAG"
+      },
       "success": {
         "description": "A execução do Dag foi acionada com sucesso.",
         "title": "Execução do Dag acionada"
       }
     },
+    "triggerAgainWithConfig": "Acionar novamente com esta configuração",
     "unpause": "Despausar {{dagDisplayName}} ao acionar"
   },
   "trimText": {
@@ -154,6 +180,7 @@
     "versionId": "ID da Versão"
   },
   "versionSelect": {
+    "allVersions": "Todas as versões",
     "dagVersion": "Versão do Dag",
     "versionCode": "v{{versionCode}}"
   }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -1,9 +1,7 @@
 {
   "backfill": {
-    "affected_many": "{{count}} execuções serão acionadas.",
     "affected_one": "1 execução será acionada.",
     "affected_other": "{{count}} execuções serão acionadas.",
-    "affected_zero": "Nenhuma execução será acionada.",
     "affectedNone": "Nenhuma execução correspondente aos critérios selecionados.",
     "allRuns": "Todas as Execuções",
     "backwards": "Executar para trás",
@@ -47,15 +45,11 @@
     "invalidJson": "Formato JSON inválido: {{errorMessage}}"
   },
   "dagWarnings": {
-    "error_many": "{{count}} Erros",
     "error_one": "1 Erro",
     "error_other": "{{count}} Erros",
-    "error_zero": "Nenhum erro",
     "errorAndWarning": "1 Erro e {{warningText}}",
-    "warning_many": "{{count}} Avisos",
     "warning_one": "1 Aviso",
-    "warning_other": "{{count}} Avisos",
-    "warning_zero": "Nenhum aviso"
+    "warning_other": "{{count}} Avisos"
   },
   "dateRangeFilter": {
     "validation": {
@@ -66,23 +60,17 @@
   },
   "durationChart": {
     "duration": "Duração (segundos)",
-    "lastDagRun_many": "Últimas {{count}} Execuções do Dag",
     "lastDagRun_one": "Última Execução do Dag",
     "lastDagRun_other": "Últimas {{count}} Execuções do Dag",
-    "lastDagRun_zero": "Nenhuma execução do Dag",
-    "lastTaskInstance_many": "Últimas {{count}} Instâncias de Tarefa",
     "lastTaskInstance_one": "Última Instância de Tarefa",
     "lastTaskInstance_other": "Últimas {{count}} Instâncias de Tarefa",
-    "lastTaskInstance_zero": "Nenhuma instância de tarefa",
     "queuedDuration": "Duração da Fila",
     "runAfter": "Executar Depois",
     "runDuration": "Duração da Execução"
   },
   "fileUpload": {
-    "files_many": "{{count}} arquivos",
     "files_one": "1 arquivo",
-    "files_other": "{{count}} arquivos",
-    "files_zero": "Nenhum arquivo"
+    "files_other": "{{count}} arquivos"
   },
   "flexibleForm": {
     "placeholder": "Selecionar Valor",
@@ -103,25 +91,19 @@
     "downloadImageError": "Falha ao baixar a imagem do gráfico.",
     "downloadImageErrorTitle": "Download Falhou",
     "otherDagRuns": "+Outras Execuções do Dag",
-    "taskCount_many": "{{count}} Tarefas",
     "taskCount_one": "{{count}} Tarefa",
     "taskCount_other": "{{count}} Tarefas",
-    "taskCount_zero": "Nenhuma tarefa",
     "taskGroup": "Grupo de Tarefas"
   },
   "limitedList": "+{{count}} mais",
   "limitedList.allItems": "Todos os {{count}} itens:",
-  "limitedList.allTags_many": "Todas as etiquetas ({{count}})",
   "limitedList.allTags_one": "Todas as etiquetas (1)",
   "limitedList.allTags_other": "Todas as etiquetas ({{count}})",
-  "limitedList.allTags_zero": "Todas as etiquetas (0)",
   "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os Dags",
   "limitedList.clickToOpenFull": "Clique em \"+{{count}} mais\" para ver a lista completa",
   "limitedList.copyPasteText": "Você pode copiar e colar o texto acima",
-  "limitedList.showingItems_many": "Mostrando {{count}} itens",
   "limitedList.showingItems_one": "Mostrando 1 item",
   "limitedList.showingItems_other": "Mostrando {{count}} itens",
-  "limitedList.showingItems_zero": "Mostrando 0 itens",
   "logs": {
     "file": "Arquivo",
     "location": "linha {{line}} em {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -69,7 +69,8 @@
     "runDuration": "Duração da Execução"
   },
   "fileUpload": {
-    "files_other": "{{count}} arquivos"
+    "files_other": "{{count}} arquivos",
+    "files_one": "1 arquivo"
   },
   "flexibleForm": {
     "placeholder": "Selecionar Valor",
@@ -165,5 +166,11 @@
     "allVersions": "Todas as versões",
     "dagVersion": "Versão do Dag",
     "versionCode": "v{{versionCode}}"
-  }
+  },
+  "limitedList_one": "+{{count}} mais",
+  "limitedList_other": "+{{count}} mais",
+  "limitedList.allItems_one": "Todos os {{count}} itens:",
+  "limitedList.allItems_other": "Todos os {{count}} itens:",
+  "limitedList.clickToOpenFull_one": "Clique em \"+{{count}} mais\" para ver a lista completa",
+  "limitedList.clickToOpenFull_other": "Clique em \"+{{count}} mais\" para ver a lista completa"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -22,12 +22,13 @@
         "title": "Backfill gerado"
       }
     },
-    "tooltip": "Backfill requer um agendamento",
     "unpause": "Despausar {{dag_display_name}} ao acionar",
     "validation": {
       "datesRequired": "Ambas as datas de início e fim do intervalo devem ser fornecidas.",
       "startBeforeEnd": "A Data Inicial do Intervalo deve ser menor ou igual à Data Final do Intervalo."
-    }
+    },
+    "overrideExistingParams": "Sobrescrever parâmetros em execuções existentes",
+    "scheduleNotBackfillable": "O agendamento deste Dag não suporta backfills"
   },
   "banner": {
     "backfillInProgress": "Backfill em progresso",
@@ -46,7 +47,6 @@
   },
   "dagWarnings": {
     "error_one": "1 Erro",
-    "error_other": "{{count}} Erros",
     "errorAndWarning": "1 Erro e {{warningText}}",
     "warning_one": "1 Aviso",
     "warning_other": "{{count}} Avisos"
@@ -69,7 +69,6 @@
     "runDuration": "Duração da Execução"
   },
   "fileUpload": {
-    "files_one": "1 arquivo",
     "files_other": "{{count}} arquivos"
   },
   "flexibleForm": {
@@ -93,7 +92,8 @@
     "otherDagRuns": "+Outras Execuções do Dag",
     "taskCount_one": "{{count}} Tarefa",
     "taskCount_other": "{{count}} Tarefas",
-    "taskGroup": "Grupo de Tarefas"
+    "taskGroup": "Grupo de Tarefas",
+    "zoomToTask": "Ampliar tarefa selecionada"
   },
   "limitedList": "+{{count}} mais",
   "limitedList.allItems": "Todos os {{count}} itens:",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -10,9 +10,11 @@
     "maxRuns": "Máximo de Execuções Ativas",
     "missingAndErroredRuns": "Execuções Faltando e com Erro",
     "missingRuns": "Execuções Faltando",
+    "overrideExistingParams": "Sobrescrever parâmetros em execuções existentes",
     "permissionDenied": "Dry run falhou: o usuário não tem permissão para criar backfills.",
     "reprocessBehavior": "Comportamento de Reprocessamento",
     "run": "Executar Backfill",
+    "scheduleNotBackfillable": "O agendamento deste Dag não suporta backfills",
     "selectDescription": "Executar este Dag para um intervalo de datas",
     "selectLabel": "Backfill",
     "title": "Executar Backfill",
@@ -26,9 +28,7 @@
     "validation": {
       "datesRequired": "Ambas as datas de início e fim do intervalo devem ser fornecidas.",
       "startBeforeEnd": "A Data Inicial do Intervalo deve ser menor ou igual à Data Final do Intervalo."
-    },
-    "overrideExistingParams": "Sobrescrever parâmetros em execuções existentes",
-    "scheduleNotBackfillable": "O agendamento deste Dag não suporta backfills"
+    }
   },
   "banner": {
     "backfillInProgress": "Backfill em progresso",
@@ -69,8 +69,8 @@
     "runDuration": "Duração da Execução"
   },
   "fileUpload": {
-    "files_other": "{{count}} arquivos",
-    "files_one": "1 arquivo"
+    "files_one": "1 arquivo",
+    "files_other": "{{count}} arquivos"
   },
   "flexibleForm": {
     "placeholder": "Selecionar Valor",
@@ -98,13 +98,19 @@
   },
   "limitedList": "+{{count}} mais",
   "limitedList.allItems": "Todos os {{count}} itens:",
+  "limitedList.allItems_one": "Todos os {{count}} itens:",
+  "limitedList.allItems_other": "Todos os {{count}} itens:",
   "limitedList.allTags_one": "Todas as etiquetas (1)",
   "limitedList.allTags_other": "Todas as etiquetas ({{count}})",
   "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os Dags",
   "limitedList.clickToOpenFull": "Clique em \"+{{count}} mais\" para ver a lista completa",
+  "limitedList.clickToOpenFull_one": "Clique em \"+{{count}} mais\" para ver a lista completa",
+  "limitedList.clickToOpenFull_other": "Clique em \"+{{count}} mais\" para ver a lista completa",
   "limitedList.copyPasteText": "Você pode copiar e colar o texto acima",
   "limitedList.showingItems_one": "Mostrando 1 item",
   "limitedList.showingItems_other": "Mostrando {{count}} itens",
+  "limitedList_one": "+{{count}} mais",
+  "limitedList_other": "+{{count}} mais",
   "logs": {
     "file": "Arquivo",
     "location": "linha {{line}} em {{name}}"
@@ -166,11 +172,5 @@
     "allVersions": "Todas as versões",
     "dagVersion": "Versão do Dag",
     "versionCode": "v{{versionCode}}"
-  },
-  "limitedList_one": "+{{count}} mais",
-  "limitedList_other": "+{{count}} mais",
-  "limitedList.allItems_one": "Todos os {{count}} itens:",
-  "limitedList.allItems_other": "Todos os {{count}} itens:",
-  "limitedList.clickToOpenFull_one": "Clique em \"+{{count}} mais\" para ver a lista completa",
-  "limitedList.clickToOpenFull_other": "Clique em \"+{{count}} mais\" para ver a lista completa"
+  }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/components.json
@@ -69,7 +69,6 @@
     "runDuration": "Duração da Execução"
   },
   "fileUpload": {
-    "files_one": "1 arquivo",
     "files_other": "{{count}} arquivos"
   },
   "flexibleForm": {
@@ -98,19 +97,13 @@
   },
   "limitedList": "+{{count}} mais",
   "limitedList.allItems": "Todos os {{count}} itens:",
-  "limitedList.allItems_one": "Todos os {{count}} itens:",
-  "limitedList.allItems_other": "Todos os {{count}} itens:",
   "limitedList.allTags_one": "Todas as etiquetas (1)",
   "limitedList.allTags_other": "Todas as etiquetas ({{count}})",
   "limitedList.clickToInteract": "Clique em uma etiqueta para filtrar os Dags",
   "limitedList.clickToOpenFull": "Clique em \"+{{count}} mais\" para ver a lista completa",
-  "limitedList.clickToOpenFull_one": "Clique em \"+{{count}} mais\" para ver a lista completa",
-  "limitedList.clickToOpenFull_other": "Clique em \"+{{count}} mais\" para ver a lista completa",
   "limitedList.copyPasteText": "Você pode copiar e colar o texto acima",
   "limitedList.showingItems_one": "Mostrando 1 item",
   "limitedList.showingItems_other": "Mostrando {{count}} itens",
-  "limitedList_one": "+{{count}} mais",
-  "limitedList_other": "+{{count}} mais",
   "logs": {
     "file": "Arquivo",
     "location": "linha {{line}} em {{name}}"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
@@ -1,0 +1,164 @@
+{
+  "allRuns": "Todas as Execuções",
+  "blockingDeps": {
+    "dependency": "Dependência",
+    "reason": "Motivo",
+    "title": "Dependências Bloqueando Tarefa de Ser Agendada"
+  },
+  "calendar": {
+    "daily": "Diário",
+    "hourly": "Por Hora",
+    "legend": {
+      "less": "Menos",
+      "mixed": "Misturado",
+      "more": "Mais"
+    },
+    "navigation": {
+      "nextMonth": "Próximo mês",
+      "nextYear": "Próximo ano",
+      "previousMonth": "Mês anterior",
+      "previousYear": "Ano anterior"
+    },
+    "noData": "Nenhum dado disponível",
+    "noFailedRuns": "Nenhuma execução com falha",
+    "noRuns": "Nenhuma execução",
+    "totalRuns": "Total de Execuções",
+    "week": "Semana {{weekNumber}}",
+    "weekdays": {
+      "friday": "Sex",
+      "monday": "Seg",
+      "saturday": "Sáb",
+      "sunday": "Dom",
+      "thursday": "Qui",
+      "tuesday": "Ter",
+      "wednesday": "Qua"
+    }
+  },
+  "code": {
+    "bundleUrl": "URL do Bundle",
+    "noCode": "Nenhum Código Encontrado",
+    "parseDuration": "Duração do Processamento:",
+    "parsedAt": "Processado em:"
+  },
+  "extraLinks": "Links Extra",
+  "grid": {
+    "buttons": {
+      "resetToLatest": "Redefinir para a Última",
+      "toggleGroup": "Alternar Grupo"
+    }
+  },
+  "header": {
+    "buttons": {
+      "advanced": "Avançado",
+      "dagDocs": "Documentação do Dag"
+    }
+  },
+  "logs": {
+    "allLevels": "Todos os Níveis de Log",
+    "allSources": "Todas as Fontes",
+    "critical": "CRÍTICO",
+    "debug": "DEBUG",
+    "error": "ERRO",
+    "fullscreen": {
+      "button": "Tela cheia",
+      "tooltip": "Pressione {{hotkey}} para tela cheia"
+    },
+    "info": "INFO",
+    "noTryNumber": "Nenhum número de tentativa",
+    "settings": "Configurações",
+    "viewInExternal": "Ver logs em {{name}} (tentativa {{attempt}})",
+    "warning": "AVISO"
+  },
+  "navigation": {
+    "navigation": "Navegação: Shift+{{arrow}}",
+    "toggleGroup": "Alternar grupo: Espaço"
+  },
+  "overview": {
+    "buttons": {
+      "failedRun_many": "Execuções Falhadas",
+      "failedRun_one": "Execução Falhada",
+      "failedRun_other": "Execuções Falhadas",
+      "failedRun_zero": "Nenhuma execução falhada",
+      "failedTask_many": "Tarefas Falhadas",
+      "failedTask_one": "Tarefa Falhada",
+      "failedTask_other": "Tarefas Falhadas",
+      "failedTask_zero": "Nenhuma tarefa falhada",
+      "failedTaskInstance_many": "Instâncias de Tarefa Falhadas",
+      "failedTaskInstance_one": "Instância de Tarefa Falhada",
+      "failedTaskInstance_other": "Instâncias de Tarefa Falhadas",
+      "failedTaskInstance_zero": "Nenhuma instância de tarefa falhada"
+    },
+    "charts": {
+      "assetEvent_many": "Eventos de Asset Criados",
+      "assetEvent_one": "Evento de Asset Criado",
+      "assetEvent_other": "Eventos de Asset Criados",
+      "assetEvent_zero": "Nenhum evento de asset criado"
+    },
+    "failedLogs": {
+      "hideLogs": "Ocultar Logs",
+      "showLogs": "Mostrar Logs",
+      "title": "Logs Recentes de Tarefas Falhadas",
+      "viewFullLogs": "Ver logs completos"
+    }
+  },
+  "panel": {
+    "buttons": {
+      "options": "Opções",
+      "showGantt": "Mostrar Gantt",
+      "showGraphShortcut": "Mostrar Gráfico (Pressione g)",
+      "showGridShortcut": "Mostrar Grade (Pressione g)"
+    },
+    "dagRuns": {
+      "label": "Número de Execuções do Dag"
+    },
+    "dependencies": {
+      "label": "Dependências",
+      "options": {
+        "allDagDependencies": "Todas as Dependências do Dag",
+        "externalConditions": "Condições Externas",
+        "onlyTasks": "Somente Tarefas"
+      },
+      "placeholder": "Dependências"
+    },
+    "graphDirection": {
+      "label": "Direção do Gráfico"
+    }
+  },
+  "paramsFailed": "Falha ao carregar parâmetros",
+  "parse": {
+    "toaster": {
+      "error": {
+        "description": "Falha ao processar o Dag. Pode haver solicitações de processamento pendentes ainda não processadas.",
+        "title": "Falha ao Reprocessar o Dag"
+      },
+      "success": {
+        "description": "O Dag deve ser reprocessado em breve.",
+        "title": "Solicitação de Reprocessamento Enviada com Sucesso"
+      }
+    }
+  },
+  "tabs": {
+    "assetEvents": "Asset Events",
+    "auditLog": "Log de Auditoria",
+    "backfills": "Backfills",
+    "calendar": "Calendário",
+    "code": "Código",
+    "details": "Detalhes",
+    "logs": "Logs",
+    "mappedTaskInstances_many": "Instâncias de Tarefa [{{count}}]",
+    "mappedTaskInstances_one": "Instância de Tarefa [{{count}}]",
+    "mappedTaskInstances_other": "Instâncias de Tarefa [{{count}}]",
+    "mappedTaskInstances_zero": "Nenhuma instância de tarefa mapeada",
+    "overview": "Visão Geral",
+    "renderedTemplates": "Modelos Renderizados",
+    "requiredActions": "Ações Necessárias",
+    "runs": "Execuções",
+    "taskInstances": "Instâncias de Tarefa",
+    "tasks": "Tarefas",
+    "xcom": "XCom"
+  },
+  "taskGroups": {
+    "collapseAll": "Recolher todos os grupos de tarefas",
+    "expandAll": "Expandir todos os grupos de tarefas"
+  }
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
@@ -73,6 +73,12 @@
     "navigation": "Navegação: Shift+{{arrow}}",
     "toggleGroup": "Alternar grupo: Espaço"
   },
+  "notFound": {
+    "back": "Voltar",
+    "backToDags": "Voltar aos DAGs",
+    "message": "O DAG \"{{dagId}}\" não existe.",
+    "title": "DAG não encontrado"
+  },
   "overview": {
     "buttons": {
       "failedRun_many": "Execuções Falhadas",
@@ -122,6 +128,35 @@
     },
     "graphDirection": {
       "label": "Direção do Gráfico"
+    },
+    "showVersionIndicator": {
+      "label": "Mostrar indicador de versão",
+      "options": {
+        "hideAll": "Ocultar tudo",
+        "showAll": "Mostrar tudo",
+        "showBundleVersion": "Mostrar versão do bundle",
+        "showDagVersion": "Mostrar versão do DAG"
+      }
+    },
+    "taskStreamFilter": {
+      "activeFilter": "Filtro ativo",
+      "clearFilter": "Limpar filtro",
+      "clickTask": "Clique em uma tarefa para selecioná-la como raiz do filtro",
+      "depth": "Profundidade",
+      "direction": "Direção",
+      "label": "Filtro",
+      "mode": "Modo",
+      "modes": {
+        "static": "Estático",
+        "traverse": "Percorrer"
+      },
+      "modeTooltip": "O modo estático mantém a visualização atual ao navegar entre tarefas; o modo percorrer atualiza o filtro ativo para a tarefa clicada para facilitar a navegação no DAG.",
+      "options": {
+        "both": "Upstream e downstream",
+        "downstream": "Downstream",
+        "upstream": "Upstream"
+      },
+      "selectedTask": "Tarefa selecionada"
     }
   },
   "paramsFailed": "Falha ao carregar parâmetros",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
@@ -43,10 +43,10 @@
   "extraLinks": "Links Extra",
   "grid": {
     "buttons": {
-      "resetToLatest": "Redefinir para a Última",
-      "toggleGroup": "Alternar Grupo",
       "newerRuns": "Execuções mais recentes",
-      "olderRuns": "Execuções mais antigas"
+      "olderRuns": "Execuções mais antigas",
+      "resetToLatest": "Redefinir para a Última",
+      "toggleGroup": "Alternar Grupo"
     },
     "runTypeLegend": "Legenda dos Tipos de Execução"
   },
@@ -71,14 +71,14 @@
     },
     "info": "INFO",
     "noTryNumber": "Nenhum número de tentativa",
-    "settings": "Configurações",
-    "viewInExternal": "Ver logs em {{name}} (tentativa {{attempt}})",
-    "warning": "AVISO",
     "search": {
       "matchCount": "{{current}} de {{total}}",
       "noMatches": "Nenhuma correspondência",
       "placeholder": "Pesquisar logs..."
-    }
+    },
+    "settings": "Configurações",
+    "viewInExternal": "Ver logs em {{name}} (tentativa {{attempt}})",
+    "warning": "AVISO"
   },
   "navigation": {
     "navigation": "Navegação: Shift+{{arrow}}",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
@@ -45,7 +45,8 @@
     "buttons": {
       "resetToLatest": "Redefinir para a Última",
       "toggleGroup": "Alternar Grupo"
-    }
+    },
+    "runTypeLegend": "Legenda dos Tipos de Execução"
   },
   "header": {
     "buttons": {
@@ -81,24 +82,16 @@
   },
   "overview": {
     "buttons": {
-      "failedRun_many": "Execuções Falhadas",
       "failedRun_one": "Execução Falhada",
       "failedRun_other": "Execuções Falhadas",
-      "failedRun_zero": "Nenhuma execução falhada",
-      "failedTask_many": "Tarefas Falhadas",
       "failedTask_one": "Tarefa Falhada",
       "failedTask_other": "Tarefas Falhadas",
-      "failedTask_zero": "Nenhuma tarefa falhada",
-      "failedTaskInstance_many": "Instâncias de Tarefa Falhadas",
       "failedTaskInstance_one": "Instância de Tarefa Falhada",
-      "failedTaskInstance_other": "Instâncias de Tarefa Falhadas",
-      "failedTaskInstance_zero": "Nenhuma instância de tarefa falhada"
+      "failedTaskInstance_other": "Instâncias de Tarefa Falhadas"
     },
     "charts": {
-      "assetEvent_many": "Eventos de Asset Criados",
       "assetEvent_one": "Evento de Asset Criado",
-      "assetEvent_other": "Eventos de Asset Criados",
-      "assetEvent_zero": "Nenhum evento de asset criado"
+      "assetEvent_other": "Eventos de Asset Criados"
     },
     "failedLogs": {
       "hideLogs": "Ocultar Logs",
@@ -146,11 +139,11 @@
       "direction": "Direção",
       "label": "Filtro",
       "mode": "Modo",
+      "modeTooltip": "O modo estático mantém a visualização atual ao navegar entre tarefas; o modo percorrer atualiza o filtro ativo para a tarefa clicada para facilitar a navegação no DAG.",
       "modes": {
         "static": "Estático",
         "traverse": "Percorrer"
       },
-      "modeTooltip": "O modo estático mantém a visualização atual ao navegar entre tarefas; o modo percorrer atualiza o filtro ativo para a tarefa clicada para facilitar a navegação no DAG.",
       "options": {
         "both": "Upstream e downstream",
         "downstream": "Downstream",
@@ -180,10 +173,8 @@
     "code": "Código",
     "details": "Detalhes",
     "logs": "Logs",
-    "mappedTaskInstances_many": "Instâncias de Tarefa [{{count}}]",
     "mappedTaskInstances_one": "Instância de Tarefa [{{count}}]",
     "mappedTaskInstances_other": "Instâncias de Tarefa [{{count}}]",
-    "mappedTaskInstances_zero": "Nenhuma instância de tarefa mapeada",
     "overview": "Visão Geral",
     "renderedTemplates": "Modelos Renderizados",
     "requiredActions": "Ações Necessárias",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
@@ -44,7 +44,9 @@
   "grid": {
     "buttons": {
       "resetToLatest": "Redefinir para a Última",
-      "toggleGroup": "Alternar Grupo"
+      "toggleGroup": "Alternar Grupo",
+      "newerRuns": "Execuções mais recentes",
+      "olderRuns": "Execuções mais antigas"
     },
     "runTypeLegend": "Legenda dos Tipos de Execução"
   },
@@ -52,6 +54,9 @@
     "buttons": {
       "advanced": "Avançado",
       "dagDocs": "Documentação do Dag"
+    },
+    "status": {
+      "deactivated": "Desativado"
     }
   },
   "logs": {
@@ -68,7 +73,12 @@
     "noTryNumber": "Nenhum número de tentativa",
     "settings": "Configurações",
     "viewInExternal": "Ver logs em {{name}} (tentativa {{attempt}})",
-    "warning": "AVISO"
+    "warning": "AVISO",
+    "search": {
+      "matchCount": "{{current}} de {{total}}",
+      "noMatches": "Nenhuma correspondência",
+      "placeholder": "Pesquisar logs..."
+    }
   },
   "navigation": {
     "navigation": "Navegação: Shift+{{arrow}}",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dag.json
@@ -82,7 +82,8 @@
   },
   "navigation": {
     "navigation": "Navegação: Shift+{{arrow}}",
-    "toggleGroup": "Alternar grupo: Espaço"
+    "toggleGroup": "Alternar grupo: Espaço",
+    "openGraphFilters": "Filtros de Tarefa: Ctrl+Shift+F"
   },
   "notFound": {
     "back": "Voltar",
@@ -108,6 +109,10 @@
       "showLogs": "Mostrar Logs",
       "title": "Logs Recentes de Tarefas Falhadas",
       "viewFullLogs": "Ver logs completos"
+    },
+    "deadlines": {
+      "showAll": "Mostrar Tudo",
+      "title": "Prazos"
     }
   },
   "panel": {
@@ -160,6 +165,16 @@
         "upstream": "Upstream"
       },
       "selectedTask": "Tarefa selecionada"
+    },
+    "graphFilters": {
+      "clearFilters": "Limpar Filtros",
+      "durationGte": "Duração mínima (s)",
+      "durationGteHint": "Para tarefas mapeadas, mede o tempo total em todas as instâncias",
+      "mapIndex": "Índice de mapa mín.",
+      "mapIndexHint": "Mostra tarefas mapeadas expandidas até pelo menos este índice",
+      "selectStatus": "Selecionar status",
+      "selectTaskGroup": "Selecionar grupo de tarefas",
+      "title": "Filtros de Tarefa"
     }
   },
   "paramsFailed": "Falha ao carregar parâmetros",
@@ -196,5 +211,31 @@
   "taskGroups": {
     "collapseAll": "Recolher todos os grupos de tarefas",
     "expandAll": "Expandir todos os grupos de tarefas"
+  },
+  "deadlineAlerts": {
+    "completionRule": "Deve concluir em {{interval}} de {{reference}}",
+    "count_one": "{{count}} prazo",
+    "count_other": "{{count}} prazos",
+    "referenceType": {
+      "AverageRuntimeDeadline": "tempo médio de execução",
+      "DagRunLogicalDateDeadline": "data lógica",
+      "DagRunQueuedAtDeadline": "tempo em fila"
+    }
+  },
+  "deadlineStatus": {
+    "actual": "Real",
+    "expected": "Esperado",
+    "finishedEarly": "Concluído {{duration}} antes do prazo",
+    "finishedLate": "Concluído {{duration}} após o prazo",
+    "label": "Prazo",
+    "met": "Atendido",
+    "missed": "Perdido",
+    "missedCount_one": "{{count}} Prazo Perdido",
+    "missedCount_other": "{{count}} Prazos Perdidos",
+    "mixedCount": "{{missedCount}} Perdidos, {{upcomingCount}} Próximos",
+    "stillRunning": "Ainda em execução",
+    "upcoming": "Próximo",
+    "upcomingCount_one": "{{count}} Prazo Próximo",
+    "upcomingCount_other": "{{count}} Prazos Próximos"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
@@ -1,0 +1,96 @@
+{
+  "assetSchedule": "{{count}} de {{total}} ativos atualizados",
+  "dagActions": {
+    "delete": {
+      "button": "Excluir Dag",
+      "warning": "Isso removerá todas as metadados relacionados ao Dag, incluindo Execuções e Tarefas."
+    }
+  },
+  "favoriteDag": "Dag Favorito",
+  "filters": {
+    "allRunTypes": "Todos os Tipos de Execução",
+    "allStates": "Todos os Estados",
+    "favorite": {
+      "all": "Todos",
+      "favorite": "Favorito",
+      "unfavorite": "Remover dos Favoritos"
+    },
+    "paused": {
+      "active": "Ativo",
+      "all": "Todos",
+      "paused": "Pausado"
+    },
+    "runIdPatternFilter": "Pesquisar Execuções de Dag"
+  },
+  "ownerLink": "Link do Proprietário para {{owner}}",
+  "runAndTaskActions": {
+    "affectedTasks": {
+      "noItemsFound": "Nenhuma tarefa encontrada.",
+      "title": "Tarefas Afetadas: {{count}}"
+    },
+    "clear": {
+      "button": "Limpar {{type}}",
+      "buttonTooltip": "Pressione shift+c para limpar",
+      "error": "Falha ao limpar {{type}}",
+      "title": "Limpar {{type}}"
+    },
+    "delete": {
+      "button": "Excluir {{type}}",
+      "dialog": {
+        "resourceName": "{{type}} {{id}}",
+        "title": "Excluir {{type}}",
+        "warning": "Isso removerá todas as metadados relacionados ao {{type}}."
+      },
+      "error": "Erro ao excluir {{type}}",
+      "success": {
+        "description": "A solicitação de exclusão do {{type}} foi bem-sucedida.",
+        "title": "{{type}} Excluído com Sucesso"
+      }
+    },
+    "markAs": {
+      "button": "Marcar {{type}} como...",
+      "buttonTooltip": {
+        "failed": "Pressione shift+f para marcar como falha",
+        "success": "Pressione shift+s para marcar como sucesso"
+      },
+      "title": "Marcar {{type}} como {{state}}"
+    },
+    "options": {
+      "downstream": "Downstream",
+      "existingTasks": "Limpar tarefas existentes",
+      "future": "Futuro",
+      "onlyFailed": "Limpar somente tarefas falhadas",
+      "past": "Passado",
+      "queueNew": "Enfileirar novas tarefas",
+      "runOnLatestVersion": "Executar com a versão mais recente do pacote",
+      "upstream": "Upstream"
+    }
+  },
+  "search": {
+    "advanced": "Pesquisa Avançada",
+    "clear": "Limpar pesquisa",
+    "dags": "Pesquisar Dags",
+    "hotkey": "+K",
+    "tasks": "Pesquisar Tarefas"
+  },
+  "sort": {
+    "displayName": {
+      "asc": "Ordenar por Nome (A-Z)",
+      "desc": "Ordenar por Nome (Z-A)"
+    },
+    "lastRunStartDate": {
+      "asc": "Ordenar por Data de Início da Última Execução (Mais Antiga-Mais Recente)",
+      "desc": "Ordenar por Data de Início da Última Execução (Mais Recente-Mais Antiga)"
+    },
+    "lastRunState": {
+      "asc": "Ordenar por Estado da Última Execução (A-Z)",
+      "desc": "Ordenar por Estado da Última Execução (Z-A)"
+    },
+    "nextDagRun": {
+      "asc": "Ordenar por Próxima Execução do Dag (Mais Antiga-Mais Recente)",
+      "desc": "Ordenar por Próxima Execução do Dag (Mais Recente-Mais Antiga)"
+    },
+    "placeholder": "Ordenar por"
+  },
+  "unfavoriteDag": "Remover Dag dos Favoritos"
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
@@ -34,6 +34,10 @@
       "error": "Falha ao limpar {{type}}",
       "title": "Limpar {{type}}"
     },
+    "confirmationDialog": {
+      "description": "A tarefa está atualmente em estado {{state}}, iniciada pelo usuário {{user}} em {{time}}. O usuário não pode limpar esta tarefa até que a execução termine ou até que alguém desmarque a opção \"Impedir nova execução se a tarefa estiver em execução\" no diálogo de limpar tarefa.",
+      "title": "Não é possível limpar a instância da tarefa"
+    },
     "delete": {
       "button": "Excluir {{type}}",
       "dialog": {
@@ -61,6 +65,7 @@
       "future": "Futuro",
       "onlyFailed": "Limpar somente tarefas falhadas",
       "past": "Passado",
+      "preventRunningTasks": "Impedir nova execução se a tarefa estiver em execução",
       "queueNew": "Enfileirar novas tarefas",
       "runOnLatestVersion": "Executar com a versão mais recente do pacote",
       "upstream": "Upstream"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
@@ -1,7 +1,5 @@
 {
   "assetSchedule": "{{count}} de {{total}} ativos atualizados",
-  "assetSchedule_one": "{{count}} de {{total}} ativos atualizados",
-  "assetSchedule_other": "{{count}} de {{total}} ativos atualizados",
   "dagActions": {
     "delete": {
       "button": "Excluir Dag",
@@ -28,9 +26,7 @@
   "runAndTaskActions": {
     "affectedTasks": {
       "noItemsFound": "Nenhuma tarefa encontrada.",
-      "title": "Tarefas Afetadas: {{count}}",
-      "title_one": "Tarefa Afetada: {{count}}",
-      "title_other": "Tarefas Afetadas: {{count}}"
+      "title": "Tarefas Afetadas: {{count}}"
     },
     "clear": {
       "button": "Limpar {{type}}",
@@ -73,6 +69,11 @@
       "queueNew": "Enfileirar novas tarefas",
       "runOnLatestVersion": "Executar com a versão mais recente do pacote",
       "upstream": "Upstream"
+    },
+    "clearAllMapped": {
+      "button": "Limpar Todas as Tarefas Mapeadas",
+      "buttonTooltip": "Pressione shift+c para limpar todas as instâncias de tarefa mapeadas",
+      "title": "Limpar Todas as Instâncias de Tarefa Mapeadas"
     }
   },
   "search": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
@@ -1,5 +1,7 @@
 {
   "assetSchedule": "{{count}} de {{total}} ativos atualizados",
+  "assetSchedule_one": "{{count}} de {{total}} ativos atualizados",
+  "assetSchedule_other": "{{count}} de {{total}} ativos atualizados",
   "dagActions": {
     "delete": {
       "button": "Excluir Dag",
@@ -99,7 +101,5 @@
     },
     "placeholder": "Ordenar por"
   },
-  "unfavoriteDag": "Remover Dag dos Favoritos",
-  "assetSchedule_one": "{{count}} de {{total}} ativos atualizados",
-  "assetSchedule_other": "{{count}} de {{total}} ativos atualizados"
+  "unfavoriteDag": "Remover Dag dos Favoritos"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dags.json
@@ -26,7 +26,9 @@
   "runAndTaskActions": {
     "affectedTasks": {
       "noItemsFound": "Nenhuma tarefa encontrada.",
-      "title": "Tarefas Afetadas: {{count}}"
+      "title": "Tarefas Afetadas: {{count}}",
+      "title_one": "Tarefa Afetada: {{count}}",
+      "title_other": "Tarefas Afetadas: {{count}}"
     },
     "clear": {
       "button": "Limpar {{type}}",
@@ -97,5 +99,7 @@
     },
     "placeholder": "Ordenar por"
   },
-  "unfavoriteDag": "Remover Dag dos Favoritos"
+  "unfavoriteDag": "Remover Dag dos Favoritos",
+  "assetSchedule_one": "{{count}} de {{total}} ativos atualizados",
+  "assetSchedule_other": "{{count}} de {{total}} ativos atualizados"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dashboard.json
@@ -1,0 +1,49 @@
+{
+  "favorite": {
+    "favoriteDags_many": "Primeiros {{count}} Dags favoritos",
+    "favoriteDags_one": "Primeiro {{count}} Dag favorito",
+    "favoriteDags_other": "Primeiros {{count}} Dags favoritos",
+    "favoriteDags_zero": "Nenhum Dag favorito",
+    "noDagRuns": "Ainda não há DagRun para este dag.",
+    "noFavoriteDags": "Nenhum favorito ainda. Clique no ícone de estrela ao lado de um Dag na lista para adicioná-lo aos seus favoritos."
+  },
+  "group": "Grupo",
+  "health": {
+    "dagProcessor": "Processador de Dag",
+    "health": "Saúde",
+    "healthy": "Saúde",
+    "lastHeartbeat": "Último Heartbeat",
+    "metaDatabase": "Base de Dados de Metadados",
+    "scheduler": "Agendador",
+    "status": "Estado",
+    "triggerer": "Disparador",
+    "unhealthy": "Não saudável"
+  },
+  "history": "Histórico",
+  "importErrors": {
+    "dagImportError_many": "Erros de Importação de Dag",
+    "dagImportError_one": "Erro de Importação de Dag",
+    "dagImportError_other": "Erros de Importação de Dag",
+    "dagImportError_zero": "Nenhum erro de importação de Dag",
+    "searchByFile": "Pesquisar por arquivo",
+    "timestamp": "Timestamp"
+  },
+  "managePools": "Gerenciar Pools",
+  "noAssetEvents": "Nenhum Evento de Asset encontrado.",
+  "poolSlots": "Slots de Pool",
+  "sortBy": {
+    "newestFirst": "Mais Recentes Primeiro",
+    "oldestFirst": "Mais Antigos Primeiro"
+  },
+  "source": "Fonte",
+  "stats": {
+    "activeDags": "Dags Ativos",
+    "failedDags": "Dags Falhados",
+    "queuedDags": "Dags em Fila",
+    "requiredActions": "Ações Necessárias",
+    "runningDags": "Dags em Execução",
+    "stats": "Estatísticas"
+  },
+  "uri": "URI",
+  "welcome": "Bem-vindo"
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dashboard.json
@@ -33,7 +33,8 @@
   "poolSlots": "Slots de Pool",
   "sortBy": {
     "newestFirst": "Mais Recentes Primeiro",
-    "oldestFirst": "Mais Antigos Primeiro"
+    "oldestFirst": "Mais Antigos Primeiro",
+    "placeholder": "Ordenar por"
   },
   "source": "Fonte",
   "stats": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/dashboard.json
@@ -1,9 +1,7 @@
 {
   "favorite": {
-    "favoriteDags_many": "Primeiros {{count}} Dags favoritos",
     "favoriteDags_one": "Primeiro {{count}} Dag favorito",
     "favoriteDags_other": "Primeiros {{count}} Dags favoritos",
-    "favoriteDags_zero": "Nenhum Dag favorito",
     "noDagRuns": "Ainda não há DagRun para este dag.",
     "noFavoriteDags": "Nenhum favorito ainda. Clique no ícone de estrela ao lado de um Dag na lista para adicioná-lo aos seus favoritos."
   },
@@ -21,10 +19,8 @@
   },
   "history": "Histórico",
   "importErrors": {
-    "dagImportError_many": "Erros de Importação de Dag",
     "dagImportError_one": "Erro de Importação de Dag",
     "dagImportError_other": "Erros de Importação de Dag",
-    "dagImportError_zero": "Nenhum erro de importação de Dag",
     "searchByFile": "Pesquisar por arquivo",
     "timestamp": "Timestamp"
   },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
@@ -1,0 +1,43 @@
+{
+  "filters": {
+    "body": "Corpo",
+    "createdAtFrom": "Criado De",
+    "createdAtTo": "Criado Até",
+    "response": {
+      "all": "Todas",
+      "pending": "Pendente",
+      "received": "Revisadas"
+    }
+  },
+  "requiredAction_many": "Ações Necessárias",
+  "requiredAction_one": "Ação Necessária",
+  "requiredAction_other": "Ações Necessárias",
+  "requiredAction_zero": "Nenhuma ação necessária",
+  "requiredActionCount_many": "Ações Necessárias ({{count}})",
+  "requiredActionCount_one": "Ação Necessária ({{count}})",
+  "requiredActionCount_other": "Ações Necessárias ({{count}})",
+  "requiredActionCount_zero": "Nenhuma ação necessária",
+  "requiredActionState": "Estado da Ação Necessária",
+  "response": {
+    "created": "Resposta criada em ",
+    "error": "Falha na resposta",
+    "optionsDescription": "Escolha suas opções para esta instância de tarefa",
+    "optionsLabel": "Opções",
+    "received": "Resposta recebida em ",
+    "respond": "Responder",
+    "responded_by_user_name": "Respondido por (Nome de usuário)",
+    "success": "Resposta de {{taskId}} bem-sucedida",
+    "title": "Instância de Tarefa Humana - {{taskId}}"
+  },
+  "state": {
+    "approvalReceived": "Aprovação Recebida",
+    "approvalRequired": "Aprovação Necessária",
+    "choiceReceived": "Escolha Recebida",
+    "choiceRequired": "Escolha Necessária",
+    "noResponseReceived": "Nenhuma Resposta Recebida",
+    "rejectionReceived": "Rejeição Recebida",
+    "responseReceived": "Resposta Recebida",
+    "responseRequired": "Resposta Necessária"
+  },
+  "subject": "Assunto"
+}

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
@@ -10,14 +10,10 @@
       "received": "Revisadas"
     }
   },
-  "requiredAction_many": "Ações Necessárias",
   "requiredAction_one": "Ação Necessária",
   "requiredAction_other": "Ações Necessárias",
-  "requiredAction_zero": "Nenhuma ação necessária",
-  "requiredActionCount_many": "Ações Necessárias ({{count}})",
   "requiredActionCount_one": "Ação Necessária ({{count}})",
   "requiredActionCount_other": "Ações Necessárias ({{count}})",
-  "requiredActionCount_zero": "Nenhuma ação necessária",
   "requiredActionState": "Estado da Ação Necessária",
   "response": {
     "created": "Resposta criada em ",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
@@ -1,6 +1,7 @@
 {
   "filters": {
     "body": "Corpo",
+    "createdAt": "Criado em",
     "createdAtFrom": "Criado De",
     "createdAtTo": "Criado Até",
     "response": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/hitl.json
@@ -2,8 +2,6 @@
   "filters": {
     "body": "Corpo",
     "createdAt": "Criado em",
-    "createdAtFrom": "Criado De",
-    "createdAtTo": "Criado Até",
     "response": {
       "all": "Todas",
       "pending": "Pendente",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/tasks.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt-BR/tasks.json
@@ -1,0 +1,10 @@
+{
+  "mapped": "Mapeado",
+  "notMapped": "Não mapeado",
+  "retries": "Tentativas",
+  "searchTasks": "Pesquisar tarefas",
+  "selectMapped": "Selecionar mapeado",
+  "selectOperator": "Selecionar operadores",
+  "selectRetryValues": "Selecionar valores de tentativa",
+  "selectTriggerRules": "Selecionar regras de gatilho"
+}

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -40,6 +40,7 @@ export const supportedLanguages = [
   { code: "nl", name: "Nederlands" },
   { code: "pl", name: "Polski" },
   { code: "pt", name: "Português" },
+  { code: "pt-BR", name: "Português (Brasil)" },
   { code: "ru", name: "Русский" },
   { code: "th", name: "ไทย" },
   { code: "tr", name: "Türkçe" },

--- a/dev/breeze/src/airflow_breeze/commands/ui_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ui_commands.py
@@ -89,6 +89,7 @@ PLURAL_SUFFIXES = {
     "nl": MOST_COMMON_PLURAL_SUFFIXES,
     "pl": ["_one", "_few", "_many", "_other"],
     "pt": ["_zero", "_one", "_many", "_other"],
+    "pt-BR": ["_zero", "_one", "_many", "_other"],
     "ru": ["_one", "_few", "_other"],
     "th": ["_other"],
     "tr": MOST_COMMON_PLURAL_SUFFIXES,

--- a/dev/breeze/src/airflow_breeze/commands/ui_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ui_commands.py
@@ -89,7 +89,7 @@ PLURAL_SUFFIXES = {
     "nl": MOST_COMMON_PLURAL_SUFFIXES,
     "pl": ["_one", "_few", "_many", "_other"],
     "pt": ["_zero", "_one", "_many", "_other"],
-    "pt-BR": ["_zero", "_one", "_many", "_other"],
+    "pt-BR": MOST_COMMON_PLURAL_SUFFIXES,
     "ru": ["_one", "_few", "_other"],
     "th": ["_other"],
     "tr": MOST_COMMON_PLURAL_SUFFIXES,


### PR DESCRIPTION
Add Portuguese (Brazil) - pt-BR - as a new supported UI locale.

> Reopening of #62965 (closed; reopen disabled). Same branch, same scope.

**Ownership (I am not an Apache Airflow committer):**

- **Translation owner (proposed)**: @andreahlert.
- **Code owner / translation sponsor (requested)**: I am asking a committer to act as code owner and, if needed, translation sponsor for this locale, so that the [approval process in section 6.1](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/ui/public/i18n/README.md#61-approval-of-ownership-candidates) can be carried out (including the dev list thread and PMC vote if the translation owner is a non-committer).

Once a committer confirms they will act as code owner (and sponsor if applicable), the CODEOWNERS entry in this PR will be updated accordingly. After that, the usual approval and dev list steps from the i18n README can proceed.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* This change adds a new supported locale; no AIP is required per the i18n policy.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).