### PR TITLE
Translate Task Group documentation modal title across UI locales

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ar/common.json
@@ -277,6 +277,9 @@
   "task_other": "مهام",
   "task_two": "مهمتان",
   "task_zero": "لا يوجد أي مهمة",
+  "taskGroup": {
+    "documentation": "وثائق مجموعة المهام"
+  },
   "taskId": "معرف المهمة",
   "taskInstance": {
     "dagVersion": "إصدار الDag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ca/common.json
@@ -267,6 +267,9 @@
   },
   "task_one": "Tasca",
   "task_other": "Tasques",
+  "taskGroup": {
+    "documentation": "Documentació del grup de tasques"
+  },
   "taskGroup_one": "Grup de tasques",
   "taskGroup_other": "Grups de tasques",
   "taskId": "ID de la tasca",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/de/common.json
@@ -267,6 +267,9 @@
   },
   "task_one": "Task",
   "task_other": "Tasks",
+  "taskGroup": {
+    "documentation": "Dokumentation der Task Gruppe"
+  },
   "taskGroup_one": "Task Gruppe",
   "taskGroup_other": "Task Gruppen",
   "taskId": "Task ID",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/el/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/el/common.json
@@ -230,6 +230,9 @@
   },
   "task_one": "Εργασία",
   "task_other": "Εργασίες",
+  "taskGroup": {
+    "documentation": "Τεκμηρίωση Ομάδας Εργασιών"
+  },
   "taskId": "ID Εργασίας",
   "taskInstance": {
     "dagVersion": "Έκδοση Dag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -245,6 +245,9 @@
   "task_many": "Tareas",
   "task_one": "Tarea",
   "task_other": "Tareas",
+  "taskGroup": {
+    "documentation": "Documentación del Grupo de Tareas"
+  },
   "taskId": "ID de la Tarea",
   "taskInstance": {
     "dagVersion": "Versión del Dag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -278,6 +278,9 @@
   "task_many": "Tâches",
   "task_one": "Tâche",
   "task_other": "Tâches",
+  "taskGroup": {
+    "documentation": "Documentation du groupe de tâches"
+  },
   "taskGroup_many": "Groupes de tâches",
   "taskGroup_one": "Groupe de tâches",
   "taskGroup_other": "Groupes de tâches",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/he/common.json
@@ -250,6 +250,9 @@
   "task_one": "משימה",
   "task_other": "משימות",
   "task_two": "משימות",
+  "taskGroup": {
+    "documentation": "תיעוד קבוצת משימות"
+  },
   "taskId": "מזהה משימה",
   "taskInstance": {
     "dagVersion": "גרסת Dag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hi/common.json
@@ -243,6 +243,9 @@
   },
   "task_one": "टास्क",
   "task_other": "टास्क्स",
+  "taskGroup": {
+    "documentation": "टास्क समूह प्रलेखन"
+  },
   "taskId": "टास्क ID",
   "taskInstance": {
     "dagVersion": "डैग संस्करण",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/hu/common.json
@@ -250,6 +250,9 @@
   },
   "task_one": "Feladat",
   "task_other": "Feladatok",
+  "taskGroup": {
+    "documentation": "Feladatcsoport dokumentáció"
+  },
   "taskId": "Feladat azonosító",
   "taskInstance": {
     "dagVersion": "Dag verzió",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/it/common.json
@@ -255,6 +255,9 @@
   "task_one": "Task",
   "task_other": "Tasks",
   "task_zero": "Nessun task",
+  "taskGroup": {
+    "documentation": "Documentazione del Gruppo di Task"
+  },
   "taskId": "ID del Task",
   "taskInstance": {
     "dagVersion": "Versione del Dag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ja/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ja/common.json
@@ -244,6 +244,9 @@
   },
   "task_one": "タスク",
   "task_other": "タスク",
+  "taskGroup": {
+    "documentation": "タスクグループドキュメント"
+  },
   "taskId": "タスク ID",
   "taskInstance": {
     "dagVersion": "Dag バージョン",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -267,6 +267,9 @@
   },
   "task_one": "태스크",
   "task_other": "태스크",
+  "taskGroup": {
+    "documentation": "태스크 그룹 문서"
+  },
   "taskGroup_one": "태스크 그룹",
   "taskGroup_other": "태스크 그룹",
   "taskId": "태스크 ID",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/nl/common.json
@@ -261,6 +261,9 @@
   },
   "task_one": "Task",
   "task_other": "Tasks",
+  "taskGroup": {
+    "documentation": "Taak Groep documentatie"
+  },
   "taskId": "Task ID",
   "taskInstance": {
     "dagVersion": "Dag versie",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -289,6 +289,9 @@
   "task_many": "Zadań",
   "task_one": "Zadanie",
   "task_other": "Zadania",
+  "taskGroup": {
+    "documentation": "Dokumentacja grupy zadań"
+  },
   "taskGroup_few": "Grupy zadań",
   "taskGroup_many": "Grup zadań",
   "taskGroup_one": "Grupa zadań",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pt/common.json
@@ -272,6 +272,9 @@
   "task_one": "Tarefa",
   "task_other": "Tarefas",
   "task_zero": "Nenhuma tarefa",
+  "taskGroup": {
+    "documentation": "Documentação do Grupo de Tarefas"
+  },
   "taskId": "ID da Tarefa",
   "taskInstance": {
     "dagVersion": "Versão do Dag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ru/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ru/common.json
@@ -254,6 +254,9 @@
   },
   "task_one": "Задача",
   "task_other": "Задач",
+  "taskGroup": {
+    "documentation": "Документация группы задач"
+  },
   "taskId": "ID задачи",
   "taskInstance": {
     "dagVersion": "Версия Dag-а",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/th/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/th/common.json
@@ -230,6 +230,9 @@
   },
   "task_one": "งาน",
   "task_other": "งาน",
+  "taskGroup": {
+    "documentation": "เอกสารประกอบกลุ่มงาน"
+  },
   "taskId": "Task ID",
   "taskInstance": {
     "dagVersion": "เวอร์ชัน Dag",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/tr/common.json
@@ -250,6 +250,9 @@
   },
   "task_one": "Görev",
   "task_other": "Görevler",
+  "taskGroup": {
+    "documentation": "Görev Grubu Dokümantasyonu"
+  },
   "taskId": "Görev Kimliği",
   "taskInstance": {
     "dagVersion": "Dag Versiyonu",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/common.json
@@ -250,6 +250,9 @@
   },
   "task_one": "任务",
   "task_other": "任务",
+  "taskGroup": {
+    "documentation": "任务组文档"
+  },
   "taskId": "任务 ID",
   "taskInstance": {
     "dagVersion": "Dag 版本",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -267,6 +267,9 @@
   },
   "task_one": "任務",
   "task_other": "任務",
+  "taskGroup": {
+    "documentation": "任務群組文件"
+  },
   "taskGroup_one": "任務群組",
   "taskGroup_other": "任務群組",
   "taskId": "任務 ID",


### PR DESCRIPTION
## Summary

[#67207](https://github.com/apache/airflow/pull/67207) added the `taskGroup.documentation` modal title key but seeded the English placeholder `"Task Group Documentation"` into all 20 non-English locale files instead of real translations. Those untranslated placeholders have since been removed, so the modal title currently falls back to English in every non-English locale. This PR adds the key back with proper native translations.

The [i18n policy](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/ui/public/i18n/README.md) explicitly allows LLM-assisted translations in the same PR as a source-string change.

## How the translations were derived

Each value reuses the locale's existing `task.documentation` ("Task Documentation") wording and its authoritative "Task Group" glossary term from `.github/skills/airflow-translations/locales/<locale>.md`, so terminology and word order match what is already in each file.

| Locale | Translation |
| --- | --- |
| ar | وثائق مجموعة المهام |
| ca | Documentació del grup de tasques |
| de | Dokumentation der Task Gruppe |
| el | Τεκμηρίωση Ομάδας Εργασιών |
| es | Documentación del Grupo de Tareas |
| fr | Documentation du groupe de tâches |
| he | תיעוד קבוצת משימות |
| hi | टास्क समूह प्रलेखन |
| hu | Feladatcsoport dokumentáció |
| it | Documentazione del Gruppo di Task |
| ja | タスクグループドキュメント |
| ko | 태스크 그룹 문서 |
| nl | Taak Groep documentatie |
| pl | Dokumentacja grupy zadań |
| pt | Documentação do Grupo de Tarefas |
| ru | Документация группы задач |
| th | เอกสารประกอบกลุ่มงาน |
| tr | Görev Grubu Dokümantasyonu |
| zh-CN | 任务组文档 |
| zh-TW | 任務群組文件 |

## Notes for locale code owners

- **nl**: follows the [locale guide](https://github.com/apache/airflow/blob/main/.github/skills/airflow-translations/locales/nl.md) (`Taak Groep`, which records the maintainer consensus to translate Task to "Taak") even though the existing `nl/common.json` still uses "Task" elsewhere. Flagging in case the nl code owner prefers to keep "Task" for now.
- **de**: uses the genitive phrasing `Dokumentation der Task Gruppe` rather than a stacked compound.

The key is consumed in [`GroupTaskHeader.tsx`](https://github.com/apache/airflow/blob/cf4c470057/airflow-core/src/airflow/ui/src/pages/Task/GroupTaskHeader.tsx#L40). `taskGroup_one` / `taskGroup_other` are referenced directly as suffixed keys, so the `taskGroup` object and the plural strings coexist without collision.
