### PR TITLE
Clarify API contribution guides

### DIFF
--- a/contributing-docs/15_node_environment_setup.rst
+++ b/contributing-docs/15_node_environment_setup.rst
@@ -19,9 +19,11 @@ Node.js Environment Setup
 =========================
 
 Contributing to the REST API in Airflow
----------------------------------
+---------------------------------------
 
-Committers will exercise their judgement on what endpoints should exist in the public ``airflow/api_fastapi/public`` versus the private ``airflow/api_fastapi/ui``
+Committers will exercise their judgement on which endpoints should exist in the public
+``airflow-core/src/airflow/api_fastapi/core_api/routes/public`` API versus the private
+``airflow-core/src/airflow/api_fastapi/core_api/routes/ui`` API used by the Airflow UI.
 
 Airflow UI
 ----------

--- a/contributing-docs/16_adding_api_endpoints.rst
+++ b/contributing-docs/16_adding_api_endpoints.rst
@@ -18,7 +18,8 @@
 Adding a New API Endpoint in Apache Airflow
 ===========================================
 
-This documentation outlines the steps required to add a new API endpoint in Apache Airflow. It includes implementing the logic, running prek hooks, and documenting the changes.
+This documentation outlines the steps required to add a new API endpoint in Apache Airflow. It includes
+implementing the logic, running prek hooks, and documenting the changes.
 
 .. contents:: Table of Contents
    :depth: 2
@@ -28,16 +29,23 @@ This documentation outlines the steps required to add a new API endpoint in Apac
 Introduction
 ------------
 
-The source code for the RestAPI is located under ``api_fastapi/core_api``. Endpoints are located under ``api_fastapi/core_api/routes`` and contains different types of endpoints. The main two are ``public`` and ``ui``.
-Public endpoints are part of the public API, standardized, well documented and most importantly backward compatible. UI endpoints are custom endpoints made for the frontend that do not respect backward compatibility i.e they can be adapted at any time for UI needs.
-When adding an endpoint you should try as much as possible to make it reusable by the community, have a stable design in mind, standardized and therefore part of the public API. If this is not possible because the data types are too specific or subject to frequent change
-then adding it to the UI endpoints is more suitable.
+The source code for the REST API is located under
+``airflow-core/src/airflow/api_fastapi/core_api``. Endpoints are located under
+``airflow-core/src/airflow/api_fastapi/core_api/routes`` and contain different types of endpoints.
+The main two are ``public`` and ``ui``.
+Public endpoints are part of the public API, standardized, well documented, and backward compatible.
+UI endpoints are custom endpoints made for the frontend that do not provide the same backward
+compatibility guarantees, so they can be adapted for UI needs at any time.
+When adding an endpoint you should try as much as possible to make it reusable by the community,
+have a stable design in mind, and make it part of the public API. If this is not possible because
+the data types are too specific or subject to frequent change, adding it to the UI endpoints is more
+suitable.
 
 
 Step 1: Implement the Endpoint Logic
 ------------------------------------
 1. Considering the details above decide whether your endpoints should be part of the ``public`` or ``ui`` interface.
-2. Navigate to the appropriate routes directory in ``api_fastapi/core_api/routes``.
+2. Navigate to the appropriate routes directory in ``airflow-core/src/airflow/api_fastapi/core_api/routes``.
 3. Register a new route for your endpoint with the appropriate HTTP method, query params, permissions, body type, etc.
 4. Specify the appropriate Pydantic type in the return type annotation.
 
@@ -45,48 +53,58 @@ Example:
 
 .. code-block:: python
 
-  @dags_router.get("/dags")  # permissions go in the dependencies parameter here
-  async def get_dags(
-      *,
-      limit: int = 100,
-      offset: int = 0,
-      tags: Annotated[list[str] | None, Query()] = None,
-      dag_id_pattern: str | None = None,
-      only_active: bool = True,
-      paused: bool | None = None,
-      order_by: str = "dag_id",
+  @dags_router.get("", dependencies=[Depends(requires_access_dag(method="GET"))])
+  def get_dags(
+      limit: QueryLimit,
+      offset: QueryOffset,
+      tags: QueryTagsFilter,
+      dag_id_pattern: QueryDagIdPatternSearch,
+      paused: QueryPausedFilter,
+      order_by: Annotated[
+          SortParam,
+          Depends(SortParam(["dag_id", "dag_display_name"], DagModel).dynamic_depends()),
+      ],
       session: SessionDep,
-  ) -> DagCollectionResponse:
+  ) -> DAGCollectionResponse:
       pass
 
 
 Step 2: Add tests for your Endpoints
 ------------------------------------
 1. Verify manually with a local API that the endpoint behaves as expected.
-2. Go to the test folder and initialize new tests.
-3. Implements extensive tests to validate query param, permissions, error handling etc.
+2. Go to the matching test folder, such as
+   ``airflow-core/tests/unit/api_fastapi/core_api/routes/public`` or
+   ``airflow-core/tests/unit/api_fastapi/core_api/routes/ui``, and initialize new tests.
+3. Implement tests to validate query params, permissions, error handling, and response bodies.
 
 
 Step 3: Documentation
 ---------------------
-Documentation is built automatically by FastAPI and our prek hooks. Verify by going to ``/docs`` that the documentation is clear and appears as expected (body and return types, query params, validation)
+Documentation is built automatically by FastAPI and our prek hooks. Verify by going to ``/docs`` that
+the documentation is clear and appears as expected (body and return types, query params, validation).
 
 
 Step 4: Run prek Hooks
 ----------------------
 1. Ensure all code meets the project's quality standards by running prek hooks.
 2. Prek hooks include static code checks, formatting, and other validations.
-3. Persisted openapi spec is located in ``v2-rest-api-generated.yaml` and a hook will take care of updating it based on your new endpoint, you just need to add and commit the change.
+3. Persisted OpenAPI specs are located in
+   ``airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml`` for public
+   endpoints and ``airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml`` for UI
+   endpoints. A hook will take care of updating the relevant spec based on your new endpoint, you
+   just need to add and commit the change.
 4. Run the following command to execute all prek hooks:
 
 .. code-block:: bash
 
-   prek --all-files
+   prek run --all-files
 
 
 Optional: Adding Pydantic Model
 -------------------------------
-In some cases, you may need to define additional models for new data structures. For example, if you are adding an endpoint that involves new data objects or collections, you may define a model in a Python file. The model will be used to validate and serialize/deserialize objects. Here's an example:
+In some cases, you may need to define additional models for new data structures. For example, if you
+are adding an endpoint that involves new data objects or collections, you may define a model in a
+Python file. The model will be used to validate and serialize/deserialize objects. Here's an example:
 
 .. code-block:: python
 
@@ -99,10 +117,13 @@ In some cases, you may need to define additional models for new data structures.
         is_active: bool
         last_parsed_time: datetime | None
 
-These models are defined to structure and validate the data handled by the API. Once defined, these models will automatically be added to the OpenAPI spec file as long as they are actually used by one endpoint.
+These models are defined to structure and validate the data handled by the API. Once defined, these
+models will automatically be added to the OpenAPI spec file as long as they are actually used by one
+endpoint.
 
 After adding or modifying Pydantic models, make sure to run the prek hooks again to update any generated files.
 
 ------
 
-If you happen to change architecture of Airflow, you can learn how we create our `Architecture diagrams <17_architecture_diagrams.rst>`__.
+If you happen to change architecture of Airflow, you can learn how we create our
+`Architecture diagrams <17_architecture_diagrams.rst>`__.

--- a/contributing-docs/19_execution_api_versioning.rst
+++ b/contributing-docs/19_execution_api_versioning.rst
@@ -47,16 +47,27 @@ Version Changes
 
 When making changes to the Execution API, you must:
 
-1. Add a new migration module (e.g., ``v2025_04_28.py``). Pick a likely date for when the Airflow version
-   will be released.
+1. Check the latest version file in ``airflow-core/src/airflow/api_fastapi/execution_api/versions/``.
+   If its date is in the future and has not been released yet, add your ``VersionChange`` class to
+   that file. Otherwise add a new migration module (e.g., ``v2025_04_28.py``). Pick a likely date
+   for when the Airflow version will be released.
 
    - Use the ``vYYYY_MM_DD`` format.
    - New migrations can be added to an existing unreleased version; not every migration needs a new version.
    - For unreleased versions, pick a likely date for when it will be released.
    - The version number should be unique and not conflict with any existing versions.
-2. Document the changes in the migration.
-3. Update tests to cover both old and new versions.
-4. Ensure backward compatibility wherever possible.
+2. Update the version bundle in
+   ``airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py`` when creating a new
+   version file.
+3. Document the changes in the migration.
+4. Regenerate Task SDK models when request or response schemas change:
+
+   .. code-block:: bash
+
+       uv run --project task-sdk python dev/generate_task_sdk_models.py
+
+5. Update tests to cover both old and new versions.
+6. Ensure backward compatibility wherever possible.
 
 Example Version Migration
 -------------------------
@@ -87,11 +98,18 @@ Directory Structure
 
 The Execution API versioning code is organized as follows:
 
-- ``airflow-core/src/airflow/api_fastapi/execution_api/versions/`` - Contains version migrations
-- ``airflow-core/src/airflow/api_fastapi/execution_api/versions/head/`` - Contains the latest version models
-- ``airflow-core/src/airflow/api_fastapi/execution_api/versions/v2025_04_28/`` - Contains version-specific models and migrations
-- ``airflow-core/tests/unit/api_fastapi/execution_api/versions/head`` - Contains tests for the latest version
-- ``airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28`` - Contains tests for the version-specific models
+- ``airflow-core/src/airflow/api_fastapi/execution_api/datamodels/`` - Contains the current
+  request and response models.
+- ``airflow-core/src/airflow/api_fastapi/execution_api/routes/`` - Contains the current endpoint
+  implementations.
+- ``airflow-core/src/airflow/api_fastapi/execution_api/versions/`` - Contains Cadwyn version
+  migrations as ``vYYYY_MM_DD.py`` files.
+- ``airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py`` - Registers the
+  version bundle.
+- ``airflow-core/tests/unit/api_fastapi/execution_api/versions/head`` - Contains tests for the latest
+  version.
+- ``airflow-core/tests/unit/api_fastapi/execution_api/versions/vYYYY_MM_DD`` - Contains
+  version-specific tests for older clients.
 
 Examples
 --------

--- a/contributing-docs/19_execution_api_versioning.rst
+++ b/contributing-docs/19_execution_api_versioning.rst
@@ -48,9 +48,9 @@ Version Changes
 When making changes to the Execution API, you must:
 
 1. Check the latest version file in ``airflow-core/src/airflow/api_fastapi/execution_api/versions/``.
-   If its date is in the future and has not been released yet, add your ``VersionChange`` class to
-   that file. Otherwise add a new migration module (e.g., ``v2025_04_28.py``). Pick a likely date
-   for when the Airflow version will be released.
+   If the latest version has not been released yet, add your ``VersionChange`` class to that file.
+   Otherwise add a new migration module (e.g., ``v2025_04_28.py``). Pick a likely date for when the
+   Airflow version will be released.
 
    - Use the ``vYYYY_MM_DD`` format.
    - New migrations can be added to an existing unreleased version; not every migration needs a new version.
@@ -64,7 +64,7 @@ When making changes to the Execution API, you must:
 
    .. code-block:: bash
 
-       uv run --project task-sdk python dev/generate_task_sdk_models.py
+       uv run --project task-sdk python task-sdk/dev/generate_task_sdk_models.py
 
 5. Update tests to cover both old and new versions.
 6. Ensure backward compatibility wherever possible.


### PR DESCRIPTION
Update the API contribution documentation so it matches the current repository layout.

This PR:
- corrects outdated public and UI API route paths
- clarifies where generated OpenAPI specs are stored
- updates the endpoint contribution guide with current route/test locations
- fixes the Execution API versioning section so it reflects the current `versions/` layout
- documents when to regenerate Task SDK models after Execution API schema changes

This is documentation-only. I validated the changed RST files with:

- `prek run rst-backticks --files ...`
- `prek run blacken-docs --files ...`
- `git diff --check`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex

Generated-by: Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)