### PR TITLE
Fix use_job_schedule=False disabling asset-triggered Dag runs

### DIFF
--- a/airflow-core/docs/best-practices.rst
+++ b/airflow-core/docs/best-practices.rst
@@ -898,7 +898,7 @@ Disable the scheduler
 
 You might consider disabling the Airflow cluster while you perform such maintenance.
 
-One way to do so would be to set the param ``[scheduler] > use_job_schedule`` to ``False`` and wait for any running Dags to complete; after this no new Dag runs will be created unless externally triggered.
+One way to do so would be to set the param ``[scheduler] > use_job_schedule`` to ``False`` and wait for any running Dags to complete; after this no new *time-based* (cron) Dag runs will be created. Note that this flag only disables cron/timetable scheduling — manually triggered runs and asset- (and partitioned-asset-) triggered runs are still created. To fully stop all new Dag runs for maintenance, use the ``dags pause`` approach below instead.
 
 A *better* way (though it's a bit more manual) is to use the ``dags pause`` command.  You'll need to keep track of the Dags that are paused before you begin this operation so that you know which ones to unpause after maintenance is complete.  First run ``airflow dags list`` and store the list of unpaused Dags.  Then use this same list to run both ``dags pause`` for each Dag prior to maintenance, and ``dags unpause`` after.  A benefit of this is you can try un-pausing just one or two Dags (perhaps dedicated :ref:`test Dags <integration-test-dags>`) after the upgrade to make sure things are working before turning everything back on.
 

--- a/airflow-core/docs/best-practices.rst
+++ b/airflow-core/docs/best-practices.rst
@@ -933,7 +933,7 @@ Disable the scheduler
 
 You might consider disabling the Airflow cluster while you perform such maintenance.
 
-One way to do so would be to set the param ``[scheduler] > use_job_schedule`` to ``False`` and wait for any running Dags to complete; after this no new Dag runs will be created unless externally triggered.
+One way to do so would be to set the param ``[scheduler] > use_job_schedule`` to ``False`` and wait for any running Dags to complete; after this no new *time-based* (cron) Dag runs will be created. Note that this flag only disables cron/timetable scheduling — manually triggered runs and asset- (and partitioned-asset-) triggered runs are still created. To fully stop all new Dag runs for maintenance, use the ``dags pause`` approach below instead.
 
 A *better* way (though it's a bit more manual) is to use the ``dags pause`` command.  You'll need to keep track of the Dags that are paused before you begin this operation so that you know which ones to unpause after maintenance is complete.  First run ``airflow dags list`` and store the list of unpaused Dags.  Then use this same list to run both ``dags pause`` for each Dag prior to maintenance, and ``dags unpause`` after.  A benefit of this is you can try un-pausing just one or two Dags (perhaps dedicated :ref:`test Dags <integration-test-dags>`) after the upgrade to make sure things are working before turning everything back on.
 

--- a/airflow-core/newsfragments/67764.bugfix.rst
+++ b/airflow-core/newsfragments/67764.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ``[scheduler] use_job_schedule=False`` wrongly disabling asset- and partitioned-asset-triggered Dag run creation. The flag now disables only time-based (cron) scheduling, as documented; manually triggered and asset-triggered Dag runs are still created.

--- a/airflow-core/newsfragments/67764.bugfix.rst
+++ b/airflow-core/newsfragments/67764.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``[scheduler] use_job_schedule=False`` wrongly disabling asset- and partitioned-asset-triggered Dag run creation. The flag now disables only time-based (cron) scheduling, as documented; manually triggered and asset-triggered Dag runs are still created.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2014,8 +2014,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-            if self._scheduler_use_job_schedule:
-                self._create_dagruns_for_dags(guard, session)
+            # ``[scheduler] use_job_schedule`` disables only cron/time-based scheduling. Asset- and
+            # partitioned-asset-triggered runs must still be created, so always run the orchestrator
+            # here; the flag is applied inside ``_create_dagruns_for_dags`` where it gates only the
+            # time-based creation.
+            self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
             guard.commit()
@@ -2471,7 +2474,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # filter asset partition triggered Dags
             if d.dag_id not in partition_dag_ids
         }
-        self._create_dag_runs(non_asset_dags, session)
+        # ``[scheduler] use_job_schedule=False`` disables only cron/time-based scheduling. Keep this
+        # gate here (not around the whole method): asset- and partitioned-asset-triggered runs above
+        # and below must still be created regardless of the flag.
+        if self._scheduler_use_job_schedule:
+            self._create_dag_runs(non_asset_dags, session)
         if asset_triggered_dags:
             self._create_dag_runs_asset_triggered(
                 dag_models=[d for d in asset_triggered_dags if d.dag_id not in partition_dag_ids],

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2014,10 +2014,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-            # ``[scheduler] use_job_schedule`` disables only cron/time-based scheduling. Asset- and
-            # partitioned-asset-triggered runs must still be created, so always run the orchestrator
-            # here; the flag is applied inside ``_create_dagruns_for_dags`` where it gates only the
-            # time-based creation.
             self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
@@ -2474,9 +2470,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # filter asset partition triggered Dags
             if d.dag_id not in partition_dag_ids
         }
-        # ``[scheduler] use_job_schedule=False`` disables only cron/time-based scheduling. Keep this
-        # gate here (not around the whole method): asset- and partitioned-asset-triggered runs above
-        # and below must still be created regardless of the flag.
+        # use_job_schedule disables only time-based scheduling; asset-triggered runs are still created.
         if self._scheduler_use_job_schedule:
             self._create_dag_runs(non_asset_dags, session)
         if asset_triggered_dags:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1996,8 +1996,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-            if self._scheduler_use_job_schedule:
-                self._create_dagruns_for_dags(guard, session)
+            # ``[scheduler] use_job_schedule`` disables only cron/time-based scheduling. Asset- and
+            # partitioned-asset-triggered runs must still be created, so always run the orchestrator
+            # here; the flag is applied inside ``_create_dagruns_for_dags`` where it gates only the
+            # time-based creation.
+            self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
             guard.commit()
@@ -2453,7 +2456,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # filter asset partition triggered Dags
             if d.dag_id not in partition_dag_ids
         }
-        self._create_dag_runs(non_asset_dags, session)
+        # ``[scheduler] use_job_schedule=False`` disables only cron/time-based scheduling. Keep this
+        # gate here (not around the whole method): asset- and partitioned-asset-triggered runs above
+        # and below must still be created regardless of the flag.
+        if self._scheduler_use_job_schedule:
+            self._create_dag_runs(non_asset_dags, session)
         if asset_triggered_dags:
             self._create_dag_runs_asset_triggered(
                 dag_models=[d for d in asset_triggered_dags if d.dag_id not in partition_dag_ids],

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1996,10 +1996,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-            # ``[scheduler] use_job_schedule`` disables only cron/time-based scheduling. Asset- and
-            # partitioned-asset-triggered runs must still be created, so always run the orchestrator
-            # here; the flag is applied inside ``_create_dagruns_for_dags`` where it gates only the
-            # time-based creation.
             self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
@@ -2456,9 +2452,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # filter asset partition triggered Dags
             if d.dag_id not in partition_dag_ids
         }
-        # ``[scheduler] use_job_schedule=False`` disables only cron/time-based scheduling. Keep this
-        # gate here (not around the whole method): asset- and partitioned-asset-triggered runs above
-        # and below must still be created regardless of the flag.
+        # use_job_schedule disables only time-based scheduling; asset-triggered runs are still created.
         if self._scheduler_use_job_schedule:
             self._create_dag_runs(non_asset_dags, session)
         if asset_triggered_dags:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1980,8 +1980,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-            if self._scheduler_use_job_schedule:
-                self._create_dagruns_for_dags(guard, session)
+            # ``[scheduler] use_job_schedule`` disables only cron/time-based scheduling. Asset- and
+            # partitioned-asset-triggered runs must still be created, so always run the orchestrator
+            # here; the flag is applied inside ``_create_dagruns_for_dags`` where it gates only the
+            # time-based creation.
+            self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
             guard.commit()
@@ -2441,7 +2444,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # filter asset partition triggered Dags
             if d.dag_id not in partition_dag_ids
         }
-        self._create_dag_runs(non_asset_dags, session)
+        # ``[scheduler] use_job_schedule=False`` disables only cron/time-based scheduling. Keep this
+        # gate here (not around the whole method): asset- and partitioned-asset-triggered runs above
+        # and below must still be created regardless of the flag.
+        if self._scheduler_use_job_schedule:
+            self._create_dag_runs(non_asset_dags, session)
         if asset_triggered_dags:
             self._create_dag_runs_asset_triggered(
                 dag_models=[d for d in asset_triggered_dags if d.dag_id not in partition_dag_ids],

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1980,10 +1980,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-            # ``[scheduler] use_job_schedule`` disables only cron/time-based scheduling. Asset- and
-            # partitioned-asset-triggered runs must still be created, so always run the orchestrator
-            # here; the flag is applied inside ``_create_dagruns_for_dags`` where it gates only the
-            # time-based creation.
             self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
@@ -2444,9 +2440,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # filter asset partition triggered Dags
             if d.dag_id not in partition_dag_ids
         }
-        # ``[scheduler] use_job_schedule=False`` disables only cron/time-based scheduling. Keep this
-        # gate here (not around the whole method): asset- and partitioned-asset-triggered runs above
-        # and below must still be created regardless of the flag.
+        # use_job_schedule disables only time-based scheduling; asset-triggered runs are still created.
         if self._scheduler_use_job_schedule:
             self._create_dag_runs(non_asset_dags, session)
         if asset_triggered_dags:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5782,6 +5782,154 @@ class TestSchedulerJob:
         assert created_run.creating_job_id == scheduler_job.id
 
     @pytest.mark.need_serialized_dag
+    @conf_vars({("scheduler", "use_job_schedule"): "False"})
+    def test_use_job_schedule_false_still_creates_asset_runs(self, session, dag_maker):
+        """
+        ``[scheduler] use_job_schedule=False`` must disable only cron/time-based scheduling.
+
+        Asset-triggered Dag runs must still be created. Regression test for #62929, driven through
+        ``_do_scheduling`` so it exercises both the orchestrator call site and the time-based gate.
+        """
+        asset1 = Asset(uri="test://asset-62929", name="asset_62929", group="test_group")
+
+        # Producer: declares the asset as an outlet so the AssetModel is registered on serialization.
+        with dag_maker(dag_id="asset-producer-62929", schedule="@daily", session=session):
+            BashOperator(task_id="producer", bash_command="echo 1", outlets=[asset1])
+        producer_run = dag_maker.create_dagrun(
+            run_id="producer_run",
+            logical_date=DEFAULT_DATE,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
+        )
+
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+        session.add(
+            AssetEvent(
+                asset_id=asset1_id,
+                source_task_id="producer",
+                source_dag_id=producer_run.dag_id,
+                source_run_id=producer_run.run_id,
+                source_map_index=-1,
+            )
+        )
+
+        # Consumer: scheduled on the asset, with the asset already queued for it.
+        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
+            EmptyOperator(task_id="consume")
+        consumer_dag_id = dag_maker.dag.dag_id
+        session.add(AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag_id))
+
+        # Time-based Dag that is eligible for a scheduled run right now (catchup + past start_date).
+        with dag_maker(dag_id="time-based-62929", schedule="@daily", catchup=True, session=session):
+            EmptyOperator(task_id="noop")
+        time_based_dag_id = dag_maker.dag.dag_id
+        session.flush()
+
+        # Sanity: the time-based Dag really is eligible, so its absence below is due to the flag,
+        # not because it was never schedulable in the first place.
+        time_based_model = session.get(DagModel, time_based_dag_id)
+        assert time_based_model.next_dagrun_create_after is not None
+        assert time_based_model.next_dagrun_create_after <= timezone.utcnow()
+
+        scheduler_job = Job()
+        # Construct the runner *under* the conf override so it reads use_job_schedule=False.
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is False
+
+        self.job_runner._do_scheduling(session)
+
+        # The asset-triggered consumer run IS created despite use_job_schedule=False.
+        consumer_runs = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()
+        assert len(consumer_runs) == 1
+        # The run was created; it may already have been moved to RUNNING by the
+        # _start_queued_dagruns step inside the same _do_scheduling call, so accept either
+        # non-terminal state. #62929 is about the run being created at all.
+        assert consumer_runs[0].state in (State.QUEUED, State.RUNNING)
+        assert consumer_runs[0].consumed_asset_events  # the AssetEvent was attached
+        # The asset queue row was consumed.
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).one_or_none()
+            is None
+        )
+
+        # The time-based run is suppressed by the flag.
+        assert session.scalars(select(DagRun).where(DagRun.dag_id == time_based_dag_id)).one_or_none() is None
+
+    @pytest.mark.need_serialized_dag
+    @conf_vars({("scheduler", "use_job_schedule"): "True"})
+    def test_use_job_schedule_true_creates_time_based_runs(self, session, dag_maker):
+        """
+        Companion to ``test_use_job_schedule_false_still_creates_asset_runs``.
+
+        With the flag on, the eligible time-based Dag does get a scheduled run. This guards against
+        accidentally inverting the gate (which would make the negative assertion above pass for the
+        wrong reason).
+        """
+        with dag_maker(dag_id="time-based-62929-on", schedule="@daily", catchup=True, session=session):
+            EmptyOperator(task_id="noop")
+        time_based_dag_id = dag_maker.dag.dag_id
+        session.flush()
+
+        time_based_model = session.get(DagModel, time_based_dag_id)
+        assert time_based_model.next_dagrun_create_after is not None
+        assert time_based_model.next_dagrun_create_after <= timezone.utcnow()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is True
+
+        self.job_runner._do_scheduling(session)
+
+        time_based_runs = session.scalars(select(DagRun).where(DagRun.dag_id == time_based_dag_id)).all()
+        assert len(time_based_runs) >= 1
+        assert time_based_runs[0].run_type == DagRunType.SCHEDULED
+
+    @pytest.mark.need_serialized_dag
+    @pytest.mark.usefixtures("clear_asset_partition_rows")
+    @conf_vars({("scheduler", "use_job_schedule"): "False"})
+    def test_use_job_schedule_false_still_creates_partition_asset_runs(self, session, dag_maker):
+        """
+        Companion to ``test_use_job_schedule_false_still_creates_asset_runs`` for the
+        partitioned-asset path. ``_create_dagruns_for_partitioned_asset_dags`` runs at the very top
+        of ``_create_dagruns_for_dags``, which ``use_job_schedule=False`` used to skip entirely.
+        Driven through ``_do_scheduling`` so it backs the newsfragment's partitioned-asset claim. #62929.
+        """
+        asset_1 = Asset(name="asset-part-62929")
+
+        with dag_maker(
+            dag_id="asset-event-consumer-62929",
+            schedule=PartitionedAssetTimetable(assets=asset_1, default_partition_mapper=IdentityMapper()),
+            session=session,
+        ):
+            EmptyOperator(task_id="hi")
+        session.commit()
+
+        apdr = _produce_and_register_asset_event(
+            dag_id="asset-event-producer-62929",
+            asset=asset_1,
+            partition_key="key-1",
+            session=session,
+            dag_maker=dag_maker,
+        )
+        apdr_id = apdr.id
+        assert apdr.created_dag_run_id is None  # pre-condition: run not created yet
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is False
+
+        self.job_runner._do_scheduling(session)
+
+        # The partitioned-asset run IS created despite use_job_schedule=False (re-query: _do_scheduling
+        # calls expunge_all).
+        apdr = session.scalar(select(AssetPartitionDagRun).where(AssetPartitionDagRun.id == apdr_id))
+        assert apdr is not None
+        assert apdr.created_dag_run_id is not None
+        partition_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+        assert partition_run is not None
+        assert partition_run.dag_id == "asset-event-consumer-62929"
+
     @pytest.mark.parametrize(
         ("catchup", "expects_old_event"),
         [
@@ -5849,6 +5997,7 @@ class TestSchedulerJob:
         assert created_run.state == State.QUEUED
         expected = {new_event.id} | ({old_event.id} if expects_old_event else set())
         assert {e.id for e in created_run.consumed_asset_events} == expected
+
 
     @pytest.mark.need_serialized_dag
     def test_asset_events_out_of_order_are_both_consumed(self, session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5800,20 +5800,21 @@ class TestSchedulerJob:
             )
         )
 
-        session.add(
-            AssetEvent(
-                asset_id=asset1_id,
-                source_task_id="producer",
-                source_dag_id=producer_run.dag_id,
-                source_run_id=producer_run.run_id,
-                source_map_index=-1,
-                timestamp=reference_created_at + timedelta(seconds=1),
-            )
+        event = AssetEvent(
+            asset_id=asset1_id,
+            source_task_id="producer",
+            source_dag_id=producer_run.dag_id,
+            source_run_id=producer_run.run_id,
+            source_map_index=-1,
+            timestamp=reference_created_at + timedelta(seconds=1),
         )
+        session.add(event)
+        session.flush()  # assign event id so the ADRQ row can reference it
         session.add(
             AssetDagRunQueue(
                 asset_id=asset1_id,
                 target_dag_id=consumer_dag_id,
+                asset_event_id=event.id,
                 created_at=reference_created_at + timedelta(hours=1),
             )
         )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5823,6 +5823,7 @@ class TestSchedulerJob:
         )
         session.add(event)
         session.flush()  # assign event id so the ADRQ row can reference it
+        assert event.id is not None
         session.add(
             AssetDagRunQueue(
                 asset_id=asset1_id,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5810,6 +5810,7 @@ class TestSchedulerJob:
         )
         session.add(event)
         session.flush()  # assign event id so the ADRQ row can reference it
+        assert event.id is not None
         session.add(
             AssetDagRunQueue(
                 asset_id=asset1_id,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5769,6 +5769,154 @@ class TestSchedulerJob:
         assert created_run.creating_job_id == scheduler_job.id
 
     @pytest.mark.need_serialized_dag
+    @conf_vars({("scheduler", "use_job_schedule"): "False"})
+    def test_use_job_schedule_false_still_creates_asset_runs(self, session, dag_maker):
+        """
+        ``[scheduler] use_job_schedule=False`` must disable only cron/time-based scheduling.
+
+        Asset-triggered Dag runs must still be created. Regression test for #62929, driven through
+        ``_do_scheduling`` so it exercises both the orchestrator call site and the time-based gate.
+        """
+        asset1 = Asset(uri="test://asset-62929", name="asset_62929", group="test_group")
+
+        # Producer: declares the asset as an outlet so the AssetModel is registered on serialization.
+        with dag_maker(dag_id="asset-producer-62929", schedule="@daily", session=session):
+            BashOperator(task_id="producer", bash_command="echo 1", outlets=[asset1])
+        producer_run = dag_maker.create_dagrun(
+            run_id="producer_run",
+            logical_date=DEFAULT_DATE,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
+        )
+
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+        session.add(
+            AssetEvent(
+                asset_id=asset1_id,
+                source_task_id="producer",
+                source_dag_id=producer_run.dag_id,
+                source_run_id=producer_run.run_id,
+                source_map_index=-1,
+            )
+        )
+
+        # Consumer: scheduled on the asset, with the asset already queued for it.
+        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
+            EmptyOperator(task_id="consume")
+        consumer_dag_id = dag_maker.dag.dag_id
+        session.add(AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag_id))
+
+        # Time-based Dag that is eligible for a scheduled run right now (catchup + past start_date).
+        with dag_maker(dag_id="time-based-62929", schedule="@daily", catchup=True, session=session):
+            EmptyOperator(task_id="noop")
+        time_based_dag_id = dag_maker.dag.dag_id
+        session.flush()
+
+        # Sanity: the time-based Dag really is eligible, so its absence below is due to the flag,
+        # not because it was never schedulable in the first place.
+        time_based_model = session.get(DagModel, time_based_dag_id)
+        assert time_based_model.next_dagrun_create_after is not None
+        assert time_based_model.next_dagrun_create_after <= timezone.utcnow()
+
+        scheduler_job = Job()
+        # Construct the runner *under* the conf override so it reads use_job_schedule=False.
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is False
+
+        self.job_runner._do_scheduling(session)
+
+        # The asset-triggered consumer run IS created despite use_job_schedule=False.
+        consumer_runs = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()
+        assert len(consumer_runs) == 1
+        # The run was created; it may already have been moved to RUNNING by the
+        # _start_queued_dagruns step inside the same _do_scheduling call, so accept either
+        # non-terminal state. #62929 is about the run being created at all.
+        assert consumer_runs[0].state in (State.QUEUED, State.RUNNING)
+        assert consumer_runs[0].consumed_asset_events  # the AssetEvent was attached
+        # The asset queue row was consumed.
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).one_or_none()
+            is None
+        )
+
+        # The time-based run is suppressed by the flag.
+        assert session.scalars(select(DagRun).where(DagRun.dag_id == time_based_dag_id)).one_or_none() is None
+
+    @pytest.mark.need_serialized_dag
+    @conf_vars({("scheduler", "use_job_schedule"): "True"})
+    def test_use_job_schedule_true_creates_time_based_runs(self, session, dag_maker):
+        """
+        Companion to ``test_use_job_schedule_false_still_creates_asset_runs``.
+
+        With the flag on, the eligible time-based Dag does get a scheduled run. This guards against
+        accidentally inverting the gate (which would make the negative assertion above pass for the
+        wrong reason).
+        """
+        with dag_maker(dag_id="time-based-62929-on", schedule="@daily", catchup=True, session=session):
+            EmptyOperator(task_id="noop")
+        time_based_dag_id = dag_maker.dag.dag_id
+        session.flush()
+
+        time_based_model = session.get(DagModel, time_based_dag_id)
+        assert time_based_model.next_dagrun_create_after is not None
+        assert time_based_model.next_dagrun_create_after <= timezone.utcnow()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is True
+
+        self.job_runner._do_scheduling(session)
+
+        time_based_runs = session.scalars(select(DagRun).where(DagRun.dag_id == time_based_dag_id)).all()
+        assert len(time_based_runs) >= 1
+        assert time_based_runs[0].run_type == DagRunType.SCHEDULED
+
+    @pytest.mark.need_serialized_dag
+    @pytest.mark.usefixtures("clear_asset_partition_rows")
+    @conf_vars({("scheduler", "use_job_schedule"): "False"})
+    def test_use_job_schedule_false_still_creates_partition_asset_runs(self, session, dag_maker):
+        """
+        Companion to ``test_use_job_schedule_false_still_creates_asset_runs`` for the
+        partitioned-asset path. ``_create_dagruns_for_partitioned_asset_dags`` runs at the very top
+        of ``_create_dagruns_for_dags``, which ``use_job_schedule=False`` used to skip entirely.
+        Driven through ``_do_scheduling`` so it backs the newsfragment's partitioned-asset claim. #62929.
+        """
+        asset_1 = Asset(name="asset-part-62929")
+
+        with dag_maker(
+            dag_id="asset-event-consumer-62929",
+            schedule=PartitionedAssetTimetable(assets=asset_1, default_partition_mapper=IdentityMapper()),
+            session=session,
+        ):
+            EmptyOperator(task_id="hi")
+        session.commit()
+
+        apdr = _produce_and_register_asset_event(
+            dag_id="asset-event-producer-62929",
+            asset=asset_1,
+            partition_key="key-1",
+            session=session,
+            dag_maker=dag_maker,
+        )
+        apdr_id = apdr.id
+        assert apdr.created_dag_run_id is None  # pre-condition: run not created yet
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is False
+
+        self.job_runner._do_scheduling(session)
+
+        # The partitioned-asset run IS created despite use_job_schedule=False (re-query: _do_scheduling
+        # calls expunge_all).
+        apdr = session.scalar(select(AssetPartitionDagRun).where(AssetPartitionDagRun.id == apdr_id))
+        assert apdr is not None
+        assert apdr.created_dag_run_id is not None
+        partition_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+        assert partition_run is not None
+        assert partition_run.dag_id == "asset-event-consumer-62929"
+
     @pytest.mark.parametrize(
         ("catchup", "expects_old_event"),
         [
@@ -5836,6 +5984,7 @@ class TestSchedulerJob:
         assert created_run.state == State.QUEUED
         expected = {new_event.id} | ({old_event.id} if expects_old_event else set())
         assert {e.id for e in created_run.consumed_asset_events} == expected
+
 
     @pytest.mark.need_serialized_dag
     def test_asset_events_out_of_order_are_both_consumed(self, session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5787,8 +5787,19 @@ class TestSchedulerJob:
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
         )
-
         asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+
+        # Consumer must exist before events so the events fall inside its schedule window
+        # (catchup=False ignores pre-creation backlog; see #39456).
+        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
+            EmptyOperator(task_id="consume")
+        consumer_dag_id = dag_maker.dag.dag_id
+        reference_created_at = session.scalar(
+            select(DagScheduleAssetReference.created_at).where(
+                DagScheduleAssetReference.dag_id == consumer_dag_id
+            )
+        )
+
         session.add(
             AssetEvent(
                 asset_id=asset1_id,
@@ -5796,14 +5807,16 @@ class TestSchedulerJob:
                 source_dag_id=producer_run.dag_id,
                 source_run_id=producer_run.run_id,
                 source_map_index=-1,
+                timestamp=reference_created_at + timedelta(seconds=1),
             )
         )
-
-        # Consumer: scheduled on the asset, with the asset already queued for it.
-        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
-            EmptyOperator(task_id="consume")
-        consumer_dag_id = dag_maker.dag.dag_id
-        session.add(AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag_id))
+        session.add(
+            AssetDagRunQueue(
+                asset_id=asset1_id,
+                target_dag_id=consumer_dag_id,
+                created_at=reference_created_at + timedelta(hours=1),
+            )
+        )
 
         # Time-based Dag that is eligible for a scheduled run right now (catchup + past start_date).
         with dag_maker(dag_id="time-based-62929", schedule="@daily", catchup=True, session=session):
@@ -5825,12 +5838,14 @@ class TestSchedulerJob:
         self.job_runner._do_scheduling(session)
 
         # The asset-triggered consumer run IS created despite use_job_schedule=False.
+        # Re-query: _do_scheduling may expunge_all.
         consumer_runs = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()
         assert len(consumer_runs) == 1
         # The run was created; it may already have been moved to RUNNING by the
         # _start_queued_dagruns step inside the same _do_scheduling call, so accept either
         # non-terminal state. #62929 is about the run being created at all.
         assert consumer_runs[0].state in (State.QUEUED, State.RUNNING)
+        assert consumer_runs[0].run_type == DagRunType.ASSET_TRIGGERED
         assert consumer_runs[0].consumed_asset_events  # the AssetEvent was attached
         # The asset queue row was consumed.
         assert (
@@ -5984,7 +5999,6 @@ class TestSchedulerJob:
         assert created_run.state == State.QUEUED
         expected = {new_event.id} | ({old_event.id} if expects_old_event else set())
         assert {e.id for e in created_run.consumed_asset_events} == expected
-
 
     @pytest.mark.need_serialized_dag
     def test_asset_events_out_of_order_are_both_consumed(self, session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5813,20 +5813,21 @@ class TestSchedulerJob:
             )
         )
 
-        session.add(
-            AssetEvent(
-                asset_id=asset1_id,
-                source_task_id="producer",
-                source_dag_id=producer_run.dag_id,
-                source_run_id=producer_run.run_id,
-                source_map_index=-1,
-                timestamp=reference_created_at + timedelta(seconds=1),
-            )
+        event = AssetEvent(
+            asset_id=asset1_id,
+            source_task_id="producer",
+            source_dag_id=producer_run.dag_id,
+            source_run_id=producer_run.run_id,
+            source_map_index=-1,
+            timestamp=reference_created_at + timedelta(seconds=1),
         )
+        session.add(event)
+        session.flush()  # assign event id so the ADRQ row can reference it
         session.add(
             AssetDagRunQueue(
                 asset_id=asset1_id,
                 target_dag_id=consumer_dag_id,
+                asset_event_id=event.id,
                 created_at=reference_created_at + timedelta(hours=1),
             )
         )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5800,8 +5800,19 @@ class TestSchedulerJob:
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
         )
-
         asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+
+        # Consumer must exist before events so the events fall inside its schedule window
+        # (catchup=False ignores pre-creation backlog; see #39456).
+        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
+            EmptyOperator(task_id="consume")
+        consumer_dag_id = dag_maker.dag.dag_id
+        reference_created_at = session.scalar(
+            select(DagScheduleAssetReference.created_at).where(
+                DagScheduleAssetReference.dag_id == consumer_dag_id
+            )
+        )
+
         session.add(
             AssetEvent(
                 asset_id=asset1_id,
@@ -5809,14 +5820,16 @@ class TestSchedulerJob:
                 source_dag_id=producer_run.dag_id,
                 source_run_id=producer_run.run_id,
                 source_map_index=-1,
+                timestamp=reference_created_at + timedelta(seconds=1),
             )
         )
-
-        # Consumer: scheduled on the asset, with the asset already queued for it.
-        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
-            EmptyOperator(task_id="consume")
-        consumer_dag_id = dag_maker.dag.dag_id
-        session.add(AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag_id))
+        session.add(
+            AssetDagRunQueue(
+                asset_id=asset1_id,
+                target_dag_id=consumer_dag_id,
+                created_at=reference_created_at + timedelta(hours=1),
+            )
+        )
 
         # Time-based Dag that is eligible for a scheduled run right now (catchup + past start_date).
         with dag_maker(dag_id="time-based-62929", schedule="@daily", catchup=True, session=session):
@@ -5838,12 +5851,14 @@ class TestSchedulerJob:
         self.job_runner._do_scheduling(session)
 
         # The asset-triggered consumer run IS created despite use_job_schedule=False.
+        # Re-query: _do_scheduling may expunge_all.
         consumer_runs = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()
         assert len(consumer_runs) == 1
         # The run was created; it may already have been moved to RUNNING by the
         # _start_queued_dagruns step inside the same _do_scheduling call, so accept either
         # non-terminal state. #62929 is about the run being created at all.
         assert consumer_runs[0].state in (State.QUEUED, State.RUNNING)
+        assert consumer_runs[0].run_type == DagRunType.ASSET_TRIGGERED
         assert consumer_runs[0].consumed_asset_events  # the AssetEvent was attached
         # The asset queue row was consumed.
         assert (
@@ -5997,7 +6012,6 @@ class TestSchedulerJob:
         assert created_run.state == State.QUEUED
         expected = {new_event.id} | ({old_event.id} if expects_old_event else set())
         assert {e.id for e in created_run.consumed_asset_events} == expected
-
 
     @pytest.mark.need_serialized_dag
     def test_asset_events_out_of_order_are_both_consumed(self, session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5781,8 +5781,19 @@ class TestSchedulerJob:
             logical_date=DEFAULT_DATE,
             data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
         )
-
         asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+
+        # Consumer must exist before events so the events fall inside its schedule window
+        # (catchup=False ignores pre-creation backlog; see #39456).
+        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
+            EmptyOperator(task_id="consume")
+        consumer_dag_id = dag_maker.dag.dag_id
+        reference_created_at = session.scalar(
+            select(DagScheduleAssetReference.created_at).where(
+                DagScheduleAssetReference.dag_id == consumer_dag_id
+            )
+        )
+
         session.add(
             AssetEvent(
                 asset_id=asset1_id,
@@ -5790,14 +5801,16 @@ class TestSchedulerJob:
                 source_dag_id=producer_run.dag_id,
                 source_run_id=producer_run.run_id,
                 source_map_index=-1,
+                timestamp=reference_created_at + timedelta(seconds=1),
             )
         )
-
-        # Consumer: scheduled on the asset, with the asset already queued for it.
-        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
-            EmptyOperator(task_id="consume")
-        consumer_dag_id = dag_maker.dag.dag_id
-        session.add(AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag_id))
+        session.add(
+            AssetDagRunQueue(
+                asset_id=asset1_id,
+                target_dag_id=consumer_dag_id,
+                created_at=reference_created_at + timedelta(hours=1),
+            )
+        )
 
         # Time-based Dag that is eligible for a scheduled run right now (catchup + past start_date).
         with dag_maker(dag_id="time-based-62929", schedule="@daily", catchup=True, session=session):
@@ -5819,12 +5832,14 @@ class TestSchedulerJob:
         self.job_runner._do_scheduling(session)
 
         # The asset-triggered consumer run IS created despite use_job_schedule=False.
+        # Re-query: _do_scheduling may expunge_all.
         consumer_runs = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()
         assert len(consumer_runs) == 1
         # The run was created; it may already have been moved to RUNNING by the
         # _start_queued_dagruns step inside the same _do_scheduling call, so accept either
         # non-terminal state. #62929 is about the run being created at all.
         assert consumer_runs[0].state in (State.QUEUED, State.RUNNING)
+        assert consumer_runs[0].run_type == DagRunType.ASSET_TRIGGERED
         assert consumer_runs[0].consumed_asset_events  # the AssetEvent was attached
         # The asset queue row was consumed.
         assert (
@@ -5975,7 +5990,6 @@ class TestSchedulerJob:
         assert created_run.state == State.QUEUED
         expected = {new_event.id} | ({old_event.id} if expects_old_event else set())
         assert {e.id for e in created_run.consumed_asset_events} == expected
-
 
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_asset_triggered_skips_stale_triggered_date(self, session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5763,6 +5763,154 @@ class TestSchedulerJob:
         assert created_run.creating_job_id == scheduler_job.id
 
     @pytest.mark.need_serialized_dag
+    @conf_vars({("scheduler", "use_job_schedule"): "False"})
+    def test_use_job_schedule_false_still_creates_asset_runs(self, session, dag_maker):
+        """
+        ``[scheduler] use_job_schedule=False`` must disable only cron/time-based scheduling.
+
+        Asset-triggered Dag runs must still be created. Regression test for #62929, driven through
+        ``_do_scheduling`` so it exercises both the orchestrator call site and the time-based gate.
+        """
+        asset1 = Asset(uri="test://asset-62929", name="asset_62929", group="test_group")
+
+        # Producer: declares the asset as an outlet so the AssetModel is registered on serialization.
+        with dag_maker(dag_id="asset-producer-62929", schedule="@daily", session=session):
+            BashOperator(task_id="producer", bash_command="echo 1", outlets=[asset1])
+        producer_run = dag_maker.create_dagrun(
+            run_id="producer_run",
+            logical_date=DEFAULT_DATE,
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
+        )
+
+        asset1_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset1.uri))
+        session.add(
+            AssetEvent(
+                asset_id=asset1_id,
+                source_task_id="producer",
+                source_dag_id=producer_run.dag_id,
+                source_run_id=producer_run.run_id,
+                source_map_index=-1,
+            )
+        )
+
+        # Consumer: scheduled on the asset, with the asset already queued for it.
+        with dag_maker(dag_id="asset-consumer-62929", schedule=[asset1], session=session):
+            EmptyOperator(task_id="consume")
+        consumer_dag_id = dag_maker.dag.dag_id
+        session.add(AssetDagRunQueue(asset_id=asset1_id, target_dag_id=consumer_dag_id))
+
+        # Time-based Dag that is eligible for a scheduled run right now (catchup + past start_date).
+        with dag_maker(dag_id="time-based-62929", schedule="@daily", catchup=True, session=session):
+            EmptyOperator(task_id="noop")
+        time_based_dag_id = dag_maker.dag.dag_id
+        session.flush()
+
+        # Sanity: the time-based Dag really is eligible, so its absence below is due to the flag,
+        # not because it was never schedulable in the first place.
+        time_based_model = session.get(DagModel, time_based_dag_id)
+        assert time_based_model.next_dagrun_create_after is not None
+        assert time_based_model.next_dagrun_create_after <= timezone.utcnow()
+
+        scheduler_job = Job()
+        # Construct the runner *under* the conf override so it reads use_job_schedule=False.
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is False
+
+        self.job_runner._do_scheduling(session)
+
+        # The asset-triggered consumer run IS created despite use_job_schedule=False.
+        consumer_runs = session.scalars(select(DagRun).where(DagRun.dag_id == consumer_dag_id)).all()
+        assert len(consumer_runs) == 1
+        # The run was created; it may already have been moved to RUNNING by the
+        # _start_queued_dagruns step inside the same _do_scheduling call, so accept either
+        # non-terminal state. #62929 is about the run being created at all.
+        assert consumer_runs[0].state in (State.QUEUED, State.RUNNING)
+        assert consumer_runs[0].consumed_asset_events  # the AssetEvent was attached
+        # The asset queue row was consumed.
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue).where(AssetDagRunQueue.target_dag_id == consumer_dag_id)
+            ).one_or_none()
+            is None
+        )
+
+        # The time-based run is suppressed by the flag.
+        assert session.scalars(select(DagRun).where(DagRun.dag_id == time_based_dag_id)).one_or_none() is None
+
+    @pytest.mark.need_serialized_dag
+    @conf_vars({("scheduler", "use_job_schedule"): "True"})
+    def test_use_job_schedule_true_creates_time_based_runs(self, session, dag_maker):
+        """
+        Companion to ``test_use_job_schedule_false_still_creates_asset_runs``.
+
+        With the flag on, the eligible time-based Dag does get a scheduled run. This guards against
+        accidentally inverting the gate (which would make the negative assertion above pass for the
+        wrong reason).
+        """
+        with dag_maker(dag_id="time-based-62929-on", schedule="@daily", catchup=True, session=session):
+            EmptyOperator(task_id="noop")
+        time_based_dag_id = dag_maker.dag.dag_id
+        session.flush()
+
+        time_based_model = session.get(DagModel, time_based_dag_id)
+        assert time_based_model.next_dagrun_create_after is not None
+        assert time_based_model.next_dagrun_create_after <= timezone.utcnow()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is True
+
+        self.job_runner._do_scheduling(session)
+
+        time_based_runs = session.scalars(select(DagRun).where(DagRun.dag_id == time_based_dag_id)).all()
+        assert len(time_based_runs) >= 1
+        assert time_based_runs[0].run_type == DagRunType.SCHEDULED
+
+    @pytest.mark.need_serialized_dag
+    @pytest.mark.usefixtures("clear_asset_partition_rows")
+    @conf_vars({("scheduler", "use_job_schedule"): "False"})
+    def test_use_job_schedule_false_still_creates_partition_asset_runs(self, session, dag_maker):
+        """
+        Companion to ``test_use_job_schedule_false_still_creates_asset_runs`` for the
+        partitioned-asset path. ``_create_dagruns_for_partitioned_asset_dags`` runs at the very top
+        of ``_create_dagruns_for_dags``, which ``use_job_schedule=False`` used to skip entirely.
+        Driven through ``_do_scheduling`` so it backs the newsfragment's partitioned-asset claim. #62929.
+        """
+        asset_1 = Asset(name="asset-part-62929")
+
+        with dag_maker(
+            dag_id="asset-event-consumer-62929",
+            schedule=PartitionedAssetTimetable(assets=asset_1, default_partition_mapper=IdentityMapper()),
+            session=session,
+        ):
+            EmptyOperator(task_id="hi")
+        session.commit()
+
+        apdr = _produce_and_register_asset_event(
+            dag_id="asset-event-producer-62929",
+            asset=asset_1,
+            partition_key="key-1",
+            session=session,
+            dag_maker=dag_maker,
+        )
+        apdr_id = apdr.id
+        assert apdr.created_dag_run_id is None  # pre-condition: run not created yet
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        assert self.job_runner._scheduler_use_job_schedule is False
+
+        self.job_runner._do_scheduling(session)
+
+        # The partitioned-asset run IS created despite use_job_schedule=False (re-query: _do_scheduling
+        # calls expunge_all).
+        apdr = session.scalar(select(AssetPartitionDagRun).where(AssetPartitionDagRun.id == apdr_id))
+        assert apdr is not None
+        assert apdr.created_dag_run_id is not None
+        partition_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+        assert partition_run is not None
+        assert partition_run.dag_id == "asset-event-consumer-62929"
+
     @pytest.mark.parametrize(
         ("catchup", "expects_old_event"),
         [
@@ -5827,6 +5975,7 @@ class TestSchedulerJob:
         assert created_run.state == State.QUEUED
         expected = {new_event.id} | ({old_event.id} if expects_old_event else set())
         assert {e.id for e in created_run.consumed_asset_events} == expected
+
 
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_asset_triggered_skips_stale_triggered_date(self, session, dag_maker):


### PR DESCRIPTION
## What is the change?

`[scheduler] use_job_schedule=False` now disables only time-based (cron/timetable) scheduling. Asset-triggered and partitioned-asset-triggered Dag runs are still created, as are manual runs.

## Why did I do it?

The flag gated the entire `_create_dagruns_for_dags` call in `_do_scheduling`, but that method also creates asset-triggered and partitioned-asset runs. Setting the flag to `False` silently stopped all asset-driven scheduling, contradicting the documented behavior. This supersedes #62931, which was closed for author inactivity; the approach itself was never disputed.

closes: #62929

## How did I do it?

I moved the flag check inside `_create_dagruns_for_dags` so it wraps only the time-based `_create_dag_runs(non_asset_dags, ...)` call. The orchestrator, and with it the asset and partition paths, always runs. I also fixed the "Disable the scheduler" maintenance doc, which claimed the flag stops all new Dag runs, and pointed readers at `dags pause` for a full stop.

## What's the impact?

Deployments that turn off cron scheduling keep their event- and data-driven pipelines. No behavior change with the flag at its default `True`.

## What's the test plan?

Three regression tests in `test_scheduler_job.py`, each verified to fail on the unfixed code: an asset-triggered run created with the flag off, a partitioned-asset run created with the flag off, and a flag-on companion proving cron runs are still gated. The full scheduler suite, the exact-query-count tests, mypy, and the static checks passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
