### PR TITLE
Fix dashboard percentage calculation when state counts exceed API cap (1000)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/DagRunMetrics.tsx
@@ -35,6 +35,7 @@ const DAGRUN_STATES: Array<keyof DAGRunStates> = ["queued", "running", "success"
 export const DagRunMetrics = ({ dagRunStates, endDate, startDate, stateCountLimit }: DagRunMetricsProps) => {
   const { t: translate } = useTranslation();
   const total = Object.values(dagRunStates).reduce((sum, count) => sum + count, 0);
+  const anyCapped = DAGRUN_STATES.some((state) => dagRunStates[state] >= stateCountLimit);
 
   return (
     <Box borderRadius={5} borderWidth={1} p={4}>
@@ -48,6 +49,7 @@ export const DagRunMetrics = ({ dagRunStates, endDate, startDate, stateCountLimi
           <MetricSection
             capped={dagRunStates[state] >= stateCountLimit}
             endDate={endDate}
+            hidePercentages={anyCapped}
             key={state}
             kind="dag_runs"
             runs={dagRunStates[state]}

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/MetricSection.tsx
@@ -30,6 +30,7 @@ const BAR_HEIGHT = 5;
 type MetricSectionProps = {
   readonly capped?: boolean;
   readonly endDate?: string;
+  readonly hidePercentages?: boolean;
   readonly kind: string;
   readonly runs: number;
   readonly startDate: string;
@@ -40,6 +41,7 @@ type MetricSectionProps = {
 export const MetricSection = ({
   capped = false,
   endDate,
+  hidePercentages = false,
   kind,
   runs,
   startDate,
@@ -48,7 +50,7 @@ export const MetricSection = ({
 }: MetricSectionProps) => {
   const stateWidth = capped ? BAR_WIDTH : total === 0 ? 0 : (runs / total) * BAR_WIDTH;
   const remainingWidth = BAR_WIDTH - stateWidth;
-  const statePercent = capped ? undefined : total === 0 ? 0 : ((runs / total) * 100).toFixed(2);
+  const statePercent = capped || hidePercentages ? undefined : total === 0 ? 0 : ((runs / total) * 100).toFixed(2);
 
   const stateParam = kind === "task_instances" ? SearchParamsKeys.TASK_STATE : SearchParamsKeys.STATE;
   const searchParams = new URLSearchParams(

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/HistoricalMetrics/TaskInstanceMetrics.tsx
@@ -54,6 +54,7 @@ export const TaskInstanceMetrics = ({
 }: TaskInstanceMetricsProps) => {
   const { t: translate } = useTranslation();
   const total = Object.values(taskInstanceStates).reduce((sum, count) => sum + count, 0);
+  const anyCapped = TASK_STATES.some((state) => taskInstanceStates[state] >= stateCountLimit);
 
   return (
     <Box borderRadius={5} borderWidth={1} mt={2} p={4}>
@@ -70,6 +71,7 @@ export const TaskInstanceMetrics = ({
             <MetricSection
               capped={taskInstanceStates[state] >= stateCountLimit}
               endDate={endDate}
+              hidePercentages={anyCapped}
               key={state}
               kind="task_instances"
               runs={taskInstanceStates[state]}


### PR DESCRIPTION
## Summary
When the backend caps state counts at `STATE_COUNT_CAP` (1000), the frontend computes `total` as the sum of these capped values. This makes the total denominator artificially low, causing percentage displays for ALL states (not just the capped one) to be wrong.

### Before (buggy)
For example, actual data: success=5000, failed=5, running=2, queued=3
- Backend returns capped: success=1000, failed=5, running=2, queued=3
- Frontend computes `total = 1000+5+2+3 = 1010`
- Failed % displayed: `5/1010 = 0.50%` — **wrong** (should be ~0.10%)
- All percentages are inflated because total is artificially low

### After (fixed)
When ANY state count reaches the cap, percentage displays are hidden for ALL states since the total denominator is unreliable. The individual state counts (shown as `1000+` for capped states) remain accurate and informative.

### Changes
- **MetricSection.tsx**: Added `hidePercentages` prop. When true, percentage text is hidden for that section.
- **DagRunMetrics.tsx**: Detects if any DagRun state is capped; passes `hidePercentages` to all MetricSections.
- **TaskInstanceMetrics.tsx**: Detects if any TaskInstance state is capped; passes `hidePercentages` to all MetricSections.

Closes #67336