### PR TITLE
Emit task.queued_duration metric on QUEUED -> RUNNING in Task SDK path

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 from structlog.contextvars import bind_contextvars
 
+from airflow._shared.observability.metrics import stats
 from airflow._shared.observability.traces import override_ids
 from airflow._shared.state import TaskScope
 from airflow._shared.timezones import timezone
@@ -154,6 +155,9 @@ def ti_run(
             TI.hostname,
             TI.unixname,
             TI.pid,
+            TI.queue,
+            TI.queued_dttm,
+            TI.end_date,
             # This selects the raw JSON value, bypassing the deserialization -- we want that to happen on the
             # client
             column("next_kwargs", JSON),
@@ -233,6 +237,17 @@ def ti_run(
                 extra=json.dumps({"host_name": ti_run_payload.hostname}) if ti_run_payload.hostname else None,
             )
         )
+        # Emit task.queued_duration on the first QUEUED -> RUNNING transition. In Airflow 2 the
+        # worker emitted this from TaskInstance._check_and_change_state_before_execution; in
+        # Airflow 3 the worker reaches RUNNING through this endpoint, so emit here instead.
+        # Skip on retries (end_date already set from a previous attempt) to keep the legacy
+        # "only on first try" semantics from TaskInstance.emit_state_change_metric.
+        if ti.end_date is None and ti.queued_dttm is not None:
+            stats.timing(
+                "task.queued_duration",
+                timezone.utcnow() - ti.queued_dttm,
+                tags={"task_id": ti.task_id, "dag_id": ti.dag_id, "queue": ti.queue},
+            )
     # Ensure there is no end date set and clear retry policy overrides from the previous attempt.
     query = query.values(
         end_date=None,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -289,6 +289,90 @@ class TestTIRunState:
         )
         assert response.status_code == 409
 
+    def test_ti_run_emits_queued_duration_metric(self, client, session, create_task_instance, time_machine):
+        """
+        On the first QUEUED -> RUNNING transition the run endpoint should emit
+        ``task.queued_duration`` (regression test for #66067 — the metric stopped
+        being emitted in Airflow 3 after the worker-side path was replaced by the
+        Execution API call).
+        """
+        run_instant = timezone.parse("2024-09-30T12:00:30Z")
+        queued_instant = timezone.parse("2024-09-30T12:00:00Z")
+        time_machine.move_to(run_instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_queued_duration_metric",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=run_instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = queued_instant
+        ti.end_date = None
+        session.commit()
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_instant.to_iso8601_string(),
+                },
+            )
+
+        assert response.status_code == 200
+        mock_stats.timing.assert_any_call(
+            "task.queued_duration",
+            run_instant - queued_instant,
+            tags={"task_id": ti.task_id, "dag_id": ti.dag_id, "queue": ti.queue},
+        )
+
+    def test_ti_run_skips_queued_duration_metric_on_retry(
+        self, client, session, create_task_instance, time_machine
+    ):
+        """
+        A retry transition (previous attempt left ``end_date`` populated before
+        the update zeros it) should not emit ``task.queued_duration`` — preserves
+        the legacy "only on first try" semantics from
+        ``TaskInstance.emit_state_change_metric``.
+        """
+        run_instant = timezone.parse("2024-09-30T12:05:00Z")
+        time_machine.move_to(run_instant, tick=False)
+
+        ti = create_task_instance(
+            task_id="test_ti_run_queued_duration_retry",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            start_date=run_instant,
+            dag_id=str(uuid4()),
+        )
+        ti.queued_dttm = run_instant.subtract(seconds=30)
+        ti.end_date = run_instant.subtract(seconds=60)
+        session.commit()
+
+        with mock.patch("airflow.api_fastapi.execution_api.routes.task_instances.stats") as mock_stats:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "random-hostname",
+                    "unixname": "random-unixname",
+                    "pid": 100,
+                    "start_date": run_instant.to_iso8601_string(),
+                },
+            )
+
+        assert response.status_code == 200
+        timing_calls = [
+            c for c in mock_stats.timing.call_args_list if c.args and c.args[0] == "task.queued_duration"
+        ]
+        assert timing_calls == []
+
     def test_ti_run_returns_execution_token(
         self, client, exec_app, session, create_task_instance, time_machine
     ):


### PR DESCRIPTION
closes: #66067
Supersedes #67190 (original fork was deleted; reopening was not possible, so re-pushed from a fresh fork)

`task.queued_duration` (legacy: `dag.<dag_id>.<task_id>.queued_duration`) stopped being emitted in Airflow 3 regardless of executor (LocalExecutor, CeleryExecutor, KubernetesExecutor). The companion metric `task.scheduled_duration` still emits.

In Airflow 2 the worker emitted `task.queued_duration` from `TaskInstance._check_and_change_state_before_execution` (`airflow-core/src/airflow/models/taskinstance.py:1366`) on the QUEUED → RUNNING transition. In Airflow 3 the worker no longer touches the DB directly — it reaches RUNNING through the Execution API endpoint `PATCH /execution/task-instances/{id}/run` (`airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py`), which never called `TaskInstance.emit_state_change_metric`. The companion metric kept working because the scheduler still emits `task.scheduled_duration` directly from `scheduler_job_runner.py:990` when it queues the TI — that path was not affected by the worker/API split.

Emit `task.queued_duration` inline from the run endpoint on the first QUEUED → RUNNING transition. The legacy `TaskInstance.emit_state_change_metric` is not reused here because the handler operates on a partial-column `Row` (not a TI ORM instance) and the update later resets `end_date` to `None`, which would defeat the method's "only on first try" guard for retries. Mirroring the guard inline (`end_date is None and queued_dttm is not None`) preserves the legacy semantics — including not emitting on retries — and uses the same tag set (`task_id`, `dag_id`, `queue`).

Two regression tests in `airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py`:
- `test_ti_run_emits_queued_duration_metric` — first transition emits with the expected metric name, timing (`now - queued_dttm`), and tags.
- `test_ti_run_skips_queued_duration_metric_on_retry` — a retry (previous attempt's `end_date` populated) does not emit, matching legacy behavior.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-06-18T21:56:15Z head=60f5321 action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @guhyunwoo** · by `@potiuk` · 2026-06-18 21:56 UTC
>
> Closing to keep the review queue clean — this draft was triaged ~9 days ago and there's been no update since:
> - No worries and nothing lost — **reopen it or open a fresh PR** whenever you're ready to pick it back up.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->