### PR TITLE
[v3-2-test] Migrate Stackdriver logging config to RemoteLogIO pattern

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -248,19 +248,25 @@ if REMOTE_LOGGING:
         )
 
     elif remote_base_log_folder.startswith("stackdriver://"):
+        from airflow.providers.google.cloud.log.stackdriver_task_handler import StackdriverRemoteLogIO
+
         key_path = conf.get_mandatory_value("logging", "GOOGLE_KEY_PATH", fallback=None)
         # stackdriver:///airflow-tasks => airflow-tasks
         log_name = urlsplit(remote_base_log_folder).path[1:]
-        STACKDRIVER_REMOTE_HANDLERS = {
-            "task": {
-                "class": "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverTaskHandler",
-                "formatter": "airflow",
-                "gcp_log_name": log_name,
-                "gcp_key_path": key_path,
-            }
-        }
 
-        DEFAULT_LOGGING_CONFIG["handlers"].update(STACKDRIVER_REMOTE_HANDLERS)
+        REMOTE_TASK_LOG = StackdriverRemoteLogIO(
+            **cast(
+                "dict[str, Any]",
+                {
+                    "base_log_folder": BASE_LOG_FOLDER,
+                    "gcp_log_name": log_name,
+                    "gcp_key_path": key_path,
+                    "delete_local_copy": delete_local_copy,
+                }
+                | _io_kwargs,
+            )
+        )
+
     elif remote_base_log_folder.startswith("oss://"):
         from airflow.providers.alibaba.cloud.log.oss_task_handler import OSSRemoteLogIO
 

--- a/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
+++ b/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
@@ -40,8 +40,12 @@ REMOTE_IO_PROVIDERS = [
     ),
     ("oss://bucket/path", "airflow.providers.alibaba.cloud.log.oss_task_handler.OSSRemoteLogIO"),
     ("hdfs://host/path", "airflow.providers.apache.hdfs.log.hdfs_task_handler.HdfsRemoteLogIO"),
+    (
+        "stackdriver://host/path",
+        "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverRemoteLogIO",
+    ),
 ]
-REMOTE_IO_IDS = ["s3", "wasb", "gcs", "cloudwatch", "oss", "hdfs"]
+REMOTE_IO_IDS = ["s3", "wasb", "gcs", "cloudwatch", "oss", "hdfs", "stackdriver"]
 
 
 @pytest.fixture


### PR DESCRIPTION
Backport of #66513 to `v3-2-test`.

closes: #66513 (backport)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

Generated-by: Claude Code (Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)