### PR TITLE
Fix scheduler crashloop from `KubernetesExecutor` completed-pod adoption

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -722,7 +722,13 @@ class KubernetesExecutor(BaseExecutor):
 
             timeout = conf.getint("scheduler", "scheduler_health_check_threshold")
             cutoff = timezone.utcnow() - timedelta(seconds=timeout)
-            with create_session() as session:
+            # Must be an *independent* (non-scoped) session. try_adopt_task_instances runs
+            # inside the scheduler's own transaction (adopt_or_reset_orphaned_tasks); a scoped
+            # session here would resolve to that same thread-local session, and the context
+            # manager's commit()/close() on exit would commit the scheduler's in-flight work
+            # early (releasing its FOR UPDATE SKIP LOCKED row locks) and detach the orphaned
+            # TaskInstances it still holds, crashing the reset path (#67813).
+            with create_session(scoped=False) as session:
                 # Iterate the scalar cursor straight into the set so we never
                 # materialize an intermediate list — keeps the memory
                 # footprint flat regardless of how many sibling schedulers

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -27,8 +27,10 @@ import pytest
 import yaml
 from kubernetes.client import models as k8s
 from kubernetes.client.rest import ApiException
+from sqlalchemy import inspect
 from urllib3 import HTTPResponse
 
+from airflow.jobs.job import Job
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.providers.cncf.kubernetes import pod_generator
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
@@ -1503,6 +1505,35 @@ class TestKubernetesExecutor:
             field_selector="status.phase=Succeeded",
             label_selector="kubernetes_executor=True,airflow-worker!=modified,airflow_executor_done!=True",
             header_params={"Accept": "application/json;as=PartialObjectMetadataList;v=v1;g=meta.k8s.io"},
+        )
+
+    @pytest.mark.db_test
+    def test_alive_other_scheduler_job_ids_does_not_detach_caller_session(self, session):
+        """``_alive_other_scheduler_job_ids`` must use an independent (non-scoped) session.
+
+        Regression test for #67813. ``try_adopt_task_instances`` runs inside the scheduler's
+        own scoped transaction (``adopt_or_reset_orphaned_tasks``). If this helper opens a
+        *scoped* ``create_session()``, the context manager's ``commit()``/``close()`` on exit
+        tears down that shared transaction: it commits the scheduler's in-flight work early
+        (releasing its ``FOR UPDATE SKIP LOCKED`` row locks) and detaches the orphaned
+        TaskInstances it still holds, crashing the reset path with ``DetachedInstanceError``.
+        """
+        # An object attached to the caller's scoped session, standing in for the orphaned
+        # TaskInstances the scheduler holds while adopting.
+        job = Job()
+        session.add(job)
+        session.flush()
+        assert inspect(job).session is not None
+
+        executor = self.kubernetes_executor
+        executor.scheduler_job_id = "5"
+
+        executor._alive_other_scheduler_job_ids()
+
+        # A scoped create_session() inside the helper would have closed this session and
+        # detached ``job``; an independent session leaves the caller's session untouched.
+        assert inspect(job).session is not None, (
+            "_alive_other_scheduler_job_ids closed/detached the caller's scoped session"
         )
 
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")


### PR DESCRIPTION
## Summary

Follow-up to #67822. Fixes the root cause of #67813: a scheduler `DetachedInstanceError` crashloop on startup when the `KubernetesExecutor` is in use.

## Root cause

`SchedulerJobRunner.adopt_or_reset_orphaned_tasks` selects orphaned TaskInstances under `FOR UPDATE SKIP LOCKED` (`with_row_locks(..., skip_locked=True)`) and, in the same open transaction, hands them to `executor.try_adopt_task_instances`. For the `KubernetesExecutor` that path reaches `_alive_other_scheduler_job_ids`, which opened a **scoped** `create_session()`.

Executors run in the scheduler thread, so a scoped session resolves to the scheduler's own in-flight session (`settings.Session` is a thread-local `scoped_session`). The `create_session` context manager runs `commit()` then `close()` on exit, so on return it:

- commits the scheduler's transaction early, releasing the `FOR UPDATE SKIP LOCKED` row locks, and
- closes the session, detaching the orphaned TaskInstances the scheduler still holds.

The reset loop then touches those detached instances (`repr(ti)`, then `prepare_db_for_next_try` -> `TaskInstanceHistory.record_ti`, then the `state = None` writes) and raises `DetachedInstanceError`. The triggering rows persist, so every restart re-crashes (CrashLoopBackOff); with HA, all schedulers die.

#67822 hardened the `repr()` read, but the crash recurs one statement later in `record_ti` (it reads `try_number` and copies every column off the same detached instance via `getattr`), and the premature commit / lock release was not addressed. This PR fixes the cause.

## How the regression got here

`_adopt_completed_pods` is reachable from two call sites, added years apart:

- #35579 (`cncf-kubernetes` 7.10.0, Nov 2023) added the call from inside `try_adopt_task_instances`, the locked adoption path.
- #61839 (`cncf-kubernetes` 10.15.0, Mar 2026) added a second, periodic call from `KubernetesExecutor.sync()`, which has no caller transaction.

Through both of those, `_adopt_completed_pods` was **database-free**: it only built a pod label selector and patched pods via the kube client, so running it inside the scheduler's locked transaction was harmless.

#66400 (`cncf-kubernetes` 10.17.1, May 2026) added `_alive_other_scheduler_job_ids`, a `Job`-table query wrapped in a scoped `create_session()`, and called it from `_adopt_completed_pods`. That turned a previously DB-free method into one that opens a session, without accounting for the long-standing caller that runs inside the scheduler's locked transaction. 10.17.1 is the first release containing #66400, and it is the version the #67813 reporter upgraded to when the crash appeared.

## Fix

```python
with create_session(scoped=False) as session:
    ...
```

`scoped=False` uses `settings.NonScopedSession`, a separate session and connection, so the helper's `commit()`/`close()` affect only itself. The scheduler keeps its transaction, its row locks, and its attached TaskInstances, and the query works unchanged from both call sites.

## Notes for future maintainers

- The helper runs from two contexts: the **locked** `try_adopt_task_instances` path (#35579) and the **lock-free** periodic `sync()` path (#61839). `scoped=False` is correct for both. It is preferred over threading the scheduler's session into the helper because the `sync()` path has no caller session to thread, and because a failed read on a shared session would abort the scheduler's locked transaction on Postgres (turning the existing exclude-self fallback into a hard failure).
- Deeper cleanup, intentionally **not** done here: the `try_adopt_task_instances` call to `_adopt_completed_pods` (#35579) overlaps with the periodic `sync()` call (#61839). If completed-pod cleanup does not need to be synchronous during adoption, dropping the call on the locked path would remove the helper from that path entirely. That predates #66400, changes takeover-cleanup timing, and should go in a separate change with maintainer sign-off, not this bugfix.

## Tradeoff

`scoped=False` checks out a second pooled connection while the scheduler holds row locks. The locked path runs only during orphaned-task adoption (scheduler startup or sibling takeover), not on a hot path, and the default pool has headroom (`sql_alchemy_pool_size` 5 + `sql_alchemy_max_overflow` 10). On a tight `pool_size=1, max_overflow=0` config the checkout could block until the pool checkout timeout, after which the pre-existing `except Exception` fallback degrades to exclude-self adoption and logs a warning.

Fixes #67813
