### PR TITLE
Fix GET /auth/login missing 400 in OpenAPI spec and use status constant

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -10294,6 +10294,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
           description: Temporary Redirect
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Bad Request
         '422':
           description: Validation Error
           content:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/auth.py
@@ -36,14 +36,16 @@ auth_router = AirflowRouter(tags=["Login"], prefix="/auth")
 
 @auth_router.get(
     "/login",
-    responses=create_openapi_http_exception_doc([status.HTTP_307_TEMPORARY_REDIRECT]),
+    responses=create_openapi_http_exception_doc(
+        [status.HTTP_307_TEMPORARY_REDIRECT, status.HTTP_400_BAD_REQUEST]
+    ),
 )
 def login(request: Request, auth_manager: AuthManagerDep, next: None | str = None) -> RedirectResponse:
     """Redirect to the login URL depending on the AuthManager configured."""
     login_url = auth_manager.get_url_login()
 
     if next and not is_safe_url(next, request=request):
-        raise HTTPException(status_code=400, detail="Invalid or unsafe next URL")
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="Invalid or unsafe next URL")
 
     if next:
         login_url += f"?{urlencode({'next': next})}"

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -4086,6 +4086,7 @@ export class LoginService {
             },
             errors: {
                 307: 'Temporary Redirect',
+                400: 'Bad Request',
                 422: 'Validation Error'
             }
         });

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -7265,6 +7265,10 @@ export type $OpenApiTs = {
                  */
                 307: HTTPExceptionResponse;
                 /**
+                 * Bad Request
+                 */
+                400: HTTPExceptionResponse;
+                /**
                  * Validation Error
                  */
                 422: HTTPValidationError;


### PR DESCRIPTION
The `/auth/login` endpoint raises HTTP 400 when the `next` redirect URL is invalid or unsafe, but this response code was missing from the `responses` decorator — so the generated OpenAPI spec didn't document it.

## Changes:
- Add `HTTP_400_BAD_REQUEST` to `create_openapi_http_exception_doc` for the login endpoint
- Replace raw integer `400` with `status.HTTP_400_BAD_REQUEST` for consistency with the rest of the codebase
