### PR TITLE
Helm Chart: Clarify 1.22.0 NetworkPolicy log-access changelog entry

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -136,7 +136,7 @@ annotations:
       links:
       - name: '#66208'
         url: https://github.com/apache/airflow/pull/66208
-    - description: Fix Airflow 3 task log access with NetworkPolicies
+    - description: Fix task log access with NetworkPolicies for Airflow 2 and 3
       kind: fixed
       links:
       - name: '#65754'

--- a/chart/RELEASE_NOTES.rst
+++ b/chart/RELEASE_NOTES.rst
@@ -63,7 +63,7 @@ Bug Fixes
 - Fix Kubernetes worker service account values (#66598)
 - Add binding for ``workers.kubernetes`` and condition workers ServiceAccount (#66730)
 - Fix launcher RBAC for executor class paths (#66208)
-- Fix Airflow 3 task log access with NetworkPolicies (#65754)
+- Fix task log access with NetworkPolicies for Airflow 2 and 3 (#65754)
 - Add missing ``tpl`` rendering for ServiceAccount annotations (#66095)
 - Fix go-template ``if`` statements for log groomer retention values (#66012)
 - Fix database cleanup lifecycle hooks (#65881)

--- a/chart/reproducible_build.yaml
+++ b/chart/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 7bed879b8afc6dfee95609243b1003a2
-source-date-epoch: 1780250367
+release-notes-hash: a21d0c33c2d19bde4049935e864c82de
+source-date-epoch: 1780262760


### PR DESCRIPTION
Follow-up to #67817. The NetworkPolicy log-access fix (#65754) is now
version-aware and works for **both Airflow 2.11 and 3**, so the 1.22.0
changelog entry should not say "Airflow 3" only.

Rewords the `chart/RELEASE_NOTES.rst` entry (and the matching
`artifacthub.io/changes` annotation in `Chart.yaml`) from
"Fix Airflow 3 task log access with NetworkPolicies" to
"Fix task log access with NetworkPolicies for Airflow 2 and 3", and refreshes
the reproducible-build epoch. Documentation-only; no chart behavior change.

Should land before the 1.22.0rc1 cut.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)