### PR TITLE
Add overwrite_file option to IMAP download_mail_attachments

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -321,13 +321,13 @@ class ImapHook(BaseHook):
     ) -> None:
         file_path = self._correct_path(name, local_output_directory)
 
-        if not overwrite_file and os.path.exists(file_path):
+        if not overwrite_file:
             base, ext = os.path.splitext(file_path)
-            counter = 1
+            counter = 0
             while True:
-                file_path = f"{base}_{counter}{ext}"
+                current_file_path = file_path if counter == 0 else f"{base}_{counter}{ext}"
                 try:
-                    with open(file_path, "xb") as file:
+                    with open(current_file_path, "xb") as file:
                         file.write(payload)
                     return
                 except FileExistsError:

--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite_file: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,8 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite_file: If set to True (default), identical filenames will overwrite existing files.
+            If set to False, it will preserve all files by automatically renaming them (e.g. file_1.ext).
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +222,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +290,16 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, overwrite_file: bool = True
+    ) -> None:
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                self._create_file(name, payload, local_output_directory, overwrite_file)
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -311,8 +316,17 @@ class ImapHook(BaseHook):
             else local_output_directory + os.sep + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _create_file(
+        self, name: str, payload: Any, local_output_directory: str, overwrite_file: bool = True
+    ) -> None:
         file_path = self._correct_path(name, local_output_directory)
+
+        if not overwrite_file and os.path.exists(file_path):
+            base, ext = os.path.splitext(file_path)
+            counter = 1
+            while os.path.exists(f"{base}_{counter}{ext}"):
+                counter += 1
+            file_path = f"{base}_{counter}{ext}"
 
         with open(file_path, "wb") as file:
             file.write(payload)

--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -324,9 +324,14 @@ class ImapHook(BaseHook):
         if not overwrite_file and os.path.exists(file_path):
             base, ext = os.path.splitext(file_path)
             counter = 1
-            while os.path.exists(f"{base}_{counter}{ext}"):
-                counter += 1
-            file_path = f"{base}_{counter}{ext}"
+            while True:
+                file_path = f"{base}_{counter}{ext}"
+                try:
+                    with open(file_path, "xb") as file:
+                        file.write(payload)
+                    return
+                except FileExistsError:
+                    counter += 1
 
         with open(file_path, "wb") as file:
             file.write(payload)

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -509,3 +509,33 @@ class TestImapHook:
 
         assert result is True
         assert 1 <= mock_conn.fetch.call_count <= 2
+
+    @patch(open_string, new_callable=mock_open)
+    @patch("airflow.providers.imap.hooks.imap.os.path.exists")
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_false(self, mock_imaplib, mock_exists, mock_open_method):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        # Mock os.path.exists to simulate existing files: test1.csv, test1_1.csv exist, but test1_2.csv does not.
+        mock_exists.side_effect = [True, True, False]
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", "test_directory", overwrite_file=False)
+
+        # Expected file path after increments: test_directory/test1_2.csv (using OS-specific separator, but the test normally mocks out the write logic, so we just check what open was called with)
+        called_path = mock_open_method.call_args[0][0]
+        assert "test1_2.csv" in called_path
+
+    @patch(open_string, new_callable=mock_open)
+    @patch("airflow.providers.imap.hooks.imap.os.path.exists")
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_true(self, mock_imaplib, mock_exists, mock_open_method):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+        
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("test1.csv", "test_directory", overwrite_file=True)
+
+        # os.path.exists should not be called since overwrite_file=True
+        mock_exists.assert_not_called()
+        
+        called_path = mock_open_method.call_args[0][0]
+        assert called_path.endswith("test1.csv")

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -511,31 +511,27 @@ class TestImapHook:
         assert 1 <= mock_conn.fetch.call_count <= 2
 
     @patch(open_string, new_callable=mock_open)
-    @patch("airflow.providers.imap.hooks.imap.os.path.exists")
     @patch(imaplib_string)
-    def test_download_mail_attachments_overwrite_false(self, mock_imaplib, mock_exists, mock_open_method):
+    def test_download_mail_attachments_overwrite_false(self, mock_imaplib, mock_open_method):
         _create_fake_imap(mock_imaplib, with_mail=True)
-        # Mock os.path.exists to simulate existing files: test1.csv, test1_1.csv exist, but test1_2.csv does not.
-        mock_exists.side_effect = [True, True, False]
+        # Simulate FileExistsError for the first two attempts
+        mock_file = mock_open().return_value
+        mock_open_method.side_effect = [FileExistsError(), FileExistsError(), mock_file]
 
         with ImapHook() as imap_hook:
             imap_hook.download_mail_attachments("test1.csv", "test_directory", overwrite_file=False)
 
-        # Expected file path after increments: test_directory/test1_2.csv (using OS-specific separator, but the test normally mocks out the write logic, so we just check what open was called with)
         called_path = mock_open_method.call_args[0][0]
         assert "test1_2.csv" in called_path
+        assert mock_open_method.call_count == 3
 
     @patch(open_string, new_callable=mock_open)
-    @patch("airflow.providers.imap.hooks.imap.os.path.exists")
     @patch(imaplib_string)
-    def test_download_mail_attachments_overwrite_true(self, mock_imaplib, mock_exists, mock_open_method):
+    def test_download_mail_attachments_overwrite_true(self, mock_imaplib, mock_open_method):
         _create_fake_imap(mock_imaplib, with_mail=True)
         
         with ImapHook() as imap_hook:
             imap_hook.download_mail_attachments("test1.csv", "test_directory", overwrite_file=True)
 
-        # os.path.exists should not be called since overwrite_file=True
-        mock_exists.assert_not_called()
-        
         called_path = mock_open_method.call_args[0][0]
         assert called_path.endswith("test1.csv")

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -529,7 +529,7 @@ class TestImapHook:
     @patch(imaplib_string)
     def test_download_mail_attachments_overwrite_true(self, mock_imaplib, mock_open_method):
         _create_fake_imap(mock_imaplib, with_mail=True)
-        
+
         with ImapHook() as imap_hook:
             imap_hook.download_mail_attachments("test1.csv", "test_directory", overwrite_file=True)
 


### PR DESCRIPTION
## Description
This PR adds a new boolean argument `overwrite_file` to `ImapHook.download_mail_attachments`.

Previously, `download_mail_attachments` would always overwrite local files if a downloaded attachment had the same filename as an existing file. By setting `overwrite_file=False`, the hook now safely preserves existing files by appending a numeric suffix (e.g., `file_1.ext`). The file creation uses exclusive creation mode (`"xb"`) to ensure atomic, race-condition-free operation.

## Testing
- Unit tests added/updated to verify `overwrite_file` logic.
- Verified that `"xb"` properly raises `FileExistsError` and loops to the next suffix.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Antigravity (Gemini-based AI coding assistant) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
* closes: #65870