### PR TITLE
feat(ui): Add option to re-run only skipped tasks from the UI

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -62,6 +62,7 @@ class DAGRunClearBody(StrictBaseModel):
 
     dry_run: bool = True
     only_failed: bool = False
+    only_skipped: bool = False
     only_new: bool = Field(
         default=False,
         description="Only queue newly added tasks in the latest Dag version without clearing existing tasks.",
@@ -80,6 +81,8 @@ class DAGRunClearBody(StrictBaseModel):
         """Validate clear Dag run form."""
         if data.get("only_new") and data.get("only_failed"):
             raise ValueError("only_new and only_failed are mutually exclusive")
+        if data.get("only_new") and data.get("only_skipped"):
+            raise ValueError("only_new and only_skipped are mutually exclusive")
         return data
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/task_instances.py
@@ -205,6 +205,7 @@ class ClearTaskInstancesBody(StrictBaseModel):
     end_date: AwareDatetime | None = None
     only_failed: bool = True
     only_running: bool = False
+    only_skipped: bool = False
     reset_dag_runs: bool = True
     task_ids: list[str | tuple[str, int]] | None = Field(
         default=None,

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -12214,13 +12214,13 @@ components:
           type: boolean
           title: Only Failed
           default: true
-        only_skipped:
-          type: boolean
-          title: Only Skipped
-          default: false
         only_running:
           type: boolean
           title: Only Running
+          default: false
+        only_skipped:
+          type: boolean
+          title: Only Skipped
           default: false
         reset_dag_runs:
           type: boolean

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -12214,6 +12214,10 @@ components:
           type: boolean
           title: Only Failed
           default: true
+        only_skipped:
+          type: boolean
+          title: Only Skipped
+          default: false
         only_running:
           type: boolean
           title: Only Running
@@ -13005,6 +13009,10 @@ components:
         only_failed:
           type: boolean
           title: Only Failed
+          default: false
+        only_skipped:
+          type: boolean
+          title: Only Skipped
           default: false
         only_new:
           type: boolean

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -370,6 +370,10 @@ def clear_dag_run(
                 ti_query = ti_query.where(
                     TaskInstance.state.in_([TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED])
                 )
+            if body.only_skipped:
+                ti_query = ti_query.where(
+                    TaskInstance.state == TaskInstanceState.SKIPPED
+                )
             task_instances = list(session.scalars(ti_query))
 
         return ClearTaskInstanceCollectionResponse(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -371,9 +371,7 @@ def clear_dag_run(
                     TaskInstance.state.in_([TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED])
                 )
             if body.only_skipped:
-                ti_query = ti_query.where(
-                    TaskInstance.state == TaskInstanceState.SKIPPED
-                )
+                ti_query = ti_query.where(TaskInstance.state == TaskInstanceState.SKIPPED)
             task_instances = list(session.scalars(ti_query))
 
         return ClearTaskInstanceCollectionResponse(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -924,6 +924,7 @@ def post_clear_task_instances(
             run_on_latest_version=resolved_run_on_latest,
             only_failed=body.only_failed,
             only_running=body.only_running,
+            only_skipped=body.only_skipped,
         )
     else:
         # Use date-based clearing when no dag_run_id or when past/future is specified
@@ -936,6 +937,7 @@ def post_clear_task_instances(
             run_on_latest_version=resolved_run_on_latest,
             only_failed=body.only_failed,
             only_running=body.only_running,
+            only_skipped=body.only_skipped,
         )
 
     if not dry_run:

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -479,6 +479,7 @@ ARG_SHUT_DOWN_LOGGING = Arg(
 ARG_UPSTREAM = Arg(("-u", "--upstream"), help="Include upstream tasks", action="store_true")
 ARG_ONLY_FAILED = Arg(("-f", "--only-failed"), help="Only failed jobs", action="store_true")
 ARG_ONLY_RUNNING = Arg(("-r", "--only-running"), help="Only running jobs", action="store_true")
+ARG_ONLY_SKIPPED = Arg(("--only-skipped",), help="Only skipped jobs", action="store_true")
 ARG_DOWNSTREAM = Arg(("-d", "--downstream"), help="Include downstream tasks", action="store_true")
 ARG_DAG_REGEX = Arg(
     ("-R", "--dag-regex"), help="Search dag_id as regex instead of exact string", action="store_true"
@@ -1150,6 +1151,7 @@ DAGS_COMMANDS = (
             ARG_PARTITION_DATE_END,
             ARG_ONLY_FAILED,
             ARG_ONLY_RUNNING,
+            ARG_ONLY_SKIPPED,
             ARG_YES,
             ARG_VERBOSE,
         ),
@@ -1394,6 +1396,7 @@ TASKS_COMMANDS = (
             ARG_YES,
             ARG_ONLY_FAILED,
             ARG_ONLY_RUNNING,
+            ARG_ONLY_SKIPPED,
             ARG_DAG_REGEX,
             ARG_VERBOSE,
         ),

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -188,6 +188,7 @@ def dag_clear(args, session: Session = NEW_SESSION) -> None:
             run_id=run_id,
             only_failed=args.only_failed,
             only_running=args.only_running,
+            only_skipped=args.only_skipped,
             session=session,
         )
     print(f"Cleared {cleared} task instance(s) across {len(run_ids)} Dag run(s).")

--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -519,6 +519,7 @@ def task_clear(args) -> None:
             end_date=args.end_date,
             only_failed=args.only_failed,
             only_running=args.only_running,
+            only_skipped=args.only_skipped,
             dry_run=True,
         )
         if not tis:
@@ -533,4 +534,5 @@ def task_clear(args) -> None:
         end_date=args.end_date,
         only_failed=args.only_failed,
         only_running=args.only_running,
+        only_skipped=args.only_skipped,
     )

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -1035,6 +1035,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         only_new: Literal[True],
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
@@ -1052,6 +1053,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         only_new: Literal[False] = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
@@ -1069,6 +1071,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         only_new: bool,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
@@ -1085,6 +1088,7 @@ class SerializedDAG:
         run_id: str,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: Literal[False] = False,
@@ -1104,6 +1108,7 @@ class SerializedDAG:
         end_date: datetime.datetime | None = None,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         session: Session = NEW_SESSION,
         exclude_task_ids: frozenset[str] | frozenset[tuple[str, int]] | None = frozenset(),
@@ -1120,6 +1125,7 @@ class SerializedDAG:
         end_date: datetime.datetime | None = None,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: Literal[False] = False,
         session: Session = NEW_SESSION,
@@ -1138,6 +1144,7 @@ class SerializedDAG:
         end_date: datetime.datetime | None = None,
         only_failed: bool = False,
         only_running: bool = False,
+        only_skipped: bool = False,
         only_new: bool = False,
         dag_run_state: DagRunState = DagRunState.QUEUED,
         dry_run: bool = False,
@@ -1155,6 +1162,7 @@ class SerializedDAG:
         :param end_date: The maximum logical_date to clear
         :param only_failed: Only clear failed tasks
         :param only_running: Only clear running tasks.
+        :param only_skipped: Only clear skipped tasks.
         :param only_new: Only newly added tasks in the latest version without clearing existing tasks
         :param dag_run_state: state to set DagRun to. If set to False, dagrun state will not
             be changed.
@@ -1178,6 +1186,8 @@ class SerializedDAG:
                 raise ValueError("only_new and only_failed are mutually exclusive")
             if only_running:
                 raise ValueError("only_new and only_running are mutually exclusive")
+            if only_skipped:
+                raise ValueError("only_new and only_skipped are mutually exclusive")
             if not run_id:
                 raise ValueError("only_new requires run_id to be specified")
             task_ids = _get_new_task_ids(self.dag_id, run_id, session)
@@ -1193,6 +1203,8 @@ class SerializedDAG:
         if only_running:
             # Yes, having `+=` doesn't make sense, but this was the existing behaviour
             state += [TaskInstanceState.RUNNING]
+        if only_skipped:
+            state += [TaskInstanceState.SKIPPED]
 
         tis_result = self._get_task_instances(
             task_ids=task_ids,
@@ -1233,6 +1245,7 @@ class SerializedDAG:
         end_date=None,
         only_failed=False,
         only_running=False,
+        only_skipped=False,
         dag_run_state=DagRunState.QUEUED,
         dry_run: bool = False,
     ):
@@ -1243,6 +1256,7 @@ class SerializedDAG:
                     end_date=end_date,
                     only_failed=only_failed,
                     only_running=only_running,
+                    only_skipped=only_skipped,
                     dag_run_state=dag_run_state,
                     dry_run=True,
                 )
@@ -1256,6 +1270,7 @@ class SerializedDAG:
                 end_date=end_date,
                 only_failed=only_failed,
                 only_running=only_running,
+                only_skipped=only_skipped,
                 dag_run_state=dag_run_state,
                 dry_run=False,
             )

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1551,6 +1551,11 @@ export const $ClearTaskInstancesBody = {
             title: 'Only Failed',
             default: true
         },
+        only_skipped: {
+            type: 'boolean',
+            title: 'Only Skipped',
+            default: false
+        },
         only_running: {
             type: 'boolean',
             title: 'Only Running',
@@ -2759,6 +2764,11 @@ export const $DAGRunClearBody = {
         only_failed: {
             type: 'boolean',
             title: 'Only Failed',
+            default: false
+        },
+        only_skipped: {
+            type: 'boolean',
+            title: 'Only Skipped',
             default: false
         },
         only_new: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -1551,14 +1551,14 @@ export const $ClearTaskInstancesBody = {
             title: 'Only Failed',
             default: true
         },
-        only_skipped: {
-            type: 'boolean',
-            title: 'Only Skipped',
-            default: false
-        },
         only_running: {
             type: 'boolean',
             title: 'Only Running',
+            default: false
+        },
+        only_skipped: {
+            type: 'boolean',
+            title: 'Only Skipped',
             default: false
         },
         reset_dag_runs: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -495,8 +495,8 @@ export type ClearTaskInstancesBody = {
     start_date?: string | null;
     end_date?: string | null;
     only_failed?: boolean;
-    only_skipped?: boolean;
     only_running?: boolean;
+    only_skipped?: boolean;
     reset_dag_runs?: boolean;
     /**
      * A list of `task_id` or [`task_id`, `map_index`]. If only the `task_id` is provided for a mapped task, all of its map indices will be targeted.

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -496,6 +496,7 @@ export type ClearTaskInstancesBody = {
     end_date?: string | null;
     only_failed?: boolean;
     only_running?: boolean;
+    only_skipped?: boolean;
     reset_dag_runs?: boolean;
     /**
      * A list of `task_id` or [`task_id`, `map_index`]. If only the `task_id` is provided for a mapped task, all of its map indices will be targeted.
@@ -743,6 +744,7 @@ export type DAGResponse = {
 export type DAGRunClearBody = {
     dry_run?: boolean;
     only_failed?: boolean;
+    only_skipped?: boolean;
     /**
      * Only queue newly added tasks in the latest Dag version without clearing existing tasks.
      */

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -496,7 +496,6 @@ export type ClearTaskInstancesBody = {
     end_date?: string | null;
     only_failed?: boolean;
     only_running?: boolean;
-    only_skipped?: boolean;
     reset_dag_runs?: boolean;
     /**
      * A list of `task_id` or [`task_id`, `map_index`]. If only the `task_id` is provided for a mapped task, all of its map indices will be targeted.
@@ -744,7 +743,6 @@ export type DAGResponse = {
 export type DAGRunClearBody = {
     dry_run?: boolean;
     only_failed?: boolean;
-    only_skipped?: boolean;
     /**
      * Only queue newly added tasks in the latest Dag version without clearing existing tasks.
      */

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -495,6 +495,7 @@ export type ClearTaskInstancesBody = {
     start_date?: string | null;
     end_date?: string | null;
     only_failed?: boolean;
+    only_skipped?: boolean;
     only_running?: boolean;
     reset_dag_runs?: boolean;
     /**
@@ -743,6 +744,7 @@ export type DAGResponse = {
 export type DAGRunClearBody = {
     dry_run?: boolean;
     only_failed?: boolean;
+    only_skipped?: boolean;
     /**
      * Only queue newly added tasks in the latest Dag version without clearing existing tasks.
      */

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
@@ -69,6 +69,7 @@
       "existingTasks": "Clear existing tasks",
       "future": "Future",
       "onlyFailed": "Clear only failed tasks",
+      "onlySkipped": "Clear only skipped tasks",
       "past": "Past",
       "preventRunningTasks": "Prevent rerun if task is running",
       "queueNew": "Queue up new tasks",

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -46,6 +46,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
   const [note, setNote] = useState<string | null>(dagRun.note);
   const [selectedOptions, setSelectedOptions] = useState<Array<string>>(["existingTasks"]);
   const onlyFailed = selectedOptions.includes("onlyFailed");
+  const onlySkipped = selectedOptions.includes("onlySkipped");
   const onlyNew = selectedOptions.includes("newTasks");
 
   const { data: dagDetails } = useDagServiceGetDagDetails({
@@ -69,6 +70,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     },
     requestBody: {
       only_failed: onlyFailed,
+      only_skipped: onlySkipped,
       only_new: onlyNew,
       run_on_latest_version: runOnLatestVersion,
     },
@@ -126,6 +128,10 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
                   value: "onlyFailed",
                 },
                 {
+                  label: translate("dags:runAndTaskActions.options.onlySkipped"),
+                  value: "onlySkipped",
+                },
+                {
                   label: translate("dags:runAndTaskActions.options.queueNew"),
                   value: "newTasks",
                 },
@@ -156,6 +162,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
                   requestBody: {
                     dry_run: false,
                     only_failed: onlyFailed,
+                    only_skipped: onlySkipped,
                     only_new: onlyNew,
                     run_on_latest_version: runOnLatestVersion,
                   },

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -70,8 +70,8 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     },
     requestBody: {
       only_failed: onlyFailed,
-      only_skipped: onlySkipped,
       only_new: onlyNew,
+      only_skipped: onlySkipped,
       run_on_latest_version: runOnLatestVersion,
     },
   });
@@ -162,8 +162,8 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
                   requestBody: {
                     dry_run: false,
                     only_failed: onlyFailed,
-                    only_skipped: onlySkipped,
                     only_new: onlyNew,
+                    only_skipped: onlySkipped,
                     run_on_latest_version: runOnLatestVersion,
                   },
                 });

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -219,6 +219,7 @@ class ClearTaskInstancesBody(BaseModel):
     end_date: Annotated[datetime | None, Field(title="End Date")] = None
     only_failed: Annotated[bool | None, Field(title="Only Failed")] = True
     only_running: Annotated[bool | None, Field(title="Only Running")] = False
+    only_skipped: Annotated[bool | None, Field(title="Only Skipped")] = False
     reset_dag_runs: Annotated[bool | None, Field(title="Reset Dag Runs")] = True
     task_ids: Annotated[
         list[str | TaskIds] | None,
@@ -355,6 +356,7 @@ class DAGRunClearBody(BaseModel):
     )
     dry_run: Annotated[bool | None, Field(title="Dry Run")] = True
     only_failed: Annotated[bool | None, Field(title="Only Failed")] = False
+    only_skipped: Annotated[bool | None, Field(title="Only Skipped")] = False
     only_new: Annotated[
         bool | None,
         Field(


### PR DESCRIPTION
## Summary

Adds a new "Only Skipped" option in the Clear Run dialog alongside the existing "Only Failed" and "Queue New" options. When selected, only task instances in the `skipped` state are cleared and re-run.

Closes #67464

## Changes

### Backend
- `SerializedDAG.clear()` — added `only_skipped` parameter (to all overloads + implementation). Validates mutual exclusivity with `only_new`. Filters for `TaskInstanceState.SKIPPED`.
- `SerializedDAG.clear_dags()` — passes `only_skipped` through.
- `DAGRunClearBody` — added `only_skipped: bool = False` field.
- `ClearTaskInstancesBody` — added `only_skipped: bool = False` field.
- `clear_dag_run()` route — dry_run filtering and pass-through for `only_skipped`.
- `clear_task_instances()` route — pass-through for `only_skipped`.

### CLI
- Added `--only-skipped` argument to both `airflow dags clear` and `airflow tasks clear`.

### UI
- `ClearRunDialog.tsx` — "Only Skipped" option in the SegmentedControl, wired to `only_skipped` in both dry-run and mutate request bodies.
- `en/dags.json` — added translation key `onlySkipped`.

<!-- pr-triage-fold: triaged=2026-06-22T06:44:41.605711+00:00 head=3bf2a28 action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @anmolxlight** · by `@potiuk` · 2026-06-22 06:44 UTC
>
> This PR is being closed to keep the review queue clean:
> - The ready-for-review label was stale: ~11 days with no author response since the last maintainer comment, and the branch now has merge conflicts.
>
> **The ball is in your court** — reopen this PR (or open a fresh one) once you've rebased onto `main` and resolved the conflicts. No rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->