### PR TITLE
Use async DB session for Execution API task-instance heartbeat

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/common.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/common.py
@@ -64,7 +64,7 @@ async def _get_async_session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-AsyncSessionDep = Annotated[AsyncSession, Depends(_get_async_session)]
+AsyncSessionDep = Annotated[AsyncSession, Depends(_get_async_session, scope="function")]
 
 
 @overload

--- a/airflow-core/src/airflow/api_fastapi/common/db/common.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/common.py
@@ -94,7 +94,7 @@ async def _get_async_session() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
-AsyncSessionDep = Annotated[AsyncSession, Depends(_get_async_session)]
+AsyncSessionDep = Annotated[AsyncSession, Depends(_get_async_session, scope="function")]
 
 
 @overload

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -33,7 +33,7 @@ from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import JsonValue
-from sqlalchemy import and_, func, or_, tuple_, update
+from sqlalchemy import and_, exists, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import DataError, NoResultFound, SQLAlchemyError
 from sqlalchemy.orm import joinedload
@@ -45,7 +45,7 @@ from airflow._shared.state import TaskScope
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.auth.tokens import JWTGenerator
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
-from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.db.common import AsyncSessionDep, SessionDep
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
@@ -856,11 +856,9 @@ def ti_skip_downstream(
     log.info("Downstream tasks skipped", tasks_skipped=getattr(result, "rowcount", 0))
 
 
-def _raise_ti_not_in_live_table(task_instance_id: UUID, session: SessionDep) -> NoReturn:
+def _raise_ti_not_in_live_table(task_instance_id: UUID, *, archived_in_history: bool) -> NoReturn:
     """Raise 410 Gone if the missing TI id was archived to history, else 404 Not Found."""
-    if session.scalar(
-        select(func.count(TIH.task_instance_id)).where(TIH.task_instance_id == task_instance_id)
-    ):
+    if archived_in_history:
         log.error("TaskInstance not in live table but archived in history", ti_id=str(task_instance_id))
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
@@ -897,10 +895,10 @@ def _raise_ti_not_in_live_table(task_instance_id: UUID, session: SessionDep) -> 
         ]
     ),
 )
-def ti_heartbeat(
+async def ti_heartbeat(
     task_instance_id: UUID,
     ti_payload: TIHeartbeatInfo,
-    session: SessionDep,
+    session: AsyncSessionDep,
 ):
     """Update the heartbeat of a TaskInstance to mark it as alive & still running."""
     bind_contextvars(ti_id=str(task_instance_id))
@@ -910,7 +908,7 @@ def ti_heartbeat(
     # so we can update last_heartbeat_at directly without first taking a row lock.
     fast_path_result = cast(
         "CursorResult[Any]",
-        session.execute(
+        await session.execute(
             update(TI)
             .where(
                 TI.id == task_instance_id,
@@ -931,7 +929,7 @@ def ti_heartbeat(
     old = select(TI.state, TI.hostname, TI.pid).where(TI.id == task_instance_id).with_for_update()
 
     try:
-        (previous_state, hostname, pid) = session.execute(old).one()
+        (previous_state, hostname, pid) = (await session.execute(old)).one()
         log.debug(
             "Retrieved current task state", state=previous_state, current_hostname=hostname, current_pid=pid
         )
@@ -939,7 +937,10 @@ def ti_heartbeat(
         # Check if the TI exists in the Task Instance History table.
         # If it does, it was likely cleared while running, so return 410 Gone
         # instead of 404 Not Found to give the client a more specific signal.
-        _raise_ti_not_in_live_table(task_instance_id, session)
+        archived_in_history = bool(
+            await session.scalar(select(exists().where(TIH.task_instance_id == task_instance_id)))
+        )
+        _raise_ti_not_in_live_table(task_instance_id, archived_in_history=archived_in_history)
 
     if hostname != ti_payload.hostname or pid != ti_payload.pid:
         log.warning(
@@ -971,7 +972,9 @@ def ti_heartbeat(
         )
 
     # Update the last heartbeat time!
-    session.execute(update(TI).where(TI.id == task_instance_id).values(last_heartbeat_at=timezone.utcnow()))
+    await session.execute(
+        update(TI).where(TI.id == task_instance_id).values(last_heartbeat_at=timezone.utcnow())
+    )
     log.debug("Heartbeat updated", state=previous_state)
 
 
@@ -1009,7 +1012,10 @@ def ti_put_rtif(
     task_instance = session.scalar(select(TI).where(TI.id == task_instance_id))
     if not task_instance:
         # On retry/clear, the server regenerates the TI id. Return 410 for the stale id.
-        _raise_ti_not_in_live_table(task_instance_id, session)
+        archived_in_history = bool(
+            session.scalar(select(exists().where(TIH.task_instance_id == task_instance_id)))
+        )
+        _raise_ti_not_in_live_table(task_instance_id, archived_in_history=archived_in_history)
     task_instance.update_rtif(put_rtif_payload, session=session)
     log.debug("RenderedTaskInstanceFields updated successfully")
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -33,7 +33,7 @@ from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import JsonValue, ValidationError
-from sqlalchemy import and_, func, or_, tuple_, update
+from sqlalchemy import and_, exists, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import DataError, NoResultFound, SQLAlchemyError
 from sqlalchemy.orm import joinedload
@@ -45,7 +45,7 @@ from airflow._shared.state import TaskScope
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.auth.tokens import JWTGenerator
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
-from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.db.common import AsyncSessionDep, SessionDep
 from airflow.api_fastapi.common.db.dags import eager_load_teams
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
@@ -892,11 +892,9 @@ def ti_skip_downstream(
     log.info("Downstream tasks skipped", tasks_skipped=getattr(result, "rowcount", 0))
 
 
-def _raise_ti_not_in_live_table(task_instance_id: UUID, session: SessionDep) -> NoReturn:
+def _raise_ti_not_in_live_table(task_instance_id: UUID, *, archived_in_history: bool) -> NoReturn:
     """Raise 410 Gone if the missing TI id was archived to history, else 404 Not Found."""
-    if session.scalar(
-        select(func.count(TIH.task_instance_id)).where(TIH.task_instance_id == task_instance_id)
-    ):
+    if archived_in_history:
         log.error("TaskInstance not in live table but archived in history", ti_id=str(task_instance_id))
         raise HTTPException(
             status_code=status.HTTP_410_GONE,
@@ -933,10 +931,10 @@ def _raise_ti_not_in_live_table(task_instance_id: UUID, session: SessionDep) -> 
         ]
     ),
 )
-def ti_heartbeat(
+async def ti_heartbeat(
     task_instance_id: UUID,
     ti_payload: TIHeartbeatInfo,
-    session: SessionDep,
+    session: AsyncSessionDep,
 ):
     """Update the heartbeat of a TaskInstance to mark it as alive & still running."""
     bind_contextvars(ti_id=str(task_instance_id))
@@ -946,7 +944,7 @@ def ti_heartbeat(
     # so we can update last_heartbeat_at directly without first taking a row lock.
     fast_path_result = cast(
         "CursorResult[Any]",
-        session.execute(
+        await session.execute(
             update(TI)
             .where(
                 TI.id == task_instance_id,
@@ -967,7 +965,7 @@ def ti_heartbeat(
     old = select(TI.state, TI.hostname, TI.pid).where(TI.id == task_instance_id).with_for_update()
 
     try:
-        (previous_state, hostname, pid) = session.execute(old).one()
+        (previous_state, hostname, pid) = (await session.execute(old)).one()
         log.debug(
             "Retrieved current task state", state=previous_state, current_hostname=hostname, current_pid=pid
         )
@@ -975,7 +973,10 @@ def ti_heartbeat(
         # Check if the TI exists in the Task Instance History table.
         # If it does, it was likely cleared while running, so return 410 Gone
         # instead of 404 Not Found to give the client a more specific signal.
-        _raise_ti_not_in_live_table(task_instance_id, session)
+        archived_in_history = bool(
+            await session.scalar(select(exists().where(TIH.task_instance_id == task_instance_id)))
+        )
+        _raise_ti_not_in_live_table(task_instance_id, archived_in_history=archived_in_history)
 
     if hostname != ti_payload.hostname or pid != ti_payload.pid:
         log.warning(
@@ -1007,7 +1008,9 @@ def ti_heartbeat(
         )
 
     # Update the last heartbeat time!
-    session.execute(update(TI).where(TI.id == task_instance_id).values(last_heartbeat_at=timezone.utcnow()))
+    await session.execute(
+        update(TI).where(TI.id == task_instance_id).values(last_heartbeat_at=timezone.utcnow())
+    )
     log.debug("Heartbeat updated", state=previous_state)
 
 
@@ -1045,7 +1048,10 @@ def ti_put_rtif(
     task_instance = session.scalar(select(TI).where(TI.id == task_instance_id))
     if not task_instance:
         # On retry/clear, the server regenerates the TI id. Return 410 for the stale id.
-        _raise_ti_not_in_live_table(task_instance_id, session)
+        archived_in_history = bool(
+            session.scalar(select(exists().where(TIH.task_instance_id == task_instance_id)))
+        )
+        _raise_ti_not_in_live_table(task_instance_id, archived_in_history=archived_in_history)
     task_instance.update_rtif(put_rtif_payload, session=session)
     log.debug("RenderedTaskInstanceFields updated successfully")
 

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -717,9 +717,12 @@ database:
     sql_alchemy_connect_args_async:
       description: |
         Import path for connect args in SQLAlchemy. Defaults to an empty dict.
-        This is similar to ``sql_alchemy_connect_args``, but only for async connections.
+        This is similar to ``sql_alchemy_connect_args``, but only for async connections and must be a dict.
 
-        This configuration is only applied to async engines, such as asyncpg.
+        This is applied to the async engine only. The default async Postgres driver (psycopg3) needs
+        no extra args. If you opt in to the ``asyncpg`` driver behind transaction-mode pgbouncer, set
+        ``statement_cache_size`` and ``prepared_statement_cache_size`` to ``0`` here to avoid "prepared
+        statement does not exist" errors. See the async driver section of the Postgres setup guide.
       version_added: 3.1.0
       type: string
       example: 'airflow_local_settings.connect_args_async'

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -240,8 +240,28 @@ def load_policy_plugins(pm: pluggy.PluginManager):
     pm.load_setuptools_entrypoints("airflow.policy")
 
 
+def _translate_asyncpg_sslmode(async_uri: str) -> str:
+    """
+    Rename the libpq ``sslmode`` query param to asyncpg's ``ssl`` equivalent.
+
+    asyncpg has no ``sslmode`` connect arg -- SQLAlchemy's asyncpg dialect passes URL
+    query params straight to ``asyncpg.connect()``, which spells the option ``ssl`` and
+    accepts the same libpq mode strings (``disable``/``prefer``/``require``/``verify-ca``/
+    ``verify-full``). A sync Postgres URI commonly carries ``sslmode`` (the official Helm
+    chart sets it unconditionally), so the derived async URI must translate it; otherwise
+    every async DB call raises ``TypeError: connect() got an unexpected keyword argument
+    'sslmode'``.
+    """
+    url = make_url(async_uri)
+    if "sslmode" not in url.query:
+        return async_uri
+    query = dict(url.query)
+    query["ssl"] = query.pop("sslmode")
+    return url.set(query=query).render_as_string(hide_password=False)
+
+
 def _get_async_conn_uri_from_sync(sync_uri):
-    # Mapping of backend to async driver:
+    # Derive the async URI scheme from the sync one by swapping in the async driver:
     AIO_LIBS_MAPPING = {
         "sqlite": "aiosqlite",
         "postgresql": "psycopg_async" if _USE_PSYCOPG3 else "asyncpg",
@@ -251,9 +271,15 @@ def _get_async_conn_uri_from_sync(sync_uri):
     scheme, rest = sync_uri.split(":", maxsplit=1)
     scheme = scheme.split("+", maxsplit=1)[0]
     aiolib = AIO_LIBS_MAPPING.get(scheme)
-    if aiolib:
-        return f"{scheme}+{aiolib}:{rest}"
-    return sync_uri
+    if not aiolib:
+        return sync_uri
+    async_uri = f"{scheme}+{aiolib}:{rest}"
+    if aiolib == "asyncpg":
+        # asyncpg-only: it is not libpq-based and has no ``sslmode`` connect arg. A
+        # libpq-based async driver (e.g. psycopg3) understands ``sslmode`` natively and
+        # would in turn reject ``ssl``, so this translation must stay gated on asyncpg.
+        async_uri = _translate_asyncpg_sslmode(async_uri)
+    return async_uri
 
 
 def configure_vars():

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -34,6 +34,7 @@ from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from airflow._shared.observability.traces import OverrideableRandomIdGenerator
@@ -2586,6 +2587,19 @@ class TestTIHealthEndpoint:
     def teardown_method(self):
         clear_db_runs()
 
+    # ti_heartbeat runs on the async engine. The async engine binds its pool to
+    # the event loop that created it (once per process), but the test harness
+    # builds a fresh FastAPI app and event loop per test, so a pooled connection
+    # from a prior test's closed loop gets reused and fails ("attached to a
+    # different loop"). Re-configuring the async session before each test rebuilds
+    # the engine on the current loop. Same workaround as TestWaitDagRun in
+    # tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py.
+    @pytest.fixture(autouse=True)
+    def reconfigure_async_db_engine(self):
+        from airflow.settings import _configure_async_session
+
+        _configure_async_session()
+
     @pytest.mark.parametrize(
         ("hostname", "pid", "expected_status_code", "expected_detail"),
         [
@@ -2844,10 +2858,10 @@ class TestTIHealthEndpoint:
         new_time = time_now.add(minutes=10)
         time_machine.move_to(new_time, tick=False)
 
-        original_execute = Session.execute
+        original_execute = AsyncSession.execute
         fast_path_intercepted = False
 
-        def execute_with_fast_path_miss(session_obj, statement, *args, **kwargs):
+        async def execute_with_fast_path_miss(session_obj, statement, *args, **kwargs):
             nonlocal fast_path_intercepted
             if (
                 not fast_path_intercepted
@@ -2856,9 +2870,9 @@ class TestTIHealthEndpoint:
             ):
                 fast_path_intercepted = True
                 return mock.MagicMock(rowcount=0)
-            return original_execute(session_obj, statement, *args, **kwargs)
+            return await original_execute(session_obj, statement, *args, **kwargs)
 
-        monkeypatch.setattr(Session, "execute", execute_with_fast_path_miss)
+        monkeypatch.setattr(AsyncSession, "execute", execute_with_fast_path_miss)
 
         response = client.put(
             f"/execution/task-instances/{ti.id}/heartbeat",
@@ -2890,10 +2904,10 @@ class TestTIHealthEndpoint:
         new_time = time_now.add(minutes=10)
         time_machine.move_to(new_time, tick=False)
 
-        original_execute = Session.execute
+        original_execute = AsyncSession.execute
         fast_path_intercepted = False
 
-        def execute_with_unknown_fast_path_rowcount(session_obj, statement, *args, **kwargs):
+        async def execute_with_unknown_fast_path_rowcount(session_obj, statement, *args, **kwargs):
             nonlocal fast_path_intercepted
             if (
                 not fast_path_intercepted
@@ -2902,9 +2916,9 @@ class TestTIHealthEndpoint:
             ):
                 fast_path_intercepted = True
                 return mock.MagicMock(rowcount=-1)
-            return original_execute(session_obj, statement, *args, **kwargs)
+            return await original_execute(session_obj, statement, *args, **kwargs)
 
-        monkeypatch.setattr(Session, "execute", execute_with_unknown_fast_path_rowcount)
+        monkeypatch.setattr(AsyncSession, "execute", execute_with_unknown_fast_path_rowcount)
 
         response = client.put(
             f"/execution/task-instances/{ti.id}/heartbeat",
@@ -2915,6 +2929,47 @@ class TestTIHealthEndpoint:
         assert fast_path_intercepted
         session.refresh(ti)
         assert ti.last_heartbeat_at == new_time
+
+    def test_ti_heartbeat_commit_failure_surfaces_error(
+        self, client, session, create_task_instance, monkeypatch
+    ):
+        """A commit failure must reach the worker as an error, never a silent 204.
+
+        ``AsyncSessionDep`` is function-scoped, so the yield-dependency commit runs
+        *before* the response is sent -- mirroring the sync ``SessionDep``. Were it
+        request-scoped (the FastAPI default for ``yield`` dependencies), the 204 would
+        be sent before the commit, so a commit failure (e.g. an asyncpg /
+        transaction-mode PgBouncer drop) would roll back *after* the worker already
+        saw success. Regression guard for the parity goal of this route conversion.
+        """
+        ti = create_task_instance(
+            task_id="test_ti_heartbeat_commit_failure",
+            state=State.RUNNING,
+            hostname="random-hostname",
+            pid=1789,
+            session=session,
+        )
+        session.commit()
+
+        async def failing_commit(self):
+            raise SQLAlchemyError("simulated commit failure (connection dropped)")
+
+        monkeypatch.setattr(AsyncSession, "commit", failing_commit)
+        # The default TestClient re-raises server exceptions, and it does so for *both*
+        # dependency scopes; the worker-visible status (500 vs a silent 204) is what
+        # tells them apart, so observe the response the worker would actually receive.
+        monkeypatch.setattr(client._transport, "raise_server_exceptions", False)
+
+        response = client.put(
+            f"/execution/task-instances/{ti.id}/heartbeat",
+            json={"hostname": "random-hostname", "pid": 1789},
+        )
+
+        # Function scope -> commit fails before the response -> 500. Request scope -> 204.
+        assert response.status_code == 500
+        # The transaction rolled back, so the heartbeat was not persisted.
+        session.refresh(ti)
+        assert ti.last_heartbeat_at is None
 
 
 class TestTIPutRTIF:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -35,6 +35,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from pydantic import ValidationError
 from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from airflow._shared.observability.traces import OverrideableRandomIdGenerator
@@ -2836,6 +2837,19 @@ class TestTIHealthEndpoint:
     def teardown_method(self):
         clear_db_runs()
 
+    # ti_heartbeat runs on the async engine. The async engine binds its pool to
+    # the event loop that created it (once per process), but the test harness
+    # builds a fresh FastAPI app and event loop per test, so a pooled connection
+    # from a prior test's closed loop gets reused and fails ("attached to a
+    # different loop"). Re-configuring the async session before each test rebuilds
+    # the engine on the current loop. Same workaround as TestWaitDagRun in
+    # tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py.
+    @pytest.fixture(autouse=True)
+    def reconfigure_async_db_engine(self):
+        from airflow.settings import _configure_async_session
+
+        _configure_async_session()
+
     @pytest.mark.parametrize(
         ("hostname", "pid", "expected_status_code", "expected_detail"),
         [
@@ -3094,10 +3108,10 @@ class TestTIHealthEndpoint:
         new_time = time_now.add(minutes=10)
         time_machine.move_to(new_time, tick=False)
 
-        original_execute = Session.execute
+        original_execute = AsyncSession.execute
         fast_path_intercepted = False
 
-        def execute_with_fast_path_miss(session_obj, statement, *args, **kwargs):
+        async def execute_with_fast_path_miss(session_obj, statement, *args, **kwargs):
             nonlocal fast_path_intercepted
             if (
                 not fast_path_intercepted
@@ -3106,9 +3120,9 @@ class TestTIHealthEndpoint:
             ):
                 fast_path_intercepted = True
                 return mock.MagicMock(rowcount=0)
-            return original_execute(session_obj, statement, *args, **kwargs)
+            return await original_execute(session_obj, statement, *args, **kwargs)
 
-        monkeypatch.setattr(Session, "execute", execute_with_fast_path_miss)
+        monkeypatch.setattr(AsyncSession, "execute", execute_with_fast_path_miss)
 
         response = client.put(
             f"/execution/task-instances/{ti.id}/heartbeat",
@@ -3140,10 +3154,10 @@ class TestTIHealthEndpoint:
         new_time = time_now.add(minutes=10)
         time_machine.move_to(new_time, tick=False)
 
-        original_execute = Session.execute
+        original_execute = AsyncSession.execute
         fast_path_intercepted = False
 
-        def execute_with_unknown_fast_path_rowcount(session_obj, statement, *args, **kwargs):
+        async def execute_with_unknown_fast_path_rowcount(session_obj, statement, *args, **kwargs):
             nonlocal fast_path_intercepted
             if (
                 not fast_path_intercepted
@@ -3152,9 +3166,9 @@ class TestTIHealthEndpoint:
             ):
                 fast_path_intercepted = True
                 return mock.MagicMock(rowcount=-1)
-            return original_execute(session_obj, statement, *args, **kwargs)
+            return await original_execute(session_obj, statement, *args, **kwargs)
 
-        monkeypatch.setattr(Session, "execute", execute_with_unknown_fast_path_rowcount)
+        monkeypatch.setattr(AsyncSession, "execute", execute_with_unknown_fast_path_rowcount)
 
         response = client.put(
             f"/execution/task-instances/{ti.id}/heartbeat",
@@ -3165,6 +3179,47 @@ class TestTIHealthEndpoint:
         assert fast_path_intercepted
         session.refresh(ti)
         assert ti.last_heartbeat_at == new_time
+
+    def test_ti_heartbeat_commit_failure_surfaces_error(
+        self, client, session, create_task_instance, monkeypatch
+    ):
+        """A commit failure must reach the worker as an error, never a silent 204.
+
+        ``AsyncSessionDep`` is function-scoped, so the yield-dependency commit runs
+        *before* the response is sent -- mirroring the sync ``SessionDep``. Were it
+        request-scoped (the FastAPI default for ``yield`` dependencies), the 204 would
+        be sent before the commit, so a commit failure (e.g. an asyncpg /
+        transaction-mode PgBouncer drop) would roll back *after* the worker already
+        saw success. Regression guard for the parity goal of this route conversion.
+        """
+        ti = create_task_instance(
+            task_id="test_ti_heartbeat_commit_failure",
+            state=State.RUNNING,
+            hostname="random-hostname",
+            pid=1789,
+            session=session,
+        )
+        session.commit()
+
+        async def failing_commit(self):
+            raise SQLAlchemyError("simulated commit failure (connection dropped)")
+
+        monkeypatch.setattr(AsyncSession, "commit", failing_commit)
+        # The default TestClient re-raises server exceptions, and it does so for *both*
+        # dependency scopes; the worker-visible status (500 vs a silent 204) is what
+        # tells them apart, so observe the response the worker would actually receive.
+        monkeypatch.setattr(client._transport, "raise_server_exceptions", False)
+
+        response = client.put(
+            f"/execution/task-instances/{ti.id}/heartbeat",
+            json={"hostname": "random-hostname", "pid": 1789},
+        )
+
+        # Function scope -> commit fails before the response -> 500. Request scope -> 204.
+        assert response.status_code == 500
+        # The transaction rolled back, so the heartbeat was not persisted.
+        session.refresh(ti)
+        assert ti.last_heartbeat_at is None
 
 
 class TestTIPutRTIF:

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -25,7 +25,7 @@ from unittest import mock
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.pool import NullPool
 
@@ -398,6 +398,61 @@ class TestMetadataEngineHooks:
             engine = settings.create_metadata_engine("sqlite://", engine_args={}, connect_args={})
             assert airflow_local_settings._engine_created
             assert engine is not None
+
+
+@pytest.mark.parametrize(
+    ("sync_uri", "expected_drivername", "expected_query"),
+    [
+        # libpq's ``sslmode`` is not an asyncpg connect arg -- it must be translated to
+        # asyncpg's ``ssl`` (which accepts the same mode strings). Without this the
+        # derived async URI raises "connect() got an unexpected keyword argument 'sslmode'"
+        # on every async DB call. The official Helm chart sets sslmode=disable by default.
+        (
+            "postgresql://airflow:pw@postgres:5432/airflow?sslmode=disable",
+            "postgresql+asyncpg",
+            {"ssl": "disable"},
+        ),
+        (
+            "postgresql://airflow:pw@postgres/airflow?sslmode=verify-full",
+            "postgresql+asyncpg",
+            {"ssl": "verify-full"},
+        ),
+        # An explicit sync driver in the scheme is dropped before swapping to asyncpg.
+        (
+            "postgresql+psycopg2://u:p@h/db?sslmode=require",
+            "postgresql+asyncpg",
+            {"ssl": "require"},
+        ),
+        # No sslmode -> the query is left untouched.
+        ("postgresql://u:p@h/db", "postgresql+asyncpg", {}),
+    ],
+)
+def test_get_async_conn_uri_translates_pg_sslmode(sync_uri, expected_drivername, expected_query):
+    from airflow import settings
+    from airflow.settings import _get_async_conn_uri_from_sync
+
+    with patch.object(settings, "_USE_PSYCOPG3", False):
+        url = make_url(_get_async_conn_uri_from_sync(sync_uri))
+    assert url.drivername == expected_drivername
+    assert "sslmode" not in url.query
+    assert dict(url.query) == expected_query
+
+
+@pytest.mark.parametrize(
+    "sync_uri",
+    [
+        # Non-postgres backends use a different driver and SSL params; the sslmode
+        # translation must not touch their query strings.
+        "mysql://u:p@h/db?charset=utf8mb4",
+        "sqlite:////tmp/airflow.db",
+    ],
+)
+def test_get_async_conn_uri_leaves_non_postgres_query_untouched(sync_uri):
+    from airflow.settings import _get_async_conn_uri_from_sync
+
+    src_query = dict(make_url(sync_uri).query)
+    out_query = dict(make_url(_get_async_conn_uri_from_sync(sync_uri)).query)
+    assert out_query == src_query
 
 
 _local_db_path_error = pytest.raises(AirflowConfigException, match=r"Cannot use relative path:")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Depends on: 
- #68496

Related:
- #36504 
- #67799 
- #68902 

## What & why

Converts the Execution API `ti_heartbeat` route from the synchronous `SessionDep` to the async `AsyncSessionDep`, adopting the async metadata engine that already ships in Airflow 3.x (`create_async_engine`, `async_sessionmaker`, `AsyncSessionDep`, `create_session_async`).

Heartbeat is the highest-QPS write path in the system (one call per running task per heartbeat interval, per worker), so it is a meaningful first production route to run on the async engine. The goal of this PR is **behavioral parity with zero regression** — not a throughput change. It follows the same low-blast-radius conversion pattern already merged for `GET /execution/variables/keys`.

## What changed

- **Route** (`execution_api/routes/task_instances.py`): `ti_heartbeat` is now `async def` and takes `AsyncSessionDep`; the fast-path `UPDATE`, the slow-path `SELECT … FOR UPDATE` (`.one()`), the Task-Instance-History existence count, and the final `UPDATE` are awaited. On the slow-path miss the route awaits its own TI-History count query and then delegates the 410/404 decision to the shared `_raise_ti_not_in_live_table` helper (see next bullet). No explicit `commit()` is added — the async dependency commits on success and rolls back (releasing the `FOR UPDATE` row lock) on exception, mirroring the sync dependency exactly. `synchronize_session=False` and `with_for_update()` are unchanged.
- **Shared helper** (`_raise_ti_not_in_live_table`): #68902 (merged into `main` after this branch was opened) refactored the inline 404/410 logic out of both `ti_heartbeat` and `ti_put_rtif` into this helper, which ran its own **synchronous** `session.scalar(...)`. That is incompatible with the async heartbeat session — a `scalar(...)` on an `AsyncSession` returns a coroutine, and `if <coroutine>:` is always truthy, so calling it unchanged would return `410` on every miss. The helper is therefore made session-agnostic: it no longer touches the DB and takes a keyword-only `archived_in_history: bool`, raising `410` / `404` from that flag. Each caller runs its own count query in its own style — the async route `await`s it, the sync `ti_put_rtif` route does not — so the log/message/response logic stays centralized in one place.
- **rtif route** (`ti_put_rtif`): updated to run the TI-History count query itself and pass the result as `archived_in_history=` to the helper. This is the one change outside the heartbeat route; it is a mechanical adaptation to the new helper signature, forced by rebasing onto #68902, and does not alter the rtif contract.
- **Tests** (`versions/head/test_task_instances.py`):
  - The two tests that intercept the fast-path `UPDATE` now patch `sqlalchemy.ext.asyncio.AsyncSession` with an async interceptor (the route now `await`s `AsyncSession.execute`); assertions are unchanged.
  - Added a `reconfigure_async_db_engine` autouse fixture to `TestTIHealthEndpoint`. The async engine binds its connection pool to the event loop that created it, while the test harness builds a fresh app and event loop per test; without this, a pooled connection from a prior test's closed loop is reused and fails (`attached to a different loop`). This is the same workaround already used by `TestWaitDagRun`.
- **Docs / config**: #67801 (merged) added a dedicated "Async SQLAlchemy engine and the async driver" section to the Postgres setup guide that already documents psycopg3 as the PgBouncer-safe default and the asyncpg opt-in `connect_args` recipe. This PR therefore no longer adds a duplicate PgBouncer block to the setup guide (that block was dropped in the rebase); it keeps only a concise note on the `sql_alchemy_connect_args_async` config reference in `config.yml`, framed around the asyncpg opt-in and pointing operators at that section.
- **Newsfragment** (improvement): notes that the heartbeat endpoint now uses the async engine and that the API server may hold both the sync and async connection pools concurrently, so operators should budget DB `max_connections` for both.

## Behavioral parity

No change to the endpoint contract: same `204` success, same `404` / `409` (running-elsewhere / not-running) / `410` (cleared-and-archived) responses with identical detail payloads, same request signature. No Execution API version bump. The 404/410 branch now routes through the shared helper introduced by #68902 rather than an inline block, but the emitted responses are identical; the heartbeat and rtif tests (including the `410` cases) pass and are the parity proof.

## Testing

Heartbeat + rtif suite passes on SQLite (aiosqlite) after the rebase onto #68902, including both `410` paths (`test_ti_heartbeat_cleared_task_returns_410`, `test_ti_put_rtif_archived_ti_returns_410`)

## Operational notes

- **Default driver is PgBouncer-safe.** #67801 switched the default async Postgres driver to psycopg3, which is safe under transaction-mode PgBouncer with no extra configuration. For the common deployment nothing is required from operators.
- **asyncpg opt-in.** asyncpg remains supported as a high-throughput opt-in (`sql_alchemy_conn_async = postgresql+asyncpg://…`). It uses named server-side prepared statements, which break under transaction-mode PgBouncer, so it needs `sql_alchemy_connect_args_async = {"statement_cache_size": 0, "prepared_statement_cache_size": 0}`. This PR documents that recipe.

## Note to reviewers

- This branch was rebased onto #68902 (stale-id `410` for the rtif API), which introduced the shared `_raise_ti_not_in_live_table` helper. Resolving that rebase is why this heartbeat PR also touches `ti_put_rtif` and the helper's signature — see the "Shared helper" / "rtif route" bullets above. No rtif behavior changes.
- A cosmetic `Event loop is closed` message is logged during session teardown when the async engine is disposed (`dispose_orm` closing the async engine synchronously). It appears on all three async drivers, is pre-existing engine disposal behavior unrelated to this change, and every run exits `0`. Tidying async-engine disposal is out of scope for this PR.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
