### PR TITLE
Fix misleading Calendar Total Runs coloring behavior

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarCell.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarCell.tsx
@@ -28,8 +28,8 @@ type Props = {
     | Record<string, string>
     | string
     | {
-        actual: string | { _dark: string; _light: string };
-        planned: string | { _dark: string; _light: string };
+        primary: string | { _dark: string; _light: string };
+        secondary: string | { _dark: string; _light: string };
       };
   readonly cellData: CalendarCellData | undefined;
   readonly index?: number;
@@ -64,7 +64,7 @@ export const CalendarCell = ({
     : [];
 
   const isMixedState =
-    typeof backgroundColor === "object" && "planned" in backgroundColor && "actual" in backgroundColor;
+    typeof backgroundColor === "object" && "secondary" in backgroundColor && "primary" in backgroundColor;
 
   const cellBox = isMixedState ? (
     <Box
@@ -82,14 +82,14 @@ export const CalendarCell = ({
       width="14px"
     >
       <Box
-        bg={backgroundColor.planned}
+        bg={backgroundColor.secondary}
         clipPath="polygon(0 100%, 100% 100%, 0 0)"
         height="100%"
         position="absolute"
         width="100%"
       />
       <Box
-        bg={backgroundColor.actual}
+        bg={backgroundColor.primary}
         clipPath="polygon(100% 0, 100% 100%, 0 0)"
         height="100%"
         position="absolute"

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarLegend.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarLegend.tsx
@@ -30,8 +30,48 @@ type Props = {
   readonly viewMode: CalendarColorMode;
 };
 
+type LegendColorType =
+  | Record<string, string>
+  | string
+  | { primary: Record<string, string> | string; secondary: Record<string, string> | string };
+
+const LegendIcon = ({ color, cursor }: { readonly color: LegendColorType; readonly cursor?: string }) => {
+  const isMixedState = typeof color === "object" && "primary" in color && "secondary" in color;
+
+  if (isMixedState) {
+    return (
+      <Box
+        borderRadius="2px"
+        boxShadow="sm"
+        cursor={cursor}
+        height="14px"
+        overflow="hidden"
+        position="relative"
+        width="14px"
+      >
+        <Box
+          bg={color.secondary}
+          clipPath="polygon(0 100%, 100% 100%, 0 0)"
+          height="100%"
+          position="absolute"
+          width="100%"
+        />
+        <Box
+          bg={color.primary}
+          clipPath="polygon(100% 0, 100% 100%, 0 0)"
+          height="100%"
+          position="absolute"
+          width="100%"
+        />
+      </Box>
+    );
+  }
+
+  return <Box bg={color} borderRadius="2px" boxShadow="sm" cursor={cursor} height="14px" width="14px" />;
+};
+
 export const CalendarLegend = ({ scale, vertical = false, viewMode }: Props) => {
-  const { t: translate } = useTranslation("dag");
+  const { t: translate } = useTranslation(["dag", "common"]);
 
   const legendTitle =
     viewMode === "failed" ? translate("overview.buttons.failedRun_other") : translate("calendar.totalRuns");
@@ -54,7 +94,9 @@ export const CalendarLegend = ({ scale, vertical = false, viewMode }: Props) => 
             <VStack gap={0.5}>
               {[...scale.legendItems].reverse().map(({ color, label }) => (
                 <Tooltip content={`${label} ${viewMode === "failed" ? "failed" : "runs"}`} key={label}>
-                  <Box bg={color} borderRadius="2px" cursor="pointer" height="14px" width="14px" />
+                  <Box>
+                    <LegendIcon color={color} cursor="pointer" />
+                  </Box>
                 </Tooltip>
               ))}
             </VStack>
@@ -70,7 +112,9 @@ export const CalendarLegend = ({ scale, vertical = false, viewMode }: Props) => 
             <HStack gap={0.5}>
               {scale.legendItems.map(({ color, label }) => (
                 <Tooltip content={`${label} ${viewMode === "failed" ? "failed" : "runs"}`} key={label}>
-                  <Box bg={color} borderRadius="2px" cursor="pointer" height="14px" width="14px" />
+                  <Box>
+                    <LegendIcon color={color} cursor="pointer" />
+                  </Box>
                 </Tooltip>
               ))}
             </HStack>
@@ -83,42 +127,49 @@ export const CalendarLegend = ({ scale, vertical = false, viewMode }: Props) => 
 
       <Box>
         <HStack gap={4} justify="center" wrap="wrap">
+          {viewMode === "total" && (
+            <>
+              <HStack gap={2}>
+                <LegendIcon color={{ _dark: "green.700", _light: "green.400" }} />
+                <Text color="fg.muted" fontSize="xs">
+                  {translate("common:states.success")}
+                </Text>
+              </HStack>
+              <HStack gap={2}>
+                <LegendIcon color={{ _dark: "cyan.700", _light: "cyan.400" }} />
+                <Text color="fg.muted" fontSize="xs">
+                  {translate("common:states.running")}
+                </Text>
+              </HStack>
+            </>
+          )}
+
+          <HStack gap={2}>
+            <LegendIcon color={{ _dark: "red.700", _light: "red.400" }} />
+            <Text color="fg.muted" fontSize="xs">
+              {translate("common:states.failed")}
+            </Text>
+          </HStack>
+
           <HStack gap={2}>
             <Box bg={PLANNED_COLOR} borderRadius="2px" boxShadow="sm" height="14px" width="14px" />
             <Text color="fg.muted" fontSize="xs">
               {translate("common:states.planned")}
             </Text>
           </HStack>
+
           <HStack gap={2}>
-            <Box
-              borderRadius="2px"
-              boxShadow="sm"
-              height="14px"
-              overflow="hidden"
-              position="relative"
-              width="14px"
-            >
-              <Box
-                bg={PLANNED_COLOR}
-                clipPath="polygon(0 100%, 100% 100%, 0 0)"
-                height="100%"
-                position="absolute"
-                width="100%"
-              />
-              <Box
-                bg={
+            <LegendIcon
+              color={{
+                primary:
                   viewMode === "failed"
                     ? { _dark: "red.700", _light: "red.400" }
-                    : { _dark: "green.700", _light: "green.400" }
-                }
-                clipPath="polygon(100% 0, 100% 100%, 0 0)"
-                height="100%"
-                position="absolute"
-                width="100%"
-              />
-            </Box>
+                    : { _dark: "green.700", _light: "green.400" },
+                secondary: PLANNED_COLOR,
+              }}
+            />
             <Text color="fg.muted" fontSize="xs">
-              {translate("calendar.legend.mixed")}
+              {translate("dag:calendar.legend.mixed")}
             </Text>
           </HStack>
         </HStack>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarTooltip.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/CalendarTooltip.tsx
@@ -32,6 +32,7 @@ type Props = {
 const stateColorMap = {
   failed: "failed.solid",
   planned: "stone.solid",
+  queued: "queued.solid",
   running: "running.solid",
   success: "success.solid",
 };

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
@@ -27,6 +27,7 @@ const EMPTY_COLOR = { _dark: "gray.700", _light: "gray.100" };
 const PLANNED_COLOR = { _dark: "stone.600", _light: "stone.500" };
 const DEFAULT_TOTAL_COLOR = { _dark: "green.700", _light: "green.400" };
 const DEFAULT_FAILED_COLOR = { _dark: "red.700", _light: "red.400" };
+const DEFAULT_RUNNING_COLOR = { _dark: "cyan.700", _light: "cyan.400" };
 
 const EMPTY_COUNTS: RunCounts = {
   failed: 0,
@@ -173,6 +174,39 @@ describe("createCalendarScale", () => {
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, success: 1, total: 2 })).toEqual({
       actual: DEFAULT_TOTAL_COLOR,
       planned: PLANNED_COLOR,
+    });
+  });
+
+  it("returns the failed color for a failed-only cell in total mode", () => {
+    const scale = createCalendarScale([run("failed", 1)], "total", "hourly");
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, total: 1 })).toEqual(DEFAULT_FAILED_COLOR);
+  });
+
+  it("returns a mixed red and green color for failed and success runs in total mode", () => {
+    const scale = createCalendarScale([run("failed", 1), run("success", 1)], "total", "hourly");
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, success: 1, total: 2 })).toEqual({
+      actual: DEFAULT_TOTAL_COLOR,
+      planned: DEFAULT_FAILED_COLOR,
+    });
+  });
+
+  it("returns a mixed cyan and green color for running and success runs in total mode", () => {
+    const scale = createCalendarScale([run("running", 1), run("success", 1)], "total", "hourly");
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, running: 1, success: 1, total: 2 })).toEqual({
+      actual: DEFAULT_TOTAL_COLOR,
+      planned: DEFAULT_RUNNING_COLOR,
+    });
+  });
+
+  it("returns a mixed cyan and red color for running and failed runs in total mode", () => {
+    const scale = createCalendarScale([run("running", 1), run("failed", 1)], "total", "hourly");
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, running: 1, total: 2 })).toEqual({
+      actual: DEFAULT_RUNNING_COLOR,
+      planned: DEFAULT_FAILED_COLOR,
     });
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
@@ -159,8 +159,8 @@ describe("createCalendarScale", () => {
     });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, planned: 1, success: 1, total: 2 })).toEqual({
-      actual: DEFAULT_TOTAL_COLOR,
-      planned: PLANNED_COLOR,
+      primary: DEFAULT_TOTAL_COLOR,
+      secondary: PLANNED_COLOR,
     });
   });
 
@@ -172,41 +172,57 @@ describe("createCalendarScale", () => {
     });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, queued: 1, success: 1, total: 2 })).toEqual({
-      actual: DEFAULT_TOTAL_COLOR,
-      planned: PLANNED_COLOR,
+      primary: DEFAULT_TOTAL_COLOR,
+      secondary: PLANNED_COLOR,
     });
   });
 
   it("returns the failed color for a failed-only cell in total mode", () => {
-    const scale = createCalendarScale([run("failed", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("failed", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, total: 1 })).toEqual(DEFAULT_FAILED_COLOR);
   });
 
   it("returns a mixed red and green color for failed and success runs in total mode", () => {
-    const scale = createCalendarScale([run("failed", 1), run("success", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("failed", 1), run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, success: 1, total: 2 })).toEqual({
-      actual: DEFAULT_TOTAL_COLOR,
-      planned: DEFAULT_FAILED_COLOR,
+      primary: DEFAULT_FAILED_COLOR,
+      secondary: DEFAULT_TOTAL_COLOR,
     });
   });
 
   it("returns a mixed cyan and green color for running and success runs in total mode", () => {
-    const scale = createCalendarScale([run("running", 1), run("success", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("running", 1), run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, running: 1, success: 1, total: 2 })).toEqual({
-      actual: DEFAULT_TOTAL_COLOR,
-      planned: DEFAULT_RUNNING_COLOR,
+      primary: DEFAULT_RUNNING_COLOR,
+      secondary: DEFAULT_TOTAL_COLOR,
     });
   });
 
   it("returns a mixed cyan and red color for running and failed runs in total mode", () => {
-    const scale = createCalendarScale([run("running", 1), run("failed", 1)], "total", "hourly");
+    const scale = createCalendarScale([run("running", 1), run("failed", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, running: 1, total: 2 })).toEqual({
-      actual: DEFAULT_RUNNING_COLOR,
-      planned: DEFAULT_FAILED_COLOR,
+      primary: DEFAULT_FAILED_COLOR,
+      secondary: DEFAULT_RUNNING_COLOR,
     });
   });
 
@@ -229,8 +245,8 @@ describe("createCalendarScale", () => {
     });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, planned: 1, total: 2 })).toEqual({
-      actual: DEFAULT_FAILED_COLOR,
-      planned: PLANNED_COLOR,
+      primary: DEFAULT_FAILED_COLOR,
+      secondary: PLANNED_COLOR,
     });
   });
 
@@ -252,8 +268,8 @@ describe("createCalendarScale", () => {
     });
 
     expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, queued: 1, total: 2 })).toEqual({
-      actual: DEFAULT_FAILED_COLOR,
-      planned: PLANNED_COLOR,
+      primary: DEFAULT_FAILED_COLOR,
+      secondary: PLANNED_COLOR,
     });
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.test.ts
@@ -272,4 +272,72 @@ describe("createCalendarScale", () => {
       secondary: PLANNED_COLOR,
     });
   });
+
+  it("returns the correct gradient color when runs span across different dates", () => {
+    const scale = createCalendarScale(
+      [run("failed", 1, "2026-04-08T10:00:00Z"), run("failed", 5, "2026-04-09T10:00:00Z")],
+      {
+        granularity: "hourly",
+        timezone: "UTC",
+        viewMode: "total",
+      },
+    );
+
+    const lowIntensityColor = { _dark: "red.900", _light: "red.200" };
+    const highIntensityColor = { _dark: "red.300", _light: "red.800" };
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, total: 1 })).toEqual(lowIntensityColor);
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 5, total: 5 })).toEqual(highIntensityColor);
+  });
+
+  it("prioritizes failed over running over success when multiple actual states coexist with pending", () => {
+    const scale = createCalendarScale([run("planned", 1), run("failed", 1), run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, planned: 1, success: 1, total: 3 })).toEqual({
+      primary: DEFAULT_FAILED_COLOR,
+      secondary: PLANNED_COLOR,
+    });
+  });
+
+  it("returns an empty scale when no data is provided", () => {
+    const scale = createCalendarScale([], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
+
+    expect(scale.type).toBe("empty");
+    expect(scale.getColor(EMPTY_COUNTS)).toEqual(EMPTY_COLOR);
+    expect(scale.legendItems).toEqual([{ color: EMPTY_COLOR, label: "0" }]);
+  });
+
+  it("prioritizes running and failed colors when failed, running, and success coexist without pending states", () => {
+    const scale = createCalendarScale([run("failed", 1), run("running", 1), run("success", 1)], {
+      granularity: "hourly",
+      timezone: "UTC",
+      viewMode: "total",
+    });
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, running: 1, success: 1, total: 3 })).toEqual({
+      primary: DEFAULT_FAILED_COLOR,
+      secondary: DEFAULT_RUNNING_COLOR,
+    });
+  });
+
+  it("returns the correct gradient color for failed mode when failed runs span across different dates", () => {
+    const scale = createCalendarScale(
+      [run("failed", 1, "2026-04-08T10:00:00Z"), run("failed", 10, "2026-04-09T10:00:00Z")],
+      { granularity: "hourly", timezone: "UTC", viewMode: "failed" },
+    );
+
+    const lowIntensityFailedColor = { _dark: "red.900", _light: "red.200" };
+    const highIntensityFailedColor = { _dark: "red.300", _light: "red.800" };
+
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 1, total: 1 })).toEqual(lowIntensityFailedColor);
+    expect(scale.getColor({ ...EMPTY_COUNTS, failed: 10, total: 10 })).toEqual(highIntensityFailedColor);
+  });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -40,6 +40,7 @@ dayjs.extend(tz);
 // Calendar color constants
 export const PLANNED_COLOR = { _dark: "stone.600", _light: "stone.500" };
 const EMPTY_COLOR = { _dark: "gray.700", _light: "gray.100" };
+const RUNNING_COLOR = { _dark: "cyan.700", _light: "cyan.400" };
 
 const TOTAL_COLOR_INTENSITIES = [
   EMPTY_COLOR, // 0
@@ -267,13 +268,29 @@ export const createCalendarScale = (
 
     return {
       getColor: (counts: RunCounts) => {
-        const actualCount = getActualRunCount(counts, viewMode);
+        const failedCount = counts.failed;
+        const runningCount = viewMode === "total" ? counts.running : 0;
+        const successCount = viewMode === "total" ? counts.success : 0;
+
         const hasPending = getPendingRunCount(counts) > 0;
-        const hasActual = actualCount > 0;
+        const hasActual = failedCount > 0 || runningCount > 0 || successCount > 0;
+
+        const failedColor = FAILURE_COLOR_INTENSITIES[2] ?? EMPTY_COLOR;
+        const successColor = TOTAL_COLOR_INTENSITIES[2] ?? EMPTY_COLOR;
 
         if (hasPending && hasActual) {
+          let actualColor = EMPTY_COLOR;
+
+          if (failedCount > 0) {
+            actualColor = failedColor;
+          } else if (runningCount > 0) {
+            actualColor = RUNNING_COLOR;
+          } else if (successCount > 0) {
+            actualColor = successColor;
+          }
+
           return {
-            actual: singleColor,
+            actual: actualColor,
             planned: PLANNED_COLOR,
           };
         }
@@ -282,7 +299,29 @@ export const createCalendarScale = (
           return PLANNED_COLOR;
         }
 
-        return actualCount === 0 ? EMPTY_COLOR : singleColor;
+        if (hasActual) {
+          if (failedCount > 0 && runningCount > 0) {
+            return { actual: RUNNING_COLOR, planned: failedColor };
+          }
+          if (failedCount > 0 && successCount > 0) {
+            return { actual: successColor, planned: failedColor };
+          }
+          if (runningCount > 0 && successCount > 0) {
+            return { actual: successColor, planned: RUNNING_COLOR };
+          }
+
+          if (failedCount > 0) {
+            return failedColor;
+          }
+          if (runningCount > 0) {
+            return RUNNING_COLOR;
+          }
+          if (successCount > 0) {
+            return successColor;
+          }
+        }
+
+        return EMPTY_COLOR;
       },
       legendItems: [
         { color: EMPTY_COLOR, label: "0" },
@@ -315,24 +354,39 @@ export const createCalendarScale = (
         actual: string | { _dark: string; _light: string };
         planned: string | { _dark: string; _light: string };
       } => {
-    const actualCount = getActualRunCount(counts, viewMode);
+    const failedCount = counts.failed;
+    const runningCount = viewMode === "total" ? counts.running : 0;
+    const successCount = viewMode === "total" ? counts.success : 0;
+
     const hasPending = getPendingRunCount(counts) > 0;
-    const hasActual = actualCount > 0;
+    const hasActual = failedCount > 0 || runningCount > 0 || successCount > 0;
 
-    if (hasPending && hasActual) {
-      let actualColor = colorScheme[0] ?? EMPTY_COLOR;
+    type ColorValue = string | { _dark: string; _light: string };
 
+    const getIntensityColor = (count: number, scheme: Array<ColorValue>) => {
+      if (count === 0) {
+        return scheme[0] ?? EMPTY_COLOR;
+      }
       for (let index = uniqueThresholds.length - 1; index >= 1; index -= 1) {
         const threshold = uniqueThresholds[index];
 
-        if (threshold !== undefined && actualCount >= threshold) {
-          actualColor = colorScheme[Math.min(index, colorScheme.length - 1)] ?? EMPTY_COLOR;
-          break;
+        if (threshold !== undefined && count >= threshold) {
+          return scheme[Math.min(index, scheme.length - 1)] ?? EMPTY_COLOR;
         }
       }
 
-      if (actualCount > 0 && actualColor === colorScheme[0]) {
-        actualColor = colorScheme[1] ?? EMPTY_COLOR;
+      return scheme[1] ?? EMPTY_COLOR;
+    };
+
+    if (hasPending && hasActual) {
+      let actualColor: ColorValue = EMPTY_COLOR;
+
+      if (failedCount > 0) {
+        actualColor = getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES);
+      } else if (runningCount > 0) {
+        actualColor = RUNNING_COLOR;
+      } else if (successCount > 0) {
+        actualColor = getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES);
       }
 
       return {
@@ -345,21 +399,40 @@ export const createCalendarScale = (
       return PLANNED_COLOR;
     }
 
-    const targetCount = actualCount;
+    if (hasActual) {
+      if (failedCount > 0 && runningCount > 0) {
+        return {
+          actual: RUNNING_COLOR,
+          planned: getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES),
+        };
+      }
 
-    if (targetCount === 0) {
-      return colorScheme[0] ?? EMPTY_COLOR;
-    }
+      if (failedCount > 0 && successCount > 0) {
+        return {
+          actual: getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES),
+          planned: getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES),
+        };
+      }
 
-    for (let index = uniqueThresholds.length - 1; index >= 1; index -= 1) {
-      const threshold = uniqueThresholds[index];
+      if (runningCount > 0 && successCount > 0) {
+        return {
+          actual: getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES),
+          planned: RUNNING_COLOR,
+        };
+      }
 
-      if (threshold !== undefined && targetCount >= threshold) {
-        return colorScheme[Math.min(index, colorScheme.length - 1)] ?? EMPTY_COLOR;
+      if (failedCount > 0) {
+        return getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES);
+      }
+      if (runningCount > 0) {
+        return RUNNING_COLOR;
+      }
+      if (successCount > 0) {
+        return getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES);
       }
     }
 
-    return colorScheme[1] ?? EMPTY_COLOR;
+    return EMPTY_COLOR;
   };
 
   const legendItems: Array<LegendItem> = [];

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/calendarUtils.ts
@@ -245,6 +245,75 @@ type ScaleOptions = {
   viewMode: CalendarColorMode;
 };
 
+type ColorValue = string | { _dark: string; _light: string };
+
+type ResolveColorParams = {
+  failedColor: ColorValue;
+  failedCount: number;
+  hasPending: boolean;
+  runningCount: number;
+  successColor: ColorValue;
+  successCount: number;
+};
+
+const resolveCellColor = ({
+  failedColor,
+  failedCount,
+  hasPending,
+  runningCount,
+  successColor,
+  successCount,
+}: ResolveColorParams): ColorValue | { primary: ColorValue; secondary: ColorValue } => {
+  const hasActual = failedCount > 0 || runningCount > 0 || successCount > 0;
+
+  if (hasPending && hasActual) {
+    let primaryColor: ColorValue = EMPTY_COLOR;
+
+    if (failedCount > 0) {
+      primaryColor = failedColor;
+    } else if (runningCount > 0) {
+      primaryColor = RUNNING_COLOR;
+    } else if (successCount > 0) {
+      primaryColor = successColor;
+    }
+
+    return {
+      primary: primaryColor,
+      secondary: PLANNED_COLOR,
+    };
+  }
+
+  if (hasPending && !hasActual) {
+    return PLANNED_COLOR;
+  }
+
+  if (hasActual) {
+    if (failedCount > 0 && runningCount > 0) {
+      return { primary: failedColor, secondary: RUNNING_COLOR };
+    }
+
+    if (failedCount > 0 && successCount > 0) {
+      return { primary: failedColor, secondary: successColor };
+    }
+
+    if (runningCount > 0 && successCount > 0) {
+      return { primary: RUNNING_COLOR, secondary: successColor };
+    }
+
+    if (failedCount > 0) {
+      return failedColor;
+    }
+    if (runningCount > 0) {
+      return RUNNING_COLOR;
+    }
+    if (successCount > 0) {
+      return successColor;
+    }
+  }
+
+  return EMPTY_COLOR;
+};
+
 export const createCalendarScale = (
   data: Array<CalendarTimeRangeResponse>,
   options: ScaleOptions,
@@ -273,55 +342,18 @@ export const createCalendarScale = (
         const successCount = viewMode === "total" ? counts.success : 0;
 
         const hasPending = getPendingRunCount(counts) > 0;
-        const hasActual = failedCount > 0 || runningCount > 0 || successCount > 0;
 
         const failedColor = FAILURE_COLOR_INTENSITIES[2] ?? EMPTY_COLOR;
         const successColor = TOTAL_COLOR_INTENSITIES[2] ?? EMPTY_COLOR;
 
-        if (hasPending && hasActual) {
-          let actualColor = EMPTY_COLOR;
-
-          if (failedCount > 0) {
-            actualColor = failedColor;
-          } else if (runningCount > 0) {
-            actualColor = RUNNING_COLOR;
-          } else if (successCount > 0) {
-            actualColor = successColor;
-          }
-
-          return {
-            actual: actualColor,
-            planned: PLANNED_COLOR,
-          };
-        }
-
-        if (hasPending && !hasActual) {
-          return PLANNED_COLOR;
-        }
-
-        if (hasActual) {
-          if (failedCount > 0 && runningCount > 0) {
-            return { actual: RUNNING_COLOR, planned: failedColor };
-          }
-          if (failedCount > 0 && successCount > 0) {
-            return { actual: successColor, planned: failedColor };
-          }
-          if (runningCount > 0 && successCount > 0) {
-            return { actual: successColor, planned: RUNNING_COLOR };
-          }
-
-          if (failedCount > 0) {
-            return failedColor;
-          }
-          if (runningCount > 0) {
-            return RUNNING_COLOR;
-          }
-          if (successCount > 0) {
-            return successColor;
-          }
-        }
-
-        return EMPTY_COLOR;
+        return resolveCellColor({
+          failedColor,
+          failedCount,
+          hasPending,
+          runningCount,
+          successColor,
+          successCount,
+        });
       },
       legendItems: [
         { color: EMPTY_COLOR, label: "0" },
@@ -351,17 +383,14 @@ export const createCalendarScale = (
     | string
     | { _dark: string; _light: string }
     | {
-        actual: string | { _dark: string; _light: string };
-        planned: string | { _dark: string; _light: string };
+        primary: string | { _dark: string; _light: string };
+        secondary: string | { _dark: string; _light: string };
       } => {
     const failedCount = counts.failed;
     const runningCount = viewMode === "total" ? counts.running : 0;
     const successCount = viewMode === "total" ? counts.success : 0;
 
     const hasPending = getPendingRunCount(counts) > 0;
-    const hasActual = failedCount > 0 || runningCount > 0 || successCount > 0;
-
-    type ColorValue = string | { _dark: string; _light: string };
 
     const getIntensityColor = (count: number, scheme: Array<ColorValue>) => {
       if (count === 0) {
@@ -378,61 +407,19 @@ export const createCalendarScale = (
       return scheme[1] ?? EMPTY_COLOR;
     };
 
-    if (hasPending && hasActual) {
-      let actualColor: ColorValue = EMPTY_COLOR;
+    const failedColor =
+      failedCount > 0 ? getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES) : EMPTY_COLOR;
+    const successColor =
+      successCount > 0 ? getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES) : EMPTY_COLOR;
 
-      if (failedCount > 0) {
-        actualColor = getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES);
-      } else if (runningCount > 0) {
-        actualColor = RUNNING_COLOR;
-      } else if (successCount > 0) {
-        actualColor = getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES);
-      }
-
-      return {
-        actual: actualColor,
-        planned: PLANNED_COLOR,
-      };
-    }
-
-    if (hasPending && !hasActual) {
-      return PLANNED_COLOR;
-    }
-
-    if (hasActual) {
-      if (failedCount > 0 && runningCount > 0) {
-        return {
-          actual: RUNNING_COLOR,
-          planned: getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES),
-        };
-      }
-
-      if (failedCount > 0 && successCount > 0) {
-        return {
-          actual: getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES),
-          planned: getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES),
-        };
-      }
-
-      if (runningCount > 0 && successCount > 0) {
-        return {
-          actual: getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES),
-          planned: RUNNING_COLOR,
-        };
-      }
-
-      if (failedCount > 0) {
-        return getIntensityColor(failedCount, FAILURE_COLOR_INTENSITIES);
-      }
-      if (runningCount > 0) {
-        return RUNNING_COLOR;
-      }
-      if (successCount > 0) {
-        return getIntensityColor(successCount, TOTAL_COLOR_INTENSITIES);
-      }
-    }
-
-    return EMPTY_COLOR;
+    return resolveCellColor({
+      failedColor,
+      failedCount,
+      hasPending,
+      runningCount,
+      successColor,
+      successCount,
+    });
   };
 
   const legendItems: Array<LegendItem> = [];

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/types.ts
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Calendar/types.ts
@@ -69,8 +69,8 @@ export type CalendarScale = {
     | string
     | { _dark: string; _light: string }
     | {
-        actual: string | { _dark: string; _light: string };
-        planned: string | { _dark: string; _light: string };
+        primary: string | { _dark: string; _light: string };
+        secondary: string | { _dark: string; _light: string };
       };
   readonly legendItems: Array<LegendItem>;
   readonly type: CalendarScaleType;


### PR DESCRIPTION
Updates the Calendar tab `Total Runs` view to render calendar cell colors based on state severity instead of simple run count aggregation, and adds missing tooltip colors.

### Why
As discussed in #66959, I identified a few misleading visual behaviors in the Calendar view.

#### 1. Misleading Cell Rendering (`Total Runs` mode)

The calendar rendering logic did not differentiate between Actual states (`Success`, `Failed`, `Running`). Instead, it relied on aggregated actual run counts to determine cell intensity and only checked whether pending states (`Queued`, `Planned`) existed to apply a mixed pending color.

As a result, cell colors primarily reflected run volume rather than execution severity.

This caused misleading UI behavior where cells containing failed runs could still appear green, making failures less noticeable.

#### 2. Missing Tooltip Colors

`CalendarTooltip.ts` was missing color definitions for the `queued` state.

As a result, queued runs could appear with fallback gray colors or visually blend with other states such as `Running`, creating inconsistent and misleading UI feedback.

### Fix
In a monitoring tool like Airflow, severity is more important than frequency.

Even if there are 100 successful runs, a single failure should remain visible.

To address this, I updated the rendering logic in `calendarUtils.ts` to prioritize colors based on execution severity.

#### Updated Cell Color Priority

Priority order:

1. Failed
2. Running
3. Success

Rendering examples:

- Success only → Green
- Running only → Cyan
- Failed only → Red
- Success + Failed → Green / Red mix
- Failed + Running + Success → Red / Cyan mix
  - Lower-priority `Success` is intentionally hidden

#### Pending State Handling (`Queued` / `Planned`)

- Mixed with actual states:
  - Stone (pending color) + highest-priority actual state color
- Pending states only:
  - Solid Stone color

### Visuals (Before & After)
| Before (Solid Green/Gray hiding errors) | After (Severity-based Mix) |
|:---:|:---:|
| <img width="2018" height="1288" alt="before" src="https://github.com/user-attachments/assets/117ce592-0059-4a26-bf8b-e413ddac3e36" />| <img width="2012" height="1292" alt="Screenshot 2026-05-26 212536" src="https://github.com/user-attachments/assets/38400aba-e842-4dae-bbe3-755c972a1e99" />|

closes: #66959

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Gemini 3.1 Pro)

Generated-by: Gemini following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.