### PR TITLE
Speed up Dag serialization by skipping redundant asset roundtrip

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -918,14 +918,16 @@ class _DependencyDetector:
 
         for obj in task.outlets or []:
             if isinstance(obj, (Asset, SerializedAsset)):
-                serialized_asset = ensure_serialized_asset(obj)
+                # The unique key only needs ``name``/``uri``, and asset encode/decode
+                # copies both verbatim, so build the key directly and skip the full
+                # ensure_serialized_asset() encode→decode roundtrip on every outlet.
                 deps.append(
                     DagDependency(
                         source=task.dag_id,
                         target="asset",
                         label=obj.name,
                         dependency_type="asset",
-                        dependency_id=SerializedAssetUniqueKey.from_asset(serialized_asset).to_str(),
+                        dependency_id=SerializedAssetUniqueKey(name=obj.name, uri=obj.uri).to_str(),
                     )
                 )
             elif isinstance(obj, (AssetAlias, SerializedAssetAlias)):


### PR DESCRIPTION
## Problem

`_DependencyDetector.detect_task_dependencies` builds the asset `dependency_id`
for **every asset outlet of every task** via:

```python
serialized_asset = ensure_serialized_asset(obj)
dependency_id = SerializedAssetUniqueKey.from_asset(serialized_asset).to_str()
```

`ensure_serialized_asset()` runs a full `decode_asset_like(encode_asset_like(obj))`
encode→decode roundtrip — rebuilding the entire `SerializedAsset` (group, extra,
watchers, access_control) — purely to read back `.name`/`.uri` for the unique key.

## Fix

`encode_asset_like` copies `name`/`uri` verbatim and `_decode_asset` reconstructs
them verbatim, so the roundtrip cannot change either field. The key is built
directly from the object instead:

```python
dependency_id = SerializedAssetUniqueKey(name=obj.name, uri=obj.uri).to_str()
```

One full encode+decode per asset outlet is removed. The asset-alias branch is
left unchanged (rare path that genuinely needs the serialized object).

## Correctness

- Output is **byte-identical** — URI normalization happens once at
  `Asset.__init__`, never inside the roundtrip, so `obj.name`/`obj.uri` already
  hold the normalized values.
- All **194** tests in
  `airflow-core/tests/unit/serialization/test_dag_serialization.py` pass.
- The benchmark's `[0]` section asserts identical keys across asset shapes
  (name+uri, uri-only, name-only, special characters, with group/extra).

## Benchmark

Comparing two separate process runs proved unreliable on a loaded machine
(absolute timings swung ~2× from background load alone). The credible
measurement is a **single-process interleaved A/B** that patches in both
implementations and times them round-by-round under identical instantaneous
load (`bench_asset_roundtrip_ab.py`):

| Scenario | OLD (roundtrip) min | NEW (direct) min | speedup |
|---|---|---|---|
| 100 tasks × 1 outlet | 10.73 ms | 10.46 ms | 1.03× |
| 100 tasks × 5 outlets | 15.28 ms | 14.52 ms | 1.05× |
| 500 tasks × 5 outlets | 77.24 ms | 70.82 ms | 1.09× |
| 1000 tasks × 5 outlets | 143.46 ms | 137.79 ms | 1.04× |
| 200 tasks × 20 outlets | 59.53 ms | 54.79 ms | 1.09× |

Consistent **~3–9% end-to-end** serialization speedup (largest on asset-heavy
Dags), and **~1.5–2×** on the changed line in isolation.

Benchmark scripts: https://gist.github.com/shahar1/841592531adfd66def64fc67fcc3ea6c

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
