### PR TITLE
Fix `airflow dags clear` clearing the wrong day for non-UTC partitioned timetables

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -188,7 +188,9 @@ ARG_END_DATE = Arg(
 ARG_PARTITION_DATE_START = Arg(
     ("--partition-date-start",),
     help=(
-        "Inclusive lower bound of the partition_date window (matched against DagRun.partition_date). "
+        "Inclusive lower bound of the partition_date window. Matched at local calendar-day "
+        "granularity: the start of the given local calendar day in the Dag's timetable timezone "
+        "(any time-of-day component is ignored). "
         "Accepts the same datetime formats as --start-date."
     ),
     type=parsedate,
@@ -196,7 +198,9 @@ ARG_PARTITION_DATE_START = Arg(
 ARG_PARTITION_DATE_END = Arg(
     ("--partition-date-end",),
     help=(
-        "Inclusive upper bound of the partition_date window (matched against DagRun.partition_date). "
+        "Inclusive upper bound of the partition_date window. Matched at local calendar-day "
+        "granularity: all runs whose partition_date falls on the given local calendar day in the "
+        "Dag's timetable timezone are included (any time-of-day component is ignored). "
         "Accepts the same datetime formats as --end-date."
     ),
     type=parsedate,
@@ -1190,7 +1194,8 @@ DAGS_COMMANDS = (
             "Clear Dag runs of the given dag_id and re-queue them for reprocessing. Exactly one "
             "of the following selectors must be provided: --run-id (single run); --partition-key "
             "(every run with that exact partition_key); or a partition_date window via "
-            "--partition-date-start and/or --partition-date-end (inclusive on both ends). "
+            "--partition-date-start and/or --partition-date-end (both bounds are inclusive local "
+            "calendar days, anchored in the Dag's timetable timezone). "
             "Intended for partitioned Dags, whose runs are keyed by partition_date / "
             "partition_key instead of logical_date. For traditional, non-partitioned Dags, use "
             "`airflow tasks clear --start-date / --end-date`."

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -173,10 +173,10 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
     else:
         query = query.where(DagRun.partition_date.is_not(None))
         if args.partition_date_start is not None:
-            lower = dag.timetable.get_partition_day_bound(args.partition_date_start.date())
+            lower = dag.timetable.resolve_day_bound(args.partition_date_start.date())
             query = query.where(DagRun.partition_date >= lower)
         if args.partition_date_end is not None:
-            upper = dag.timetable.get_partition_day_bound(
+            upper = dag.timetable.resolve_day_bound(
                 args.partition_date_end.date() + datetime.timedelta(days=1)
             )
             query = query.where(DagRun.partition_date < upper)

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -126,7 +126,15 @@ def dag_delete(args) -> None:
 @providers_configuration_loaded
 @provide_session
 def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
-    """Clear Dag runs selected by run_id, partition_key, or a partition_date window."""
+    """
+    Clear Dag runs selected by run_id, partition_key, or a partition_date window.
+
+    When a partition_date window is given, both bounds are **day-granular** and
+    anchored in the timetable's timezone for tz-aware partitioned timetables.
+    --partition-date-start is the inclusive start local calendar day;
+    --partition-date-end is the inclusive end local calendar day (any
+    time-of-day component in either value is ignored).
+    """
     has_range = args.partition_date_start is not None or args.partition_date_end is not None
     selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])
     if selectors_used == 0:
@@ -157,10 +165,52 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
         query = query.where(DagRun.partition_key == args.partition_key)
     else:
         query = query.where(DagRun.partition_date.is_not(None))
-        if args.partition_date_start is not None:
-            query = query.where(DagRun.partition_date >= args.partition_date_start)
-        if args.partition_date_end is not None:
-            query = query.where(DagRun.partition_date <= args.partition_date_end)
+        tt_tz = getattr(dag.timetable, "timezone", None) if dag.timetable.partitioned else None
+        if tt_tz is not None:
+            # Partitioned runs are stored as local-midnight UTC instants; compare at day
+            # granularity in the timetable's timezone rather than at the raw UTC instant.
+            if args.partition_date_start is not None:
+                start_label = args.partition_date_start.date()
+                lower_utc = timezone.convert_to_utc(
+                    timezone.make_aware(
+                        datetime.datetime(start_label.year, start_label.month, start_label.day),
+                        tt_tz,
+                    )
+                )
+                query = query.where(DagRun.partition_date >= lower_utc)
+            if args.partition_date_end is not None:
+                end_label = args.partition_date_end.date()
+                # Half-open upper bound: include all of the end local calendar day.
+                next_day = datetime.date(end_label.year, end_label.month, end_label.day) + datetime.timedelta(
+                    days=1
+                )
+                upper_utc = timezone.convert_to_utc(
+                    timezone.make_aware(
+                        datetime.datetime(next_day.year, next_day.month, next_day.day),
+                        tt_tz,
+                    )
+                )
+                query = query.where(DagRun.partition_date < upper_utc)
+        else:
+            # No timetable timezone: partition_date values are midnight-anchored UTC dates,
+            # so time-of-day on the CLI flags is not meaningful — truncate to calendar day.
+            if args.partition_date_start is not None:
+                start_day = args.partition_date_start.date()
+                query = query.where(
+                    DagRun.partition_date
+                    >= datetime.datetime(
+                        start_day.year, start_day.month, start_day.day, tzinfo=datetime.timezone.utc
+                    )
+                )
+            if args.partition_date_end is not None:
+                end_day = args.partition_date_end.date()
+                next_day = end_day + datetime.timedelta(days=1)
+                query = query.where(
+                    DagRun.partition_date
+                    < datetime.datetime(
+                        next_day.year, next_day.month, next_day.day, tzinfo=datetime.timezone.utc
+                    )
+                )
     query = query.order_by(DagRun.partition_date, DagRun.run_id)
 
     runs = list(session.execute(query).all())

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -45,7 +45,6 @@ from airflow.jobs.job import Job
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.timetables._cron import CronMixin
 from airflow.timetables.base import TimeRestriction
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import (
@@ -66,7 +65,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from graphviz.dot import Dot
-    from pendulum.tz.timezone import FixedTimezone, Timezone
     from sqlalchemy.orm import Session
 
     from airflow import DAG
@@ -124,27 +122,6 @@ def dag_delete(args) -> None:
         print("Cancelled")
 
 
-def _compute_day_bound(label: datetime.date, tt_tz: Timezone | FixedTimezone | None) -> datetime.datetime:
-    """
-    Return the UTC instant of `label`'s local midnight in `tt_tz`.
-
-    When `tt_tz` is None the partition_date values are midnight-anchored UTC
-    dates (no time-of-day meaning), so the result is simply midnight UTC for
-    that calendar day. When `tt_tz` is a timetable timezone (only set for
-    CronMixin subclasses such as CronPartitionTimetable), partitioned runs are
-    stored as local-midnight UTC instants and the comparison must be done in
-    the timetable's timezone rather than at the raw UTC instant.
-
-    Callers pass ``label`` for the inclusive lower bound and
-    ``label + timedelta(days=1)`` for the half-open upper bound.
-    """
-    if tt_tz is None:
-        return datetime.datetime(label.year, label.month, label.day, tzinfo=datetime.timezone.utc)
-    return timezone.convert_to_utc(
-        timezone.make_aware(datetime.datetime(label.year, label.month, label.day), tt_tz)
-    )
-
-
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -188,12 +165,13 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
         query = query.where(DagRun.partition_key == args.partition_key)
     else:
         query = query.where(DagRun.partition_date.is_not(None))
-        tt_tz = dag.timetable.timezone if isinstance(dag.timetable, CronMixin) else None
         if args.partition_date_start is not None:
-            lower = _compute_day_bound(args.partition_date_start.date(), tt_tz)
+            lower = dag.timetable.get_partition_day_bound(args.partition_date_start.date())
             query = query.where(DagRun.partition_date >= lower)
         if args.partition_date_end is not None:
-            upper = _compute_day_bound(args.partition_date_end.date() + datetime.timedelta(days=1), tt_tz)
+            upper = dag.timetable.get_partition_day_bound(
+                args.partition_date_end.date() + datetime.timedelta(days=1)
+            )
             query = query.where(DagRun.partition_date < upper)
     query = query.order_by(DagRun.partition_date, DagRun.run_id)
 

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -133,14 +133,8 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
     anchored in the timetable's timezone for tz-aware partitioned timetables.
     --partition-date-start is the inclusive start local calendar day;
     --partition-date-end is the inclusive end local calendar day (any
-    time-of-day component in either value is ignored).
-
-    Each bound is parsed by ``parsedate``:
-    naive input is read in the configured default timezone (UTC unless
-    overridden), and tz-aware input is normalized to UTC before ``.date()``
-    extracts the calendar day -- no re-projection to the timetable timezone
-    occurs. To avoid an off-by-one-day shift, supply a naive date
-    (e.g. ``2026-02-19``) or a value already expressed in UTC.
+    time-of-day or timezone-offset component in either value is ignored; only
+    the calendar date is used).
     """
     has_range = args.partition_date_start is not None or args.partition_date_end is not None
     selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -45,6 +45,7 @@ from airflow.jobs.job import Job
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.timetables._cron import CronMixin
 from airflow.timetables.base import TimeRestriction
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import (
@@ -65,6 +66,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from graphviz.dot import Dot
+    from pendulum.tz.timezone import FixedTimezone, Timezone
     from sqlalchemy.orm import Session
 
     from airflow import DAG
@@ -122,6 +124,27 @@ def dag_delete(args) -> None:
         print("Cancelled")
 
 
+def _compute_day_bound(label: datetime.date, tt_tz: Timezone | FixedTimezone | None) -> datetime.datetime:
+    """
+    Return the UTC instant of `label`'s local midnight in `tt_tz`.
+
+    When `tt_tz` is None the partition_date values are midnight-anchored UTC
+    dates (no time-of-day meaning), so the result is simply midnight UTC for
+    that calendar day. When `tt_tz` is a timetable timezone (only set for
+    CronMixin subclasses such as CronPartitionTimetable), partitioned runs are
+    stored as local-midnight UTC instants and the comparison must be done in
+    the timetable's timezone rather than at the raw UTC instant.
+
+    Callers pass ``label`` for the inclusive lower bound and
+    ``label + timedelta(days=1)`` for the half-open upper bound.
+    """
+    if tt_tz is None:
+        return datetime.datetime(label.year, label.month, label.day, tzinfo=datetime.timezone.utc)
+    return timezone.convert_to_utc(
+        timezone.make_aware(datetime.datetime(label.year, label.month, label.day), tt_tz)
+    )
+
+
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -165,52 +188,13 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
         query = query.where(DagRun.partition_key == args.partition_key)
     else:
         query = query.where(DagRun.partition_date.is_not(None))
-        tt_tz = getattr(dag.timetable, "timezone", None) if dag.timetable.partitioned else None
-        if tt_tz is not None:
-            # Partitioned runs are stored as local-midnight UTC instants; compare at day
-            # granularity in the timetable's timezone rather than at the raw UTC instant.
-            if args.partition_date_start is not None:
-                start_label = args.partition_date_start.date()
-                lower_utc = timezone.convert_to_utc(
-                    timezone.make_aware(
-                        datetime.datetime(start_label.year, start_label.month, start_label.day),
-                        tt_tz,
-                    )
-                )
-                query = query.where(DagRun.partition_date >= lower_utc)
-            if args.partition_date_end is not None:
-                end_label = args.partition_date_end.date()
-                # Half-open upper bound: include all of the end local calendar day.
-                next_day = datetime.date(end_label.year, end_label.month, end_label.day) + datetime.timedelta(
-                    days=1
-                )
-                upper_utc = timezone.convert_to_utc(
-                    timezone.make_aware(
-                        datetime.datetime(next_day.year, next_day.month, next_day.day),
-                        tt_tz,
-                    )
-                )
-                query = query.where(DagRun.partition_date < upper_utc)
-        else:
-            # No timetable timezone: partition_date values are midnight-anchored UTC dates,
-            # so time-of-day on the CLI flags is not meaningful — truncate to calendar day.
-            if args.partition_date_start is not None:
-                start_day = args.partition_date_start.date()
-                query = query.where(
-                    DagRun.partition_date
-                    >= datetime.datetime(
-                        start_day.year, start_day.month, start_day.day, tzinfo=datetime.timezone.utc
-                    )
-                )
-            if args.partition_date_end is not None:
-                end_day = args.partition_date_end.date()
-                next_day = end_day + datetime.timedelta(days=1)
-                query = query.where(
-                    DagRun.partition_date
-                    < datetime.datetime(
-                        next_day.year, next_day.month, next_day.day, tzinfo=datetime.timezone.utc
-                    )
-                )
+        tt_tz = dag.timetable.timezone if isinstance(dag.timetable, CronMixin) else None
+        if args.partition_date_start is not None:
+            lower = _compute_day_bound(args.partition_date_start.date(), tt_tz)
+            query = query.where(DagRun.partition_date >= lower)
+        if args.partition_date_end is not None:
+            upper = _compute_day_bound(args.partition_date_end.date() + datetime.timedelta(days=1), tt_tz)
+            query = query.where(DagRun.partition_date < upper)
     query = query.order_by(DagRun.partition_date, DagRun.run_id)
 
     runs = list(session.execute(query).all())

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -134,6 +134,13 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
     --partition-date-start is the inclusive start local calendar day;
     --partition-date-end is the inclusive end local calendar day (any
     time-of-day component in either value is ignored).
+
+    Each bound is parsed by ``parsedate``:
+    naive input is read in the configured default timezone (UTC unless
+    overridden), and tz-aware input is normalized to UTC before ``.date()``
+    extracts the calendar day -- no re-projection to the timetable timezone
+    occurs. To avoid an off-by-one-day shift, supply a naive date
+    (e.g. ``2026-02-19``) or a value already expressed in UTC.
     """
     has_range = args.partition_date_start is not None or args.partition_date_end is not None
     selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])

--- a/airflow-core/src/airflow/timetables/_cron.py
+++ b/airflow-core/src/airflow/timetables/_cron.py
@@ -143,14 +143,13 @@ class CronMixin:
         except (CroniterBadCronError, CroniterBadDateError) as e:
             raise AirflowTimetableInvalid(str(e))
 
-    def get_partition_day_bound(self, day: datetime.date) -> DateTime:
+    def resolve_day_bound(self, day: datetime.date) -> DateTime:
         """
         Return the UTC instant of *day*'s local midnight in this timetable's timezone.
 
-        Overrides the base default (midnight UTC) so that partition-date range
-        comparisons for :class:`~airflow.timetables._cron.CronMixin`-based
-        timetables are evaluated in the timetable's local timezone rather than at
-        the raw UTC midnight instant.
+        Overrides the base default (midnight UTC) so day-bound comparisons are
+        evaluated in the timetable's local timezone rather than at the raw UTC
+        instant.
         """
         return convert_to_utc(make_aware(datetime.datetime(day.year, day.month, day.day), self._timezone))
 

--- a/airflow-core/src/airflow/timetables/_cron.py
+++ b/airflow-core/src/airflow/timetables/_cron.py
@@ -147,6 +147,17 @@ class CronMixin:
         except (CroniterBadCronError, CroniterBadDateError) as e:
             raise AirflowTimetableInvalid(str(e))
 
+    def get_partition_day_bound(self, day: datetime.date) -> DateTime:
+        """
+        Return the UTC instant of *day*'s local midnight in this timetable's timezone.
+
+        Overrides the base default (midnight UTC) so that partition-date range
+        comparisons for :class:`~airflow.timetables._cron.CronMixin`-based
+        timetables are evaluated in the timetable's local timezone rather than at
+        the raw UTC midnight instant.
+        """
+        return convert_to_utc(make_aware(datetime.datetime(day.year, day.month, day.day), self._timezone))
+
     def _get_next(self, current: DateTime) -> DateTime:
         """Get the first schedule after specified time, with DST fixed."""
         naive = make_naive(current, self._timezone)

--- a/airflow-core/src/airflow/timetables/_cron.py
+++ b/airflow-core/src/airflow/timetables/_cron.py
@@ -137,10 +137,6 @@ class CronMixin:
     def summary(self) -> str:
         return self._expression
 
-    @property
-    def timezone(self) -> Timezone | FixedTimezone:
-        return self._timezone
-
     def validate(self) -> None:
         try:
             croniter(self._expression)

--- a/airflow-core/src/airflow/timetables/_cron.py
+++ b/airflow-core/src/airflow/timetables/_cron.py
@@ -137,6 +137,10 @@ class CronMixin:
     def summary(self) -> str:
         return self._expression
 
+    @property
+    def timezone(self) -> Timezone | FixedTimezone:
+        return self._timezone
+
     def validate(self) -> None:
         try:
             croniter(self._expression)

--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, TypedDict, runtime_checkable
 
 from typing_extensions import NotRequired
@@ -256,6 +257,22 @@ class Timetable(Protocol):
             f"partition mapper (asset name={name!r}, uri={uri!r})."
         )
         raise NotImplementedError(msg)
+
+    def get_partition_day_bound(self, day: datetime.date) -> DateTime:
+        """
+        Return the UTC instant of *day*'s midnight boundary.
+
+        Partition dates are midnight-anchored UTC calendar days by default.
+        Callers pass *day* for the inclusive lower bound and
+        ``day + timedelta(days=1)`` for the half-open upper bound.
+
+        Timetables with a local timezone (e.g. :class:`~airflow.timetables._cron.CronMixin`
+        subclasses) override this to return local-midnight converted to UTC so
+        that partition-date comparisons are done in the timetable's timezone.
+        """
+        return timezone.coerce_datetime(
+            datetime.datetime(day.year, day.month, day.day, tzinfo=datetime.timezone.utc)
+        )
 
     @property
     def partition_mapper_info(self) -> list[PartitionMapperInfo]:

--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -258,17 +258,16 @@ class Timetable(Protocol):
         )
         raise NotImplementedError(msg)
 
-    def get_partition_day_bound(self, day: datetime.date) -> DateTime:
+    def resolve_day_bound(self, day: datetime.date) -> DateTime:
         """
-        Return the UTC instant of *day*'s midnight boundary.
+        Return the UTC instant of *day*'s start (midnight).
 
-        Partition dates are midnight-anchored UTC calendar days by default.
-        Callers pass *day* for the inclusive lower bound and
-        ``day + timedelta(days=1)`` for the half-open upper bound.
-
-        Timetables with a local timezone (e.g. :class:`~airflow.timetables._cron.CronMixin`
-        subclasses) override this to return local-midnight converted to UTC so
-        that partition-date comparisons are done in the timetable's timezone.
+        By default a calendar day starts at midnight UTC. Timetables with a local
+        timezone (e.g. :class:`~airflow.timetables._cron.CronMixin` subclasses)
+        override this to anchor at local midnight in their timezone, converted to
+        UTC. Callers pass *day* for an inclusive lower bound and
+        ``day + timedelta(days=1)`` for a half-open upper bound (e.g. ``dag_clear``
+        uses it to bound ``partition_date`` queries).
         """
         return timezone.coerce_datetime(
             datetime.datetime(day.year, day.month, day.day, tzinfo=datetime.timezone.utc)

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -1882,7 +1882,7 @@ class TestCliDagsClear:
         """PartitionedAssetTimetable uses the base default; day-granular UTC bounds are correct.
 
         PartitionedAssetTimetable has no local timezone, so
-        get_partition_day_bound returns midnight UTC for each calendar day.
+        resolve_day_bound returns midnight UTC for each calendar day.
         The full window 2026-04-10 to 2026-04-14 (inclusive) should clear the
         at-boundary and within-window runs; 2026-04-15 and partition_date=None
         must not be touched.

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -48,6 +48,7 @@ from airflow.sdk import DAG, Asset, BaseOperator, CronPartitionTimetable, Partit
 from airflow.sdk.definitions.dag import _run_inline_trigger
 from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
+from airflow.timetables.base import Timetable
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.cli import get_db_dag
 from airflow.utils.session import create_session
@@ -1200,6 +1201,15 @@ class TestCliDagsReserialize:
         assert dag_processor_parsing_result.serialized_dags[0].hash == serialized_dag_hash[0]
 
 
+class _NoTzTimetable(Timetable):
+    """Stub timetable: partitioned=True but no timezone attribute.
+
+    Used by tests that exercise the no-tz fallback branch in dag_clear.
+    """
+
+    partitioned = True
+
+
 class TestCliDagsClear:
     """Tests for the `airflow dags clear` partition-range subcommand."""
 
@@ -1521,27 +1531,31 @@ class TestCliDagsClear:
             serialized=True,
         ):
             EmptyOperator(task_id="t1")
-        dag_maker.create_dagrun(
-            run_id="taipei_2026_02_18",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 2, 17, 16, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-02-18T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="taipei_2026_02_19",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 2, 18, 16, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-02-19T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="taipei_2026_02_20",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 2, 19, 16, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-02-20T00:00:00",
-        )
+        runs = [
+            (
+                "taipei_2026_02_18",
+                datetime(2026, 2, 17, 16, 0, 0, tzinfo=pendulum.UTC),
+                "2026-02-18T00:00:00",
+            ),
+            (
+                "taipei_2026_02_19",
+                datetime(2026, 2, 18, 16, 0, 0, tzinfo=pendulum.UTC),
+                "2026-02-19T00:00:00",
+            ),
+            (
+                "taipei_2026_02_20",
+                datetime(2026, 2, 19, 16, 0, 0, tzinfo=pendulum.UTC),
+                "2026-02-20T00:00:00",
+            ),
+        ]
+        for run_id, partition_date, partition_key in runs:
+            dag_maker.create_dagrun(
+                run_id=run_id,
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=partition_date,
+                partition_key=partition_key,
+            )
         dag_maker.sync_dagbag_to_db()
 
     @pytest.mark.usefixtures("seeded_taipei_runs")
@@ -1648,27 +1662,19 @@ class TestCliDagsClear:
             serialized=True,
         ):
             EmptyOperator(task_id="t1")
-        dag_maker.create_dagrun(
-            run_id="ny_2026_02_18",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 2, 18, 5, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-02-18T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="ny_2026_02_19",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 2, 19, 5, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-02-19T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="ny_2026_02_20",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 2, 20, 5, 0, 0, tzinfo=pendulum.UTC),
-            partition_key="2026-02-20T00:00:00",
-        )
+        runs = [
+            ("ny_2026_02_18", datetime(2026, 2, 18, 5, 0, 0, tzinfo=pendulum.UTC), "2026-02-18T00:00:00"),
+            ("ny_2026_02_19", datetime(2026, 2, 19, 5, 0, 0, tzinfo=pendulum.UTC), "2026-02-19T00:00:00"),
+            ("ny_2026_02_20", datetime(2026, 2, 20, 5, 0, 0, tzinfo=pendulum.UTC), "2026-02-20T00:00:00"),
+        ]
+        for run_id, partition_date, partition_key in runs:
+            dag_maker.create_dagrun(
+                run_id=run_id,
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=partition_date,
+                partition_key=partition_key,
+            )
         dag_maker.sync_dagbag_to_db()
 
     @pytest.mark.usefixtures("seeded_ny_runs")
@@ -1700,10 +1706,6 @@ class TestCliDagsClear:
         # local 2026-02-20 is outside the half-open upper bound.
         assert states["ny_2026_02_20"] == DagRunState.SUCCESS
 
-    # ------------------------------------------------------------------
-    # No-tz fallback: partitioned=True but timetable has no timezone attr
-    # ------------------------------------------------------------------
-
     @pytest.fixture
     def seeded_no_tz_runs(self, dag_maker):
         """Seed runs with UTC midnight partition_dates for the no-tz fallback path.
@@ -1725,20 +1727,18 @@ class TestCliDagsClear:
             serialized=True,
         ):
             EmptyOperator(task_id="t1")
-        dag_maker.create_dagrun(
-            run_id="no_tz_2026_03_08",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 3, 8, tzinfo=pendulum.UTC),
-            partition_key="2026-03-08T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="no_tz_2026_03_09",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 3, 9, tzinfo=pendulum.UTC),
-            partition_key="2026-03-09T00:00:00",
-        )
+        runs = [
+            ("no_tz_2026_03_08", datetime(2026, 3, 8, tzinfo=pendulum.UTC), "2026-03-08T00:00:00"),
+            ("no_tz_2026_03_09", datetime(2026, 3, 9, tzinfo=pendulum.UTC), "2026-03-09T00:00:00"),
+        ]
+        for run_id, partition_date, partition_key in runs:
+            dag_maker.create_dagrun(
+                run_id=run_id,
+                state=DagRunState.SUCCESS,
+                logical_date=None,
+                partition_date=partition_date,
+                partition_key=partition_key,
+            )
         dag_maker.sync_dagbag_to_db()
 
     @pytest.mark.usefixtures("seeded_no_tz_runs")
@@ -1750,10 +1750,6 @@ class TestCliDagsClear:
         run (so it is included).  Without truncation the raw-instant comparison
         would be 2026-03-08T12:00Z > 2026-03-08T00:00Z and the run would be missed.
         """
-        from airflow.timetables.base import Timetable
-
-        class _NoTzTimetable(Timetable):
-            partitioned = True
 
         def _patched(*, bundle_names, dag_id):
             dag = get_db_dag(bundle_names=bundle_names, dag_id=dag_id)
@@ -1789,10 +1785,6 @@ class TestCliDagsClear:
         partition_date < 2026-03-09T00Z (included).  The 2026-03-09T00Z run
         does NOT satisfy partition_date < 2026-03-09T00Z (excluded).
         """
-        from airflow.timetables.base import Timetable
-
-        class _NoTzTimetable(Timetable):
-            partitioned = True
 
         def _patched(*, bundle_names, dag_id):
             dag = get_db_dag(bundle_names=bundle_names, dag_id=dag_id)
@@ -1819,10 +1811,6 @@ class TestCliDagsClear:
         # 2026-03-09T00Z is NOT < 2026-03-09T00Z → excluded.
         assert states["no_tz_2026_03_09"] == DagRunState.SUCCESS
 
-    # ------------------------------------------------------------------
-    # PartitionedAssetTimetable: partitioned=True, not CronMixin → no-tz path
-    # ------------------------------------------------------------------
-
     @pytest.fixture
     def seeded_asset_partitioned_runs(self, dag_maker):
         """Seed DagRuns for a PartitionedAssetTimetable Dag.
@@ -1847,34 +1835,40 @@ class TestCliDagsClear:
             serialized=True,
         ):
             EmptyOperator(task_id="t1")
-        dag_maker.create_dagrun(
-            run_id="asset_2026_04_10",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 4, 10, tzinfo=pendulum.UTC),
-            partition_key="2026-04-10T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="asset_2026_04_12",
-            state=DagRunState.FAILED,
-            logical_date=None,
-            partition_date=datetime(2026, 4, 12, tzinfo=pendulum.UTC),
-            partition_key="2026-04-12T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="asset_2026_04_14",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 4, 14, tzinfo=pendulum.UTC),
-            partition_key="2026-04-14T00:00:00",
-        )
-        dag_maker.create_dagrun(
-            run_id="asset_2026_04_15",
-            state=DagRunState.SUCCESS,
-            logical_date=None,
-            partition_date=datetime(2026, 4, 15, tzinfo=pendulum.UTC),
-            partition_key="2026-04-15T00:00:00",
-        )
+        runs = [
+            (
+                "asset_2026_04_10",
+                DagRunState.SUCCESS,
+                datetime(2026, 4, 10, tzinfo=pendulum.UTC),
+                "2026-04-10T00:00:00",
+            ),
+            (
+                "asset_2026_04_12",
+                DagRunState.FAILED,
+                datetime(2026, 4, 12, tzinfo=pendulum.UTC),
+                "2026-04-12T00:00:00",
+            ),
+            (
+                "asset_2026_04_14",
+                DagRunState.SUCCESS,
+                datetime(2026, 4, 14, tzinfo=pendulum.UTC),
+                "2026-04-14T00:00:00",
+            ),
+            (
+                "asset_2026_04_15",
+                DagRunState.SUCCESS,
+                datetime(2026, 4, 15, tzinfo=pendulum.UTC),
+                "2026-04-15T00:00:00",
+            ),
+        ]
+        for run_id, state, partition_date, partition_key in runs:
+            dag_maker.create_dagrun(
+                run_id=run_id,
+                state=state,
+                logical_date=None,
+                partition_date=partition_date,
+                partition_key=partition_key,
+            )
         dag_maker.create_dagrun(
             run_id="asset_non_part",
             state=DagRunState.SUCCESS,

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -1745,17 +1745,15 @@ class TestCliDagsClear:
     def test_no_tz_lower_bound_truncates_time_of_day(self, parser, monkeypatch):
         """--partition-date-start with a non-midnight time-of-day must still match the day.
 
-        With no timetable timezone the else-branch truncates the CLI value to
-        date() and compares against UTC midnight.  A start of 2026-03-08T12:00:00
-        truncates to 2026-03-08, giving lower = 2026-03-08T00:00Z, which is <=
-        the stored 2026-03-08T00:00Z run (so it is included).  Without truncation
-        the raw-instant comparison would be 2026-03-08T12:00Z > 2026-03-08T00:00Z
-        and the run would be missed.
+        A start of 2026-03-08T12:00:00 truncates to 2026-03-08 via .date(),
+        giving lower = 2026-03-08T00:00Z, which is <= the stored 2026-03-08T00:00Z
+        run (so it is included).  Without truncation the raw-instant comparison
+        would be 2026-03-08T12:00Z > 2026-03-08T00:00Z and the run would be missed.
         """
+        from airflow.timetables.base import Timetable
 
-        class _NoTzTimetable:
+        class _NoTzTimetable(Timetable):
             partitioned = True
-            # no timezone attribute — triggers the no-tz else-branch
 
         def _patched(*, bundle_names, dag_id):
             dag = get_db_dag(bundle_names=bundle_names, dag_id=dag_id)
@@ -1791,10 +1789,10 @@ class TestCliDagsClear:
         partition_date < 2026-03-09T00Z (included).  The 2026-03-09T00Z run
         does NOT satisfy partition_date < 2026-03-09T00Z (excluded).
         """
+        from airflow.timetables.base import Timetable
 
-        class _NoTzTimetable:
+        class _NoTzTimetable(Timetable):
             partitioned = True
-            # no timezone attribute — triggers the no-tz else-branch
 
         def _patched(*, bundle_names, dag_id):
             dag = get_db_dag(bundle_names=bundle_names, dag_id=dag_id)
@@ -1887,11 +1885,11 @@ class TestCliDagsClear:
 
     @pytest.mark.usefixtures("seeded_asset_partitioned_runs")
     def test_asset_timetable_clears_window_inclusive(self, parser):
-        """PartitionedAssetTimetable uses the no-tz path; day-granular UTC bounds are correct.
+        """PartitionedAssetTimetable uses the base default; day-granular UTC bounds are correct.
 
-        isinstance(dag.timetable, CronMixin) is False, so tt_tz=None and
-        _compute_day_bound returns midnight UTC for each calendar day.  The
-        full window 2026-04-10 to 2026-04-14 (inclusive) should clear the
+        PartitionedAssetTimetable has no local timezone, so
+        get_partition_day_bound returns midnight UTC for each calendar day.
+        The full window 2026-04-10 to 2026-04-14 (inclusive) should clear the
         at-boundary and within-window runs; 2026-04-15 and partition_date=None
         must not be touched.
         """

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -44,7 +44,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
-from airflow.sdk import DAG, BaseOperator, CronPartitionTimetable, task
+from airflow.sdk import DAG, Asset, BaseOperator, CronPartitionTimetable, PartitionedAssetTimetable, task
 from airflow.sdk.definitions.dag import _run_inline_trigger
 from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
@@ -1820,6 +1820,157 @@ class TestCliDagsClear:
         assert states["no_tz_2026_03_08"] == DagRunState.QUEUED
         # 2026-03-09T00Z is NOT < 2026-03-09T00Z → excluded.
         assert states["no_tz_2026_03_09"] == DagRunState.SUCCESS
+
+    # ------------------------------------------------------------------
+    # PartitionedAssetTimetable: partitioned=True, not CronMixin → no-tz path
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    def seeded_asset_partitioned_runs(self, dag_maker):
+        """Seed DagRuns for a PartitionedAssetTimetable Dag.
+
+        PartitionedAssetTimetable has partitioned=True but is NOT a CronMixin
+        subclass, so isinstance(dag.timetable, CronMixin) is False and
+        tt_tz=None.  partition_date values are plain UTC midnights (just like
+        the no-tz fallback path).
+
+        Runs:
+          asset_2026_04_10 → partition_date = 2026-04-10T00:00:00Z  (at lower boundary)
+          asset_2026_04_12 → partition_date = 2026-04-12T00:00:00Z  (within window)
+          asset_2026_04_14 → partition_date = 2026-04-14T00:00:00Z  (at upper boundary)
+          asset_2026_04_15 → partition_date = 2026-04-15T00:00:00Z  (just outside upper boundary)
+          asset_non_part   → partition_date = None                   (never cleared)
+        """
+        with dag_maker(
+            self.DAG_ID,
+            schedule=PartitionedAssetTimetable(assets=Asset("test_asset_for_clear")),
+            start_date=datetime(2026, 4, 1, tzinfo=pendulum.UTC),
+            catchup=False,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        dag_maker.create_dagrun(
+            run_id="asset_2026_04_10",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 4, 10, tzinfo=pendulum.UTC),
+            partition_key="2026-04-10T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="asset_2026_04_12",
+            state=DagRunState.FAILED,
+            logical_date=None,
+            partition_date=datetime(2026, 4, 12, tzinfo=pendulum.UTC),
+            partition_key="2026-04-12T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="asset_2026_04_14",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 4, 14, tzinfo=pendulum.UTC),
+            partition_key="2026-04-14T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="asset_2026_04_15",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 4, 15, tzinfo=pendulum.UTC),
+            partition_key="2026-04-15T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="asset_non_part",
+            state=DagRunState.SUCCESS,
+            logical_date=datetime(2026, 4, 11, tzinfo=pendulum.UTC),
+            partition_date=None,
+        )
+        dag_maker.sync_dagbag_to_db()
+
+    @pytest.mark.usefixtures("seeded_asset_partitioned_runs")
+    def test_asset_timetable_clears_window_inclusive(self, parser):
+        """PartitionedAssetTimetable uses the no-tz path; day-granular UTC bounds are correct.
+
+        isinstance(dag.timetable, CronMixin) is False, so tt_tz=None and
+        _compute_day_bound returns midnight UTC for each calendar day.  The
+        full window 2026-04-10 to 2026-04-14 (inclusive) should clear the
+        at-boundary and within-window runs; 2026-04-15 and partition_date=None
+        must not be touched.
+        """
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-04-10",
+                "--partition-date-end",
+                "2026-04-14",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        assert states == {
+            "asset_2026_04_10": DagRunState.QUEUED,
+            "asset_2026_04_12": DagRunState.QUEUED,
+            "asset_2026_04_14": DagRunState.QUEUED,
+            # Outside the half-open upper bound — must NOT be cleared.
+            "asset_2026_04_15": DagRunState.SUCCESS,
+            # NULL partition_date is never matched by the date-range filter.
+            "asset_non_part": DagRunState.SUCCESS,
+        }
+
+    @pytest.mark.usefixtures("seeded_asset_partitioned_runs")
+    def test_asset_timetable_upper_bound_at_cap(self, parser):
+        """--partition-date-end 2026-04-14 must include the run at exactly that UTC midnight (at-cap)."""
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-end",
+                "2026-04-14",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # All runs on or before 2026-04-14 UTC midnight must be cleared.
+        assert states["asset_2026_04_10"] == DagRunState.QUEUED
+        assert states["asset_2026_04_12"] == DagRunState.QUEUED
+        assert states["asset_2026_04_14"] == DagRunState.QUEUED
+        # 2026-04-15 is outside the half-open upper bound.
+        assert states["asset_2026_04_15"] == DagRunState.SUCCESS
+        assert states["asset_non_part"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_asset_partitioned_runs")
+    def test_asset_timetable_upper_bound_over_cap(self, parser):
+        """--partition-date-end 2026-04-13 must NOT include the 2026-04-14 run (over-cap).
+
+        Half-open upper bound: end=2026-04-13 → upper = 2026-04-14T00:00Z.
+        The run stored at 2026-04-14T00:00Z satisfies partition_date < 2026-04-14T00:00Z
+        as False, so it is excluded.
+        """
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-end",
+                "2026-04-13",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        assert states["asset_2026_04_10"] == DagRunState.QUEUED
+        assert states["asset_2026_04_12"] == DagRunState.QUEUED
+        # 2026-04-14 is exactly at the half-open boundary — must NOT be cleared.
+        assert states["asset_2026_04_14"] == DagRunState.SUCCESS
+        assert states["asset_2026_04_15"] == DagRunState.SUCCESS
+        assert states["asset_non_part"] == DagRunState.SUCCESS
 
 
 class TestDagDetailsIsBackfillable:

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -49,6 +49,7 @@ from airflow.sdk.definitions.dag import _run_inline_trigger
 from airflow.sdk.execution_time.comms import _RequestFrame, _ResponseFrame
 from airflow.serialization.serialized_objects import DagSerialization, LazyDeserializedDAG
 from airflow.triggers.base import TriggerEvent
+from airflow.utils.cli import get_db_dag
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -1499,6 +1500,326 @@ class TestCliDagsClear:
         )
         with pytest.raises(AirflowException, match="could not be found in the database"):
             dag_command.dag_clear(args)
+
+    @pytest.fixture
+    def seeded_taipei_runs(self, dag_maker):
+        """Seed DagRuns for a Asia/Taipei (UTC+8) CronPartitionTimetable.
+
+        Local midnight in Taipei is stored as UTC-8h in partition_date.
+        Written as explicit UTC instants so the oracle is independent of the
+        timetable under test:
+
+          local 2026-02-18 midnight  → datetime(2026, 2, 17, 16, 0, 0, UTC)
+          local 2026-02-19 midnight  → datetime(2026, 2, 18, 16, 0, 0, UTC)
+          local 2026-02-20 midnight  → datetime(2026, 2, 19, 16, 0, 0, UTC)  (outside window)
+        """
+        with dag_maker(
+            self.DAG_ID,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone="Asia/Taipei"),
+            start_date=datetime(2026, 2, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        dag_maker.create_dagrun(
+            run_id="taipei_2026_02_18",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 2, 17, 16, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-02-18T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="taipei_2026_02_19",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 2, 18, 16, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-02-19T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="taipei_2026_02_20",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 2, 19, 16, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-02-20T00:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+    @pytest.mark.usefixtures("seeded_taipei_runs")
+    def test_taipei_lower_bound_selects_correct_partition(self, parser):
+        """--partition-date-start 2026-02-19 must match the run stored at 2026-02-18T16Z.
+
+        Without the timezone fix, parsedate("2026-02-19") yields 2026-02-19T00:00:00Z
+        under the UTC default timezone.  The old filter compares
+        partition_date >= 2026-02-19T00:00Z; the run for the local 2026-02-19 partition
+        is stored as 2026-02-18T16:00Z, which is *before* that UTC boundary, so the run
+        is NOT selected and the requested boundary day is silently missed.  Converting
+        the bound through the timetable timezone fixes the off-by-one: the run whose
+        partition_date is the UTC representation of Taipei 2026-02-19 midnight is
+        selected, the earlier run is not.
+        """
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-02-19",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # 2026-02-19 local midnight stored as 2026-02-18T16Z — must be cleared.
+        assert states["taipei_2026_02_19"] == DagRunState.QUEUED
+        # 2026-02-20 local midnight stored as 2026-02-19T16Z — also in window (no upper bound).
+        assert states["taipei_2026_02_20"] == DagRunState.QUEUED
+        # 2026-02-18 local midnight stored as 2026-02-17T16Z — before the start, must NOT be cleared.
+        assert states["taipei_2026_02_18"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_taipei_runs")
+    def test_taipei_upper_bound_at_cap(self, parser):
+        """--partition-date-end 2026-02-19 must include the run stored at 2026-02-18T16Z (at-cap)."""
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-end",
+                "2026-02-19",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # Both 2026-02-18 and 2026-02-19 local dates are within the window.
+        assert states["taipei_2026_02_18"] == DagRunState.QUEUED
+        assert states["taipei_2026_02_19"] == DagRunState.QUEUED
+        # 2026-02-20 is outside the half-open upper bound — must NOT be cleared.
+        assert states["taipei_2026_02_20"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_taipei_runs")
+    def test_taipei_upper_bound_over_cap(self, parser):
+        """--partition-date-end 2026-02-18 must NOT include the run stored at 2026-02-18T16Z (over-cap).
+
+        The half-open upper bound is strictly less than 2026-02-19 midnight in
+        Taipei (= 2026-02-18T16Z), so the run for local 2026-02-19 falls outside
+        the window.
+        """
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-end",
+                "2026-02-18",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # Only the 2026-02-18 local date run is within the window.
+        assert states["taipei_2026_02_18"] == DagRunState.QUEUED
+        # 2026-02-19 and 2026-02-20 are outside — must NOT be cleared.
+        assert states["taipei_2026_02_19"] == DagRunState.SUCCESS
+        assert states["taipei_2026_02_20"] == DagRunState.SUCCESS
+
+    @pytest.fixture
+    def seeded_ny_runs(self, dag_maker):
+        """Seed DagRuns for an America/New_York (UTC-5, EST in February) CronPartitionTimetable.
+
+        Local midnight in New York is stored as UTC+5h in partition_date, so for a
+        west-of-UTC timetable the pre-fix off-by-one lands on the *upper* bound (the
+        end day's run sits later in the UTC day than the user-typed boundary) rather
+        than the lower bound exercised by the Asia/Taipei cases.  Explicit UTC instants
+        keep the oracle independent of the timetable under test:
+
+          local 2026-02-18 midnight  → datetime(2026, 2, 18, 5, 0, 0, UTC)
+          local 2026-02-19 midnight  → datetime(2026, 2, 19, 5, 0, 0, UTC)
+          local 2026-02-20 midnight  → datetime(2026, 2, 20, 5, 0, 0, UTC)  (outside window)
+        """
+        with dag_maker(
+            self.DAG_ID,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone="America/New_York"),
+            start_date=datetime(2026, 2, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        dag_maker.create_dagrun(
+            run_id="ny_2026_02_18",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 2, 18, 5, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-02-18T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="ny_2026_02_19",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 2, 19, 5, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-02-19T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="ny_2026_02_20",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 2, 20, 5, 0, 0, tzinfo=pendulum.UTC),
+            partition_key="2026-02-20T00:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+    @pytest.mark.usefixtures("seeded_ny_runs")
+    def test_ny_upper_bound_includes_end_day(self, parser):
+        """--partition-date-end 2026-02-19 must include the local 2026-02-19 run (stored 2026-02-19T05Z).
+
+        parsedate("2026-02-19") yields 2026-02-19T00:00Z, so the pre-fix filter compares
+        partition_date <= 2026-02-19T00:00Z.  The local 2026-02-19 run is stored at
+        2026-02-19T05:00Z, which is *after* that UTC boundary, so the old code wrongly
+        drops the requested end day.  The timezone-aware half-open bound includes it.
+        """
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-end",
+                "2026-02-19",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # local 2026-02-18 and 2026-02-19 are within the window (no lower bound).
+        assert states["ny_2026_02_18"] == DagRunState.QUEUED
+        # The end-day run: dropped by the pre-fix code, included after the fix.
+        assert states["ny_2026_02_19"] == DagRunState.QUEUED
+        # local 2026-02-20 is outside the half-open upper bound.
+        assert states["ny_2026_02_20"] == DagRunState.SUCCESS
+
+    # ------------------------------------------------------------------
+    # No-tz fallback: partitioned=True but timetable has no timezone attr
+    # ------------------------------------------------------------------
+
+    @pytest.fixture
+    def seeded_no_tz_runs(self, dag_maker):
+        """Seed runs with UTC midnight partition_dates for the no-tz fallback path.
+
+        The Dag is created with CronPartitionTimetable(timezone=UTC) so that
+        serialization works normally.  The tests monkeypatch get_db_dag to swap
+        the timetable for a stub that has partitioned=True but no timezone
+        attribute, forcing the else-branch in dag_clear.
+
+        Stored partition_dates are plain UTC midnights:
+          2026-03-08 → datetime(2026, 3, 8, 0, 0, 0, UTC)
+          2026-03-09 → datetime(2026, 3, 9, 0, 0, 0, UTC)
+        """
+        with dag_maker(
+            self.DAG_ID,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2026, 3, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        dag_maker.create_dagrun(
+            run_id="no_tz_2026_03_08",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 3, 8, tzinfo=pendulum.UTC),
+            partition_key="2026-03-08T00:00:00",
+        )
+        dag_maker.create_dagrun(
+            run_id="no_tz_2026_03_09",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 3, 9, tzinfo=pendulum.UTC),
+            partition_key="2026-03-09T00:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+    @pytest.mark.usefixtures("seeded_no_tz_runs")
+    def test_no_tz_lower_bound_truncates_time_of_day(self, parser, monkeypatch):
+        """--partition-date-start with a non-midnight time-of-day must still match the day.
+
+        With no timetable timezone the else-branch truncates the CLI value to
+        date() and compares against UTC midnight.  A start of 2026-03-08T12:00:00
+        truncates to 2026-03-08, giving lower = 2026-03-08T00:00Z, which is <=
+        the stored 2026-03-08T00:00Z run (so it is included).  Without truncation
+        the raw-instant comparison would be 2026-03-08T12:00Z > 2026-03-08T00:00Z
+        and the run would be missed.
+        """
+
+        class _NoTzTimetable:
+            partitioned = True
+            # no timezone attribute — triggers the no-tz else-branch
+
+        def _patched(*, bundle_names, dag_id):
+            dag = get_db_dag(bundle_names=bundle_names, dag_id=dag_id)
+            dag.timetable = _NoTzTimetable()
+            return dag
+
+        monkeypatch.setattr(dag_command, "get_db_dag", _patched)
+
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-03-08T12:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # 2026-03-08T12 truncates to 2026-03-08 → lower = 2026-03-08T00Z; run is included.
+        assert states["no_tz_2026_03_08"] == DagRunState.QUEUED
+        # 2026-03-09 is also >= 2026-03-08T00Z (no upper bound).
+        assert states["no_tz_2026_03_09"] == DagRunState.QUEUED
+
+    @pytest.mark.usefixtures("seeded_no_tz_runs")
+    def test_no_tz_upper_bound_is_half_open(self, parser, monkeypatch):
+        """--partition-date-end 2026-03-08T00:00:00 must include 2026-03-08 and exclude 2026-03-09.
+
+        The end date truncates to 2026-03-08; next_day = 2026-03-09, upper =
+        2026-03-09T00:00Z (half-open).  The 2026-03-08T00Z run satisfies
+        partition_date < 2026-03-09T00Z (included).  The 2026-03-09T00Z run
+        does NOT satisfy partition_date < 2026-03-09T00Z (excluded).
+        """
+
+        class _NoTzTimetable:
+            partitioned = True
+            # no timezone attribute — triggers the no-tz else-branch
+
+        def _patched(*, bundle_names, dag_id):
+            dag = get_db_dag(bundle_names=bundle_names, dag_id=dag_id)
+            dag.timetable = _NoTzTimetable()
+            return dag
+
+        monkeypatch.setattr(dag_command, "get_db_dag", _patched)
+
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-end",
+                "2026-03-08T00:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        states = self._get_run_states()
+        # 2026-03-08T00Z < 2026-03-09T00Z (upper, half-open) → included.
+        assert states["no_tz_2026_03_08"] == DagRunState.QUEUED
+        # 2026-03-09T00Z is NOT < 2026-03-09T00Z → excluded.
+        assert states["no_tz_2026_03_09"] == DagRunState.SUCCESS
 
 
 class TestDagDetailsIsBackfillable:

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -183,19 +183,19 @@ def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
     assert expected_key in fp
 
 
-def test_base_get_partition_day_bound_returns_midnight_utc():
+def test_base_resolve_day_bound_returns_midnight_utc():
     """Base default returns midnight UTC as a pendulum DateTime for any calendar day."""
     tt = NullTimetable()
-    result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
+    result = tt.resolve_day_bound(datetime.date(2026, 4, 10))
 
     expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
     assert result == expected
     assert result.timezone_name == "UTC"
 
 
-def test_base_get_partition_day_bound_is_pendulum_datetime():
+def test_base_resolve_day_bound_is_pendulum_datetime():
     """Return value from the base default is a pendulum DateTime, not stdlib datetime."""
     tt = NullTimetable()
-    result = tt.get_partition_day_bound(datetime.date(2026, 1, 1))
+    result = tt.resolve_day_bound(datetime.date(2026, 1, 1))
 
     assert isinstance(result, pendulum.DateTime)

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -16,6 +16,9 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
+
+import pendulum
 import pytest
 
 from airflow._shared.module_loading import qualname
@@ -177,3 +180,30 @@ def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
     )
     fp = compute_rollup_fingerprint(tt)
     assert expected_key in fp
+
+
+# ---------------------------------------------------------------------------
+# get_partition_day_bound — base default
+# ---------------------------------------------------------------------------
+
+
+def test_base_get_partition_day_bound_returns_midnight_utc():
+    """Base default returns midnight UTC as a pendulum DateTime for any calendar day."""
+    from airflow.timetables.simple import NullTimetable
+
+    tt = NullTimetable()
+    result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
+
+    expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
+    assert result == expected
+    assert result.timezone_name == "UTC"
+
+
+def test_base_get_partition_day_bound_is_pendulum_datetime():
+    """Return value from the base default is a pendulum DateTime, not stdlib datetime."""
+    from airflow.timetables.simple import NullTimetable
+
+    tt = NullTimetable()
+    result = tt.get_partition_day_bound(datetime.date(2026, 1, 1))
+
+    assert isinstance(result, pendulum.DateTime)

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -22,6 +22,7 @@ import pendulum
 import pytest
 
 from airflow._shared.module_loading import qualname
+from airflow.timetables.simple import NullTimetable
 
 
 def test_builtin_timetable_type_name_returns_class_name():
@@ -182,15 +183,8 @@ def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
     assert expected_key in fp
 
 
-# ---------------------------------------------------------------------------
-# get_partition_day_bound — base default
-# ---------------------------------------------------------------------------
-
-
 def test_base_get_partition_day_bound_returns_midnight_utc():
     """Base default returns midnight UTC as a pendulum DateTime for any calendar day."""
-    from airflow.timetables.simple import NullTimetable
-
     tt = NullTimetable()
     result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
 
@@ -201,8 +195,6 @@ def test_base_get_partition_day_bound_returns_midnight_utc():
 
 def test_base_get_partition_day_bound_is_pendulum_datetime():
     """Return value from the base default is a pendulum DateTime, not stdlib datetime."""
-    from airflow.timetables.simple import NullTimetable
-
     tt = NullTimetable()
     result = tt.get_partition_day_bound(datetime.date(2026, 1, 1))
 

--- a/airflow-core/tests/unit/timetables/test_cron_mixin.py
+++ b/airflow-core/tests/unit/timetables/test_cron_mixin.py
@@ -45,11 +45,6 @@ def test_dom_and_dow_conflict():
     assert "Every minute, only on Monday" in desc
 
 
-# ---------------------------------------------------------------------------
-# get_partition_day_bound — CronMixin override
-# ---------------------------------------------------------------------------
-
-
 def test_cron_mixin_get_partition_day_bound_utc_tz():
     """UTC timetable: local midnight equals UTC midnight."""
     cm = CronMixin("0 0 * * *", "UTC")

--- a/airflow-core/tests/unit/timetables/test_cron_mixin.py
+++ b/airflow-core/tests/unit/timetables/test_cron_mixin.py
@@ -16,6 +16,10 @@
 # under the License.
 from __future__ import annotations
 
+import datetime
+
+import pendulum
+
 from airflow.timetables._cron import CronMixin
 
 SAMPLE_TZ = "UTC"
@@ -39,3 +43,34 @@ def test_dom_and_dow_conflict():
     assert "(or)" in desc
     assert "Every minute, on day 1 of the month" in desc
     assert "Every minute, only on Monday" in desc
+
+
+# ---------------------------------------------------------------------------
+# get_partition_day_bound — CronMixin override
+# ---------------------------------------------------------------------------
+
+
+def test_cron_mixin_get_partition_day_bound_utc_tz():
+    """UTC timetable: local midnight equals UTC midnight."""
+    cm = CronMixin("0 0 * * *", "UTC")
+    result = cm.get_partition_day_bound(datetime.date(2026, 4, 10))
+
+    expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
+    assert result == expected
+
+
+def test_cron_mixin_get_partition_day_bound_utc_plus8_crosses_day():
+    """UTC+8 timetable: 2026-02-19 local midnight = 2026-02-18T16:00:00Z."""
+    cm = CronMixin("0 0 * * *", "Asia/Taipei")
+    result = cm.get_partition_day_bound(datetime.date(2026, 2, 19))
+
+    expected = pendulum.datetime(2026, 2, 18, 16, 0, 0, tz="UTC")
+    assert result == expected
+
+
+def test_cron_mixin_get_partition_day_bound_is_pendulum_datetime():
+    """Return value is a pendulum DateTime."""
+    cm = CronMixin("0 0 * * *", "Asia/Taipei")
+    result = cm.get_partition_day_bound(datetime.date(2026, 1, 1))
+
+    assert isinstance(result, pendulum.DateTime)

--- a/airflow-core/tests/unit/timetables/test_cron_mixin.py
+++ b/airflow-core/tests/unit/timetables/test_cron_mixin.py
@@ -45,27 +45,27 @@ def test_dom_and_dow_conflict():
     assert "Every minute, only on Monday" in desc
 
 
-def test_cron_mixin_get_partition_day_bound_utc_tz():
+def test_cron_mixin_resolve_day_bound_utc_tz():
     """UTC timetable: local midnight equals UTC midnight."""
     cm = CronMixin("0 0 * * *", "UTC")
-    result = cm.get_partition_day_bound(datetime.date(2026, 4, 10))
+    result = cm.resolve_day_bound(datetime.date(2026, 4, 10))
 
     expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
     assert result == expected
 
 
-def test_cron_mixin_get_partition_day_bound_utc_plus8_crosses_day():
+def test_cron_mixin_resolve_day_bound_utc_plus8_crosses_day():
     """UTC+8 timetable: 2026-02-19 local midnight = 2026-02-18T16:00:00Z."""
     cm = CronMixin("0 0 * * *", "Asia/Taipei")
-    result = cm.get_partition_day_bound(datetime.date(2026, 2, 19))
+    result = cm.resolve_day_bound(datetime.date(2026, 2, 19))
 
     expected = pendulum.datetime(2026, 2, 18, 16, 0, 0, tz="UTC")
     assert result == expected
 
 
-def test_cron_mixin_get_partition_day_bound_is_pendulum_datetime():
+def test_cron_mixin_resolve_day_bound_is_pendulum_datetime():
     """Return value is a pendulum DateTime."""
     cm = CronMixin("0 0 * * *", "Asia/Taipei")
-    result = cm.get_partition_day_bound(datetime.date(2026, 1, 1))
+    result = cm.resolve_day_bound(datetime.date(2026, 1, 1))
 
     assert isinstance(result, pendulum.DateTime)

--- a/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
@@ -17,11 +17,13 @@
 
 from __future__ import annotations
 
+import datetime
 from collections.abc import Callable, Iterable
 from contextlib import ExitStack
 from typing import TYPE_CHECKING
 from unittest import mock
 
+import pendulum
 import pytest
 
 from airflow._shared.module_loading import qualname
@@ -255,3 +257,29 @@ class TestPartitionedAssetTimetable:
         assert timetable.asset_condition == ser_asset
         assert isinstance(timetable.default_partition_mapper, IdentityMapper)
         assert isinstance(timetable.partition_mapper_config[ser_asset], IdentityMapper)
+
+
+# ---------------------------------------------------------------------------
+# get_partition_day_bound — PartitionedAssetTimetable uses base default
+# ---------------------------------------------------------------------------
+
+
+def test_partitioned_asset_timetable_get_partition_day_bound_returns_midnight_utc():
+    """PartitionedAssetTimetable has no local timezone; get_partition_day_bound uses the base default.
+
+    Non-regression: verifies the timetable walks the base-default code path
+    (midnight UTC) rather than any CronMixin path.
+    """
+    from airflow.partition_mappers.identity import IdentityMapper
+    from airflow.sdk import Asset
+    from airflow.timetables.simple import PartitionedAssetTimetable
+
+    tt = PartitionedAssetTimetable(
+        assets=Asset(name="asset-a"),
+        default_partition_mapper=IdentityMapper(),
+    )
+    result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
+
+    expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
+    assert result == expected
+    assert result.timezone_name == "UTC"

--- a/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
@@ -258,8 +258,8 @@ class TestPartitionedAssetTimetable:
         assert isinstance(timetable.default_partition_mapper, IdentityMapper)
         assert isinstance(timetable.partition_mapper_config[ser_asset], IdentityMapper)
 
-    def test_partitioned_asset_timetable_get_partition_day_bound_returns_midnight_utc(self):
-        """PartitionedAssetTimetable has no local timezone; get_partition_day_bound uses the base default.
+    def test_partitioned_asset_timetable_resolve_day_bound_returns_midnight_utc(self):
+        """PartitionedAssetTimetable has no local timezone; resolve_day_bound uses the base default.
 
         Non-regression: verifies the timetable walks the base-default code path
         (midnight UTC) rather than any CronMixin path.
@@ -268,7 +268,7 @@ class TestPartitionedAssetTimetable:
             assets=Asset(name="asset-a"),
             default_partition_mapper=IdentityMapper(),
         )
-        result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
+        result = tt.resolve_day_bound(datetime.date(2026, 4, 10))
 
         expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
         assert result == expected

--- a/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
@@ -258,28 +258,18 @@ class TestPartitionedAssetTimetable:
         assert isinstance(timetable.default_partition_mapper, IdentityMapper)
         assert isinstance(timetable.partition_mapper_config[ser_asset], IdentityMapper)
 
+    def test_partitioned_asset_timetable_get_partition_day_bound_returns_midnight_utc(self):
+        """PartitionedAssetTimetable has no local timezone; get_partition_day_bound uses the base default.
 
-# ---------------------------------------------------------------------------
-# get_partition_day_bound — PartitionedAssetTimetable uses base default
-# ---------------------------------------------------------------------------
+        Non-regression: verifies the timetable walks the base-default code path
+        (midnight UTC) rather than any CronMixin path.
+        """
+        tt = PartitionedAssetTimetable(
+            assets=Asset(name="asset-a"),
+            default_partition_mapper=IdentityMapper(),
+        )
+        result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
 
-
-def test_partitioned_asset_timetable_get_partition_day_bound_returns_midnight_utc():
-    """PartitionedAssetTimetable has no local timezone; get_partition_day_bound uses the base default.
-
-    Non-regression: verifies the timetable walks the base-default code path
-    (midnight UTC) rather than any CronMixin path.
-    """
-    from airflow.partition_mappers.identity import IdentityMapper
-    from airflow.sdk import Asset
-    from airflow.timetables.simple import PartitionedAssetTimetable
-
-    tt = PartitionedAssetTimetable(
-        assets=Asset(name="asset-a"),
-        default_partition_mapper=IdentityMapper(),
-    )
-    result = tt.get_partition_day_bound(datetime.date(2026, 4, 10))
-
-    expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
-    assert result == expected
-    assert result.timezone_name == "UTC"
+        expected = pendulum.datetime(2026, 4, 10, 0, 0, 0, tz="UTC")
+        assert result == expected
+        assert result.timezone_name == "UTC"


### PR DESCRIPTION
## Why

`airflow dags clear --partition-date-start/--partition-date-end` parsed the user-supplied dates as UTC and compared those bounds directly against `DagRun.partition_date`. For a timetable whose timezone is not UTC, that comparison is off by a day:

- UTC+ zones (e.g. Asia/Taipei, UTC+8): the start day's runs were dropped — the lower bound excluded partitions that belong to the requested local day.
- UTC- zones (e.g. America/New_York, EST): the end day's runs were dropped — the upper bound excluded partitions that belong to the requested local day.

A user asking to clear a local-calendar day expects the runs of that local day, not a UTC-shifted window.

## What

- Resolve the partition window through the timetable's timezone instead of comparing UTC-parsed dates directly:
  - The `--partition-date-start date` is interpreted as local midnight in the timetable timezone, converted to UTC, and used as an inclusive lower
bound (`partition_date >= lower_utc`).
  - The `--partition-date-end date` is interpreted as local midnight of the next day in the timetable timezone, converted to UTC, and used as an
exclusive upper bound (`partition_date < upper_utc`). This half-open range keeps the whole requested end day inside the window.
  - This timezone resolution only applies when the timetable is partitioned and exposes a timezone; otherwise the previous inclusive >= start / <= end behaviour is preserved as a fallback.
- Add a public CronMixin.timezone accessor so dag_clear can read the timetable timezone without reaching into the private `_timezone` attribute.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
