### PR TITLE
Fix UI time picker omitting seconds by setting step to the datetime input

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.test.tsx
@@ -1,0 +1,153 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { fireEvent, render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { FieldDateTime } from "./FieldDateTime";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockParamsDict: Record<string, any> = {};
+const mockSetParamsDict = vi.fn();
+
+vi.mock("src/queries/useParamStore", () => ({
+  paramPlaceholder: {
+    schema: {},
+    value: null,
+  },
+  useParamStore: () => ({
+    disabled: false,
+    paramsDict: mockParamsDict,
+    setParamsDict: mockSetParamsDict,
+  }),
+}));
+
+const getInputByName = (name: string) =>
+  document.querySelector<HTMLInputElement>(`#element_${name}`) as HTMLInputElement;
+
+describe("FieldDateTime — time field (issue #66492)", () => {
+  beforeEach(() => {
+    mockSetParamsDict.mockClear();
+    Object.keys(mockParamsDict).forEach((key) => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete mockParamsDict[key];
+    });
+  });
+
+  it("renders time input with step=1 so the picker exposes the seconds field", () => {
+    mockParamsDict.cutoff_time = {
+      schema: { format: "time", type: "string" },
+      value: null,
+    };
+
+    render(<FieldDateTime name="cutoff_time" onUpdate={vi.fn()} type="time" />, {
+      wrapper: Wrapper,
+    });
+
+    const input = getInputByName("cutoff_time");
+
+    expect(input.type).toBe("time");
+    expect(input.getAttribute("step")).toBe("1");
+  });
+
+  it("does not set step on a date input", () => {
+    mockParamsDict.cutoff_date = {
+      schema: { format: "date", type: "string" },
+      value: null,
+    };
+
+    render(<FieldDateTime name="cutoff_date" onUpdate={vi.fn()} type="date" />, {
+      wrapper: Wrapper,
+    });
+
+    const input = getInputByName("cutoff_date");
+
+    expect(input.type).toBe("date");
+    expect(input.getAttribute("step")).toBeNull();
+  });
+
+  it("passes a fully-qualified HH:MM:SS value through unchanged", () => {
+    mockParamsDict.cutoff_time = {
+      schema: { format: "time", type: "string" },
+      value: null,
+    };
+    const onUpdate = vi.fn();
+
+    render(<FieldDateTime name="cutoff_time" onUpdate={onUpdate} type="time" />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.change(getInputByName("cutoff_time"), { target: { value: "15:58:42" } });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockParamsDict.cutoff_time.value).toBe("15:58:42");
+    expect(onUpdate).toHaveBeenLastCalledWith("15:58:42");
+  });
+
+  it("clears the param to null when the time input is emptied", () => {
+    mockParamsDict.cutoff_time = {
+      schema: { format: "time", type: "string" },
+      value: "15:58:00",
+    };
+    const onUpdate = vi.fn();
+
+    render(<FieldDateTime name="cutoff_time" onUpdate={onUpdate} type="time" />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.change(getInputByName("cutoff_time"), { target: { value: "" } });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockParamsDict.cutoff_time.value).toBeNull();
+    expect(onUpdate).toHaveBeenLastCalledWith("");
+  });
+
+  it("does not pad date inputs whose value never matches the HH:MM pattern", () => {
+    // Guard against the time normalizer leaking into date handling.
+    mockParamsDict.cutoff_date = {
+      schema: { format: "date", type: "string" },
+      value: null,
+    };
+    const onUpdate = vi.fn();
+
+    render(<FieldDateTime name="cutoff_date" onUpdate={onUpdate} type="date" />, {
+      wrapper: Wrapper,
+    });
+
+    fireEvent.change(getInputByName("cutoff_date"), { target: { value: "2026-05-28" } });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockParamsDict.cutoff_date.value).toBe("2026-05-28");
+    expect(onUpdate).toHaveBeenLastCalledWith("2026-05-28");
+  });
+
+  it("preserves a previously-stored HH:MM:SS value when re-rendering", () => {
+    mockParamsDict.cutoff_time = {
+      schema: { format: "time", type: "string" },
+      value: "09:15:30",
+    };
+
+    render(<FieldDateTime name="cutoff_time" onUpdate={vi.fn()} type="time" />, {
+      wrapper: Wrapper,
+    });
+
+    expect(getInputByName("cutoff_time").value).toBe("09:15:30");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldDateTime.tsx
@@ -27,10 +27,12 @@ export const FieldDateTime = ({
   name,
   namespace = "default",
   onUpdate,
+  type,
   ...rest
 }: FlexibleFormElementProps & InputProps) => {
   const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
+  const isTime = type === "time";
   const handleChange = (value: string) => {
     // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
     if (paramsDict[name]) {
@@ -41,7 +43,7 @@ export const FieldDateTime = ({
     onUpdate(value);
   };
 
-  if (rest.type === "datetime-local") {
+  if (type === "datetime-local") {
     return (
       <DateTimeInput
         disabled={disabled}
@@ -62,7 +64,8 @@ export const FieldDateTime = ({
       onChange={(event) => handleChange(event.target.value)}
       required={rest.required}
       size="sm"
-      type={rest.type}
+      step={isTime ? 1 : undefined}
+      type={type}
       value={((param.value ?? "") as string).slice(0, 16)}
     />
   );


### PR DESCRIPTION
* closes: #66492 

---

### Description

When triggering a DAG with a `Param` configured with `format='time'` and without default, the frontend UI time field can emit hours and minutes (`HH:MM`) depending on browser implementation. However, the backend validation uses `jsonschema.FormatChecker`, which strictly expects a full `HH:MM:SS` format parsed via `datetime.strptime(instance, "%H:%M:%S")`. This mismatch causes the UI to fail immediately with a `400 Bad Request` validation error upon form submission.

[Screencast from 2026-05-28 17-13-43.webm](https://github.com/user-attachments/assets/f275d34c-58ed-489c-b995-cb299682f4d4)


This PR resolves the issue directly within the `FieldDateTime` component input pipeline:

#### Changes:
**HTML Picker Attribute**: Enabled `step="1"` conditionally on the native time picker element so that compliant rendering engines naturally expose the seconds selection column.  
   
[Screencast from 2026-05-28 17-10-41.webm](https://github.com/user-attachments/assets/802a44e0-6f67-4fde-8ea2-bafc14e6b635)


---