### PR TITLE
Fix Helm chart executor label to support executor aliases

### DIFF
--- a/chart/newsfragments/67762.bugfix.rst
+++ b/chart/newsfragments/67762.bugfix.rst
@@ -1,0 +1,6 @@
+Fix scheduler ``executor`` label for executor aliases
+
+The scheduler ``executor`` label now replaces the colon used in executor aliases
+(``name:ExecutorClass``) in addition to the comma separator between multiple
+executors, so aliased and multi-executor configurations render a valid Kubernetes
+label instead of failing to deploy.

--- a/chart/newsfragments/67762.bugfix.rst
+++ b/chart/newsfragments/67762.bugfix.rst
@@ -1,6 +1,0 @@
-Fix scheduler ``executor`` label for executor aliases
-
-The scheduler ``executor`` label now replaces the colon used in executor aliases
-(``name:ExecutorClass``) in addition to the comma separator between multiple
-executors, so aliased and multi-executor configurations render a valid Kubernetes
-label instead of failing to deploy.

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -50,7 +50,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    executor: {{ .Values.executor | replace "," "-" | trunc 63 | trimSuffix "-" | trimSuffix ":" | trimSuffix "_" | trimSuffix "." | quote }}
+    executor: {{ .Values.executor | replace "," "-" | replace ":" "-" | trunc 63 | trimSuffix "-" | trimSuffix ":" | trimSuffix "_" | trimSuffix "." | quote }}
     {{- with .Values.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/chart/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
+++ b/chart/tests/helm_tests/airflow_aux/test_basic_helm_chart.py
@@ -204,6 +204,7 @@ class TestBaseChartTest:
         [
             "CeleryExecutor",
             "CeleryExecutor,KubernetesExecutor",
+            "CeleryExecutor,harvest_exec:KubernetesExecutor",
         ],
     )
     def test_labels_are_valid(self, executor):
@@ -326,6 +327,8 @@ class TestBaseChartTest:
                 expected_labels["executor"] = "CeleryExecutor"
                 if executor == "CeleryExecutor,KubernetesExecutor":
                     expected_labels["executor"] = "CeleryExecutor-KubernetesExecutor"
+                elif executor == "CeleryExecutor,harvest_exec:KubernetesExecutor":
+                    expected_labels["executor"] = "CeleryExecutor-harvest_exec-KubernetesExecutor"
 
             if (
                 executor == "CeleryExecutor"


### PR DESCRIPTION
## What does this PR do?

The chart renders the `executor` option into a Kubernetes `executor` label on the scheduler `Deployment`/`StatefulSet` (`chart/templates/scheduler/scheduler-deployment.yaml`). The value was sanitized for the comma separating multiple executors, but not for the colon used in [executor aliases](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/executor/index.html#aliases) (`name:ExecutorClass`).

So `executor: CeleryExecutor,harvest_exec:KubernetesExecutor` rendered the label `CeleryExecutor-harvest_exec:KubernetesExecutor`, whose embedded `:` is an invalid label character and made the scheduler fail to deploy:

```
metadata.labels: Invalid value: "CeleryExecutor-harvest_exec:KubernetesExecutor": a valid label must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character
```

## Fix

Add `replace ":" "-"` next to the existing comma handling so aliased and multi-executor values render a valid label. This is the only place the executor option is used as a label value; the `AIRFLOW__CORE__EXECUTOR` env var still receives the raw string.

## Tests

Added an aliased multi-executor case to `test_labels_are_valid`. It reproduces the invalid label without the fix and passes with it; the full `test_basic_helm_chart.py` suite passes (45) on Helm 3.19.0.

closes: #67723

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
