### PR TITLE
Fix long param names overflowing Trigger DAG modal  Body:

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldRow.tsx
@@ -59,8 +59,8 @@ export const FieldRow = ({
 
   return (
     <Field.Root invalid={!isValid} orientation="horizontal" required={isRequired(param)}>
-      <Stack>
-        <Field.Label fontSize="md" style={{ flexBasis: "30%" }}>
+      <Stack minWidth={0} style={{ flexBasis: "30%" }}>
+        <Field.Label fontSize="md" wordBreak="break-word">
           {param.schema.title ?? name} <Field.RequiredIndicator />
         </Field.Label>
       </Stack>


### PR DESCRIPTION
Closes #67851
When a DAG param has a very long key name, the label was overflowing the Trigger DAG modal and breaking the layout.
The 'flexBasis: "30%"' was being set on the 'Field.Label' element instead of its 'Stack' parent, so it had no effect on the flex layout — the label column just grew to fit whatever content was inside it. Added 'minWidth: 0' to the 'Stack' so it can shrink properly, moved 'flexBasis' there, and added 'wordBreak="break-word"' on the label so long names wrap within the column instead of overflowing.

I used Claude (claude.ai) as an AI assistant for parts of this implementation.
