### PR TITLE
feat: add SerializedDagModel.get_count() and serialized_dag.count StatsD gauge

### DIFF
--- a/airflow-core/newsfragments/67572.feature.rst
+++ b/airflow-core/newsfragments/67572.feature.rst
@@ -1,0 +1,1 @@
+Add ``SerializedDagModel.get_count()`` classmethod and a ``serialized_dag.count`` StatsD gauge (configurable via ``[scheduler] emit_serialized_dag_count_metric``, default enabled) to expose the total number of serialized DAGs in the metadata database; a ``serialized_dag.count_error`` counter is incremented if the DB query fails so dashboards can alert on missing samples.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2574,6 +2574,16 @@ scheduler:
       type: float
       example: ~
       default: "30.0"
+    emit_serialized_dag_count_metric:
+      description: |
+        When enabled, the DAG processing manager emits a ``serialized_dag.count`` gauge
+        (the total number of rows in the ``serialized_dag`` table) once per parse loop.
+        Disable this on large deployments where the extra ``COUNT(*)`` query causes
+        noticeable metadata-database load.
+      version_added: ~
+      type: boolean
+      example: ~
+      default: "True"
     scheduler_health_check_threshold:
       description: |
         If the last scheduler heartbeat happened more than ``[scheduler] scheduler_health_check_threshold``

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import attrs
 import structlog
 from sqlalchemy import select, update
-from sqlalchemy.exc import OperationalError, SQLAlchemyError
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import load_only
 from tabulate import tabulate
 from uuid6 import uuid7
@@ -1725,7 +1725,7 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     try:
         with create_session() as session:
             stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
-    except SQLAlchemyError:
+    except OperationalError:
         log.exception("Failed to emit serialized_dag.count metric")
 
 

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import attrs
 import structlog
 from sqlalchemy import select, update
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import load_only
 from tabulate import tabulate
 from uuid6 import uuid7
@@ -1720,7 +1720,7 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     try:
         with create_session() as session:
             stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
-    except Exception:
+    except (RuntimeError, SQLAlchemyError):
         log.exception("Failed to emit serialized_dag.count metric")
 
 

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import attrs
 import structlog
 from sqlalchemy import select, update
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import load_only
 from tabulate import tabulate
 from uuid6 import uuid7

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1718,8 +1718,10 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     stats.gauge("dagbag_size", sum(stat.num_dags for stat in dag_file_stats))
     stats.gauge("dag_processing.import_errors", sum(stat.import_errors for stat in dag_file_stats))
     # COUNT(*) on the serialized_dag table adds one DB round-trip per parse loop.
-    # On large installations this is typically fast (index scan on the PK), but
-    # we isolate the call so that a transient DB error never kills the parse loop.
+    # This can be expensive on large deployments (query plan is DB-dependent and
+    # may involve a full table scan).  The call is isolated so that a transient
+    # DB error never kills the parse loop; throttling this metric in the future
+    # is a straightforward follow-up if the round-trip becomes a bottleneck.
     try:
         with create_session() as session:
             stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1717,10 +1717,13 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     stats.gauge("dag_processing.total_parse_time", parse_time)
     stats.gauge("dagbag_size", sum(stat.num_dags for stat in dag_file_stats))
     stats.gauge("dag_processing.import_errors", sum(stat.import_errors for stat in dag_file_stats))
+    # COUNT(*) on the serialized_dag table adds one DB round-trip per parse loop.
+    # On large installations this is typically fast (index scan on the PK), but
+    # we isolate the call so that a transient DB error never kills the parse loop.
     try:
         with create_session() as session:
             stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
-    except (RuntimeError, SQLAlchemyError):
+    except SQLAlchemyError:
         log.exception("Failed to emit serialized_dag.count metric")
 
 

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1718,15 +1718,16 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     stats.gauge("dagbag_size", sum(stat.num_dags for stat in dag_file_stats))
     stats.gauge("dag_processing.import_errors", sum(stat.import_errors for stat in dag_file_stats))
     # COUNT(*) on the serialized_dag table adds one DB round-trip per parse loop.
-    # This can be expensive on large deployments (query plan is DB-dependent and
-    # may involve a full table scan).  The call is isolated so that a transient
-    # DB error never kills the parse loop; throttling this metric in the future
-    # is a straightforward follow-up if the round-trip becomes a bottleneck.
+    # This can be expensive on large deployments; throttling this metric is a
+    # straightforward follow-up if the round-trip becomes a bottleneck.
+    # On failure, an error counter is incremented so dashboards can alert on
+    # missing samples rather than silently showing a stale last value.
     try:
         with create_session() as session:
             stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
     except SQLAlchemyError:
         log.exception("Failed to emit serialized_dag.count metric")
+        stats.incr("serialized_dag.count_error")
 
 
 def process_parse_results(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -61,10 +61,10 @@ from airflow.models.asset import remove_references_to_deleted_dags
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagPriorityParsingRequest
 from airflow.models.dagbundle import DagBundleModel
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.errors import ParseImportError
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.observability.metrics import stats_utils
 from airflow.sdk import SecretCache
 from airflow.sdk.log import init_log_file, logging_processors

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1717,17 +1717,16 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     stats.gauge("dag_processing.total_parse_time", parse_time)
     stats.gauge("dagbag_size", sum(stat.num_dags for stat in dag_file_stats))
     stats.gauge("dag_processing.import_errors", sum(stat.import_errors for stat in dag_file_stats))
-    # COUNT(*) on the serialized_dag table adds one DB round-trip per parse loop.
-    # This can be expensive on large deployments; throttling this metric is a
-    # straightforward follow-up if the round-trip becomes a bottleneck.
-    # On failure, an error counter is incremented so dashboards can alert on
+    # Gated by config so large deployments can opt out of the extra DB round-trip.
+    # On failure an error counter is incremented so dashboards can alert on
     # missing samples rather than silently showing a stale last value.
-    try:
-        with create_session() as session:
-            stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
-    except SQLAlchemyError:
-        log.exception("Failed to emit serialized_dag.count metric")
-        stats.incr("serialized_dag.count_error")
+    if conf.getboolean("scheduler", "emit_serialized_dag_count_metric", fallback=True):
+        try:
+            with create_session() as session:
+                stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
+        except SQLAlchemyError:
+            log.exception("Failed to emit serialized_dag.count metric")
+            stats.incr("serialized_dag.count_error")
 
 
 def process_parse_results(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -61,6 +61,7 @@ from airflow.models.asset import remove_references_to_deleted_dags
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagPriorityParsingRequest
 from airflow.models.dagbundle import DagBundleModel
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.dagwarning import DagWarning
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.errors import ParseImportError
@@ -95,6 +96,9 @@ if TYPE_CHECKING:
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.dag_processing.bundles.base import BaseDagBundle
     from airflow.sdk.api.client import Client
+
+
+log = structlog.get_logger(__name__)
 
 
 def _make_execution_api() -> InProcessExecutionAPI:
@@ -1713,6 +1717,11 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     stats.gauge("dag_processing.total_parse_time", parse_time)
     stats.gauge("dagbag_size", sum(stat.num_dags for stat in dag_file_stats))
     stats.gauge("dag_processing.import_errors", sum(stat.import_errors for stat in dag_file_stats))
+    try:
+        with create_session() as session:
+            stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
+    except Exception:
+        log.exception("Failed to emit serialized_dag.count metric")
 
 
 def process_parse_results(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -40,7 +40,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 import attrs
 import structlog
 from sqlalchemy import select, update
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import load_only
 from tabulate import tabulate
 from uuid6 import uuid7
@@ -1725,7 +1725,7 @@ def emit_metrics(*, parse_time: float, dag_file_stats: Sequence[DagFileStat]):
     try:
         with create_session() as session:
             stats.gauge("serialized_dag.count", SerializedDagModel.get_count(session=session))
-    except OperationalError:
+    except SQLAlchemyError:
         log.exception("Failed to emit serialized_dag.count metric")
 
 

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -915,16 +915,14 @@ class SerializedDagModel(Base):
         """
         Return the total number of serialized DAGs stored in the database.
 
+        Uses ``scalar_one()`` so that a DB connectivity failure surfaces as a
+        ``SQLAlchemyError`` rather than a silent ``None`` return.  ``COUNT(*)``
+        always produces exactly one row, so ``NoResultFound`` is never raised
+        under normal conditions.
+
         :param session: ORM Session
-        :raises RuntimeError: if the database returns None for the COUNT query, which indicates
-            a transient connectivity issue rather than an empty table (COUNT always returns an int).
         """
-        result = session.scalar(select(func.count()).select_from(cls))
-        if result is None:
-            raise RuntimeError(
-                "COUNT query on serialized_dag returned None - possible database connectivity issue"
-            )
-        return result
+        return session.execute(select(func.count()).select_from(cls)).scalar_one()
 
     @classmethod
     @provide_session

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -922,7 +922,7 @@ class SerializedDagModel(Base):
         result = session.scalar(select(func.count()).select_from(cls))
         if result is None:
             raise RuntimeError(
-                "COUNT query on serialized_dag returned None — possible database connectivity issue"
+                "COUNT query on serialized_dag returned None - possible database connectivity issue"
             )
         return result
 

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -915,10 +915,10 @@ class SerializedDagModel(Base):
         """
         Return the total number of serialized DAGs stored in the database.
 
-        Uses ``scalar_one()`` so that a DB connectivity failure surfaces as a
-        ``SQLAlchemyError`` rather than a silent ``None`` return.  ``COUNT(*)``
-        always produces exactly one row, so ``NoResultFound`` is never raised
-        under normal conditions.
+        Uses ``scalar_one()`` to enforce "exactly one row" semantics.
+        ``COUNT(*)`` always returns exactly one row, so ``scalar_one()`` makes
+        that contract explicit and will raise ``MultipleResultsFound`` if the
+        query shape ever changes unexpectedly.
 
         :param session: ORM Session
         """

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -911,6 +911,23 @@ class SerializedDagModel(Base):
 
     @classmethod
     @provide_session
+    def get_count(cls, session: Session = NEW_SESSION) -> int:
+        """
+        Return the total number of serialized DAGs stored in the database.
+
+        :param session: ORM Session
+        :raises RuntimeError: if the database returns None for the COUNT query, which indicates
+            a transient connectivity issue rather than an empty table (COUNT always returns an int).
+        """
+        result = session.scalar(select(func.count()).select_from(cls))
+        if result is None:
+            raise RuntimeError(
+                "COUNT query on serialized_dag returned None — possible database connectivity issue"
+            )
+        return result
+
+    @classmethod
+    @provide_session
     def get_dag(cls, dag_id: str, *, session: Session = NEW_SESSION) -> SerializedDAG | None:
         row = cls.get(dag_id, session=session)
         if row:

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3223,12 +3223,14 @@ class TestEmitMetrics:
         """emit_metrics emits the serialized_dag.count gauge with the value from get_count."""
         from airflow.dag_processing.manager import emit_metrics
 
-        with mock.patch("airflow.dag_processing.manager.create_session"):
-            with mock.patch(
-                "airflow.dag_processing.manager.SerializedDagModel.get_count", return_value=3
-            ):
-                with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
-                    emit_metrics(parse_time=1.0, dag_file_stats=[])
+        with mock.patch("airflow.dag_processing.manager.conf") as mock_conf:
+            mock_conf.getboolean.return_value = True
+            with mock.patch("airflow.dag_processing.manager.create_session"):
+                with mock.patch(
+                    "airflow.dag_processing.manager.SerializedDagModel.get_count", return_value=3
+                ):
+                    with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+                        emit_metrics(parse_time=1.0, dag_file_stats=[])
 
         mock_stats.gauge.assert_any_call("serialized_dag.count", 3)
 
@@ -3238,14 +3240,34 @@ class TestEmitMetrics:
 
         from airflow.dag_processing.manager import emit_metrics
 
-        with mock.patch("airflow.dag_processing.manager.create_session"):
-            with mock.patch(
-                "airflow.dag_processing.manager.SerializedDagModel.get_count",
-                side_effect=SQLAlchemyError("db failure"),
-            ):
-                with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
-                    with mock.patch("airflow.dag_processing.manager.log") as mock_log:
-                        emit_metrics(parse_time=1.0, dag_file_stats=[])
+        with mock.patch("airflow.dag_processing.manager.conf") as mock_conf:
+            mock_conf.getboolean.return_value = True
+            with mock.patch("airflow.dag_processing.manager.create_session"):
+                with mock.patch(
+                    "airflow.dag_processing.manager.SerializedDagModel.get_count",
+                    side_effect=SQLAlchemyError("db failure"),
+                ):
+                    with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+                        with mock.patch("airflow.dag_processing.manager.log") as mock_log:
+                            emit_metrics(parse_time=1.0, dag_file_stats=[])
 
         mock_log.exception.assert_called_once_with("Failed to emit serialized_dag.count metric")
         mock_stats.incr.assert_called_once_with("serialized_dag.count_error")
+
+    def test_emit_metrics_skips_serialized_dag_count_when_disabled(self):
+        """emit_metrics does not query or emit serialized_dag.count when config is False."""
+        from airflow.dag_processing.manager import emit_metrics
+
+        with mock.patch("airflow.dag_processing.manager.conf") as mock_conf:
+            mock_conf.getboolean.return_value = False
+            with mock.patch(
+                "airflow.dag_processing.manager.SerializedDagModel.get_count"
+            ) as mock_get_count:
+                with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+                    emit_metrics(parse_time=1.0, dag_file_stats=[])
+
+        mock_get_count.assert_not_called()
+        assert not any(
+            call == mock.call("serialized_dag.count", mock.ANY)
+            for call in mock_stats.gauge.call_args_list
+        )

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3219,20 +3219,19 @@ class TestMultiTeamMetrics:
 class TestEmitMetrics:
     """Tests for the emit_metrics module-level function."""
 
-    @pytest.mark.db_test
-    def test_emit_metrics_emits_serialized_dag_count(self, dag_maker, session):
-        """emit_metrics emits the serialized_dag.count gauge with the DB count."""
+    def test_emit_metrics_emits_serialized_dag_count(self):
+        """emit_metrics emits the serialized_dag.count gauge with the value from get_count."""
         from airflow.dag_processing.manager import emit_metrics
 
-        with dag_maker("emit_count_dag"):
-            pass
-
-        with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
-            emit_metrics(parse_time=1.0, dag_file_stats=[])
+        with mock.patch(
+            "airflow.dag_processing.manager.SerializedDagModel.get_count", return_value=3
+        ):
+            with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+                emit_metrics(parse_time=1.0, dag_file_stats=[])
 
         calls = {call[0][0]: call[0][1] for call in mock_stats.gauge.call_args_list}
         assert "serialized_dag.count" in calls
-        assert calls["serialized_dag.count"] == 1
+        assert calls["serialized_dag.count"] == 3
 
     def test_emit_metrics_does_not_raise_on_db_error(self):
         """emit_metrics logs and swallows RuntimeError from get_count on DB failure."""
@@ -3240,7 +3239,7 @@ class TestEmitMetrics:
 
         with mock.patch(
             "airflow.dag_processing.manager.SerializedDagModel.get_count",
-            side_effect=RuntimeError("COUNT query on serialized_dag returned None"),
+            side_effect=RuntimeError("COUNT query on serialized_dag returned None - possible"),
         ):
             with mock.patch("airflow.dag_processing.manager.stats"):
                 emit_metrics(parse_time=1.0, dag_file_stats=[])

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3223,11 +3223,12 @@ class TestEmitMetrics:
         """emit_metrics emits the serialized_dag.count gauge with the value from get_count."""
         from airflow.dag_processing.manager import emit_metrics
 
-        with mock.patch(
-            "airflow.dag_processing.manager.SerializedDagModel.get_count", return_value=3
-        ):
-            with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
-                emit_metrics(parse_time=1.0, dag_file_stats=[])
+        with mock.patch("airflow.dag_processing.manager.create_session"):
+            with mock.patch(
+                "airflow.dag_processing.manager.SerializedDagModel.get_count", return_value=3
+            ):
+                with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+                    emit_metrics(parse_time=1.0, dag_file_stats=[])
 
         mock_stats.gauge.assert_any_call("serialized_dag.count", 3)
 
@@ -3237,13 +3238,14 @@ class TestEmitMetrics:
 
         from airflow.dag_processing.manager import emit_metrics
 
-        with mock.patch(
-            "airflow.dag_processing.manager.SerializedDagModel.get_count",
-            side_effect=SQLAlchemyError("db failure"),
-        ):
-            with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
-                with mock.patch("airflow.dag_processing.manager.log") as mock_log:
-                    emit_metrics(parse_time=1.0, dag_file_stats=[])
+        with mock.patch("airflow.dag_processing.manager.create_session"):
+            with mock.patch(
+                "airflow.dag_processing.manager.SerializedDagModel.get_count",
+                side_effect=SQLAlchemyError("db failure"),
+            ):
+                with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+                    with mock.patch("airflow.dag_processing.manager.log") as mock_log:
+                        emit_metrics(parse_time=1.0, dag_file_stats=[])
 
         mock_log.exception.assert_called_once_with("Failed to emit serialized_dag.count metric")
         mock_stats.incr.assert_called_once_with("serialized_dag.count_error")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3233,13 +3233,18 @@ class TestEmitMetrics:
         assert "serialized_dag.count" in calls
         assert calls["serialized_dag.count"] == 3
 
-    def test_emit_metrics_does_not_raise_on_db_error(self):
-        """emit_metrics logs and swallows RuntimeError from get_count on DB failure."""
+    def test_emit_metrics_logs_and_swallows_db_error(self):
+        """emit_metrics logs via log.exception and swallows SQLAlchemyError from get_count."""
+        from sqlalchemy.exc import SQLAlchemyError
+
         from airflow.dag_processing.manager import emit_metrics
 
         with mock.patch(
             "airflow.dag_processing.manager.SerializedDagModel.get_count",
-            side_effect=RuntimeError("COUNT query on serialized_dag returned None - possible"),
+            side_effect=SQLAlchemyError("db failure"),
         ):
             with mock.patch("airflow.dag_processing.manager.stats"):
-                emit_metrics(parse_time=1.0, dag_file_stats=[])
+                with mock.patch("airflow.dag_processing.manager.log") as mock_log:
+                    emit_metrics(parse_time=1.0, dag_file_stats=[])
+
+        mock_log.exception.assert_called_once_with("Failed to emit serialized_dag.count metric")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3232,7 +3232,7 @@ class TestEmitMetrics:
         mock_stats.gauge.assert_any_call("serialized_dag.count", 3)
 
     def test_emit_metrics_logs_and_swallows_db_error(self):
-        """emit_metrics logs via log.exception and swallows SQLAlchemyError from get_count."""
+        """emit_metrics logs, increments error counter, and swallows SQLAlchemyError from get_count."""
         from sqlalchemy.exc import SQLAlchemyError
 
         from airflow.dag_processing.manager import emit_metrics
@@ -3241,8 +3241,9 @@ class TestEmitMetrics:
             "airflow.dag_processing.manager.SerializedDagModel.get_count",
             side_effect=SQLAlchemyError("db failure"),
         ):
-            with mock.patch("airflow.dag_processing.manager.stats"):
+            with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
                 with mock.patch("airflow.dag_processing.manager.log") as mock_log:
                     emit_metrics(parse_time=1.0, dag_file_stats=[])
 
         mock_log.exception.assert_called_once_with("Failed to emit serialized_dag.count metric")
+        mock_stats.incr.assert_called_once_with("serialized_dag.count_error")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3233,13 +3233,13 @@ class TestEmitMetrics:
 
     def test_emit_metrics_logs_and_swallows_db_error(self):
         """emit_metrics logs via log.exception and swallows SQLAlchemyError from get_count."""
-        from sqlalchemy.exc import OperationalError
+        from sqlalchemy.exc import SQLAlchemyError
 
         from airflow.dag_processing.manager import emit_metrics
 
         with mock.patch(
             "airflow.dag_processing.manager.SerializedDagModel.get_count",
-            side_effect=OperationalError("db failure", None, None),
+            side_effect=SQLAlchemyError("db failure"),
         ):
             with mock.patch("airflow.dag_processing.manager.stats"):
                 with mock.patch("airflow.dag_processing.manager.log") as mock_log:

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3233,13 +3233,13 @@ class TestEmitMetrics:
 
     def test_emit_metrics_logs_and_swallows_db_error(self):
         """emit_metrics logs via log.exception and swallows SQLAlchemyError from get_count."""
-        from sqlalchemy.exc import SQLAlchemyError
+        from sqlalchemy.exc import OperationalError
 
         from airflow.dag_processing.manager import emit_metrics
 
         with mock.patch(
             "airflow.dag_processing.manager.SerializedDagModel.get_count",
-            side_effect=SQLAlchemyError("db failure"),
+            side_effect=OperationalError("db failure", None, None),
         ):
             with mock.patch("airflow.dag_processing.manager.stats"):
                 with mock.patch("airflow.dag_processing.manager.log") as mock_log:

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3229,9 +3229,7 @@ class TestEmitMetrics:
             with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
                 emit_metrics(parse_time=1.0, dag_file_stats=[])
 
-        calls = {call[0][0]: call[0][1] for call in mock_stats.gauge.call_args_list}
-        assert "serialized_dag.count" in calls
-        assert calls["serialized_dag.count"] == 3
+        mock_stats.gauge.assert_any_call("serialized_dag.count", 3)
 
     def test_emit_metrics_logs_and_swallows_db_error(self):
         """emit_metrics logs via log.exception and swallows SQLAlchemyError from get_count."""

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3214,3 +3214,33 @@ class TestMultiTeamMetrics:
             manager._add_callback_to_queue(request)
 
         mock_incr.assert_called_once_with("dag_processing.other_callback_count", tags=expected_tags)
+
+
+class TestEmitMetrics:
+    """Tests for the emit_metrics module-level function."""
+
+    @pytest.mark.db_test
+    def test_emit_metrics_emits_serialized_dag_count(self, dag_maker, session):
+        """emit_metrics emits the serialized_dag.count gauge with the DB count."""
+        from airflow.dag_processing.manager import emit_metrics
+
+        with dag_maker("emit_count_dag"):
+            pass
+
+        with mock.patch("airflow.dag_processing.manager.stats") as mock_stats:
+            emit_metrics(parse_time=1.0, dag_file_stats=[])
+
+        calls = {call[0][0]: call[0][1] for call in mock_stats.gauge.call_args_list}
+        assert "serialized_dag.count" in calls
+        assert calls["serialized_dag.count"] == 1
+
+    def test_emit_metrics_does_not_raise_on_db_error(self):
+        """emit_metrics logs and swallows RuntimeError from get_count on DB failure."""
+        from airflow.dag_processing.manager import emit_metrics
+
+        with mock.patch(
+            "airflow.dag_processing.manager.SerializedDagModel.get_count",
+            side_effect=RuntimeError("COUNT query on serialized_dag returned None"),
+        ):
+            with mock.patch("airflow.dag_processing.manager.stats"):
+                emit_metrics(parse_time=1.0, dag_file_stats=[])

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1027,12 +1027,10 @@ class TestSerializedDagModel:
     def test_get_count_returns_correct_value(self, dag_maker, session):
         """get_count() returns the exact number of serialized DAGs in the table."""
         baseline = SDM.get_count(session=session)
-        with dag_maker("dag_count_1"):
+        with dag_maker("dag_count_1", session=session):
             pass
-        with dag_maker("dag_count_2"):
+        with dag_maker("dag_count_2", session=session):
             pass
-        # dag_maker writes SerializedDagModel rows on context exit; flush to make
-        # them visible within the same session before asserting.
         session.flush()
         assert SDM.get_count(session=session) == baseline + 2
 

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1029,11 +1029,16 @@ class TestSerializedDagModel:
             pass
         with dag_maker("dag_count_2"):
             pass
+        # dag_maker writes SerializedDagModel rows on context exit; flush to make
+        # them visible within the same session before asserting.
+        session.flush()
         count = SDM.get_count(session=session)
         assert count == 2
 
-    def test_get_count_raises_on_none_result(self, session):
-        """get_count() raises RuntimeError when session.scalar returns None (simulates DB failure)."""
-        with mock.patch.object(session, "scalar", return_value=None):
-            with pytest.raises(RuntimeError, match="COUNT query on serialized_dag returned None - possible"):
+    def test_get_count_propagates_db_error(self, session):
+        """get_count() lets SQLAlchemyError propagate so callers can handle DB failures."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        with mock.patch.object(session, "execute", side_effect=SQLAlchemyError("db failure")):
+            with pytest.raises(SQLAlchemyError):
                 SDM.get_count(session=session)

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1041,7 +1041,7 @@ class TestSerializedDagModel:
         from sqlalchemy.exc import OperationalError
 
         with mock.patch.object(
-            session, "execute", side_effect=OperationalError("db failure", None, Exception("db failure"))
+            session, "execute", side_effect=OperationalError("db failure", {}, Exception("db failure"))
         ):
             with pytest.raises(OperationalError):
                 SDM.get_count(session=session)

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1020,11 +1020,8 @@ class TestSerializedDagModel:
         assert updated_alert.name == "updated name"
 
     def test_get_count_returns_zero_on_empty_table(self, session):
-        """get_count() returns 0 when no serialized DAGs are stored.
-
-        The autouse ``setup_test_cases`` fixture calls ``db.clear_db_serialized_dags()``
-        before this test runs, guaranteeing a known-empty starting state.
-        """
+        """get_count() returns 0 when no serialized DAGs are stored."""
+        db.clear_db_serialized_dags()
         assert SDM.get_count(session=session) == 0
 
     def test_get_count_returns_correct_value(self, dag_maker, session):

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1025,6 +1025,7 @@ class TestSerializedDagModel:
 
     def test_get_count_returns_correct_value(self, dag_maker, session):
         """get_count() returns the exact number of serialized DAGs in the table."""
+        baseline = SDM.get_count(session=session)
         with dag_maker("dag_count_1"):
             pass
         with dag_maker("dag_count_2"):
@@ -1032,8 +1033,7 @@ class TestSerializedDagModel:
         # dag_maker writes SerializedDagModel rows on context exit; flush to make
         # them visible within the same session before asserting.
         session.flush()
-        count = SDM.get_count(session=session)
-        assert count == 2
+        assert SDM.get_count(session=session) == baseline + 2
 
     def test_get_count_propagates_db_error(self, session):
         """get_count() lets SQLAlchemyError propagate so callers can handle DB failures."""

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1020,9 +1020,11 @@ class TestSerializedDagModel:
         assert updated_alert.name == "updated name"
 
     def test_get_count_returns_zero_on_empty_table(self, session):
-        """get_count() returns 0 when no serialized DAGs are stored."""
-        session.execute(delete(SDM))
-        session.commit()
+        """get_count() returns 0 when no serialized DAGs are stored.
+
+        The autouse ``setup_test_cases`` fixture calls ``db.clear_db_serialized_dags()``
+        before this test runs, guaranteeing a known-empty starting state.
+        """
         assert SDM.get_count(session=session) == 0
 
     def test_get_count_returns_correct_value(self, dag_maker, session):
@@ -1038,9 +1040,9 @@ class TestSerializedDagModel:
         assert SDM.get_count(session=session) == baseline + 2
 
     def test_get_count_propagates_db_error(self, session):
-        """get_count() lets SQLAlchemyError propagate so callers can handle DB failures."""
-        from sqlalchemy.exc import SQLAlchemyError
+        """get_count() lets OperationalError propagate so callers can handle DB failures."""
+        from sqlalchemy.exc import OperationalError
 
-        with mock.patch.object(session, "execute", side_effect=SQLAlchemyError("db failure")):
-            with pytest.raises(SQLAlchemyError):
+        with mock.patch.object(session, "execute", side_effect=OperationalError("db failure", None, None)):
+            with pytest.raises(OperationalError):
                 SDM.get_count(session=session)

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1040,6 +1040,8 @@ class TestSerializedDagModel:
         """get_count() lets OperationalError propagate so callers can handle DB failures."""
         from sqlalchemy.exc import OperationalError
 
-        with mock.patch.object(session, "execute", side_effect=OperationalError("db failure", None, None)):
+        with mock.patch.object(
+            session, "execute", side_effect=OperationalError("db failure", None, Exception("db failure"))
+        ):
             with pytest.raises(OperationalError):
                 SDM.get_count(session=session)

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1021,6 +1021,8 @@ class TestSerializedDagModel:
 
     def test_get_count_returns_zero_on_empty_table(self, session):
         """get_count() returns 0 when no serialized DAGs are stored."""
+        session.execute(delete(SDM))
+        session.commit()
         assert SDM.get_count(session=session) == 0
 
     def test_get_count_returns_correct_value(self, dag_maker, session):

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1018,3 +1018,22 @@ class TestSerializedDagModel:
 
         # The name must have been updated in the DB.
         assert updated_alert.name == "updated name"
+
+    def test_get_count_returns_zero_on_empty_table(self, session):
+        """get_count() returns 0 when no serialized DAGs are stored."""
+        assert SDM.get_count(session=session) == 0
+
+    def test_get_count_returns_correct_value(self, dag_maker, session):
+        """get_count() returns the exact number of serialized DAGs in the table."""
+        with dag_maker("dag_count_1"):
+            pass
+        with dag_maker("dag_count_2"):
+            pass
+        count = SDM.get_count(session=session)
+        assert count == 2
+
+    def test_get_count_raises_on_none_result(self, session):
+        """get_count() raises RuntimeError when session.scalar returns None (simulates DB failure)."""
+        with mock.patch.object(session, "scalar", return_value=None):
+            with pytest.raises(RuntimeError, match="COUNT query on serialized_dag returned None"):
+                SDM.get_count(session=session)

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -1035,5 +1035,5 @@ class TestSerializedDagModel:
     def test_get_count_raises_on_none_result(self, session):
         """get_count() raises RuntimeError when session.scalar returns None (simulates DB failure)."""
         with mock.patch.object(session, "scalar", return_value=None):
-            with pytest.raises(RuntimeError, match="COUNT query on serialized_dag returned None"):
+            with pytest.raises(RuntimeError, match="COUNT query on serialized_dag returned None - possible"):
                 SDM.get_count(session=session)

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -180,6 +180,12 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "serialized_dag.count_error"
+    description: "Number of failures querying the serialized DAG count metric from the database"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "scheduler.tasks.killed_externally"
     description: "Number of tasks killed externally. Metric with dag_id and task_id tagging."
     type: "counter"
@@ -369,6 +375,12 @@ metrics:
   # ==========
   - name: "dagbag_size"
     description: "Number of Dags found when the scheduler ran a scan based on its configuration"
+    type: "gauge"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "serialized_dag.count"
+    description: "Total number of serialized DAGs stored in the database"
     type: "gauge"
     legacy_name: "-"
     name_variables: []


### PR DESCRIPTION
## Summary

Fixes #66796

Adds ``SerializedDagModel.get_count()`` and a new ``serialized_dag.count`` StatsD gauge so operators can monitor the total number of serialized DAGs in the metadata database.

``COUNT(*)`` on an aggregate column always returns an integer — ``None`` from ``session.scalar()`` is only possible on a transient DB connectivity failure, not when the table is empty (which returns ``0``). The previous ``or 0`` pattern silently swallows that failure and emits a zero count, which can trigger false on-call pages ("all DAGs disappeared!") while hiding the real problem.

- Add ``SerializedDagModel.get_count()`` classmethod using ``scalar_one()`` to enforce "exactly one row" semantics; ``COUNT(*)`` always returns one row so this makes the contract explicit and propagates DB errors to callers
- Emit a ``serialized_dag.count`` gauge in ``dag_processing/manager.py``'s ``emit_metrics()``, gated by ``[scheduler] emit_serialized_dag_count_metric`` (default: ``True``) so large deployments can opt out of the extra DB round-trip
- On DB failure the gauge is skipped and ``serialized_dag.count_error`` is incremented so dashboards can alert on missing samples rather than showing a stale last value
- Register both new metrics in ``metrics_template.yaml`` as required by the metrics registry check

## Changes

- ``airflow-core/src/airflow/models/serialized_dag.py`` — add ``get_count()`` classmethod
- ``airflow-core/src/airflow/dag_processing/manager.py`` — import ``SerializedDagModel``, emit ``serialized_dag.count`` metric with error isolation
- ``airflow-core/src/airflow/config_templates/config.yml`` — register ``emit_serialized_dag_count_metric`` in the ``[scheduler]`` section
- ``shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml`` — register ``serialized_dag.count`` (gauge) and ``serialized_dag.count_error`` (counter)
- ``airflow-core/newsfragments/67572.feature.rst`` — changelog entry

## Test plan

- [ ] ``tests/unit/models/test_serialized_dag.py::TestSerializedDagModel::test_get_count_returns_zero_on_empty_table``
- [ ] ``tests/unit/models/test_serialized_dag.py::TestSerializedDagModel::test_get_count_returns_correct_value``
- [ ] ``tests/unit/models/test_serialized_dag.py::TestSerializedDagModel::test_get_count_propagates_db_error``
- [ ] ``tests/unit/dag_processing/test_manager.py::TestEmitMetrics::test_emit_metrics_emits_serialized_dag_count``
- [ ] ``tests/unit/dag_processing/test_manager.py::TestEmitMetrics::test_emit_metrics_logs_and_swallows_db_error``
- [ ] ``tests/unit/dag_processing/test_manager.py::TestEmitMetrics::test_emit_metrics_skips_serialized_dag_count_when_disabled``

## Gen-AI disclosure

This PR was created with the assistance of Claude Code (Anthropic).

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=974d31a action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @gingeekrishna** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Static checks`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->