### PR TITLE
Fix DagVersion when clearing tasks with run on latest version (#65835)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -1752,6 +1752,8 @@ components:
       - text
       - href
       title: ExtraMenuItem
+      description: Define a menu item that can be added to the menu by auth managers
+        or plugins.
     GridNodeResponse:
       properties:
         id:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -250,6 +250,11 @@ def clear_task_instances(
             ti.state = None
             ti.external_executor_id = None
             ti.clear_next_method_args()
+            # Match DagVersion to latest serialized DAG when run_on_latest_version.
+            if run_on_latest_version:
+                latest_dag_version = DagVersion.get_latest_version(ti.dag_id, session=session)
+                if latest_dag_version is not None:
+                    ti.dag_version_id = latest_dag_version.id
             session.merge(ti)
 
     if dag_run_state is not False and tis:
@@ -281,8 +286,7 @@ def clear_task_instances(
                         dr.created_dag_version_id = dag_version.id
                         dr.dag = dr_dag
                         dr.verify_integrity(session=session, dag_version_id=dag_version.id)
-                        for ti in dr.task_instances:
-                            ti.dag_version_id = dag_version.id
+                        # Only cleared TIs get latest dag_version_id above; do not rewrite others.
                 else:
                     dr_dag = scheduler_dagbag.get_dag_for_run(dag_run=dr, session=session)
                 if not dr_dag:
@@ -296,6 +300,20 @@ def clear_task_instances(
                     dr.start_date = None
                     dr.clear_number += 1
                     dr.queued_at = timezone.utcnow()
+            elif run_on_latest_version:
+                # Queued/running DagRun: update DR to latest version/bundle for workloads that use it.
+                dag_version = DagVersion.get_latest_version(dr.dag_id, session=session)
+                if dag_version and dr.created_dag_version_id != dag_version.id:
+                    dr_dag = scheduler_dagbag.get_latest_version_of_dag(dr.dag_id, session=session)
+                    if not dr_dag:
+                        log.warning("No serialized dag found for dag '%s'", dr.dag_id)
+                    else:
+                        dr.created_dag_version_id = dag_version.id
+                        dr.dag = dr_dag
+                        if not dr_dag.disable_bundle_versioning:
+                            bundle_version = dr.dag_model.bundle_version
+                            if bundle_version is not None:
+                                dr.bundle_version = bundle_version
     session.flush()
 
 

--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -222,7 +222,7 @@ class EdgeExecutor(BaseExecutor):
                 )
             )
 
-    def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
+    def _process_workloads(self, _workloads: Sequence[Any]) -> None:
         """
         No-op: EdgeExecutor does not use the BaseExecutor workload pipeline.
 


### PR DESCRIPTION
This backports the DagVersion alignment fix from #65835 to the 3.1 line.

When clearing task instances with `run_on_latest_version=True`, the cleared task instances should use the latest serialized DAG version. For queued or running DagRuns, the DagRun's created DAG version and bundle version also need to be aligned so the next task execution uses the latest DAG bundle instead of the older one.

This issue was reported against Airflow 3.1.6 in #67657. The fix already exists on newer branches, but was missing from `v3-1-test`.

Testing:
- `uv run ruff check airflow-core/src/airflow/models/taskinstance.py`