### PR TITLE
Fix example_opensearch_serverless system test

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_opensearch_serverless.py
+++ b/providers/amazon/tests/system/amazon/aws/example_opensearch_serverless.py
@@ -16,7 +16,10 @@
 # under the License.
 from __future__ import annotations
 
+import json
 from datetime import datetime
+
+import boto3
 
 from airflow.providers.amazon.aws.operators.opensearch_serverless import (
     OpenSearchServerlessCreateCollectionOperator,
@@ -40,10 +43,27 @@ DAG_ID = "example_opensearch_serverless"
 sys_test_context_task = SystemTestContextBuilder().build()
 
 
+@task
+def create_encryption_policy(collection_name: str, policy_name: str):
+    boto3.client("opensearchserverless").create_security_policy(
+        name=policy_name,
+        type="encryption",
+        policy=json.dumps(
+            {
+                "Rules": [{"ResourceType": "collection", "Resource": [f"collection/{collection_name}"]}],
+                "AWSOwnedKey": True,
+            }
+        ),
+    )
+
+
+@task(trigger_rule=TriggerRule.ALL_DONE)
+def delete_encryption_policy(policy_name: str):
+    boto3.client("opensearchserverless").delete_security_policy(name=policy_name, type="encryption")
+
+
 @task(trigger_rule=TriggerRule.ALL_DONE)
 def delete_collection(collection_id: str):
-    import boto3
-
     boto3.client("opensearchserverless").delete_collection(id=collection_id)
 
 
@@ -56,6 +76,7 @@ with DAG(
     test_context = sys_test_context_task()
     env_id = test_context[ENV_ID_KEY]
     collection_name = f"{env_id}-collection"
+    encryption_policy_name = f"{env_id}-enc-policy"
 
     # [START howto_operator_opensearch_serverless_create_collection]
     create_collection = OpenSearchServerlessCreateCollectionOperator(
@@ -75,11 +96,13 @@ with DAG(
     chain(
         # TEST SETUP
         test_context,
+        create_encryption_policy(collection_name, encryption_policy_name),
         # TEST BODY
         create_collection,
         wait_for_collection,
         # TEST TEARDOWN
         delete_collection(create_collection.output),
+        delete_encryption_policy(encryption_policy_name),
     )
 
     from tests_common.test_utils.watcher import watcher


### PR DESCRIPTION
Add encryption security policy creation before CreateCollection. OpenSearch Serverless requires an encryption policy matching the collection name before a collection can be created.

Also add cleanup of the encryption policy in teardown.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes

Generated-by: Kiro following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
