### PR TITLE
Fix flaky SSH test_command_timeout_fail on loaded CI runners

### DIFF
--- a/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
+++ b/providers/ssh/tests/unit/ssh/hooks/test_ssh.py
@@ -791,10 +791,15 @@ class TestSSHHook:
             assert ret == (0, b"airflow\n", b"")
 
     def test_command_timeout_fail(self):
+        # cmd_timeout is forwarded to paramiko's exec_command, which uses it both to open the
+        # channel and to read the command output. It must therefore be large enough to reliably
+        # open the channel (otherwise a loaded runner raises "Timeout opening channel." instead of
+        # the AirflowException we expect) while staying smaller than the command runtime so the
+        # read loop times out. A sub-millisecond timeout makes channel opening flaky.
         hook = SSHHook(
             ssh_conn_id="ssh_default",
             conn_timeout=30,
-            cmd_timeout=0.001,
+            cmd_timeout=0.5,
             banner_timeout=100,
         )
 
@@ -802,7 +807,7 @@ class TestSSHHook:
             with pytest.raises(AirflowException):
                 hook.exec_ssh_client_command(
                     client,
-                    "sleep 1",
+                    "sleep 5",
                     False,
                     None,
                 )


### PR DESCRIPTION
`test_command_timeout_fail` set `cmd_timeout=0.001`, which the SSH hook forwards into paramiko's `exec_command`. paramiko applies that value to **opening the channel** as well as reading command output, so on a loaded CI runner opening the channel exceeds 1 ms and raises `SSHException("Timeout opening channel.")` *before* the hook's command-timeout logic runs — instead of the expected `AirflowException`. This flaked in the scheduled [Tests (AMD) run 26732900291](https://github.com/apache/airflow/actions/runs/26732900291/attempts/1) (Low dep tests: providers) and passed on rerun.

Fix: use a `cmd_timeout` large enough to reliably open the channel (`0.5s`) and a longer command (`sleep 5`) so the read loop is what times out, keeping the test on its intended `AirflowException` path.

No newsfragment: providers do not consume them, and this is a test-only change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)