### PR TITLE
Respect Dag-specific read access in graph structure endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
@@ -26,7 +26,7 @@ from airflow.api_fastapi.common.parameters import QueryIncludeDownstream, QueryI
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.structure import StructureDataResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import ReadableDagsFilterDep, requires_access_dag
+from airflow.api_fastapi.core_api.security import GetUserDep, ReadableDagsFilterDep, requires_access_dag
 from airflow.api_fastapi.core_api.services.ui.structure import (
     bind_output_assets_to_tasks,
     get_upstream_assets,
@@ -40,6 +40,18 @@ from airflow.utils.dag_edges import dag_edges
 structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
 
 
+def check_structure_data_access(
+    request: Request,
+    user: GetUserDep,
+    external_dependencies: bool = False,
+) -> None:
+    """Check permissions for the structure endpoint."""
+    requires_access_dag("GET")(request, user)
+
+    if external_dependencies:
+        requires_access_dag("GET", DagAccessEntity.DEPENDENCIES)(request, user)
+
+
 @structure_router.get(
     "/structure_data",
     responses=create_openapi_http_exception_doc(
@@ -48,11 +60,7 @@ structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
             status.HTTP_404_NOT_FOUND,
         ]
     ),
-    dependencies=[
-        Depends(requires_access_dag("GET")),
-        Depends(requires_access_dag("GET", DagAccessEntity.DEPENDENCIES)),
-        Depends(requires_access_dag("GET", DagAccessEntity.TASK_INSTANCE)),
-    ],
+    dependencies=[Depends(check_structure_data_access)],
 )
 def structure_data(
     session: SessionDep,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -26,6 +26,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from airflow._shared.timezones import timezone
+from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.models.asset import AssetAliasModel, AssetEvent, AssetModel
 from airflow.models.dagbag import DBDagBag
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -249,6 +251,23 @@ def asset3_id(make_dags, asset3, session) -> str:
 
 
 class TestStructureDataEndpoint:
+    @staticmethod
+    def _restrict_dag_access(
+        allowed_dag_ids: set[str],
+        allowed_entities: set[DagAccessEntity] | None = None,
+    ):
+        allowed_entities = allowed_entities or set()
+
+        def restricted_is_authorized_dag(self, *, method, user, access_entity=None, details=None):
+            return (
+                method == "GET"
+                and details is not None
+                and details.id in allowed_dag_ids
+                and (access_entity is None or access_entity in allowed_entities)
+            )
+
+        return mock.patch.object(SimpleAuthManager, "is_authorized_dag", restricted_is_authorized_dag)
+
     @pytest.mark.parametrize(
         ("params", "expected", "expected_queries_count"),
         [
@@ -707,6 +726,42 @@ class TestStructureDataEndpoint:
     def test_delete_dag_should_response_403(self, unauthorized_test_client):
         response = unauthorized_test_client.get("/structure/structure_data", params={"dag_id": DAG_ID})
         assert response.status_code == 403
+
+    @pytest.mark.usefixtures("make_dags")
+    def test_should_allow_structure_data_with_dag_specific_read(self, test_client):
+        with self._restrict_dag_access({DAG_ID}):
+            response = test_client.get("/structure/structure_data", params={"dag_id": DAG_ID})
+
+        assert response.status_code == 200
+
+    @pytest.mark.usefixtures("make_dags")
+    def test_should_deny_structure_data_for_unreadable_dag(self, test_client):
+        with self._restrict_dag_access({DAG_ID}):
+            response = test_client.get(
+                "/structure/structure_data", params={"dag_id": DAG_ID_EXTERNAL_TRIGGER}
+            )
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("make_dags")
+    def test_external_dependencies_requires_dependency_access(self, test_client):
+        with self._restrict_dag_access({DAG_ID}):
+            response = test_client.get(
+                "/structure/structure_data",
+                params={"dag_id": DAG_ID, "external_dependencies": True},
+            )
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("make_dags")
+    def test_external_dependencies_allows_dag_specific_read_with_dependency_access(self, test_client):
+        with self._restrict_dag_access({DAG_ID}, {DagAccessEntity.DEPENDENCIES}):
+            response = test_client.get(
+                "/structure/structure_data",
+                params={"dag_id": DAG_ID, "external_dependencies": True},
+            )
+
+        assert response.status_code == 200
 
     @mock.patch(
         "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",


### PR DESCRIPTION
The graph/structure payload endpoint now authorizes against the requested Dag with normal Dag read access. This fixes the #62532 task group detail failure because that UI path loads `/ui/structure/structure_data?dag_id=...`; users with read access to only `Dag:<dag_id>` can fetch the structure payload for that Dag without requiring global Dag read access.

Access to unreadable Dags remains denied. External dependency data is still gated separately and only requests dependency access when `external_dependencies=true`.

closes: #62532

Tests:
- `SKIP_BREEZE_SELF_UPGRADE_CHECK=true breeze run --answer n --skip-image-upgrade-check pytest airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py::TestStructureDataEndpoint::test_should_allow_structure_data_with_dag_specific_read airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py::TestStructureDataEndpoint::test_should_deny_structure_data_for_unreadable_dag airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py::TestStructureDataEndpoint::test_external_dependencies_requires_dependency_access airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py::TestStructureDataEndpoint::test_external_dependencies_allows_dag_specific_read_with_dependency_access -xvs --with-db-init` - 4 passed, 1 warning

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
