### PR TITLE
Use oracledb AuthMode/Purity enums in Oracle hook connection config

### DIFF
--- a/providers/oracle/README.rst
+++ b/providers/oracle/README.rst
@@ -56,7 +56,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``oracledb``                                ``>=2.0.0``
+``oracledb``                                ``>=2.3.0``
 ==========================================  ==================
 
 Cross provider package dependencies

--- a/providers/oracle/docs/index.rst
+++ b/providers/oracle/docs/index.rst
@@ -103,7 +103,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.8.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``oracledb``                                ``>=2.0.0``
+``oracledb``                                ``>=2.3.0``
 ==========================================  ==================
 
 Cross provider package dependencies

--- a/providers/oracle/pyproject.toml
+++ b/providers/oracle/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.8.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    "oracledb>=2.0.0",
+    "oracledb>=2.3.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
+++ b/providers/oracle/src/airflow/providers/oracle/hooks/oracle.py
@@ -238,33 +238,19 @@ class OracleHook(DbApiHook):
         if "events" in conn.extra_dejson:
             conn_config["events"] = conn.extra_dejson.get("events")
 
-        # TODO: Replace mapping with oracledb.AuthMode enum once python-oracledb>=2.3
-        # mode = getattr(oracledb.AuthMode, conn.extra_dejson.get("mode", "").upper(), None)
-        mode = conn.extra_dejson.get("mode", "").lower()
-        if mode == "sysdba":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSDBA
-        elif mode == "sysasm":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSASM
-        elif mode == "sysoper":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSOPER
-        elif mode == "sysbkp":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSBKP
-        elif mode == "sysdgd":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSDGD
-        elif mode == "syskmt":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSKMT
-        elif mode == "sysrac":
-            conn_config["mode"] = oracledb.AUTH_MODE_SYSRAC
+        # Map the connection extra "mode"/"purity" string (e.g. "sysdba") to the
+        # matching python-oracledb AuthMode/Purity enum member by name. Compare
+        # against None explicitly: Purity.DEFAULT is 0, so a truthiness check
+        # would silently drop it.
+        if mode_name := conn.extra_dejson.get("mode"):
+            auth_mode = getattr(oracledb.AuthMode, mode_name.upper(), None)
+            if auth_mode is not None:
+                conn_config["mode"] = auth_mode
 
-        # TODO: Replace mapping with oracledb.Purity enum once python-oracledb>=2.3
-        # purity = getattr(oracledb.Purity, conn.extra_dejson.get("purity", "").upper(), None)
-        purity = conn.extra_dejson.get("purity", "").lower()
-        if purity == "new":
-            conn_config["purity"] = oracledb.PURITY_NEW
-        elif purity == "self":
-            conn_config["purity"] = oracledb.PURITY_SELF
-        elif purity == "default":
-            conn_config["purity"] = oracledb.PURITY_DEFAULT
+        if purity_name := conn.extra_dejson.get("purity"):
+            purity = getattr(oracledb.Purity, purity_name.upper(), None)
+            if purity is not None:
+                conn_config["purity"] = purity
 
         expire_time = conn.extra_dejson.get("expire_time")
         if expire_time:

--- a/uv.lock
+++ b/uv.lock
@@ -6869,7 +6869,7 @@ requires-dist = [
     { name = "numpy", marker = "python_full_version == '3.12.*' and extra == 'numpy'", specifier = ">=1.26.0" },
     { name = "numpy", marker = "python_full_version == '3.13.*' and extra == 'numpy'", specifier = ">=2.1.0" },
     { name = "numpy", marker = "python_full_version >= '3.14' and extra == 'numpy'", specifier = ">=2.4.3" },
-    { name = "oracledb", specifier = ">=2.0.0" },
+    { name = "oracledb", specifier = ">=2.3.0" },
 ]
 provides-extras = ["numpy", "openlineage"]
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Description

Resolves the long-standing TODO in `OracleHook.get_conn` to map the connection `extra` **mode**/**purity** strings via the `oracledb.AuthMode` and `oracledb.Purity` enums, replacing the hand-written `if/elif` chains.

### Key changes

* **Enum mapping:** the connection extra `mode`/`purity` string is now resolved against the matching `AuthMode`/`Purity` enum member by name (case-insensitive), collapsing two `if/elif` chains into a single `getattr` lookup each.
* **Minimum bump:** `oracledb.AuthMode`/`oracledb.Purity` were introduced in python-oracledb **2.3**, so the floor is raised from `2.0.0` to `2.3.0` (a minor release within the same major).
* **Wider coverage:** matching now covers every `AuthMode`/`Purity` value instead of the previously hard-coded subset.

### Compatibility

The legacy `AUTH_MODE_*` / `PURITY_*` module constants are aliases of these enum members, so resolved connection values are unchanged. `None` is compared explicitly because `Purity.DEFAULT` is `0` and a truthiness check would drop it.

> If raising the `oracledb` floor is undesirable, the same de-duplication can be achieved without a bump via `getattr(oracledb, f"AUTH_MODE_{name}")` on the legacy constants — happy to switch if preferred.

### Verification

* `prek` (ruff, pre-commit hooks): passed
* Existing `test_get_conn_mode` / `test_get_conn_purity` and the full `test_oracle.py` hook suite (55 tests): passed unchanged

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
