### PR TITLE
Document REST scheme and port connection fields for Spark

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -712,6 +712,7 @@ repos:
           ^providers/apache/kafka/docs/connections/kafka\.rst$|
           ^providers/apache/spark/docs/decorators/pyspark\.rst$|
           ^providers/apache/spark/docs/connections/spark-submit.rst$|
+          ^providers/apache/spark/docs/operators\.rst$|
           ^providers/apache/spark/src/airflow/providers/apache/spark/decorators/|
           ^providers/apache/spark/src/airflow/providers/apache/spark/hooks/|
           ^providers/apache/spark/src/airflow/providers/apache/spark/operators/|

--- a/providers/apache/spark/docs/connections/spark-submit.rst
+++ b/providers/apache/spark/docs/connections/spark-submit.rst
@@ -49,6 +49,15 @@ Spark binary (optional)
 Kubernetes namespace (optional, only applies to spark on kubernetes applications)
     Kubernetes namespace (``spark.kubernetes.namespace``) to divide cluster resources between multiple users (via resource quota).
 
+REST scheme (optional, only applies to Spark standalone cluster mode)
+    Scheme used to reach the Spark standalone REST API (``http`` or ``https``). Defaults to ``http``.
+    Set to ``https`` when the Spark master REST API is TLS-enabled
+    (``spark.ssl.standalone.enabled=true``).
+
+REST port (optional, only applies to Spark standalone cluster mode)
+    Port of the Spark standalone REST API (``spark.master.rest.port``). Defaults to ``6066``.
+    Override when your cluster uses a non-default REST port.
+
 .. note::
 
   When specifying the connection in environment variable you should specify

--- a/providers/apache/spark/docs/operators.rst
+++ b/providers/apache/spark/docs/operators.rst
@@ -199,6 +199,18 @@ a crash-safety net for teams running sync operators for log observability, org c
 because a Triggerer is not available. Teams with a Triggerer available may also consider
 deferrable operators, which free the worker slot but may come with added complexity.
 
+**Connection requirements for crash recovery**
+
+The reconnection polling calls the Spark standalone REST API
+(``GET /v1/submissions/status/{driverId}``). Make sure the Spark connection's
+``REST scheme`` and ``REST port`` extras match your cluster's configuration:
+
+* ``REST scheme`` — set to ``https`` if your cluster has TLS enabled on the REST port
+  (``spark.ssl.standalone.enabled=true``). Defaults to ``http``.
+* ``REST port`` — set to the value of ``spark.master.rest.port`` on your cluster. Defaults to ``6066``.
+
+See :doc:`connections/spark-submit` for how to configure these fields.
+
 .. note::
     Crash recovery in cluster mode requires Airflow 3.3+ (``task_state`` support). On earlier
     versions the operator falls back to the previous behavior of always submitting fresh.


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


`rest-scheme` and `rest-port` Spark connection extras were added in #67118 but were undocumented in the user-facing connection and operator docs. Users who need to override these (HTTPS clusters or non-6066 REST ports) had no indication they existed or that crash recovery depends on them.


Added REST scheme and REST port to `connections/spark-submit.rst` with descriptions of when to override each.
Added a "Connection requirements for crash recovery" callout to the crash recovery section in operators.rst explaining that both fields must match the cluster configured values for `spark.ssl.standalone.enabled` and `spark.master.rest.port` configuration

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
