### PR TITLE
Fix flaky test_send_thread_safety in Task SDK comms tests

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -32,6 +32,7 @@ from airflow.sdk.execution_time.comms import (
     MaskSecret,
     StartupDetails,
     VariableResult,
+    _RequestFrame,
     _ResponseFrame,
 )
 
@@ -165,10 +166,8 @@ class TestCommsDecoder:
         num_threads = 5
         results = [None] * num_threads
         errors = [None] * num_threads
-        request_sent = [threading.Event() for _ in range(num_threads)]
 
         def send_and_store(idx):
-            request_sent[idx].set()  # Signal that this thread is about to send
             try:
                 msg = VariableResult(key=f"key{idx}", value=f"value{idx}", type="VariableResult")
                 results[idx] = decoder.send(msg)
@@ -179,12 +178,25 @@ class TestCommsDecoder:
         for t in threads:
             t.start()
 
-        # For each thread, wait until it signals it's ready, then send the response
-        for idx in range(num_threads):
-            request_sent[idx].wait()
-            resp = {"type": "VariableResult", "key": f"key{idx}", "value": f"value{idx}"}
-            frame = _ResponseFrame(idx, resp, None)
-            data = msgspec.msgpack.encode(frame)
+        def _recv_exactly(sock, n):
+            buffer = bytearray()
+            while len(buffer) < n:
+                chunk = sock.recv(n - len(buffer))
+                if not chunk:
+                    raise EOFError("socket closed before a full frame was received")
+                buffer.extend(chunk)
+            return bytes(buffer)
+
+        # The order in which the concurrent ``send`` calls reach the socket is not
+        # deterministic, so the parent must not assume requests arrive in thread-index
+        # order. Read each request as it arrives and echo a response built from that
+        # request's own body, so every thread reliably gets the response to its own
+        # message regardless of thread scheduling.
+        for _ in range(num_threads):
+            length = int.from_bytes(_recv_exactly(w, 4), byteorder="big")
+            request = msgspec.msgpack.decode(_recv_exactly(w, length), type=_RequestFrame)
+            resp = {"type": "VariableResult", "key": request.body["key"], "value": request.body["value"]}
+            data = msgspec.msgpack.encode(_ResponseFrame(request.id, resp, None))
             w.sendall(len(data).to_bytes(4, byteorder="big") + data)
 
         for t in threads:


### PR DESCRIPTION
test_send_thread_safety assumed concurrent `send()` calls would be answered
in thread-index order. But `send()` serializes the write+read under a lock and
correlates responses FIFO, so the lock-acquisition order (and thus the order
requests arrive) is non-deterministic — the test only passed when threads
happened to take the lock in start order, and flaked under scheduling jitter
(seen on the Tests (ARM) scheduled run).

The parent side now reads each request off the socket and echoes a response
for that exact request, so every thread reliably receives the response to its
own message regardless of scheduling. The production code is unchanged — this
is a test-only fix.

Verified by running the test 40x with no failures.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)