### PR TITLE
Honour `serialize_output=True` on `LLMFileAnalysisOperator`

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_file_analysis.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel
+
 from airflow.providers.common.ai.operators.llm import LLMOperator
 from airflow.providers.common.ai.utils.file_analysis import build_file_analysis_request
 from airflow.providers.common.ai.utils.logging import log_run_summary
@@ -138,6 +140,13 @@ class LLMFileAnalysisOperator(LLMOperator):
 
         if self.require_approval:
             self.defer_for_approval(context, output)  # type: ignore[misc]
+
+        if self._serialize_model_output and isinstance(output, BaseModel):
+            # Honour ``serialize_output=True`` and the older-Airflow fallback,
+            # matching ``LLMOperator.execute``. ``LLMFileAnalysisOperator``
+            # overrides ``execute`` rather than calling ``super().execute()``,
+            # so the dump step has to be repeated here.
+            output = output.model_dump()
 
         return output
 

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_file_analysis.py
@@ -146,6 +146,34 @@ class TestLLMFileAnalysisOperator:
         assert isinstance(result, Summary)
         assert result.findings == ["error spike"]
 
+    @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
+    @patch(
+        "airflow.providers.common.ai.operators.llm_file_analysis.build_file_analysis_request", autospec=True
+    )
+    def test_execute_serialize_output_returns_dict(self, mock_build_request, mock_hook_cls):
+        """serialize_output=True dumps the BaseModel to a dict on the wire."""
+        mock_build_request.return_value = FileAnalysisRequest(
+            user_content="prepared prompt",
+            resolved_paths=["/tmp/app.log"],
+            total_size_bytes=10,
+        )
+        mock_agent = MagicMock(spec=["run_sync"])
+        mock_agent.run_sync.return_value = _make_mock_run_result(Summary(findings=["error spike"]))
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+
+        op = LLMFileAnalysisOperator(
+            task_id="test",
+            prompt="Summarize the file",
+            llm_conn_id="my_llm",
+            file_path="/tmp/app.log",
+            output_type=Summary,
+            serialize_output=True,
+        )
+        result = op.execute(context={})
+
+        assert result == {"findings": ["error spike"]}
+        assert not isinstance(result, Summary)
+
     @patch(
         "airflow.providers.common.ai.operators.llm_file_analysis.build_file_analysis_request", autospec=True
     )


### PR DESCRIPTION
Follow-up from #67644: `LLMFileAnalysisOperator` silently ignores `serialize_output=True` and always returns a Pydantic instance instead of the dict the user asked for.

## Root cause

`LLMOperator.execute` ends with:

```python
if self._serialize_model_output and isinstance(output, BaseModel):
    output = output.model_dump()
return output
```

`LLMFileAnalysisOperator` overrides `execute()` (it needs to build the file-analysis request before calling the agent) and returns `output` directly without invoking `super().execute()` or replicating that branch. So the `serialize_output=True` opt-in had no effect on this operator -- both `serialize_output=False` and `serialize_output=True` returned the Pydantic instance.

## Fix

Mirror the same `isinstance(output, BaseModel) -> model_dump()` block at the end of `LLMFileAnalysisOperator.execute`. A short comment explains why the duplication is necessary (override doesn't call `super`).

Adds a regression test that constructs the operator with `serialize_output=True` and asserts the result is a `dict`, not a `Summary`. Verified locally: 10 tests pass.

## Notes

- The `execute_complete` path on this operator was already correct (it uses the helper from `output_type.rehydrate_pydantic_output`, which respects `_serialize_model_output`). Only `execute` was missing the branch.
- Same shape as the other two operators: `LLMOperator` and `AgentOperator` each handle the dump in their own `execute` because none of them share an `execute` implementation by inheritance today. A future refactor could pull the dump into a shared post-process step, but it's a one-line block per operator for now.