### PR TITLE
Helm Chart: Document configurable enableServiceLinks in 1.22.0 notes

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -75,6 +75,12 @@ annotations:
       links:
       - name: '#67681'
         url: https://github.com/apache/airflow/pull/67681
+    - description: >
+        Added support for configuring enableServiceLinks (default will become false in Chart 2.0)
+      kind: added
+      links:
+      - name: '#67447'
+        url: https://github.com/apache/airflow/pull/67447
     - description: Add optional OTel service to the Airflow Helm Chart
       kind: added
       links:

--- a/chart/RELEASE_NOTES.rst
+++ b/chart/RELEASE_NOTES.rst
@@ -36,6 +36,11 @@ Default Airflow image is updated to ``3.2.2`` (#67681)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
 The default Airflow image that is used with the Chart is now ``3.2.2``, previously it was ``3.2.1``.
 
+Added support for configuring ``enableServiceLinks`` (#67447)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+The default will become ``false`` in Chart 2.0. If you rely on these environment variables,
+explicitly set ``enableServiceLinks: true``, or migrate your code to use DNS-based service lookups.
+
 New Features
 ^^^^^^^^^^^^
 

--- a/chart/newsfragments/67447.significant.rst
+++ b/chart/newsfragments/67447.significant.rst
@@ -1,3 +1,0 @@
-Added support for configuring ``enableServiceLinks``.
-
-Warning: The default will become ``false`` in ``Chart 2.0``. If you rely on these environment variables, explicitly set ``enableServiceLinks: true``, or migrate your code to use dns based service lookups.

--- a/chart/reproducible_build.yaml
+++ b/chart/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 555560f2b9c7368541573c873bcc915c
-source-date-epoch: 1780245150
+release-notes-hash: 7bed879b8afc6dfee95609243b1003a2
+source-date-epoch: 1780250367


### PR DESCRIPTION
The `enableServiceLinks` feature (#67447) was backported to the 1.x chart
line (via #67802) after the initial 1.22.0 release notes were prepared in
#67806, leaving its `significant` newsfragment unconsumed and the feature
undocumented for the release.

This adds it to the 1.22.0 Significant Changes section (including the
deprecation note that the default becomes `false` in Chart 2.0), adds the
matching `artifacthub.io/changes` annotation, and consumes the newsfragment.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)