### PR TITLE
Fix map_index_template not rendered for sensors in reschedule mode

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -166,6 +166,7 @@ class TIRescheduleStatePayload(StrictBaseModel):
     ]
     reschedule_date: UtcDateTime
     end_date: UtcDateTime
+    rendered_map_index: str | None = None
 
 
 class TIAwaitingInputStatePayload(StrictBaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -722,7 +722,10 @@ def _create_ti_state_update_query_and_update_state(
             query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
         # clear the next_method and next_kwargs so that none of the retries pick them up
         updated_state = TaskInstanceState.UP_FOR_RESCHEDULE
-        query = query.values(state=updated_state, next_method=None, next_kwargs=None)
+        reschedule_values: dict[str, Any] = {"state": updated_state, "next_method": None, "next_kwargs": None}
+        if ti_patch_payload.rendered_map_index is not None:
+            reschedule_values["_rendered_map_index"] = ti_patch_payload.rendered_map_index
+        query = query.values(**reschedule_values)
     else:
         raise ValueError(f"Unexpected Payload Type {type(ti_patch_payload)}")
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -49,6 +49,7 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_16 import (
 from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
     AddAwaitingInputStatePayload,
     AddConnectionTestEndpoint,
+    AddRenderedMapIndexToReschedulePayload,
     AddVariableKeysEndpoint,
 )
 
@@ -59,6 +60,7 @@ bundle = VersionBundle(
         AddVariableKeysEndpoint,
         AddConnectionTestEndpoint,
         AddAwaitingInputStatePayload,
+        AddRenderedMapIndexToReschedulePayload,
     ),
     Version(
         "2026-06-16",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 from cadwyn import VersionChange, endpoint, schema
 
-from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIAwaitingInputStatePayload
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+    TIAwaitingInputStatePayload,
+    TIRescheduleStatePayload,
+)
 
 
 class AddVariableKeysEndpoint(VersionChange):
@@ -52,4 +55,14 @@ class AddAwaitingInputStatePayload(VersionChange):
         schema(TIAwaitingInputStatePayload).field("next_method").didnt_exist,
         schema(TIAwaitingInputStatePayload).field("next_kwargs").didnt_exist,
         schema(TIAwaitingInputStatePayload).field("rendered_map_index").didnt_exist,
+    )
+
+
+class AddRenderedMapIndexToReschedulePayload(VersionChange):
+    """Add the ``rendered_map_index`` field to TIRescheduleStatePayload."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(TIRescheduleStatePayload).field("rendered_map_index").didnt_exist,
     )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1611,6 +1611,7 @@ class TestTIUpdateState:
             "state": "up_for_reschedule",
             "reschedule_date": "2024-10-31T11:03:00+00:00",
             "end_date": DEFAULT_END_DATE.isoformat(),
+            "rendered_map_index": "my-sensor-label",
         }
 
         response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
@@ -1626,6 +1627,7 @@ class TestTIUpdateState:
         assert tis[0].next_method is None
         assert tis[0].next_kwargs is None
         assert tis[0].duration == 129600
+        assert tis[0].rendered_map_index == "my-sensor-label"
 
         trs = session.scalars(select(TaskReschedule)).all()
         assert len(trs) == 1

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -317,6 +317,7 @@ class TIRescheduleStatePayload(BaseModel):
     state: Annotated[Literal["up_for_reschedule"] | None, Field(title="State")] = "up_for_reschedule"
     reschedule_date: Annotated[AwareDatetime, Field(title="Reschedule Date")]
     end_date: Annotated[AwareDatetime, Field(title="End Date")]
+    rendered_map_index: Annotated[str | None, Field(title="Rendered Map Index")] = None
 
 
 class TIRetryStatePayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -3285,6 +3285,18 @@
           "title": "End Date",
           "type": "string"
         },
+        "rendered_map_index": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rendered Map Index"
+        },
         "type": {
           "const": "RescheduleTask",
           "default": "RescheduleTask",

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1718,6 +1718,7 @@ class ActivitySubprocess(WatchedSubprocess):
             self._rendered_map_index = msg.rendered_map_index
             self._send_terminal_state_msg(msg)
         elif isinstance(msg, RescheduleTask):
+            self._rendered_map_index = msg.rendered_map_index
             self._send_terminal_state_msg(msg)
         elif isinstance(msg, SkipDownstreamTasks):
             self.client.task_instances.skip_downstream_tasks(self.id, msg)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1521,7 +1521,9 @@ def run(
         log.info("::group::Post Execute")
         log.info("Rescheduling task, marking task as UP_FOR_RESCHEDULE")
         msg = RescheduleTask(
-            reschedule_date=reschedule.reschedule_date, end_date=datetime.now(tz=timezone.utc)
+            reschedule_date=reschedule.reschedule_date,
+            end_date=datetime.now(tz=timezone.utc),
+            rendered_map_index=ti.rendered_map_index,
         )
         state = TaskInstanceState.UP_FOR_RESCHEDULE
     except (AirflowFailException, AirflowSensorTimeout) as e:

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -310,6 +310,27 @@ class TestBaseSensor:
             state, _, _ = run_task(sensor)
         assert state == TaskInstanceState.SUCCESS
 
+    def test_reschedule_includes_rendered_map_index(self, run_task, make_sensor, time_machine):
+        """Test that RescheduleTask message includes rendered_map_index when map_index_template is set."""
+        sensor = make_sensor(
+            return_value=None,
+            poke_interval=10,
+            timeout=25,
+            mode="reschedule",
+            map_index_template="{{ task.task_id }}",
+        )
+        sensor.poke = Mock(return_value=False)
+
+        date1 = timezone.utcnow()
+        time_machine.move_to(date1, tick=False)
+
+        state, msg, _ = run_task(task=sensor)
+
+        assert state == TaskInstanceState.UP_FOR_RESCHEDULE
+        assert isinstance(msg, RescheduleTask)
+        assert msg.rendered_map_index == SENSOR_OP
+        assert msg.end_date == date1
+
     def test_sensor_with_invalid_poke_interval(self):
         negative_poke_interval = -10
         non_number_poke_interval = "abcd"


### PR DESCRIPTION
closes: #67521


When a sensor is configured with \`map_index_template\` and runs in reschedule mode, the rendered label was not being persisted to the database on each reschedule. As a result, the task instance's \`rendered_map_index\` column was left NULL, causing the UI to display the raw numeric \`map_index\` (e.g. "0", "1") instead of the human-readable rendered label.

**Root cause:** \`TIRescheduleStatePayload\` was missing the \`rendered_map_index\` field that all other terminal/retry state payloads have (\`TIRetryStatePayload\`, \`TaskState\`). The reschedule route handler builds a brand-new \`UPDATE\` query for the reschedule-specific columns (discarding the initial shared one), so the field had to be explicitly included in that new query as well.

**Changes:**
- Add \`rendered_map_index\` to \`TIRescheduleStatePayload\` (server-side datamodel)
- Update reschedule route handler to write \`rendered_map_index\` to the DB
- Add Cadwyn version migration \`AddRenderedMapIndexToReschedulePayload\` in \`v2026_06_30.py\`
- Update \`_generated.py\` (task-sdk client model) to include the new field
- Pass \`ti.rendered_map_index\` in the \`RescheduleTask\` message from the task runner
- Save \`_rendered_map_index\` from \`RescheduleTask\` in the supervisor
- Add regression test: \`test_reschedule_includes_rendered_map_index\`

