### PR TITLE
Make partition_key provenance-only and inherit it onto asset events

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -27,6 +27,7 @@ from pydantic import AliasPath, AwareDatetime, Field, NonNegativeInt, model_vali
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
+from airflow.exceptions import DagNotPartitionedError
 from airflow.timetables.base import DataInterval
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -171,6 +172,14 @@ class TriggerDAGRunPostBody(StrictBaseModel):
         return self
 
     def validate_context(self, dag: SerializedDAG) -> dict:
+        if (
+            self.partition_key is not None
+            and not dag.timetable.partitioned
+            and not dag.timetable.partitioned_at_runtime
+        ):
+            raise DagNotPartitionedError(
+                f"Dag '{dag.dag_id}' is not a partitioned Dag and does not accept a partition_key."
+            )
         coerced_logical_date = timezone.coerce_datetime(self.logical_date)
         run_after = self.run_after or timezone.utcnow()
         data_interval = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -27,7 +27,6 @@ from pydantic import AliasPath, AwareDatetime, Field, NonNegativeInt, model_vali
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
-from airflow.exceptions import DagNotPartitionedError
 from airflow.timetables.base import DataInterval
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -172,14 +171,7 @@ class TriggerDAGRunPostBody(StrictBaseModel):
         return self
 
     def validate_context(self, dag: SerializedDAG) -> dict:
-        if (
-            self.partition_key is not None
-            and not dag.timetable.partitioned
-            and not dag.timetable.partitioned_at_runtime
-        ):
-            raise DagNotPartitionedError(
-                f"Dag '{dag.dag_id}' is not a partitioned Dag and does not accept a partition_key."
-            )
+        dag.validate_partition_key(self.partition_key)
         coerced_logical_date = timezone.coerce_datetime(self.logical_date)
         run_after = self.run_after or timezone.utcnow()
         data_interval = None

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -668,9 +668,8 @@ def trigger_dag_run(
         triggered_by = DagRunTriggeredByType.REST_API
 
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
-    params = body.validate_context(dag)
-
     try:
+        params = body.validate_context(dag)
         dag_run = dag.create_dagrun(
             run_id=params["run_id"],
             logical_date=params["logical_date"],

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/dag_runs.py
@@ -34,7 +34,7 @@ from airflow.api_fastapi.execution_api.datamodels.dagrun import DagRunStateRespo
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun
 from airflow.api_fastapi.execution_api.datamodels.token import TIToken
 from airflow.api_fastapi.execution_api.security import CurrentTIToken
-from airflow.exceptions import DagRunAlreadyExists
+from airflow.exceptions import DagNotPartitionedError, DagRunAlreadyExists
 from airflow.models.dag import DagModel
 from airflow.models.dagrun import DagRun as DagRunModel
 from airflow.models.taskinstance import TaskInstance
@@ -152,6 +152,11 @@ def trigger_dag_run(
                 "reason": "already_exists",
                 "message": f"A run already exists for Dag '{dag_id}' with run_id '{run_id}'",
             },
+        )
+    except DagNotPartitionedError as e:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={"reason": "not_partitioned", "message": str(e)},
         )
 
 

--- a/airflow-core/src/airflow/exceptions.py
+++ b/airflow-core/src/airflow/exceptions.py
@@ -141,6 +141,10 @@ class DagRunNotFound(AirflowNotFoundException):
     """Raise when a DAG Run is not available in the system."""
 
 
+class DagNotPartitionedError(ValueError):
+    """Raise when a partition_key is supplied for a Dag that is not partitioned."""
+
+
 class DagRunAlreadyExists(AirflowBadRequest):
     """Raise when creating a DAG run for DAG which already has DAG run entry."""
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1525,7 +1525,6 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         )
 
         payloads_by_asset: dict[SerializedAssetUniqueKey, list[OutletEventPayload]] = defaultdict(list)
-        runtime_pks: set[str] = set()
         for outlet_event in outlet_events:
             # Alias-emitted events are handled separately further down via
             # register_asset_change_for_alias, which uses the DagRun-level
@@ -1539,16 +1538,6 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             payloads_by_asset[asset_key].append(
                 OutletEventPayload(extra=outlet_event["extra"], partition_key=partition_key)
             )
-            if partition_key is not None:
-                runtime_pks.add(partition_key)
-
-        # Back-fill DagRun.partition_key from the task emission when the task
-        # emitted exactly one distinct partition_key across all outlet events
-        # and the DagRun did not already have one set. This lets a task that
-        # discovers the partition at runtime (rather than via params) act as
-        # the source of truth for the DagRun-level key.
-        if len(runtime_pks) == 1 and ti.dag_run.partition_key is None:
-            ti.dag_run.partition_key = next(iter(runtime_pks))
         dag_run_partition_key = ti.dag_run.partition_key
 
         asset_keys = {
@@ -1589,11 +1578,14 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 )
                 return
             for payload in payloads_for_asset:
+                effective_pk = (
+                    payload.partition_key if payload.partition_key is not None else dag_run_partition_key
+                )
                 asset_manager.register_asset_change(
                     task_instance=ti,
                     asset=am,
                     extra=payload.extra,
-                    partition_key=payload.partition_key,
+                    partition_key=effective_pk,
                     session=session,
                 )
 

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -500,6 +500,26 @@ class SerializedDAG:
         )
         return total_tasks >= self.max_active_tasks
 
+    def validate_partition_key(self, partition_key: str | None) -> None:
+        """
+        Raise ``DagNotPartitionedError`` if a partition key is supplied for a non-partitioned Dag.
+
+        A ``None`` value is always accepted. A non-``None`` value is accepted only when the
+        Dag's timetable sets ``partitioned=True`` or ``partitioned_at_runtime=True``.
+
+        :param partition_key: The partition key to validate, or ``None`` to skip validation.
+        :raises DagNotPartitionedError: When ``partition_key`` is not ``None`` and the Dag's
+            timetable is neither ``partitioned`` nor ``partitioned_at_runtime``.
+        """
+        if (
+            partition_key is not None
+            and not self.timetable.partitioned
+            and not self.timetable.partitioned_at_runtime
+        ):
+            raise DagNotPartitionedError(
+                f"Dag '{self.dag_id}' is not a partitioned Dag and does not accept a partition_key."
+            )
+
     @provide_session
     def create_dagrun(
         self,
@@ -586,14 +606,7 @@ class SerializedDAG:
                     f"is reserved for {inferred_run_type.value} runs"
                 )
 
-        if (
-            partition_key is not None
-            and not self.timetable.partitioned
-            and not self.timetable.partitioned_at_runtime
-        ):
-            raise DagNotPartitionedError(
-                f"Dag '{self.dag_id}' is not a partitioned Dag and does not accept a partition_key."
-            )
+        self.validate_partition_key(partition_key)
 
         # todo: AIP-78 add verification that if run type is backfill then we have a backfill id
         copied_params = self.params.deep_merge(conf)

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -33,7 +33,7 @@ from sqlalchemy import func, or_, select, tuple_
 from airflow._shared.observability.metrics import stats
 from airflow._shared.timezones.timezone import coerce_datetime
 from airflow.configuration import conf as airflow_conf
-from airflow.exceptions import AirflowException, NodeNotFound, TaskNotFound
+from airflow.exceptions import AirflowException, DagNotPartitionedError, NodeNotFound, TaskNotFound
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
@@ -585,6 +585,15 @@ class SerializedDAG:
                     f"A {run_type.value} DAG run cannot use ID {run_id!r} since it "
                     f"is reserved for {inferred_run_type.value} runs"
                 )
+
+        if (
+            partition_key is not None
+            and not self.timetable.partitioned
+            and not self.timetable.partitioned_at_runtime
+        ):
+            raise DagNotPartitionedError(
+                f"Dag '{self.dag_id}' is not a partitioned Dag and does not accept a partition_key."
+            )
 
         # todo: AIP-78 add verification that if run type is backfill then we have a backfill id
         copied_params = self.params.deep_merge(conf)

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -189,6 +189,12 @@ class PartitionAtRuntime(NullTimetable):
     Timetable that never schedules anything; partition keys are set at runtime.
 
     This corresponds to ``schedule=PartitionAtRuntime()``.
+
+    A run's ``partition_key`` (run-level provenance) must be supplied at trigger
+    time — for example via the REST API's ``partition_key`` field. Partition keys
+    discovered at task runtime populate the emitted :class:`~airflow.sdk.AssetEvent`
+    records but do **not** back-fill ``DagRun.partition_key`` after the run has
+    been created.
     """
 
     description: str = "Never, partition key(s) set at runtime"

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -41,6 +41,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.trigger import Trigger
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.timetables.simple import PartitionAtRuntime
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
@@ -1462,7 +1463,10 @@ class TestPostAssetMaterialize(TestAssets):
         assets = {
             i: am.to_serialized() for i, am in enumerate(self.create_assets(session=session, num=3), start=1)
         }
-        with dag_maker(self.DAG_ASSET1_ID, schedule=None, session=session):
+        # DAG_ASSET1_ID is materialized with a partition_key in several tests below, so it must be a
+        # partitioned Dag. PartitionAtRuntime accepts runtime-discovered partition keys without
+        # requiring a partitioned timetable.
+        with dag_maker(self.DAG_ASSET1_ID, schedule=PartitionAtRuntime(), session=session):
             EmptyOperator(task_id="task", outlets=assets[1])
         with dag_maker(self.DAG_ASSET2_ID_A, schedule=None, session=session):
             EmptyOperator(task_id="task", outlets=assets[2])

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -27,10 +27,14 @@ import time_machine
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select, update
 
+from airflow import plugins_manager
+from airflow._shared.module_loading import qualname
 from airflow._shared.timezones import timezone
+from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.api_fastapi.core_api.datamodels.dag_versions import DagVersionResponse
 from airflow.api_fastapi.core_api.services.public.common import resolve_run_on_latest_version
+from airflow.exceptions import ParamValidationError
 from airflow.models import DagModel, DagRun, Log
 from airflow.models.asset import AssetEvent, AssetModel
 from airflow.models.dagbundle import DagBundleModel
@@ -39,7 +43,10 @@ from airflow.models.team import Team
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.definitions.param import Param
+from airflow.settings import _configure_async_session
 from airflow.timetables.interval import CronDataIntervalTimetable
+from airflow.timetables.simple import PartitionAtRuntime
+from airflow.timetables.trigger import CronPartitionTimetable
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -56,6 +63,7 @@ from tests_common.test_utils.db import (
     clear_db_serialized_dags,
 )
 from tests_common.test_utils.format_datetime import from_datetime_to_zulu, from_datetime_to_zulu_without_ms
+from unit.listeners.class_listener import ClassBasedListener
 
 if TYPE_CHECKING:
     from airflow.models.dag_version import DagVersion
@@ -83,9 +91,6 @@ class CustomTimetable(CronDataIntervalTimetable):
 @pytest.fixture
 def custom_timetable_plugin(monkeypatch):
     """Fixture to register CustomTimetable for serialization."""
-    from airflow import plugins_manager
-    from airflow._shared.module_loading import qualname
-
     timetable_class_name = qualname(CustomTimetable)
     existing_timetables = getattr(plugins_manager, "timetable_classes", None) or {}
 
@@ -1513,8 +1518,6 @@ class TestPatchDagRun:
     )
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_patch_dag_run_notifies_listeners(self, test_client, state, listener_state, listener_manager):
-        from unit.listeners.class_listener import ClassBasedListener
-
         listener = ClassBasedListener()
         listener_manager(listener)
         response = test_client.patch(f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}", json={"state": state})
@@ -2459,8 +2462,6 @@ class TestTriggerDagRun:
 
     @mock.patch("airflow.serialization.definitions.dag.SerializedDAG.create_dagrun")
     def test_dagrun_creation_param_validation_error_returns_400(self, mock_create_dagrun, test_client):
-        from airflow.exceptions import ParamValidationError
-
         now = timezone.utcnow().isoformat()
         error_message = "Invalid input for param x"
         mock_create_dagrun.side_effect = ParamValidationError(error_message)
@@ -2712,6 +2713,74 @@ class TestTriggerDagRun:
         run = session.scalars(select(DagRun).where(DagRun.run_id == run_id_without_logical_date)).one()
         assert run.dag_id == custom_dag_id
 
+    def test_should_respond_400_when_partition_key_given_for_non_partitioned_dag(self, test_client):
+        """Passing partition_key to a non-partitioned Dag via REST trigger must return 400, not 500.
+
+        The validation happens in TriggerDAGRunPostBody.validate_context(), which is now called
+        inside the try/except block that converts ValueError to HTTP 400.
+        """
+        now = timezone.utcnow().isoformat()
+        response = test_client.post(
+            f"/dags/{DAG1_ID}/dagRuns",
+            json={"logical_date": now, "partition_key": "some-partition"},
+        )
+        assert response.status_code == 400
+        assert "not a partitioned Dag" in response.json()["detail"]
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_should_respond_200_when_partition_key_given_for_partitioned_dag(
+        self, dag_maker, test_client, session
+    ):
+        """partition_key on a genuinely partitioned Dag must not be rejected (happy-path guard).
+
+        Uses CronPartitionTimetable (partitioned=True) to confirm the reject path does not
+        fire for legitimate partitioned Dags.
+        """
+        partitioned_dag_id = "test_partitioned_dag_trigger"
+        with dag_maker(
+            dag_id=partitioned_dag_id,
+            schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"),
+            start_date=START_DATE1,
+            session=session,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task")
+
+        session.commit()
+
+        response = test_client.post(
+            f"/dags/{partitioned_dag_id}/dagRuns",
+            json={"logical_date": None, "partition_key": "2025-01-01T00:00:00"},
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_should_respond_200_when_partition_key_given_for_partition_at_runtime_dag(
+        self, dag_maker, test_client, session
+    ):
+        """partition_key on a PartitionAtRuntime Dag must also be accepted (deferred validation).
+
+        partitioned_at_runtime=True means the Dag accepts runtime-discovered partition keys, so
+        the REST layer must not reject it even though timetable.partitioned is False.
+        """
+        runtime_dag_id = "test_partition_at_runtime_dag_trigger"
+        with dag_maker(
+            dag_id=runtime_dag_id,
+            schedule=PartitionAtRuntime(),
+            start_date=START_DATE1,
+            session=session,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task")
+
+        session.commit()
+
+        response = test_client.post(
+            f"/dags/{runtime_dag_id}/dagRuns",
+            json={"logical_date": None, "partition_key": "runtime-key"},
+        )
+        assert response.status_code == 200
+
 
 class TestResolveRunOnLatestVersion:
     @pytest.mark.parametrize("explicit_value", [True, False])
@@ -2802,8 +2871,6 @@ class TestWaitDagRun:
     # test at least makes the tests run correctly.
     @pytest.fixture(autouse=True)
     def reconfigure_async_db_engine(self):
-        from airflow.settings import _configure_async_session
-
         _configure_async_session()
 
     def test_should_respond_401(self, unauthenticated_test_client):
@@ -2847,8 +2914,6 @@ class TestWaitDagRun:
         assert data == {"state": DagRunState.SUCCESS, "results": {"task_1": '"result_1"'}}
 
     def test_should_respond_403_when_user_lacks_xcom_permission(self, test_client):
-        from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
-
         with mock.patch(
             "airflow.api_fastapi.core_api.routes.public.dag_run.get_auth_manager",
             autospec=True,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1573,7 +1573,11 @@ class TestGetDagRunAssetTriggerEvents:
     def test_should_respond_200(self, partition_key, test_client, dag_maker, session):
         asset1 = Asset(name="ds1", uri="file:///da1")
 
-        with dag_maker(dag_id="source_dag", start_date=START_DATE1, session=session):
+        # Use PartitionAtRuntime for partitioned cases so the partition_key gate does not reject the key.
+        source_schedule = PartitionAtRuntime() if partition_key is not None else timedelta(days=1)
+        with dag_maker(
+            dag_id="source_dag", start_date=START_DATE1, schedule=source_schedule, session=session
+        ):
             EmptyOperator(task_id="task", outlets=[asset1])
         dr = dag_maker.create_dagrun(partition_key=partition_key)
         ti = dr.task_instances[0]
@@ -1589,13 +1593,21 @@ class TestGetDagRunAssetTriggerEvents:
         )
         session.add(event)
 
-        with dag_maker(dag_id="TEST_DAG_ID", start_date=START_DATE1, session=session):
+        trigger_schedule = PartitionAtRuntime() if partition_key is not None else timedelta(days=1)
+        with dag_maker(
+            dag_id="TEST_DAG_ID", start_date=START_DATE1, schedule=trigger_schedule, session=session
+        ):
             pass
-        dr = dag_maker.create_dagrun(
-            run_id="TEST_DAG_RUN_ID",
-            run_type=DagRunType.ASSET_TRIGGERED,
-            partition_key=partition_key,
-        )
+        create_dagrun_kwargs: dict = {
+            "run_id": "TEST_DAG_RUN_ID",
+            "run_type": DagRunType.ASSET_TRIGGERED,
+            "partition_key": partition_key,
+        }
+        if partition_key is not None:
+            # PartitionAtRuntime is a null-timetable with no scheduled runs; supply logical_date=None
+            # explicitly so dag_maker does not try to infer it via next_dagrun_info (which returns None).
+            create_dagrun_kwargs["logical_date"] = None
+        dr = dag_maker.create_dagrun(**create_dagrun_kwargs)
         dr.consumed_asset_events.append(event)
 
         session.commit()

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_dag_runs.py
@@ -28,6 +28,7 @@ from airflow.api_fastapi.execution_api.security import require_auth
 from airflow.models import DagModel
 from airflow.models.dagrun import DagRun
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.timetables.trigger import CronPartitionTimetable
 from airflow.utils.state import DagRunState, State
 from airflow.utils.types import DagRunType
 
@@ -66,12 +67,18 @@ class TestDagRunTrigger:
         assert dag_run.run_type == DagRunType.OPERATOR_TRIGGERED
 
     def test_trigger_dag_run_with_partition_key(self, client, session, dag_maker):
+        """partition_key accepted when Dag uses a partitioned timetable (happy-path guard)."""
         dag_id = "test_trigger_dag_run_partition_key"
         run_id = "test_run_id"
         logical_date = timezone.datetime(2025, 2, 20)
         partition_key = "2025-02-20"
 
-        with dag_maker(dag_id=dag_id, session=session, serialized=True):
+        with dag_maker(
+            dag_id=dag_id,
+            schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"),
+            session=session,
+            serialized=True,
+        ):
             EmptyOperator(task_id="test_task")
 
         session.commit()
@@ -91,6 +98,33 @@ class TestDagRunTrigger:
         assert dag_run.conf == {"key1": "value1"}
         assert dag_run.logical_date == logical_date
         assert dag_run.partition_key == partition_key
+
+    def test_trigger_dag_run_partition_key_for_non_partitioned_dag(self, client, session, dag_maker):
+        """partition_key on a non-partitioned Dag via Execution API must return 400."""
+        dag_id = "test_trigger_non_partitioned_partition_key"
+        run_id = "test_run_id_np"
+        logical_date = timezone.datetime(2025, 2, 20)
+
+        with dag_maker(dag_id=dag_id, session=session, serialized=True):
+            EmptyOperator(task_id="test_task")
+
+        session.commit()
+
+        response = client.post(
+            f"/execution/dag-runs/{dag_id}/{run_id}",
+            json={
+                "logical_date": logical_date.isoformat(),
+                "partition_key": "2025-02-20",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": {
+                "reason": "not_partitioned",
+                "message": f"Dag '{dag_id}' is not a partitioned Dag and does not accept a partition_key.",
+            }
+        }
 
     def test_trigger_dag_run_dag_not_found(self, client):
         """Test that a DAG that does not exist cannot be triggered."""

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -293,10 +293,13 @@ class TestAssetManager:
 
         expected_fp = compute_rollup_fingerprint(core_rollup_schedule)
 
-        # Produce an asset event to trigger APDR creation.
+        # Produce an asset event to trigger APDR creation. The producer is a
+        # partition-at-runtime Dag so its run can carry a ``partition_key`` that
+        # the emitted ``AssetEvent`` inherits.
         from airflow.models.taskinstance import TaskInstance
+        from airflow.sdk import PartitionAtRuntime
 
-        with dag_maker(dag_id="stamp-producer", schedule=None, session=session) as producer_dag:
+        with dag_maker(dag_id="stamp-producer", schedule=PartitionAtRuntime(), session=session) as producer_dag:
             from airflow.providers.standard.operators.empty import EmptyOperator
 
             EmptyOperator(task_id="hi", outlets=[asset_1])

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -299,7 +299,9 @@ class TestAssetManager:
         from airflow.models.taskinstance import TaskInstance
         from airflow.sdk import PartitionAtRuntime
 
-        with dag_maker(dag_id="stamp-producer", schedule=PartitionAtRuntime(), session=session) as producer_dag:
+        with dag_maker(
+            dag_id="stamp-producer", schedule=PartitionAtRuntime(), session=session
+        ) as producer_dag:
             from airflow.providers.standard.operators.empty import EmptyOperator
 
             EmptyOperator(task_id="hi", outlets=[asset_1])

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -64,6 +64,7 @@ from airflow.sdk.definitions.timetables.assets import PartitionedAssetTimetable
 from airflow.serialization.definitions.assets import SerializedAsset
 from airflow.serialization.encoders import encode_trigger, ensure_serialized_asset
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
+from airflow.timetables.simple import PartitionAtRuntime
 from airflow.triggers.base import BaseEventTrigger
 from airflow.utils.types import DagRunType
 
@@ -135,7 +136,7 @@ def test_statement_latest_runs_loads_timetable_fields(dag_maker, session):
 
 @pytest.mark.db_test
 def test_statement_latest_runs_partitioned_sorted_by_partition_date(dag_maker, session):
-    with dag_maker("fake-dag", schedule=None):
+    with dag_maker("fake-dag", schedule=PartitionAtRuntime()):
         pass
     dag_maker.sync_dagbag_to_db()
     for i, (run_id, partition_key, partition_date) in enumerate(

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -115,7 +115,10 @@ from airflow.serialization.definitions.dag import SerializedDAG
 from airflow.serialization.encoders import ensure_serialized_asset
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.base import DagRunInfo, DataInterval, compute_rollup_fingerprint
-from airflow.timetables.simple import PartitionedAssetTimetable as CorePartitionedAssetTimetable
+from airflow.timetables.simple import (
+    PartitionAtRuntime,
+    PartitionedAssetTimetable as CorePartitionedAssetTimetable,
+)
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.sqlalchemy import with_row_locks
 from airflow.utils.state import CallbackState, DagRunState, State, TaskInstanceState
@@ -9817,7 +9820,7 @@ def _produce_and_register_asset_event(
     if expected_partition_key is None:
         expected_partition_key = partition_key
 
-    with dag_maker(dag_id=dag_id, schedule=None, session=session) as dag:
+    with dag_maker(dag_id=dag_id, schedule=PartitionAtRuntime(), session=session) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
 
     dr = dag_maker.create_dagrun(partition_key=partition_key, session=session)

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -41,7 +41,7 @@ from airflow._shared.timezones import timezone
 from airflow._shared.timezones.timezone import datetime as datetime_tz
 from airflow.configuration import conf
 from airflow.dag_processing.dagbag import BundleDagBag, DagBag
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, DagNotPartitionedError
 from airflow.models.asset import (
     AssetAliasModel,
     AssetDagRunQueue,
@@ -70,6 +70,7 @@ from airflow.sdk import (
     DAG,
     BaseOperator,
     CronPartitionTimetable,
+    PartitionAtRuntime,
     TaskGroup,
     setup,
     task as task_decorator,
@@ -1508,14 +1509,24 @@ class TestDag:
         )
         assert dr.note == note
 
-    @pytest.mark.parametrize("partition_key", [None, "my-key", 123])
-    def test_create_dagrun_partition_key(self, partition_key, dag_maker):
+    @pytest.mark.parametrize(
+        ("partition_key", "expected_cm"),
+        [
+            (None, nullcontext()),
+            (
+                "my-key",
+                pytest.raises(DagNotPartitionedError, match="not a partitioned Dag"),
+            ),
+            (
+                123,
+                pytest.raises(DagNotPartitionedError, match="not a partitioned Dag"),
+            ),
+        ],
+    )
+    def test_create_dagrun_partition_key(self, partition_key, expected_cm, dag_maker):
         with dag_maker("test_create_dagrun_partition_key"):
             ...
-        cm = nullcontext()
-        if isinstance(partition_key, int):
-            cm = pytest.raises(ValueError, match="Expected partition_key to be `str` | `None` but got `int`")
-        with cm:
+        with expected_cm:
             dr = dag_maker.create_dagrun(
                 run_id="test_create_dagrun_partition_key",
                 run_after=DEFAULT_DATE,
@@ -1525,6 +1536,70 @@ class TestDag:
                 partition_key=partition_key,
             )
             assert dr.partition_key == partition_key
+
+    def test_create_dagrun_partition_key_accepted_for_partitioned_dag(self, dag_maker):
+        """create_dagrun accepts a str partition_key when the Dag uses a partitioned timetable."""
+        with dag_maker(
+            "test_create_dagrun_partitioned",
+            schedule=CronPartitionTimetable("@daily", timezone="UTC"),
+        ):
+            ...
+        dr = dag_maker.create_dagrun(
+            run_id="test_create_dagrun_partitioned",
+            run_after=DEFAULT_DATE,
+            run_type=DagRunType.MANUAL,
+            state=State.NONE,
+            triggered_by=DagRunTriggeredByType.TEST,
+            partition_key="my-key",
+        )
+        assert dr.partition_key == "my-key"
+
+    def test_create_dagrun_int_partition_key_rejected_for_partitioned_dag(self, dag_maker):
+        """DagRun-level type check rejects int partition_key even for partitioned Dags."""
+        with dag_maker(
+            "test_create_dagrun_partitioned_int_key",
+            schedule=PartitionAtRuntime(),
+        ):
+            ...
+        with pytest.raises(
+            ValueError,
+            match=r"Expected partition_key to be a `str` or `None` but got `int`",
+        ):
+            dag_maker.create_dagrun(
+                run_id="test_create_dagrun_partitioned_int_key",
+                run_after=DEFAULT_DATE,
+                run_type=DagRunType.MANUAL,
+                state=State.NONE,
+                triggered_by=DagRunTriggeredByType.TEST,
+                partition_key=123,
+            )
+
+    @pytest.mark.need_serialized_dag
+    @pytest.mark.parametrize(
+        ("partition_key", "schedule", "should_raise"),
+        [
+            ("my-key", None, True),
+            (None, None, False),
+            ("my-key", CronPartitionTimetable("@daily", timezone="UTC"), False),
+            ("my-key", PartitionAtRuntime(), False),
+        ],
+    )
+    def test_serialized_dag_validate_partition_key(
+        self,
+        partition_key,
+        schedule,
+        should_raise,
+        dag_maker,
+    ):
+        """SerializedDAG.validate_partition_key raises for non-partitioned Dags and accepts for partitioned."""
+        with dag_maker("test_validate_partition_key", schedule=schedule):
+            ...
+        sdag = dag_maker.serialized_dag
+        if should_raise:
+            with pytest.raises(DagNotPartitionedError, match="not a partitioned Dag"):
+                sdag.validate_partition_key(partition_key)
+        else:
+            sdag.validate_partition_key(partition_key)  # must not raise
 
     def test_dag_add_task_sets_default_task_group(self):
         dag = DAG(dag_id="test_dag_add_task_sets_default_task_group", schedule=None, start_date=DEFAULT_DATE)

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -105,6 +105,7 @@ from airflow.ti_deps.dependencies_states import RUNNABLE_STATES
 from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep, _UpstreamTIStates
+from airflow.timetables.simple import PartitionAtRuntime
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.span_status import SpanStatus
 from airflow.utils.state import DagRunState, State, TaskInstanceState
@@ -3524,7 +3525,7 @@ def test_find_relevant_relatives_with_non_mapped_task_as_tuple(dag_maker, sessio
 
 def test_when_dag_run_has_partition_then_asset_does(dag_maker, session):
     asset = Asset(name="hello")
-    with dag_maker(dag_id="asset_event_tester", schedule=None) as dag:
+    with dag_maker(dag_id="asset_event_tester", schedule=PartitionAtRuntime()) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dr = dag_maker.create_dagrun(partition_key="abc123", session=session)
     assert dr.partition_key == "abc123"
@@ -3547,7 +3548,7 @@ def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_popula
     session,
 ):
     asset = Asset(name="hello")
-    with dag_maker(dag_id="asset_event_tester", schedule=None, session=session) as dag:
+    with dag_maker(dag_id="asset_event_tester", schedule=PartitionAtRuntime(), session=session) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dag1_id = dag.dag_id
     dr = dag_maker.create_dagrun(partition_key="abc123", session=session)
@@ -3582,8 +3583,13 @@ def test_when_dag_run_has_partition_and_downstreams_listening_then_tables_popula
     assert pakl.target_dag_id == "asset_event_listener"
 
 
-def test_runtime_partition_key_backfills_dag_run_when_none(dag_maker, session):
-    """Single runtime key on a PartitionAtRuntime-style run (dag_run.partition_key=None) back-fills the run."""
+def test_runtime_partition_key_does_not_backfill_dag_run_when_none(dag_maker, session):
+    """Task-emitted partition_key lands on the AssetEvent but does NOT back-fill DagRun.partition_key.
+
+    DagRun.partition_key (provenance) is set by the scheduler / trigger side, not by task
+    runtime emission. A run that started with partition_key=None should remain None even when
+    a task emits an outlet event carrying its own key.
+    """
     asset = Asset(name="hello")
     with dag_maker(dag_id="rt_pk_backfill", schedule=None) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
@@ -3602,13 +3608,13 @@ def test_runtime_partition_key_backfills_dag_run_when_none(dag_maker, session):
     event = session.scalar(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id))
     assert event.partition_key == "us"
     session.refresh(dr)
-    assert dr.partition_key == "us"
+    assert dr.partition_key is None
 
 
 def test_runtime_partition_key_does_not_overwrite_scheduler_partition(dag_maker, session):
     """Task-emitted key lands on the AssetEvent but does NOT overwrite a scheduler-set DagRun.partition_key."""
     asset = Asset(name="hello")
-    with dag_maker(dag_id="rt_pk_no_overwrite", schedule=None) as dag:
+    with dag_maker(dag_id="rt_pk_no_overwrite", schedule=PartitionAtRuntime()) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dr = dag_maker.create_dagrun(partition_key="scheduler-key", session=session)
     [ti] = dr.get_task_instances(session=session)
@@ -3651,10 +3657,15 @@ def test_runtime_partition_keys_fan_out_to_one_event_per_key(dag_maker, session)
     assert dr.partition_key is None
 
 
-def test_runtime_partition_key_is_none_when_event_has_no_key(dag_maker, session):
-    """An outlet event without partition_key produces an AssetEvent with partition_key=None."""
+def test_runtime_partition_key_inherits_dag_run_key_when_event_has_no_key(dag_maker, session):
+    """An outlet event without partition_key inherits DagRun.partition_key as the routing pointer.
+
+    When a task emits an outlet event that carries no explicit partition_key, the resulting
+    AssetEvent should inherit the DagRun's partition_key so that downstream partitioned consumers
+    can still be routed correctly.
+    """
     asset = Asset(name="hello")
-    with dag_maker(dag_id="rt_pk_none", schedule=None) as dag:
+    with dag_maker(dag_id="rt_pk_none", schedule=PartitionAtRuntime()) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dr = dag_maker.create_dagrun(partition_key="from-run", session=session)
     [ti] = dr.get_task_instances(session=session)
@@ -3668,13 +3679,13 @@ def test_runtime_partition_key_is_none_when_event_has_no_key(dag_maker, session)
         session=session,
     )
     event = session.scalar(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id))
-    assert event.partition_key is None
+    assert event.partition_key == "from-run"
 
 
 def test_runtime_partition_key_mixed_events_for_same_asset(dag_maker, session):
-    """One event with partition_key + one without produce two AssetEvents (key + None)."""
+    """One event with an explicit key + one without produce two AssetEvents (explicit key + inherited run key)."""
     asset = Asset(name="hello")
-    with dag_maker(dag_id="rt_pk_mixed", schedule=None) as dag:
+    with dag_maker(dag_id="rt_pk_mixed", schedule=PartitionAtRuntime()) as dag:
         EmptyOperator(task_id="hi", outlets=[asset])
     dr = dag_maker.create_dagrun(partition_key="from-run", session=session)
     [ti] = dr.get_task_instances(session=session)
@@ -3689,9 +3700,64 @@ def test_runtime_partition_key_mixed_events_for_same_asset(dag_maker, session):
         session=session,
     )
     events = session.scalars(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id)).all()
-    assert {e.partition_key for e in events} == {"us", None}
+    assert {e.partition_key for e in events} == {"us", "from-run"}
     session.refresh(dr)
     assert dr.partition_key == "from-run"
+
+
+def test_runtime_partition_key_event_stays_none_when_no_key_and_no_run_key(dag_maker, session):
+    """Task has no partition_key and run has no partition_key -> event.partition_key is None.
+
+    Pins the `is not None` guard: both sides are None so effective_pk stays None and no
+    routing pointer is written to the AssetEvent.
+    """
+    asset = Asset(name="hello")
+    with dag_maker(dag_id="rt_pk_both_none", schedule=None) as dag:
+        EmptyOperator(task_id="hi", outlets=[asset])
+    dr = dag_maker.create_dagrun(session=session)
+    assert dr.partition_key is None
+    [ti] = dr.get_task_instances(session=session)
+
+    TaskInstance.register_asset_changes_in_db(
+        ti=ti,
+        task_outlets=[ensure_serialized_asset(asset).asprofile()],
+        outlet_events=[
+            {"dest_asset_key": {"name": "hello", "uri": "hello"}, "extra": {}},
+        ],
+        session=session,
+    )
+    event = session.scalar(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id))
+    assert event.partition_key is None
+
+
+def test_runtime_partition_key_does_not_backfill_partition_at_runtime_run(dag_maker, session):
+    """Task-emitted key lands on AssetEvent but does NOT back-fill DagRun.partition_key on a PartitionAtRuntime run.
+
+    Provenance contract: DagRun.partition_key is set only at run-creation/trigger time.
+    A PartitionAtRuntime Dag triggered via REST without a partition_key starts with
+    partition_key=None. Even when a task discovers a partition at runtime and emits an
+    outlet event carrying an explicit key, DagRun.partition_key must remain None — the
+    key belongs to the AssetEvent, not to the run's provenance.
+    """
+    asset = Asset(name="hello")
+    with dag_maker(dag_id="rt_pk_par_backfill", schedule=PartitionAtRuntime()) as dag:
+        EmptyOperator(task_id="hi", outlets=[asset])
+    dr = dag_maker.create_dagrun(session=session)
+    assert dr.partition_key is None
+    [ti] = dr.get_task_instances(session=session)
+
+    TaskInstance.register_asset_changes_in_db(
+        ti=ti,
+        task_outlets=[ensure_serialized_asset(asset).asprofile()],
+        outlet_events=[
+            {"dest_asset_key": {"name": "hello", "uri": "hello"}, "extra": {}, "partition_key": "2025-01-01"},
+        ],
+        session=session,
+    )
+    event = session.scalar(select(AssetEvent).where(AssetEvent.source_dag_id == dag.dag_id))
+    assert event.partition_key == "2025-01-01"
+    session.refresh(dr)
+    assert dr.partition_key is None
 
 
 def test_when_runtime_partition_keys_and_downstreams_listening_then_tables_populated(

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -93,7 +93,8 @@ from airflow.task.priority_strategy import (
     validate_and_load_priority_weight_strategy,
 )
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
-from airflow.timetables.simple import NullTimetable, OnceTimetable
+from airflow.timetables.simple import NullTimetable, OnceTimetable, PartitionAtRuntime
+from airflow.timetables.trigger import CronPartitionTimetable
 from airflow.triggers.base import StartTriggerArgs
 from airflow.utils.types import DagRunType
 
@@ -2751,6 +2752,41 @@ class TestStringifiedDAGs:
             "__type": "dict",
             "__var": {"resume_after": {"__type": "timedelta", "__var": 5.0}},
         }
+
+    @pytest.mark.db_test
+    def test_create_dagrun_rejects_partition_key_for_non_partitioned_dag(self, dag_maker):
+        """create_dagrun raises ValueError when partition_key is passed to a non-partitioned Dag."""
+        with dag_maker(dag_id="test_non_partitioned", serialized=True):
+            pass
+
+        with pytest.raises(ValueError, match="not a partitioned Dag"):
+            dag_maker.create_dagrun(partition_key="some-key")
+
+    @pytest.mark.db_test
+    def test_create_dagrun_accepts_partition_key_for_partitioned_dag(self, dag_maker):
+        """create_dagrun does not raise when partition_key is passed to a partitioned Dag."""
+        with dag_maker(
+            dag_id="test_partitioned",
+            schedule=CronPartitionTimetable("0 * * * *", timezone="UTC"),
+            serialized=True,
+        ):
+            pass
+
+        dr = dag_maker.create_dagrun(partition_key="2025-01-01T00:00:00")
+        assert dr.partition_key == "2025-01-01T00:00:00"
+
+    @pytest.mark.db_test
+    def test_create_dagrun_accepts_partition_key_for_partition_at_runtime_dag(self, dag_maker):
+        """create_dagrun does not raise when partition_key is passed to a PartitionAtRuntime Dag."""
+        with dag_maker(
+            dag_id="test_partition_at_runtime",
+            schedule=PartitionAtRuntime(),
+            serialized=True,
+        ):
+            pass
+
+        dr = dag_maker.create_dagrun(partition_key="runtime-key")
+        assert dr.partition_key == "runtime-key"
 
 
 def test_kubernetes_optional():


### PR DESCRIPTION
## Why

`partition_key` semantics for `DagRun` and `AssetEvent` had three rough edges, all on unreleased AIP-76 behaviour (first ships in 3.2.0):

- A task emitting outlet events could overwrite `DagRun.partition_key` via a runtime back-fill. That blurred ownership of the run's key — it should be provenance set by the scheduler / trigger side, not rewritten by task emission.
- An outlet event emitted without an explicit key landed with `partition_key = None`, which left downstream partitioned consumers unable to route off it — even though the run it came from carried a key.
- The REST trigger endpoint accepted a manual `partition_key` for Dags that are not partitioned at all, silently ignoring it.

closes: #67368

## What

- Drop the runtime back-fill in `register_asset_changes_in_db`. A task emitting outlet events no longer writes `DagRun.partition_key`; the run's key stays provenance-only, set by the scheduler / trigger side.
- An `AssetEvent` emitted without an explicit `partition_key` now inherits the run's `partition_key` instead of staying `None`, so downstream partitioned consumers can route off it.
- The REST trigger endpoint now rejects a `partition_key` for non-partitioned Dags with a `400` (Dags that are neither `timetable.partitioned` nor `timetable.partitioned_at_runtime`). The validation runs inside the route's error-handling block so the domain `ValueError` surfaces as `400` rather than `500`.

All behaviour is unreleased, so the changes land in place with no compatibility shim and no newsfragment.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
