### PR TITLE
Add include_id_token setting for keycloak /login_callback

### DIFF
--- a/providers/keycloak/provider.yaml
+++ b/providers/keycloak/provider.yaml
@@ -73,6 +73,13 @@ config:
         version_added: 0.0.1
         example: ~
         default: ~
+      include_id_token:
+        description: |
+          Include the _id_token cookie from the keycloak userinfo on login requests.
+        type: boolean
+        version_added: ~
+        example: ~
+        default: "True"
       realm:
         description: |
           Realm configured in Keycloak associated to Airflow.

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -116,9 +116,10 @@ def login_callback(request: Request):
 
     # Save id token as separate cookie.
     # Cookies have a size limit (usually 4k), saving all the tokens in a same cookie goes beyond this limit
-    response.set_cookie(
-        COOKIE_NAME_ID_TOKEN, tokens["id_token"], path=cookie_path, secure=secure, httponly=True
-    )
+    if conf.getboolean("keycloak_auth_manager", "include_id_token", fallback=True):
+        response.set_cookie(
+            COOKIE_NAME_ID_TOKEN, tokens["id_token"], path=cookie_path, secure=secure, httponly=True
+        )
 
     return response
 

--- a/providers/keycloak/src/airflow/providers/keycloak/get_provider_info.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/get_provider_info.py
@@ -57,6 +57,13 @@ def get_provider_info():
                         "example": None,
                         "default": None,
                     },
+                    "include_id_token": {
+                        "description": "Include the _id_token cookie from the keycloak userinfo on login requests.\n",
+                        "type": "boolean",
+                        "version_added": None,
+                        "example": None,
+                        "default": "True",
+                    },
                     "realm": {
                         "description": "Realm configured in Keycloak associated to Airflow.\nThis realm define all users, roles and groups used in Airflow.\n",
                         "type": "string",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [x] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Add include_id_token setting for keycloak /login_callback
---

Add a setting to disable populating the `_id_token` cookie for the keycloak auth manager. This allows slimming down the cookies sent to the browser from keycloak.

