### PR TITLE
Verify TCP connection ownership before accepting Java coordinator supervisor channel

### DIFF
--- a/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
+++ b/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
@@ -37,6 +37,7 @@ import time
 from typing import TYPE_CHECKING, TypeVar, cast
 
 import attrs
+import psutil
 import structlog
 
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
@@ -63,6 +64,31 @@ def _start_server() -> socket.socket:
     server.setblocking(True)
     server.listen(1)  # Just need to listen to the child process.
     return server
+
+
+def _socket_address(value: tuple | str) -> tuple[str, int] | None:
+    if not isinstance(value, tuple) or len(value) < 2:
+        return None
+    host, port = value[:2]
+    return str(host), int(port)
+
+
+def _is_connection_from_process(conn: socket.socket, proc: subprocess.Popen) -> bool:
+    """Return whether the accepted TCP connection belongs to the child process."""
+    peer = _socket_address(conn.getpeername())
+    local = _socket_address(conn.getsockname())
+    if peer is None or local is None:
+        return False
+    try:
+        process = psutil.Process(proc.pid)
+        connections = process.net_connections(kind="tcp")
+    except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError):
+        log.warning("Unable to verify child process connection", pid=proc.pid, exc_info=True)
+        return False
+    for connection in connections:
+        if _socket_address(connection.laddr) == peer and _socket_address(connection.raddr) == local:
+            return True
+    return False
 
 
 def _accept_connections(
@@ -102,6 +128,15 @@ def _accept_connections(
                 else:
                     log.debug("Accepting child process connection", key=event.data)
                     conn, _ = soc.accept()
+                    if not _is_connection_from_process(conn, proc):
+                        log.warning(
+                            "Rejected connection not owned by child process",
+                            key=event.data,
+                            pid=proc.pid,
+                            peer=conn.getpeername(),
+                        )
+                        conn.close()
+                        continue
                     sel.unregister(soc)
                     accepted[soc] = conn
     return accepted, drained

--- a/task-sdk/src/airflow/sdk/coordinators/java/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/java/coordinator.py
@@ -156,7 +156,6 @@ class _JarInfo:
         raise FileNotFoundError(tp.format(main_class, os.pathsep.join(os.fspath(p.resolve()) for p in roots)))
 
 
-
 def _convert_jars_root(
     value: None | os.PathLike[str] | pathlib.Path | list[os.PathLike[str] | pathlib.Path],
 ) -> list[pathlib.Path]:

--- a/task-sdk/src/airflow/sdk/coordinators/java/coordinator.py
+++ b/task-sdk/src/airflow/sdk/coordinators/java/coordinator.py
@@ -156,6 +156,7 @@ class _JarInfo:
         raise FileNotFoundError(tp.format(main_class, os.pathsep.join(os.fspath(p.resolve()) for p in roots)))
 
 
+
 def _convert_jars_root(
     value: None | os.PathLike[str] | pathlib.Path | list[os.PathLike[str] | pathlib.Path],
 ) -> list[pathlib.Path]:

--- a/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
+++ b/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
@@ -18,8 +18,10 @@
 from __future__ import annotations
 
 import contextlib
+import os
 import socket
 import subprocess
+import sys
 import threading
 import time
 from unittest.mock import ANY, MagicMock, call, patch
@@ -32,6 +34,7 @@ from airflow.sdk.api.client import Client, TaskInstanceOperations
 from airflow.sdk.coordinators._subprocess import (
     SubprocessCoordinator,
     _accept_connections,
+    _is_connection_from_process,
     _PopenActivitySubprocess,
     _ResourceTracker,
     _start_server,
@@ -102,6 +105,14 @@ class TestStartServer:
 
 
 class TestAcceptConnections:
+    @pytest.fixture(autouse=True)
+    def mock_child_connection_check(self):
+        with patch(
+            "airflow.sdk.coordinators._subprocess._is_connection_from_process",
+            return_value=True,
+        ) as mock_check:
+            yield mock_check
+
     def _connect_after_delay(self, addr: tuple[str, int], delay: float = 0.0) -> None:
         def _connect():
             time.sleep(delay)
@@ -254,6 +265,96 @@ class TestAcceptConnections:
             assert "comm" not in accepted
             accepted[server].close()
         finally:
+            server.close()
+
+    def test_rejects_connections_not_owned_by_child_process(self, mock_child_connection_check):
+        server = _start_server()
+        _, port = server.getsockname()
+        mock_child_connection_check.side_effect = [False, True]
+        self._connect_after_delay(("127.0.0.1", port))
+        self._connect_after_delay(("127.0.0.1", port), delay=0.05)
+
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+
+        try:
+            accepted, _ = _accept_connections({"comm": server}, {}, mock_proc)
+            assert mock_child_connection_check.call_count == 2
+            assert server in accepted
+            accepted[server].close()
+        finally:
+            server.close()
+
+
+class TestAcceptConnectionsProcessValidation:
+    def _start_connector_process(self, addr: tuple[str, int], *, delay: float = 0.0) -> subprocess.Popen:
+        script = """
+import socket
+import sys
+import time
+
+time.sleep(float(sys.argv[3]))
+sock = socket.socket()
+sock.connect((sys.argv[1], int(sys.argv[2])))
+sock.recv(1)
+"""
+        return subprocess.Popen([sys.executable, "-c", script, addr[0], str(addr[1]), str(delay)])
+
+    def test_rejects_racing_connection_from_other_process(self):
+        server = _start_server()
+        addr = server.getsockname()
+        attacker = socket.socket()
+        attacker.connect(addr)
+        child_proc = self._start_connector_process(addr, delay=0.05)
+
+        try:
+            accepted, _ = _accept_connections({"comm": server}, {}, child_proc)
+            accepted[server].sendall(b"x")
+            accepted[server].close()
+            assert child_proc.wait(timeout=5) == 0
+            assert attacker.recv(1) == b""
+        finally:
+            attacker.close()
+            server.close()
+            if child_proc.poll() is None:
+                child_proc.terminate()
+                child_proc.wait(timeout=5)
+
+
+class TestConnectionFromProcess:
+    def test_matches_child_process_tcp_connection(self):
+        server = _start_server()
+        _, port = server.getsockname()
+        client = socket.socket()
+        client.connect(("127.0.0.1", port))
+        conn, _ = server.accept()
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = os.getpid()
+
+        try:
+            assert _is_connection_from_process(conn, mock_proc) is True
+        finally:
+            conn.close()
+            client.close()
+            server.close()
+
+    def test_rejects_tcp_connection_not_owned_by_child_process(self):
+        server = _start_server()
+        _, port = server.getsockname()
+        client = socket.socket()
+        client.connect(("127.0.0.1", port))
+        conn, _ = server.accept()
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.pid = os.getpid()
+
+        try:
+            with patch("airflow.sdk.coordinators._subprocess.psutil.Process") as mock_process:
+                mock_process.return_value.net_connections.return_value = []
+                assert _is_connection_from_process(conn, mock_proc) is False
+        finally:
+            conn.close()
+            client.close()
             server.close()
 
 


### PR DESCRIPTION
The Java coordinator accepted the first loopback TCP client unconditionally, exposing the supervisor channel to any local process that could race the spawned Java subprocess
  and connect first. 

 - New helper _is_connection_from_process checks whether an accepted peer address belongs to the spawned Java subprocess using psutil.Process().net_connections()
  - New helper _socket_address extracts the peer address from a socket in a testable form
  - _accept_connections now rejects and closes sockets that cannot be proven to originate from the expected child process
  - When psutil cannot verify ownership (permission error, process already exited, etc.), a warning is logged and the connection is rejected rather than silently accepted


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
- codex

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
