### PR TITLE
[chart/v1-2x-test] Chart: Fix Airflow 3 task log access with NetworkPolicies (#65754)

### DIFF
--- a/chart/templates/scheduler/scheduler-networkpolicy.yaml
+++ b/chart/templates/scheduler/scheduler-networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: airflow
-          component: webserver
+          component: api-server
           release: {{ .Release.Name }}
     ports:
     - protocol: TCP

--- a/chart/templates/triggerer/triggerer-networkpolicy.yaml
+++ b/chart/templates/triggerer/triggerer-networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
         matchLabels:
           tier: airflow
           release: {{ .Release.Name }}
-          component: webserver
+          component: api-server
     ports:
     - protocol: TCP
       port: {{ .Values.ports.triggererLogs }}

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -64,7 +64,7 @@ spec:
         matchLabels:
           tier: airflow
           release: {{ .Release.Name }}
-          component: webserver
+          component: api-server
     ports:
     - protocol: TCP
       port: {{ .Values.ports.workerLogs }}

--- a/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
@@ -1065,6 +1065,20 @@ class TestSchedulerNetworkPolicy:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    def test_should_allow_api_server_to_read_scheduler_logs(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "networkPolicies": {"enabled": True},
+            },
+            show_only=["templates/scheduler/scheduler-networkpolicy.yaml"],
+        )
+
+        assert (
+            jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
+            == "api-server"
+        )
+
 
 class TestSchedulerLogGroomer(LogGroomerTestBase):
     """Scheduler log groomer."""

--- a/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
@@ -788,6 +788,23 @@ class TestTriggererServiceAccount:
         assert jmespath.search("automountServiceAccountToken", docs[0]) is False
 
 
+class TestTriggererNetworkPolicy:
+    """Tests triggerer network policy."""
+
+    def test_should_allow_api_server_to_read_triggerer_logs(self):
+        docs = render_chart(
+            values={
+                "networkPolicies": {"enabled": True},
+            },
+            show_only=["templates/triggerer/triggerer-networkpolicy.yaml"],
+        )
+
+        assert (
+            jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
+            == "api-server"
+        )
+
+
 class TestTriggererLogGroomer(LogGroomerTestBase):
     """Triggerer log groomer."""
 

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2802,6 +2802,21 @@ class TestWorkerNetworkPolicy:
         assert labels["test_label"] == "test_label_value"
         assert "key" not in labels
 
+    @pytest.mark.parametrize("executor", ["CeleryExecutor", "CeleryExecutor,KubernetesExecutor"])
+    def test_should_allow_api_server_to_read_worker_logs(self, executor):
+        docs = render_chart(
+            values={
+                "networkPolicies": {"enabled": True},
+                "executor": executor,
+            },
+            show_only=["templates/workers/worker-networkpolicy.yaml"],
+        )
+
+        assert (
+            jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
+            == "api-server"
+        )
+
 
 class TestWorkerService:
     """Tests worker service."""


### PR DESCRIPTION
Backport of #65754 to the 1.x Helm chart line (chart/v1-2x-test).

On Airflow 3, task logs are served by the `api-server` component, but the
1.x chart's NetworkPolicy ingress rules for the scheduler, triggerer, and
worker still allow log traffic only from the legacy `webserver` component.
With `networkPolicies.enabled=true`, this blocks the API server from
reading task logs. This retargets the three log-ingress selectors to
`component: api-server` and adds rendering tests for each.

Cherry-picked from 8b2ce0016b (the two scheduler/triggerer template hunks
were adapted by hand: the 1.x base used `component: webserver` where main
used `scheduler`/`triggerer`, all corrected to `api-server`).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)