### PR TITLE
Fix typo in IMAP provider connection docs

### DIFF
--- a/providers/imap/docs/connections/imap.rst
+++ b/providers/imap/docs/connections/imap.rst
@@ -49,7 +49,7 @@ Host
     Specify the IMAP host url.
 
 Port
-    Specify the IMAP port to connect to. The default depends on the whether you use ssl or not.
+    Specify the IMAP port to connect to. The default depends on whether you use ssl or not.
 
 Extra (optional)
     Specify the extra parameters (as json dictionary)


### PR DESCRIPTION
Remove extraneous 'the' before 'whether' in the Port description of the IMAP connection documentation.

```diff
- The default depends on the whether you use ssl or not.
+ The default depends on whether you use ssl or not.
```