### PR TITLE
Fix edge3 TestQueueWorkload tests missing required `session` argument in main

### DIFF
--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -602,7 +602,8 @@ class TestQueueWorkload:
         executor = EdgeExecutor()
         workload = self._make_execute_task()
 
-        executor.queue_workload(workload)
+        with create_session() as session:
+            executor.queue_workload(workload, session=session)
 
         with create_session() as session:
             job = session.scalar(select(EdgeJobModel))
@@ -617,8 +618,10 @@ class TestQueueWorkload:
         executor = EdgeExecutor()
         workload = self._make_execute_task()
 
-        executor.queue_workload(workload)
-        executor.queue_workload(workload)
+        with create_session() as session:
+            executor.queue_workload(workload, session=session)
+        with create_session() as session:
+            executor.queue_workload(workload, session=session)
 
         with create_session() as session:
             jobs = session.scalars(select(EdgeJobModel)).all()
@@ -644,7 +647,8 @@ class TestQueueWorkload:
             log_path="test.log",
         )
 
-        executor.queue_workload(workload)
+        with create_session() as session:
+            executor.queue_workload(workload, session=session)
 
         with create_session() as session:
             job = session.scalar(select(EdgeJobModel))
@@ -673,8 +677,10 @@ class TestQueueWorkload:
             log_path="test.log",
         )
 
-        executor.queue_workload(workload)
-        executor.queue_workload(workload)
+        with create_session() as session:
+            executor.queue_workload(workload, session=session)
+        with create_session() as session:
+            executor.queue_workload(workload, session=session)
 
         with create_session() as session:
             jobs = session.scalars(select(EdgeJobModel)).all()
@@ -683,5 +689,6 @@ class TestQueueWorkload:
 
     def test_queue_workload_unknown_type_raises(self):
         executor = EdgeExecutor()
-        with pytest.raises(TypeError, match="Don't know how to queue workload"):
-            executor.queue_workload(MagicMock(spec=[]))
+        with create_session() as session:
+            with pytest.raises(TypeError, match="Don't know how to queue workload"):
+                executor.queue_workload(MagicMock(spec=[]), session=session)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

queue_workload() requires a session (the scheduler always passes one), but the tests called it without, failing on the all-provider CI jobs. Pass session via create_session() to match production

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
