### PR TITLE
Restrict reproducible-build dirty check to dockerignore-allowed paths

### DIFF
--- a/airflow-core/hatch_build.py
+++ b/airflow-core/hatch_build.py
@@ -71,6 +71,40 @@ class CustomBuild(BuilderInterface[BuilderConfig, PluginManager]):
         dist_path = Path(self.root) / "src" / "airflow" / "ui" / "dist"
         return dist_path.resolve().as_posix()
 
+    @staticmethod
+    def _dockerignore_allowed_paths(work_dir: Path) -> list[str] | None:
+        # The repo's ``.dockerignore`` follows a deny-by-default pattern (``**``)
+        # plus an explicit allowlist of ``!path`` entries. When the package is
+        # built inside the docker image (``COPY . /opt/airflow``), only the
+        # allowlisted files reach the container, so paths outside the allowlist
+        # are guaranteed to be absent and would otherwise be reported as
+        # ``deleted`` by ``git diff`` — stamping every release as ``.dirty``.
+        # Parse the allowlist at build time so this stays in sync with the file.
+        dockerignore = work_dir / ".dockerignore"
+        if not dockerignore.exists():
+            return None
+        allowed: list[str] = []
+        for raw_line in dockerignore.read_text().splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or not line.startswith("!"):
+                continue
+            path = line[1:].strip().rstrip("/")
+            if path:
+                allowed.append(path)
+        return allowed or None
+
+    @classmethod
+    def _is_dirty_within_build_context(cls, repo: Any, work_dir: Path) -> bool:
+        allowed_paths = cls._dockerignore_allowed_paths(work_dir)
+        if not allowed_paths:
+            return repo.is_dirty()
+        try:
+            diff = repo.git.diff("HEAD", "--name-only", "--", *allowed_paths)
+        except Exception as exc:
+            log.warning("Restricted dirty check failed (%s); falling back to is_dirty().", exc)
+            return repo.is_dirty()
+        return bool(diff.strip())
+
     def get_git_version(self) -> str:
         """
         Return a version to identify the state of the underlying git repo.
@@ -80,6 +114,10 @@ class CustomBuild(BuilderInterface[BuilderConfig, PluginManager]):
         prefix and the latter with a '.dev0' suffix. Following the prefix will be a sha of the
         current branch head. Finally, a "dirty" suffix is appended to indicate that uncommitted
         changes are present.
+
+        The "dirty" check is restricted to paths that are part of the docker build context (per
+        ``.dockerignore``). This avoids spurious ``.dirty`` markers on official builds, where the
+        deny-by-default ``.dockerignore`` excludes tracked top-level files from ``COPY``.
 
         Example pre-release version: ".dev0+2f635dc265e78db6708f59f68e8009abb92c1e65".
         Example release version: ".release+2f635dc265e78db6708f59f68e8009abb92c1e65".
@@ -106,7 +144,8 @@ class CustomBuild(BuilderInterface[BuilderConfig, PluginManager]):
             return ""
         if repo:
             sha = repo.head.commit.hexsha
-            if repo.is_dirty():
+            work_dir = Path(self.root).parent.resolve()
+            if self._is_dirty_within_build_context(repo, work_dir):
                 return f".dev0+{sha}.dirty"
             # commit is clean
             return f".release:{sha}"


### PR DESCRIPTION
## Summary

Restrict the reproducible-build `dirty` check in
`airflow-core/hatch_build.py` to paths inside the docker build context
(per `.dockerignore`). Without this, official airflow-core releases
ship with a misleading `git_version = .dev0+<SHA>.dirty` even when
built from a clean tag, because the deny-by-default `.dockerignore`
excludes ~220 tracked top-level files from `COPY . /opt/airflow`,
so `git is_dirty()` inside the container reports them as deletions.

Verified against 3.2.2rc3:
- before fix: `apache_airflow_core` wheel's `airflow/git_version` =
  `.dev0+cde4885818be51a6cdcfdf9275e100bf070025de.dirty`
- after fix: `.release:<SHA>`

## Test plan

- [x] Built `apache-airflow-core` wheel via docker on `main` with the fix —
  `git_version` is now `.release:<SHA>` (no `.dirty` suffix)
- [x] Dirty detection still fires for genuine in-context changes:
  modifying `airflow-core/README.md` → restricted check returns `True`
- [x] Dockerignored-only changes no longer trip dirty:
  modifying `.asf.yaml` → restricted check returns `False`
- [x] `prek run mypy-airflow-core` passes
- [x] `ruff format` / `ruff check` clean
- [x] Falls back to `repo.is_dirty()` when `.dockerignore` is missing
  or has no `!` entries (preserves prior behavior in unusual contexts)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)