### PR TITLE
Drain result_queue in LocalExecutor to prevent process join deadlock

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -264,30 +264,36 @@ class LocalExecutor(BaseExecutor):
             # Send the shutdown message once for each alive worker
             if proc.is_alive():
                 self.activity_queue.put(None)
-        
+
         # To prevent deadlock, we should consume results from result_queue while waiting for processes to join.
         # Otherwise, a worker blocked on putting results into a full result_queue pipe will never exit,
         # and an unbounded proc.join() will hang the scheduler indefinitely.
-
-        for proc in self.workers.values():
-            if proc.is_alive():
-                try:
+        try:
+            for proc in self.workers.values():
+                if proc.is_alive():
                     while proc.is_alive():
                         self._read_results()
                         proc.join(timeout=0.05)
-                except (KeyboardInterrupt, SystemExit):
-                    self.log.error("KeyboardInterrupt received during shutdown. Force terminating workers.")
-                    for p in self.workers.values():
-                        if p.is_alive():
-                            p.terminate()
-                    raise
-            proc.close()
+        except (KeyboardInterrupt, SystemExit):
+            self.log.error("KeyboardInterrupt received during shutdown. Force terminating workers.")
+            for p in self.workers.values():
+                if p.is_alive():
+                    p.terminate()
+                    p.join(timeout=0.2)
+            raise
+        finally:
+            # Process any extra results before closing
+            self._read_results()
 
-        # Process any extra results before closing
-        self._read_results()
+            for proc in self.workers.values():
+                try:
+                    proc.close()
+                except ValueError:
+                    # Raised if the process is still running/alive
+                    pass
 
-        self.activity_queue.close()
-        self.result_queue.close()
+            self.activity_queue.close()
+            self.result_queue.close()
 
     def terminate(self):
         """Forcefully terminate all worker processes under control of the executor."""
@@ -295,6 +301,7 @@ class LocalExecutor(BaseExecutor):
         for proc in self.workers.values():
             if proc.is_alive():
                 proc.terminate()
+                proc.join(timeout=0.2)
 
     def _process_workloads(self, workload_list):
         for workload in workload_list:

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -25,6 +25,7 @@ LocalExecutor.
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import multiprocessing
 import multiprocessing.sharedctypes
@@ -286,17 +287,14 @@ class LocalExecutor(BaseExecutor):
             self._read_results()
 
             for proc in self.workers.values():
-                try:
+                with contextlib.suppress(ValueError):
                     proc.close()
-                except ValueError:
-                    # Raised if the process is still running/alive
-                    pass
 
             self.activity_queue.close()
             self.result_queue.close()
 
     def terminate(self):
-        """Forcefully terminate all worker processes under control of the executor."""
+        """Terminate all worker processes under control of the executor forcefully."""
         self.log.info("Terminating all LocalExecutor worker processes.")
         for proc in self.workers.values():
             if proc.is_alive():

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -243,10 +243,12 @@ class LocalExecutor(BaseExecutor):
         self._check_workers()
 
     def _read_results(self):
-        while not self.result_queue.empty():
-            key, state, exc = self.result_queue.get()
-
-            self.change_state(key, state)
+        try:
+            while not self.result_queue.empty():
+                key, state, exc = self.result_queue.get()
+                self.change_state(key, state)
+        except (OSError, EOFError):
+            self.log.exception("Error reading from result queue")
 
     def end(self) -> None:
         """End the executor."""
@@ -262,10 +264,23 @@ class LocalExecutor(BaseExecutor):
             # Send the shutdown message once for each alive worker
             if proc.is_alive():
                 self.activity_queue.put(None)
+        
+        # To prevent deadlock, we should consume results from result_queue while waiting for processes to join.
+        # Otherwise, a worker blocked on putting results into a full result_queue pipe will never exit,
+        # and an unbounded proc.join() will hang the scheduler indefinitely.
 
         for proc in self.workers.values():
             if proc.is_alive():
-                proc.join()
+                try:
+                    while proc.is_alive():
+                        self._read_results()
+                        proc.join(timeout=0.05)
+                except (KeyboardInterrupt, SystemExit):
+                    self.log.error("KeyboardInterrupt received during shutdown. Force terminating workers.")
+                    for p in self.workers.values():
+                        if p.is_alive():
+                            p.terminate()
+                    raise
             proc.close()
 
         # Process any extra results before closing
@@ -275,7 +290,11 @@ class LocalExecutor(BaseExecutor):
         self.result_queue.close()
 
     def terminate(self):
-        """Terminate the executor is not doing anything."""
+        """Forcefully terminate all worker processes under control of the executor."""
+        self.log.info("Terminating all LocalExecutor worker processes.")
+        for proc in self.workers.values():
+            if proc.is_alive():
+                proc.terminate()
 
     def _process_workloads(self, workload_list):
         for workload in workload_list:

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -271,16 +271,13 @@ class LocalExecutor(BaseExecutor):
         # and an unbounded proc.join() will hang the scheduler indefinitely.
         try:
             for proc in self.workers.values():
-                if proc.is_alive():
-                    while proc.is_alive():
-                        self._read_results()
-                        proc.join(timeout=0.05)
+                while proc.is_alive():
+                    self._read_results()
+                    proc.join(timeout=0.05)
         except (KeyboardInterrupt, SystemExit):
             self.log.error("KeyboardInterrupt received during shutdown. Force terminating workers.")
-            for p in self.workers.values():
-                if p.is_alive():
-                    p.terminate()
-                    p.join(timeout=0.2)
+            for proc in self.workers.values():
+                self._terminate_worker_process(proc)
             raise
         finally:
             # Process any extra results before closing
@@ -297,9 +294,19 @@ class LocalExecutor(BaseExecutor):
         """Terminate all worker processes under control of the executor forcefully."""
         self.log.info("Terminating all LocalExecutor worker processes.")
         for proc in self.workers.values():
-            if proc.is_alive():
-                proc.terminate()
-                proc.join(timeout=0.2)
+            self._terminate_worker_process(proc)
+
+    def _terminate_worker_process(self, proc: multiprocessing.Process) -> None:
+        """Terminate a worker process, escalating to kill if it stays alive."""
+        if not proc.is_alive():
+            return
+
+        proc.terminate()
+        proc.join(timeout=0.2)
+        if proc.is_alive():
+            self.log.warning("Worker process %s did not stop after SIGTERM. Sending SIGKILL.", proc.pid)
+            proc.kill()
+            proc.join(timeout=0.2)
 
     def _process_workloads(self, workload_list):
         for workload in workload_list:

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -35,6 +35,7 @@ from airflow.executors.workloads.base import BundleInfo
 from airflow.executors.workloads.callback import CallbackDTO
 from airflow.executors.workloads.task import TaskInstanceDTO
 from airflow.models.callback import CallbackFetchMethod
+from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.settings import Session
 from airflow.utils.state import State
 
@@ -88,6 +89,13 @@ def _make_task_workload():
         token="test_token",
         log_path=None,
     )
+
+
+def _write_large_results_to_queue(result_queue, result_count, payload_size):
+    payload = RuntimeError("x" * payload_size)
+    for index in range(result_count):
+        key = TaskInstanceKey("test_dag", f"test_task_{index}", "test_run")
+        result_queue.put((key, State.SUCCESS, payload))
 
 
 class TestLocalExecutor:
@@ -273,6 +281,87 @@ class TestLocalExecutor:
             pass
         finally:
             executor.end()
+
+    def test_end_drains_results_while_joining_workers(self):
+        executor = LocalExecutor(parallelism=1)
+        executor.activity_queue = mock.MagicMock()
+        executor.result_queue = mock.MagicMock()
+        proc = mock.MagicMock(spec=multiprocessing.Process)
+        proc.is_alive.side_effect = [True, True, True, False]
+        executor.workers = {1: proc}
+
+        with mock.patch.object(executor, "_read_results") as mock_read_results:
+            executor.end()
+
+        executor.activity_queue.put.assert_called_once_with(None)
+        assert proc.join.call_args_list == [mock.call(timeout=0.05), mock.call(timeout=0.05)]
+        assert mock_read_results.call_count == 3
+        proc.close.assert_called_once()
+        executor.activity_queue.close.assert_called_once()
+        executor.result_queue.close.assert_called_once()
+
+    def test_end_terminates_workers_and_closes_resources_on_interrupt(self):
+        executor = LocalExecutor(parallelism=1)
+        executor.activity_queue = mock.MagicMock()
+        executor.result_queue = mock.MagicMock()
+        proc = mock.MagicMock(spec=multiprocessing.Process)
+        proc.is_alive.side_effect = [True, True]
+        executor.workers = {1: proc}
+
+        with (
+            mock.patch.object(executor, "_read_results", side_effect=[KeyboardInterrupt, None]),
+            mock.patch.object(executor, "_terminate_worker_process") as mock_terminate_worker_process,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            executor.end()
+
+        mock_terminate_worker_process.assert_called_once_with(proc)
+        proc.close.assert_called_once()
+        executor.activity_queue.close.assert_called_once()
+        executor.result_queue.close.assert_called_once()
+
+    def test_terminate_joins_worker_after_sigterm(self):
+        executor = LocalExecutor(parallelism=1)
+        proc = mock.MagicMock(spec=multiprocessing.Process)
+        proc.is_alive.side_effect = [True, False]
+        executor.workers = {1: proc}
+
+        executor.terminate()
+
+        proc.terminate.assert_called_once_with()
+        proc.join.assert_called_once_with(timeout=0.2)
+        proc.kill.assert_not_called()
+
+    def test_terminate_kills_worker_that_ignores_sigterm(self):
+        executor = LocalExecutor(parallelism=1)
+        proc = mock.MagicMock(spec=multiprocessing.Process)
+        proc.pid = 123
+        proc.is_alive.side_effect = [True, True]
+        executor.workers = {1: proc}
+
+        executor.terminate()
+
+        proc.terminate.assert_called_once_with()
+        proc.kill.assert_called_once_with()
+        assert proc.join.call_args_list == [mock.call(timeout=0.2), mock.call(timeout=0.2)]
+
+    @pytest.mark.execution_timeout(10)
+    def test_end_drains_result_queue_to_avoid_join_deadlock(self):
+        executor = LocalExecutor(parallelism=1)
+        executor.activity_queue = multiprocessing.SimpleQueue()
+        executor.result_queue = multiprocessing.SimpleQueue()
+        result_count = 8
+        payload_size = 128 * 1024
+        proc = multiprocessing.Process(
+            target=_write_large_results_to_queue,
+            args=(executor.result_queue, result_count, payload_size),
+        )
+        proc.start()
+        executor.workers = {proc.pid: proc}
+
+        executor.end()
+
+        assert len(executor.event_buffer) == result_count
 
     @pytest.mark.parametrize(
         ("conf_values", "expected_server"),


### PR DESCRIPTION
closes: #67870

### Description
This PR fixes a deadlock in the `LocalExecutor` during executor shutdown (`end()`).

Currently, the executor calls `proc.join()` on active worker processes. However, if a worker has written enough results to the `result_queue` to fill the OS-level pipe buffer (typically 64KB), the worker process blocks indefinitely on its `put()` call. 
Because the parent scheduler process is blocked on the unbounded `proc.join()` and not reading from `result_queue`, a classic multiprocessing deadlock occurs. The scheduler hangs indefinitely, stopping heartbeats and preventing systemd/Kubernetes from restarting the process (as it never exits).

### Changes
1. **Draining during Join:** Updated the shutdown loop in `LocalExecutor.end()` to continuously drain the `result_queue` using `_read_results()` while waiting for worker processes to join with a small timeout.
2. **Robust Queue Reading:** Wrapped the queue drainage loop in `_read_results()` with a `try/except (OSError, EOFError)` block to gracefully handle cases where pipes are already broken or closed during task exit.
3. **Forced Terminate:** Implemented the `LocalExecutor.terminate()` method to forcefully kill any remaining workers when a hard stop is requested.

### Context
This contribution was created as part of the required capstone of the CodePath AI301 course, where students learn how to make responsible and effective use of generative AI tools for open-source software contributions.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Antigravity IDE powered by Gemini)

Generated-by: Antigravity IDE (Gemini) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=33cd755 action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @SakshamKapoor2911 → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @SakshamKapoor2911 — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->