### PR TITLE
Make session parameter in dag_clear CLI keyword only

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -125,7 +125,7 @@ def dag_delete(args) -> None:
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
-def dag_clear(args, session: Session = NEW_SESSION) -> None:
+def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
     """Clear Dag runs selected by run_id, partition_key, or a partition_date window."""
     has_range = args.partition_date_start is not None or args.partition_date_end is not None
     selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])


### PR DESCRIPTION
- related: #66004
- fail run: https://github.com/apache/airflow/actions/runs/26440852647/job/77843698384?pr=67150

## What

- The https://github.com/apache/airflow/pull/67150 static check catched the new violation in `dag_clear` CLI command introduced yesterday. 

```
Check that no new @provide_session functions declare `session` positionally...............................Failed
- hook id: check-no-new-provide-session-positional
- exit code: 1

  ╭────────────────────────────────────── Check failed ──────────────────────────────────────╮
  │ New @provide_session function with positional ``session`` detected.                      │
  │ Move ``session`` after a bare ``*`` in the signature so callers must pass it by keyword: │
  │                                                                                          │
  │   @provide_session                                                                       │
  │   def foo(arg, *, session: Session = NEW_SESSION) -> None: ...                           │
  │                                                                                          │
  │ If this usage is intentional and pre-existing, run:                                      │
  │                                                                                          │
  │   uv run ./scripts/ci/prek/check_provide_session_kwargs.py --generate                    │
  │                                                                                          │
  │ to regenerate the allowlist, then commit the updated                                     │
  │ scripts/ci/prek/known_provide_session_positional.txt.                                    │
  ╰──────────────────────────────────────────────────────────────────────────────────────────╯
    airflow-core/src/airflow/cli/commands/dag_command.py  count=9 (allowed=8)
        L128 def dag_clear(...)
        L365 def dag_state(...)
        L476 def dag_list_dags(...)
        L564 def dag_details(...)
        L586 def dag_list_import_errors(...)
        L675 def dag_list_jobs(...)
        L706 def dag_list_dag_runs(...)
        L744 def dag_test(...)
        L802 def dag_reserialize(...)
```