### PR TITLE
Fix smus_notebook system test failure in deferrable CI rotation

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
@@ -146,6 +146,7 @@ with DAG(
         domain_identifier=domain_id,
         owning_project_identifier=project_id,
         wait_for_completion=True,
+        deferrable=False,
     )
 
     run_notebook_b = SageMakerUnifiedStudioNotebookOperator(
@@ -159,6 +160,7 @@ with DAG(
             "employee_age": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.age') }}",
         },
         wait_for_completion=True,
+        deferrable=False,
     )
     # [END howto_operator_sagemaker_unified_studio_notebook_pass_outputs]
 


### PR DESCRIPTION
Two operator instances in `example_sagemaker_unified_studio_notebook` were missing
explicit `deferrable=False`, causing them to inherit `DEFAULT_DEFERRABLE=true` when
[CI randomizes](https://aws-mwaa.github.io/#/open-source/system-tests/dashboard.html) the deferrable flag. This made the test fail ~50% of runs.

The first operator instance already had `deferrable=False` set; the other two did not.