### PR TITLE
Correct the configuration key of triggerer log server port

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/logging-tasks.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/logging-tasks.rst
@@ -180,7 +180,7 @@ Most task handlers send logs upon completion of a task. In order to view logs in
 
 In triggerer, logs are served unless the service is started with option ``--skip-serve-logs``.
 
-The server is running on the port specified by ``worker_log_server_port`` option in ``[logging]`` section, and option ``triggerer_log_server_port`` for triggerer.  Defaults are 8793 and 8794, respectively.
+The server is running on the port specified by ``worker_log_server_port`` option in ``[logging]`` section, and option ``trigger_log_server_port`` for triggerer.  Defaults are 8793 and 8794, respectively.
 Communication between the webserver and the worker is signed with the key specified by ``secret_key`` option  in ``[api]`` section. You must ensure that the key matches so that communication can take place without problems.
 
 We are using `Gunicorn <https://gunicorn.org/>`__ as a WSGI server. Its configuration options can be overridden with the ``GUNICORN_CMD_ARGS`` env variable. For details, see `Gunicorn settings <https://docs.gunicorn.org/en/latest/settings.html#settings>`__.

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -714,7 +714,18 @@ class FileTaskHandler(logging.Handler):
         if log_type == LogType.TRIGGER:
             if not ti.triggerer_job:
                 raise RuntimeError("Could not build triggerer log URL; no triggerer job.")
-            config_key = "triggerer_log_server_port"
+            config_key = "trigger_log_server_port"
+            deprecated_config_key = "triggerer_log_server_port"
+            if (
+                conf.get("logging", config_key, fallback=None) is None
+                and conf.get("logging", deprecated_config_key, fallback=None) is not None
+            ):
+                logger.warning(
+                    "The [logging] %s option is deprecated. Please use [logging] %s instead.",
+                    deprecated_config_key,
+                    config_key,
+                )
+                config_key = deprecated_config_key
             config_default = 8794
             hostname = ti.triggerer_job.hostname
             log_relative_path = self.add_triggerer_suffix(log_relative_path, job_id=ti.triggerer_job.id)

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -857,6 +857,106 @@ class TestLogUrl:
             "DYNAMIC_PATH.trigger.123.log",
         )
 
+    def test_log_retrieval_trigger_uses_trigger_log_server_port(self, create_task_instance):
+        with conf_vars({("logging", "trigger_log_server_port"): "9001"}):
+            ti = create_task_instance(
+                dag_id="dag_for_testing_filename_rendering",
+                task_id="task_for_testing_filename_rendering",
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+            )
+            ti.hostname = "hostname"
+            trigger = Trigger("", {})
+            job = Job(TriggererJobRunner.job_type)
+            job.id = 123
+            trigger.triggerer_job = job
+            ti.trigger = trigger
+            actual = FileTaskHandler("")._get_log_retrieval_url(ti, "DYNAMIC_PATH", log_type=LogType.TRIGGER)
+            hostname = get_hostname()
+            assert actual == (
+                f"http://{hostname}:9001/log/DYNAMIC_PATH.trigger.123.log",
+                "DYNAMIC_PATH.trigger.123.log",
+            )
+
+    def test_log_retrieval_trigger_falls_back_to_deprecated_config(self, create_task_instance):
+        with conf_vars(
+            {
+                ("logging", "trigger_log_server_port"): None,
+                ("logging", "triggerer_log_server_port"): "9002",
+            }
+        ):
+            ti = create_task_instance(
+                dag_id="dag_for_testing_filename_rendering",
+                task_id="task_for_testing_filename_rendering",
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+            )
+            ti.hostname = "hostname"
+            trigger = Trigger("", {})
+            job = Job(TriggererJobRunner.job_type)
+            job.id = 123
+            trigger.triggerer_job = job
+            ti.trigger = trigger
+            actual = FileTaskHandler("")._get_log_retrieval_url(ti, "DYNAMIC_PATH", log_type=LogType.TRIGGER)
+            hostname = get_hostname()
+            assert actual == (
+                f"http://{hostname}:9002/log/DYNAMIC_PATH.trigger.123.log",
+                "DYNAMIC_PATH.trigger.123.log",
+            )
+
+    def test_log_retrieval_trigger_prefers_new_config_over_deprecated(self, create_task_instance):
+        with conf_vars(
+            {
+                ("logging", "trigger_log_server_port"): "9001",
+                ("logging", "triggerer_log_server_port"): "9002",
+            }
+        ):
+            ti = create_task_instance(
+                dag_id="dag_for_testing_filename_rendering",
+                task_id="task_for_testing_filename_rendering",
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+            )
+            ti.hostname = "hostname"
+            trigger = Trigger("", {})
+            job = Job(TriggererJobRunner.job_type)
+            job.id = 123
+            trigger.triggerer_job = job
+            ti.trigger = trigger
+            actual = FileTaskHandler("")._get_log_retrieval_url(ti, "DYNAMIC_PATH", log_type=LogType.TRIGGER)
+            hostname = get_hostname()
+            assert actual == (
+                f"http://{hostname}:9001/log/DYNAMIC_PATH.trigger.123.log",
+                "DYNAMIC_PATH.trigger.123.log",
+            )
+
+    def test_log_retrieval_trigger_warns_on_deprecated_config(self, create_task_instance):
+        with conf_vars(
+            {
+                ("logging", "trigger_log_server_port"): None,
+                ("logging", "triggerer_log_server_port"): "9002",
+            }
+        ):
+            ti = create_task_instance(
+                dag_id="dag_for_testing_filename_rendering",
+                task_id="task_for_testing_filename_rendering",
+                run_type=DagRunType.SCHEDULED,
+                logical_date=DEFAULT_DATE,
+            )
+            ti.hostname = "hostname"
+            trigger = Trigger("", {})
+            job = Job(TriggererJobRunner.job_type)
+            job.id = 123
+            trigger.triggerer_job = job
+            ti.trigger = trigger
+            with mock.patch("airflow.utils.log.file_task_handler.logger.warning") as mock_logger_warning:
+                FileTaskHandler("")._get_log_retrieval_url(ti, "DYNAMIC_PATH", log_type=LogType.TRIGGER)
+                mock_logger_warning.assert_called_once_with(
+                    "The [logging] %s option is deprecated. Please use [logging] %s instead.",
+                    "triggerer_log_server_port",
+                    "trigger_log_server_port",
+                )
+
 
 log_sample = """[2022-11-16T00:05:54.278-0800] {taskinstance.py:1257} INFO -
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The key of the port that api-server used to retrieve triggerer`s log (trigger**er**_log_server_port) is not align with the one defined in [configurations-ref](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#trigger-log-server-port) (trigger_log_server_port):

api-server use `triggerer_log_server_port` to retrieve triggerer`s log - airflow.utils.log.file_task_handler.FileTaskHandler._get_log_retrieval_url
```
    def _get_log_retrieval_url(
        self,
        ti: TaskInstance | TaskInstanceHistory,
        log_relative_path: str,
        log_type: LogType | None = None,
    ) -> tuple[str | None, str | None]:
        """Given TI, generate URL with which to fetch logs from service log server."""
        if log_type == LogType.TRIGGER:
            if not ti.triggerer_job:
                raise RuntimeError("Could not build triggerer log URL; no triggerer job.")
            config_key = "trigger_log_server_port"
            config_default = 8794
            hostname = ti.triggerer_job.hostname
            log_relative_path = self.add_triggerer_suffix(log_relative_path, job_id=ti.triggerer_job.id)
        else:
            hostname = ti.hostname
            config_key = "worker_log_server_port"
            config_default = 8793

        if not hostname:
            return None, None

        return (
            urljoin(
                f"http://{hostname}:{conf.get('logging', config_key, fallback=config_default)}/log/",
                log_relative_path,
            ),
            log_relative_path,
        )
```

As a result, api-server will always fetch triggerer`s log with the default port - 8794, when triggerer is not using the default server port (8794), api-server will fail to connect to the customized port to retrieve the log.

**Fix:**
- Change the key from triggerer_log_server_port to trigger_log_server_port to make it align.


---

##### Was generative AI tooling used to co-author this PR?

- [X] No

<!-- pr-triage-fold: triaged=2026-06-17T18:53:58Z head=2e77e5c action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @vin-c-ent** · by `@potiuk` · 2026-06-17 18:53 UTC
>
> Some review feedback from `jason810496` is waiting on you:
> - Please respond to the open review thread(s) — reply or push a fix in each, then mark them resolved.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->