### PR TITLE
Hide Dashboard metric percentages when a state count is capped

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -35,6 +35,10 @@ const DAGRUN_STATES: Array<keyof DAGRunStates> = ["queued", "running", "success"
 export const DagRunMetrics = ({ dagRunStates, endDate, startDate, stateCountLimit }: DagRunMetricsProps) => {
   const { t: translate } = useTranslation();
   const total = Object.values(dagRunStates).reduce((sum, count) => sum + count, 0);
+  // When any state hit the API's STATE_COUNT_CAP, the summed total is only a
+  // lower bound, so per-state percentages computed from it are wrong (#67336).
+  // Suppress percentages for the whole group in that case.
+  const isTotalTruncated = Object.values(dagRunStates).some((count) => count >= stateCountLimit);
 
   return (
     <Box borderRadius={5} borderWidth={1} p={4}>
@@ -48,6 +52,7 @@ export const DagRunMetrics = ({ dagRunStates, endDate, startDate, stateCountLimi
           <MetricSection
             capped={dagRunStates[state] >= stateCountLimit}
             endDate={endDate}
+            isTotalTruncated={isTotalTruncated}
             key={state}
             kind="dag_runs"
             runs={dagRunStates[state]}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -30,6 +30,7 @@ const BAR_HEIGHT = 5;
 type MetricSectionProps = {
   readonly capped?: boolean;
   readonly endDate?: string;
+  readonly isTotalTruncated?: boolean;
   readonly kind: string;
   readonly runs: number;
   readonly startDate: string;
@@ -40,6 +41,7 @@ type MetricSectionProps = {
 export const MetricSection = ({
   capped = false,
   endDate,
+  isTotalTruncated = false,
   kind,
   runs,
   startDate,
@@ -48,7 +50,8 @@ export const MetricSection = ({
 }: MetricSectionProps) => {
   const stateWidth = capped ? BAR_WIDTH : total === 0 ? 0 : (runs / total) * BAR_WIDTH;
   const remainingWidth = BAR_WIDTH - stateWidth;
-  const statePercent = capped ? undefined : total === 0 ? 0 : ((runs / total) * 100).toFixed(2);
+  const hidePercent = isTotalTruncated;
+  const statePercent = hidePercent ? undefined : total === 0 ? 0 : ((runs / total) * 100).toFixed(2);
 
   const stateParam = kind === "task_instances" ? SearchParamsKeys.TASK_STATE : SearchParamsKeys.STATE;
   const searchParams = new URLSearchParams(

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -54,6 +54,10 @@ export const TaskInstanceMetrics = ({
 }: TaskInstanceMetricsProps) => {
   const { t: translate } = useTranslation();
   const total = Object.values(taskInstanceStates).reduce((sum, count) => sum + count, 0);
+  // When any state hit the API's STATE_COUNT_CAP, the summed total is only a
+  // lower bound, so per-state percentages computed from it are wrong (#67336).
+  // Suppress percentages for the whole group in that case.
+  const isTotalTruncated = Object.values(taskInstanceStates).some((count) => count >= stateCountLimit);
 
   return (
     <Box borderRadius={5} borderWidth={1} mt={2} p={4}>
@@ -70,6 +74,7 @@ export const TaskInstanceMetrics = ({
             <MetricSection
               capped={taskInstanceStates[state] >= stateCountLimit}
               endDate={endDate}
+              isTotalTruncated={isTotalTruncated}
               key={state}
               kind="task_instances"
               runs={taskInstanceStates[state]}


### PR DESCRIPTION
### What

The Dashboard "Historical Metrics" percentages are computed in the frontend as count / total, where total is the sum of the per-state counts. The `/ui/dashboard/historical_metrics_data` endpoint caps each state count at `STATE_COUNT_CAP` (1000) for performance, so when any state exceeds the cap the summed total is only a lower bound and every per-state percentage is wrong. Example from the issue: success has 2500 runs but the API returns 1000, so failure (7) shows 7/1007 instead of 7/2507.

### Fix

This takes option 2 from the issue: hide the percentages for a metric group when any of its states is capped, rather than display a wrong number. `MetricSection` already hid the percentage for a state that is itself capped; this adds a group-level `totalCapped` flag (true when any state is at or above the limit) so the percentage is hidden for all states in the group when the total is unreliable. The per-state "N+" label and the API cap stay as they are.

I kept the cap and fixed this in the frontend rather than returning real counts (option 1), because the cap on this endpoint is a deliberate performance bound that has been optimized for large installations (e.g. #62152, #63166); returning unbounded counts would reintroduce that cost.

closes: #67336

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code
