### PR TITLE
Fix `TriggerDagRunOperator`'s `fail_when_dag_is_paused` on Airflow 3.2+

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -43,7 +43,12 @@ from airflow.providers.common.compat.sdk import (
 )
 from airflow.providers.standard.triggers.external_task import DagStateTrigger
 from airflow.providers.standard.utils.openlineage import safe_inject_openlineage_properties_into_dagrun_conf
-from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS, BaseOperator, is_arg_set
+from airflow.providers.standard.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_PLUS,
+    BaseOperator,
+    is_arg_set,
+)
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
 
@@ -145,7 +150,9 @@ class TriggerDagRunOperator(BaseOperator):
         Default is ``[DagRunState.FAILED]``.
     :param skip_when_already_exists: Set to true to mark the task as SKIPPED if a DAG run of the triggered
         DAG for the same logical date already exists.
-    :param fail_when_dag_is_paused: If the dag to trigger is paused, DagIsPaused will be raised.
+    :param fail_when_dag_is_paused: If the dag to trigger is paused, DagIsPaused will be raised. On
+        Airflow 3.x this requires Airflow 3.2.0+ (it relies on the task-SDK DAG state endpoint added then);
+        on Airflow 3.0/3.1 setting this raises ``NotImplementedError``.
     :param deferrable: If waiting for completion, whether to defer the task until done, default is ``False``.
     :param openlineage_inject_parent_info: whether to include OpenLineage metadata about the parent task
         in the triggered DAG run's conf, enabling improved lineage tracking. The metadata is only injected
@@ -218,8 +225,11 @@ class TriggerDagRunOperator(BaseOperator):
         run_after = _validate_datetime_param("run_after", run_after)
         self.logical_date = logical_date
         self.run_after = run_after
-        if fail_when_dag_is_paused and AIRFLOW_V_3_0_PLUS:
-            raise NotImplementedError("Setting `fail_when_dag_is_paused` not yet supported for Airflow 3.x")
+        if fail_when_dag_is_paused and AIRFLOW_V_3_0_PLUS and not AIRFLOW_V_3_2_PLUS:
+            raise NotImplementedError(
+                "Setting `fail_when_dag_is_paused` requires Airflow 3.2.0+ on Airflow 3.x "
+                "(it relies on the task-SDK DAG state endpoint added in 3.2.0)."
+            )
 
     def execute(self, context: Context):
         if self.logical_date is NOTSET:
@@ -267,14 +277,17 @@ class TriggerDagRunOperator(BaseOperator):
         self.trigger_run_id = run_id
 
         if self.fail_when_dag_is_paused:
-            dag_model = DagModel.get_current(self.trigger_dag_id)
-            if not dag_model:
-                raise ValueError(f"Dag {self.trigger_dag_id} is not found")
-            if dag_model.is_paused:
-                # TODO: enable this when dag state endpoint available from task sdk
-                # if AIRFLOW_V_3_0_PLUS:
-                #     raise DagIsPaused(dag_id=self.trigger_dag_id)
-                raise AirflowException(f"Dag {self.trigger_dag_id} is paused")
+            if AIRFLOW_V_3_0_PLUS:
+                # Tasks cannot access the ORM directly in Airflow 3.x; fetch the DAG state via the
+                # task-SDK supervisor (GetDag execution-API endpoint, available from Airflow 3.2.0).
+                if context["ti"].get_dag(self.trigger_dag_id).is_paused:
+                    raise DagIsPaused(dag_id=self.trigger_dag_id)
+            else:
+                dag_model = DagModel.get_current(self.trigger_dag_id)
+                if not dag_model:
+                    raise ValueError(f"Dag {self.trigger_dag_id} is not found")
+                if dag_model.is_paused:
+                    raise AirflowException(f"Dag {self.trigger_dag_id} is paused")
 
         if AIRFLOW_V_3_0_PLUS:
             self._trigger_dag_af_3(

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -38,7 +38,11 @@ from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils.db import parse_and_sync_to_db
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
+    AIRFLOW_V_3_2_PLUS,
+)
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.providers.common.compat.sdk import DagRunTriggerException
@@ -332,10 +336,13 @@ class TestDagRunOperator:
                 {}, {"dag_id": "dag_id", "run_ids": ["run_id_1"], "poll_interval": 15, "run_id_1": "success"}
             )
 
-    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")
-    def test_trigger_dag_run_with_fail_when_dag_is_paused_should_fail(self):
+    @pytest.mark.skipif(
+        not (AIRFLOW_V_3_0_PLUS and not AIRFLOW_V_3_2_PLUS),
+        reason="On Airflow 3.0/3.1 the worker cannot resolve the DAG paused state",
+    )
+    def test_trigger_dag_run_with_fail_when_dag_is_paused_should_fail_below_3_2(self):
         with pytest.raises(
-            NotImplementedError, match="Setting `fail_when_dag_is_paused` not yet supported for Airflow 3.x"
+            NotImplementedError, match="Setting `fail_when_dag_is_paused` requires Airflow 3.2.0"
         ):
             TriggerDagRunOperator(
                 task_id="test_task",
@@ -343,6 +350,45 @@ class TestDagRunOperator:
                 conf={"foo": "bar"},
                 fail_when_dag_is_paused=True,
             )
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_2_PLUS, reason="Needs the task-SDK GetDag endpoint added in Airflow 3.2.0"
+    )
+    def test_trigger_dagrun_fails_when_target_dag_is_paused(self):
+        from airflow.providers.standard.operators.trigger_dagrun import DagIsPaused
+
+        task = TriggerDagRunOperator(
+            task_id="test_task",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            fail_when_dag_is_paused=True,
+            openlineage_inject_parent_info=False,
+        )
+        mock_ti = mock.MagicMock()
+        mock_ti.get_dag.return_value.is_paused = True
+
+        with pytest.raises(DagIsPaused, match=f"Dag {TRIGGERED_DAG_ID} is paused"):
+            task.execute(context={"ti": mock_ti})
+
+        mock_ti.get_dag.assert_called_once_with(TRIGGERED_DAG_ID)
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_2_PLUS, reason="Needs the task-SDK GetDag endpoint added in Airflow 3.2.0"
+    )
+    def test_trigger_dagrun_proceeds_when_target_dag_is_not_paused(self):
+        task = TriggerDagRunOperator(
+            task_id="test_task",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            fail_when_dag_is_paused=True,
+            openlineage_inject_parent_info=False,
+        )
+        mock_ti = mock.MagicMock()
+        mock_ti.get_dag.return_value.is_paused = False
+
+        with pytest.raises(DagRunTriggerException) as exc_info:
+            task.execute(context={"ti": mock_ti})
+
+        assert exc_info.value.trigger_dag_id == TRIGGERED_DAG_ID
+        mock_ti.get_dag.assert_called_once_with(TRIGGERED_DAG_ID)
 
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Implementation is different for Airflow 2 & 3")
     def test_trigger_dagrun_with_str_conf(self):


### PR DESCRIPTION
`TriggerDagRunOperator(fail_when_dag_is_paused=True)` doesn't work on Airflow 3.x. The paused check calls `DagModel.get_current()`, which goes straight to the ORM, and that's blocked from task execution in Airflow 3 ("Direct database access via the ORM is not allowed in Airflow 3.0"). #56965 stubbed it out to raise `NotImplementedError` for the flag on 3.x as a stop-gap.

This wires the check to the task-SDK `get_dag()` accessor (backed by the `GetDag` execution-API endpoint from #56955) and raises `DagIsPaused` when the target is paused. The check runs in `execute()` before the operator raises `DagRunTriggerException`, so a paused target fails the task without triggering anything. I gated it on `AIRFLOW_V_3_2_PLUS` because that's when the endpoint and the `RuntimeTaskInstance.get_dag()` accessor landed: it works on 3.2.0+, still raises `NotImplementedError` at construction on 3.0/3.1 (the endpoint isn't there and tasks can't reach the DB, so there's nothing to query), and the 2.x path is untouched since the direct ORM lookup is fine there.

The original report is on 3.1.0, so those users will need to move to 3.2.0+ to pick this up. It can't be backported since the endpoint only exists from 3.2.0.

Fixes #56954.
