### PR TITLE
Fix Task Instance mark-as downstream default

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.test.tsx
@@ -1,0 +1,90 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import { Wrapper } from "src/utils/Wrapper";
+
+import MarkTaskInstanceAsDialog from "./MarkTaskInstanceAsDialog";
+
+vi.mock("src/queries/usePatchTaskInstance", () => ({
+  usePatchTaskInstance: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+vi.mock("src/queries/usePatchTaskInstanceDryRun", () => ({
+  usePatchTaskInstanceDryRun: () => ({
+    data: {
+      task_instances: [],
+      total_entries: 0,
+    },
+    isPending: false,
+  }),
+}));
+
+const taskInstance: TaskInstanceResponse = {
+  dag_display_name: "Test DAG",
+  dag_id: "test_dag",
+  dag_run_id: "manual__2025-01-01T00:00:00+00:00",
+  dag_version: null,
+  duration: null,
+  end_date: null,
+  executor: null,
+  executor_config: "{}",
+  hostname: null,
+  id: "test_task_instance",
+  logical_date: "2025-01-01T00:00:00Z",
+  map_index: 0,
+  max_tries: 0,
+  note: null,
+  operator: "EmptyOperator",
+  operator_name: "EmptyOperator",
+  pid: null,
+  pool: "default_pool",
+  pool_slots: 1,
+  priority_weight: null,
+  queue: null,
+  queued_when: null,
+  rendered_fields: undefined,
+  rendered_map_index: null,
+  run_after: "2025-01-01T00:00:00Z",
+  scheduled_when: null,
+  start_date: null,
+  state: "failed",
+  task_display_name: "task_1",
+  task_id: "task_1",
+  trigger: null,
+  triggerer_job: null,
+  try_number: 1,
+  unixname: null,
+};
+
+describe("MarkTaskInstanceAsDialog", () => {
+  it("does not select downstream by default", () => {
+    render(<MarkTaskInstanceAsDialog onClose={vi.fn()} open state="success" taskInstance={taskInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByRole("button", { name: /downstream/iu })).not.toHaveAttribute("data-selected");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -107,7 +107,6 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
         <Dialog.Body width="full">
           <Flex justifyContent="center">
             <SegmentedControl
-              defaultValues={["downstream"]}
               multiple
               onChange={setSelectedOptions}
               options={[


### PR DESCRIPTION
## What

This PR updates the Task Instance mark-as dialog so that the `downstream` option is no longer selected by default.

## Why

In the Task Instances view, marking a failed task instance as success should not automatically include downstream task instances unless the user explicitly selects that option.

Previously, the dialog defaulted to `downstream`, which meant the request was sent with `include_downstream: true`. This could cause downstream `upstream_failed` task instances to be affected and resume within the same DagRun, which differs from the older Airflow 2 Task Instances view behavior.

This change makes the action safer and more explicit: only the selected task instance is updated by default, while users can still choose downstream manually when they want that behavior.

## How

- Removed the default `downstream` selection from `MarkTaskInstanceAsDialog`
- Added a regression test to verify that `downstream` is not selected by default

## Tests

cd airflow-core/src/airflow/ui
pnpm test MarkTaskInstanceAsDialog.test.tsx

Result:
✓ src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.test.tsx (1 test) 123ms
  ✓ MarkTaskInstanceAsDialog (1)
    ✓ does not select downstream by default 120ms

Test Files  1 passed (1)
Tests       1 passed (1)

uv run prek run ts-compile-lint-ui --all-files

Result:
Running hooks for `airflow-core`:
Compile / format / lint UI...............................................Passed