### PR TITLE
Fix `none_failed_min_one_success` trigger rule checks

### DIFF
--- a/airflow-core/newsfragments/67873.bugfix.rst
+++ b/airflow-core/newsfragments/67873.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``none_failed_min_one_success`` trigger rule evaluation when no upstream task succeeds, including mapped tasks whose upstream instances are all ``removed``.

--- a/airflow-core/newsfragments/67873.bugfix.rst
+++ b/airflow-core/newsfragments/67873.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ``none_failed_min_one_success`` trigger rule evaluation when no upstream task succeeds, including mapped tasks whose upstream instances are all ``removed``.

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -538,7 +538,7 @@ class TriggerRuleDep(BaseTIDep):
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
                     )
-            elif trigger_rule == TR.NONE_FAILED or trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS:
+            elif trigger_rule == TR.NONE_FAILED:
                 num_failures = upstream - success - skipped
                 if ti.map_index > -1:
                     num_failures -= removed
@@ -551,7 +551,20 @@ class TriggerRuleDep(BaseTIDep):
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
                     )
-                elif trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS and success <= 0:
+            elif trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS:
+                num_failures = upstream - success - skipped
+                if ti.map_index > -1:
+                    num_failures -= removed
+                if num_failures > 0:
+                    yield self._failing_status(
+                        reason=(
+                            f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have "
+                            f"succeeded or been skipped, but found {num_failures} non-success(es). "
+                            f"upstream_states={upstream_states}, "
+                            f"upstream_task_ids={task.upstream_task_ids}"
+                        )
+                    )
+                elif success <= 0:
                     yield self._failing_status(
                         reason=(
                             f"Task's trigger rule '{trigger_rule_str}' requires at least one upstream task "

--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -429,6 +429,8 @@ class TriggerRuleDep(BaseTIDep):
                         new_state = TaskInstanceState.UPSTREAM_FAILED
                     elif skipped == upstream:
                         new_state = TaskInstanceState.SKIPPED
+                    elif upstream_done and success == 0:
+                        new_state = TaskInstanceState.UPSTREAM_FAILED
                 elif trigger_rule == TR.NONE_SKIPPED:
                     if skipped:
                         new_state = TaskInstanceState.SKIPPED
@@ -546,6 +548,14 @@ class TriggerRuleDep(BaseTIDep):
                             f"Task's trigger rule '{trigger_rule_str}' requires all upstream tasks to have "
                             f"succeeded or been skipped, but found {num_failures} non-success(es). "
                             f"upstream_states={upstream_states}, "
+                            f"upstream_task_ids={task.upstream_task_ids}"
+                        )
+                    )
+                elif trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS and success <= 0:
+                    yield self._failing_status(
+                        reason=(
+                            f"Task's trigger rule '{trigger_rule_str}' requires at least one upstream task "
+                            f"success, but none were found. upstream_states={upstream_states}, "
                             f"upstream_task_ids={task.upstream_task_ids}"
                         )
                     )

--- a/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
+++ b/airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
@@ -620,12 +620,18 @@ class TestTriggerRuleDep:
         )
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
 
-    @pytest.mark.parametrize(("flag_upstream_failed", "expected_ti_state"), [(True, SKIPPED), (False, None)])
+    @pytest.mark.parametrize(
+        ("flag_upstream_failed", "expected_ti_state", "expected_reason"),
+        [
+            (True, SKIPPED, "requires at least one upstream task success"),
+            (False, None, "requires at least one upstream task success"),
+        ],
+    )
     def test_none_failed_min_one_success_tr_skipped(
-        self, session, get_task_instance, flag_upstream_failed, expected_ti_state
+        self, session, get_task_instance, flag_upstream_failed, expected_ti_state, expected_reason
     ):
         """
-        None failed min one success trigger rule success with all skipped
+        None failed min one success trigger rule with all skipped upstreams
         """
         ti = get_task_instance(
             TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
@@ -642,6 +648,7 @@ class TestTriggerRuleDep:
             session=session,
             flag_upstream_failed=flag_upstream_failed,
             expected_ti_state=expected_ti_state,
+            expected_reason=expected_reason,
         )
 
     @pytest.mark.parametrize(
@@ -1508,6 +1515,51 @@ class TestTriggerRuleDep:
         monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
 
         _test_trigger_rule(ti=ti, session=session, flag_upstream_failed=flag_upstream_failed)
+
+    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.parametrize(
+        ("flag_upstream_failed", "expected_ti_state"),
+        [(True, UPSTREAM_FAILED), (False, None)],
+    )
+    def test_mapped_task_upstream_all_removed_with_none_failed_min_one_success_trigger_rule(
+        self,
+        monkeypatch,
+        session,
+        get_mapped_task_dagrun,
+        flag_upstream_failed,
+        expected_ti_state,
+    ):
+        """
+        Test NONE_FAILED_MIN_ONE_SUCCESS trigger rule with all mapped upstream tasks removed.
+        """
+        dr, task, _ = get_mapped_task_dagrun(
+            trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
+            state=REMOVED,
+        )
+
+        # ti with removed upstream ti
+        ti = dr.get_task_instance(task_id="do_something_else", map_index=3, session=session)
+        ti.task = task
+
+        upstream_states = _UpstreamTIStates(
+            success=0,
+            skipped=0,
+            failed=0,
+            removed=5,
+            upstream_failed=0,
+            done=5,
+            skipped_setup=0,
+            success_setup=0,
+        )
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
+
+        _test_trigger_rule(
+            ti=ti,
+            session=session,
+            flag_upstream_failed=flag_upstream_failed,
+            expected_reason="requires at least one upstream task success",
+            expected_ti_state=expected_ti_state,
+        )
 
 
 def test_upstream_in_mapped_group_triggers_only_relevant(dag_maker, session):


### PR DESCRIPTION
## Summary

[`none_failed_min_one_success`](https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html) requires all upstream tasks to avoid `failed` / `upstream_failed` and at least one upstream task to succeed.

The existing `TriggerRuleDep` dep-check path shared the same [failure-count logic](https://github.com/apache/airflow/blob/33363d541851f3017ee96f94ceb328d684ed8360/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py#L539-L540) as `none_failed`. As a result, zero-success upstream states could be reported as dependencies met, even though the trigger rule's min-one-success contract could not be satisfied.

This showed up in two counterexamples:

- all upstream tasks skipped while `flag_upstream_failed=False`, where direct dependency checks such as `airflow tasks failed-deps` missed the trigger-rule failure reason;
- dynamically mapped upstreams where all upstream task instances were `removed`, where the scheduler rewrite path also did not assign a terminal failure state.

Before the fix, `airflow tasks failed-deps` did not report the trigger-rule violation for an all-skipped upstream case:

<details>
<summary>Reproduction Dag</summary>

```python
import pendulum

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.providers.standard.operators.python import BranchPythonOperator
from airflow.sdk import DAG


def choose_branch():
    return "branch_b"


with DAG(
    dag_id="pattern5_repro",
    schedule=None,
    start_date=pendulum.datetime(2026, 1, 1, tz="UTC"),
    catchup=False,
    tags=["z3-counterexample"],
) as dag:
    pick = BranchPythonOperator(
        task_id="pick",
        python_callable=choose_branch,
    )

    branch_a = EmptyOperator(task_id="branch_a")
    branch_b = EmptyOperator(task_id="branch_b")

    downstream = EmptyOperator(
        task_id="downstream",
        trigger_rule="none_failed_min_one_success",
    )

    pick >> [branch_a, branch_b]
    branch_a >> downstream
```

</details>

```console
[Breeze:3.10.20] root@57ce6ad76e64:/opt/airflow$ airflow tasks failed-deps pattern5_repro downstream manual__2026-05-31T23:57:32.573541+00:00
Task instance dependencies not met:
Dagrun Running: Task instance's dagrun was not in the 'running' state but in the state 'success'.
Task Instance State: Task is in the 'skipped' state.
```

After the fix, the missing trigger-rule dependency is reported:

```console
[Breeze:3.10.20] root@57ce6ad76e64:/opt/airflow$ airflow tasks failed-deps pattern5_repro downstream manual__2026-05-31T23:57:32.573541+00:00
Task instance dependencies not met:
Trigger Rule: Task's trigger rule 'none_failed_min_one_success' requires at least one upstream task success, but none were found.
Dagrun Running: Task instance's dagrun was not in the 'running' state but in the state 'success'.
Task Instance State: Task is in the 'skipped' state.
```

## Fix

Fail the `none_failed_min_one_success` dep check whenever no upstream task has succeeded.

Also extend the `flag_upstream_failed=True` rewrite path so that, once all upstreams are terminal and none succeeded, the downstream task instance is marked `UPSTREAM_FAILED`. This covers mapped tasks whose relevant upstream task instances were all `removed`.

The existing all-skipped behavior is preserved: that case is still rewritten to `SKIPPED` before the new all-terminal zero-success branch can run.

## Test

Updated regression coverage for `none_failed_min_one_success`:

- all-skipped upstreams now report the missing upstream success for both `flag_upstream_failed=True` and `False`;
- all-removed mapped upstreams now report the missing upstream success, and with `flag_upstream_failed=True` the task instance is rewritten to `UPSTREAM_FAILED`.

Verified with:

```bash
uv run ruff format airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
uv run ruff check --fix airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py
breeze run --backend postgres --python 3.10 --skip-image-upgrade-check --answer no pytest airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py::TestTriggerRuleDep::test_none_failed_min_one_success_tr_skipped airflow-core/tests/unit/ti_deps/deps/test_trigger_rule_dep.py::TestTriggerRuleDep::test_mapped_task_upstream_all_removed_with_none_failed_min_one_success_trigger_rule -xvs
```

Result: `4 passed, 1 warning`.

## Reported by

SMT solver sweep of Airflow trigger-rule semantics using a local Z3 model.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
