### PR TITLE
Fix internal server error on backfill API for SQLite

### DIFF
--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -382,6 +382,9 @@ def with_row_locks(
     if not dialect_name:
         return query
 
+    if dialect_name == "sqlite":
+        return query
+
     # Don't use row level locks if the MySQL dialect (Mariadb & MySQL < 8) does not support it.
     if not USE_ROW_LEVEL_LOCKING:
         return query

--- a/airflow-core/tests/unit/utils/test_sqlalchemy.py
+++ b/airflow-core/tests/unit/utils/test_sqlalchemy.py
@@ -158,7 +158,7 @@ class TestSqlAlchemyUtils:
             ("mysql", False, False, False),
             ("mysql", True, True, True),
             ("mysql", True, False, False),
-            ("sqlite", False, True, True),
+            ("sqlite", False, True, False),
         ],
     )
     def test_with_row_locks(


### PR DESCRIPTION
Fixes #66726 by ignoring skip_locked for SQLite dialect in with_row_locks

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Antigravity (Gemini-based AI coding assistant) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* closes: #66726