### PR TITLE
Add overwrite_file parameter to IMAP hook download_mail_attachments

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite_file: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,8 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite_file: If set to True (default), existing files will be overwritten.
+            If set to False, existing files will be skipped and a warning will be logged.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +222,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file=overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +290,14 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(self, mail_attachments: list, local_output_directory: str, *, overwrite_file: bool = True) -> None:
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                self._create_file(name, payload, local_output_directory, overwrite_file=overwrite_file)
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -311,8 +314,12 @@ class ImapHook(BaseHook):
             else local_output_directory + os.sep + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _create_file(self, name: str, payload: Any, local_output_directory: str, *, overwrite_file: bool = True) -> None:
         file_path = self._correct_path(name, local_output_directory)
+
+        if not overwrite_file and os.path.isfile(file_path):
+            self.log.warning("File %s already exists, skipping...", file_path)
+            return
 
         with open(file_path, "wb") as file:
             file.write(payload)

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -509,3 +509,51 @@ class TestImapHook:
 
         assert result is True
         assert 1 <= mock_conn.fetch.call_count <= 2
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    @patch("airflow.providers.imap.hooks.imap.os.path.isfile", return_value=True)
+    def test_download_mail_attachments_skips_existing_file_when_overwrite_false(
+        self, mock_isfile, mock_imaplib, mock_open_method
+    ):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "test1.csv", "test_directory", overwrite_file=False
+            )
+
+        mock_open_method.assert_not_called()
+        mock_open_method.return_value.write.assert_not_called()
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    @patch("airflow.providers.imap.hooks.imap.os.path.isfile", return_value=False)
+    def test_download_mail_attachments_writes_when_file_not_exists_and_overwrite_false(
+        self, mock_isfile, mock_imaplib, mock_open_method
+    ):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "test1.csv", "test_directory", overwrite_file=False
+            )
+
+        mock_open_method.assert_called_once_with("test_directory/test1.csv", "wb")
+        mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
+
+    @patch(open_string, new_callable=mock_open)
+    @patch(imaplib_string)
+    @patch("airflow.providers.imap.hooks.imap.os.path.isfile", return_value=True)
+    def test_download_mail_attachments_overwrites_existing_file_when_overwrite_true(
+        self, mock_isfile, mock_imaplib, mock_open_method
+    ):
+        _create_fake_imap(mock_imaplib, with_mail=True)
+
+        with ImapHook() as imap_hook:
+            imap_hook.download_mail_attachments(
+                "test1.csv", "test_directory", overwrite_file=True
+            )
+
+        mock_open_method.assert_called_once_with("test_directory/test1.csv", "wb")
+        mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")


### PR DESCRIPTION
## Summary

Adds an `overwrite_file` parameter to `ImapHook.download_mail_attachments` to give users control over whether existing files are overwritten when downloading attachments with identical filenames.

## Related issue(s)

Closes #65870

## Changes

### Hook (`imap.py`)
- Added `overwrite_file: bool = True` parameter to `download_mail_attachments`
- Propagated the parameter through `_create_files` and `_create_file`
- When `overwrite_file=False` and the target file already exists, the file is skipped and a warning is logged (instead of silently overwriting)

### Tests (`test_imap.py`)
Added 3 new test methods:
- `test_download_mail_attachments_skips_existing_file_when_overwrite_false` — verifies existing files are skipped when `overwrite_file=False`
- `test_download_mail_attachments_writes_when_file_not_exists_and_overwrite_false` — verifies new files are still written when `overwrite_file=False`
- `test_download_mail_attachments_overwrites_existing_file_when_overwrite_true` — verifies existing files are overwritten when `overwrite_file=True`