### PR TITLE
Add new terms to spelling wordlist: newsfragments and pyyaml

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1083,6 +1083,7 @@ neo4j
 neptune
 neq
 NetworkPolicy
+newsfragments
 NFS
 nginx
 nobr
@@ -1300,6 +1301,7 @@ PythonOperator
 pythonpath
 pyvespa
 pywinrm
+pyyaml
 Qdrant
 qdrant
 Qingping


### PR DESCRIPTION
Add `pyyaml` and `newsfragments` to `docs/spelling_wordlist.txt` to fix the scheduled docs spellcheck [failure](https://github.com/apache/airflow/actions/runs/26488165004/job/78001330675) introduced by #67562, which added these words to `airflow-ctl/RELEASE_NOTES.rst` without updating the wordlist.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
   Generated-by: Claude Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

