### PR TITLE
Fix 'airflow dags next-execution --table' crash when no next run exists

### DIFF
--- a/airflow-core/newsfragments/67394.bugfix.rst
+++ b/airflow-core/newsfragments/67394.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``airflow dags next-execution --table`` crash when a DAG has no next scheduled run.

--- a/airflow-core/newsfragments/67394.bugfix.rst
+++ b/airflow-core/newsfragments/67394.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``airflow dags next-execution --table`` crash when a DAG has no next scheduled run.

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -444,7 +444,17 @@ def dag_next_execution(args) -> None:
         else:
             columns = ["logical_date", "data_interval.start", "data_interval.end", "run_after"]
         getters = [(c, operator.attrgetter(c)) for c in columns]
-        AirflowConsole().print_as_table([{n: f(o) for n, f in getters} for o in iter_next_dagrun_info()])
+        rows = []
+        for info in iter_next_dagrun_info():
+            if info is None:
+                print(
+                    "[WARN] No following schedule can be found. "
+                    "This DAG may have schedule interval '@once' or `None`.",
+                    file=sys.stderr,
+                )
+            else:
+                rows.append({n: f(info) for n, f in getters})
+        AirflowConsole().print_as_table(rows)
         return
 
     if args.field:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -274,6 +274,45 @@ class TestCliDags:
         clear_db_dags()
         parse_and_sync_to_db(os.devnull, include_examples=True)
 
+    @conf_vars({("core", "load_examples"): "false"})
+    @pytest.mark.parametrize(
+        ("dag_id", "schedule"),
+        [
+            pytest.param("table_none_schedule", "None", id="schedule_none"),
+            pytest.param("table_once_schedule", "'@once'", id="schedule_once_with_two_executions"),
+        ],
+    )
+    def test_next_execution_table_flag_with_no_next_run(
+        self, dag_id, schedule, tmp_path, stdout_capture, stderr_capture
+    ):
+        """Regression test for #67394: --table must not crash when schedule yields None."""
+        file_content = os.linesep.join(
+            [
+                "from airflow import DAG",
+                "from airflow.providers.standard.operators.empty import EmptyOperator",
+                "from datetime import timedelta; from pendulum import today",
+                f"dag = DAG('{dag_id}', start_date=today(tz='UTC') + timedelta(days=-5), schedule={schedule})",
+                "task = EmptyOperator(task_id='empty_task', dag=dag)",
+            ]
+        )
+        dag_file = tmp_path / f"{dag_id}.py"
+        dag_file.write_text(file_content)
+
+        with time_machine.travel(DEFAULT_DATE):
+            clear_db_dags()
+            parse_and_sync_to_db(tmp_path, include_examples=False)
+
+        args = self.parser.parse_args(["dags", "next-execution", dag_id, "--table", "--num-executions", "2"])
+        # Must not raise AttributeError on None DagRunInfo
+        with stdout_capture:
+            with stderr_capture as temp_stderr:
+                dag_command.dag_next_execution(args)
+        assert "No following schedule" in temp_stderr.getvalue()
+
+        # Rebuild Test DB for other tests
+        clear_db_dags()
+        parse_and_sync_to_db(os.devnull, include_examples=True)
+
     @conf_vars({("core", "load_examples"): "true"})
     def test_cli_report(self, stdout_capture):
         args = self.parser.parse_args(["dags", "report", "--output", "json"])


### PR DESCRIPTION
closes: #67394

\`airflow dags next-execution --table\` crashes with \`AttributeError\` when the DAG has \`schedule=None\` or \`@once\` (when requesting more than one execution via \`--num-executions\`).

The \`--table\` code path applied \`attrgetter\` to every yielded object from \`iter_next_dagrun_info()\` without checking for \`None\` first. The non-table path already had the correct \`if info is None\` guard. This fix mirrors the same guard in the table path and prints a warning to stderr instead of crashing.



 