### PR TITLE
[v3-2-test] Fix SimpleAuthManager redirect after login

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/routes/login.py
@@ -28,6 +28,7 @@ from airflow.api_fastapi.auth.managers.simple.utils import parse_login_body
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.common.types import Mimetype
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
+from airflow.api_fastapi.core_api.security import is_safe_url
 from airflow.configuration import conf
 
 login_router = AirflowRouter(tags=["SimpleAuthManagerLogin"])
@@ -85,7 +86,10 @@ def create_token_all_admins() -> LoginResponse:
 )
 def login_all_admins(request: Request) -> RedirectResponse:
     """Login the user with no credentials."""
-    response = RedirectResponse(url=conf.get("api", "base_url", fallback="/"))
+    fallback_url = conf.get("api", "base_url", fallback="/")
+    next_url = request.query_params.get("next")
+    redirect_url = next_url if next_url and is_safe_url(next_url, request=request) else fallback_url
+    response = RedirectResponse(url=redirect_url)
 
     # The default config has this as an empty string, so we can't use `has_option`.
     # And look at the request info (needs `--proxy-headers` flag to api-server)

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/routes/test_login.py
@@ -86,6 +86,28 @@ class TestLogin:
             assert "location" in response.headers
             assert response.cookies.get("_token") is not None
 
+    def test_login_all_admins_redirects_to_next_url(self, test_client):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true", ("api", "ssl_cert"): "false"}):
+            response = test_client.get(
+                "/auth/token/login?next=/dags/example_dag/runs/manual__2026-05-20/tasks/example_task",
+                follow_redirects=False,
+            )
+            assert response.status_code == 307
+            assert (
+                response.headers["location"] == "/dags/example_dag/runs/manual__2026-05-20/tasks/example_task"
+            )
+            assert response.cookies.get("_token") is not None
+
+    def test_login_all_admins_ignores_unsafe_next_url(self, test_client):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true", ("api", "ssl_cert"): "false"}):
+            response = test_client.get(
+                "/auth/token/login?next=https://example.com/malicious",
+                follow_redirects=False,
+            )
+            assert response.status_code == 307
+            assert response.headers["location"] == "/"
+            assert response.cookies.get("_token") is not None
+
     def test_login_all_admins_config_disabled(self, test_client):
         response = test_client.get("/auth/token/login", follow_redirects=False)
         assert response.status_code == 403


### PR DESCRIPTION
Backport of #67483 to `v3-2-test`.

Preserves safe `next` redirects after SimpleAuthManager auto-login and falls back to the configured base URL for unsafe targets. The original fix was authored by @Codingaditya17 and cherry-picked from commit `11f348694fc3024b81888e29618c25091fa41f66`.

 