### PR TITLE
Helm Chart: Prepare release notes for 1.22.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: airflow
-version: 1.21.0
+version: 1.22.0
 appVersion: 3.2.2
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
@@ -44,7 +44,7 @@ type: application
 annotations:
   artifacthub.io/links: |
     - name: Documentation
-      url: https://airflow.apache.org/docs/helm-chart/1.21.0/
+      url: https://airflow.apache.org/docs/helm-chart/1.22.0/
   artifacthub.io/screenshots: |
     - title: Home Page
       url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/home_dark.png
@@ -64,111 +64,115 @@ annotations:
       url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_code.png
   artifacthub.io/changes: |
     - description: >
-        Workers config options have been moved under workers.celery.* and workers.kubernetes.*:
-        safeToEvict, hostAliases, priorityClassName, runtimeClassName, schedulerName,
-        serviceAccount, extraContainers, extraInitContainers, extraVolumes, affinity,
-        tolerations, topologySpreadConstraints, podAnnotations, labels, env, extraVolumeMounts
-        are moved to both; extraPorts, volumeClaimTemplates, waitForMigrations, hpa,
-        annotations, logGroomerSidecar are Celery-specific and moved under workers.celery.*
+        Minimum Helm version was updated to 3.19.0
       kind: changed
       links:
-      - name: '#61915'
-        url: https://github.com/apache/airflow/pull/61915
-      - name: '#61919'
-        url: https://github.com/apache/airflow/pull/61919
-      - name: '#61960'
-        url: https://github.com/apache/airflow/pull/61960
-      - name: '#61961'
-        url: https://github.com/apache/airflow/pull/61961
-      - name: '#61962'
-        url: https://github.com/apache/airflow/pull/61962
-      - name: '#62030'
-        url: https://github.com/apache/airflow/pull/62030
-      - name: '#62048'
-        url: https://github.com/apache/airflow/pull/62048
-      - name: '#62054'
-        url: https://github.com/apache/airflow/pull/62054
-      - name: '#64730'
-        url: https://github.com/apache/airflow/pull/64730
-      - name: '#64734'
-        url: https://github.com/apache/airflow/pull/64734
-      - name: '#64739'
-        url: https://github.com/apache/airflow/pull/64739
-      - name: '#64741'
-        url: https://github.com/apache/airflow/pull/64741
-      - name: '#64746'
-        url: https://github.com/apache/airflow/pull/64746
-      - name: '#64860'
-        url: https://github.com/apache/airflow/pull/64860
-      - name: '#64976'
-        url: https://github.com/apache/airflow/pull/64976
-      - name: '#64980'
-        url: https://github.com/apache/airflow/pull/64980
-      - name: '#64982'
-        url: https://github.com/apache/airflow/pull/64982
-      - name: '#65027'
-        url: https://github.com/apache/airflow/pull/65027
-      - name: '#65030'
-        url: https://github.com/apache/airflow/pull/65030
-      - name: '#65033'
-        url: https://github.com/apache/airflow/pull/65033
-      - name: '#65056'
-        url: https://github.com/apache/airflow/pull/65056
-      - name: '#65059'
-        url: https://github.com/apache/airflow/pull/65059
-    - description: Default Airflow image updated to 3.2.2
-      kind: changed
-      links:
-      - name: '#64841'
-        url: https://github.com/apache/airflow/pull/64841
-    - description: Fix wrong broker URL secret ref
-      kind: fixed
-      links:
-      - name: '#65006'
-        url: https://github.com/apache/airflow/pull/65006
-    - description: Add ttlSecondsAfterFinished to database cleanup job
-      kind: added
-      links:
-      - name: '#64164'
-        url: https://github.com/apache/airflow/pull/64164
+      - name: '#66970'
+        url: https://github.com/apache/airflow/pull/66970
     - description: >
-        Support tpl rendering in ServiceAccount annotations, metadataConnection, and config ConfigMap names
-      kind: added
-      links:
-      - name: '#64763'
-        url: https://github.com/apache/airflow/pull/64763
-    - description: Generate JWT Secret of recommended length
+        Default Airflow image is updated to 3.2.2 (previously 3.2.1)
       kind: changed
       links:
-      - name: '#65082'
-        url: https://github.com/apache/airflow/pull/65082
-    - description: Fix Helm chart image volume schema validation
+      - name: '#67681'
+        url: https://github.com/apache/airflow/pull/67681
+    - description: Add optional OTel service to the Airflow Helm Chart
+      kind: added
+      links:
+      - name: '#64902'
+        url: https://github.com/apache/airflow/pull/64902
+    - description: Add ``serviceAccountTokenVolume`` to cleanup cron
+      kind: added
+      links:
+      - name: '#67446'
+        url: https://github.com/apache/airflow/pull/67446
+    - description: Add ``requirePersistence`` option to worker ``logGroomerSidecar``
+      kind: added
+      links:
+      - name: '#65884'
+        url: https://github.com/apache/airflow/pull/65884
+    - description: Add checksum for api-server config in API server deployment
+      kind: changed
+      links:
+      - name: '#66468'
+        url: https://github.com/apache/airflow/pull/66468
+    - description: Fix Helm chart executor label to support executor aliases
       kind: fixed
       links:
-      - name: '#65409'
-        url: https://github.com/apache/airflow/pull/65409
-    - description: Remove duplicate fallback branch in airflowPodSecurityContextsIds helper
+      - name: '#67762'
+        url: https://github.com/apache/airflow/pull/67762
+    - description: Fix triggerer KEDA database connection rendering
       kind: fixed
       links:
-      - name: '#65558'
-        url: https://github.com/apache/airflow/pull/65558
-    - description: Render cleanup RBAC only for KubernetesExecutor
+      - name: '#67538'
+        url: https://github.com/apache/airflow/pull/67538
+    - description: Fix Celery worker liveness probe hostname lookup
       kind: fixed
       links:
-      - name: '#65539'
-        url: https://github.com/apache/airflow/pull/65539
-    - description: Fix default args/command for database cleanup
+      - name: '#67471'
+        url: https://github.com/apache/airflow/pull/67471
+    - description: Fix Go template error comparing slice to nil using ``eq``
       kind: fixed
       links:
-      - name: '#63821'
-        url: https://github.com/apache/airflow/pull/63821
-    - description: Fix invalid deprecation warning in NOTES.txt
+      - name: '#64032'
+        url: https://github.com/apache/airflow/pull/64032
+    - description: Fix Kubernetes worker service account values
       kind: fixed
       links:
-      - name: '#64296'
-        url: https://github.com/apache/airflow/pull/64296
-    - description: Add missing fields in schema file
+      - name: '#66598'
+        url: https://github.com/apache/airflow/pull/66598
+    - description: Add binding for ``workers.kubernetes`` and condition workers ServiceAccount
       kind: fixed
       links:
-      - name: '#64339'
-        url: https://github.com/apache/airflow/pull/64339
+      - name: '#66730'
+        url: https://github.com/apache/airflow/pull/66730
+    - description: Fix launcher RBAC for executor class paths
+      kind: fixed
+      links:
+      - name: '#66208'
+        url: https://github.com/apache/airflow/pull/66208
+    - description: Fix Airflow 3 task log access with NetworkPolicies
+      kind: fixed
+      links:
+      - name: '#65754'
+        url: https://github.com/apache/airflow/pull/65754
+    - description: Add missing ``tpl`` rendering for ServiceAccount annotations
+      kind: fixed
+      links:
+      - name: '#66095'
+        url: https://github.com/apache/airflow/pull/66095
+    - description: Fix go-template ``if`` statements for log groomer retention values
+      kind: fixed
+      links:
+      - name: '#66012'
+        url: https://github.com/apache/airflow/pull/66012
+    - description: Fix database cleanup lifecycle hooks
+      kind: fixed
+      links:
+      - name: '#65881'
+        url: https://github.com/apache/airflow/pull/65881
+    - description: Fix cleanup pod lifecycle hooks not being applied
+      kind: fixed
+      links:
+      - name: '#65764'
+        url: https://github.com/apache/airflow/pull/65764
+    - description: Fix deprecation warning
+      kind: fixed
+      links:
+      - name: '#66238'
+        url: https://github.com/apache/airflow/pull/66238
+    - description: 'Docs: Expand Helm Chart upgrade tasks in the Airflow 3 migration guide'
+      kind: changed
+      links:
+      - name: '#66118'
+        url: https://github.com/apache/airflow/pull/66118
+    - description: 'Misc: Change job/pod role bindings rendering and refactor related
+        tests'
+      kind: changed
+      links:
+      - name: '#66626'
+        url: https://github.com/apache/airflow/pull/66626
+    - description: 'Misc: Standardize on ``Dag`` capitalization in chart wording'
+      kind: changed
+      links:
+      - name: '#66114'
+        url: https://github.com/apache/airflow/pull/66114

--- a/chart/RELEASE_NOTES.rst
+++ b/chart/RELEASE_NOTES.rst
@@ -23,6 +23,60 @@ Run ``helm repo update`` before upgrading the chart to the latest version.
 
 .. towncrier release notes start
 
+Airflow Helm Chart 1.22.0 (2026-06-01)
+--------------------------------------
+
+Significant Changes
+^^^^^^^^^^^^^^^^^^^
+
+Minimum Helm version was updated to ``3.19.0`` (#66970)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Default Airflow image is updated to ``3.2.2`` (#67681)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The default Airflow image that is used with the Chart is now ``3.2.2``, previously it was ``3.2.1``.
+
+New Features
+^^^^^^^^^^^^
+
+- Add optional OTel service to the Airflow Helm Chart (#64902)
+- Add ``serviceAccountTokenVolume`` to cleanup cron (#67446)
+- Add ``requirePersistence`` option to worker ``logGroomerSidecar`` (#65884)
+
+Improvements
+^^^^^^^^^^^^
+
+- Add checksum for api-server config in API server deployment (#66468)
+
+Bug Fixes
+^^^^^^^^^
+
+- Fix Helm chart executor label to support executor aliases (#67762)
+- Fix triggerer KEDA database connection rendering (#67538)
+- Fix Celery worker liveness probe hostname lookup (#67471)
+- Fix Go template error comparing slice to nil using ``eq`` (#64032)
+- Fix Kubernetes worker service account values (#66598)
+- Add binding for ``workers.kubernetes`` and condition workers ServiceAccount (#66730)
+- Fix launcher RBAC for executor class paths (#66208)
+- Fix Airflow 3 task log access with NetworkPolicies (#65754)
+- Add missing ``tpl`` rendering for ServiceAccount annotations (#66095)
+- Fix go-template ``if`` statements for log groomer retention values (#66012)
+- Fix database cleanup lifecycle hooks (#65881)
+- Fix cleanup pod lifecycle hooks not being applied (#65764)
+- Fix deprecation warning (#66238)
+
+Doc only changes
+^^^^^^^^^^^^^^^^
+
+- Expand Helm Chart upgrade tasks in the Airflow 3 migration guide (#66118)
+
+Misc
+^^^^
+
+- Change job/pod role bindings rendering and refactor related tests (#66626)
+- Standardize on ``Dag`` capitalization in chart wording (#66114)
+
+
 Airflow Helm Chart 1.21.0 (2026-04-21)
 --------------------------------------
 

--- a/chart/newsfragments/66970.significant.rst
+++ b/chart/newsfragments/66970.significant.rst
@@ -1,1 +1,0 @@
-Minimum Helm version was updated to ``3.19.0``

--- a/chart/newsfragments/67681.significant.rst
+++ b/chart/newsfragments/67681.significant.rst
@@ -1,3 +1,0 @@
-Default Airflow image is updated to ``3.2.2``
-
-The default Airflow image that is used with the Chart is now ``3.2.2``, previously it was ``3.2.1``.

--- a/chart/reproducible_build.yaml
+++ b/chart/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: d05c9f69d0a418b377ccd2a4328c4bb8
-source-date-epoch: 1776802957
+release-notes-hash: 555560f2b9c7368541573c873bcc915c
+source-date-epoch: 1780245150


### PR DESCRIPTION
Prepares the release notes and metadata for Apache Airflow Helm Chart 1.22.0.

- Adds the 1.22.0 section to `chart/RELEASE_NOTES.rst` (2 significant
  changes, 3 features, 2 improvements, 12 bug fixes, 1 doc, 2 misc),
  categorized from the chart-relevant commits since `helm-chart/1.21.0`.
- Bumps `chart/Chart.yaml` to `version: 1.22.0` (appVersion stays 3.2.2),
  updates the docs URL, and rebuilds the `artifacthub.io/changes`
  annotations.
- Consumes the two `significant` newsfragments and refreshes
  `chart/reproducible_build.yaml`.

Note: once the #65754 backport (#67805) merges, the notes will be
regenerated to add it under Bug Fixes.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)