### PR TITLE
fix(imap): Add overwrite_file parameter to prevent silent attachment overwrites

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite_file: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,10 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite_file: If set to False, files with duplicate names will be saved
+            with a unique suffix (e.g., ``_1``, ``_2``) to prevent data loss.
+            If set to True (default), the original behavior is preserved and files
+            may be silently overwritten.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +224,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +292,27 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(self, mail_attachments: list, local_output_directory: str, overwrite_file: bool = True) -> None:
+        seen_filenames: dict[str, int] = {}
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
+                if not overwrite_file:
+                    name = self._make_unique_filename(name, seen_filenames)
                 self._create_file(name, payload, local_output_directory)
+
+    def _make_unique_filename(self, name: str, seen_filenames: dict[str, int]) -> str:
+        """Generate a unique filename by appending a suffix when duplicates are detected."""
+        if name in seen_filenames:
+            seen_filenames[name] += 1
+            base, ext = os.path.splitext(name)
+            return f"{base}_{seen_filenames[name]}{ext}"
+        else:
+            seen_filenames[name] = 0
+            return name
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -509,3 +509,130 @@ class TestImapHook:
 
         assert result is True
         assert 1 <= mock_conn.fetch.call_count <= 2
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_file_default(self, mock_imaplib, mock_open_method):
+        """When overwrite_file=True (default), files with same name overwrite each other."""
+        mock_conn = _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="report.csv")
+        mock_conn.search.return_value = ("OK", [b"1 2"])
+        # Make fetch return the same attachment for both mail IDs
+        mail_string = (
+            "Content-Type: multipart/mixed; "
+            "boundary=123\r\n--123\r\n"
+            "Content-Disposition: attachment; "
+            'filename="report.csv";'
+            "Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+        )
+        mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments("report.csv", "test_directory")
+
+        # Default overwrite_file=True: both files written to same path -> second overwrites first
+        assert mock_open_method.call_count == 2
+        mock_open_method.assert_any_call("test_directory/report.csv", "wb")
+        # Both calls should use the same path (no suffix)
+        calls = [call for call in mock_open_method.call_args_list if call[0][0].endswith("report.csv")]
+        assert len(calls) == 2
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_file_true(self, mock_imaplib, mock_open_method):
+        """With explicit overwrite_file=True, files with same name overwrite each other."""
+        mock_conn = _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="report.csv")
+        mock_conn.search.return_value = ("OK", [b"1 2"])
+        mail_string = (
+            "Content-Type: multipart/mixed; "
+            "boundary=123\r\n--123\r\n"
+            "Content-Disposition: attachment; "
+            'filename="report.csv";'
+            "Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+        )
+        mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "report.csv", "test_directory", overwrite_file=True
+            )
+
+        assert mock_open_method.call_count == 2
+        mock_open_method.assert_any_call("test_directory/report.csv", "wb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_file_false(self, mock_imaplib, mock_open_method):
+        """With overwrite_file=False, duplicate filenames get unique suffixes."""
+        mock_conn = _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="report.csv")
+        mock_conn.search.return_value = ("OK", [b"1 2"])
+        mail_string = (
+            "Content-Type: multipart/mixed; "
+            "boundary=123\r\n--123\r\n"
+            "Content-Disposition: attachment; "
+            'filename="report.csv";'
+            "Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+        )
+        mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "report.csv", "test_directory", overwrite_file=False
+            )
+
+        # First file gets original name, second gets _1 suffix
+        assert mock_open_method.call_count == 2
+        mock_open_method.assert_any_call("test_directory/report.csv", "wb")
+        mock_open_method.assert_any_call("test_directory/report_1.csv", "wb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_file_false_multiple_duplicates(
+        self, mock_imaplib, mock_open_method
+    ):
+        """With overwrite_file=False, three duplicate files get _1, _2 suffixes."""
+        mock_conn = _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="data.xlsx")
+        mock_conn.search.return_value = ("OK", [b"1 2 3"])
+        mail_string = (
+            "Content-Type: multipart/mixed; "
+            "boundary=123\r\n--123\r\n"
+            "Content-Disposition: attachment; "
+            'filename="data.xlsx";'
+            "Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+        )
+        mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "data.xlsx", "test_directory", overwrite_file=False
+            )
+
+        assert mock_open_method.call_count == 3
+        mock_open_method.assert_any_call("test_directory/data.xlsx", "wb")
+        mock_open_method.assert_any_call("test_directory/data_1.xlsx", "wb")
+        mock_open_method.assert_any_call("test_directory/data_2.xlsx", "wb")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrite_file_false_no_extension(
+        self, mock_imaplib, mock_open_method
+    ):
+        """With overwrite_file=False and files without extensions, suffix is appended correctly."""
+        mock_conn = _create_fake_imap(mock_imaplib, with_mail=True, attachment_name="README")
+        mock_conn.search.return_value = ("OK", [b"1 2"])
+        mail_string = (
+            "Content-Type: multipart/mixed; "
+            "boundary=123\r\n--123\r\n"
+            "Content-Disposition: attachment; "
+            'filename="README";'
+            "Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+        )
+        mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "README", "test_directory", overwrite_file=False
+            )
+
+        assert mock_open_method.call_count == 2
+        mock_open_method.assert_any_call("test_directory/README", "wb")
+        mock_open_method.assert_any_call("test_directory/README_1", "wb")


### PR DESCRIPTION
## Description

When using `ImapHook.download_mail_attachments`, attachments with identical filenames are silently overwritten, causing data loss. This PR adds an `overwrite_file` parameter to control how filename collisions are handled.

### Changes

1. **New `overwrite_file` parameter** on `download_mail_attachments` (default: `True` to preserve existing behavior)
2. When `overwrite_file=False`, duplicate filenames are saved with unique suffixes (`_1`, `_2`, etc.) before the file extension
3. New helper method `_make_unique_filename` for clean suffix generation
4. Unit tests for all scenarios: default behavior, explicit `True`, `False`, multiple duplicates, and files without extensions

### Related

Closes #65870