### PR TITLE
Update number of callback types from six to five in callbacks docs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/callbacks.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/callbacks.rst
@@ -51,7 +51,7 @@ There are three different places where callbacks can be defined.
 Callback Types
 --------------
 
-There are six types of events that can trigger a callback:
+There are five types of callbacks triggered on specific events:
 
 =========================================== ======================================================================= =================
 Name                                        Description                                                             Availability


### PR DESCRIPTION
Missed this somehow in https://github.com/apache/airflow/pull/61274, but there are just five events...