### PR TITLE
Fix missing task.queued_duration metric in Airflow 3

### DIFF
--- a/airflow-core/newsfragments/67592.bugfix.rst
+++ b/airflow-core/newsfragments/67592.bugfix.rst
@@ -1,0 +1,1 @@
+Restore the ``task.queued_duration`` metric, which stopped being emitted when Airflow 3 workers moved to the Task SDK, and record it once per queue wait so that a task resuming from deferral also reports the wait for its worker slot.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow._shared.observability.metrics import stats
 from airflow._shared.observability.traces import override_ids
 from airflow._shared.state import TaskScope
 from airflow._shared.timezones import timezone
@@ -159,6 +160,8 @@ def ti_run(
             TI.try_number,
             TI.max_tries,
             TI.start_date,
+            TI.queue,
+            TI.queued_dttm,
             TI.next_method,
             TI.hostname,
             TI.unixname,
@@ -199,6 +202,10 @@ def ti_run(
     query = update(TI).where(TI.id == task_instance_id).values(data)
 
     previous_state = ti.state
+    # Set on a genuine QUEUED -> RUNNING transition so task.queued_duration is emitted once the
+    # DagRun is loaded below (its stats_tags supply the tags). A duplicate start request falls
+    # through the branch below without raising, so the flag keeps it from emitting twice.
+    emit_queued_duration = False
 
     # If we are already running, but this is a duplicate request from the same client return the same OK
     # -- it's possible there was a network glitch and they never got the response
@@ -242,6 +249,14 @@ def ti_run(
                 extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
+        # The scheduler refreshes queued_dttm every time it queues a task, so utcnow() - queued_dttm
+        # is a meaningful queue wait for first runs and retries alike (a retry is a new try that
+        # genuinely waited in the queue) -- mirroring the legacy emit in emit_state_change_metric,
+        # which fired on every transition to RUNNING. Only resumes from deferral are skipped,
+        # identified by next_method (the trigger sets it on resume), to avoid re-emitting within the
+        # same try. queued_dttm is None only in rare races and test setups.
+        emit_queued_duration = ti.queued_dttm is not None and ti.next_method is None
+
     # Ensure there is no end date set and clear retry policy overrides from the previous attempt.
     query = query.values(
         end_date=None,
@@ -297,7 +312,21 @@ def ti_run(
             or 0
         )
 
-        dr.team_name = get_team_name_for_ti(task_instance_id, session)
+        team_name = get_team_name_for_ti(task_instance_id, session)
+        dr.team_name = team_name
+
+        if emit_queued_duration:
+            # Tag via dr.stats_tags so this stays sliceable the same way as its sibling
+            # task.scheduled_duration, which emit_state_change_metric sends as
+            # {**ti.stats_tags, "queue": ti.queue} -- that is dag_run.stats_tags plus task_id.
+            # Team lives on the Bundle rather than the DagRun schema, so stats_tags cannot resolve
+            # it here; add the value looked up above instead. Falsy values are pruned from
+            # stats_tags, so only set it when there is a team. The registry-derived legacy name
+            # dag.<dag_id>.<task_id>.queued_duration is emitted by stats.timing automatically.
+            tags = {**dr.stats_tags, "task_id": ti.task_id, "queue": ti.queue}
+            if team_name:
+                tags["team_name"] = team_name
+            stats.timing("task.queued_duration", timezone.utcnow() - ti.queued_dttm, tags=tags)
 
         context = TIRunContext(
             dag_run=dr,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -249,12 +249,15 @@ def ti_run(
                 extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
-        # The scheduler refreshes queued_dttm every time it queues a task, so utcnow() - queued_dttm
-        # is a meaningful queue wait for first runs and retries alike (a retry is a new try that
-        # genuinely waited in the queue) -- mirroring the legacy emit in emit_state_change_metric,
-        # which fired on every transition to RUNNING. Only resumes from deferral are skipped,
-        # identified by next_method (the trigger sets it on resume), to avoid re-emitting within the
-        # same try. queued_dttm is None only in rare races and test setups.
+        # Aims at one sample per try: the scheduler refreshes queued_dttm on every queueing, so a
+        # retry measures its own wait, while a resume from deferral is the same try continuing and
+        # is skipped via next_method (set on the DEFERRED transition, left in place until resume).
+        # Two known gaps in that reading: an operator with start_from_trigger=True is deferred
+        # straight from SCHEDULED without ever being queued, so the resume leg skipped here is its
+        # only real wait and it goes unmeasured; and this disagrees with task.scheduled_duration on
+        # retries, which emit_state_change_metric skips because the previous attempt's end_date is
+        # still on the row when the scheduler queues the TI.
+        # queued_dttm is None only in rare races and test setups.
         emit_queued_duration = ti.queued_dttm is not None and ti.next_method is None
 
     # Ensure there is no end date set and clear retry policy overrides from the previous attempt.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -251,12 +251,15 @@ def ti_run(
                 extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
-        # The scheduler refreshes queued_dttm every time it queues a task, so utcnow() - queued_dttm
-        # is a meaningful queue wait for first runs and retries alike (a retry is a new try that
-        # genuinely waited in the queue) -- mirroring the legacy emit in emit_state_change_metric,
-        # which fired on every transition to RUNNING. Only resumes from deferral are skipped,
-        # identified by next_method (the trigger sets it on resume), to avoid re-emitting within the
-        # same try. queued_dttm is None only in rare races and test setups.
+        # Aims at one sample per try: the scheduler refreshes queued_dttm on every queueing, so a
+        # retry measures its own wait, while a resume from deferral is the same try continuing and
+        # is skipped via next_method (set on the DEFERRED transition, left in place until resume).
+        # Two known gaps in that reading: an operator with start_from_trigger=True is deferred
+        # straight from SCHEDULED without ever being queued, so the resume leg skipped here is its
+        # only real wait and it goes unmeasured; and this disagrees with task.scheduled_duration on
+        # retries, which emit_state_change_metric skips because the previous attempt's end_date is
+        # still on the row when the scheduler queues the TI.
+        # queued_dttm is None only in rare races and test setups.
         emit_queued_duration = ti.queued_dttm is not None and ti.next_method is None
 
     # Ensure there is no end date set and clear retry policy overrides from the previous attempt.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow._shared.observability.metrics import stats
 from airflow._shared.observability.traces import override_ids
 from airflow._shared.state import TaskScope
 from airflow._shared.timezones import timezone
@@ -165,6 +166,8 @@ def ti_run(
             TI.try_number,
             TI.max_tries,
             TI.start_date,
+            TI.queue,
+            TI.queued_dttm,
             TI.next_method,
             TI.hostname,
             TI.unixname,
@@ -206,6 +209,10 @@ def ti_run(
     query = update(TI).where(TI.id == task_instance_id).values(data)
 
     previous_state = ti.state
+    # Set on a genuine QUEUED -> RUNNING transition so task.queued_duration is emitted once the
+    # DagRun is loaded below (its stats_tags supply the tags). A duplicate start request falls
+    # through the branch below without raising, so the flag keeps it from emitting twice.
+    emit_queued_duration = False
 
     # If we are already running, but this is a duplicate request from the same client return the same OK
     # -- it's possible there was a network glitch and they never got the response
@@ -244,6 +251,14 @@ def ti_run(
                 extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
+        # The scheduler refreshes queued_dttm every time it queues a task, so utcnow() - queued_dttm
+        # is a meaningful queue wait for first runs and retries alike (a retry is a new try that
+        # genuinely waited in the queue) -- mirroring the legacy emit in emit_state_change_metric,
+        # which fired on every transition to RUNNING. Only resumes from deferral are skipped,
+        # identified by next_method (the trigger sets it on resume), to avoid re-emitting within the
+        # same try. queued_dttm is None only in rare races and test setups.
+        emit_queued_duration = ti.queued_dttm is not None and ti.next_method is None
+
     # Ensure there is no end date set and clear retry policy overrides from the previous attempt.
     query = query.values(
         end_date=None,
@@ -298,6 +313,21 @@ def ti_run(
             )
             or 0
         )
+
+        team_name = get_team_name_for_ti(task_instance_id, session)
+
+        if emit_queued_duration:
+            # Tag via dr.stats_tags so this stays sliceable the same way as its sibling
+            # task.scheduled_duration, which emit_state_change_metric sends as
+            # {**ti.stats_tags, "queue": ti.queue} -- that is dag_run.stats_tags plus task_id.
+            # Team lives on the Bundle rather than the DagRun schema, so stats_tags cannot resolve
+            # it here; add the value looked up above instead. Falsy values are pruned from
+            # stats_tags, so only set it when there is a team. The registry-derived legacy name
+            # dag.<dag_id>.<task_id>.queued_duration is emitted by stats.timing automatically.
+            tags = {**dr.stats_tags, "task_id": ti.task_id, "queue": ti.queue}
+            if team_name:
+                tags["team_name"] = team_name
+            stats.timing("task.queued_duration", timezone.utcnow() - ti.queued_dttm, tags=tags)
 
         context = TIRunContext(
             dag_run=dr,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -251,16 +251,11 @@ def ti_run(
                 extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
-        # Aims at one sample per try: the scheduler refreshes queued_dttm on every queueing, so a
-        # retry measures its own wait, while a resume from deferral is the same try continuing and
-        # is skipped via next_method (set on the DEFERRED transition, left in place until resume).
-        # Two known gaps in that reading: an operator with start_from_trigger=True is deferred
-        # straight from SCHEDULED without ever being queued, so the resume leg skipped here is its
-        # only real wait and it goes unmeasured; and this disagrees with task.scheduled_duration on
-        # retries, which emit_state_change_metric skips because the previous attempt's end_date is
-        # still on the row when the scheduler queues the TI.
+        # One sample per queue wait, not per try: the scheduler refreshes queued_dttm on every
+        # queueing, so a retry and a resume from deferral each waited for a slot of their own.
+        # task.scheduled_duration counts per try instead, so the two disagree on retries by design.
         # queued_dttm is None only in rare races and test setups.
-        emit_queued_duration = ti.queued_dttm is not None and ti.next_method is None
+        emit_queued_duration = ti.queued_dttm is not None
 
     # Ensure there is no end date set and clear retry policy overrides from the previous attempt.
     query = query.values(
@@ -278,11 +273,23 @@ def ti_run(
         result = session.execute(query)
         log.info("Task instance state updated", rows_affected=getattr(result, "rowcount", 0))
 
+        # stats_tags lazy-loads dag_model.tags when dag tags are emitted as metric tags, and ti_run
+        # runs once per task start -- load them up front as the scheduler loop does.
+        dag_tag_options = (
+            (joinedload(DR.dag_model).selectinload(DagModel.tags),)
+            if emit_queued_duration and conf.getboolean("metrics", "dag_tags_in_metrics", fallback=False)
+            else ()
+        )
+
         dr = (
             session.scalars(
                 select(DR)
                 .filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
-                .options(joinedload(DR.consumed_asset_events), *eager_load_teams(DR.dag_model))
+                .options(
+                    joinedload(DR.consumed_asset_events),
+                    *eager_load_teams(DR.dag_model),
+                    *dag_tag_options,
+                )
             )
             .unique()
             .one_or_none()
@@ -317,19 +324,12 @@ def ti_run(
             or 0
         )
 
-        team_name = get_team_name_for_ti(task_instance_id, session)
-
         if emit_queued_duration:
-            # Tag via dr.stats_tags so this stays sliceable the same way as its sibling
-            # task.scheduled_duration, which emit_state_change_metric sends as
-            # {**ti.stats_tags, "queue": ti.queue} -- that is dag_run.stats_tags plus task_id.
-            # Team lives on the Bundle rather than the DagRun schema, so stats_tags cannot resolve
-            # it here; add the value looked up above instead. Falsy values are pruned from
-            # stats_tags, so only set it when there is a team. The registry-derived legacy name
-            # dag.<dag_id>.<task_id>.queued_duration is emitted by stats.timing automatically.
+            # Tags mirror the sibling task.scheduled_duration, which emit_state_change_metric sends
+            # as {**ti.stats_tags, "queue": ti.queue}; stats_tags reads the team off the transient
+            # _team_name. stats.timing also emits the legacy dotted name from the metrics registry.
+            dr._team_name = dr.team_name
             tags = {**dr.stats_tags, "task_id": ti.task_id, "queue": ti.queue}
-            if team_name:
-                tags["team_name"] = team_name
             stats.timing("task.queued_duration", timezone.utcnow() - ti.queued_dttm, tags=tags)
 
         context = TIRunContext(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1072,6 +1072,148 @@ class TestTIRunState:
         assert logs[0].owner == ti.task.owner
         assert logs[0].extra == '{"host_name": "random-hostname"}'
 
+    @pytest.mark.parametrize(
+        "scenario",
+        ["first_run", "retry"],
+    )
+    def test_ti_run_emits_queued_duration_metric(
+        self, client, session, create_task_instance, time_machine, scenario
+    ):
+        """task.queued_duration is emitted on a real QUEUED -> RUNNING transition.
+
+        The scheduler refreshes queued_dttm every time it queues a task, so a retry has a
+        fresh queue wait just like a first run and must emit too. A retry still carries the
+        previous attempt's end_date on the row when ti_run is reached, so this asserts the
+        emit does not depend on end_date being unset.
+        """
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+
+        ti = create_task_instance(
+            task_id=f"test_ti_run_emits_queued_duration_metric_{scenario}",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_at,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_at
+        ti.queue = "default"
+        if scenario == "retry":
+            # A retried TI still has the previous attempt's end_date set on the row until
+            # ti_run clears it; the metric must fire regardless.
+            ti.end_date = queued_at.add(seconds=10)
+        session.commit()
+
+        # The metric has to stay sliceable the same way as its sibling task.scheduled_duration,
+        # which emit_state_change_metric sends as {**ti.stats_tags, "queue": ti.queue}. Deriving
+        # the expectation from that same expression makes the two drift apart only if this fails.
+        expected_tags = {**ti.stats_tags, "queue": ti.queue}
+        assert "run_type" in expected_tags
+
+        time_machine.move_to(run_at, tick=False)
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_called_once_with(
+            "task.queued_duration",
+            run_at - queued_at,
+            tags=expected_tags,
+        )
+
+    @pytest.mark.parametrize(
+        "skip_reason",
+        ["deferral_resume", "queued_dttm_missing"],
+    )
+    def test_ti_run_skips_queued_duration_metric(
+        self, client, session, create_task_instance, time_machine, skip_reason
+    ):
+        """task.queued_duration is skipped on a resume from deferral (next_method set, so
+        the queue wait belongs to the same try already counted) and when queued_dttm was
+        not recorded (rare race / test setups)."""
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(run_at, tick=False)
+
+        ti = create_task_instance(
+            task_id=f"test_ti_run_skips_queued_duration_metric_{skip_reason}",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_at,
+            dag_id=str(uuid4()),
+        )
+        if skip_reason == "deferral_resume":
+            ti.queued_dttm = queued_at
+            ti.next_method = "execute_complete"
+        else:
+            ti.queued_dttm = None
+        session.commit()
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_not_called()
+
+    def test_ti_run_skips_queued_duration_metric_on_duplicate_start(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """A start request replayed by the same worker after a network glitch returns the same
+        200 without re-running the transition, so it must not double-count the queue wait."""
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(run_at, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_skips_queued_duration_metric_on_duplicate_start",
+            state=State.RUNNING,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_at,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_at
+        ti.hostname = "random-hostname"
+        ti.unixname = "random-unixname"
+        ti.pid = 100
+        session.commit()
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_not_called()
+
 
 class TestTIUpdateState:
     def setup_method(self):
@@ -1537,6 +1679,8 @@ class TestTIUpdateState:
                             try_number=1,
                             max_tries=0,
                             start_date=None,
+                            queue="default",
+                            queued_dttm=timezone.utcnow(),
                             next_method=None,
                             hostname=None,
                             unixname=None,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1214,6 +1214,60 @@ class TestTIRunState:
         assert response.status_code == 200
         mock_stats.timing.assert_not_called()
 
+    def test_ti_run_queued_duration_metric_is_tagged_with_team_name(
+        self, client, session, dag_maker, time_machine
+    ):
+        """The team tag has to be pinned with multi-team on: with it off both the metric and any
+        expectation derived from stats_tags omit the key, so they would agree for the wrong reason.
+        """
+        from airflow.models.dagbundle import DagBundleModel
+        from airflow.models.team import Team
+
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(queued_at, tick=False)
+
+        dag_id = str(uuid4())
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id="task")
+        dr = dag_maker.create_dagrun(
+            run_id="test", logical_date=queued_at, state=DagRunState.RUNNING, start_date=queued_at
+        )
+        ti = dr.get_task_instance(task_id="task")
+        session.execute(
+            update(TaskInstance)
+            .where(TaskInstance.id == ti.id)
+            .values(state=State.QUEUED, queued_dttm=queued_at, queue="default")
+        )
+
+        bundle_name = f"bundle-{dag_id}"
+        team_name = f"team-{dag_id[:8]}"
+        bundle = DagBundleModel(name=bundle_name)
+        bundle.teams.append(Team(name=team_name))
+        session.add(bundle)
+        session.flush()
+        session.execute(update(DagModel).where(DagModel.dag_id == dag_id).values(bundle_name=bundle_name))
+        session.commit()
+
+        time_machine.move_to(run_at, tick=False)
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+                response = client.patch(
+                    f"/execution/task-instances/{ti.id}/run",
+                    json={
+                        "state": "running",
+                        "hostname": "random-hostname",
+                        "unixname": "random-unixname",
+                        "pid": 100,
+                        "start_date": run_at.isoformat(),
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_called_once()
+        assert mock_stats.timing.call_args.kwargs["tags"]["team_name"] == team_name
+
 
 class TestTIUpdateState:
     def setup_method(self):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1268,6 +1268,75 @@ class TestTIRunState:
         mock_stats.timing.assert_called_once()
         assert mock_stats.timing.call_args.kwargs["tags"]["team_name"] == team_name
 
+    def test_ti_run_emits_no_queued_duration_for_start_from_trigger(
+        self, client, session, dag_maker, time_machine
+    ):
+        """A start_from_trigger operator is deferred straight from SCHEDULED, so the resume that the
+        next_method guard skips is its only trip through the queue and nothing is ever measured.
+        """
+        from airflow.sdk import BaseOperator
+        from airflow.triggers.base import StartTriggerArgs
+
+        class StartFromTriggerOperator(BaseOperator):
+            start_trigger_args = StartTriggerArgs(
+                trigger_cls="airflow.triggers.testing.SuccessTrigger",
+                trigger_kwargs={},
+                next_method="execute_complete",
+                timeout=None,
+            )
+            start_from_trigger = True
+
+            def execute_complete(self):
+                pass
+
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(queued_at, tick=False)
+
+        with dag_maker(dag_id=str(uuid4()), session=session):
+            StartFromTriggerOperator(task_id="task")
+        dr = dag_maker.create_dagrun(run_id="test", logical_date=queued_at, state=DagRunState.RUNNING)
+
+        ti = dr.get_task_instance(task_id="task")
+        ti.task = dr.dag.get_task("task")
+        assert dr.schedule_tis((ti,), session=session) == 0
+        session.merge(ti)
+        session.commit()
+
+        # Read the row back rather than the in-memory TI: what ti_run sees is the persisted state,
+        # and the point of this test is that the deferral lands without the TI ever being queued.
+        state, next_method, queued_dttm = session.execute(
+            select(TaskInstance.state, TaskInstance.next_method, TaskInstance.queued_dttm).where(
+                TaskInstance.id == ti.id
+            )
+        ).one()
+        assert (state, next_method, queued_dttm) == (TaskInstanceState.DEFERRED, "execute_complete", None)
+
+        # The trigger fires and the scheduler queues it -- the first and only real queue wait.
+        session.execute(
+            update(TaskInstance)
+            .where(TaskInstance.id == ti.id)
+            .values(state=State.QUEUED, queued_dttm=queued_at, queue="default")
+        )
+        session.commit()
+
+        time_machine.move_to(run_at, tick=False)
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        assert mock_stats.timing.call_args_list == []
+
 
 class TestTIUpdateState:
     def setup_method(self):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1387,6 +1387,60 @@ class TestTIRunState:
         assert response.status_code == 200
         mock_stats.timing.assert_not_called()
 
+    def test_ti_run_queued_duration_metric_is_tagged_with_team_name(
+        self, client, session, dag_maker, time_machine
+    ):
+        """The team tag has to be pinned with multi-team on: with it off both the metric and any
+        expectation derived from stats_tags omit the key, so they would agree for the wrong reason.
+        """
+        from airflow.models.dagbundle import DagBundleModel
+        from airflow.models.team import Team
+
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(queued_at, tick=False)
+
+        dag_id = str(uuid4())
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id="task")
+        dr = dag_maker.create_dagrun(
+            run_id="test", logical_date=queued_at, state=DagRunState.RUNNING, start_date=queued_at
+        )
+        ti = dr.get_task_instance(task_id="task")
+        session.execute(
+            update(TaskInstance)
+            .where(TaskInstance.id == ti.id)
+            .values(state=State.QUEUED, queued_dttm=queued_at, queue="default")
+        )
+
+        bundle_name = f"bundle-{dag_id}"
+        team_name = f"team-{dag_id[:8]}"
+        bundle = DagBundleModel(name=bundle_name)
+        bundle.teams.append(Team(name=team_name))
+        session.add(bundle)
+        session.flush()
+        session.execute(update(DagModel).where(DagModel.dag_id == dag_id).values(bundle_name=bundle_name))
+        session.commit()
+
+        time_machine.move_to(run_at, tick=False)
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+                response = client.patch(
+                    f"/execution/task-instances/{ti.id}/run",
+                    json={
+                        "state": "running",
+                        "hostname": "random-hostname",
+                        "unixname": "random-unixname",
+                        "pid": 100,
+                        "start_date": run_at.isoformat(),
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_called_once()
+        assert mock_stats.timing.call_args.kwargs["tags"]["team_name"] == team_name
+
 
 class TestTIUpdateState:
     def setup_method(self):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1245,6 +1245,148 @@ class TestTIRunState:
         assert logs[0].owner == ti.task.owner
         assert logs[0].extra == '{"host_name": "random-hostname"}'
 
+    @pytest.mark.parametrize(
+        "scenario",
+        ["first_run", "retry"],
+    )
+    def test_ti_run_emits_queued_duration_metric(
+        self, client, session, create_task_instance, time_machine, scenario
+    ):
+        """task.queued_duration is emitted on a real QUEUED -> RUNNING transition.
+
+        The scheduler refreshes queued_dttm every time it queues a task, so a retry has a
+        fresh queue wait just like a first run and must emit too. A retry still carries the
+        previous attempt's end_date on the row when ti_run is reached, so this asserts the
+        emit does not depend on end_date being unset.
+        """
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+
+        ti = create_task_instance(
+            task_id=f"test_ti_run_emits_queued_duration_metric_{scenario}",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_at,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_at
+        ti.queue = "default"
+        if scenario == "retry":
+            # A retried TI still has the previous attempt's end_date set on the row until
+            # ti_run clears it; the metric must fire regardless.
+            ti.end_date = queued_at.add(seconds=10)
+        session.commit()
+
+        # The metric has to stay sliceable the same way as its sibling task.scheduled_duration,
+        # which emit_state_change_metric sends as {**ti.stats_tags, "queue": ti.queue}. Deriving
+        # the expectation from that same expression makes the two drift apart only if this fails.
+        expected_tags = {**ti.stats_tags, "queue": ti.queue}
+        assert "run_type" in expected_tags
+
+        time_machine.move_to(run_at, tick=False)
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_called_once_with(
+            "task.queued_duration",
+            run_at - queued_at,
+            tags=expected_tags,
+        )
+
+    @pytest.mark.parametrize(
+        "skip_reason",
+        ["deferral_resume", "queued_dttm_missing"],
+    )
+    def test_ti_run_skips_queued_duration_metric(
+        self, client, session, create_task_instance, time_machine, skip_reason
+    ):
+        """task.queued_duration is skipped on a resume from deferral (next_method set, so
+        the queue wait belongs to the same try already counted) and when queued_dttm was
+        not recorded (rare race / test setups)."""
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(run_at, tick=False)
+
+        ti = create_task_instance(
+            task_id=f"test_ti_run_skips_queued_duration_metric_{skip_reason}",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_at,
+            dag_id=str(uuid4()),
+        )
+        if skip_reason == "deferral_resume":
+            ti.queued_dttm = queued_at
+            ti.next_method = "execute_complete"
+        else:
+            ti.queued_dttm = None
+        session.commit()
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_not_called()
+
+    def test_ti_run_skips_queued_duration_metric_on_duplicate_start(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """A start request replayed by the same worker after a network glitch returns the same
+        200 without re-running the transition, so it must not double-count the queue wait."""
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(run_at, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_skips_queued_duration_metric_on_duplicate_start",
+            state=State.RUNNING,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=queued_at,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_at
+        ti.hostname = "random-hostname"
+        ti.unixname = "random-unixname"
+        ti.pid = 100
+        session.commit()
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_not_called()
+
 
 class TestTIUpdateState:
     def setup_method(self):
@@ -1787,6 +1929,8 @@ class TestTIUpdateState:
                             try_number=1,
                             max_tries=0,
                             start_date=None,
+                            queue="default",
+                            queued_dttm=timezone.utcnow(),
                             next_method=None,
                             hostname=None,
                             unixname=None,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1247,17 +1247,17 @@ class TestTIRunState:
 
     @pytest.mark.parametrize(
         "scenario",
-        ["first_run", "retry"],
+        ["first_run", "retry", "deferral_resume"],
     )
     def test_ti_run_emits_queued_duration_metric(
         self, client, session, create_task_instance, time_machine, scenario
     ):
-        """task.queued_duration is emitted on a real QUEUED -> RUNNING transition.
+        """task.queued_duration is emitted once per queue wait.
 
-        The scheduler refreshes queued_dttm every time it queues a task, so a retry has a
-        fresh queue wait just like a first run and must emit too. A retry still carries the
-        previous attempt's end_date on the row when ti_run is reached, so this asserts the
-        emit does not depend on end_date being unset.
+        The scheduler refreshes queued_dttm every time it queues a task, so a retry and a
+        resume from deferral each waited for a worker slot of their own and must emit too. A
+        retry still carries the previous attempt's end_date on the row when ti_run is reached,
+        so this also asserts the emit does not depend on end_date being unset.
         """
         queued_at = timezone.parse("2024-09-30T12:00:00Z")
         run_at = queued_at.add(seconds=42)
@@ -1276,6 +1276,8 @@ class TestTIRunState:
             # A retried TI still has the previous attempt's end_date set on the row until
             # ti_run clears it; the metric must fire regardless.
             ti.end_date = queued_at.add(seconds=10)
+        elif scenario == "deferral_resume":
+            ti.next_method = "execute_complete"
         session.commit()
 
         # The metric has to stay sliceable the same way as its sibling task.scheduled_duration,
@@ -1305,33 +1307,24 @@ class TestTIRunState:
             tags=expected_tags,
         )
 
-    @pytest.mark.parametrize(
-        "skip_reason",
-        ["deferral_resume", "queued_dttm_missing"],
-    )
-    def test_ti_run_skips_queued_duration_metric(
-        self, client, session, create_task_instance, time_machine, skip_reason
+    def test_ti_run_skips_queued_duration_metric_without_queued_dttm(
+        self, client, session, create_task_instance, time_machine
     ):
-        """task.queued_duration is skipped on a resume from deferral (next_method set, so
-        the queue wait belongs to the same try already counted) and when queued_dttm was
-        not recorded (rare race / test setups)."""
+        """queued_dttm is what the wait is measured from, so a row without one (rare race /
+        test setups) has nothing to report."""
         queued_at = timezone.parse("2024-09-30T12:00:00Z")
         run_at = queued_at.add(seconds=42)
         time_machine.move_to(run_at, tick=False)
 
         ti = create_task_instance(
-            task_id=f"test_ti_run_skips_queued_duration_metric_{skip_reason}",
+            task_id="test_ti_run_skips_queued_duration_metric_without_queued_dttm",
             state=State.QUEUED,
             dagrun_state=DagRunState.RUNNING,
             session=session,
             start_date=queued_at,
             dag_id=str(uuid4()),
         )
-        if skip_reason == "deferral_resume":
-            ti.queued_dttm = queued_at
-            ti.next_method = "execute_complete"
-        else:
-            ti.queued_dttm = None
+        ti.queued_dttm = None
         session.commit()
 
         with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
@@ -1441,11 +1434,52 @@ class TestTIRunState:
         mock_stats.timing.assert_called_once()
         assert mock_stats.timing.call_args.kwargs["tags"]["team_name"] == team_name
 
-    def test_ti_run_emits_no_queued_duration_for_start_from_trigger(
+    def test_ti_run_queued_duration_metric_carries_dag_tags(self, client, session, dag_maker, time_machine):
+        """With dag_tags_in_metrics on, stats_tags would lazy-load dag_model.tags per task start;
+        the select eager-loads them instead, so the tags have to survive that route."""
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(queued_at, tick=False)
+
+        dag_id = str(uuid4())
+        with dag_maker(dag_id=dag_id, tags=["critical", "env:prod"], session=session):
+            EmptyOperator(task_id="task")
+        dr = dag_maker.create_dagrun(
+            run_id="test", logical_date=queued_at, state=DagRunState.RUNNING, start_date=queued_at
+        )
+        ti = dr.get_task_instance(task_id="task")
+        session.execute(
+            update(TaskInstance)
+            .where(TaskInstance.id == ti.id)
+            .values(state=State.QUEUED, queued_dttm=queued_at, queue="default")
+        )
+        session.commit()
+
+        time_machine.move_to(run_at, tick=False)
+
+        with conf_vars({("metrics", "dag_tags_in_metrics"): "True"}):
+            with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+                response = client.patch(
+                    f"/execution/task-instances/{ti.id}/run",
+                    json={
+                        "state": "running",
+                        "hostname": "random-hostname",
+                        "unixname": "random-unixname",
+                        "pid": 100,
+                        "start_date": run_at.isoformat(),
+                    },
+                )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_called_once()
+        tags = mock_stats.timing.call_args.kwargs["tags"]
+        assert (tags["critical"], tags["env"]) == ("", "prod")
+
+    def test_ti_run_emits_queued_duration_for_start_from_trigger(
         self, client, session, dag_maker, time_machine
     ):
-        """A start_from_trigger operator is deferred straight from SCHEDULED, so the resume that the
-        next_method guard skips is its only trip through the queue and nothing is ever measured.
+        """A start_from_trigger operator is deferred straight from SCHEDULED and only reaches the
+        queue once the trigger fires, so that resume is the one wait it ever has to report.
         """
         from airflow.sdk import BaseOperator
         from airflow.triggers.base import StartTriggerArgs
@@ -1508,7 +1542,11 @@ class TestTIRunState:
             )
 
         assert response.status_code == 200
-        assert mock_stats.timing.call_args_list == []
+        # Assert off the call rather than the in-memory TI, whose queue is stale after the
+        # raw update above.
+        mock_stats.timing.assert_called_once()
+        assert mock_stats.timing.call_args.args == ("task.queued_duration", run_at - queued_at)
+        assert mock_stats.timing.call_args.kwargs["tags"]["queue"] == "default"
 
 
 class TestTIUpdateState:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1441,6 +1441,75 @@ class TestTIRunState:
         mock_stats.timing.assert_called_once()
         assert mock_stats.timing.call_args.kwargs["tags"]["team_name"] == team_name
 
+    def test_ti_run_emits_no_queued_duration_for_start_from_trigger(
+        self, client, session, dag_maker, time_machine
+    ):
+        """A start_from_trigger operator is deferred straight from SCHEDULED, so the resume that the
+        next_method guard skips is its only trip through the queue and nothing is ever measured.
+        """
+        from airflow.sdk import BaseOperator
+        from airflow.triggers.base import StartTriggerArgs
+
+        class StartFromTriggerOperator(BaseOperator):
+            start_trigger_args = StartTriggerArgs(
+                trigger_cls="airflow.triggers.testing.SuccessTrigger",
+                trigger_kwargs={},
+                next_method="execute_complete",
+                timeout=None,
+            )
+            start_from_trigger = True
+
+            def execute_complete(self):
+                pass
+
+        queued_at = timezone.parse("2024-09-30T12:00:00Z")
+        run_at = queued_at.add(seconds=42)
+        time_machine.move_to(queued_at, tick=False)
+
+        with dag_maker(dag_id=str(uuid4()), session=session):
+            StartFromTriggerOperator(task_id="task")
+        dr = dag_maker.create_dagrun(run_id="test", logical_date=queued_at, state=DagRunState.RUNNING)
+
+        ti = dr.get_task_instance(task_id="task")
+        ti.task = dr.dag.get_task("task")
+        assert dr.schedule_tis((ti,), session=session) == 0
+        session.merge(ti)
+        session.commit()
+
+        # Read the row back rather than the in-memory TI: what ti_run sees is the persisted state,
+        # and the point of this test is that the deferral lands without the TI ever being queued.
+        state, next_method, queued_dttm = session.execute(
+            select(TaskInstance.state, TaskInstance.next_method, TaskInstance.queued_dttm).where(
+                TaskInstance.id == ti.id
+            )
+        ).one()
+        assert (state, next_method, queued_dttm) == (TaskInstanceState.DEFERRED, "execute_complete", None)
+
+        # The trigger fires and the scheduler queues it -- the first and only real queue wait.
+        session.execute(
+            update(TaskInstance)
+            .where(TaskInstance.id == ti.id)
+            .values(state=State.QUEUED, queued_dttm=queued_at, queue="default")
+        )
+        session.commit()
+
+        time_machine.move_to(run_at, tick=False)
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_at.isoformat(),
+                },
+            )
+
+        assert response.status_code == 200
+        assert mock_stats.timing.call_args_list == []
+
 
 class TestTIUpdateState:
     def setup_method(self):


### PR DESCRIPTION
## Summary

`task.queued_duration` (and its registry-derived legacy name `dag.<dag_id>.<task_id>.queued_duration`) stopped firing entirely after the Airflow 3 worker switched to the Task SDK / supervisor / Execution API.

The metric was only emitted by `TaskInstance.emit_state_change_metric`, which is only reachable from `_check_and_change_state_before_execution` — the legacy LocalTaskJob path. Airflow 3 workers flip TI state to `RUNNING` through the `ti_run` Execution API endpoint instead, which bypasses the emit site.

This is the same regression pattern as #62019 (missing `ti.start` / `ti.finish`).

## Fix

Emit `task.queued_duration` from `ti_run` at the moment it transitions the TI from QUEUED to RUNNING. Skip the emit on transitions that are not the genuine first run of a try:

  - retry of a previous attempt, identified by an existing `end_date`;
  - resume from deferral, identified by `next_method` (the trigger sets it and `end_date` stays `None` across a deferral, so `end_date` alone cannot catch it);
  - missing `queued_dttm` (rare race / test setups).

The legacy dotted name is emitted automatically by `stats.timing` via the `metrics_template.yaml` registry — no manual second call needed.

## Test plan

- [x] New `test_ti_run_emits_queued_duration_metric` confirmed to fail before the fix and pass after (verified by stashing the production change and re-running the test).
- [x] New parametrized `test_ti_run_skips_queued_duration_metric` covers all three skip conditions (`end_date` set / `deferral_resume` / `queued_dttm` missing).
- [x] All 33 existing `TestTIRunState` tests still pass.
- [x] `ruff format` / `ruff check` / `mypy-airflow-core` / `prek run --from-ref upstream/main --stage pre-commit` all green.

closes: #63503
closes: #66067

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=5f57b80 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @myps6415** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@ashb`, `@henry3260` is waiting on you:
> - 3 unresolved review thread(s) from `@ashb`, `@henry3260` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->