### PR TITLE
Widen type hint for DagRun.get_task_instances / fetch_task_instances state parameter

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -836,7 +836,7 @@ class DagRun(Base, LoggingMixin):
         dag_id: str | None = None,
         run_id: str | None = None,
         task_ids: list[str] | None = None,
-        state: Iterable[TaskInstanceState | None] | None = None,
+        state: TaskInstanceState | Iterable[TaskInstanceState | None] | None = None,
         *,
         session: Session = NEW_SESSION,
     ) -> list[TI]:
@@ -917,7 +917,7 @@ class DagRun(Base, LoggingMixin):
     @provide_session
     def get_task_instances(
         self,
-        state: Iterable[TaskInstanceState | None] | None = None,
+        state: TaskInstanceState | Iterable[TaskInstanceState | None] | None = None,
         *,
         session: Session = NEW_SESSION,
     ) -> list[TI]:


### PR DESCRIPTION
### Fixes #67653

The `state` parameter on `DagRun.get_task_instances` and `DagRun.fetch_task_instances` was annotated as `Iterable[TaskInstanceState | None] | None`, but the runtime handles a single `TaskInstanceState` value via an `isinstance(state, str)` short-circuit. Since `TaskInstanceState(str, Enum)` inherits from `str`, calling with `state=TaskInstanceState.FAILED` works at runtime but mypy/pyright flags it.

**Fix:** Widen the annotation to `TaskInstanceState | Iterable[TaskInstanceState | None] | None` on both methods to match the actual runtime behaviour.