### PR TITLE
Fix typos in docs/spelling_wordlist.txt via codespell

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -4,7 +4,7 @@ AbstractFileSystem
 AbstractToolset
 accessor
 AccessSecretVersionResponse
-aci
+acpi
 Ack
 ack
 ackIds
@@ -22,7 +22,7 @@ adls
 adobjects
 AdsInsights
 adsinsights
-afterall
+after all
 agentic
 ai
 aio
@@ -40,7 +40,7 @@ airflowignore
 ajax
 Akeyless
 akeyless
-aks
+ask
 AlertApi
 alertPolicies
 Alibaba
@@ -62,8 +62,8 @@ analyzeSyntax
 Aneesh
 AnExampleDisplayName
 AnotherExampleDisplayName
-ans
-anser
+and
+answer
 Ansible
 anyOf
 apache
@@ -101,9 +101,9 @@ AspectType
 AspectTypes
 AssetEvent
 AssetEvents
-assigment
+assignment
 ast
-astroid
+asteroid
 Async
 async
 asyncio
@@ -296,7 +296,7 @@ configs
 conftest
 conn
 connectTimeoutMS
-connexion
+connection
 conns
 containerConfiguration
 containerd
@@ -900,7 +900,7 @@ js
 Json
 json
 jsonl
-juli
+july
 Jupyter
 jupyter
 jvm
@@ -1151,7 +1151,7 @@ opsgenie
 Optimise
 optimise
 optimizationObjective
-OptIn
+option
 optionality
 ora
 oracledb
@@ -1258,7 +1258,7 @@ preselected
 presign
 presigned
 prestodb
-pretify
+prettify
 prev
 Proc
 proc
@@ -1413,7 +1413,7 @@ runtime
 runTimeoutInMinutes
 runtimes
 SaaS
-sade
+sad
 Sagemaker
 sagemaker
 salesforce
@@ -1456,7 +1456,7 @@ selectin
 Sendgrid
 sendgrid
 sentimentMax
-ser
+set
 serde
 serialise
 serializable
@@ -1555,7 +1555,7 @@ starttls
 stateful
 StatefulSet
 StatefulSets
-statics
+statistics
 StatsD
 statsd
 stderr
@@ -1854,7 +1854,7 @@ whitespace
 whl
 wildcarded
 winrm
-WIT
+WITH
 workgroup
 workspaces
 writeable

--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -804,7 +804,7 @@ Misc
 * ``Replace usage of 'set_extra' with 'extra' for athena sql hook (#52340)``
 * ``Drop support for Python 3.9 (#52072)``
 * ``Replace 'models.BaseOperator' to Task SDK one for Standard Provider (#52292)``
-* ``Replace occurences of 'get_password' with 'password' to ease migration (#52333)``
+* ``Replace occurrences of 'get_password' with 'password' to ease migration (#52333)``
 * ``Use BaseSensorOperator from task sdk in providers (#52296)``
 * ``Use base AWS classes in Glue Trigger / Sensor and implement custom waiter (#52243)``
 * ``Add Airflow 3.0+ Task SDK support to AWS Batch Executor (#52121)``

--- a/providers/imap/docs/connections/imap.rst
+++ b/providers/imap/docs/connections/imap.rst
@@ -49,7 +49,7 @@ Host
     Specify the IMAP host url.
 
 Port
-    Specify the IMAP port to connect to. The default depends on the whether you use ssl or not.
+    Specify the IMAP port to connect to. The default depends on whether you use ssl or not.
 
 Extra (optional)
     Specify the extra parameters (as json dictionary)


### PR DESCRIPTION
Auto-fixed typos in `docs/spelling_wordlist.txt` using `codespell`. The following corrections were made:

- aci -> acpi
- afterall -> after all
- aks -> ask
- ans -> and
- anser -> answer
- assigment -> assignment
- astroid -> asteroid
- connexion -> connection
- juli -> july
- OptIn -> option
- pretify -> prettify
- sade -> sad
- ser -> set
- statics -> statistics
- WIT -> WITH