### PR TITLE
Emit OpenTelemetry spans around task callback invocations

### DIFF
--- a/airflow-core/tests/integration/otel/dags/otel_test_dag.py
+++ b/airflow-core/tests/integration/otel/dags/otel_test_dag.py
@@ -34,7 +34,15 @@ args = {
 }
 
 
-@task
+def on_execute(context):
+    logger.info("on_execute_callback fired")
+
+
+def on_success(context):
+    logger.info("on_success_callback fired")
+
+
+@task(on_execute_callback=on_execute, on_success_callback=on_success)
 def task1():
     logger.info("starting task1")
 

--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -351,6 +351,11 @@ class TestOtelIntegration:
                     # calls get wrapped in spans at detail level > 1.
                     "listener.on_task_instance_running": "_prepare",
                     "listener.on_task_instance_success": "finalize",
+                    # Task callbacks get wrapped in callback.<kind> spans at
+                    # detail level > 1; on_execute runs during _execute_task and
+                    # on_success runs during finalize.
+                    "callback.on_execute_callback": "_execute_task",
+                    "callback.on_success_callback": "finalize",
                 },
                 id="detail_spans",
             ),

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1986,7 +1986,17 @@ def _run_task_state_change_callbacks(
     callback: Callable[[Context], None]
     for i, callback in enumerate(getattr(task, kind)):
         try:
-            create_executable_runner(callback, context_get_outlet_events(context), logger=log).run(context)
+            with detail_span(
+                f"callback.{kind}",
+                attributes={
+                    "airflow.callback.kind": kind,
+                    "airflow.callback.index": i,
+                    "airflow.callback.name": getattr(callback, "__name__", repr(callback)),
+                },
+            ):
+                create_executable_runner(callback, context_get_outlet_events(context), logger=log).run(
+                    context
+                )
         except Exception:
             log.exception("Failed to run task callback", kind=kind, index=i, callback=callback)
 
@@ -2131,10 +2141,17 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
 
     outlet_events = context_get_outlet_events(context)
 
+    def _run_hook(span_kind: str, hook, *run_args):
+        with detail_span(
+            f"callback.{span_kind}",
+            attributes={"airflow.callback.name": getattr(hook, "__name__", repr(hook))},
+        ):
+            create_executable_runner(hook, outlet_events, logger=log).run(*run_args)
+
     if (pre_execute_hook := task._pre_execute_hook) is not None:
-        create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
+        _run_hook("pre_execute", pre_execute_hook, context)
     if getattr(pre_execute_hook := task.pre_execute, "__func__", None) is not BaseOperator.pre_execute:
-        create_executable_runner(pre_execute_hook, outlet_events, logger=log).run(context)
+        _run_hook("pre_execute", pre_execute_hook, context)
 
     _run_task_state_change_callbacks(task, "on_execute_callback", context, log)
 
@@ -2143,9 +2160,9 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
     result = _run_execute_callable(context, execute, task)
 
     if (post_execute_hook := task._post_execute_hook) is not None:
-        create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context, result)
+        _run_hook("post_execute", post_execute_hook, context, result)
     if getattr(post_execute_hook := task.post_execute, "__func__", None) is not BaseOperator.post_execute:
-        create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context)
+        _run_hook("post_execute", post_execute_hook, context)
 
     return result
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -2140,7 +2140,7 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
 
     outlet_events = context_get_outlet_events(context)
 
-    def _run_hook(span_kind: str, hook, *run_args):
+    def _run_hook(span_kind: str, hook: Callable[..., Any], *run_args: Any) -> None:
         with detail_span(
             f"callback.{span_kind}",
             attributes={"airflow.callback.name": getattr(hook, "__name__", repr(hook))},

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1989,7 +1989,6 @@ def _run_task_state_change_callbacks(
             with detail_span(
                 f"callback.{kind}",
                 attributes={
-                    "airflow.callback.kind": kind,
                     "airflow.callback.index": i,
                     "airflow.callback.name": getattr(callback, "__name__", repr(callback)),
                 },

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -2148,9 +2148,9 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
             create_executable_runner(hook, outlet_events, logger=log).run(*run_args)
 
     if (pre_execute_hook := task._pre_execute_hook) is not None:
-        _run_hook("pre_execute", pre_execute_hook, context)
+        _run_hook("pre_execute_hook", pre_execute_hook, context)
     if getattr(pre_execute_hook := task.pre_execute, "__func__", None) is not BaseOperator.pre_execute:
-        _run_hook("pre_execute", pre_execute_hook, context)
+        _run_hook("pre_execute_override", pre_execute_hook, context)
 
     _run_task_state_change_callbacks(task, "on_execute_callback", context, log)
 
@@ -2159,9 +2159,9 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
     result = _run_execute_callable(context, execute, task)
 
     if (post_execute_hook := task._post_execute_hook) is not None:
-        _run_hook("post_execute", post_execute_hook, context, result)
+        _run_hook("post_execute_hook", post_execute_hook, context, result)
     if getattr(post_execute_hook := task.post_execute, "__func__", None) is not BaseOperator.post_execute:
-        _run_hook("post_execute", post_execute_hook, context)
+        _run_hook("post_execute_override", post_execute_hook, context)
 
     return result
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5834,7 +5834,7 @@ class TestCallbackSpans:
         return provider.get_tracer("test")
 
     def test_state_change_callback_span_at_level_2(self):
-        """A state-change callback gets a callback.<kind> span carrying kind/index/name attributes."""
+        """A state-change callback gets a callback.<kind> span carrying index/name attributes."""
         exporter = InMemorySpanExporter()
         t = self._make_tracer(exporter)
         parent_ctx = TraceContextTextMapPropagator().extract(
@@ -5853,7 +5853,6 @@ class TestCallbackSpans:
         spans = {s.name: s for s in exporter.get_finished_spans()}
         assert "callback.on_failure_callback" in spans
         attrs = spans["callback.on_failure_callback"].attributes
-        assert attrs["airflow.callback.kind"] == "on_failure_callback"
         assert attrs["airflow.callback.index"] == 0
         assert attrs["airflow.callback.name"] == "my_callback"
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -170,6 +170,7 @@ from airflow.sdk.execution_time.task_runner import (
     _push_xcom_if_needed,
     _register_deserialization_allowed_classes,
     _run_execute_callable,
+    _run_task_state_change_callbacks,
     _serialize_outlet_events,
     _xcom_push,
     detail_span,
@@ -5811,6 +5812,146 @@ class TestRunExecuteCallable:
         assert result == "ok"
         names = [s.name for s in exporter.get_finished_spans()]
         assert "task.execute" not in names
+
+
+class TestCallbackSpans:
+    """Tests for spans emitted around task callback / pre-post-execute invocations."""
+
+    @staticmethod
+    def _make_tracer(exporter):
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        return provider.get_tracer("test")
+
+    def test_state_change_callback_span_at_level_2(self):
+        """A state-change callback gets a callback.<kind> span carrying kind/index/name attributes."""
+        exporter = InMemorySpanExporter()
+        t = self._make_tracer(exporter)
+        parent_ctx = TraceContextTextMapPropagator().extract(
+            new_dagrun_trace_carrier(task_span_detail_level=2)
+        )
+
+        def my_callback(context):
+            pass
+
+        task = BaseOperator(task_id="t", on_failure_callback=[my_callback])
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
+            with t.start_as_current_span("parent", context=parent_ctx):
+                _run_task_state_change_callbacks(task, "on_failure_callback", {}, mock.MagicMock())
+
+        spans = {s.name: s for s in exporter.get_finished_spans()}
+        assert "callback.on_failure_callback" in spans
+        attrs = spans["callback.on_failure_callback"].attributes
+        assert attrs["airflow.callback.kind"] == "on_failure_callback"
+        assert attrs["airflow.callback.index"] == 0
+        assert attrs["airflow.callback.name"] == "my_callback"
+
+    def test_state_change_callback_index_attribute(self):
+        """Each callback of the same kind gets its own span with the right index attribute."""
+        exporter = InMemorySpanExporter()
+        t = self._make_tracer(exporter)
+        parent_ctx = TraceContextTextMapPropagator().extract(
+            new_dagrun_trace_carrier(task_span_detail_level=2)
+        )
+
+        def cb_one(context):
+            pass
+
+        def cb_two(context):
+            pass
+
+        task = BaseOperator(task_id="t", on_success_callback=[cb_one, cb_two])
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
+            with t.start_as_current_span("parent", context=parent_ctx):
+                _run_task_state_change_callbacks(task, "on_success_callback", {}, mock.MagicMock())
+
+        indexes = sorted(
+            s.attributes["airflow.callback.index"]
+            for s in exporter.get_finished_spans()
+            if s.name == "callback.on_success_callback"
+        )
+        assert indexes == [0, 1]
+
+    def test_state_change_callback_no_span_at_level_1(self):
+        """At detail level 1 no callback span is recorded, but the callback still runs."""
+        exporter = InMemorySpanExporter()
+        t = self._make_tracer(exporter)
+        parent_ctx = TraceContextTextMapPropagator().extract(
+            new_dagrun_trace_carrier(task_span_detail_level=1)
+        )
+        ran = []
+
+        def my_callback(context):
+            ran.append(True)
+
+        task = BaseOperator(task_id="t", on_failure_callback=[my_callback])
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
+            with t.start_as_current_span("parent", context=parent_ctx):
+                _run_task_state_change_callbacks(task, "on_failure_callback", {}, mock.MagicMock())
+
+        assert ran == [True]
+        assert "callback.on_failure_callback" not in {s.name for s in exporter.get_finished_spans()}
+
+    def test_raising_state_change_callback_records_error_and_is_swallowed(self):
+        """A raising callback records ERROR status on its span and the exception is swallowed."""
+        exporter = InMemorySpanExporter()
+        t = self._make_tracer(exporter)
+        parent_ctx = TraceContextTextMapPropagator().extract(
+            new_dagrun_trace_carrier(task_span_detail_level=2)
+        )
+
+        def boom(context):
+            raise ValueError("boom")
+
+        task = BaseOperator(task_id="t", on_failure_callback=[boom])
+        log = mock.MagicMock()
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
+            with t.start_as_current_span("parent", context=parent_ctx):
+                # Must not raise.
+                _run_task_state_change_callbacks(task, "on_failure_callback", {}, log)
+
+        span = next(s for s in exporter.get_finished_spans() if s.name == "callback.on_failure_callback")
+        assert span.status.status_code == trace.StatusCode.ERROR
+        log.exception.assert_called_once()
+
+    @pytest.mark.parametrize(
+        ("detail_level", "expected_present"),
+        [(2, True), (1, False)],
+    )
+    def test_pre_post_execute_hook_spans(
+        self, create_runtime_ti, mock_supervisor_comms, detail_level, expected_present
+    ):
+        """pre_execute / post_execute hooks get callback.<kind> spans only at detail level > 1."""
+        exporter = InMemorySpanExporter()
+        t = self._make_tracer(exporter)
+        parent_ctx = TraceContextTextMapPropagator().extract(
+            new_dagrun_trace_carrier(task_span_detail_level=detail_level)
+        )
+
+        def pre_hook(context):
+            pass
+
+        def post_hook(context, result):
+            pass
+
+        class MyOperator(BaseOperator):
+            def execute(self, context):
+                return "result"
+
+        task = MyOperator(task_id="t", pre_execute=pre_hook, post_execute=post_hook)
+        ti = create_runtime_ti(task=task)
+
+        with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
+            with t.start_as_current_span("parent", context=parent_ctx):
+                _execute_task(ti.get_template_context(), ti, mock.MagicMock())
+
+        names = {s.name for s in exporter.get_finished_spans()}
+        assert ("callback.pre_execute" in names) is expected_present
+        assert ("callback.post_execute" in names) is expected_present
 
 
 def test_dag_add_result(create_runtime_ti, mock_supervisor_comms):

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5563,26 +5563,28 @@ class TestTaskInstanceMetrics:
             backend.incr.assert_any_call(ti_metric, tags=stats_tags)
 
 
+@pytest.fixture
+def _sampled_carrier_provider():
+    """Make new_dagrun_trace_carrier produce a SAMPLED carrier.
+
+    new_dagrun_trace_carrier consults the global tracer provider's sampler to
+    decide the carrier's SAMPLED flag. In the test process the global provider
+    is a no-op ProxyTracerProvider (no sampler) -> unsampled carrier, which
+    would make the parent span (and its detail children) non-recording. Patch
+    the lookup to a real SDK provider whose default sampler
+    (parentbased_always_on) samples the root, mirroring "otel on" in production.
+    """
+    provider = TracerProvider()
+    with mock.patch(
+        "airflow._shared.observability.traces.trace.get_tracer_provider",
+        return_value=provider,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("_sampled_carrier_provider")
 class TestDetailSpan:
     """Tests for the detail_span decorator / context manager."""
-
-    @pytest.fixture(autouse=True)
-    def _sampled_carrier_provider(self):
-        """Make new_dagrun_trace_carrier produce a SAMPLED carrier.
-
-        new_dagrun_trace_carrier consults the global tracer provider's sampler to
-        decide the carrier's SAMPLED flag. In the test process the global provider
-        is a no-op ProxyTracerProvider (no sampler) -> unsampled carrier, which
-        would make the parent span (and its detail children) non-recording. Patch
-        the lookup to a real SDK provider whose default sampler
-        (parentbased_always_on) samples the root, mirroring "otel on" in production.
-        """
-        provider = TracerProvider()
-        with mock.patch(
-            "airflow._shared.observability.traces.trace.get_tracer_provider",
-            return_value=provider,
-        ):
-            yield
 
     def test_level_1_no_child_span_as_context_manager(self):
         """At detail level 1, entering detail_span should not create a real recorded span."""
@@ -5677,6 +5679,7 @@ class TestDetailSpan:
                         raise ValueError("boom")
 
 
+@pytest.mark.usefixtures("_sampled_carrier_provider")
 class TestRunExecuteCallable:
     """Tests for ``_run_execute_callable``.
 
@@ -5684,16 +5687,6 @@ class TestRunExecuteCallable:
     the ExecutorSafeguard tracker set), applies the execution timeout when one is
     configured, and wraps the call in a ``task.execute`` detail span.
     """
-
-    @pytest.fixture(autouse=True)
-    def _sampled_carrier_provider(self):
-        """Make new_dagrun_trace_carrier produce a SAMPLED carrier (see TestDetailSpan)."""
-        provider = TracerProvider()
-        with mock.patch(
-            "airflow._shared.observability.traces.trace.get_tracer_provider",
-            return_value=provider,
-        ):
-            yield
 
     @staticmethod
     def _make_task(execution_timeout=None):
@@ -5814,18 +5807,9 @@ class TestRunExecuteCallable:
         assert "task.execute" not in names
 
 
+@pytest.mark.usefixtures("_sampled_carrier_provider")
 class TestCallbackSpans:
     """Tests for spans emitted around task callback / pre-post-execute invocations."""
-
-    @pytest.fixture(autouse=True)
-    def _sampled_carrier_provider(self):
-        """Make new_dagrun_trace_carrier produce a SAMPLED carrier (see TestDetailSpan)."""
-        provider = TracerProvider()
-        with mock.patch(
-            "airflow._shared.observability.traces.trace.get_tracer_provider",
-            return_value=provider,
-        ):
-            yield
 
     @staticmethod
     def _make_tracer(exporter):

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5817,6 +5817,16 @@ class TestRunExecuteCallable:
 class TestCallbackSpans:
     """Tests for spans emitted around task callback / pre-post-execute invocations."""
 
+    @pytest.fixture(autouse=True)
+    def _sampled_carrier_provider(self):
+        """Make new_dagrun_trace_carrier produce a SAMPLED carrier (see TestDetailSpan)."""
+        provider = TracerProvider()
+        with mock.patch(
+            "airflow._shared.observability.traces.trace.get_tracer_provider",
+            return_value=provider,
+        ):
+            yield
+
     @staticmethod
     def _make_tracer(exporter):
         provider = TracerProvider()

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5918,7 +5918,7 @@ class TestCallbackSpans:
     def test_pre_post_execute_hook_spans(
         self, create_runtime_ti, mock_supervisor_comms, detail_level, expected_present
     ):
-        """pre_execute / post_execute hooks get callback.<kind> spans only at detail level > 1."""
+        """The instance hook and the method override each get a distinctly named span, only at detail level > 1."""
         exporter = InMemorySpanExporter()
         t = self._make_tracer(exporter)
         parent_ctx = TraceContextTextMapPropagator().extract(
@@ -5932,8 +5932,14 @@ class TestCallbackSpans:
             pass
 
         class MyOperator(BaseOperator):
+            def pre_execute(self, context):
+                pass
+
             def execute(self, context):
                 return "result"
+
+            def post_execute(self, context, result=None):
+                pass
 
         task = MyOperator(task_id="t", pre_execute=pre_hook, post_execute=post_hook)
         ti = create_runtime_ti(task=task)
@@ -5943,8 +5949,10 @@ class TestCallbackSpans:
                 _execute_task(ti.get_template_context(), ti, mock.MagicMock())
 
         names = {s.name for s in exporter.get_finished_spans()}
-        assert ("callback.pre_execute" in names) is expected_present
-        assert ("callback.post_execute" in names) is expected_present
+        assert ("callback.pre_execute_hook" in names) is expected_present
+        assert ("callback.pre_execute_override" in names) is expected_present
+        assert ("callback.post_execute_hook" in names) is expected_present
+        assert ("callback.post_execute_override" in names) is expected_present
 
 
 def test_dag_add_result(create_runtime_ti, mock_supervisor_comms):


### PR DESCRIPTION
Follow-up to #67347 (which added `listener.<hook_name>` spans). This wraps each task callback and pre/post-execute hook invocation in a `callback.<kind>` span, gated on task span detail level > 1.

Covered invocations (all routed through `create_executable_runner(...).run(...)` in `task-sdk/.../task_runner.py`):

- the five state-change callbacks: `on_execute_callback`, `on_success_callback`, `on_failure_callback`, `on_retry_callback`, `on_skipped_callback` (centralized in `_run_task_state_change_callbacks`)
- the `pre_execute` / `post_execute` hooks in `_execute_task`

The callback function name and index are recorded as span attributes; a raising state-change callback records `ERROR` status on its span and is still swallowed/logged as before.

Note: the span is added at the genuine call sites in `task_runner.py`, **not** pushed down into `create_executable_runner`/`callback_runner.py`, because that runner is also reused to execute the actual task body (`python_callable`) in the standard `PythonOperator` — wrapping there would mislabel the main task execution.

Tests: new `TestCallbackSpans` unit tests in `test_task_runner.py` (span presence/attributes at level 2, none at level 1, error recording for a raising callback, pre/post-execute gating) and the otel integration test now asserts `callback.on_execute_callback` → `_execute_task` and `callback.on_success_callback` → `finalize`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)