### PR TITLE
Add aiohttp trust_env config for Snowflake async hook

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2242,6 +2242,21 @@ lineage:
       type: integer
       example: ~
       default: "200"
+aiohttp:
+  description: |
+    Options for aiohttp client sessions used by asynchronous Airflow components and providers.
+  options:
+    trust_env:
+      description: |
+        Trust environment variables for proxy configuration when creating aiohttp client sessions.
+
+        When enabled, aiohttp can use environment variables such as ``HTTP_PROXY``, ``HTTPS_PROXY``,
+        and ``NO_PROXY``. This is useful in environments where outbound traffic must go through
+        a corporate proxy.
+      version_added: 3.2.0
+      type: boolean
+      example: "true"
+      default: "false"
 operators:
   description: ~
   options:

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py
@@ -37,6 +37,7 @@ from tenacity import (
 )
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
+from airflow.providers.common.compat.sdk import conf
 from airflow.providers.common.sql.hooks.lineage import send_sql_hook_lineage
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from airflow.providers.snowflake.utils.sql_api_generate_jwt import JWTGenerator
@@ -131,7 +132,10 @@ class SnowflakeSqlApiHook(SnowflakeHook):
             self.retry_config.update(api_retry_args)
 
         self.http_request_kwargs = http_request_kwargs or {}
-        self.aiohttp_session_kwargs = aiohttp_session_kwargs or {}
+        self.aiohttp_session_kwargs = {
+            "trust_env": conf.getboolean("aiohttp", "trust_env", fallback=False),
+            **(aiohttp_session_kwargs or {}),
+        }
         self.aiohttp_request_kwargs = aiohttp_request_kwargs or {}
 
     def execute_query(

--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
@@ -461,6 +461,7 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
                     snowflake_conn_id=self.snowflake_conn_id,
                     token_life_time=self.token_life_time,
                     token_renewal_delta=self.token_renewal_delta,
+                    aiohttp_session_kwargs=self.hook_params.get("aiohttp_session_kwargs"),
                 ),
                 method_name="execute_complete",
             )

--- a/providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py
@@ -45,6 +45,7 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
         snowflake_conn_id: str,
         token_life_time: timedelta,
         token_renewal_delta: timedelta,
+        aiohttp_session_kwargs: dict[str, Any] | None = None,
     ):
         super().__init__()
         self.poll_interval = poll_interval
@@ -52,6 +53,7 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
         self.snowflake_conn_id = snowflake_conn_id
         self.token_life_time = token_life_time
         self.token_renewal_delta = token_renewal_delta
+        self.aiohttp_session_kwargs = aiohttp_session_kwargs or {}
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize SnowflakeSqlApiTrigger arguments and classpath."""
@@ -63,6 +65,7 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
                 "snowflake_conn_id": self.snowflake_conn_id,
                 "token_life_time": self.token_life_time,
                 "token_renewal_delta": self.token_renewal_delta,
+                "aiohttp_session_kwargs": self.aiohttp_session_kwargs,
             },
         )
 
@@ -72,6 +75,7 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
             self.snowflake_conn_id,
             self.token_life_time,
             self.token_renewal_delta,
+            aiohttp_session_kwargs=self.aiohttp_session_kwargs,
         )
 
         try:
@@ -102,6 +106,7 @@ class SnowflakeSqlApiTrigger(BaseTrigger):
                 self.snowflake_conn_id,
                 self.token_life_time,
                 self.token_renewal_delta,
+                aiohttp_session_kwargs=self.aiohttp_session_kwargs,
             )
 
         return await hook.get_sql_api_query_status_async(query_id)

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -1707,6 +1707,32 @@ class TestSnowflakeSqlApiHook:
             assert timeout_obj.total == 7.0
 
     @pytest.mark.asyncio
+    @mock.patch(f"{MODULE_PATH}.conf.getboolean", return_value=True)
+    async def test_make_api_call_with_retries_async_uses_trust_env_config(self, mock_getboolean):
+        """
+        Test that aiohttp trust_env config is forwarded to aiohttp.ClientSession.
+        """
+        hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
+
+        with mock.patch(f"{MODULE_PATH}.aiohttp.ClientSession") as client_session_cls:
+            session_cm = mock.MagicMock()
+            client_session_cls.return_value.__aenter__ = AsyncMock(return_value=session_cm)
+
+            req_cm = mock.MagicMock()
+            session_cm.request.return_value = req_cm
+
+            resp = mock.MagicMock()
+            resp.status = 200
+            resp.raise_for_status.return_value = None
+            resp.json = AsyncMock(return_value=GET_RESPONSE)
+            req_cm.__aenter__ = AsyncMock(return_value=resp)
+
+            await hook._make_api_call_with_retries_async("GET", API_URL, HEADERS)
+
+            _, kwargs = client_session_cls.call_args
+            assert kwargs["trust_env"] is True
+
+    @pytest.mark.asyncio
     async def test_make_api_call_with_retries_async_retries_on_timeout_error(self, mock_async_request):
         """
         Test that the async API call is retried when a timeout error occurs.

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -372,6 +372,33 @@ class TestSnowflakeSqlApiOperator:
             "Trigger is not a SnowflakeSqlApiTrigger"
         )
 
+    @mock.patch("airflow.providers.snowflake.hooks.snowflake_sql_api.SnowflakeSqlApiHook.execute_query")
+    def test_snowflake_sql_api_execute_operator_async_passes_aiohttp_session_kwargs(
+        self, mock_execute_query, mock_get_sql_api_query_status
+    ):
+        """
+        Asserts that aiohttp session kwargs are passed to the trigger when the operator defers.
+        """
+        operator = SnowflakeSqlApiOperator(
+            task_id=TASK_ID,
+            snowflake_conn_id=CONN_ID,
+            sql=SINGLE_STMT,
+            statement_count=1,
+            deferrable=True,
+            hook_params={"aiohttp_session_kwargs": {"trust_env": True}},
+        )
+
+        mock_execute_query.return_value = ["uuid1"]
+        mock_get_sql_api_query_status.side_effect = [{"status": "running"}]
+
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(create_context(operator))
+
+        assert isinstance(exc.value.trigger, SnowflakeSqlApiTrigger), (
+            "Trigger is not a SnowflakeSqlApiTrigger"
+        )
+        assert exc.value.trigger.aiohttp_session_kwargs == {"trust_env": True}
+
     def test_snowflake_sql_api_execute_complete_failure(self):
         """Test SnowflakeSqlApiOperator raise RuntimeError of error event"""
 

--- a/providers/snowflake/tests/unit/snowflake/triggers/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/triggers/test_snowflake.py
@@ -40,6 +40,7 @@ class TestSnowflakeSqlApiTrigger:
         snowflake_conn_id="test_conn",
         token_life_time=LIFETIME,
         token_renewal_delta=RENEWAL_DELTA,
+        aiohttp_session_kwargs={"trust_env": True},
     )
 
     def test_snowflake_sql_trigger_serialization(self):
@@ -55,7 +56,27 @@ class TestSnowflakeSqlApiTrigger:
             "snowflake_conn_id": "test_conn",
             "token_life_time": LIFETIME,
             "token_renewal_delta": RENEWAL_DELTA,
+            "aiohttp_session_kwargs": {"trust_env": True},
         }
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiHook")
+    async def test_snowflake_sql_trigger_passes_aiohttp_session_kwargs_to_hook(self, mock_hook):
+        """
+        Asserts that aiohttp session kwargs are used when the trigger creates its hook.
+        """
+        mock_hook.return_value.get_sql_api_query_status_async = mock.AsyncMock(
+            return_value={"status": "success"}
+        )
+
+        await self.TRIGGER.get_query_status("uuid")
+
+        mock_hook.assert_called_once_with(
+            "test_conn",
+            LIFETIME,
+            RENEWAL_DELTA,
+            aiohttp_session_kwargs={"trust_env": True},
+        )
 
     @pytest.mark.asyncio
     @mock.patch(f"{MODULE}.triggers.snowflake_trigger.SnowflakeSqlApiTrigger.get_query_status")


### PR DESCRIPTION
Closes: #67893

### Approach

This PR keeps the change focused on the Snowflake SQL API async path, which is one of the affected deferrable operator paths mentioned in the issue.

The change adds a new `[aiohttp] trust_env` Airflow config option with a default value of `false`. The Snowflake SQL API hook reads this config and includes it in the default `aiohttp_session_kwargs` used when creating `aiohttp.ClientSession`.

Explicitly provided `aiohttp_session_kwargs` still take precedence, so users can override the global config at the hook level when needed.

This PR also passes `aiohttp_session_kwargs` through `SnowflakeSqlApiTrigger` serialization. Without this, the operator could create the hook with async session options, but the deferrable triggerer path would lose those options when recreating the hook during polling.

### What changed

- Added `[aiohttp] trust_env` config support.
- Applied the configured `trust_env` value in `SnowflakeSqlApiHook`.
- Passed `aiohttp_session_kwargs` from `SnowflakeSqlApiOperator` into `SnowflakeSqlApiTrigger`.
- Serialized `aiohttp_session_kwargs` in the trigger so the triggerer preserves async session options.
- Added tests for config based `trust_env`, trigger serialization, trigger hook creation, and operator deferral.

### Tested

```bash
uv run ruff check \
  providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_sql_api.py \
  providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py \
  providers/snowflake/src/airflow/providers/snowflake/triggers/snowflake_trigger.py \
  providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py \
  providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py \
  providers/snowflake/tests/unit/snowflake/triggers/test_snowflake.py

uv run pytest providers/snowflake/tests/unit/snowflake/triggers/test_snowflake.py
uv run pytest providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py::TestSnowflakeSqlApiOperator
uv run pytest providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py -k "aiohttp_session_kwargs or trust_env or async"
uv run pytest airflow-core/tests/unit/core/test_configuration.py -k "default_config or config"

<!-- pr-triage-fold: triaged=2026-07-02T17:38:30Z head=3d2c6de action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Codingaditya17** · by `@potiuk` · 2026-07-02 17:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - The following required checks are failing: `provider distributions tests / Compat 3.0.6:P3.10:`. Please investigate and push a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->