### PR TITLE
[AIP-94] airflowctl tasks: add state command

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -261,6 +261,18 @@ ARG_AUTH_PASSWORD = Arg(
     help="The password to use for authentication",
 )
 
+# Task Commands Args
+ARG_TASK_ID = Arg(
+    flags=("task_id",),
+    type=str,
+    help="The Task ID of the task instance",
+)
+ARG_DAG_RUN_ID = Arg(
+    flags=("dag_run_id",),
+    type=str,
+    help="The Dag Run ID of the task instance",
+)
+
 # Dag Commands Args
 ARG_DAG_ID = Arg(
     flags=("dag_id",),
@@ -1015,6 +1027,20 @@ VARIABLE_COMMANDS = (
     ),
 )
 
+TASK_COMMANDS = (
+    ActionCommand(
+        name="state",
+        help="Show the state of a specific task instance",
+        func=lazy_load_command("airflowctl.ctl.commands.task_command.state"),
+        args=(
+            ARG_DAG_ID,
+            ARG_DAG_RUN_ID,
+            ARG_TASK_ID,
+            ARG_OUTPUT,
+        ),
+    ),
+)
+
 core_commands: list[CLICommand] = [
     GroupCommand(
         name="auth",
@@ -1041,6 +1067,11 @@ core_commands: list[CLICommand] = [
         name="pools",
         help="Manage Airflow pools",
         subcommands=POOL_COMMANDS,
+    ),
+    GroupCommand(
+        name="tasks",
+        help="Interact with Airflow task instances",
+        subcommands=TASK_COMMANDS,
     ),
     ActionCommand(
         name="version",

--- a/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/task_command.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import sys
+
+import rich
+
+from airflowctl.api.client import NEW_API_CLIENT, ClientKind, ServerResponseError, provide_api_client
+from airflowctl.api.datamodels.generated import TaskInstanceResponse
+from airflowctl.ctl.console_formatting import AirflowConsole
+
+
+@provide_api_client(kind=ClientKind.CLI)
+def state(args, api_client=NEW_API_CLIENT) -> None:
+    """Show the state of a specific task instance."""
+    try:
+        response = api_client.get(
+            f"dags/{args.dag_id}/dagRuns/{args.dag_run_id}/taskInstances/{args.task_id}"
+        )
+        task_instance = TaskInstanceResponse.model_validate_json(response.content)
+    except ServerResponseError as e:
+        rich.print(f"[red]Error retrieving task instance state: {e}[/red]")
+        sys.exit(1)
+
+    state_value = task_instance.state.value if task_instance.state else "None"
+    rich.print(f"[green]Task {args.task_id} state: {state_value}[/green]")
+
+    result = task_instance.model_dump(mode="json")
+    AirflowConsole().print_as(
+        data=[result],
+        output=args.output,
+    )


### PR DESCRIPTION
## Summary

Implements AIP-94: adds a `airflowctl tasks state` CLI subcommand that displays the state of a specific task instance.

Fixes #66174

## Usage

```
airflowctl tasks state <dag_id> <dag_run_id> <task_id> [--output table|json|yaml|plain]
```

## Description

This new subcommand fetches a task instance via the Airflow REST API (`GET /dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}`) and displays its state (e.g. success, failed, running, queued, etc.) along with full task instance details.

## Files Changed

- **`airflow-ctl/src/airflowctl/ctl/commands/task_command.py`** — new file with the `state` function
- **`airflow-ctl/src/airflowctl/ctl/cli_config.py`** — added `ARG_TASK_ID`, `ARG_DAG_RUN_ID`, `TASK_COMMANDS`, and registered the `tasks` group