### PR TITLE
Recreate Supervisor Schema with Pydantic mechanism

### DIFF
--- a/scripts/ci/prek/check_supervisor_schemas_versions.py
+++ b/scripts/ci/prek/check_supervisor_schemas_versions.py
@@ -84,6 +84,7 @@ def dump_snapshot(cwd: Path) -> str:
             "run",
             "-p",
             "3.12",
+            "--frozen",
             "--no-progress",
             "--project",
             "task-sdk",

--- a/scripts/ci/prek/dump_supervisor_schemas.py
+++ b/scripts/ci/prek/dump_supervisor_schemas.py
@@ -31,25 +31,49 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from pydantic import BaseModel
+from pydantic import json_schema
 
 os.environ["_AIRFLOW__AS_LIBRARY"] = "1"
 
 from airflow.sdk.execution_time.schema import bundle, registered_models_by_name
 
-
-def _registered_models_sorted() -> tuple[type[BaseModel], ...]:
-    """Return registered head models sorted by class name for stable snapshot diffs."""
-    by_name = registered_models_by_name()
-    return tuple(by_name[name] for name in sorted(by_name))
-
-
+# Models are sorted by name before being passed to generation for stable diffs.
+_, snapshot = json_schema.models_json_schema(
+    [(m, "serialization") for _, m in sorted(registered_models_by_name().items())],
+    schema_generator=json_schema.GenerateJsonSchema,
+)
 snapshot = {
+    "$schema": json_schema.GenerateJsonSchema.schema_dialect,
     "api_version": str(bundle.versions[0].value),
-    "schemas": {cls.__name__: cls.model_json_schema() for cls in _registered_models_sorted()},
+    "description": "Apache Airflow SDK Supervisor Schema",
+    "$defs": snapshot["$defs"],
 }
-json.dump(snapshot, sys.stdout, indent=2, sort_keys=True)
+
+# We currently still have references to non-SDK models from SDK. This cause
+# issues since Pydantic would see two classes for one (logical) model. This
+# post-process Pydantic's output to merge those class pairs into one. Eventually
+# we should have clean separation between SDK and Core, and won't need this
+# anymore. But that is still quite some way away.
+renames: dict[str, str] = {}
+for key, val in (defs := snapshot["$defs"]).items():
+    if (title := (val.get("title") or key)) != key:
+        renames[key] = title
+
+for key in list(defs):
+    try:
+        title = renames[key]
+    except KeyError:
+        continue
+    entry = defs.pop(key)
+    if title in defs:  # Dup, don't need this one.
+        continue
+    defs[title] = entry
+
+output = json.dumps(snapshot, indent=2)
+for old, new in renames.items():
+    output = output.replace(f'"#/$defs/{old}"', f'"#/$defs/{new}"')
+
+
+sys.stdout.write(output)
 sys.stdout.write("\n")

--- a/scripts/ci/prek/generate_supervisor_schemas_snapshot.py
+++ b/scripts/ci/prek/generate_supervisor_schemas_snapshot.py
@@ -64,6 +64,7 @@ def dump_snapshot(cwd: Path) -> str:
             "run",
             "-p",
             "3.12",
+            "--frozen",
             "--no-progress",
             "--project",
             "task-sdk",

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -1,251 +1,131 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "api_version": "2026-06-16",
-  "schemas": {
-    "AssetEventsResult": {
-      "$defs": {
-        "AssetEventResponse": {
-          "description": "Asset event schema with fields that are needed for Runtime.",
-          "properties": {
-            "asset": {
-              "$ref": "#/$defs/AssetResponse"
-            },
-            "created_dagruns": {
-              "items": {
-                "$ref": "#/$defs/DagRunAssetReference"
+  "description": "Apache Airflow SDK Supervisor Schema",
+  "$defs": {
+    "AssetAliasReferenceAssetEventDagRun": {
+      "additionalProperties": false,
+      "description": "Schema for AssetAliasModel used in AssetEventDagRunReference.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "AssetAliasReferenceAssetEventDagRun",
+      "type": "object"
+    },
+    "AssetEventResponse": {
+      "description": "Asset event schema with fields that are needed for Runtime.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "integer"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "title": "Timestamp",
+          "type": "string"
+        },
+        "extra": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/JsonValue"
               },
-              "title": "Created Dagruns",
-              "type": "array"
+              "type": "object"
             },
-            "extra": {
-              "anyOf": [
-                {
-                  "additionalProperties": {
-                    "$ref": "#/$defs/JsonValue"
-                  },
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Extra"
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Extra"
+        },
+        "asset": {
+          "$ref": "#/$defs/AssetResponse"
+        },
+        "created_dagruns": {
+          "items": {
+            "$ref": "#/$defs/DagRunAssetReference"
+          },
+          "title": "Created Dagruns",
+          "type": "array"
+        },
+        "source_task_id": {
+          "anyOf": [
+            {
+              "type": "string"
             },
-            "id": {
-              "title": "Id",
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Task Id"
+        },
+        "source_dag_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Dag Id"
+        },
+        "source_run_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Source Run Id"
+        },
+        "source_map_index": {
+          "anyOf": [
+            {
               "type": "integer"
             },
-            "partition_key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Partition Key"
-            },
-            "source_dag_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Dag Id"
-            },
-            "source_map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Map Index"
-            },
-            "source_run_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Run Id"
-            },
-            "source_task_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Task Id"
-            },
-            "timestamp": {
-              "format": "date-time",
-              "title": "Timestamp",
-              "type": "string"
+            {
+              "type": "null"
             }
-          },
-          "required": [
-            "id",
-            "timestamp",
-            "asset",
-            "created_dagruns"
           ],
-          "title": "AssetEventResponse",
-          "type": "object"
+          "default": null,
+          "title": "Source Map Index"
         },
-        "AssetResponse": {
-          "description": "Asset schema for responses with fields that are needed for Runtime.",
-          "properties": {
-            "extra": {
-              "anyOf": [
-                {
-                  "additionalProperties": {
-                    "$ref": "#/$defs/JsonValue"
-                  },
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Extra"
-            },
-            "group": {
-              "title": "Group",
+        "partition_key": {
+          "anyOf": [
+            {
               "type": "string"
             },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
+            {
+              "type": "null"
             }
-          },
-          "required": [
-            "name",
-            "uri",
-            "group"
           ],
-          "title": "AssetResponse",
-          "type": "object"
-        },
-        "DagRunAssetReference": {
-          "additionalProperties": false,
-          "description": "DagRun serializer for asset responses.",
-          "properties": {
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "data_interval_end": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Data Interval End"
-            },
-            "data_interval_start": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Data Interval Start"
-            },
-            "end_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "End Date"
-            },
-            "logical_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Logical Date"
-            },
-            "partition_key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Partition Key"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "start_date": {
-              "format": "date-time",
-              "title": "Start Date",
-              "type": "string"
-            },
-            "state": {
-              "title": "State",
-              "type": "string"
-            }
-          },
-          "required": [
-            "run_id",
-            "dag_id",
-            "start_date",
-            "state"
-          ],
-          "title": "DagRunAssetReference",
-          "type": "object"
-        },
-        "JsonValue": {}
+          "default": null,
+          "title": "Partition Key"
+        }
       },
+      "required": [
+        "id",
+        "timestamp",
+        "asset",
+        "created_dagruns"
+      ],
+      "title": "AssetEventResponse",
+      "type": "object"
+    },
+    "AssetEventsResult": {
       "description": "Response to GetAssetEvent request.",
       "properties": {
         "asset_events": {
@@ -268,12 +148,127 @@
       "title": "AssetEventsResult",
       "type": "object"
     },
-    "AssetResult": {
-      "$defs": {
-        "JsonValue": {}
+    "AssetProfile": {
+      "additionalProperties": false,
+      "description": "Profile of an asset-like object.\n\nAsset will have name, uri defined, with type set to 'Asset'.\nAssetNameRef will have name defined, type set to 'AssetNameRef'.\nAssetUriRef will have uri defined, type set to 'AssetUriRef'.\nAssetAlias will have name defined, type set to 'AssetAlias'.\n\nNote that 'type' here is distinct from 'asset_type' the user declares on an\nAsset (or subclass). This field is for distinguishing between different\nasset-related types (Asset, AssetRef, or AssetAlias).",
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "uri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uri"
+        },
+        "type": {
+          "title": "Type",
+          "type": "string"
+        }
       },
+      "required": [
+        "type"
+      ],
+      "title": "AssetProfile",
+      "type": "object"
+    },
+    "AssetReferenceAssetEventDagRun": {
+      "additionalProperties": false,
+      "description": "Schema for AssetModel used in AssetEventDagRunReference.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
+        "extra": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "title": "Extra",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "uri",
+        "extra"
+      ],
+      "title": "AssetReferenceAssetEventDagRun",
+      "type": "object"
+    },
+    "AssetResponse": {
+      "description": "Asset schema for responses with fields that are needed for Runtime.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
+        "group": {
+          "title": "Group",
+          "type": "string"
+        },
+        "extra": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/JsonValue"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Extra"
+        }
+      },
+      "required": [
+        "name",
+        "uri",
+        "group"
+      ],
+      "title": "AssetResponse",
+      "type": "object"
+    },
+    "AssetResult": {
       "description": "Response to ReadXCom request.",
       "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
+        "group": {
+          "title": "Group",
+          "type": "string"
+        },
         "extra": {
           "anyOf": [
             {
@@ -289,22 +284,10 @@
           "default": null,
           "title": "Extra"
         },
-        "group": {
-          "title": "Group",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
         "type": {
           "const": "AssetResult",
           "default": "AssetResult",
           "title": "Type",
-          "type": "string"
-        },
-        "uri": {
-          "title": "Uri",
           "type": "string"
         }
       },
@@ -317,20 +300,17 @@
       "type": "object"
     },
     "AssetStateResult": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "additionalProperties": false,
       "description": "Response to GetAssetState; wraps the generated API response for supervisor to worker comms.",
       "properties": {
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        },
         "type": {
           "const": "AssetStateResult",
           "default": "AssetStateResult",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -340,54 +320,6 @@
       "type": "object"
     },
     "AssetsByAliasResult": {
-      "$defs": {
-        "AssetResult": {
-          "description": "Response to ReadXCom request.",
-          "properties": {
-            "extra": {
-              "anyOf": [
-                {
-                  "additionalProperties": {
-                    "$ref": "#/$defs/JsonValue"
-                  },
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Extra"
-            },
-            "group": {
-              "title": "Group",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "type": {
-              "const": "AssetResult",
-              "default": "AssetResult",
-              "title": "Type",
-              "type": "string"
-            },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "uri",
-            "group"
-          ],
-          "title": "AssetResult",
-          "type": "object"
-        },
-        "JsonValue": {}
-      },
       "description": "Response to GetAssetsByAlias; list of concrete assets resolved from an alias.",
       "properties": {
         "assets": {
@@ -408,6 +340,32 @@
         "assets"
       ],
       "title": "AssetsByAliasResult",
+      "type": "object"
+    },
+    "BundleInfo": {
+      "description": "Schema for telling task which bundle to run with.",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Version"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "BundleInfo",
       "type": "object"
     },
     "ClearAssetStateByName": {
@@ -431,14 +389,14 @@
     },
     "ClearAssetStateByUri": {
       "properties": {
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
         "type": {
           "const": "ClearAssetStateByUri",
           "default": "ClearAssetStateByUri",
           "title": "Type",
-          "type": "string"
-        },
-        "uri": {
-          "title": "Uri",
           "type": "string"
         }
       },
@@ -450,15 +408,15 @@
     },
     "ClearTaskState": {
       "properties": {
-        "all_map_indices": {
-          "default": false,
-          "title": "All Map Indices",
-          "type": "boolean"
-        },
         "ti_id": {
           "format": "uuid",
           "title": "Ti Id",
           "type": "string"
+        },
+        "all_map_indices": {
+          "default": false,
+          "title": "All Map Indices",
+          "type": "boolean"
         },
         "type": {
           "const": "ClearTaskState",
@@ -483,18 +441,6 @@
           "title": "Conn Type",
           "type": "string"
         },
-        "extra": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Extra"
-        },
         "host": {
           "anyOf": [
             {
@@ -506,6 +452,18 @@
           ],
           "default": null,
           "title": "Host"
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Schema"
         },
         "login": {
           "anyOf": [
@@ -543,7 +501,7 @@
           "default": null,
           "title": "Port"
         },
-        "schema": {
+        "extra": {
           "anyOf": [
             {
               "type": "string"
@@ -553,7 +511,7 @@
             }
           ],
           "default": null,
-          "title": "Schema"
+          "title": "Extra"
         },
         "type": {
           "const": "ConnectionResult",
@@ -570,43 +528,24 @@
       "type": "object"
     },
     "CreateHITLDetailPayload": {
-      "$defs": {
-        "HITLUser": {
-          "description": "Schema for a Human-in-the-loop users.",
-          "properties": {
-            "id": {
-              "title": "Id",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "id",
-            "name"
-          ],
-          "title": "HITLUser",
-          "type": "object"
-        }
-      },
       "description": "Add the input request part of a Human-in-the-loop response.",
       "properties": {
-        "assigned_users": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/HITLUser"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Assigned Users"
+        "ti_id": {
+          "format": "uuid",
+          "title": "Ti Id",
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Options",
+          "type": "array"
+        },
+        "subject": {
+          "title": "Subject",
+          "type": "string"
         },
         "body": {
           "anyOf": [
@@ -647,14 +586,6 @@
           "default": false,
           "title": "Multiple"
         },
-        "options": {
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Options",
-          "type": "array"
-        },
         "params": {
           "anyOf": [
             {
@@ -668,14 +599,20 @@
           "default": null,
           "title": "Params"
         },
-        "subject": {
-          "title": "Subject",
-          "type": "string"
-        },
-        "ti_id": {
-          "format": "uuid",
-          "title": "Ti Id",
-          "type": "string"
+        "assigned_users": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HITLUser"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assigned Users"
         },
         "type": {
           "const": "CreateHITLDetailPayload",
@@ -712,893 +649,102 @@
       "title": "DRCount",
       "type": "object"
     },
-    "DagFileParseRequest": {
-      "$defs": {
-        "AssetAliasReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetAliasModel used in AssetEventDagRunReference.",
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "title": "AssetAliasReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "AssetEventDagRunReference": {
-          "additionalProperties": false,
-          "description": "Schema for AssetEvent model used in DagRun.",
-          "properties": {
-            "asset": {
-              "$ref": "#/$defs/AssetReferenceAssetEventDagRun"
-            },
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "source_aliases": {
-              "items": {
-                "$ref": "#/$defs/AssetAliasReferenceAssetEventDagRun"
-              },
-              "title": "Source Aliases",
-              "type": "array"
-            },
-            "source_dag_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Source Dag Id"
-            },
-            "source_map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Source Map Index"
-            },
-            "source_run_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Source Run Id"
-            },
-            "source_task_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Source Task Id"
-            },
-            "timestamp": {
-              "format": "date-time",
-              "title": "Timestamp",
-              "type": "string"
-            }
-          },
-          "required": [
-            "asset",
-            "extra",
-            "source_task_id",
-            "source_dag_id",
-            "source_run_id",
-            "source_map_index",
-            "source_aliases",
-            "timestamp"
-          ],
-          "title": "AssetEventDagRunReference",
-          "type": "object"
-        },
-        "AssetReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetModel used in AssetEventDagRunReference.",
-          "properties": {
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "uri",
-            "extra"
-          ],
-          "title": "AssetReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "ConnectionResponse": {
-          "description": "Connection schema for responses with fields that are needed for Runtime.",
-          "properties": {
-            "conn_id": {
-              "title": "Conn Id",
-              "type": "string"
-            },
-            "conn_type": {
-              "title": "Conn Type",
-              "type": "string"
-            },
-            "extra": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Extra"
-            },
-            "host": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Host"
-            },
-            "login": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Login"
-            },
-            "password": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Password"
-            },
-            "port": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Port"
-            },
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Schema"
-            }
-          },
-          "required": [
-            "conn_id",
-            "conn_type",
-            "host",
-            "schema",
-            "login",
-            "password",
-            "port",
-            "extra"
-          ],
-          "title": "ConnectionResponse",
-          "type": "object"
-        },
-        "DagCallbackRequest": {
-          "description": "A Class with information about the success/failure DAG callback to be executed.",
-          "properties": {
-            "bundle_name": {
-              "title": "Bundle Name",
-              "type": "string"
-            },
-            "bundle_version": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Bundle Version"
-            },
-            "context_from_server": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/DagRunContext"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null
-            },
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "filepath": {
-              "title": "Filepath",
-              "type": "string"
-            },
-            "is_failure_callback": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": true,
-              "title": "Is Failure Callback"
-            },
-            "msg": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Msg"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "type": {
-              "const": "DagCallbackRequest",
-              "default": "DagCallbackRequest",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          "required": [
-            "filepath",
-            "bundle_name",
-            "bundle_version",
-            "dag_id",
-            "run_id"
-          ],
-          "title": "DagCallbackRequest",
-          "type": "object"
-        },
-        "DagRun": {
-          "additionalProperties": false,
-          "description": "Schema for DagRun model with minimal required fields needed for Runtime.",
-          "properties": {
-            "clear_number": {
-              "default": 0,
-              "title": "Clear Number",
-              "type": "integer"
-            },
-            "conf": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Conf"
-            },
-            "consumed_asset_events": {
-              "items": {
-                "$ref": "#/$defs/AssetEventDagRunReference"
-              },
-              "title": "Consumed Asset Events",
-              "type": "array"
-            },
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "data_interval_end": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Data Interval End"
-            },
-            "data_interval_start": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Data Interval Start"
-            },
-            "end_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "End Date"
-            },
-            "logical_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Logical Date"
-            },
-            "note": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Note"
-            },
-            "partition_key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Partition Key"
-            },
-            "run_after": {
-              "format": "date-time",
-              "title": "Run After",
-              "type": "string"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "run_type": {
-              "$ref": "#/$defs/DagRunType"
-            },
-            "start_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Start Date"
-            },
-            "state": {
-              "$ref": "#/$defs/DagRunState"
-            },
-            "team_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Team Name"
-            },
-            "triggering_user_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Triggering User Name"
-            }
-          },
-          "required": [
-            "dag_id",
-            "run_id",
-            "logical_date",
-            "data_interval_start",
-            "data_interval_end",
-            "run_after",
-            "start_date",
-            "end_date",
-            "run_type",
-            "state",
-            "consumed_asset_events",
-            "partition_key"
-          ],
-          "title": "DagRun",
-          "type": "object"
-        },
-        "DagRunContext": {
-          "description": "Class to pass context info from the server to build a Execution context object.",
-          "properties": {
-            "dag_run": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/DagRun"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null
-            },
-            "last_ti": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/TaskInstance"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null
-            }
-          },
-          "title": "DagRunContext",
-          "type": "object"
-        },
-        "DagRunState": {
-          "description": "All possible states that a DagRun can be in.\n\nThese are \"shared\" with TaskInstanceState in some parts of the code,\nso please ensure that their values always match the ones with the\nsame name in TaskInstanceState.",
-          "enum": [
-            "queued",
-            "running",
-            "success",
-            "failed"
-          ],
-          "title": "DagRunState",
-          "type": "string"
-        },
-        "DagRunType": {
-          "description": "Class with DagRun types.",
-          "enum": [
-            "backfill",
-            "scheduled",
-            "manual",
-            "operator_triggered",
-            "asset_triggered",
-            "asset_materialization"
-          ],
-          "title": "DagRunType",
-          "type": "string"
-        },
-        "EmailRequest": {
-          "description": "Email notification request for task failures/retries.",
-          "properties": {
-            "bundle_name": {
-              "title": "Bundle Name",
-              "type": "string"
-            },
-            "bundle_version": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Bundle Version"
-            },
-            "context_from_server": {
-              "$ref": "#/$defs/TIRunContext"
-            },
-            "email_type": {
-              "default": "failure",
-              "enum": [
-                "failure",
-                "retry"
-              ],
-              "title": "Email Type",
-              "type": "string"
-            },
-            "filepath": {
-              "title": "Filepath",
-              "type": "string"
-            },
-            "msg": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Msg"
-            },
-            "ti": {
-              "$ref": "#/$defs/TaskInstance"
-            },
-            "type": {
-              "const": "EmailRequest",
-              "default": "EmailRequest",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          "required": [
-            "filepath",
-            "bundle_name",
-            "bundle_version",
-            "ti",
-            "context_from_server"
-          ],
-          "title": "EmailRequest",
-          "type": "object"
-        },
-        "JsonValue": {},
-        "TIRunContext": {
-          "description": "Response schema for TaskInstance run context.",
-          "properties": {
-            "connections": {
-              "items": {
-                "$ref": "#/$defs/ConnectionResponse"
-              },
-              "title": "Connections",
-              "type": "array"
-            },
-            "dag_run": {
-              "$ref": "#/$defs/DagRun"
-            },
-            "max_tries": {
-              "title": "Max Tries",
-              "type": "integer"
-            },
-            "next_kwargs": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Next Kwargs"
-            },
-            "next_method": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Next Method"
-            },
-            "should_retry": {
-              "default": false,
-              "title": "Should Retry",
-              "type": "boolean"
-            },
-            "start_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Start Date"
-            },
-            "task_reschedule_count": {
-              "default": 0,
-              "title": "Task Reschedule Count",
-              "type": "integer"
-            },
-            "variables": {
-              "items": {
-                "$ref": "#/$defs/VariableResponse"
-              },
-              "title": "Variables",
-              "type": "array"
-            },
-            "xcom_keys_to_clear": {
-              "items": {
-                "type": "string"
-              },
-              "title": "Xcom Keys To Clear",
-              "type": "array"
-            }
-          },
-          "required": [
-            "dag_run",
-            "max_tries"
-          ],
-          "title": "TIRunContext",
-          "type": "object"
-        },
-        "TaskCallbackRequest": {
-          "description": "Task callback status information.\n\nA Class with information about the success/failure TI callback to be executed. Currently, only failure\ncallbacks when tasks are externally killed or experience heartbeat timeouts are run via DagFileProcessorProcess.",
-          "properties": {
-            "bundle_name": {
-              "title": "Bundle Name",
-              "type": "string"
-            },
-            "bundle_version": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Bundle Version"
-            },
-            "context_from_server": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/TIRunContext"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null
-            },
-            "filepath": {
-              "title": "Filepath",
-              "type": "string"
-            },
-            "msg": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Msg"
-            },
-            "task_callback_type": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/TaskInstanceState"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null
-            },
-            "ti": {
-              "$ref": "#/$defs/TaskInstance"
-            },
-            "type": {
-              "const": "TaskCallbackRequest",
-              "default": "TaskCallbackRequest",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          "required": [
-            "filepath",
-            "bundle_name",
-            "bundle_version",
-            "ti"
-          ],
-          "title": "TaskCallbackRequest",
-          "type": "object"
-        },
-        "TaskInstance": {
-          "description": "Schema for TaskInstance model with minimal required fields needed for Runtime.",
-          "properties": {
-            "context_carrier": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Context Carrier"
-            },
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "dag_version_id": {
-              "format": "uuid",
-              "title": "Dag Version Id",
-              "type": "string"
-            },
-            "hostname": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Hostname"
-            },
-            "id": {
-              "format": "uuid",
-              "title": "Id",
-              "type": "string"
-            },
-            "map_index": {
-              "default": -1,
-              "title": "Map Index",
-              "type": "integer"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "task_id": {
-              "title": "Task Id",
-              "type": "string"
-            },
-            "try_number": {
-              "title": "Try Number",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "id",
-            "task_id",
-            "dag_id",
-            "run_id",
-            "try_number",
-            "dag_version_id"
-          ],
-          "title": "TaskInstance",
-          "type": "object"
-        },
-        "TaskInstanceState": {
-          "description": "All possible states that a Task Instance can be in.\n\nNote that None is also allowed, so always use this in a type hint with Optional.",
-          "enum": [
-            "removed",
-            "scheduled",
-            "queued",
-            "running",
-            "success",
-            "restarting",
-            "failed",
-            "up_for_retry",
-            "up_for_reschedule",
-            "upstream_failed",
-            "skipped",
-            "deferred"
-          ],
-          "title": "TaskInstanceState",
-          "type": "string"
-        },
-        "VariableResponse": {
-          "additionalProperties": false,
-          "description": "Variable schema for responses with fields that are needed for Runtime.",
-          "properties": {
-            "key": {
-              "title": "Key",
-              "type": "string"
-            },
-            "value": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Value"
-            }
-          },
-          "required": [
-            "key",
-            "value"
-          ],
-          "title": "VariableResponse",
-          "type": "object"
-        }
-      },
-      "description": "Request for DAG File Parsing.\n\nThis is the request that the manager will send to the DAG parser with the dag file and\nany other necessary metadata.",
+    "DagCallbackRequest": {
+      "description": "A Class with information about the success/failure DAG callback to be executed.",
       "properties": {
+        "filepath": {
+          "title": "Filepath",
+          "type": "string"
+        },
         "bundle_name": {
           "title": "Bundle Name",
+          "type": "string"
+        },
+        "bundle_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Bundle Version"
+        },
+        "msg": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Msg"
+        },
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "context_from_server": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DagRunContext"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "is_failure_callback": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": true,
+          "title": "Is Failure Callback"
+        },
+        "type": {
+          "const": "DagCallbackRequest",
+          "default": "DagCallbackRequest",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "filepath",
+        "bundle_name",
+        "bundle_version",
+        "dag_id",
+        "run_id"
+      ],
+      "title": "DagCallbackRequest",
+      "type": "object"
+    },
+    "DagFileParseRequest": {
+      "description": "Request for DAG File Parsing.\n\nThis is the request that the manager will send to the DAG parser with the dag file and\nany other necessary metadata.",
+      "properties": {
+        "file": {
+          "title": "File",
           "type": "string"
         },
         "bundle_path": {
           "format": "path",
           "title": "Bundle Path",
+          "type": "string"
+        },
+        "bundle_name": {
+          "title": "Bundle Name",
           "type": "string"
         },
         "callback_requests": {
@@ -1626,10 +772,6 @@
           "title": "Callback Requests",
           "type": "array"
         },
-        "file": {
-          "title": "File",
-          "type": "string"
-        },
         "type": {
           "const": "DagFileParseRequest",
           "default": "DagFileParseRequest",
@@ -1646,41 +788,31 @@
       "type": "object"
     },
     "DagFileParsingResult": {
-      "$defs": {
-        "LazyDeserializedDAG": {
-          "description": "Lazily build information from the serialized DAG structure.\n\nAn object that will present \"enough\" of the DAG like interface to update DAG db models etc, without having\nto deserialize the full DAG and Task hierarchy.",
-          "properties": {
-            "data": {
-              "additionalProperties": true,
-              "title": "Data",
-              "type": "object"
-            },
-            "last_loaded": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Last Loaded"
-            }
-          },
-          "required": [
-            "data"
-          ],
-          "title": "LazyDeserializedDAG",
-          "type": "object"
-        }
-      },
       "description": "Result of DAG File Parsing.\n\nThis is the result of a successful DAG parse, in this class, we gather all serialized DAGs,\nimport errors and warnings to send back to the scheduler to store in the DB.",
       "properties": {
         "fileloc": {
           "title": "Fileloc",
           "type": "string"
+        },
+        "serialized_dags": {
+          "items": {
+            "$ref": "#/$defs/LazyDeserializedDAG"
+          },
+          "title": "Serialized Dags",
+          "type": "array"
+        },
+        "warnings": {
+          "anyOf": [
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Warnings"
         },
         "import_errors": {
           "anyOf": [
@@ -1697,31 +829,11 @@
           "default": null,
           "title": "Import Errors"
         },
-        "serialized_dags": {
-          "items": {
-            "$ref": "#/$defs/LazyDeserializedDAG"
-          },
-          "title": "Serialized Dags",
-          "type": "array"
-        },
         "type": {
           "const": "DagFileParsingResult",
           "default": "DagFileParsingResult",
           "title": "Type",
           "type": "string"
-        },
-        "warnings": {
-          "anyOf": [
-            {
-              "items": {},
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Warnings"
         }
       },
       "required": [
@@ -1733,6 +845,14 @@
     },
     "DagResult": {
       "properties": {
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
+        "is_paused": {
+          "title": "Is Paused",
+          "type": "boolean"
+        },
         "bundle_name": {
           "anyOf": [
             {
@@ -1757,18 +877,9 @@
           "default": null,
           "title": "Bundle Version"
         },
-        "dag_id": {
-          "title": "Dag Id",
-          "type": "string"
-        },
-        "is_paused": {
-          "title": "Is Paused",
-          "type": "boolean"
-        },
-        "next_dagrun": {
+        "relative_fileloc": {
           "anyOf": [
             {
-              "format": "date-time",
               "type": "string"
             },
             {
@@ -1776,7 +887,7 @@
             }
           ],
           "default": null,
-          "title": "Next Dagrun"
+          "title": "Relative Fileloc"
         },
         "owners": {
           "anyOf": [
@@ -1790,9 +901,17 @@
           "default": null,
           "title": "Owners"
         },
-        "relative_fileloc": {
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        },
+        "next_dagrun": {
           "anyOf": [
             {
+              "format": "date-time",
               "type": "string"
             },
             {
@@ -1800,14 +919,7 @@
             }
           ],
           "default": null,
-          "title": "Relative Fileloc"
-        },
-        "tags": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Tags",
-          "type": "array"
+          "title": "Next Dagrun"
         },
         "type": {
           "const": "DagResult",
@@ -1824,237 +936,17 @@
       "title": "DagResult",
       "type": "object"
     },
-    "DagRunResult": {
-      "$defs": {
-        "AssetAliasReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetAliasModel used in AssetEventDagRunReference.",
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "title": "AssetAliasReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "AssetEventDagRunReference": {
-          "additionalProperties": false,
-          "description": "Schema for AssetEvent model used in DagRun.",
-          "properties": {
-            "asset": {
-              "$ref": "#/$defs/AssetReferenceAssetEventDagRun"
-            },
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "source_aliases": {
-              "items": {
-                "$ref": "#/$defs/AssetAliasReferenceAssetEventDagRun"
-              },
-              "title": "Source Aliases",
-              "type": "array"
-            },
-            "source_dag_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Dag Id"
-            },
-            "source_map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Map Index"
-            },
-            "source_run_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Run Id"
-            },
-            "source_task_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Task Id"
-            },
-            "timestamp": {
-              "format": "date-time",
-              "title": "Timestamp",
-              "type": "string"
-            }
-          },
-          "required": [
-            "asset",
-            "extra",
-            "source_aliases",
-            "timestamp"
-          ],
-          "title": "AssetEventDagRunReference",
-          "type": "object"
-        },
-        "AssetReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetModel used in AssetEventDagRunReference.",
-          "properties": {
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "uri",
-            "extra"
-          ],
-          "title": "AssetReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "DagRunState": {
-          "description": "All possible states that a DagRun can be in.\n\nThese are \"shared\" with TaskInstanceState in some parts of the code,\nso please ensure that their values always match the ones with the\nsame name in TaskInstanceState.",
-          "enum": [
-            "queued",
-            "running",
-            "success",
-            "failed"
-          ],
-          "title": "DagRunState",
-          "type": "string"
-        },
-        "DagRunType": {
-          "description": "Class with DagRun types.",
-          "enum": [
-            "backfill",
-            "scheduled",
-            "manual",
-            "operator_triggered",
-            "asset_triggered",
-            "asset_materialization"
-          ],
-          "title": "DagRunType",
-          "type": "string"
-        },
-        "JsonValue": {}
-      },
+    "DagRunAssetReference": {
       "additionalProperties": false,
+      "description": "DagRun serializer for asset responses.",
       "properties": {
-        "clear_number": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": 0,
-          "title": "Clear Number"
-        },
-        "conf": {
-          "anyOf": [
-            {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Conf"
-        },
-        "consumed_asset_events": {
-          "items": {
-            "$ref": "#/$defs/AssetEventDagRunReference"
-          },
-          "title": "Consumed Asset Events",
-          "type": "array"
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
         },
         "dag_id": {
           "title": "Dag Id",
           "type": "string"
-        },
-        "data_interval_end": {
-          "anyOf": [
-            {
-              "format": "date-time",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Data Interval End"
-        },
-        "data_interval_start": {
-          "anyOf": [
-            {
-              "format": "date-time",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Data Interval Start"
-        },
-        "end_date": {
-          "anyOf": [
-            {
-              "format": "date-time",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "End Date"
         },
         "logical_date": {
           "anyOf": [
@@ -2069,9 +961,15 @@
           "default": null,
           "title": "Logical Date"
         },
-        "note": {
+        "start_date": {
+          "format": "date-time",
+          "title": "Start Date",
+          "type": "string"
+        },
+        "end_date": {
           "anyOf": [
             {
+              "format": "date-time",
               "type": "string"
             },
             {
@@ -2079,7 +977,37 @@
             }
           ],
           "default": null,
-          "title": "Note"
+          "title": "End Date"
+        },
+        "state": {
+          "title": "State",
+          "type": "string"
+        },
+        "data_interval_start": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Data Interval Start"
+        },
+        "data_interval_end": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Data Interval End"
         },
         "partition_key": {
           "anyOf": [
@@ -2092,18 +1020,100 @@
           ],
           "default": null,
           "title": "Partition Key"
+        }
+      },
+      "required": [
+        "run_id",
+        "dag_id",
+        "start_date",
+        "state"
+      ],
+      "title": "DagRunAssetReference",
+      "type": "object"
+    },
+    "DagRunContext": {
+      "description": "Class to pass context info from the server to build a Execution context object.",
+      "properties": {
+        "dag_run": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DagRun"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
-        "run_after": {
-          "format": "date-time",
-          "title": "Run After",
+        "last_ti": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TaskInstance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "DagRunContext",
+      "type": "object"
+    },
+    "DagRunResult": {
+      "additionalProperties": false,
+      "properties": {
+        "dag_id": {
+          "title": "Dag Id",
           "type": "string"
         },
         "run_id": {
           "title": "Run Id",
           "type": "string"
         },
-        "run_type": {
-          "$ref": "#/$defs/DagRunType"
+        "logical_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Logical Date"
+        },
+        "data_interval_start": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Data Interval Start"
+        },
+        "data_interval_end": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Data Interval End"
+        },
+        "run_after": {
+          "format": "date-time",
+          "title": "Run After",
+          "type": "string"
         },
         "start_date": {
           "anyOf": [
@@ -2118,12 +1128,10 @@
           "default": null,
           "title": "Start Date"
         },
-        "state": {
-          "$ref": "#/$defs/DagRunState"
-        },
-        "team_name": {
+        "end_date": {
           "anyOf": [
             {
+              "format": "date-time",
               "type": "string"
             },
             {
@@ -2131,7 +1139,38 @@
             }
           ],
           "default": null,
-          "title": "Team Name"
+          "title": "End Date"
+        },
+        "clear_number": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0,
+          "title": "Clear Number"
+        },
+        "run_type": {
+          "$ref": "#/$defs/DagRunType"
+        },
+        "state": {
+          "$ref": "#/$defs/DagRunState"
+        },
+        "conf": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conf"
         },
         "triggering_user_name": {
           "anyOf": [
@@ -2144,6 +1183,49 @@
           ],
           "default": null,
           "title": "Triggering User Name"
+        },
+        "consumed_asset_events": {
+          "items": {
+            "$ref": "#/$defs/AssetEventDagRunReference"
+          },
+          "title": "Consumed Asset Events",
+          "type": "array"
+        },
+        "partition_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Partition Key"
+        },
+        "note": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Note"
+        },
+        "team_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Team Name"
         },
         "type": {
           "const": "DagRunResult",
@@ -2163,20 +1245,18 @@
       "title": "DagRunResult",
       "type": "object"
     },
+    "DagRunState": {
+      "description": "All possible states that a DagRun can be in.\n\nThese are \"shared\" with TaskInstanceState in some parts of the code,\nso please ensure that their values always match the ones with the\nsame name in TaskInstanceState.",
+      "enum": [
+        "queued",
+        "running",
+        "success",
+        "failed"
+      ],
+      "title": "DagRunState",
+      "type": "string"
+    },
     "DagRunStateResult": {
-      "$defs": {
-        "DagRunState": {
-          "description": "All possible states that a DagRun can be in.\n\nThese are \"shared\" with TaskInstanceState in some parts of the code,\nso please ensure that their values always match the ones with the\nsame name in TaskInstanceState.",
-          "enum": [
-            "queued",
-            "running",
-            "success",
-            "failed"
-          ],
-          "title": "DagRunState",
-          "type": "string"
-        }
-      },
       "properties": {
         "state": {
           "$ref": "#/$defs/DagRunState"
@@ -2194,60 +1274,23 @@
       "title": "DagRunStateResult",
       "type": "object"
     },
+    "DagRunType": {
+      "description": "Class with DagRun types.",
+      "enum": [
+        "backfill",
+        "scheduled",
+        "manual",
+        "operator_triggered",
+        "asset_triggered",
+        "asset_materialization"
+      ],
+      "title": "DagRunType",
+      "type": "string"
+    },
     "DeferTask": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "additionalProperties": false,
       "description": "Update a task instance state to deferred.",
       "properties": {
-        "classpath": {
-          "title": "Classpath",
-          "type": "string"
-        },
-        "next_kwargs": {
-          "anyOf": [
-            {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Next Kwargs"
-        },
-        "next_method": {
-          "title": "Next Method",
-          "type": "string"
-        },
-        "queue": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Queue"
-        },
-        "rendered_map_index": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Rendered Map Index"
-        },
         "state": {
           "anyOf": [
             {
@@ -2260,6 +1303,10 @@
           ],
           "default": "deferred",
           "title": "State"
+        },
+        "classpath": {
+          "title": "Classpath",
+          "type": "string"
         },
         "trigger_kwargs": {
           "anyOf": [
@@ -2292,6 +1339,49 @@
           "default": null,
           "title": "Trigger Timeout"
         },
+        "queue": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Queue"
+        },
+        "next_method": {
+          "title": "Next Method",
+          "type": "string"
+        },
+        "next_kwargs": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/JsonValue"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Next Kwargs"
+        },
+        "rendered_map_index": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rendered Map Index"
+        },
         "type": {
           "const": "DeferTask",
           "default": "DeferTask",
@@ -2308,12 +1398,12 @@
     },
     "DeleteAssetStateByName": {
       "properties": {
-        "key": {
-          "title": "Key",
-          "type": "string"
-        },
         "name": {
           "title": "Name",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
           "type": "string"
         },
         "type": {
@@ -2332,6 +1422,10 @@
     },
     "DeleteAssetStateByUri": {
       "properties": {
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
         "key": {
           "title": "Key",
           "type": "string"
@@ -2340,10 +1434,6 @@
           "const": "DeleteAssetStateByUri",
           "default": "DeleteAssetStateByUri",
           "title": "Type",
-          "type": "string"
-        },
-        "uri": {
-          "title": "Uri",
           "type": "string"
         }
       },
@@ -2356,13 +1446,13 @@
     },
     "DeleteTaskState": {
       "properties": {
-        "key": {
-          "title": "Key",
-          "type": "string"
-        },
         "ti_id": {
           "format": "uuid",
           "title": "Ti Id",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
           "type": "string"
         },
         "type": {
@@ -2400,12 +1490,20 @@
     },
     "DeleteXCom": {
       "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
         "dag_id": {
           "title": "Dag Id",
           "type": "string"
         },
-        "key": {
-          "title": "Key",
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "task_id": {
+          "title": "Task Id",
           "type": "string"
         },
         "map_index": {
@@ -2419,14 +1517,6 @@
           ],
           "default": null,
           "title": "Map Index"
-        },
-        "run_id": {
-          "title": "Run Id",
-          "type": "string"
-        },
-        "task_id": {
-          "title": "Task Id",
-          "type": "string"
         },
         "type": {
           "const": "DeleteXCom",
@@ -2444,27 +1534,78 @@
       "title": "DeleteXCom",
       "type": "object"
     },
-    "ErrorResponse": {
-      "$defs": {
-        "ErrorType": {
-          "description": "Error types used in the API client.",
-          "enum": [
-            "CONNECTION_NOT_FOUND",
-            "VARIABLE_NOT_FOUND",
-            "XCOM_NOT_FOUND",
-            "ASSET_NOT_FOUND",
-            "TASK_STATE_NOT_FOUND",
-            "ASSET_STATE_NOT_FOUND",
-            "DAGRUN_ALREADY_EXISTS",
-            "PERMISSION_DENIED",
-            "GENERIC_ERROR",
-            "API_SERVER_ERROR"
+    "EmailRequest": {
+      "description": "Email notification request for task failures/retries.",
+      "properties": {
+        "filepath": {
+          "title": "Filepath",
+          "type": "string"
+        },
+        "bundle_name": {
+          "title": "Bundle Name",
+          "type": "string"
+        },
+        "bundle_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "title": "ErrorType",
+          "title": "Bundle Version"
+        },
+        "msg": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Msg"
+        },
+        "ti": {
+          "$ref": "#/$defs/TaskInstance"
+        },
+        "email_type": {
+          "default": "failure",
+          "enum": [
+            "failure",
+            "retry"
+          ],
+          "title": "Email Type",
+          "type": "string"
+        },
+        "context_from_server": {
+          "$ref": "#/$defs/TIRunContext"
+        },
+        "type": {
+          "const": "EmailRequest",
+          "default": "EmailRequest",
+          "title": "Type",
           "type": "string"
         }
       },
+      "required": [
+        "filepath",
+        "bundle_name",
+        "bundle_version",
+        "ti",
+        "context_from_server"
+      ],
+      "title": "EmailRequest",
+      "type": "object"
+    },
+    "ErrorResponse": {
       "properties": {
+        "error": {
+          "$ref": "#/$defs/ErrorType",
+          "default": "GENERIC_ERROR"
+        },
         "detail": {
           "anyOf": [
             {
@@ -2478,10 +1619,6 @@
           "default": null,
           "title": "Detail"
         },
-        "error": {
-          "$ref": "#/$defs/ErrorType",
-          "default": "GENERIC_ERROR"
-        },
         "type": {
           "const": "ErrorResponse",
           "default": "ErrorResponse",
@@ -2491,6 +1628,23 @@
       },
       "title": "ErrorResponse",
       "type": "object"
+    },
+    "ErrorType": {
+      "description": "Error types used in the API client.",
+      "enum": [
+        "CONNECTION_NOT_FOUND",
+        "VARIABLE_NOT_FOUND",
+        "XCOM_NOT_FOUND",
+        "ASSET_NOT_FOUND",
+        "TASK_STATE_NOT_FOUND",
+        "ASSET_STATE_NOT_FOUND",
+        "DAGRUN_ALREADY_EXISTS",
+        "PERMISSION_DENIED",
+        "GENERIC_ERROR",
+        "API_SERVER_ERROR"
+      ],
+      "title": "ErrorType",
+      "type": "string"
     },
     "GetAssetByName": {
       "properties": {
@@ -2513,14 +1667,14 @@
     },
     "GetAssetByUri": {
       "properties": {
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
         "type": {
           "const": "GetAssetByUri",
           "default": "GetAssetByUri",
           "title": "Type",
-          "type": "string"
-        },
-        "uri": {
-          "title": "Uri",
           "type": "string"
         }
       },
@@ -2532,49 +1686,6 @@
     },
     "GetAssetEventByAsset": {
       "properties": {
-        "after": {
-          "anyOf": [
-            {
-              "format": "date-time",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "After"
-        },
-        "ascending": {
-          "default": true,
-          "title": "Ascending",
-          "type": "boolean"
-        },
-        "before": {
-          "anyOf": [
-            {
-              "format": "date-time",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Before"
-        },
-        "limit": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Limit"
-        },
         "name": {
           "anyOf": [
             {
@@ -2586,12 +1697,6 @@
           ],
           "title": "Name"
         },
-        "type": {
-          "const": "GetAssetEventByAsset",
-          "default": "GetAssetEventByAsset",
-          "title": "Type",
-          "type": "string"
-        },
         "uri": {
           "anyOf": [
             {
@@ -2602,17 +1707,7 @@
             }
           ],
           "title": "Uri"
-        }
-      },
-      "required": [
-        "name",
-        "uri"
-      ],
-      "title": "GetAssetEventByAsset",
-      "type": "object"
-    },
-    "GetAssetEventByAssetAlias": {
-      "properties": {
+        },
         "after": {
           "anyOf": [
             {
@@ -2625,15 +1720,6 @@
           ],
           "default": null,
           "title": "After"
-        },
-        "alias_name": {
-          "title": "Alias Name",
-          "type": "string"
-        },
-        "ascending": {
-          "default": true,
-          "title": "Ascending",
-          "type": "boolean"
         },
         "before": {
           "anyOf": [
@@ -2659,6 +1745,74 @@
           ],
           "default": null,
           "title": "Limit"
+        },
+        "ascending": {
+          "default": true,
+          "title": "Ascending",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "GetAssetEventByAsset",
+          "default": "GetAssetEventByAsset",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "title": "GetAssetEventByAsset",
+      "type": "object"
+    },
+    "GetAssetEventByAssetAlias": {
+      "properties": {
+        "alias_name": {
+          "title": "Alias Name",
+          "type": "string"
+        },
+        "after": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "After"
+        },
+        "before": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Before"
+        },
+        "limit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Limit"
+        },
+        "ascending": {
+          "default": true,
+          "title": "Ascending",
+          "type": "boolean"
         },
         "type": {
           "const": "GetAssetEventByAssetAlias",
@@ -2675,12 +1829,12 @@
     },
     "GetAssetStateByName": {
       "properties": {
-        "key": {
-          "title": "Key",
-          "type": "string"
-        },
         "name": {
           "title": "Name",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
           "type": "string"
         },
         "type": {
@@ -2699,6 +1853,10 @@
     },
     "GetAssetStateByUri": {
       "properties": {
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
         "key": {
           "title": "Key",
           "type": "string"
@@ -2707,10 +1865,6 @@
           "const": "GetAssetStateByUri",
           "default": "GetAssetStateByUri",
           "title": "Type",
-          "type": "string"
-        },
-        "uri": {
-          "title": "Uri",
           "type": "string"
         }
       },
@@ -2970,31 +2124,14 @@
       "type": "object"
     },
     "GetPreviousTI": {
-      "$defs": {
-        "TaskInstanceState": {
-          "description": "All possible states that a Task Instance can be in.\n\nNote that None is also allowed, so always use this in a type hint with Optional.",
-          "enum": [
-            "removed",
-            "scheduled",
-            "queued",
-            "running",
-            "success",
-            "restarting",
-            "failed",
-            "up_for_retry",
-            "up_for_reschedule",
-            "upstream_failed",
-            "skipped",
-            "deferred"
-          ],
-          "title": "TaskInstanceState",
-          "type": "string"
-        }
-      },
       "description": "Request to get previous task instance.",
       "properties": {
         "dag_id": {
           "title": "Dag Id",
+          "type": "string"
+        },
+        "task_id": {
+          "title": "Task Id",
           "type": "string"
         },
         "logical_date": {
@@ -3026,10 +2163,6 @@
           ],
           "default": null
         },
-        "task_id": {
-          "title": "Task Id",
-          "type": "string"
-        },
         "type": {
           "const": "GetPreviousTI",
           "default": "GetPreviousTI",
@@ -3050,6 +2183,45 @@
           "title": "Dag Id",
           "type": "string"
         },
+        "map_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Map Index"
+        },
+        "task_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task Ids"
+        },
+        "task_group_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task Group Id"
+        },
         "logical_dates": {
           "anyOf": [
             {
@@ -3065,18 +2237,6 @@
           ],
           "default": null,
           "title": "Logical Dates"
-        },
-        "map_index": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Map Index"
         },
         "run_ids": {
           "anyOf": [
@@ -3107,33 +2267,6 @@
           ],
           "default": null,
           "title": "States"
-        },
-        "task_group_id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Task Group Id"
-        },
-        "task_ids": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Task Ids"
         },
         "type": {
           "const": "GetTICount",
@@ -3199,13 +2332,13 @@
     },
     "GetTaskState": {
       "properties": {
-        "key": {
-          "title": "Key",
-          "type": "string"
-        },
         "ti_id": {
           "format": "uuid",
           "title": "Ti Id",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
           "type": "string"
         },
         "type": {
@@ -3228,6 +2361,45 @@
           "title": "Dag Id",
           "type": "string"
         },
+        "map_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Map Index"
+        },
+        "task_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task Ids"
+        },
+        "task_group_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task Group Id"
+        },
         "logical_dates": {
           "anyOf": [
             {
@@ -3244,18 +2416,6 @@
           "default": null,
           "title": "Logical Dates"
         },
-        "map_index": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Map Index"
-        },
         "run_ids": {
           "anyOf": [
             {
@@ -3270,33 +2430,6 @@
           ],
           "default": null,
           "title": "Run Ids"
-        },
-        "task_group_id": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Task Group Id"
-        },
-        "task_ids": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Task Ids"
         },
         "type": {
           "const": "GetTaskStates",
@@ -3332,16 +2465,6 @@
     },
     "GetVariableKeys": {
       "properties": {
-        "limit": {
-          "default": 1000,
-          "title": "Limit",
-          "type": "integer"
-        },
-        "offset": {
-          "default": 0,
-          "title": "Offset",
-          "type": "integer"
-        },
         "prefix": {
           "anyOf": [
             {
@@ -3353,6 +2476,16 @@
           ],
           "default": null,
           "title": "Prefix"
+        },
+        "limit": {
+          "default": 1000,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "title": "Offset",
+          "type": "integer"
         },
         "type": {
           "const": "GetVariableKeys",
@@ -3366,17 +2499,20 @@
     },
     "GetXCom": {
       "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
         "dag_id": {
           "title": "Dag Id",
           "type": "string"
         },
-        "include_prior_dates": {
-          "default": false,
-          "title": "Include Prior Dates",
-          "type": "boolean"
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
         },
-        "key": {
-          "title": "Key",
+        "task_id": {
+          "title": "Task Id",
           "type": "string"
         },
         "map_index": {
@@ -3391,13 +2527,10 @@
           "default": null,
           "title": "Map Index"
         },
-        "run_id": {
-          "title": "Run Id",
-          "type": "string"
-        },
-        "task_id": {
-          "title": "Task Id",
-          "type": "string"
+        "include_prior_dates": {
+          "default": false,
+          "title": "Include Prior Dates",
+          "type": "boolean"
         },
         "type": {
           "const": "GetXCom",
@@ -3418,12 +2551,12 @@
     "GetXComCount": {
       "description": "Get the number of (mapped) XCom values available.",
       "properties": {
-        "dag_id": {
-          "title": "Dag Id",
-          "type": "string"
-        },
         "key": {
           "title": "Key",
+          "type": "string"
+        },
+        "dag_id": {
+          "title": "Dag Id",
           "type": "string"
         },
         "run_id": {
@@ -3452,17 +2585,13 @@
     },
     "GetXComSequenceItem": {
       "properties": {
-        "dag_id": {
-          "title": "Dag Id",
-          "type": "string"
-        },
         "key": {
           "title": "Key",
           "type": "string"
         },
-        "offset": {
-          "title": "Offset",
-          "type": "integer"
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
         },
         "run_id": {
           "title": "Run Id",
@@ -3471,6 +2600,10 @@
         "task_id": {
           "title": "Task Id",
           "type": "string"
+        },
+        "offset": {
+          "title": "Offset",
+          "type": "integer"
         },
         "type": {
           "const": "GetXComSequenceItem",
@@ -3491,21 +2624,20 @@
     },
     "GetXComSequenceSlice": {
       "properties": {
-        "dag_id": {
-          "title": "Dag Id",
-          "type": "string"
-        },
-        "include_prior_dates": {
-          "default": false,
-          "title": "Include Prior Dates",
-          "type": "boolean"
-        },
         "key": {
           "title": "Key",
           "type": "string"
         },
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
         "run_id": {
           "title": "Run Id",
+          "type": "string"
+        },
+        "task_id": {
+          "title": "Task Id",
           "type": "string"
         },
         "start": {
@@ -3519,17 +2651,6 @@
           ],
           "title": "Start"
         },
-        "step": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Step"
-        },
         "stop": {
           "anyOf": [
             {
@@ -3541,9 +2662,21 @@
           ],
           "title": "Stop"
         },
-        "task_id": {
-          "title": "Task Id",
-          "type": "string"
+        "step": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Step"
+        },
+        "include_prior_dates": {
+          "default": false,
+          "title": "Include Prior Dates",
+          "type": "boolean"
         },
         "type": {
           "const": "GetXComSequenceSlice",
@@ -3565,43 +2698,24 @@
       "type": "object"
     },
     "HITLDetailRequestResult": {
-      "$defs": {
-        "HITLUser": {
-          "description": "Schema for a Human-in-the-loop users.",
-          "properties": {
-            "id": {
-              "title": "Id",
-              "type": "string"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "id",
-            "name"
-          ],
-          "title": "HITLUser",
-          "type": "object"
-        }
-      },
       "description": "Response to CreateHITLDetailPayload request.",
       "properties": {
-        "assigned_users": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/HITLUser"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Assigned Users"
+        "ti_id": {
+          "format": "uuid",
+          "title": "Ti Id",
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Options",
+          "type": "array"
+        },
+        "subject": {
+          "title": "Subject",
+          "type": "string"
         },
         "body": {
           "anyOf": [
@@ -3642,14 +2756,6 @@
           "default": false,
           "title": "Multiple"
         },
-        "options": {
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Options",
-          "type": "array"
-        },
         "params": {
           "anyOf": [
             {
@@ -3663,14 +2769,20 @@
           "default": null,
           "title": "Params"
         },
-        "subject": {
-          "title": "Subject",
-          "type": "string"
-        },
-        "ti_id": {
-          "format": "uuid",
-          "title": "Ti Id",
-          "type": "string"
+        "assigned_users": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/HITLUser"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assigned Users"
         },
         "type": {
           "const": "HITLDetailRequestResult",
@@ -3687,48 +2799,26 @@
       "title": "HITLDetailRequestResult",
       "type": "object"
     },
-    "InactiveAssetsResult": {
-      "$defs": {
-        "AssetProfile": {
-          "additionalProperties": false,
-          "description": "Profile of an asset-like object.\n\nAsset will have name, uri defined, with type set to 'Asset'.\nAssetNameRef will have name defined, type set to 'AssetNameRef'.\nAssetUriRef will have uri defined, type set to 'AssetUriRef'.\nAssetAlias will have name defined, type set to 'AssetAlias'.\n\nNote that 'type' here is distinct from 'asset_type' the user declares on an\nAsset (or subclass). This field is for distinguishing between different\nasset-related types (Asset, AssetRef, or AssetAlias).",
-          "properties": {
-            "name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Name"
-            },
-            "type": {
-              "title": "Type",
-              "type": "string"
-            },
-            "uri": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Uri"
-            }
-          },
-          "required": [
-            "type"
-          ],
-          "title": "AssetProfile",
-          "type": "object"
+    "HITLUser": {
+      "description": "Schema for a Human-in-the-loop users.",
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
         }
       },
+      "required": [
+        "id",
+        "name"
+      ],
+      "title": "HITLUser",
+      "type": "object"
+    },
+    "InactiveAssetsResult": {
       "description": "Response of InactiveAssets requests.",
       "properties": {
         "inactive_assets": {
@@ -3756,12 +2846,41 @@
       "title": "InactiveAssetsResult",
       "type": "object"
     },
-    "MaskSecret": {
-      "$defs": {
-        "JsonValue": {}
+    "JsonValue": {},
+    "LazyDeserializedDAG": {
+      "description": "Lazily build information from the serialized DAG structure.\n\nAn object that will present \"enough\" of the DAG like interface to update DAG db models etc, without having\nto deserialize the full DAG and Task hierarchy.",
+      "properties": {
+        "data": {
+          "additionalProperties": true,
+          "title": "Data",
+          "type": "object"
+        },
+        "last_loaded": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Loaded"
+        }
       },
+      "required": [
+        "data"
+      ],
+      "title": "LazyDeserializedDAG",
+      "type": "object"
+    },
+    "MaskSecret": {
       "description": "Add a new value to be redacted in task logs.",
       "properties": {
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        },
         "name": {
           "anyOf": [
             {
@@ -3779,9 +2898,6 @@
           "default": "MaskSecret",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -3811,19 +2927,6 @@
     },
     "PrevSuccessfulDagRunResult": {
       "properties": {
-        "data_interval_end": {
-          "anyOf": [
-            {
-              "format": "date-time",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Data Interval End"
-        },
         "data_interval_start": {
           "anyOf": [
             {
@@ -3837,7 +2940,7 @@
           "default": null,
           "title": "Data Interval Start"
         },
-        "end_date": {
+        "data_interval_end": {
           "anyOf": [
             {
               "format": "date-time",
@@ -3848,7 +2951,7 @@
             }
           ],
           "default": null,
-          "title": "End Date"
+          "title": "Data Interval End"
         },
         "start_date": {
           "anyOf": [
@@ -3863,6 +2966,19 @@
           "default": null,
           "title": "Start Date"
         },
+        "end_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Date"
+        },
         "type": {
           "const": "PrevSuccessfulDagRunResult",
           "default": "PrevSuccessfulDagRunResult",
@@ -3874,340 +2990,6 @@
       "type": "object"
     },
     "PreviousDagRunResult": {
-      "$defs": {
-        "AssetAliasReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetAliasModel used in AssetEventDagRunReference.",
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "title": "AssetAliasReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "AssetEventDagRunReference": {
-          "additionalProperties": false,
-          "description": "Schema for AssetEvent model used in DagRun.",
-          "properties": {
-            "asset": {
-              "$ref": "#/$defs/AssetReferenceAssetEventDagRun"
-            },
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "source_aliases": {
-              "items": {
-                "$ref": "#/$defs/AssetAliasReferenceAssetEventDagRun"
-              },
-              "title": "Source Aliases",
-              "type": "array"
-            },
-            "source_dag_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Dag Id"
-            },
-            "source_map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Map Index"
-            },
-            "source_run_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Run Id"
-            },
-            "source_task_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Task Id"
-            },
-            "timestamp": {
-              "format": "date-time",
-              "title": "Timestamp",
-              "type": "string"
-            }
-          },
-          "required": [
-            "asset",
-            "extra",
-            "source_aliases",
-            "timestamp"
-          ],
-          "title": "AssetEventDagRunReference",
-          "type": "object"
-        },
-        "AssetReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetModel used in AssetEventDagRunReference.",
-          "properties": {
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "uri",
-            "extra"
-          ],
-          "title": "AssetReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "DagRun": {
-          "additionalProperties": false,
-          "description": "Schema for DagRun model with minimal required fields needed for Runtime.",
-          "properties": {
-            "clear_number": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": 0,
-              "title": "Clear Number"
-            },
-            "conf": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Conf"
-            },
-            "consumed_asset_events": {
-              "items": {
-                "$ref": "#/$defs/AssetEventDagRunReference"
-              },
-              "title": "Consumed Asset Events",
-              "type": "array"
-            },
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "data_interval_end": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Data Interval End"
-            },
-            "data_interval_start": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Data Interval Start"
-            },
-            "end_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "End Date"
-            },
-            "logical_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Logical Date"
-            },
-            "note": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Note"
-            },
-            "partition_key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Partition Key"
-            },
-            "run_after": {
-              "format": "date-time",
-              "title": "Run After",
-              "type": "string"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "run_type": {
-              "$ref": "#/$defs/DagRunType"
-            },
-            "start_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Start Date"
-            },
-            "state": {
-              "$ref": "#/$defs/DagRunState"
-            },
-            "team_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Team Name"
-            },
-            "triggering_user_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Triggering User Name"
-            }
-          },
-          "required": [
-            "dag_id",
-            "run_id",
-            "run_after",
-            "run_type",
-            "state",
-            "consumed_asset_events"
-          ],
-          "title": "DagRun",
-          "type": "object"
-        },
-        "DagRunState": {
-          "description": "All possible states that a DagRun can be in.\n\nThese are \"shared\" with TaskInstanceState in some parts of the code,\nso please ensure that their values always match the ones with the\nsame name in TaskInstanceState.",
-          "enum": [
-            "queued",
-            "running",
-            "success",
-            "failed"
-          ],
-          "title": "DagRunState",
-          "type": "string"
-        },
-        "DagRunType": {
-          "description": "Class with DagRun types.",
-          "enum": [
-            "backfill",
-            "scheduled",
-            "manual",
-            "operator_triggered",
-            "asset_triggered",
-            "asset_materialization"
-          ],
-          "title": "DagRunType",
-          "type": "string"
-        },
-        "JsonValue": {}
-      },
       "description": "Response containing previous Dag run information.",
       "properties": {
         "dag_run": {
@@ -4231,113 +3013,111 @@
       "title": "PreviousDagRunResult",
       "type": "object"
     },
-    "PreviousTIResult": {
-      "$defs": {
-        "PreviousTIResponse": {
-          "description": "Schema for response with previous TaskInstance information.",
-          "properties": {
-            "dag_id": {
-              "title": "Dag Id",
+    "PreviousTIResponse": {
+      "description": "Schema for response with previous TaskInstance information.",
+      "properties": {
+        "task_id": {
+          "title": "Task Id",
+          "type": "string"
+        },
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "logical_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
               "type": "string"
             },
-            "duration": {
-              "anyOf": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Duration"
-            },
-            "end_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "End Date"
-            },
-            "logical_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Logical Date"
-            },
-            "map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": -1,
-              "title": "Map Index"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "start_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Start Date"
-            },
-            "state": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "State"
-            },
-            "task_id": {
-              "title": "Task Id",
-              "type": "string"
-            },
-            "try_number": {
-              "title": "Try Number",
-              "type": "integer"
+            {
+              "type": "null"
             }
-          },
-          "required": [
-            "task_id",
-            "dag_id",
-            "run_id",
-            "try_number"
           ],
-          "title": "PreviousTIResponse",
-          "type": "object"
+          "default": null,
+          "title": "Logical Date"
+        },
+        "start_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Date"
+        },
+        "end_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Date"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "State"
+        },
+        "try_number": {
+          "title": "Try Number",
+          "type": "integer"
+        },
+        "map_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": -1,
+          "title": "Map Index"
+        },
+        "duration": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Duration"
         }
       },
+      "required": [
+        "task_id",
+        "dag_id",
+        "run_id",
+        "try_number"
+      ],
+      "title": "PreviousTIResponse",
+      "type": "object"
+    },
+    "PreviousTIResult": {
       "description": "Response containing previous task instance data.",
       "properties": {
         "task_instance": {
@@ -4363,25 +3143,8 @@
     },
     "PutVariable": {
       "properties": {
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Description"
-        },
         "key": {
           "title": "Key",
-          "type": "string"
-        },
-        "type": {
-          "const": "PutVariable",
-          "default": "PutVariable",
-          "title": "Type",
           "type": "string"
         },
         "value": {
@@ -4394,6 +3157,23 @@
             }
           ],
           "title": "Value"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Description"
+        },
+        "type": {
+          "const": "PutVariable",
+          "default": "PutVariable",
+          "title": "Type",
+          "type": "string"
         }
       },
       "required": [
@@ -4408,16 +3188,6 @@
       "additionalProperties": false,
       "description": "Update a task instance state to reschedule/up_for_reschedule.",
       "properties": {
-        "end_date": {
-          "format": "date-time",
-          "title": "End Date",
-          "type": "string"
-        },
-        "reschedule_date": {
-          "format": "date-time",
-          "title": "Reschedule Date",
-          "type": "string"
-        },
         "state": {
           "anyOf": [
             {
@@ -4430,6 +3200,16 @@
           ],
           "default": "up_for_reschedule",
           "title": "State"
+        },
+        "reschedule_date": {
+          "format": "date-time",
+          "title": "Reschedule Date",
+          "type": "string"
+        },
+        "end_date": {
+          "format": "date-time",
+          "title": "End Date",
+          "type": "string"
         },
         "type": {
           "const": "RescheduleTask",
@@ -4461,6 +3241,19 @@
       "additionalProperties": false,
       "description": "Update a task instance state to up_for_retry.",
       "properties": {
+        "state": {
+          "anyOf": [
+            {
+              "const": "up_for_retry",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "up_for_retry",
+          "title": "State"
+        },
         "end_date": {
           "format": "date-time",
           "title": "End Date",
@@ -4502,19 +3295,6 @@
           "default": null,
           "title": "Retry Reason"
         },
-        "state": {
-          "anyOf": [
-            {
-              "const": "up_for_retry",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "up_for_retry",
-          "title": "State"
-        },
         "type": {
           "const": "RetryTask",
           "default": "RetryTask",
@@ -4530,18 +3310,18 @@
     },
     "SentFDs": {
       "properties": {
+        "type": {
+          "const": "SentFDs",
+          "default": "SentFDs",
+          "title": "Type",
+          "type": "string"
+        },
         "fds": {
           "items": {
             "type": "integer"
           },
           "title": "Fds",
           "type": "array"
-        },
-        "type": {
-          "const": "SentFDs",
-          "default": "SentFDs",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -4551,26 +3331,23 @@
       "type": "object"
     },
     "SetAssetStateByName": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
         "key": {
           "title": "Key",
           "type": "string"
         },
-        "name": {
-          "title": "Name",
-          "type": "string"
+        "value": {
+          "$ref": "#/$defs/JsonValue"
         },
         "type": {
           "const": "SetAssetStateByName",
           "default": "SetAssetStateByName",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -4582,26 +3359,23 @@
       "type": "object"
     },
     "SetAssetStateByUri": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "properties": {
+        "uri": {
+          "title": "Uri",
+          "type": "string"
+        },
         "key": {
           "title": "Key",
           "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
         },
         "type": {
           "const": "SetAssetStateByUri",
           "default": "SetAssetStateByUri",
           "title": "Type",
           "type": "string"
-        },
-        "uri": {
-          "title": "Uri",
-          "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -4613,9 +3387,6 @@
       "type": "object"
     },
     "SetRenderedFields": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "description": "Payload for setting RTIF for a task instance.",
       "properties": {
         "rendered_fields": {
@@ -4659,10 +3430,19 @@
       "type": "object"
     },
     "SetTaskState": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "properties": {
+        "ti_id": {
+          "format": "uuid",
+          "title": "Ti Id",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        },
         "expires_at": {
           "anyOf": [
             {
@@ -4675,23 +3455,11 @@
           ],
           "title": "Expires At"
         },
-        "key": {
-          "title": "Key",
-          "type": "string"
-        },
-        "ti_id": {
-          "format": "uuid",
-          "title": "Ti Id",
-          "type": "string"
-        },
         "type": {
           "const": "SetTaskState",
           "default": "SetTaskState",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -4704,21 +3472,24 @@
       "type": "object"
     },
     "SetXCom": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        },
         "dag_id": {
           "title": "Dag Id",
           "type": "string"
         },
-        "dag_result": {
-          "default": false,
-          "title": "Dag Result",
-          "type": "boolean"
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
         },
-        "key": {
-          "title": "Key",
+        "task_id": {
+          "title": "Task Id",
           "type": "string"
         },
         "map_index": {
@@ -4733,6 +3504,11 @@
           "default": null,
           "title": "Map Index"
         },
+        "dag_result": {
+          "default": false,
+          "title": "Dag Result",
+          "type": "boolean"
+        },
         "mapped_length": {
           "anyOf": [
             {
@@ -4745,22 +3521,11 @@
           "default": null,
           "title": "Mapped Length"
         },
-        "run_id": {
-          "title": "Run Id",
-          "type": "string"
-        },
-        "task_id": {
-          "title": "Task Id",
-          "type": "string"
-        },
         "type": {
           "const": "SetXCom",
           "default": "SetXCom",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -4815,712 +3580,28 @@
       "type": "object"
     },
     "StartupDetails": {
-      "$defs": {
-        "AssetAliasReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetAliasModel used in AssetEventDagRunReference.",
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "title": "AssetAliasReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "AssetEventDagRunReference": {
-          "additionalProperties": false,
-          "description": "Schema for AssetEvent model used in DagRun.",
-          "properties": {
-            "asset": {
-              "$ref": "#/$defs/AssetReferenceAssetEventDagRun"
-            },
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "source_aliases": {
-              "items": {
-                "$ref": "#/$defs/AssetAliasReferenceAssetEventDagRun"
-              },
-              "title": "Source Aliases",
-              "type": "array"
-            },
-            "source_dag_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Dag Id"
-            },
-            "source_map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Map Index"
-            },
-            "source_run_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Run Id"
-            },
-            "source_task_id": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Source Task Id"
-            },
-            "timestamp": {
-              "format": "date-time",
-              "title": "Timestamp",
-              "type": "string"
-            }
-          },
-          "required": [
-            "asset",
-            "extra",
-            "source_aliases",
-            "timestamp"
-          ],
-          "title": "AssetEventDagRunReference",
-          "type": "object"
-        },
-        "AssetReferenceAssetEventDagRun": {
-          "additionalProperties": false,
-          "description": "Schema for AssetModel used in AssetEventDagRunReference.",
-          "properties": {
-            "extra": {
-              "additionalProperties": {
-                "$ref": "#/$defs/JsonValue"
-              },
-              "title": "Extra",
-              "type": "object"
-            },
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "uri": {
-              "title": "Uri",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "uri",
-            "extra"
-          ],
-          "title": "AssetReferenceAssetEventDagRun",
-          "type": "object"
-        },
-        "BundleInfo": {
-          "description": "Schema for telling task which bundle to run with.",
-          "properties": {
-            "name": {
-              "title": "Name",
-              "type": "string"
-            },
-            "version": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Version"
-            }
-          },
-          "required": [
-            "name"
-          ],
-          "title": "BundleInfo",
-          "type": "object"
-        },
-        "ConnectionResponse": {
-          "description": "Connection schema for responses with fields that are needed for Runtime.",
-          "properties": {
-            "conn_id": {
-              "title": "Conn Id",
-              "type": "string"
-            },
-            "conn_type": {
-              "title": "Conn Type",
-              "type": "string"
-            },
-            "extra": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Extra"
-            },
-            "host": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Host"
-            },
-            "login": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Login"
-            },
-            "password": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Password"
-            },
-            "port": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Port"
-            },
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Schema"
-            }
-          },
-          "required": [
-            "conn_id",
-            "conn_type"
-          ],
-          "title": "ConnectionResponse",
-          "type": "object"
-        },
-        "DagRun": {
-          "additionalProperties": false,
-          "description": "Schema for DagRun model with minimal required fields needed for Runtime.",
-          "properties": {
-            "clear_number": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": 0,
-              "title": "Clear Number"
-            },
-            "conf": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Conf"
-            },
-            "consumed_asset_events": {
-              "items": {
-                "$ref": "#/$defs/AssetEventDagRunReference"
-              },
-              "title": "Consumed Asset Events",
-              "type": "array"
-            },
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "data_interval_end": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Data Interval End"
-            },
-            "data_interval_start": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Data Interval Start"
-            },
-            "end_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "End Date"
-            },
-            "logical_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Logical Date"
-            },
-            "note": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Note"
-            },
-            "partition_key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Partition Key"
-            },
-            "run_after": {
-              "format": "date-time",
-              "title": "Run After",
-              "type": "string"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "run_type": {
-              "$ref": "#/$defs/DagRunType"
-            },
-            "start_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Start Date"
-            },
-            "state": {
-              "$ref": "#/$defs/DagRunState"
-            },
-            "team_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Team Name"
-            },
-            "triggering_user_name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Triggering User Name"
-            }
-          },
-          "required": [
-            "dag_id",
-            "run_id",
-            "run_after",
-            "run_type",
-            "state",
-            "consumed_asset_events"
-          ],
-          "title": "DagRun",
-          "type": "object"
-        },
-        "DagRunState": {
-          "description": "All possible states that a DagRun can be in.\n\nThese are \"shared\" with TaskInstanceState in some parts of the code,\nso please ensure that their values always match the ones with the\nsame name in TaskInstanceState.",
-          "enum": [
-            "queued",
-            "running",
-            "success",
-            "failed"
-          ],
-          "title": "DagRunState",
-          "type": "string"
-        },
-        "DagRunType": {
-          "description": "Class with DagRun types.",
-          "enum": [
-            "backfill",
-            "scheduled",
-            "manual",
-            "operator_triggered",
-            "asset_triggered",
-            "asset_materialization"
-          ],
-          "title": "DagRunType",
-          "type": "string"
-        },
-        "JsonValue": {},
-        "TIRunContext": {
-          "description": "Response schema for TaskInstance run context.",
-          "properties": {
-            "connections": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/$defs/ConnectionResponse"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Connections"
-            },
-            "dag_run": {
-              "$ref": "#/$defs/DagRun"
-            },
-            "max_tries": {
-              "title": "Max Tries",
-              "type": "integer"
-            },
-            "next_kwargs": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Next Kwargs"
-            },
-            "next_method": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Next Method"
-            },
-            "should_retry": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": false,
-              "title": "Should Retry"
-            },
-            "start_date": {
-              "anyOf": [
-                {
-                  "format": "date-time",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Start Date"
-            },
-            "task_reschedule_count": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": 0,
-              "title": "Task Reschedule Count"
-            },
-            "variables": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/$defs/VariableResponse"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Variables"
-            },
-            "xcom_keys_to_clear": {
-              "anyOf": [
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Xcom Keys To Clear"
-            }
-          },
-          "required": [
-            "dag_run",
-            "max_tries"
-          ],
-          "title": "TIRunContext",
-          "type": "object"
-        },
-        "TaskInstance": {
-          "description": "Schema for TaskInstance model with minimal required fields needed for Runtime.",
-          "properties": {
-            "context_carrier": {
-              "anyOf": [
-                {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Context Carrier"
-            },
-            "dag_id": {
-              "title": "Dag Id",
-              "type": "string"
-            },
-            "dag_version_id": {
-              "format": "uuid",
-              "title": "Dag Version Id",
-              "type": "string"
-            },
-            "hostname": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Hostname"
-            },
-            "id": {
-              "format": "uuid",
-              "title": "Id",
-              "type": "string"
-            },
-            "map_index": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": -1,
-              "title": "Map Index"
-            },
-            "run_id": {
-              "title": "Run Id",
-              "type": "string"
-            },
-            "task_id": {
-              "title": "Task Id",
-              "type": "string"
-            },
-            "try_number": {
-              "title": "Try Number",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "id",
-            "task_id",
-            "dag_id",
-            "run_id",
-            "try_number",
-            "dag_version_id"
-          ],
-          "title": "TaskInstance",
-          "type": "object"
-        },
-        "VariableResponse": {
-          "additionalProperties": false,
-          "description": "Variable schema for responses with fields that are needed for Runtime.",
-          "properties": {
-            "key": {
-              "title": "Key",
-              "type": "string"
-            },
-            "value": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Value"
-            }
-          },
-          "required": [
-            "key"
-          ],
-          "title": "VariableResponse",
-          "type": "object"
-        }
-      },
       "properties": {
-        "bundle_info": {
-          "$ref": "#/$defs/BundleInfo"
+        "ti": {
+          "$ref": "#/$defs/TaskInstance"
         },
         "dag_rel_path": {
           "title": "Dag Rel Path",
           "type": "string"
         },
-        "sentry_integration": {
-          "title": "Sentry Integration",
-          "type": "string"
+        "bundle_info": {
+          "$ref": "#/$defs/BundleInfo"
         },
         "start_date": {
           "format": "date-time",
           "title": "Start Date",
           "type": "string"
         },
-        "ti": {
-          "$ref": "#/$defs/TaskInstance"
-        },
         "ti_context": {
           "$ref": "#/$defs/TIRunContext"
+        },
+        "sentry_integration": {
+          "title": "Sentry Integration",
+          "type": "string"
         },
         "type": {
           "const": "StartupDetails",
@@ -5541,54 +3622,41 @@
       "type": "object"
     },
     "SucceedTask": {
-      "$defs": {
-        "AssetProfile": {
-          "additionalProperties": false,
-          "description": "Profile of an asset-like object.\n\nAsset will have name, uri defined, with type set to 'Asset'.\nAssetNameRef will have name defined, type set to 'AssetNameRef'.\nAssetUriRef will have uri defined, type set to 'AssetUriRef'.\nAssetAlias will have name defined, type set to 'AssetAlias'.\n\nNote that 'type' here is distinct from 'asset_type' the user declares on an\nAsset (or subclass). This field is for distinguishing between different\nasset-related types (Asset, AssetRef, or AssetAlias).",
-          "properties": {
-            "name": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Name"
-            },
-            "type": {
-              "title": "Type",
-              "type": "string"
-            },
-            "uri": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "title": "Uri"
-            }
-          },
-          "required": [
-            "type"
-          ],
-          "title": "AssetProfile",
-          "type": "object"
-        }
-      },
       "additionalProperties": false,
       "description": "Update a task's state to success. Includes task_outlets and outlet_events for registering asset events.",
       "properties": {
+        "state": {
+          "anyOf": [
+            {
+              "const": "success",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "success",
+          "title": "State"
+        },
         "end_date": {
           "format": "date-time",
           "title": "End Date",
           "type": "string"
+        },
+        "task_outlets": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/AssetProfile"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Task Outlets"
         },
         "outlet_events": {
           "anyOf": [
@@ -5617,34 +3685,6 @@
           ],
           "default": null,
           "title": "Rendered Map Index"
-        },
-        "state": {
-          "anyOf": [
-            {
-              "const": "success",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": "success",
-          "title": "State"
-        },
-        "task_outlets": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/$defs/AssetProfile"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Task Outlets"
         },
         "type": {
           "const": "SucceedTask",
@@ -5702,6 +3742,100 @@
       "title": "TaskBreadcrumbsResult",
       "type": "object"
     },
+    "TaskCallbackRequest": {
+      "description": "Task callback status information.\n\nA Class with information about the success/failure TI callback to be executed. Currently, only failure\ncallbacks when tasks are externally killed or experience heartbeat timeouts are run via DagFileProcessorProcess.",
+      "properties": {
+        "filepath": {
+          "title": "Filepath",
+          "type": "string"
+        },
+        "bundle_name": {
+          "title": "Bundle Name",
+          "type": "string"
+        },
+        "bundle_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Bundle Version"
+        },
+        "msg": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Msg"
+        },
+        "ti": {
+          "$ref": "#/$defs/TaskInstance"
+        },
+        "task_callback_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TaskInstanceState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "context_from_server": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TIRunContext"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "TaskCallbackRequest",
+          "default": "TaskCallbackRequest",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "filepath",
+        "bundle_name",
+        "bundle_version",
+        "ti"
+      ],
+      "title": "TaskCallbackRequest",
+      "type": "object"
+    },
+    "TaskInstanceState": {
+      "description": "All possible states that a Task Instance can be in.\n\nNote that None is also allowed, so always use this in a type hint with Optional.",
+      "enum": [
+        "removed",
+        "scheduled",
+        "queued",
+        "running",
+        "success",
+        "restarting",
+        "failed",
+        "up_for_retry",
+        "up_for_reschedule",
+        "upstream_failed",
+        "skipped",
+        "deferred"
+      ],
+      "title": "TaskInstanceState",
+      "type": "string"
+    },
     "TaskRescheduleStartDate": {
       "description": "Response containing the first reschedule date for a task instance.",
       "properties": {
@@ -5733,6 +3867,15 @@
     "TaskState": {
       "description": "Update a task's state.\n\nIf a process exits without sending one of these the state will be derived from the exit code:\n- 0 = SUCCESS\n- anything else = FAILED",
       "properties": {
+        "state": {
+          "enum": [
+            "failed",
+            "skipped",
+            "removed"
+          ],
+          "title": "State",
+          "type": "string"
+        },
         "end_date": {
           "anyOf": [
             {
@@ -5746,6 +3889,12 @@
           "default": null,
           "title": "End Date"
         },
+        "type": {
+          "const": "TaskState",
+          "default": "TaskState",
+          "title": "Type",
+          "type": "string"
+        },
         "rendered_map_index": {
           "anyOf": [
             {
@@ -5757,21 +3906,6 @@
           ],
           "default": null,
           "title": "Rendered Map Index"
-        },
-        "state": {
-          "enum": [
-            "failed",
-            "skipped",
-            "removed"
-          ],
-          "title": "State",
-          "type": "string"
-        },
-        "type": {
-          "const": "TaskState",
-          "default": "TaskState",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -5781,20 +3915,17 @@
       "type": "object"
     },
     "TaskStateResult": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "additionalProperties": false,
       "description": "Response to GetTaskState; wraps the generated API response for supervisor to worker comms.",
       "properties": {
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        },
         "type": {
           "const": "TaskStateResult",
           "default": "TaskStateResult",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -5826,23 +3957,6 @@
     "TriggerDagRun": {
       "additionalProperties": false,
       "properties": {
-        "conf": {
-          "anyOf": [
-            {
-              "additionalProperties": true,
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Conf"
-        },
-        "dag_id": {
-          "title": "Dag Id",
-          "type": "string"
-        },
         "logical_date": {
           "anyOf": [
             {
@@ -5856,9 +3970,10 @@
           "default": null,
           "title": "Logical Date"
         },
-        "note": {
+        "run_after": {
           "anyOf": [
             {
+              "format": "date-time",
               "type": "string"
             },
             {
@@ -5866,19 +3981,20 @@
             }
           ],
           "default": null,
-          "title": "Note"
+          "title": "Run After"
         },
-        "partition_key": {
+        "conf": {
           "anyOf": [
             {
-              "type": "string"
+              "additionalProperties": true,
+              "type": "object"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "title": "Partition Key"
+          "title": "Conf"
         },
         "reset_dag_run": {
           "anyOf": [
@@ -5892,10 +4008,9 @@
           "default": false,
           "title": "Reset Dag Run"
         },
-        "run_after": {
+        "partition_key": {
           "anyOf": [
             {
-              "format": "date-time",
               "type": "string"
             },
             {
@@ -5903,7 +4018,23 @@
             }
           ],
           "default": null,
-          "title": "Run After"
+          "title": "Partition Key"
+        },
+        "note": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Note"
+        },
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
         },
         "run_id": {
           "title": "Dag Run Id",
@@ -5926,6 +4057,11 @@
     "UpdateHITLDetail": {
       "description": "Update the response content part of an existing Human-in-the-loop response.",
       "properties": {
+        "ti_id": {
+          "format": "uuid",
+          "title": "Ti Id",
+          "type": "string"
+        },
         "chosen_options": {
           "items": {
             "type": "string"
@@ -5946,11 +4082,6 @@
           ],
           "default": null,
           "title": "Params Input"
-        },
-        "ti_id": {
-          "format": "uuid",
-          "title": "Ti Id",
-          "type": "string"
         },
         "type": {
           "const": "UpdateHITLDetail",
@@ -6020,12 +4151,6 @@
           "title": "Key",
           "type": "string"
         },
-        "type": {
-          "const": "VariableResult",
-          "default": "VariableResult",
-          "title": "Type",
-          "type": "string"
-        },
         "value": {
           "anyOf": [
             {
@@ -6037,6 +4162,12 @@
           ],
           "default": null,
           "title": "Value"
+        },
+        "type": {
+          "const": "VariableResult",
+          "default": "VariableResult",
+          "title": "Type",
+          "type": "string"
         }
       },
       "required": [
@@ -6065,23 +4196,20 @@
       "type": "object"
     },
     "XComResult": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "description": "Response to ReadXCom request.",
       "properties": {
         "key": {
           "title": "Key",
           "type": "string"
         },
+        "value": {
+          "$ref": "#/$defs/JsonValue"
+        },
         "type": {
           "const": "XComResult",
           "default": "XComResult",
           "title": "Type",
           "type": "string"
-        },
-        "value": {
-          "$ref": "#/$defs/JsonValue"
         }
       },
       "required": [
@@ -6092,9 +4220,6 @@
       "type": "object"
     },
     "XComSequenceIndexResult": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "properties": {
         "root": {
           "$ref": "#/$defs/JsonValue"
@@ -6113,9 +4238,6 @@
       "type": "object"
     },
     "XComSequenceSliceResult": {
-      "$defs": {
-        "JsonValue": {}
-      },
       "properties": {
         "root": {
           "items": {
@@ -6135,6 +4257,542 @@
         "root"
       ],
       "title": "XComSequenceSliceResult",
+      "type": "object"
+    },
+    "ConnectionResponse": {
+      "description": "Connection schema for responses with fields that are needed for Runtime.",
+      "properties": {
+        "conn_id": {
+          "title": "Conn Id",
+          "type": "string"
+        },
+        "conn_type": {
+          "title": "Conn Type",
+          "type": "string"
+        },
+        "host": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Host"
+        },
+        "schema": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Schema"
+        },
+        "login": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Login"
+        },
+        "password": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Password"
+        },
+        "port": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Port"
+        },
+        "extra": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Extra"
+        }
+      },
+      "required": [
+        "conn_id",
+        "conn_type",
+        "host",
+        "schema",
+        "login",
+        "password",
+        "port",
+        "extra"
+      ],
+      "title": "ConnectionResponse",
+      "type": "object"
+    },
+    "AssetEventDagRunReference": {
+      "additionalProperties": false,
+      "description": "Schema for AssetEvent model used in DagRun.",
+      "properties": {
+        "asset": {
+          "$ref": "#/$defs/AssetReferenceAssetEventDagRun"
+        },
+        "extra": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonValue"
+          },
+          "title": "Extra",
+          "type": "object"
+        },
+        "source_task_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Source Task Id"
+        },
+        "source_dag_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Source Dag Id"
+        },
+        "source_run_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Source Run Id"
+        },
+        "source_map_index": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Source Map Index"
+        },
+        "source_aliases": {
+          "items": {
+            "$ref": "#/$defs/AssetAliasReferenceAssetEventDagRun"
+          },
+          "title": "Source Aliases",
+          "type": "array"
+        },
+        "timestamp": {
+          "format": "date-time",
+          "title": "Timestamp",
+          "type": "string"
+        }
+      },
+      "required": [
+        "asset",
+        "extra",
+        "source_task_id",
+        "source_dag_id",
+        "source_run_id",
+        "source_map_index",
+        "source_aliases",
+        "timestamp"
+      ],
+      "title": "AssetEventDagRunReference",
+      "type": "object"
+    },
+    "DagRun": {
+      "additionalProperties": false,
+      "description": "Schema for DagRun model with minimal required fields needed for Runtime.",
+      "properties": {
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "logical_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Logical Date"
+        },
+        "data_interval_start": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Data Interval Start"
+        },
+        "data_interval_end": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Data Interval End"
+        },
+        "run_after": {
+          "format": "date-time",
+          "title": "Run After",
+          "type": "string"
+        },
+        "start_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Start Date"
+        },
+        "end_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "End Date"
+        },
+        "clear_number": {
+          "default": 0,
+          "title": "Clear Number",
+          "type": "integer"
+        },
+        "run_type": {
+          "$ref": "#/$defs/DagRunType"
+        },
+        "state": {
+          "$ref": "#/$defs/DagRunState"
+        },
+        "conf": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conf"
+        },
+        "triggering_user_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Triggering User Name"
+        },
+        "consumed_asset_events": {
+          "items": {
+            "$ref": "#/$defs/AssetEventDagRunReference"
+          },
+          "title": "Consumed Asset Events",
+          "type": "array"
+        },
+        "partition_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Partition Key"
+        },
+        "note": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Note"
+        },
+        "team_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Team Name"
+        }
+      },
+      "required": [
+        "dag_id",
+        "run_id",
+        "logical_date",
+        "data_interval_start",
+        "data_interval_end",
+        "run_after",
+        "start_date",
+        "end_date",
+        "run_type",
+        "state",
+        "consumed_asset_events",
+        "partition_key"
+      ],
+      "title": "DagRun",
+      "type": "object"
+    },
+    "TIRunContext": {
+      "description": "Response schema for TaskInstance run context.",
+      "properties": {
+        "dag_run": {
+          "$ref": "#/$defs/DagRun"
+        },
+        "task_reschedule_count": {
+          "default": 0,
+          "title": "Task Reschedule Count",
+          "type": "integer"
+        },
+        "max_tries": {
+          "title": "Max Tries",
+          "type": "integer"
+        },
+        "variables": {
+          "items": {
+            "$ref": "#/$defs/VariableResponse"
+          },
+          "title": "Variables",
+          "type": "array"
+        },
+        "connections": {
+          "items": {
+            "$ref": "#/$defs/ConnectionResponse"
+          },
+          "title": "Connections",
+          "type": "array"
+        },
+        "next_method": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Next Method"
+        },
+        "next_kwargs": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Next Kwargs"
+        },
+        "xcom_keys_to_clear": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Xcom Keys To Clear",
+          "type": "array"
+        },
+        "should_retry": {
+          "default": false,
+          "title": "Should Retry",
+          "type": "boolean"
+        },
+        "start_date": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Date"
+        }
+      },
+      "required": [
+        "dag_run",
+        "max_tries"
+      ],
+      "title": "TIRunContext",
+      "type": "object"
+    },
+    "TaskInstance": {
+      "description": "Schema for TaskInstance model with minimal required fields needed for Runtime.",
+      "properties": {
+        "id": {
+          "format": "uuid",
+          "title": "Id",
+          "type": "string"
+        },
+        "task_id": {
+          "title": "Task Id",
+          "type": "string"
+        },
+        "dag_id": {
+          "title": "Dag Id",
+          "type": "string"
+        },
+        "run_id": {
+          "title": "Run Id",
+          "type": "string"
+        },
+        "try_number": {
+          "title": "Try Number",
+          "type": "integer"
+        },
+        "dag_version_id": {
+          "format": "uuid",
+          "title": "Dag Version Id",
+          "type": "string"
+        },
+        "map_index": {
+          "default": -1,
+          "title": "Map Index",
+          "type": "integer"
+        },
+        "hostname": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Hostname"
+        },
+        "context_carrier": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Context Carrier"
+        }
+      },
+      "required": [
+        "id",
+        "task_id",
+        "dag_id",
+        "run_id",
+        "try_number",
+        "dag_version_id"
+      ],
+      "title": "TaskInstance",
+      "type": "object"
+    },
+    "VariableResponse": {
+      "additionalProperties": false,
+      "description": "Variable schema for responses with fields that are needed for Runtime.",
+      "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "Value"
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ],
+      "title": "VariableResponse",
       "type": "object"
     }
   }


### PR DESCRIPTION
I was applying Supervisor Schema to Java SDK. It turns out we need to change some processing for this to work properly. This is submitted separately so it can be used in both the Java SDK and coordinator PRs.