### PR TITLE
Bump minimum google-api-core to 2.30.3 to fix Dag import timeout

### DIFF
--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -72,7 +72,7 @@ PIP package                                 Version required
 ``gcsfs``                                   ``>=2023.10.0``
 ``google-ads``                              ``>=26.0.0,!=28.0.0.post2``
 ``google-analytics-admin``                  ``>=0.9.0``
-``google-api-core``                         ``>=2.11.0,!=2.16.0,!=2.18.0``
+``google-api-core``                         ``>=2.30.3``
 ``google-api-python-client``                ``>=2.0.2``
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -125,7 +125,7 @@ PIP package                                 Version required
 ``gcsfs``                                   ``>=2023.10.0``
 ``google-ads``                              ``>=26.0.0,!=28.0.0.post2``
 ``google-analytics-admin``                  ``>=0.9.0``
-``google-api-core``                         ``>=2.11.0,!=2.16.0,!=2.18.0``
+``google-api-core``                         ``>=2.30.3``
 ``google-api-python-client``                ``>=2.0.2``
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -71,10 +71,12 @@ dependencies = [
     "gcsfs>=2023.10.0",
     "google-ads>=26.0.0,!=28.0.0.post2",
     "google-analytics-admin>=0.9.0",
-    # Google-api-core 2.16.0 back-compat issue:
-    # - https://github.com/googleapis/python-api-core/issues/576
-    # - https://github.com/apache/airflow/issues/39394
-    "google-api-core>=2.11.0,!=2.16.0,!=2.18.0",
+    # Floor raised to 2.30.3: google-api-core 2.28.1-2.30.2 has an import-time
+    # performance regression (it scans the whole venv on import), which trips the
+    # Dag import timeout for operators that import it. Fixed in 2.30.3.
+    # - https://github.com/apache/airflow/issues/62373
+    # - https://github.com/googleapis/google-cloud-python/issues/15015
+    "google-api-core>=2.30.3",
     "google-api-python-client>=2.0.2",
     "google-auth>=2.29.0",
     "google-auth-httplib2>=0.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -5489,7 +5489,7 @@ requires-dist = [
     { name = "gcsfs", specifier = ">=2023.10.0" },
     { name = "google-ads", specifier = ">=26.0.0,!=28.0.0.post2" },
     { name = "google-analytics-admin", specifier = ">=0.9.0" },
-    { name = "google-api-core", specifier = ">=2.11.0,!=2.16.0,!=2.18.0" },
+    { name = "google-api-core", specifier = ">=2.30.3" },
     { name = "google-api-python-client", specifier = ">=2.0.2" },
     { name = "google-auth", specifier = ">=2.29.0" },
     { name = "google-auth-httplib2", specifier = ">=0.0.1" },


### PR DESCRIPTION
### Problem being addressed

Dags that import `DataprocCreateBatchOperator` or `BigQueryInsertJobOperator` can fail to
parse because those imports are slow enough to trip the Dag file import timeout (default 30s)
on smaller workers. Reported in [#62373](https://github.com/apache/airflow/issues/62373)
(seen on Airflow 3.1.x and Cloud Composer).

The slow import is **not** caused by these operators or by Airflow's import layout. The root
cause is an upstream performance regression: `google-api-core` 2.28.1 added a Python-version
check in `google/api_core/__init__.py` that calls `importlib.metadata.packages_distributions()`,
which scans **every** installed package on each import. In a large Airflow venv this adds several
seconds to importing `google.api_core` and everything built on it. A maintainer confirmed this on
the issue and measured that upgrading to 2.30.3 cuts import time from 30–50s to 2–5s. The
regression was fixed upstream in `google-api-core` 2.30.3
([googleapis/google-cloud-python#16579](https://github.com/googleapis/google-cloud-python/pull/16579),
root cause [#15015](https://github.com/googleapis/google-cloud-python/issues/15015)).

### What was implemented

- **`providers/google/pyproject.toml`** — raised the floor
  `google-api-core>=2.11.0,!=2.16.0,!=2.18.0` → `google-api-core>=2.30.3`, which excludes the
  regressed 2.28.1–2.30.2 range. The old `!=2.16.0,!=2.18.0` exclusions are subsumed by the higher
  floor and dropped; the stale comment is replaced with one explaining the new floor.
- **`uv.lock`** — updated the matching specifier. The workspace already resolves
  `google-api-core` to 2.30.3, so there is no dependency-tree change — only the recorded specifier
  string.
- **`providers/google/README.rst`** and **`providers/google/docs/index.rst`** — regenerated the
  Requirements tables to match (via the `sync-provider-readme` prek hook).

This is the floor-bump approach a maintainer endorsed, rather than the operator lazy-import
refactors attempted in [#63206](https://github.com/apache/airflow/pull/63206) and
[#64938](https://github.com/apache/airflow/pull/64938) — both closed unmerged because the
refactors broke provider tests and addressed the wrong layer.

### Impact

- Dags importing the affected Google operators parse within the timeout again on small workers,
  with no operator code changes.
- Pre-flight ran clean locally: `breeze ci selective-check` (google provider compatibility matrix
  vs Airflow 2.11.1 / 3.0.6 / 3.1.8 / 3.2.2 plus mypy-providers) and `prek` pre-commit + manual
  static-check stages all pass.

### Potential impact / risk

- Raises the minimum `google-api-core` for the Google provider from 2.11.0 to 2.30.3 (released
  2026-04-09). Users pinned to an older `google-api-core` for unrelated reasons would need to
  upgrade. 2.30.3 requires Python ≥3.9 (the provider targets ≥3.10) and protobuf ≥4.25.8 (and
  allows 7.x).
- Low resolution risk: the workspace already resolves to 2.30.3 and it is the latest release, so
  the bump cannot cascade to newer transitive versions; the LowestDeps CI job installs exactly
  2.30.3, which is the fixed version.

### Files to review

- [`providers/google/pyproject.toml`](https://github.com/Vamsi-klu/airflow/blob/19531c3d32/providers/google/pyproject.toml#L74-L79)
- [`uv.lock`](https://github.com/Vamsi-klu/airflow/blob/19531c3d32/uv.lock#L5492)
- [`providers/google/README.rst`](https://github.com/Vamsi-klu/airflow/blob/19531c3d32/providers/google/README.rst)
- [`providers/google/docs/index.rst`](https://github.com/Vamsi-klu/airflow/blob/19531c3d32/providers/google/docs/index.rst)

closes: #62373

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
