### PR TITLE
UI: Fix unresponsive page after closing Clear / Mark-as dialog

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -55,7 +55,7 @@ const ClearRunButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
       >
         <CgRedo />
       </IconButton>
-      {open ? <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} /> : undefined}
+      <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} />
     </>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -62,6 +62,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagId,
     dagRunId,
     options: {
+      enabled: open,
       refetchInterval: (query) =>
         query.state.data?.task_instances.some((ti) => "state" in ti && isStatePending(ti.state))
           ? refetchInterval

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
@@ -45,6 +45,17 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
 
   const [note, setNote] = useState<string | null>(dagRun.note);
   const [selectedOptions, setSelectedOptions] = useState<Array<string>>(["existingTasks"]);
+
+  // Reset local form state after the close transition completes so the next
+  // open shows the dag run's note / default options, not whatever the user
+  // typed before cancelling. Mirrors the fresh-mount semantics #47071 used
+  // before we had to keep the dialog mounted for Chakra to clean up properly.
+  useEffect(() => {
+    if (!open) {
+      setNote(dagRun.note);
+      setSelectedOptions(["existingTasks"]);
+    }
+  }, [open, dagRun.note]);
   const onlyFailed = selectedOptions.includes("onlyFailed");
   const onlyNew = selectedOptions.includes("newTasks");
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -87,12 +87,11 @@ const ClearTaskInstanceButton = ({
         <CgRedo />
       </IconButton>
 
-      {useInternalDialog && open && isGroup ? (
+      {useInternalDialog && isGroup ? (
         <ClearGroupTaskInstanceDialog onClose={onClose} open={open} taskInstance={groupTaskInstance} />
       ) : undefined}
 
       {useInternalDialog &&
-      open &&
       !isGroup &&
       allMapped &&
       dagId !== undefined &&
@@ -108,7 +107,7 @@ const ClearTaskInstanceButton = ({
         />
       ) : undefined}
 
-      {useInternalDialog && open && !isGroup && !allMapped && taskInstance ? (
+      {useInternalDialog && !isGroup && !allMapped && taskInstance ? (
         <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
       ) : undefined}
     </>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, useDisclosure, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
@@ -98,6 +98,16 @@ const ClearTaskInstanceDialog = (props: Props) => {
     dagRunId,
     taskId,
   });
+
+  // Reset form state after the dialog closes so the next open starts from
+  // the task instance's own note / default propagation options.
+  useEffect(() => {
+    if (!openDialog) {
+      setSelectedOptions(["downstream"]);
+      setPreventRunningTask(true);
+      setNote(taskInstance?.note ?? null);
+    }
+  }, [openDialog, taskInstance?.note]);
 
   // Get current DAG's bundle version to compare with task instance's DAG version bundle version
   const { data: dagDetails } = useDagServiceGetDagDetails({

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -109,7 +109,7 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
         </Menu.Content>
       </Menu.Root>
 
-      {open ? <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} /> : undefined}
+      <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { DagRunMutableStates, DAGRunResponse } from "openapi/requests/types.gen";
@@ -40,6 +40,14 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
 
   const [note, setNote] = useState<string | null>(dagRun.note);
   const { isPending, mutate } = usePatchDagRun({ dagId, dagRunId, onSuccess: onClose });
+
+  // Reset the note after each close so the next open shows the dag run's
+  // own note, not whatever the user typed before cancelling.
+  useEffect(() => {
+    if (!open) {
+      setNote(dagRun.note);
+    }
+  }, [open, dagRun.note]);
 
   return (
     <Dialog.Root lazyMount onOpenChange={onClose} open={open}>

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -109,9 +109,7 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Pro
         </Menu.Content>
       </Menu.Root>
 
-      {open ? (
-        <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
-      ) : undefined}
+      <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
@@ -51,6 +51,15 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
   const downstream = selectedOptions.includes("downstream");
 
   const [note, setNote] = useState<string | null>(taskInstance.note);
+
+  // Reset form state after the dialog closes so the next open starts from
+  // the task instance's own note / no propagation options selected.
+  useEffect(() => {
+    if (!open) {
+      setNote(taskInstance.note);
+      setSelectedOptions([]);
+    }
+  }, [open, taskInstance.note]);
 
   const { isPending, mutate } = usePatchTaskInstance({
     dagId,

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -121,13 +121,11 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
         stats={stats}
         title={`${taskInstance.task_display_name}${taskInstance.map_index > -1 ? ` [${taskInstance.rendered_map_index ?? taskInstance.map_index}]` : ""}`}
       />
-      {clearOpen ? (
-        <ClearTaskInstanceDialog
-          onClose={() => setClearOpen(false)}
-          open={clearOpen}
-          taskInstance={taskInstance}
-        />
-      ) : undefined}
+      <ClearTaskInstanceDialog
+        onClose={() => setClearOpen(false)}
+        open={clearOpen}
+        taskInstance={taskInstance}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Symptom

Open a Clear or Mark-as-success/failed dialog on a Dag Run or task
instance, close it without confirming, and the page becomes
unresponsive — only scroll works. Reopening another dialog doesn't
help; only a hard refresh recovers.

## Root cause

The buttons that own these dialogs render them like

```tsx
{open ? <ClearRunDialog ... open={open} /> : undefined}
```

When the user closes the dialog, ``open`` flips to ``false`` and the
parent unmounts the dialog component *synchronously*. Chakra never
gets to run ``Dialog.Root``'s close transition, which is what removes
the body-scroll lock + ``pointer-events`` overlay it applies on open.
The overlay stays on ``document``, blocking every click while still
letting wheel events through.

## Fix

Drop the conditional wrapper in the five callers (``ClearRunButton``,
``MarkRunAsButton``, ``ClearTaskInstanceButton`` — three discriminator
branches, ``MarkTaskInstanceAsButton``, and the ``ClearTaskInstance``
mount on the Task Instance Header) and always render the dialog.
``lazyMount`` (already set on every ``Dialog.Root``) defers the very
first mount until the user actually opens the dialog, and the
``open`` prop drives visibility cleanly across subsequent cycles.

``ClearRunDialog``'s ``useClearDagRunDryRun`` was the only dry-run
query in this set that didn't already gate on ``open``; adding
``enabled: open`` so the now-always-mounted dialog doesn't fire it
in the background. The four other dialogs already do this.

## Screenshots

UI bug-fix with no visual change — the dialog looks the same, it just
stops trapping the page after close. No screenshot can show that;
exercising in the browser is the only way to confirm.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)