### PR TITLE
Google Cloud Run: replace AirflowException with Python built-in exceptions

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
@@ -24,7 +24,7 @@ import google.cloud.exceptions
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.run_v2 import Job, Service
 
-from airflow.providers.common.compat.sdk import AirflowException, conf
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.google.cloud.hooks.cloud_run import CloudRunHook, CloudRunServiceHook
 from airflow.providers.google.cloud.links.cloud_run import CloudRunJobLoggingLink
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
@@ -259,7 +259,7 @@ class CloudRunListJobsOperator(GoogleCloudBaseOperator):
         self.limit = limit
         self.use_regional_endpoint = use_regional_endpoint
         if limit is not None and limit < 0:
-            raise AirflowException("The limit for the list jobs request should be greater or equal to zero")
+            raise RuntimeError("The limit for the list jobs request should be greater or equal to zero")
 
     def execute(self, context: Context):
         hook: CloudRunHook = CloudRunHook(
@@ -361,7 +361,7 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
         )
 
         if self.operation is None:
-            raise AirflowException("Operation is None")
+            raise RuntimeError("Operation is None")
 
         if self.operation.metadata.log_uri:
             CloudRunJobLoggingLink.persist(
@@ -398,12 +398,12 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
         status = event["status"]
 
         if status == RunJobStatus.TIMEOUT.value:
-            raise AirflowException("Operation timed out")
+            raise TimeoutError("Operation timed out")
 
         if status == RunJobStatus.FAIL.value:
             error_code = event["operation_error_code"]
             error_message = event["operation_error_message"]
-            raise AirflowException(
+            raise RuntimeError(
                 f"Operation failed with error code [{error_code}] and error message [{error_message}]"
             )
 
@@ -427,17 +427,17 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
         failed_count = execution.failed_count
 
         if succeeded_count + failed_count != task_count:
-            raise AirflowException("Not all tasks finished execution")
+            raise RuntimeError("Not all tasks finished execution")
 
         if failed_count > 0:
-            raise AirflowException("Some tasks failed execution")
+            raise RuntimeError("Some tasks failed execution")
 
     def _wait_for_operation(self, operation: operation.Operation):
         try:
             return operation.result(timeout=self.timeout_seconds)
         except Exception:
             error = operation.exception(timeout=self.timeout_seconds)
-            raise AirflowException(error)
+            raise RuntimeError(error)
 
 
 class CloudRunCreateServiceOperator(GoogleCloudBaseOperator):
@@ -487,7 +487,7 @@ class CloudRunCreateServiceOperator(GoogleCloudBaseOperator):
     def _validate_inputs(self):
         missing_fields = [k for k in ["project_id", "region", "service_name"] if not getattr(self, k)]
         if not self.project_id or not self.region or not self.service_name:
-            raise AirflowException(
+            raise RuntimeError(
                 f"Required parameters are missing: {missing_fields}. These parameters be passed either as "
                 "keyword parameter or as extra field in Airflow connection definition. Both are not set!"
             )
@@ -569,7 +569,7 @@ class CloudRunDeleteServiceOperator(GoogleCloudBaseOperator):
     def _validate_inputs(self):
         missing_fields = [k for k in ["project_id", "region", "service_name"] if not getattr(self, k)]
         if not self.project_id or not self.region or not self.service_name:
-            raise AirflowException(
+            raise RuntimeError(
                 f"Required parameters are missing: {missing_fields}. These parameters be passed either as "
                 "keyword parameter or as extra field in Airflow connection definition. Both are not set!"
             )

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
@@ -28,7 +28,7 @@ from google.api_core.exceptions import AlreadyExists
 from google.cloud.exceptions import GoogleCloudError
 from google.cloud.run_v2 import Job, Service
 
-from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
+from airflow.providers.common.compat.sdk import TaskDeferred
 from airflow.providers.google.cloud.operators.cloud_run import (
     CloudRunCreateJobOperator,
     CloudRunCreateServiceOperator,
@@ -163,7 +163,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME
         )
 
-        with pytest.raises(AirflowException) as exception:
+        with pytest.raises(RuntimeError) as exception:
             operator.execute(context=mock.MagicMock())
 
         assert "Some tasks failed execution" in str(exception.value)
@@ -176,7 +176,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME
         )
 
-        with pytest.raises(AirflowException) as exception:
+        with pytest.raises(RuntimeError) as exception:
             operator.execute(context=mock.MagicMock())
 
         assert "Some tasks failed execution" in str(exception.value)
@@ -189,7 +189,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME
         )
 
-        with pytest.raises(AirflowException) as exception:
+        with pytest.raises(RuntimeError) as exception:
             operator.execute(context=mock.MagicMock())
 
         assert "Not all tasks finished execution" in str(exception.value)
@@ -202,7 +202,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME
         )
 
-        with pytest.raises(AirflowException) as exception:
+        with pytest.raises(RuntimeError) as exception:
             operator.execute(context=mock.MagicMock())
 
         assert "Not all tasks finished execution" in str(exception.value)
@@ -224,7 +224,7 @@ class TestCloudRunExecuteJobOperator:
 
         event = {"status": RunJobStatus.TIMEOUT.value, "job_name": JOB_NAME}
 
-        with pytest.raises(AirflowException) as e:
+        with pytest.raises(TimeoutError) as e:
             operator.execute_complete(mock.MagicMock(), event)
 
         assert "Operation timed out" in str(e.value)
@@ -245,7 +245,7 @@ class TestCloudRunExecuteJobOperator:
             "job_name": JOB_NAME,
         }
 
-        with pytest.raises(AirflowException) as e:
+        with pytest.raises(RuntimeError) as e:
             operator.execute_complete(mock.MagicMock(), event)
 
         assert f"Operation failed with error code [{error_code}] and error message [{error_message}]" in str(
@@ -256,8 +256,8 @@ class TestCloudRunExecuteJobOperator:
     def test_execute_deferrable_execute_complete_method_fail_on_cancellation(self, hook_mock):
         """
         Pin the contract that a FAIL event emitted by the trigger when a Cloud Run Job is
-        cancelled (no ``operation.error`` but ``cancelled_count > 0``) propagates as an
-        AirflowException — see #57791.
+        cancelled (no ``operation.error`` but ``cancelled_count > 0``) propagates as a
+        RuntimeError — see #57791.
         """
         operator = CloudRunExecuteJobOperator(
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, deferrable=True
@@ -273,7 +273,7 @@ class TestCloudRunExecuteJobOperator:
             "job_name": JOB_NAME,
         }
 
-        with pytest.raises(AirflowException) as e:
+        with pytest.raises(RuntimeError) as e:
             operator.execute_complete(mock.MagicMock(), event)
 
         assert "cancelled_count=2" in str(e.value)
@@ -342,7 +342,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, overrides=overrides
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(RuntimeError):
             operator.execute(context=mock.MagicMock())
 
     @mock.patch(CLOUD_RUN_HOOK_PATH)
@@ -357,7 +357,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, overrides=overrides
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(RuntimeError):
             operator.execute(context=mock.MagicMock())
 
     @mock.patch(CLOUD_RUN_HOOK_PATH)
@@ -372,7 +372,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, overrides=overrides
         )
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(RuntimeError):
             operator.execute(context=mock.MagicMock())
 
     def _mock_operation(self, task_count, succeeded_count, failed_count):
@@ -476,7 +476,7 @@ class TestCloudRunListJobsOperator:
     @mock.patch(CLOUD_RUN_HOOK_PATH)
     def test_execute_with_invalid_limit(self, hook_mock):
         limit = -1
-        with pytest.raises(expected_exception=AirflowException):
+        with pytest.raises(expected_exception=RuntimeError):
             CloudRunListJobsOperator(task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, limit=limit)
 
 

--- a/scripts/ci/prek/known_airflow_exceptions.txt
+++ b/scripts/ci/prek/known_airflow_exceptions.txt
@@ -252,7 +252,6 @@ providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::4
 providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::4
 providers/google/src/airflow/providers/google/cloud/operators/cloud_composer.py::6
 providers/google/src/airflow/providers/google/cloud/operators/cloud_logging_sink.py::2
-providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py::9
 providers/google/src/airflow/providers/google/cloud/operators/cloud_sql.py::15
 providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py::16
 providers/google/src/airflow/providers/google/cloud/operators/compute.py::19


### PR DESCRIPTION
## Summary

`AirflowException` is pending deprecation. Replace all usages in `providers/google/cloud/operators/cloud_run.py` with the appropriate Python built-in exception types:

- `TimeoutError` for operation timeouts in `execute_complete`
- `RuntimeError` for all other error conditions throughout the file

Update test assertions to match and remove the file entry from `scripts/ci/prek/known_airflow_exceptions.txt` since no `AirflowException` usages remain.

This is a pure exception-type cleanup with no behaviour change. Spun out of #67767 to keep concerns separate.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)