### PR TITLE
Chart: Select NetworkPolicy log-access component by Airflow version

### DIFF
--- a/chart/templates/scheduler/scheduler-networkpolicy.yaml
+++ b/chart/templates/scheduler/scheduler-networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: airflow
-          component: api-server
+          component: {{ if semverCompare ">=3.0.0" .Values.airflowVersion }}api-server{{ else }}webserver{{ end }}
           release: {{ .Release.Name }}
     ports:
     - protocol: TCP

--- a/chart/templates/triggerer/triggerer-networkpolicy.yaml
+++ b/chart/templates/triggerer/triggerer-networkpolicy.yaml
@@ -48,7 +48,7 @@ spec:
         matchLabels:
           tier: airflow
           release: {{ .Release.Name }}
-          component: api-server
+          component: {{ if semverCompare ">=3.0.0" .Values.airflowVersion }}api-server{{ else }}webserver{{ end }}
     ports:
     - protocol: TCP
       port: {{ .Values.ports.triggererLogs }}

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -64,7 +64,7 @@ spec:
         matchLabels:
           tier: airflow
           release: {{ .Release.Name }}
-          component: api-server
+          component: {{ if semverCompare ">=3.0.0" .Values.airflowVersion }}api-server{{ else }}webserver{{ end }}
     ports:
     - protocol: TCP
       port: {{ .Values.ports.workerLogs }}

--- a/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_scheduler.py
@@ -1065,9 +1065,14 @@ class TestSchedulerNetworkPolicy:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
-    def test_should_allow_api_server_to_read_scheduler_logs(self):
+    @pytest.mark.parametrize(
+        ("airflow_version", "expected_component"),
+        [("3.0.0", "api-server"), ("2.11.0", "webserver")],
+    )
+    def test_should_allow_log_server_to_read_scheduler_logs(self, airflow_version, expected_component):
         docs = render_chart(
             values={
+                "airflowVersion": airflow_version,
                 "executor": "LocalExecutor",
                 "networkPolicies": {"enabled": True},
             },
@@ -1076,7 +1081,7 @@ class TestSchedulerNetworkPolicy:
 
         assert (
             jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
-            == "api-server"
+            == expected_component
         )
 
 

--- a/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_triggerer.py
@@ -791,9 +791,14 @@ class TestTriggererServiceAccount:
 class TestTriggererNetworkPolicy:
     """Tests triggerer network policy."""
 
-    def test_should_allow_api_server_to_read_triggerer_logs(self):
+    @pytest.mark.parametrize(
+        ("airflow_version", "expected_component"),
+        [("3.0.0", "api-server"), ("2.11.0", "webserver")],
+    )
+    def test_should_allow_log_server_to_read_triggerer_logs(self, airflow_version, expected_component):
         docs = render_chart(
             values={
+                "airflowVersion": airflow_version,
                 "networkPolicies": {"enabled": True},
             },
             show_only=["templates/triggerer/triggerer-networkpolicy.yaml"],
@@ -801,7 +806,7 @@ class TestTriggererNetworkPolicy:
 
         assert (
             jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
-            == "api-server"
+            == expected_component
         )
 
 

--- a/helm-tests/tests/helm_tests/airflow_core/test_worker.py
+++ b/helm-tests/tests/helm_tests/airflow_core/test_worker.py
@@ -2803,9 +2803,14 @@ class TestWorkerNetworkPolicy:
         assert "key" not in labels
 
     @pytest.mark.parametrize("executor", ["CeleryExecutor", "CeleryExecutor,KubernetesExecutor"])
-    def test_should_allow_api_server_to_read_worker_logs(self, executor):
+    @pytest.mark.parametrize(
+        ("airflow_version", "expected_component"),
+        [("3.0.0", "api-server"), ("2.11.0", "webserver")],
+    )
+    def test_should_allow_log_server_to_read_worker_logs(self, executor, airflow_version, expected_component):
         docs = render_chart(
             values={
+                "airflowVersion": airflow_version,
                 "networkPolicies": {"enabled": True},
                 "executor": executor,
             },
@@ -2814,7 +2819,7 @@ class TestWorkerNetworkPolicy:
 
         assert (
             jmespath.search("spec.ingress[0].from[0].podSelector.matchLabels.component", docs[0])
-            == "api-server"
+            == expected_component
         )
 
 


### PR DESCRIPTION
Follow-up to #67805 (backport of #65754), addressing review feedback: the
1.2x chart line supports **both Airflow 2.11 and Airflow 3**, so the
NetworkPolicy log-ingress selector must depend on the Airflow version rather
than being replaced outright.

In Airflow 2.11 task logs are served by the **webserver**; in Airflow 3 they
are served by the **api-server**. #65754 unconditionally changed the
scheduler / triggerer / worker NetworkPolicy log-ingress `from` selectors to
`component: api-server`, which would break task log access on Airflow 2.11
deployments (where no `api-server` component exists).

This selects the component based on `.Values.airflowVersion`:

```
component: {{ if semverCompare ">=3.0.0" .Values.airflowVersion }}api-server{{ else }}webserver{{ end }}
```

— mirroring how the chart already chooses between the `webserver` and
`api-server` components elsewhere (deployments, services, network policies).
The render tests for all three components now cover both Airflow 2.11
(`webserver`) and Airflow 3 (`api-server`).

This targets `chart/v1-2x-test` and should land before the 1.22.0rc1 cut so
the regression never ships.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)