### PR TITLE
Log check_query_output response via format string in Snowflake SQL API hook

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -324,7 +324,7 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             _, response_json = self._make_api_call_with_retries(
                 method="GET", url=url, headers=header, params=params
             )
-            self.log.info(response_json)
+            self.log.info("Snowflake SQL API result for query %s: %s", query_id, response_json)
 
     def _process_response(self, status_code, resp):
         self.log.info("Snowflake SQL GET statements status API response: %s", resp)

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -472,7 +472,9 @@ class TestSnowflakeSqlApiHook:
         hook = SnowflakeSqlApiHook("mock_conn_id")
         with mock.patch.object(hook.log, "info") as mock_log_info:
             hook.check_query_output(query_ids)
-        mock_log_info.assert_called_with(GET_RESPONSE)
+        mock_log_info.assert_called_with(
+            "Snowflake SQL API result for query %s: %s", query_ids[-1], GET_RESPONSE
+        )
 
     @pytest.mark.parametrize("query_ids", [["uuid", "uuid1"]])
     @mock.patch(f"{HOOK_PATH}.get_request_url_header_params")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Error:`SnowflakeSqlApiHook.check_query_output` logs the raw response dict, which violates `StructuredLogMessage.event`'s str type.

This prevents logs from being displayed in the UI after a deferred `SnowflakeSqlApiOperator` finishes executing:

```shell
1 validation error for StructuredLogMessage
event
  Input should be a valid string [type=string_type, input_value={'resultSetMetaData': {'n...eatedOn': 1780320202371}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type
```

Fix: Log the query response JSON in a templated string, matching the pattern used by other methods in the file.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=d2d64c2 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @michaelneely** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Failing test jobs**: `provider distributions tests / Compat 2.11.1:P3.10:`, `provider distributions tests / Compat 3.0.6:P3.10:`, `provider distributions tests / Compat 3.1.8:P3.10:`, `provider distributions tests / Compat 3.2.2:P3.10:`. Reproduce and fix locally, then push.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->