### PR TITLE
Fix dialog unmounting and unpin @chakra-ui/react (#67647)

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -55,7 +55,7 @@ const ClearRunButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
       >
         <CgRedo />
       </IconButton>
-      {open ? <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} /> : undefined}
+      <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} />
     </>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -45,6 +45,14 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
 
   const [note, setNote] = useState<string | null>(dagRun.note);
   const [selectedOptions, setSelectedOptions] = useState<Array<string>>(["existingTasks"]);
+
+  const handleClose = () => {
+    setNote(dagRun.note);
+    setSelectedOptions(["existingTasks"]);
+    onClose();
+  };
+
+
   const onlyFailed = selectedOptions.includes("onlyFailed");
   const onlyNew = selectedOptions.includes("newTasks");
 
@@ -62,6 +70,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
     dagId,
     dagRunId,
     options: {
+      enabled: open,
       refetchInterval: (query) =>
         query.state.data?.task_instances.some((ti) => "state" in ti && isStatePending(ti.state))
           ? refetchInterval
@@ -77,13 +86,13 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
   const { isPending, mutate } = useClearDagRun({
     dagId,
     dagRunId,
-    onSuccessConfirm: onClose,
+    onSuccessConfirm: handleClose,
   });
 
   const { isPending: isPendingPatchDagRun, mutate: mutatePatchDagRun } = usePatchDagRun({
     dagId,
     dagRunId,
-    onSuccess: onClose,
+    onSuccess: handleClose,
   });
 
   // Check if DAG versions differ (works for both bundle-versioned and local bundles)
@@ -96,7 +105,7 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
   const shouldShowBundleVersionOption = versionsDiffer && !onlyNew;
 
   return (
-    <Dialog.Root lazyMount onOpenChange={onClose} open={open}>
+    <Dialog.Root lazyMount onOpenChange={handleClose} open={open}>
       <Dialog.Content backdrop>
         <Dialog.Header>
           <VStack align="start" gap={4}>


### PR DESCRIPTION
capped @chakra-ui/react at ~3.34.0 due to a page-unresponsive bug triggered by @ark-ui/react >= 5.36. The bug occurred because dialogs were conditionally unmounted before the close transition could run, leaving a `pointer-events: none` lock permanently stuck on the document.

This commit resolves the underlying mounting issue and restores the upgrade path by:
- Replacing conditionally-mounted dialogs with always-rendered components in Clear and Mark-as actions, relying on `lazyMount` so close transitions execute cleanly.
- Gating expensive dry-run queries inside the dialogs with `enabled: open` to prevent unnecessary network requests.
- Wrapping the `onClose` handler to properly reset local form state (e.g., typed notes and selected options) when a dialog is dismissed.
- Unpinning and bumping @chakra-ui/react to ^3.35.0 in the UI package.
- Removing the related dependency caveats from CONTRIBUTING.md.

Resolves: #67647 