### PR TITLE
Added an example for http repsonse branching

### DIFF
--- a/providers/http/docs/operators.rst
+++ b/providers/http/docs/operators.rst
@@ -104,6 +104,20 @@ the response body.
     :start-after: [START howto_operator_http_task_get_op_response_filter]
     :end-before: [END howto_operator_http_task_get_op_response_filter]
 
+A common pattern is combining ``response_filter`` with ``@task.branch`` to route
+downstream work based on an API response. For example, a health-check endpoint
+can determine whether to proceed with processing or send a notification.
+
+.. code-block:: python
+
+    from airflow.decorators import task
+
+    @task.branch
+    def route(api_status):
+        if api_status == "healthy":
+            return "process_data"
+        return "send_notification"
+
 In the third example we are performing a ``PUT`` operation to put / set data according to the data that is being
 provided to the request.
 


### PR DESCRIPTION
Added a small example showing the combination of response_filter with @task.branch to route downstream work based on API response.

No functionality was added.

#67677 
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

<!-- pr-triage-fold: triaged=2026-06-18T21:56:15Z head=fcdce58 action=close -->

---

> [!NOTE]
> **🛠️ Maintainer triage note for @everetch** · by `@potiuk` · 2026-06-18 21:56 UTC
>
> Closing to keep the review queue clean — this draft was triaged ~9 days ago and there's been no update since:
> - No worries and nothing lost — **reopen it or open a fresh PR** whenever you're ready to pick it back up.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->