### PR TITLE
Fix compat test flakiness in SnowflakeSqlApiHook timeout test

### DIFF
--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -1245,19 +1245,19 @@ class TestSnowflakeSqlApiHook:
         assert result == {"status": "queued", "info": ["a", "b"]}
         sleep_mock.assert_not_called()
 
-    @mock.patch(f"{MODULE_PATH}.time.time")
     @mock.patch(f"{MODULE_PATH}.time.sleep")
-    def test_wait_for_query_timeout_error(self, sleep_mock, time_mock):
+    def test_wait_for_query_timeout_error(self, sleep_mock, time_machine):
         hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
 
         # Simulate a query that keeps running and never finishes
         hook.get_sql_api_query_status = mock.MagicMock(return_value={"status": "running"})
 
-        # More side effects to ensure we hit the timeout and avoid StopIteration error
-        time_mock.side_effect = list(range(10))
-
         qid = "qid-789"
         timeout = 3
+
+        # Freeze the clock. Each sleep advances it explicitly so logger time.time() calls do not skew the timeout.
+        time_machine.move_to(0, tick=False)
+        sleep_mock.side_effect = lambda seconds: time_machine.shift(seconds + 0.1)
 
         with pytest.raises(TimeoutError):
             hook.wait_for_query(query_id=qid, timeout=timeout, poll_interval=1)
@@ -1267,7 +1267,6 @@ class TestSnowflakeSqlApiHook:
         sleep_mock.assert_has_calls([mock.call(1)] * 3)
         assert hook.get_sql_api_query_status.call_count == 4
         hook.get_sql_api_query_status.assert_has_calls([mock.call(query_id=qid)] * 4)
-        assert time_mock.call_count >= 3
 
     @mock.patch(f"{HOOK_PATH}._make_api_call_with_retries")
     @mock.patch(f"{HOOK_PATH}._process_response")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


Observed this failure:

```
================================================================================================ FAILURES ================================================================================================
_______________________________________________________________________ TestSnowflakeSqlApiHook.test_wait_for_query_timeout_error ________________________________________________________________________
providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py:1266: in test_wait_for_query_timeout_error
    assert sleep_mock.call_count == 3
E   AssertionError: assert 0 == 3
E    +  where 0 = <MagicMock name='sleep' id='281320323411984'>.call_count
```

Example: https://github.com/apache/airflow/actions/runs/26564368176/job/78257418836

The test mocks `time.time` with a fixed side-effect list. Additional `time.time()` calls made by change between start_time assignment and the timeout check consume values from the list, causing the elapsed-time arithmetic to exceed the timeout immediately on the first iteration itself.

Proposing to make it more stable by replacing the `time.time` mock approach with the `time_machine` pytest fixture `(move_to(0, tick=False))`. The frozen clock isolates the test from any incidental `time.time()` calls in the surrounding environment. The `time.sleep` mock advances the frozen clock explicitly so the timeout triggers after exactly 3 polls. Also removes the redundant `assert time_mock.call_count >= 3`, which is covered by `get_sql_api_query_status.call_count == 4` anyways



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
