### PR TITLE
Fix typo: occurences -> occurrences in Amazon provider changelog

### DIFF
--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -804,7 +804,7 @@ Misc
 * ``Replace usage of 'set_extra' with 'extra' for athena sql hook (#52340)``
 * ``Drop support for Python 3.9 (#52072)``
 * ``Replace 'models.BaseOperator' to Task SDK one for Standard Provider (#52292)``
-* ``Replace occurences of 'get_password' with 'password' to ease migration (#52333)``
+* ``Replace occurrences of 'get_password' with 'password' to ease migration (#52333)``
 * ``Use BaseSensorOperator from task sdk in providers (#52296)``
 * ``Use base AWS classes in Glue Trigger / Sensor and implement custom waiter (#52243)``
 * ``Add Airflow 3.0+ Task SDK support to AWS Batch Executor (#52121)``

--- a/providers/imap/docs/connections/imap.rst
+++ b/providers/imap/docs/connections/imap.rst
@@ -49,7 +49,7 @@ Host
     Specify the IMAP host url.
 
 Port
-    Specify the IMAP port to connect to. The default depends on the whether you use ssl or not.
+    Specify the IMAP port to connect to. The default depends on whether you use ssl or not.
 
 Extra (optional)
     Specify the extra parameters (as json dictionary)


### PR DESCRIPTION
Fix a typo in the Amazon provider changelog docs: `occurences` -> `occurrences`.