### PR TITLE
Restore queued_duration metric in Airflow 3

### DIFF
--- a/airflow-core/newsfragments/67668.bugfix.rst
+++ b/airflow-core/newsfragments/67668.bugfix.rst
@@ -1,0 +1,1 @@
+Restore the ``dag.<dag_id>.<task_id>.queued_duration`` metric, which stopped being emitted in Airflow 3 after the queued-to-running transition moved out of the ORM into the execution API.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow._shared.observability.metrics import stats
 from airflow._shared.observability.traces import override_ids
 from airflow._shared.state import TaskScope
 from airflow._shared.timezones import timezone
@@ -159,6 +160,9 @@ def ti_run(
             TI.try_number,
             TI.max_tries,
             TI.start_date,
+            TI.end_date,
+            TI.queued_dttm,
+            TI.queue,
             TI.next_method,
             TI.hostname,
             TI.unixname,
@@ -257,6 +261,20 @@ def ti_run(
     try:
         result = session.execute(query)
         log.info("Task instance state updated", rows_affected=getattr(result, "rowcount", 0))
+
+        # queued_duration was historically emitted on the move to RUNNING; in Airflow 3 that
+        # transition happens here rather than in the ORM, so emit it here (mirrors scheduled_duration).
+        # Emit only on the first try (no prior end_date), matching the Airflow 2 behavior.
+        if (
+            previous_state in (TaskInstanceState.QUEUED, TaskInstanceState.RESTARTING)
+            and ti.queued_dttm
+            and ti.end_date is None
+        ):
+            stats.timing(
+                "task.queued_duration",
+                timezone.utcnow() - ti.queued_dttm,
+                tags={"task_id": ti.task_id, "dag_id": ti.dag_id, "queue": ti.queue},
+            )
 
         dr = (
             session.scalars(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -289,6 +289,115 @@ class TestTIRunState:
         )
         assert response.status_code == 409
 
+    def test_ti_run_emits_queued_duration_metric(self, client, session, create_task_instance, time_machine):
+        """The queued_duration metric is re-emitted on the QUEUED -> RUNNING transition (Airflow 3)."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_emits_queued_duration",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = instant.subtract(seconds=42)
+        session.commit()
+        expected_tags = {"task_id": ti.task_id, "dag_id": ti.dag_id, "queue": ti.queue}
+
+        body = {
+            "state": "running",
+            "hostname": "random-hostname",
+            "unixname": "random-unixname",
+            "pid": 100,
+            "start_date": instant_str,
+        }
+        with mock.patch("airflow._shared.observability.metrics.stats.timing") as mock_timing:
+            response = client.patch(f"/execution/task-instances/{ti.id}/run", json=body)
+            assert response.status_code == 200
+
+            queued_duration_calls = [
+                call for call in mock_timing.call_args_list if call.args[0] == "task.queued_duration"
+            ]
+            assert len(queued_duration_calls) == 1
+            assert queued_duration_calls[0].args[1].total_seconds() == 42
+            assert queued_duration_calls[0].kwargs["tags"] == expected_tags
+
+            # A duplicate run request from the same worker must not emit the metric a second time.
+            response = client.patch(f"/execution/task-instances/{ti.id}/run", json=body)
+            assert response.status_code == 200
+            queued_duration_calls = [
+                call for call in mock_timing.call_args_list if call.args[0] == "task.queued_duration"
+            ]
+            assert len(queued_duration_calls) == 1
+
+    def test_ti_run_skips_queued_duration_without_queued_dttm(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """No queued_duration is emitted when the task has no queued_dttm recorded."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_no_queued_dttm",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = None
+        session.commit()
+
+        with mock.patch("airflow._shared.observability.metrics.stats.timing") as mock_timing:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": instant_str,
+                },
+            )
+        assert response.status_code == 200
+        assert all(call.args[0] != "task.queued_duration" for call in mock_timing.call_args_list)
+
+    def test_ti_run_skips_queued_duration_on_retry(self, client, session, create_task_instance, time_machine):
+        """queued_duration fires only on the first try (no prior end_date), matching Airflow 2."""
+        instant_str = "2024-09-30T12:00:00Z"
+        instant = timezone.parse(instant_str)
+        time_machine.move_to(instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_queued_duration_retry",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = instant.subtract(seconds=42)
+        ti.end_date = instant.subtract(seconds=10)  # a prior attempt already ended
+        session.commit()
+
+        with mock.patch("airflow._shared.observability.metrics.stats.timing") as mock_timing:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": instant_str,
+                },
+            )
+        assert response.status_code == 200
+        assert all(call.args[0] != "task.queued_duration" for call in mock_timing.call_args_list)
+
     def test_ti_run_returns_execution_token(
         self, client, exec_app, session, create_task_instance, time_machine
     ):


### PR DESCRIPTION
The `dag.<dag_id>.<task_id>.queued_duration` timer stopped being emitted after the Airflow 3 upgrade (#63503).

In Airflow 2 it was sent from `TaskInstance.emit_state_change_metric` when the task moved to RUNNING. In Airflow 3 that transition happens in the execution API `ti_run` handler rather than in the ORM, so the emit no longer fired. Its sibling `scheduled_duration` still works because it is emitted server side from the scheduler on the QUEUED transition.

This change emits `task.queued_duration` from `ti_run` on the QUEUED to RUNNING transition. The metric template already maps `task.queued_duration` to the legacy `dag.<dag_id>.<task_id>.queued_duration` name, so both the tagged and statsd forms are restored. It is guarded on `queued_dttm` being set and emitted only on the first try (no prior `end_date`), matching the Airflow 2 behavior.

Unit tests cover the emit, the no-op when `queued_dttm` is missing, the first-try-only guard, and that a duplicate run request does not double-emit.

closes: #63503

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
