### PR TITLE
Add run_type tag to dagrun.duration.failed timeout metric

### DIFF
--- a/airflow-core/newsfragments/67765.bugfix.rst
+++ b/airflow-core/newsfragments/67765.bugfix.rst
@@ -1,0 +1,1 @@
+Add the ``run_type`` tag to the ``dagrun.duration.failed`` metric emitted when a Dag run times out, making it consistent with the same metric emitted on normal Dag run completion.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2888,7 +2888,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     duration,
                     tags=prune_dict(
                         {
-                            "dag_id": dag_run.dag_id,
+                            **dag_run.stats_tags,
                             "team_name": self._get_team_names_for_dag_ids([dag_run.dag_id], session).get(
                                 dag_run.dag_id
                             )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4173,6 +4173,44 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    @mock.patch("airflow._shared.observability.metrics.stats._get_backend")
+    def test_dagrun_timeout_duration_metric_has_run_type(self, mock_get_backend, dag_maker):
+        """
+        The ``dagrun.duration.failed`` metric emitted when a Dag run times out must carry the
+        ``run_type`` tag, matching the metric emitted on normal Dag run completion via
+        ``DagRun._emit_duration_stats_for_finished_state``.
+        """
+        mock_stats = mock.MagicMock(spec=StatsLogger)
+        mock_get_backend.return_value = mock_stats
+
+        session = settings.Session()
+        with dag_maker(
+            dag_id="test_dagrun_timeout_duration_metric",
+            dagrun_timeout=datetime.timedelta(seconds=60),
+            session=session,
+        ):
+            EmptyOperator(task_id="dummy")
+
+        dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        self.job_runner._schedule_dag_run(dr, session)
+        session.flush()
+
+        session.refresh(dr)
+        assert dr.state == State.FAILED
+
+        mock_stats.timing.assert_any_call(
+            "dagrun.duration.failed",
+            mock.ANY,
+            tags={"dag_id": dr.dag_id, "run_type": dr.run_type},
+        )
+
+        session.rollback()
+        session.close()
+
     def test_dagrun_timeout_fails_run_and_update_next_dagrun(self, dag_maker):
         """
         Test that dagrun timeout fails run and update the next dagrun


### PR DESCRIPTION
### What / impact

When a Dag run timed out, the scheduler emitted the `dagrun.duration.failed` timing metric with only a `dag_id` tag. Every other `dagrun.duration.*` emission also carries `run_type`, so dashboards and alerts that segment by `run_type` silently dropped timed-out runs (or saw an inconsistent tag set). After this change the timeout path emits both `dag_id` and `run_type`, consistent with normal completion.

### Why

The timeout branch in `_schedule_dag_run` hardcoded `tags={"dag_id": dag_run.dag_id}`, while the canonical emitter `DagRun._emit_duration_stats_for_finished_state` uses `dag_run.stats_tags` (which includes `run_type`). This replaces the hardcoded dict with `dag_run.stats_tags`. `run_type` is `NOT NULL` and low-cardinality, so the new tag set is a safe strict superset of the old one and the metric name is unchanged.

### How it unblocks

Makes timeout-duration metrics consistent and usable in `run_type`-segmented observability. Supersedes #64768, which stalled on CI/static checks rather than design — this keeps the diff to a single value change and ships green static checks, including the metrics-registry sync check that blocked the prior attempt.

### Tests

One new regression test in `test_scheduler_job.py`, verified to fail on the unfixed code, asserting the `dagrun.duration.failed` timing call carries `tags={"dag_id": …, "run_type": …}`. Full scheduler suite passes; mypy + pre-commit + manual static checks (incl. metrics-registry sync) are green.

closes: #64765

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=4f9d0e8 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Vamsi-klu** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - This PR has **merge conflicts with `main`**. Please rebase onto the latest `main` and resolve them.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->