### PR TITLE
Fix example_mwaa_serverless system test race condition with stop_workflow_run

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_mwaa_serverless.py
+++ b/providers/amazon/tests/system/amazon/aws/example_mwaa_serverless.py
@@ -46,7 +46,7 @@ DAG_ID = "example_mwaa_serverless"
 # Externally fetched variables:
 ROLE_ARN_KEY = "ROLE_ARN"
 
-# Valid MWAA Serverless YAML: tasks as mapping, FQN operators, flat parameters.
+# Quick workflow - checks for a key that exists, completes immediately
 WORKFLOW_YAML = """\
 systest_mwaa_serverless:
   schedule: null
@@ -59,8 +59,23 @@ systest_mwaa_serverless:
       bucket_key: workflow.yaml
 """
 
-sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).build()
+# Long-running workflow - waits for a key that never arrives, used to test stopping
+STOPPABLE_WORKFLOW_YAML = """\
+systest_mwaa_serverless_stoppable:
+  schedule: null
+  description: "System test: long-running workflow for stop testing"
+  tasks:
+    wait_for_stop:
+      task_id: wait_for_stop
+      operator: airflow.providers.amazon.aws.sensors.s3.S3KeySensor
+      bucket_name: {bucket}
+      bucket_key: never_exists.txt
+      poke_interval: 30
+      timeout: 600
+      soft_fail: true
+"""
 
+sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).build()
 
 with DAG(
     dag_id=DAG_ID,
@@ -80,6 +95,13 @@ with DAG(
         s3_bucket=bucket_name,
         s3_key="workflow.yaml",
         data=WORKFLOW_YAML.format(bucket=bucket_name),
+    )
+
+    upload_stoppable_workflow_yaml = S3CreateObjectOperator(
+        task_id="upload_stoppable_workflow_yaml",
+        s3_bucket=bucket_name,
+        s3_key="stoppable_workflow.yaml",
+        data=STOPPABLE_WORKFLOW_YAML.format(bucket=bucket_name),
     )
 
     # [START howto_operator_mwaa_serverless_create_workflow]
@@ -123,13 +145,14 @@ with DAG(
     update_workflow = MwaaServerlessUpdateWorkflowOperator(
         task_id="update_workflow",
         workflow_arn=workflow_arn,
-        definition_s3_location={"Bucket": bucket_name, "ObjectKey": "workflow.yaml"},
+        definition_s3_location={"Bucket": bucket_name, "ObjectKey": "stoppable_workflow.yaml"},
         role_arn=role_arn,
-        description="Updated system test workflow",
+        description="Updated to stoppable workflow for stop testing",
     )
     # [END howto_operator_mwaa_serverless_update_workflow]
 
-    # Start a second run to test stopping
+    # Start a second run to test stopping - this uses the stoppable workflow
+    # that will keep running until explicitly stopped
     start_workflow_2 = MwaaServerlessStartWorkflowRunOperator(
         task_id="start_workflow_2",
         workflow_arn=workflow_arn,
@@ -162,7 +185,7 @@ with DAG(
         # TEST SETUP
         test_context,
         create_bucket,
-        upload_workflow_yaml,
+        [upload_workflow_yaml, upload_stoppable_workflow_yaml],
         workflow_arn,
         # TEST BODY
         create_workflow_again,


### PR DESCRIPTION
The stop_workflow_run task was failing with a ValidationException because the workflow run completed before the stop command could be issued. This was particularly problematic on high-latency executors (e.g., ECS) where task launch overhead (~90s) gave the workflow enough time to finish.

The fix introduces a second workflow definition (stoppable_workflow.yaml) that sensors for a non-existent S3 key, keeping the workflow running indefinitely until explicitly stopped.

Ran the system test locally and it passed

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
