### PR TITLE
fix: remove conditional dialog mounts; bump @chakra-ui/react to ^3.35.0

### DIFF
--- a/airflow-core/src/airflow/ui/CONTRIBUTING.md
+++ b/airflow-core/src/airflow/ui/CONTRIBUTING.md
@@ -40,27 +40,6 @@ Manually:
 - Run `pnpm install && pnpm dev`
 - Note: Make sure to access the UI via the Airflow localhost port (8080 or 28080) and not the vite port (5173)
 
-## Dependency upgrade caveats
-
-### `@chakra-ui/react` — held at `~3.34.0`
-
-Do not relax this pin or bump `@chakra-ui/react` above `3.34.x` without
-re-checking every dialog in this codebase that is mounted conditionally
-(`{open ? <Dialog ... /> : undefined}`), e.g. `ClearRunButton`,
-`MarkRunAsButton`, `ClearTaskInstanceButton`, `MarkTaskInstanceAsButton`.
-
-`@chakra-ui/react@3.35.0` pulls in `@ark-ui/react@>=5.36.0`, where dialog
-`pointer-events` cleanup moved from an inline style on the dialog DOM
-to the dismissable layer's close-transition completion. Conditionally
-mounted dialogs unmount before that transition runs, leaving the
-`pointer-events: none` lock stuck on `document` — the page then refuses
-every click (scroll still works) until a full refresh. See PR #67646
-for the original revert and the timeline.
-
-To bump safely, first rewrite the conditional-mount sites to always
-render the dialog (and gate any expensive dry-run queries with
-`enabled: open`) so the dialog can drive its own close transition.
-
 ## More
 
 See [node environment setup docs](/contributing-docs/15_node_environment_setup.rst)

--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@chakra-ui/anatomy": "^2.3.4",
-    "@chakra-ui/react": "~3.34.0",
+    "@chakra-ui/react": "^3.35.0",
     "@emotion/react": "^11.14.0",
     "@guanmingchiu/sqlparser-ts": "^0.61.1",
     "@lezer/highlight": "^1.2.3",

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunButton.tsx
@@ -55,7 +55,7 @@ const ClearRunButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
       >
         <CgRedo />
       </IconButton>
-      {open ? <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} /> : undefined}
+      <ClearRunDialog dagRun={dagRun} onClose={onClose} open={open} />
     </>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/Run/ClearRunDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
@@ -44,6 +44,17 @@ const ClearRunDialog = ({ dagRun, onClose, open }: Props) => {
 
   const [note, setNote] = useState<string | null>(dagRun.note);
   const [selectedOptions, setSelectedOptions] = useState<Array<string>>(["existingTasks"]);
+
+  // Reset local state when the dialog closes so re-opening shows the current run note,
+  // not whatever the user typed before cancelling. Previously this reset happened
+  // automatically because the parent conditionally unmounted this component; we now
+  // always render it (to let Ark UI's dismiss layer clean up pointer-events correctly).
+  useEffect(() => {
+    if (!open) {
+      setNote(dagRun.note);
+      setSelectedOptions(["existingTasks"]);
+    }
+  }, [open, dagRun.note]);
   const onlyFailed = selectedOptions.includes("onlyFailed");
   const onlyNew = selectedOptions.includes("newTasks");
 

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceButton.tsx
@@ -87,12 +87,11 @@ const ClearTaskInstanceButton = ({
         <CgRedo />
       </IconButton>
 
-      {useInternalDialog && open && isGroup ? (
+      {useInternalDialog && isGroup ? (
         <ClearGroupTaskInstanceDialog onClose={onClose} open={open} taskInstance={groupTaskInstance} />
       ) : undefined}
 
       {useInternalDialog &&
-      open &&
       !isGroup &&
       allMapped &&
       dagId !== undefined &&
@@ -108,7 +107,7 @@ const ClearTaskInstanceButton = ({
         />
       ) : undefined}
 
-      {useInternalDialog && open && !isGroup && !allMapped && taskInstance ? (
+      {useInternalDialog && !isGroup && !allMapped && taskInstance ? (
         <ClearTaskInstanceDialog onClose={onClose} open={open} taskInstance={taskInstance} />
       ) : undefined}
     </>

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, useDisclosure, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
@@ -92,6 +92,18 @@ const ClearTaskInstanceDialog = (props: Props) => {
   const [preventRunningTask, setPreventRunningTask] = useState(true);
 
   const [note, setNote] = useState<string | null>(taskInstance?.note ?? null);
+
+  // Reset local state on close so re-opening shows the current TI note, not what
+  // the user typed before cancelling. Previously the conditional mount in
+  // ClearTaskInstanceButton achieved this via unmount; we now always render the
+  // dialog so Ark UI's dismiss layer can properly remove pointer-events.
+  useEffect(() => {
+    if (!props.open) {
+      setNote(taskInstance?.note ?? null);
+      setSelectedOptions(["downstream"]);
+      setPreventRunningTask(true);
+    }
+  }, [props.open, taskInstance?.note]);
 
   // Get current DAG's bundle version to compare with task instance's DAG version bundle version
   const { data: dagDetails } = useDagServiceGetDagDetails({

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsButton.tsx
@@ -109,7 +109,7 @@ const MarkRunAsButton = ({ dagRun, isHotkeyEnabled = false }: Props) => {
         </Menu.Content>
       </Menu.Root>
 
-      {open ? <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} /> : undefined}
+      <MarkRunAsDialog dagRun={dagRun} onClose={onClose} open={open} state={state} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/Run/MarkRunAsDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { DagRunMutableStates, DAGRunResponse } from "openapi/requests/types.gen";
@@ -40,6 +40,12 @@ const MarkRunAsDialog = ({ dagRun, onClose, open, state }: Props) => {
 
   const [note, setNote] = useState<string | null>(dagRun.note);
   const { isPending, mutate } = usePatchDagRun({ dagId, dagRunId, onSuccess: onClose });
+
+  useEffect(() => {
+    if (!open) {
+      setNote(dagRun.note);
+    }
+  }, [open, dagRun.note]);
 
   return (
     <Dialog.Root lazyMount onOpenChange={onClose} open={open}>

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx
@@ -109,9 +109,7 @@ const MarkTaskInstanceAsButton = ({ isHotkeyEnabled = false, taskInstance }: Pro
         </Menu.Content>
       </Menu.Root>
 
-      {open ? (
-        <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
-      ) : undefined}
+      <MarkTaskInstanceAsDialog onClose={onClose} open={open} state={state} taskInstance={taskInstance} />
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/MarkAs/TaskInstance/MarkTaskInstanceAsDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { Button, Flex, Heading, VStack } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { TaskInstanceResponse, TaskInstanceState } from "openapi/requests/types.gen";
@@ -51,6 +51,13 @@ const MarkTaskInstanceAsDialog = ({ onClose, open, state, taskInstance }: Props)
   const downstream = selectedOptions.includes("downstream");
 
   const [note, setNote] = useState<string | null>(taskInstance.note);
+
+  useEffect(() => {
+    if (!open) {
+      setNote(taskInstance.note);
+      setSelectedOptions([]);
+    }
+  }, [open, taskInstance.note]);
 
   const { isPending, mutate } = usePatchTaskInstance({
     dagId,

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -121,13 +121,11 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
         stats={stats}
         title={`${taskInstance.task_display_name}${taskInstance.map_index > -1 ? ` [${taskInstance.rendered_map_index ?? taskInstance.map_index}]` : ""}`}
       />
-      {clearOpen ? (
-        <ClearTaskInstanceDialog
-          onClose={() => setClearOpen(false)}
-          open={clearOpen}
-          taskInstance={taskInstance}
-        />
-      ) : undefined}
+      <ClearTaskInstanceDialog
+        onClose={() => setClearOpen(false)}
+        open={clearOpen}
+        taskInstance={taskInstance}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Resolves #67647.

Ark UI 5.36 moved `pointer-events` cleanup from an inline DOM style to the dismissable layer's close-transition callback. Dialogs that were conditionally mounted (`{open ? <Dialog/> : undefined}`) unmounted before that transition ran, leaving `pointer-events: none` permanently stuck on `document` — every button/link click was silently swallowed until a hard refresh.

## Root cause

The conditional mount pattern was intentional: unmounting reset `useState` (note, selectedOptions, etc.) so re-opening the dialog showed the server value, not the user's uncommitted input. Ark UI 5.36 made this pattern incompatible with the new cleanup approach.

## Fix

**Buttons** — remove the `open` guard; always render the dialog:
```tsx
// before
{open ? <ClearRunDialog ... /> : undefined}

// after
<ClearRunDialog ... />
```

**Dialogs** — add `useEffect` to reset local state when `open` goes `false`:
```tsx
useEffect(() => {
  if (!open) {
    setNote(dagRun.note);
    setSelectedOptions(["existingTasks"]);
  }
}, [open, dagRun.note]);
```

This preserves the note-reset behaviour (#47071) while letting the dialog drive its own close transition.

## Affected files

- `Clear/Run/ClearRunButton.tsx` + `ClearRunDialog.tsx`
- `Clear/TaskInstance/ClearTaskInstanceButton.tsx` + `ClearTaskInstanceDialog.tsx`
- `MarkAs/Run/MarkRunAsButton.tsx` + `MarkRunAsDialog.tsx`
- `MarkAs/TaskInstance/MarkTaskInstanceAsButton.tsx` + `MarkTaskInstanceAsDialog.tsx`
- `pages/TaskInstance/Header.tsx`
- `package.json`: `~3.34.0` → `^3.35.0`
- `CONTRIBUTING.md`: remove now-resolved caveat section

## Verification checklist

- [ ] Open any Clear/Mark-as dialog; cancel via X, Escape, or backdrop click; confirm the rest of the page remains clickable
- [ ] Reopen the same dialog; confirm the note field shows the run/TI server value
- [ ] Confirm a clear/mark-as action; close success dialog; confirm page is still clickable