### PR TITLE
Apply note when clearing a Dag Run / task instances

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -73,6 +73,13 @@ class DAGRunClearBody(StrictBaseModel):
         "then the ``[core] rerun_with_latest_version`` config option, "
         "and finally ``False`` (the historical default for clear/rerun).",
     )
+    note: str | None = Field(
+        default=None,
+        max_length=1000,
+        description="Optional note to attach to the Dag Run as part of the clear. "
+        "``None`` (the default) leaves the existing note untouched; any string value "
+        '(including ``""``) replaces it.',
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -76,9 +76,6 @@ class DAGRunClearBody(StrictBaseModel):
     note: str | None = Field(
         default=None,
         max_length=1000,
-        description="Optional note to attach to the Dag Run as part of the clear. "
-        "``None`` (the default) leaves the existing note untouched; any string value "
-        '(including ``""``) replaces it.',
     )
 
     @model_validator(mode="before")

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13021,6 +13021,15 @@ components:
             after clearing the Dag Run. If not specified, falls back to the DAG-level
             ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version``
             config option, and finally ``False`` (the historical default for clear/rerun).
+        note:
+          anyOf:
+          - type: string
+            maxLength: 1000
+          - type: 'null'
+          title: Note
+          description: Optional note to attach to the Dag Run as part of the clear.
+            ``None`` (the default) leaves the existing note untouched; any string
+            value (including ``""``) replaces it.
       additionalProperties: false
       type: object
       title: DAGRunClearBody

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13027,9 +13027,6 @@ components:
             maxLength: 1000
           - type: 'null'
           title: Note
-          description: Optional note to attach to the Dag Run as part of the clear.
-            ``None`` (the default) leaves the existing note untouched; any string
-            value (including ``""``) replaces it.
       additionalProperties: false
       type: object
       title: DAGRunClearBody

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -319,6 +319,7 @@ def clear_dag_run(
     body: DAGRunClearBody,
     dag_bag: DagBagDep,
     session: SessionDep,
+    user: GetUserDep,
 ) -> ClearTaskInstanceCollectionResponse | DAGRunResponse:
     dag_run = session.scalar(
         select(DagRun).filter_by(dag_id=dag_id, run_id=dag_run_id).options(joinedload(DagRun.dag_model))
@@ -388,6 +389,14 @@ def clear_dag_run(
     dag_run_cleared = session.scalar(select(DagRun).where(DagRun.id == dag_run.id))
     if not dag_run_cleared:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Dag run not found after clearing")
+    # ``note=None`` means "leave existing note untouched"; any string (including ``""``)
+    # replaces it. Mirrors the convention used by ``ClearTaskInstancesBody``.
+    if body.note is not None:
+        if dag_run_cleared.dag_run_note is None:
+            dag_run_cleared.note = (body.note, user.get_id())
+        else:
+            dag_run_cleared.dag_run_note.content = body.note
+            dag_run_cleared.dag_run_note.user_id = user.get_id()
     return dag_run_cleared
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -389,8 +389,6 @@ def clear_dag_run(
     dag_run_cleared = session.scalar(select(DagRun).where(DagRun.id == dag_run.id))
     if not dag_run_cleared:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Dag run not found after clearing")
-    # ``note=None`` means "leave existing note untouched"; any string (including ``""``)
-    # replaces it. Mirrors the convention used by ``ClearTaskInstancesBody``.
     if body.note is not None:
         if dag_run_cleared.dag_run_note is None:
             dag_run_cleared.note = (body.note, user.get_id())

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2789,8 +2789,7 @@ export const $DAGRunClearBody = {
                     type: 'null'
                 }
             ],
-            title: 'Note',
-            description: 'Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.'
+            title: 'Note'
         }
     },
     additionalProperties: false,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2778,6 +2778,19 @@ export const $DAGRunClearBody = {
             ],
             title: 'Run On Latest Version',
             description: '(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).'
+        },
+        note: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 1000
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Note',
+            description: 'Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.'
         }
     },
     additionalProperties: false,

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -751,9 +751,6 @@ export type DAGRunClearBody = {
      * (Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).
      */
     run_on_latest_version?: boolean | null;
-    /**
-     * Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.
-     */
     note?: string | null;
 };
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -751,6 +751,10 @@ export type DAGRunClearBody = {
      * (Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).
      */
     run_on_latest_version?: boolean | null;
+    /**
+     * Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.
+     */
+    note?: string | null;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -29,7 +29,6 @@ import { Checkbox, Dialog } from "src/components/ui";
 import SegmentedControl from "src/components/ui/SegmentedControl";
 import { useClearDagRunDryRun } from "src/queries/useClearDagRunDryRun";
 import { useClearDagRun } from "src/queries/useClearRun";
-import { usePatchDagRun } from "src/queries/usePatchDagRun";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 type Props = {
@@ -78,12 +77,6 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagId,
     dagRunId,
     onSuccessConfirm: onClose,
-  });
-
-  const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } = usePatchDagRun({
-    dagId,
-    dagRunId,
-    onSuccess: onClose,
   });
 
   // Check if DAG versions differ (works for both bundle-versioned and local bundles)
@@ -148,25 +141,19 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
             ) : undefined}
             <Button
               disabled={affectedTasks.total_entries === 0}
-              loading={isPending || isPendingPatchDagRun}
+              loading={isPending}
               onClick={() => {
                 mutate({
                   dagId,
                   dagRunId,
                   requestBody: {
                     dry_run: false,
+                    note: note === dagRun.note ? undefined : note,
                     only_failed: onlyFailed,
                     only_new: onlyNew,
                     run_on_latest_version: runOnLatestVersion,
                   },
                 });
-                if (note !== dagRun.note) {
-                  mutatePatchDagRun({
-                    dagId,
-                    dagRunId,
-                    requestBody: { note },
-                  });
-                }
               }}
             >
               <CgRedo /> {translate("modal.confirm")}

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -30,7 +30,6 @@ import { Checkbox, Dialog } from "src/components/ui";
 import SegmentedControl from "src/components/ui/SegmentedControl";
 import { useClearTaskInstances } from "src/queries/useClearTaskInstances";
 import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
-import { usePatchTaskInstance } from "src/queries/usePatchTaskInstance";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
 import ClearTaskInstanceConfirmationDialog from "./ClearTaskInstanceConfirmationDialog";
@@ -93,11 +92,6 @@ const ClearTaskInstanceDialog = (props: Props) => {
   const [preventRunningTask, setPreventRunningTask] = useState(true);
 
   const [note, setNote] = useState<string | null>(taskInstance?.note ?? null);
-  const { isPending: isPendingPatchDagRun, mutate: mutatePatchTaskInstance } = usePatchTaskInstance({
-    dagId,
-    dagRunId,
-    taskId,
-  });
 
   // Get current DAG's bundle version to compare with task instance's DAG version bundle version
   const { data: dagDetails } = useDagServiceGetDagDetails({
@@ -229,11 +223,7 @@ const ClearTaskInstanceDialog = (props: Props) => {
               >
                 {translate("dags:runAndTaskActions.options.preventRunningTasks")}
               </Checkbox>
-              <Button
-                disabled={affectedTasks.total_entries === 0}
-                loading={isPending || isPendingPatchDagRun}
-                onClick={onOpen}
-              >
+              <Button disabled={affectedTasks.total_entries === 0} loading={isPending} onClick={onOpen}>
                 <CgRedo /> {translate("modal.confirm")}
               </Button>
             </Flex>
@@ -255,6 +245,8 @@ const ClearTaskInstanceDialog = (props: Props) => {
           }}
           onClose={onClose}
           onConfirm={() => {
+            const noteChanged = note !== (taskInstance?.note ?? null);
+
             mutate({
               dagId,
               requestBody: {
@@ -264,21 +256,16 @@ const ClearTaskInstanceDialog = (props: Props) => {
                 include_future: future,
                 include_past: past,
                 include_upstream: upstream,
+                // The clear endpoint applies the note in the same transaction
+                // when it is provided; leaving it off leaves any existing note
+                // on the cleared TIs untouched.
+                ...(noteChanged ? { note } : {}),
                 only_failed: onlyFailed,
                 run_on_latest_version: runOnLatestVersion,
                 task_ids: allMapped ? [taskId] : [[taskId, mapIndex as number]],
                 ...(preventRunningTask ? { prevent_running_task: true } : {}),
               },
             });
-            if (note !== (taskInstance?.note ?? null)) {
-              mutatePatchTaskInstance({
-                dagId,
-                dagRunId,
-                ...(allMapped ? {} : { mapIndex }),
-                requestBody: { note },
-                taskId,
-              });
-            }
             onCloseDialog();
           }}
           open={open}

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -256,10 +256,7 @@ const ClearTaskInstanceDialog = (props: Props) => {
                 include_future: future,
                 include_past: past,
                 include_upstream: upstream,
-                // The clear endpoint applies the note in the same transaction
-                // when it is provided; leaving it off leaves any existing note
-                // on the cleared TIs untouched.
-                ...(noteChanged ? { note } : {}),
+                note: noteChanged ? note : undefined,
                 only_failed: onlyFailed,
                 run_on_latest_version: runOnLatestVersion,
                 task_ids: allMapped ? [taskId] : [[taskId, mapIndex as number]],

--- a/airflow-core/src/airflow/ui/src/queries/useBulkClearDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useBulkClearDagRuns.ts
@@ -106,9 +106,7 @@ export const useBulkClearDagRuns = ({ deselectKeys, onSuccessConfirm }: Props) =
           dagRunId: dagRun.dag_run_id,
           requestBody: {
             dry_run: false,
-            // The clear endpoint applies the note in the same transaction when
-            // it is provided; ``null`` / unset leaves the existing note alone.
-            ...(options.note === null ? {} : { note: options.note }),
+            note: options.note ?? undefined,
             only_failed: options.onlyFailed,
             only_new: options.onlyNew,
           },

--- a/airflow-core/src/airflow/ui/src/queries/useBulkClearDagRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useBulkClearDagRuns.ts
@@ -106,6 +106,9 @@ export const useBulkClearDagRuns = ({ deselectKeys, onSuccessConfirm }: Props) =
           dagRunId: dagRun.dag_run_id,
           requestBody: {
             dry_run: false,
+            // The clear endpoint applies the note in the same transaction when
+            // it is provided; ``null`` / unset leaves the existing note alone.
+            ...(options.note === null ? {} : { note: options.note }),
             only_failed: options.onlyFailed,
             only_new: options.onlyNew,
           },
@@ -129,26 +132,6 @@ export const useBulkClearDagRuns = ({ deselectKeys, onSuccessConfirm }: Props) =
         });
       }
     });
-
-    if (succeeded.length > 0 && options.note !== null) {
-      const noteSettled = await Promise.allSettled(
-        succeeded
-          .filter((dagRun) => dagRun.note !== options.note)
-          .map((dagRun) =>
-            DagRunService.patchDagRun({
-              dagId: dagRun.dag_id,
-              dagRunId: dagRun.dag_run_id,
-              requestBody: { note: options.note },
-            }).then(() => dagRun),
-          ),
-      );
-
-      noteSettled.forEach((outcome) => {
-        if (outcome.status === "rejected") {
-          errors.push({ error: `note: ${formatError(outcome.reason)}` });
-        }
-      });
-    }
 
     await invalidateQueries(dagRuns);
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1694,6 +1694,40 @@ class TestClearDagRun:
         assert response.status_code == 403
 
     @pytest.mark.parametrize(
+        ("body", "expected_note"),
+        [
+            ({"dry_run": False, "note": "cleared by test"}, "cleared by test"),
+            ({"dry_run": False, "note": ""}, ""),
+            ({"dry_run": False, "note": None}, "test_note"),
+            ({"dry_run": False}, "test_note"),
+        ],
+        ids=["set-new-note", "set-empty-note", "explicit-null-leaves-existing", "omit-leaves-existing"],
+    )
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_clear_dag_run_applies_note(self, test_client, session, body, expected_note):
+        """``note`` in the clear body writes to the Dag Run; ``None`` / unset leaves it alone."""
+        response = test_client.post(f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}/clear", json=body)
+        assert response.status_code == 200
+        assert response.json()["note"] == expected_note
+        dag_run = session.scalar(
+            select(DagRun).where(DagRun.dag_id == DAG1_ID, DagRun.run_id == DAG1_RUN1_ID)
+        )
+        assert dag_run.note == expected_note
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_clear_dag_run_dry_run_does_not_apply_note(self, test_client, session):
+        """``note`` is ignored on dry-run (no side effects)."""
+        response = test_client.post(
+            f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}/clear",
+            json={"dry_run": True, "note": "ignored"},
+        )
+        assert response.status_code == 200
+        dag_run = session.scalar(
+            select(DagRun).where(DagRun.dag_id == DAG1_ID, DagRun.run_id == DAG1_RUN1_ID)
+        )
+        assert dag_run.note == "test_note"
+
+    @pytest.mark.parametrize(
         ("body", "dag_run_id", "expected_state"),
         [
             [{"dry_run": True}, DAG1_RUN1_ID, ["success", "success"]],

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -345,17 +345,6 @@ class DAGPatchBody(BaseModel):
     is_paused: Annotated[bool, Field(title="Is Paused")]
 
 
-class Note2(RootModel[str]):
-    root: Annotated[
-        str,
-        Field(
-            description='Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.',
-            max_length=1000,
-            title="Note",
-        ),
-    ]
-
-
 class DAGRunClearBody(BaseModel):
     """
     Dag Run serializer for clear endpoint body.
@@ -380,17 +369,7 @@ class DAGRunClearBody(BaseModel):
             title="Run On Latest Version",
         ),
     ] = None
-    note: Annotated[
-        Note2 | None,
-        Field(
-            description='Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.',
-            title="Note",
-        ),
-    ] = None
-
-
-class Note3(RootModel[str]):
-    root: Annotated[str, Field(max_length=1000, title="Note")]
+    note: Annotated[Note | None, Field(title="Note")] = None
 
 
 class DAGSourceResponse(BaseModel):
@@ -1635,7 +1614,7 @@ class DAGRunPatchBody(BaseModel):
         extra="forbid",
     )
     state: DagRunMutableStates | None = None
-    note: Annotated[Note3 | None, Field(title="Note")] = None
+    note: Annotated[Note | None, Field(title="Note")] = None
 
 
 class DAGRunResponse(BaseModel):
@@ -1804,7 +1783,7 @@ class PatchTaskInstanceBody(BaseModel):
         extra="forbid",
     )
     new_state: TaskInstanceState | None = None
-    note: Annotated[Note3 | None, Field(title="Note")] = None
+    note: Annotated[Note | None, Field(title="Note")] = None
     include_upstream: Annotated[bool | None, Field(title="Include Upstream")] = False
     include_downstream: Annotated[bool | None, Field(title="Include Downstream")] = False
     include_future: Annotated[bool | None, Field(title="Include Future")] = False

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -345,6 +345,17 @@ class DAGPatchBody(BaseModel):
     is_paused: Annotated[bool, Field(title="Is Paused")]
 
 
+class Note2(RootModel[str]):
+    root: Annotated[
+        str,
+        Field(
+            description='Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.',
+            max_length=1000,
+            title="Note",
+        ),
+    ]
+
+
 class DAGRunClearBody(BaseModel):
     """
     Dag Run serializer for clear endpoint body.
@@ -369,6 +380,17 @@ class DAGRunClearBody(BaseModel):
             title="Run On Latest Version",
         ),
     ] = None
+    note: Annotated[
+        Note2 | None,
+        Field(
+            description='Optional note to attach to the Dag Run as part of the clear. ``None`` (the default) leaves the existing note untouched; any string value (including ``""``) replaces it.',
+            title="Note",
+        ),
+    ] = None
+
+
+class Note3(RootModel[str]):
+    root: Annotated[str, Field(max_length=1000, title="Note")]
 
 
 class DAGSourceResponse(BaseModel):
@@ -1613,7 +1635,7 @@ class DAGRunPatchBody(BaseModel):
         extra="forbid",
     )
     state: DagRunMutableStates | None = None
-    note: Annotated[Note | None, Field(title="Note")] = None
+    note: Annotated[Note3 | None, Field(title="Note")] = None
 
 
 class DAGRunResponse(BaseModel):
@@ -1782,7 +1804,7 @@ class PatchTaskInstanceBody(BaseModel):
         extra="forbid",
     )
     new_state: TaskInstanceState | None = None
-    note: Annotated[Note | None, Field(title="Note")] = None
+    note: Annotated[Note3 | None, Field(title="Note")] = None
     include_upstream: Annotated[bool | None, Field(title="Include Upstream")] = False
     include_downstream: Annotated[bool | None, Field(title="Include Downstream")] = False
     include_future: Annotated[bool | None, Field(title="Include Future")] = False


### PR DESCRIPTION
Today the Clear dialogs (single and bulk, both for Dag Runs and
Task Instances) issue two requests on confirm: first ``POST .../clear``
to actually clear, then a follow-up ``PATCH .../dagRuns/{run_id}`` /
``PATCH .../taskInstances/...`` to attach the note the user typed in
the dialog.

Fix this by adding the backend option to specify the 'note' when clearing. (TI already supported that). And wire this in the front-end so we only emit 1 request to clear TI/Run with a note.

## Summary

- **Backend:** ``DAGRunClearBody`` gains a ``note: str | None`` field
  (max length 1000). After the clear succeeds in ``clear_dag_run``,
  if ``note`` is set we apply it to the cleared run with the same
  ``dag_run.note = (text, user_id)`` / ``dag_run_note.content = …``
  shape that ``patch_dag_run`` already uses.

  ``ClearTaskInstancesBody`` already carries this field and already
  applies it via ``_patch_task_instance_note`` in the same
  transaction — that side is unchanged.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)