### PR TITLE
Fix CloudRunExecuteJobOperator ignoring task failures in deferrable mode

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
@@ -407,6 +407,17 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
                 f"Operation failed with error code [{error_code}] and error message [{error_message}]"
             )
 
+        if "task_count" in event:
+            task_count = event["task_count"]
+            succeeded_count = event["succeeded_count"]
+            failed_count = event["failed_count"]
+
+            if succeeded_count + failed_count != task_count:
+                raise RuntimeError("Not all tasks finished execution")
+
+            if failed_count > 0:
+                raise RuntimeError("Some tasks failed execution")
+
         hook: CloudRunHook = CloudRunHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
@@ -299,6 +299,48 @@ class TestCloudRunExecuteJobOperator:
         assert result["name"] == JOB_NAME
 
     @mock.patch(CLOUD_RUN_HOOK_PATH)
+    def test_execute_deferrable_execute_complete_method_cancelled(self, hook_mock):
+        hook_mock.return_value.get_job.return_value = JOB
+
+        operator = CloudRunExecuteJobOperator(
+            task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, deferrable=True
+        )
+
+        event = {
+            "status": RunJobStatus.SUCCESS.value,
+            "job_name": JOB_NAME,
+            "task_count": 3,
+            "succeeded_count": 1,
+            "failed_count": 0,
+        }
+
+        with pytest.raises(RuntimeError) as e:
+            operator.execute_complete(mock.MagicMock(), event)
+
+        assert "Not all tasks finished execution" in str(e.value)
+
+    @mock.patch(CLOUD_RUN_HOOK_PATH)
+    def test_execute_deferrable_execute_complete_method_failed_tasks(self, hook_mock):
+        hook_mock.return_value.get_job.return_value = JOB
+
+        operator = CloudRunExecuteJobOperator(
+            task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, deferrable=True
+        )
+
+        event = {
+            "status": RunJobStatus.SUCCESS.value,
+            "job_name": JOB_NAME,
+            "task_count": 3,
+            "succeeded_count": 1,
+            "failed_count": 2,
+        }
+
+        with pytest.raises(RuntimeError) as e:
+            operator.execute_complete(mock.MagicMock(), event)
+
+        assert "Some tasks failed execution" in str(e.value)
+
+    @mock.patch(CLOUD_RUN_HOOK_PATH)
     def test_execute_overrides(self, hook_mock):
         hook_mock.return_value.get_job.return_value = JOB
         hook_mock.return_value.execute_job.return_value = self._mock_operation(3, 3, 0)


### PR DESCRIPTION
**This PR continues and replaces #62278 by @Ajay9704.**

## Summary

When `CloudRunExecuteJobOperator` runs with `deferrable=True` and the underlying Cloud Run Job is cancelled (e.g. via the Google Cloud UI or API), the LRO completes without setting `operation.error` — cancelled tasks appear in `cancelled_count` rather than `failed_count`. The original deferrable path therefore silently returned success instead of failing, diverging from the non-deferrable behavior.

The trigger (`CloudRunJobFinishedTrigger`) was already fixed in `main` to detect this by deserialising the `Execution` proto and emitting a `FAIL` event. This PR adds a matching defensive check in `execute_complete` for the case where a `SUCCESS` event still carries task-count fields indicating an incomplete or partially-failed run — mirroring the validation already done on the non-deferrable path via `_fail_if_execution_failed`.

### Changes

- **`execute_complete`**: raises `RuntimeError` when `succeeded_count + failed_count != task_count` or when `failed_count > 0`.
- **Tests**: two new unit tests covering the cancelled-job and failed-tasks scenarios.

closes: #57791

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)