### PR TITLE
Harden S3 sync target paths

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/exceptions.py
@@ -50,3 +50,7 @@ class EcsOperatorError(Exception):
 
 class S3HookUriParseFailure(AirflowException):
     """When parse_s3_url fails to parse URL, this error is thrown."""
+
+
+class S3HookPathTraversalError(AirflowException):
+    """Raise when an S3 object key resolves outside the target local directory."""

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -58,7 +58,7 @@ from boto3.s3.transfer import S3Transfer, TransferConfig
 from botocore.exceptions import ClientError
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
-from airflow.providers.amazon.aws.exceptions import S3HookUriParseFailure
+from airflow.providers.amazon.aws.exceptions import S3HookPathTraversalError, S3HookUriParseFailure
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.utils.tags import format_tags
 from airflow.providers.common.compat.lineage.hook import get_hook_lineage_collector
@@ -1815,7 +1815,7 @@ class S3Hook(AwsBaseHook):
             try:
                 local_target_path.resolve().relative_to(local_dir_resolved)
             except ValueError:
-                raise AirflowException(
+                raise S3HookPathTraversalError(
                     f"S3 object key {obj.key!r} resolves outside local directory {local_dir}"
                 ) from None
             if not local_target_path.parent.exists():

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1804,6 +1804,7 @@ class S3Hook(AwsBaseHook):
         """Download S3 files from the S3 bucket to the local directory."""
         self.log.debug("Downloading data from s3://%s/%s to %s", bucket_name, s3_prefix, local_dir)
 
+        local_dir_resolved = local_dir.resolve()
         local_s3_objects = []
         s3_bucket = self.get_bucket(bucket_name)
         for obj in s3_bucket.objects.filter(Prefix=s3_prefix):
@@ -1811,6 +1812,12 @@ class S3Hook(AwsBaseHook):
                 continue
             obj_path = Path(obj.key)
             local_target_path = local_dir.joinpath(obj_path.relative_to(s3_prefix))
+            try:
+                local_target_path.resolve().relative_to(local_dir_resolved)
+            except ValueError:
+                raise AirflowException(
+                    f"S3 object key {obj.key!r} resolves outside local directory {local_dir}"
+                ) from None
             if not local_target_path.parent.exists():
                 local_target_path.parent.mkdir(parents=True, exist_ok=True)
                 self.log.debug("Created local directory: %s", local_target_path.parent)

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -1976,6 +1976,17 @@ class TestAwsS3Hook:
         assert "local file last modified" in logs_string
         assert "Downloaded dag_04.py to" in logs_string
 
+    def test_sync_to_local_dir_rejects_key_path_traversal(self, s3_bucket, s3_client, tmp_path):
+        s3_client.put_object(Bucket=s3_bucket, Key="dags/../../outside.py", Body=b"test data")
+
+        sync_local_dir = tmp_path / "s3_sync_dir"
+        hook = S3Hook()
+
+        with pytest.raises(AirflowException, match="resolves outside local directory"):
+            hook.sync_to_local_dir(bucket_name=s3_bucket, local_dir=sync_local_dir, s3_prefix="dags/")
+
+        assert not (tmp_path / "outside.py").exists()
+
 
 @pytest.mark.parametrize(
     ("key_kind", "has_conn", "has_bucket", "precedence", "expected"),

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -35,7 +35,7 @@ from moto import mock_aws
 
 from airflow.models import Connection
 from airflow.providers.amazon.aws.assets.s3 import Asset
-from airflow.providers.amazon.aws.exceptions import S3HookUriParseFailure
+from airflow.providers.amazon.aws.exceptions import S3HookPathTraversalError, S3HookUriParseFailure
 from airflow.providers.amazon.aws.hooks.s3 import (
     NO_ACL,
     S3Hook,
@@ -1982,7 +1982,7 @@ class TestAwsS3Hook:
         sync_local_dir = tmp_path / "s3_sync_dir"
         hook = S3Hook()
 
-        with pytest.raises(AirflowException, match="resolves outside local directory"):
+        with pytest.raises(S3HookPathTraversalError, match="resolves outside local directory"):
             hook.sync_to_local_dir(bucket_name=s3_bucket, local_dir=sync_local_dir, s3_prefix="dags/")
 
         assert not (tmp_path / "outside.py").exists()


### PR DESCRIPTION
S3Hook.sync_to_local_dir() derives local target paths from object keys after removing the configured prefix. Current upstream already contains the analogous GCS guard; this PR applies the same containment check to S3 sync targets.

The change resolves each candidate S3 download target and rejects keys that would land outside the requested local directory before creating parent directories or downloading content.

Regression coverage adds a traversal-shaped S3 object key under the requested prefix.

Validation performed locally:
- python -m py_compile providers\amazon\src\airflow\providers\amazon\aws\hooks\s3.py providers\amazon\tests\unit\amazon\aws\hooks\test_s3.py
- python -m ruff check providers\amazon\src\airflow\providers\amazon\aws\hooks\s3.py providers\amazon\tests\unit\amazon\aws\hooks\test_s3.py
- git diff --check -- providers\amazon\src\airflow\providers\amazon\aws\hooks\s3.py providers\amazon\tests\unit\amazon\aws\hooks\test_s3.py

The focused pytest command could not run in this local checkout because the Airflow pytest plugin dependency time_machine is not installed in the current environment.

Gen-AI disclosure:
- This PR was prepared with assistance from OpenAI Codex.
- I reviewed the generated code and tests for relevance, correctness, and scope before submitting.
- I ran the checks listed above locally, and I take responsibility for the final submitted changes.

<!-- pr-triage-fold: triaged=2026-06-12T11:23:19Z head=2c4e1f0 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @dfgvaetyj3456356-hash** · by `@potiuk` · 2026-06-12 11:23 UTC
>
> Some review feedback from `@shahar1` is waiting on you:
> - You've pushed new commits since `@shahar1` requested changes, but the review hasn't been followed up.
>
> **The ball is in your court** — you've been assigned to this PR. Address the outstanding comments (reply or push a fix), then ping the reviewer for a re-review.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->