### PR TITLE
Optimize TaskGroup.topological_sort for reverse-declared Dags

### DIFF
--- a/airflow-core/newsfragments/67688.improvement.rst
+++ b/airflow-core/newsfragments/67688.improvement.rst
@@ -1,0 +1,1 @@
+Further optimize ``TaskGroup.topological_sort`` for reverse-declared DAGs via pass-number traversal; dramatically improves the O(N²) worst-case for adversarial shapes (e.g., reverse-insertion chains).

--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -227,9 +227,22 @@ class SerializedTaskGroup(DAGNode):
         children = self.children
         if not children:
             return []
+
         nodes = list(children.values())
+        n = len(nodes)
         id_to_idx = {nid: i for i, nid in enumerate(children)}
-        projected = [self._project_child_deps(i, c, id_to_idx) for i, c in enumerate(nodes)]
+
+        projected: list[tuple[int, ...]] = [()] * n
+        nodes_with_back_edge = 0
+        for i, child in enumerate(nodes):
+            deps = self._project_child_deps(i, child, id_to_idx)
+            if deps:
+                projected[i] = deps
+                if any(d > i for d in deps):
+                    nodes_with_back_edge += 1
+
+        if nodes_with_back_edge * 2 > n:
+            return self._sort_via_pass_numbering(nodes, projected)
         return self._sweep_projection(nodes, projected)
 
     def _project_child_deps(
@@ -242,16 +255,18 @@ class SerializedTaskGroup(DAGNode):
         for edge_id in upstream_ids:
             j = id_to_idx.get(edge_id)
             if j is not None:
-                sib_deps.add(j)
-                continue
-            tg = self.dag.get_task(edge_id).task_group
-            while tg is not None:
-                j = id_to_idx.get(tg.node_id)
-                if j is not None:
+                if j != child_idx:
                     sib_deps.add(j)
+                continue
+            edge = self.dag.get_task(edge_id)
+            tg = edge.task_group
+            while tg is not None:
+                anc_idx = id_to_idx.get(tg.node_id)
+                if anc_idx is not None:
+                    if anc_idx != child_idx:
+                        sib_deps.add(anc_idx)
                     break
                 tg = tg.parent_group
-        sib_deps.discard(child_idx)
         return tuple(sib_deps)
 
     def _sweep_projection(self, nodes: list[DAGNode], projected: list[tuple[int, ...]]) -> list[DAGNode]:
@@ -290,6 +305,42 @@ class SerializedTaskGroup(DAGNode):
                 raise ValueError(f"A cyclic dependency occurred in dag: {self.dag_id}")
             pending = next_pending
         return order
+
+    def _sort_via_pass_numbering(
+        self, nodes: list[DAGNode], projected: list[tuple[int, ...]]
+    ) -> list[DAGNode]:
+        n = len(nodes)
+        in_degree = [len(deps) for deps in projected]
+        successors: list[list[int]] = [[] for _ in range(n)]
+        for i, deps in enumerate(projected):
+            for d in deps:
+                successors[d].append(i)
+
+        pass_of = [0] * n
+        queue: deque[int] = deque(i for i in range(n) if in_degree[i] == 0)
+        processed = 0
+        while queue:
+            i = queue.popleft()
+            my_pass = 1
+            for d in projected[i]:
+                d_pass = pass_of[d]
+                if d < i:
+                    if d_pass > my_pass:
+                        my_pass = d_pass
+                elif d_pass + 1 > my_pass:
+                    my_pass = d_pass + 1
+            pass_of[i] = my_pass
+            processed += 1
+            for s in successors[i]:
+                in_degree[s] -= 1
+                if in_degree[s] == 0:
+                    queue.append(s)
+
+        if processed != n:
+            raise ValueError(f"A cyclic dependency occurred in dag: {self.dag_id}")
+
+        sorted_indices = sorted(range(n), key=lambda i: (pass_of[i], i))
+        return [nodes[i] for i in sorted_indices]
 
     def add(self, node: DAGNode) -> DAGNode:
         # Set the TG first, as setting it might change the return value of node_id!

--- a/airflow-core/src/airflow/serialization/definitions/taskgroup.py
+++ b/airflow-core/src/airflow/serialization/definitions/taskgroup.py
@@ -241,7 +241,9 @@ class SerializedTaskGroup(DAGNode):
                 if any(d > i for d in deps):
                     nodes_with_back_edge += 1
 
-        if nodes_with_back_edge * 2 > n:
+        # The ratio catches dense back-heavy groups; a 32-node absolute cutoff keeps
+        # padded reverse-declared runs on the fast path once sweep rescans overtake pass-numbering.
+        if nodes_with_back_edge >= 32 or nodes_with_back_edge * 2 > n:
             return self._sort_via_pass_numbering(nodes, projected)
         return self._sweep_projection(nodes, projected)
 

--- a/airflow-core/tests/unit/utils/test_task_group.py
+++ b/airflow-core/tests/unit/utils/test_task_group.py
@@ -1100,6 +1100,21 @@ def test_hierarchical_alphabetical_sort():
     ]
 
 
+def _make_padded_reverse_chain(chain_length: int, independent_count: int) -> DAG:
+    with DAG(
+        f"padded_reverse_chain_{chain_length}_{independent_count}",
+        schedule=None,
+        start_date=DEFAULT_DATE,
+    ) as dag:
+        tasks = [EmptyOperator(task_id=f"r{chain_length - 1 - i}") for i in range(chain_length)]
+        by_id = {task.task_id: task for task in tasks}
+        for i in range(chain_length - 1):
+            by_id[f"r{i}"] >> by_id[f"r{i + 1}"]
+        for i in range(independent_count):
+            EmptyOperator(task_id=f"i{i}")
+    return dag
+
+
 def test_topological_group_dep():
     logical_date = pendulum.parse("20200101")
     with DAG("test_dag_edges", schedule=None, start_date=logical_date) as dag:
@@ -1161,6 +1176,33 @@ def test_topological_sort_serialized_layered():
                 assert position[upstream.task_id] < position[downstream.task_id], (
                     f"{upstream.task_id!r} must precede {downstream.task_id!r}, got {order!r}"
                 )
+
+
+def test_topological_sort_serialized_padded_reverse_chain_uses_pass_numbering(monkeypatch):
+    dag = _make_padded_reverse_chain(chain_length=80, independent_count=80)
+    serialized = create_scheduler_dag(dag)
+    serialized.task_group.children = {
+        **{f"r{i}": serialized.task_group.children[f"r{i}"] for i in range(79, -1, -1)},
+        **{f"i{i}": serialized.task_group.children[f"i{i}"] for i in range(80)},
+    }
+
+    called = {"value": False}
+    serialized_task_group_cls = type(serialized.task_group)
+    original = serialized_task_group_cls._sort_via_pass_numbering
+
+    def spy(self, nodes, projected):
+        called["value"] = True
+        return original(self, nodes, projected)
+
+    monkeypatch.setattr(serialized_task_group_cls, "_sort_via_pass_numbering", spy)
+
+    order = [node.node_id for node in serialized.task_group.topological_sort()]
+    position = {node_id: i for i, node_id in enumerate(order)}
+
+    assert called["value"]
+    assert set(position) == {*(f"r{i}" for i in range(80)), *(f"i{i}" for i in range(80))}
+    for i in range(79):
+        assert position[f"r{i}"] < position[f"r{i + 1}"]
 
 
 def test_task_group_arrow_with_setup_group():

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -571,7 +571,9 @@ class TaskGroup(DAGNode):
                 if any(d > i for d in deps):
                     nodes_with_back_edge += 1
 
-        if nodes_with_back_edge * 2 > n:
+        # The ratio catches dense back-heavy groups; a 32-node absolute cutoff keeps
+        # padded reverse-declared runs on the fast path once sweep rescans overtake pass-numbering.
+        if nodes_with_back_edge >= 32 or nodes_with_back_edge * 2 > n:
             return self._sort_via_pass_numbering(nodes, projected)
         return self._sweep_projection(nodes, projected)
 

--- a/task-sdk/src/airflow/sdk/definitions/taskgroup.py
+++ b/task-sdk/src/airflow/sdk/definitions/taskgroup.py
@@ -544,25 +544,40 @@ class TaskGroup(DAGNode):
         """
         Sort children topologically — a task always comes after its upstream dependencies.
 
-        Projects each child's per-task upstream IDs onto sibling-level integer indices once,
-        then runs a greedy multi-pass sweep using a bytearray-backed emission flag. Equivalent
-        in emission order to the previous modified-Kahn implementation, but moves the per-edge
-        ``upstream_list`` materialization and ``parent_group`` walks out of the sweep's inner
-        loop so they happen once per call instead of once per outer-loop pass.
+        Projects per-task upstream edges onto sibling-level integer indices, then dispatches:
+
+        - Forward-declared DAGs (few/no children declared after their dependents): greedy
+          multi-pass sweep over the projection, O(V + E) for the common case.
+        - Reverse-declared DAGs (many children declared before their dependents): pass-number
+          traversal, O((V + E) log V), avoids the O(N²) blowup the sweep would hit.
+
+        Both branches produce the same emission order: level-by-legacy-pass, ties broken by
+        children insertion order.
         """
         children = self.children
         if not children:
             return []
+
         nodes = list(children.values())
+        n = len(nodes)
         id_to_idx = {nid: i for i, nid in enumerate(children)}
-        projected = [self._project_child_deps(i, c, id_to_idx) for i, c in enumerate(nodes)]
+
+        projected: list[tuple[int, ...]] = [()] * n
+        nodes_with_back_edge = 0
+        for i, child in enumerate(nodes):
+            deps = self._project_child_deps(i, child, id_to_idx)
+            if deps:
+                projected[i] = deps
+                if any(d > i for d in deps):
+                    nodes_with_back_edge += 1
+
+        if nodes_with_back_edge * 2 > n:
+            return self._sort_via_pass_numbering(nodes, projected)
         return self._sweep_projection(nodes, projected)
 
     def _project_child_deps(
         self, child_idx: int, child: DAGNode, id_to_idx: dict[str, int]
     ) -> tuple[int, ...]:
-        # Project one child's per-task upstream IDs onto sibling-level integer indices.
-        # Self-deps are filtered once at the end via ``discard`` so the inner loop stays tight.
         upstream_ids = child.upstream_task_ids
         if not upstream_ids:
             return ()
@@ -570,23 +585,25 @@ class TaskGroup(DAGNode):
         for edge_id in upstream_ids:
             j = id_to_idx.get(edge_id)
             if j is not None:
-                sib_deps.add(j)
-                continue
-            tg = self.dag.get_task(edge_id).task_group
-            while tg is not None:
-                j = id_to_idx.get(tg.node_id)
-                if j is not None:
+                if j != child_idx:
                     sib_deps.add(j)
+                continue
+            edge = self.dag.get_task(edge_id)
+            tg = edge.task_group
+            while tg is not None:
+                anc_idx = id_to_idx.get(tg.node_id)
+                if anc_idx is not None:
+                    if anc_idx != child_idx:
+                        sib_deps.add(anc_idx)
                     break
                 tg = tg.parent_group
-        sib_deps.discard(child_idx)
         return tuple(sib_deps)
 
     def _sweep_projection(self, nodes: list[DAGNode], projected: list[tuple[int, ...]]) -> list[DAGNode]:
         # Greedy multi-pass sweep. emitted[i] == 1 iff nodes[i] has been emitted.
         # Pass 1 iterates range(n) directly; only blocked nodes are recorded into
-        # ``pending`` and re-checked in subsequent passes. Avoids paying for a
-        # ``list(range(n))`` allocation on single-pass shapes (the common case) while
+        # `pending` and re-checked in subsequent passes. Avoids paying for a
+        # `list(range(n))` allocation on single-pass shapes (the common case) while
         # still skipping already-emitted nodes on multi-pass shapes (e.g. a diamond's
         # single trailing sink).
         n = len(nodes)
@@ -624,6 +641,47 @@ class TaskGroup(DAGNode):
                 raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
             pending = next_pending
         return order
+
+    def _sort_via_pass_numbering(
+        self, nodes: list[DAGNode], projected: list[tuple[int, ...]]
+    ) -> list[DAGNode]:
+        # Sort by (pass_number, insertion_index). pass_number(X) is the earliest pass at
+        # which a greedy-sweep emission of X would occur:
+        #   pass(X) = max over deps d of (pass(d) if idx(d) < idx(X) else pass(d)+1)
+        # A dep declared before X can be emitted in the same pass; a dep declared after X
+        # forces X into the next pass. Computed via Kahn's traversal in O(V + E).
+        n = len(nodes)
+        in_degree = [len(deps) for deps in projected]
+        successors: list[list[int]] = [[] for _ in range(n)]
+        for i, deps in enumerate(projected):
+            for d in deps:
+                successors[d].append(i)
+
+        pass_of = [0] * n
+        queue: deque[int] = deque(i for i in range(n) if in_degree[i] == 0)
+        processed = 0
+        while queue:
+            i = queue.popleft()
+            my_pass = 1
+            for d in projected[i]:
+                d_pass = pass_of[d]
+                if d < i:
+                    if d_pass > my_pass:
+                        my_pass = d_pass
+                elif d_pass + 1 > my_pass:
+                    my_pass = d_pass + 1
+            pass_of[i] = my_pass
+            processed += 1
+            for s in successors[i]:
+                in_degree[s] -= 1
+                if in_degree[s] == 0:
+                    queue.append(s)
+
+        if processed != n:
+            raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
+
+        sorted_indices = sorted(range(n), key=lambda i: (pass_of[i], i))
+        return [nodes[i] for i in sorted_indices]
 
     def iter_mapped_task_groups(self) -> Iterator[MappedTaskGroup]:
         """

--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -1011,6 +1011,21 @@ def _make_reverse_chain(n: int) -> DAG:
     return dag
 
 
+def _make_padded_reverse_chain(chain_length: int, independent_count: int) -> DAG:
+    with DAG(
+        f"padded_reverse_chain_{chain_length}_{independent_count}",
+        schedule=None,
+        start_date=DEFAULT_DATE,
+    ) as dag:
+        tasks = [EmptyOperator(task_id=f"r{chain_length - 1 - i}") for i in range(chain_length)]
+        by_id = {t.task_id: t for t in tasks}
+        for i in range(chain_length - 1):
+            by_id[f"r{i}"] >> by_id[f"r{i + 1}"]
+        for i in range(independent_count):
+            EmptyOperator(task_id=f"i{i}")
+    return dag
+
+
 def _make_diamond(n: int) -> DAG:
     with DAG(f"diamond_{n}", schedule=None, start_date=DEFAULT_DATE) as dag:
         root = EmptyOperator(task_id="root")
@@ -1124,3 +1139,33 @@ def test_topological_sort_shape_correctness(shape, builder, n):
     for group in _walk_groups(dag.task_group):
         order = [node.node_id for node in group.topological_sort()]
         _assert_valid_topological_order(group, order)
+
+
+def test_topological_sort_reverse_declared_order_matches_sweep():
+    dag = _make_reverse_chain(100)
+    group = dag.task_group
+    nodes = list(group.children.values())
+    id_to_idx = {nid: i for i, nid in enumerate(group.children)}
+    projected = [group._project_child_deps(i, child, id_to_idx) for i, child in enumerate(nodes)]
+
+    sweep_order = [node.node_id for node in group._sweep_projection(nodes, projected)]
+    pass_number_order = [node.node_id for node in group._sort_via_pass_numbering(nodes, projected)]
+
+    assert pass_number_order == sweep_order
+
+
+def test_topological_sort_padded_reverse_chain_uses_pass_numbering(monkeypatch):
+    dag = _make_padded_reverse_chain(chain_length=80, independent_count=80)
+    called = {"value": False}
+    original = TaskGroup._sort_via_pass_numbering
+
+    def spy(self, nodes, projected):
+        called["value"] = True
+        return original(self, nodes, projected)
+
+    monkeypatch.setattr(TaskGroup, "_sort_via_pass_numbering", spy)
+
+    order = [node.node_id for node in dag.task_group.topological_sort()]
+
+    assert called["value"]
+    _assert_valid_topological_order(dag.task_group, order)


### PR DESCRIPTION
## Human Summary

Further optimization of `TaskGroup.topological_sort` to handle reverse-declared Dags (where many children are declared before their dependencies) efficiently. This is the follow-up to PR #67288.

### Explanation
The idea is to optimize `TaskGroup.topological_sort` for Dags whose tasks are declared in reverse of their dependency order, for example:
```python

@dag
def dag():
    task3 = EmptyOperator()
    task2 = EmptyOperator()
    task1 = EmptyOperator()

    task1 >> task2 >> task3
```

Note that we insert `task3`, then `task2`, then `task1`, but their topological order is the other way round.

The issue with this shape is that the current sweep algorithm revisits blocked nodes. In a reversed-declared chain, we end up in a situation where total of `N + (N-1) + (N-2) + ... + 1` nodes are revisited, leading to a time complexity of O(N^2).
To solve this, we first use [Kahn's algorithm](https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm) to compute the pass number at which each node would be emitted by the existing sweep algorithm. Once the pass numbers are known, we sort nodes by `(pass_number, insertion_order)`, which produces the exact same ordering as the sweep algorithm while avoiding the repeated rescans.

Since the pass-numbering approach has a higher constant overhead than the sweep algorithm, we only enable it for TaskGroups with a significant number of back edges (`nodes_with_back_edge >= 32`), where the cost of repeated sweeps is expected to outweigh that overhead (backed up by a [benchmark script](https://gist.github.com/shahar1/879dea2621e95b5f3e6927378a68c2aa)).

### Was generative AI tooling used to co-author this PR?
- [X] Yes — Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

## AI Summary
<details>
<summary>Click here</summary>
Addresses the O(N²) worst-case behavior of the greedy-sweep approach on adversarial Dag shapes such as reverse-insertion chains.

Uses a hybrid strategy:

- **Forward-declared Dags** (common case): greedy multi-pass sweep, O(V + E)
- **Reverse-declared Dags** (many back edges): pass-number traversal via Kahn's algorithm, O((V + E) log V)
- **Mixed Dags where independent children dilute the ratio**: the dispatcher also flips once the group has at least 32 back-edge nodes, which catches the padded reverse-chain case raised in review

Both approaches emit the same order: level-by-legacy-pass, ties broken by insertion order.

## Benchmark Results

Run the benchmark with: `uv run --project task-sdk python dev/bench_topological_sort_comparison.py`

See [the gist](https://gist.github.com/shahar1/879dea2621e95b5f3e6927378a68c2aa) for the benchmark script.

### Reverse-Chain Speedup (Worst Case)

| N | Sweep-only (ms) | Hybrid (ms) | Speedup |
|---|---|---|---|
| 100 | 0.29 | 0.07 | **4.35x** |
| 500 | 6.01 | 0.43 | **13.88x** |
| 1000 | 24.15 | 0.75 | **32.06x** |
| 2000 | 96.79 | 1.77 | **54.58x** |

### Padded Reverse-Chain (Review Case)

| Shape | Sweep-only (ms) | Hybrid (ms) | Speedup |
|---|---|---|---|
| 1000 reverse + 1000 independent | 24.35 | 1.18 | **20.72x** |

### Performance Progression

- **Before PR #67288** (old Kahn's): ~894ms for reverse-chain N=2000
- **After PR #67288** (sweep-only): ~119ms
- **With this follow-up** (hybrid): ~1.77ms ✅

The dispatcher now switches when a group is clearly back-heavy either by ratio or by an absolute back-edge count, so padded reverse-declared Dags no longer fall back to the quadratic sweep.

## Test Plan

- Reran the benchmark from the gist after rebasing onto `main`
- Added a reverse-declared order-equivalence regression that asserts `_sort_via_pass_numbering` matches `_sweep_projection`
- Added padded reverse-chain dispatch regressions for both `TaskGroup` and `SerializedTaskGroup`
- `uv run --project task-sdk pytest task-sdk/tests/task_sdk/definitions/test_taskgroup.py -k 'reverse_declared_order_matches_sweep or padded_reverse_chain_uses_pass_numbering or topological_sort_shape_correctness' -xvs`
- `uv run --project airflow-core pytest airflow-core/tests/unit/utils/test_task_group.py -k 'serialized_padded_reverse_chain_uses_pass_numbering or topological_sort_serialized_layered' -xvs`
</details>


