### PR TITLE
Go-SDK: exclude oversized-payload framing test from -race builds

### DIFF
--- a/go-sdk/pkg/execution/frames_oversized_test.go
+++ b/go-sdk/pkg/execution/frames_oversized_test.go
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !race
+
+// The oversized-payload test uses unsafe.Slice to fabricate a slice whose
+// length exceeds MaxFrameSize without actually allocating 4 GiB of memory.
+// Under -race, Go's checkptr instrumentation treats the resulting slice as
+// straddling allocations and fatals the entire test binary, which would
+// prevent `go test -race ./pkg/execution/` from running on the package. The
+// guard under test is a single len() comparison, so excluding it from race
+// builds keeps the rest of the package's race coverage runnable at the cost
+// of losing race-mode coverage on this one path.
+
+package execution
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteFrameRejectsOversizedPayload pins the guard at the top of
+// writeFrame against the rename/refactor that previously dropped its
+// coverage. The guard only inspects len(payload) before doing any allocation
+// or read of payload bytes, so we hand it a fake-length slice built with
+// unsafe.Slice (one real byte of backing storage, length > MaxFrameSize)
+// rather than allocating 4 GiB of real memory.
+//
+// The matching read-side guard at the top of readFrame is dead code with
+// MaxFrameSize pinned at the uint32 maximum (payloadLen is uint32, so
+// payloadLen > MaxFrameSize is never true) and cannot be exercised without
+// modifying production code; it remains as defense-in-depth in case
+// MaxFrameSize is ever lowered.
+func TestWriteFrameRejectsOversizedPayload(t *testing.T) {
+	if strconv.IntSize < 64 {
+		t.Skip("requires 64-bit int to construct a slice longer than MaxFrameSize")
+	}
+	var backing byte
+	payload := unsafe.Slice(&backing, uint64(MaxFrameSize)+1)
+
+	err := writeFrame(&bytes.Buffer{}, payload)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds max")
+}

--- a/go-sdk/pkg/execution/frames_test.go
+++ b/go-sdk/pkg/execution/frames_test.go
@@ -20,9 +20,7 @@ package execution
 import (
 	"bytes"
 	"encoding/binary"
-	"strconv"
 	"testing"
-	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -158,30 +156,6 @@ func TestDecodeFrameRejectsNonMapError(t *testing.T) {
 	_, err := decodeFrame(buf.Bytes())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error element: expected map")
-}
-
-// TestWriteFrameRejectsOversizedPayload pins the guard at the top of
-// writeFrame against the rename/refactor that previously dropped its
-// coverage. The guard only inspects len(payload) before doing any allocation
-// or read of payload bytes, so we hand it a fake-length slice built with
-// unsafe.Slice (one real byte of backing storage, length > MaxFrameSize)
-// rather than allocating 4 GiB of real memory.
-//
-// The matching read-side guard at the top of readFrame is dead code with
-// MaxFrameSize pinned at the uint32 maximum (payloadLen is uint32, so
-// payloadLen > MaxFrameSize is never true) and cannot be exercised without
-// modifying production code; it remains as defense-in-depth in case
-// MaxFrameSize is ever lowered.
-func TestWriteFrameRejectsOversizedPayload(t *testing.T) {
-	if strconv.IntSize < 64 {
-		t.Skip("requires 64-bit int to construct a slice longer than MaxFrameSize")
-	}
-	var backing byte
-	payload := unsafe.Slice(&backing, uint64(MaxFrameSize)+1)
-
-	err := writeFrame(&bytes.Buffer{}, payload)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds max")
 }
 
 func TestRoundTripMultipleFrames(t *testing.T) {


### PR DESCRIPTION
## Why

`go test -race ./pkg/execution/` currently fatals before any test in the package can run. `TestWriteFrameRejectsOversizedPayload` constructs a 4 GiB+ slice with `unsafe.Slice(&backing, MaxFrameSize+1)` to exercise `writeFrame`'s size guard cheaply, and the checkptr instrumentation that `-race` enables treats the resulting "slice straddles allocations" as a fatal violation. The existing `strconv.IntSize` runtime skip does not help — checkptr fires inside `unsafe.Slice` itself, before any `t.Skip` could run.

## What

- Move `TestWriteFrameRejectsOversizedPayload` out of `frames_test.go` into a new file `frames_oversized_test.go` carrying `//go:build !race`, so the file (and the `unsafe.Slice` call inside it) is excluded from the build under `-race`.
- Drop the now-unused `strconv` and `unsafe` imports from `frames_test.go`.

The guard under test is a single `len(payload) > MaxFrameSize` comparison; the non-race build keeps full coverage of it, the race build loses coverage on that one path in exchange for being runnable at all.

## Verification

1. **Non-race build still exercises the test.**

   ```
   $ go test -run TestWriteFrameRejectsOversizedPayload -v ./pkg/execution/
   === RUN   TestWriteFrameRejectsOversizedPayload
   --- PASS: TestWriteFrameRejectsOversizedPayload (0.00s)
   PASS
   ok  	github.com/apache/airflow/go-sdk/pkg/execution	0.171s
   ```

2. **Race build skips the test (no checkptr fatal).**

   ```
   $ go test -race -run TestWriteFrameRejectsOversizedPayload -v ./pkg/execution/
   testing: warning: no tests to run
   PASS
   ok  	github.com/apache/airflow/go-sdk/pkg/execution	1.235s [no tests to run]
   ```

3. **Whole package now passes under `-race`** (previously fatal):

   ```
   $ go test -race ./pkg/execution/
   ok  	github.com/apache/airflow/go-sdk/pkg/execution	1.823s
   ```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
