### PR TITLE
Run the Airflow triggerer through the Execution API

### DIFF
--- a/airflow-core/newsfragments/67919.significant.rst
+++ b/airflow-core/newsfragments/67919.significant.rst
@@ -1,0 +1,21 @@
+Triggerer no longer requires metadata-database access
+
+The triggerer now performs all of its work through the Execution API instead of connecting
+to the metadata database directly. It claims triggers, fetches their workloads, reports fired
+events and failures, cleans up orphaned triggers, and registers and heartbeats its liveness
+through the api-server, the same way task workers already communicate with it.
+
+Operationally:
+
+- The triggerer process no longer opens a metadata-database connection, so database
+  credentials can be dropped from triggerer-only deployments.
+- The api-server's Execution API must be reachable from the triggerer, and the triggerer
+  must be able to mint a token with the configured JWT signing key. Triggers that fetch
+  connections, variables, or XComs already relied on this path (served in-process before);
+  it is now a remote call.
+
+No Dag or trigger code changes are required.
+
+* Migration rules needed
+
+  * None

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/job.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/job.py
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
+
+
+class JobRegisterBody(StrictBaseModel):
+    """Body for registering a new ``Job`` row (e.g. a DB-free triggerer claiming an identity)."""
+
+    job_type: str
+    """The job type, e.g. ``TriggererJob``."""
+    hostname: str
+    """Hostname of the registering process, so the Job row records it (not the api-server's)."""
+
+
+class JobRegisterResponse(BaseModel):
+    """Response carrying the id of the freshly registered ``Job`` row."""
+
+    job_id: int

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/trigger.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/trigger.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import JsonValue
+
+from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
+
+
+class TriggerLoadBody(StrictBaseModel):
+    """Body for requesting triggers to be assigned to and loaded for a triggerer."""
+
+    triggerer_id: int
+    """Id of the requesting triggerer's Job row."""
+    capacity: int
+    """Maximum number of triggers the triggerer can run concurrently."""
+    health_check_threshold: float
+    """Seconds since last heartbeat after which a triggerer is considered dead."""
+    queues: list[str] | None = None
+    """Optional set of trigger queues this triggerer serves."""
+    team_name: str | None = None
+    """Optional team this triggerer serves (multi-team setups)."""
+
+
+class TriggerIdsResponse(BaseModel):
+    """Response listing the trigger IDs currently assigned to a triggerer."""
+
+    trigger_ids: list[int]
+
+
+class TriggerWorkloadsBody(StrictBaseModel):
+    """Body for requesting runnable workloads for a set of trigger IDs."""
+
+    trigger_ids: list[int]
+
+
+class TriggerWorkloadsResponse(BaseModel):
+    """Response carrying serialized ``RunTrigger`` workloads."""
+
+    workloads: list[dict[str, Any]]
+    """Each entry is a ``RunTrigger.model_dump(mode="json")``."""
+
+
+class TriggerEventBody(StrictBaseModel):
+    """Body for submitting a trigger event payload."""
+
+    payload: JsonValue = None
+    """
+    The event payload to resume a deferred task instance with.
+
+    This must be an ``airflow.sdk.serde.serialize(...)`` output, **not** arbitrary JSON. The
+    ``/triggers/{trigger_id}/event`` route stores it **without deserializing** -- it is spliced
+    straight into the task instance's ``next_kwargs``, and the worker deserializes it on resume.
+    The server never reconstructs the worker-supplied object, so passing raw JSON that was never
+    serde-serialized will deserialize into the wrong shape on the worker.
+    """
+
+
+class TriggerFailureBody(StrictBaseModel):
+    """Body for submitting a trigger failure."""
+
+    error: list[str] | None = None
+    """Traceback lines (``traceback.format_exception`` output), kept as a list end-to-end."""

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/__init__.py
@@ -29,9 +29,11 @@ from airflow.api_fastapi.execution_api.routes import (
     dags,
     health,
     hitl,
+    jobs,
     task_instances,
     task_reschedules,
     task_store,
+    triggers,
     variables,
     xcoms,
 )
@@ -60,5 +62,7 @@ authenticated_router.include_router(xcoms.router, prefix="/xcoms", tags=["XComs"
 authenticated_router.include_router(hitl.router, prefix="/hitlDetails", tags=["Human in the Loop"])
 authenticated_router.include_router(task_store.router, prefix="/store/ti", tags=["Task Store"])
 authenticated_router.include_router(asset_store.router, prefix="/store/asset", tags=["Asset Store"])
+authenticated_router.include_router(triggers.router, prefix="/triggers", tags=["Triggers"])
+authenticated_router.include_router(jobs.router, prefix="/jobs", tags=["Jobs"])
 
 execution_api_router.include_router(authenticated_router)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/jobs.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/jobs.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Execution API routes for ``Job`` registration and liveness (AIP-92).
+
+A DB-free triggerer has no metadata-DB access of its own, but trigger assignment in
+``Trigger.assign_unassigned`` keys off a live ``Job`` row (it skips triggerers whose
+heartbeat is stale). These endpoints let such a triggerer register a ``Job`` over HTTP
+and keep it alive, so its triggers are not reassigned to other triggerers.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cadwyn import VersionedAPIRouter
+from fastapi import HTTPException, status
+
+from airflow._shared.timezones import timezone
+from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.execution_api.datamodels.job import JobRegisterBody, JobRegisterResponse
+from airflow.jobs.job import Job, JobState
+
+router = VersionedAPIRouter()
+
+log = logging.getLogger(__name__)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def register_job(body: JobRegisterBody, session: SessionDep) -> JobRegisterResponse:
+    """Create a started + heartbeated ``Job`` row and return its id."""
+    # ``Job.__init__`` already stamps hostname/start_date/latest_heartbeat/unixname; we only
+    # need to mark it RUNNING (mirrors ``Job.prepare_for_execution``) so it counts as alive.
+    job = Job(job_type=body.job_type, state=JobState.RUNNING)
+    # ``Job.__init__`` records the api-server's hostname; overwrite it with the registering
+    # process's hostname so log retrieval (FileTaskHandler) reaches the right host.
+    job.hostname = body.hostname
+    session.add(job)
+    session.flush()
+    return JobRegisterResponse(job_id=job.id)
+
+
+@router.post("/{job_id}/heartbeat", status_code=status.HTTP_204_NO_CONTENT)
+def heartbeat_job(job_id: int, session: SessionDep) -> None:
+    """Record a fresh heartbeat for the given ``Job`` so it stays alive."""
+    job = session.get(Job, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Job {job_id} not found")
+    job.latest_heartbeat = timezone.utcnow()
+    job.end_date = None
+
+
+@router.post("/{job_id}/complete", status_code=status.HTTP_204_NO_CONTENT)
+def complete_job(job_id: int, session: SessionDep) -> None:
+    """Mark the given ``Job`` finished by stamping its end date (mirrors ``Job.complete_execution``)."""
+    job = session.get(Job, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Job {job_id} not found")
+    job.end_date = timezone.utcnow()

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/triggers.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/triggers.py
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Execution API routes for the triggerer (AIP-92).
+
+These endpoints let a DB-free triggerer orchestrate over HTTP instead of accessing the
+metadata database directly: claim triggers, fetch the corresponding runnable workloads,
+and report events/failures/cleanup back to the database.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from cadwyn import VersionedAPIRouter
+from fastapi import status
+
+from airflow.api_fastapi.common.dagbag import DagBagDep
+from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.execution_api.datamodels.trigger import (
+    TriggerEventBody,
+    TriggerFailureBody,
+    TriggerIdsResponse,
+    TriggerLoadBody,
+    TriggerWorkloadsBody,
+    TriggerWorkloadsResponse,
+)
+from airflow.jobs.triggerer_workloads import build_run_trigger_workloads
+from airflow.models.trigger import Trigger
+from airflow.utils.helpers import log_filename_template_renderer
+
+router = VersionedAPIRouter()
+
+log = logging.getLogger(__name__)
+
+
+@router.post("/load", status_code=status.HTTP_200_OK)
+def load_triggers(body: TriggerLoadBody, session: SessionDep) -> TriggerIdsResponse:
+    """Assign unassigned triggers to the triggerer and return its assigned trigger IDs."""
+    queues = set(body.queues) if body.queues else None
+    Trigger.assign_unassigned(
+        body.triggerer_id,
+        body.capacity,
+        body.health_check_threshold,
+        queues=queues,
+        team_name=body.team_name,
+        session=session,
+    )
+    trigger_ids = Trigger.ids_for_triggerer(
+        body.triggerer_id,
+        queues=queues,
+        team_name=body.team_name,
+        session=session,
+    )
+    return TriggerIdsResponse(trigger_ids=trigger_ids)
+
+
+@router.post("/workloads", status_code=status.HTTP_200_OK)
+def get_trigger_workloads(
+    body: TriggerWorkloadsBody,
+    session: SessionDep,
+    dag_bag: DagBagDep,
+) -> TriggerWorkloadsResponse:
+    """Build the runnable ``RunTrigger`` workloads for the given trigger IDs."""
+    render_log_fname = log_filename_template_renderer()
+    built = build_run_trigger_workloads(
+        set(body.trigger_ids),
+        dag_bag=dag_bag,
+        render_log_fname=render_log_fname,
+        session=session,
+    )
+    return TriggerWorkloadsResponse(workloads=[w.model_dump(mode="json") for w in built])
+
+
+@router.post("/{trigger_id}/event", status_code=status.HTTP_204_NO_CONTENT)
+def submit_trigger_event(trigger_id: int, body: TriggerEventBody, session: SessionDep) -> None:
+    """Submit an event for a trigger, resuming any deferred task instances waiting on it."""
+    # ``body.payload`` is a serde (``airflow.sdk.serde.serialize``) output supplied by an
+    # execution-scoped worker. The server stores it WITHOUT deserializing -- it is spliced
+    # straight into the task instance's next_kwargs, and the worker deserializes it on resume.
+    # This avoids running ``import_string`` on a worker-controlled body in the trusted api-server.
+    Trigger.submit_event_serialized(trigger_id, body.payload, session=session)
+
+
+@router.post("/{trigger_id}/failure", status_code=status.HTTP_204_NO_CONTENT)
+def submit_trigger_failure(trigger_id: int, body: TriggerFailureBody, session: SessionDep) -> None:
+    """Submit a failure for a trigger, re-scheduling dependent task instances to fail."""
+    Trigger.submit_failure(trigger_id, body.error, session=session)
+
+
+@router.post("/cleanup", status_code=status.HTTP_204_NO_CONTENT)
+def cleanup_triggers(session: SessionDep) -> None:
+    """Delete triggers that no longer have any task, asset, or callback depending on them."""
+    Trigger.clean_unused(session=session)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -50,9 +50,11 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
     AddConnectionTestEndpoint,
     AddVariableKeysEndpoint,
 )
+from airflow.api_fastapi.execution_api.versions.v2026_07_14 import AddJobEndpoints, AddTriggerEndpoints
 
 bundle = VersionBundle(
     HeadVersion(),
+    Version("2026-07-14", AddTriggerEndpoints, AddJobEndpoints),
     Version("2026-06-30", AddVariableKeysEndpoint, AddConnectionTestEndpoint),
     Version(
         "2026-06-16",

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_07_14.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_07_14.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from cadwyn import VersionChange, endpoint
+
+
+class AddTriggerEndpoints(VersionChange):
+    """Add triggerer orchestration endpoints so a DB-free triggerer can run over HTTP (AIP-92)."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        endpoint("/triggers/load", ["POST"]).didnt_exist,
+        endpoint("/triggers/workloads", ["POST"]).didnt_exist,
+        endpoint("/triggers/{trigger_id}/event", ["POST"]).didnt_exist,
+        endpoint("/triggers/{trigger_id}/failure", ["POST"]).didnt_exist,
+        endpoint("/triggers/cleanup", ["POST"]).didnt_exist,
+    )
+
+
+class AddJobEndpoints(VersionChange):
+    """Add Job register/heartbeat endpoints so a DB-free triggerer can claim a Job identity (AIP-92)."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        endpoint("/jobs", ["POST"]).didnt_exist,
+        endpoint("/jobs/{job_id}/heartbeat", ["POST"]).didnt_exist,
+        endpoint("/jobs/{job_id}/complete", ["POST"]).didnt_exist,
+    )

--- a/airflow-core/src/airflow/cli/commands/triggerer_command.py
+++ b/airflow-core/src/airflow/cli/commands/triggerer_command.py
@@ -26,7 +26,7 @@ from multiprocessing import Process
 from airflow.cli.commands.daemon_utils import run_command_with_daemon_option
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
-from airflow.jobs.job import Job, run_job
+from airflow.jobs.job import Job
 from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.utils import cli as cli_utils
 from airflow.utils.memray_utils import MemrayTraceComponents, enable_memray_trace
@@ -59,13 +59,17 @@ def triggerer_run(
     team_name: str | None = None,
 ):
     with _serve_logs(skip_serve_logs):
+        # AIP-92: the triggerer holds no metadata-DB connection. Its supervisor registers and
+        # heartbeats a liveness Job through the Execution API, so run the job runner directly
+        # instead of through run_job, whose prepare_for_execution would write a Job row to the
+        # database. The in-memory Job below is never persisted; it only carries the job type.
         triggerer_job_runner = TriggererJobRunner(
             job=Job(heartrate=triggerer_heartrate), capacity=capacity, queues=queues, team_name=team_name
         )
-        run_job(job=triggerer_job_runner.job, execute_callable=triggerer_job_runner._execute)
+        triggerer_job_runner._execute()
 
 
-@cli_utils.action_cli
+@cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def triggerer(args):
     """Start Airflow Triggerer."""

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -38,6 +38,7 @@ from uuid import uuid4
 import anyio
 import attrs
 import greenback
+import httpx
 import structlog
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
@@ -49,14 +50,19 @@ from structlog.contextvars import bind_contextvars as bind_log_contextvars
 from airflow._shared.module_loading import import_string
 from airflow._shared.observability.metrics import stats
 from airflow._shared.timezones import timezone
+from airflow.api_fastapi.auth.tokens import JWTGenerator, get_signing_args
 from airflow.configuration import conf
+
+# Imported at runtime (not under TYPE_CHECKING) because Pydantic models below
+# (e.g. TriggerStateSync) resolve `workloads.RunTrigger` annotations at class build time.
 from airflow.executors import workloads
+from airflow.executors.base_executor import get_execution_api_server_url
 from airflow.executors.workloads.task import TaskInstanceDTO
 from airflow.jobs.base_job_runner import BaseJobRunner
-from airflow.jobs.job import perform_heartbeat
-from airflow.models.dagbag import DBDagBag
+from airflow.jobs.job import Job
 from airflow.models.trigger import Trigger
 from airflow.observability.metrics import stats_utils
+from airflow.sdk.api.client import Client, ServerResponseError
 from airflow.sdk.api.datamodels._generated import HITLDetailResponse
 from airflow.sdk.execution_time.comms import (
     CommsDecoder,
@@ -107,21 +113,20 @@ from airflow.sdk.execution_time.request_handlers import (
 )
 from airflow.sdk.execution_time.supervisor import WatchedSubprocess, make_buffered_socket_reader
 from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+from airflow.sdk.serde import serialize as serde_serialize
 from airflow.serialization.serialized_objects import DagSerialization
 from airflow.triggers.base import BaseEventTrigger, BaseTrigger, DiscrimatedTriggerEvent, TriggerEvent
 from airflow.triggers.shared_stream import SharedStreamManager
 from airflow.utils.helpers import log_filename_template_renderer
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import create_session, provide_session
+from airflow.utils.net import get_hostname
+from airflow.utils.session import provide_session
 
 if TYPE_CHECKING:
     from opentelemetry.util._decorator import _AgnosticContextManager
     from sqlalchemy.orm import Session
     from structlog.typing import FilteringBoundLogger, WrappedLogger
 
-    from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
-    from airflow.jobs.job import Job
-    from airflow.sdk.api.client import Client
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 
@@ -131,6 +136,36 @@ tracer = trace.get_tracer(__name__)
 _USER_ACTION_CANCEL_MSG = "__airflow_user_action__"
 
 _ON_CANCEL_TIMEOUT: int = conf.getint("triggerer", "on_kill_timeout", fallback=30)
+
+# Sentinel ``sub`` accepted by the execution_api ``require_auth`` (scope defaults to "execution";
+# the trigger/job routes do not enforce ``ti:self``). Mirrors the parse-time token pattern.
+_SENTINEL_SUB = "00000000-0000-0000-0000-000000000000"
+
+# httpx/Client errors caught at the guarded per-loop call sites. This is deliberately broad
+# (it catches 4xx as well as 5xx) so the ``except`` clauses are cheap to write; ``_is_transient``
+# below then re-raises the non-transient ones so a persistent 4xx crashes loudly instead of
+# looping forever at WARNING.
+_TRANSIENT_API_ERRORS = (ServerResponseError, httpx.HTTPError)
+
+
+def _is_transient(exc: Exception) -> bool:
+    """
+    Return ``True`` only for failures worth retrying next loop (a transient API blip).
+
+    A persistent 4xx (e.g. a malformed body or auth problem) is a logic bug the client never
+    retries; swallowing it would wedge the triggerer silently. ``ServerResponseError`` subclasses
+    ``httpx.HTTPStatusError``, so the first branch covers both.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    # Connection resets, timeouts, DNS failures, etc. -- genuinely transient.
+    return isinstance(exc, httpx.TransportError)
+
+
+# How long to keep retrying the initial Job registration while the api-server is still starting up.
+# The triggerer often boots alongside the api-server (e.g. docker-compose), so an early transient
+# error means "not ready yet, wait" rather than a fatal misconfiguration. After this, give up loudly.
+_STARTUP_REGISTER_TIMEOUT = 300.0
 
 
 def _make_trigger_span(
@@ -240,16 +275,19 @@ class TriggererJobRunner(BaseJobRunner, LoggingMixin):
             export_legacy_names=conf.getboolean("metrics", "legacy_names_on"),
         )
         try:
-            # Kick off runner sub-process without DB access
+            # AIP-92: the triggerer orchestrates through the Execution API with no metadata-DB
+            # access. Kick off the runner sub-process without DB access. ``job=None``: the
+            # supervisor registers and heartbeats its liveness Job through the Execution API,
+            # not a metadata-DB row.
             self.trigger_runner = TriggerRunnerSupervisor.start(
-                job=self.job,
+                job=None,
                 capacity=self.capacity,
                 logger=log,
                 queues=self.queues,
                 team_name=self.team_name,
             )
 
-            # Run the main DB comms loop in this process
+            # Run the main comms loop in this process
             self.trigger_runner.run()
             return self.trigger_runner._exit_code
         except Exception:
@@ -409,27 +447,20 @@ class TriggerLoggingFactory:
         upload_to_remote(self.bound_logger, self.ti)
 
 
-def in_process_api_server() -> InProcessExecutionAPI:
-    from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
-
-    api = InProcessExecutionAPI()
-    return api
-
-
 @attrs.define(kw_only=True)
 class TriggerRunnerSupervisor(WatchedSubprocess):
     """
-    TriggerRunnerSupervisor is responsible for monitoring the subprocess and marshalling DB access.
+    Monitor the async TriggerRunner subprocess and orchestrate triggers over the Execution API.
 
-    This class (which runs in the main/sync process) is responsible for querying the DB, sending RunTrigger
-    workload messages to the subprocess, and collecting results and updating them in the DB.
+    This class (which runs in the main/sync process) holds **no** metadata-DB access (AIP-92).
+    Instead of reading/writing the ``trigger``/``job`` tables directly, it routes all
+    orchestration through the Execution API: it registers a ``Job`` over HTTP, claims triggers,
+    fetches their ``RunTrigger`` workloads, sends them to the subprocess, and reports
+    events/failures/cleanup back to the server.
 
-    ``job`` is optional so AIP-92 Execution-API-backed subclasses can run without a metadata-DB
-    ``Job``. Such subclasses **must** override the methods that read ``self.job`` —
-    :meth:`heartbeat`, :meth:`load_triggers`, and :meth:`metric_tags` — to source their data
-    from the Execution API or another backend. The base implementations of those methods raise
-    :class:`RuntimeError` when called with ``job=None`` so a missing override fails immediately
-    rather than silently zombieing the supervisor.
+    ``job`` is always ``None``: the supervisor registers and heartbeats a liveness ``Job`` through
+    the Execution API rather than a metadata-DB row. Keeping the supervisor DB-free is what lets it
+    eventually move into the ``task_sdk`` module, which has no metadata-DB access.
     """
 
     job: Job | None = None
@@ -442,6 +473,19 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
     runner: TriggerRunner | None = None
     stop: bool = False
+
+    # Id of the Job row this triggerer registered over the API. Used wherever a Job id is needed
+    # (heartbeat, trigger-load, log filename). Set in ``run_context`` once the client is available.
+    _triggerer_id: int | None = attrs.field(init=False, default=None)
+
+    # Monotonic timestamp of the last successful Job heartbeat, used to throttle to the heartrate
+    # so we don't POST every single loop iteration.
+    _last_heartbeat: float = attrs.field(init=False, default=0.0)
+    _heartrate: float = attrs.field(init=False, factory=lambda: Job._heartrate("TriggererJob"))
+
+    # Lazily-built log-filename renderer (DB-free: reads only ``logging.log_filename_template``).
+    # Used to reconstruct the per-trigger log path so logs are captured and uploaded on finish.
+    _log_fname_renderer: Callable[..., str] | None = attrs.field(init=False, default=None)
 
     # Timestamp of the last message received from the TriggerRunner subprocess.  Updated on
     # every message; if it goes silent for longer than runner_health_check_threshold the
@@ -496,21 +540,22 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         return self.make_client()
 
     def make_client(self) -> Client:
-        """
-        Build the API client used to talk to the API server.
+        """Build a REMOTE client pointing at the execution API, authenticated with a minted token."""
+        token = JWTGenerator(
+            valid_for=conf.getint("execution_api", "jwt_expiration_time"),
+            audience=conf.get_mandatory_list_value("execution_api", "jwt_audience")[0],
+            issuer=conf.get("api_auth", "jwt_issuer", fallback=None),
+            **get_signing_args(make_secret_key_if_needed=False),
+        ).generate({"sub": _SENTINEL_SUB})
+        return Client(base_url=get_execution_api_server_url(), token=token, dry_run=False)
 
-        Subclasses may override this to substitute a different transport — e.g. a
-        real HTTP client pointing at a remote API server — instead of the default
-        in-process one. The returned client must have ``base_url`` set; downstream
-        request handling (``self.client.variables``, ``.xcoms``, etc.) reads it
-        when issuing requests.
-        """
-        from airflow.sdk.api.client import Client
-
-        client = Client(base_url=None, token="", dry_run=True, transport=in_process_api_server().transport)
-        # Mypy is wrong -- the setter accepts a string on the property setter! `URLType = URL | str`
-        client.base_url = "http://in-process.invalid./"
-        return client
+    @property
+    def triggerer_id(self) -> int:
+        if self._triggerer_id is None:
+            raise RuntimeError(
+                "Triggerer Job has not been registered yet; run_context() must run before this is used."
+            )
+        return self._triggerer_id
 
     def _handle_request(self, msg: ToTriggerSupervisor, log: FilteringBoundLogger, req_id: int) -> None:
 
@@ -594,7 +639,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         self.send_msg(resp, request_id=req_id, error=None, **dump_opts)
 
     def run(self) -> None:
-        """Run synchronously and handle all database reads/writes."""
+        """Run the synchronous supervisor loop, orchestrating triggers over the Execution API."""
         with self.run_context():
             while not self.should_stop():
                 if not self.is_alive():
@@ -602,10 +647,41 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                     break
                 self.run_once()
 
+    def _register_triggerer_job(self) -> int:
+        """
+        Register the liveness Job over the API, retrying while the api-server is still starting.
+
+        The triggerer can boot before the api-server is ready to serve (they often start together),
+        so a transient error here means "not up yet, wait" rather than a fatal misconfiguration.
+        Retry with capped backoff until ``_STARTUP_REGISTER_TIMEOUT``, then let the error propagate.
+        """
+        deadline = time.monotonic() + _STARTUP_REGISTER_TIMEOUT
+        delay = 1.0
+        while True:
+            try:
+                return self.client.jobs.register("TriggererJob", get_hostname())
+            except _TRANSIENT_API_ERRORS as e:
+                if not _is_transient(e) or time.monotonic() >= deadline:
+                    raise
+                log.warning("Execution API not ready; retrying triggerer Job registration", exc_info=True)
+                time.sleep(delay)
+                delay = min(delay * 2, 10.0)
+
     @contextmanager
     def run_context(self) -> Iterator[None]:
-        """Wrap the run loop. Subclasses can override to install setup/teardown."""
-        yield
+        """Register a Job over the API once before the run loop starts; finalize it on shutdown."""
+        self._triggerer_id = self._register_triggerer_job()
+        log.info("Registered triggerer Job via Execution API", triggerer_id=self._triggerer_id)
+        try:
+            yield
+        finally:
+            # Stamp the Job's end_date so it isn't left looking RUNNING forever. Best-effort:
+            # a transient API blip here shouldn't mask the real shutdown reason.
+            if self._triggerer_id is not None:
+                try:
+                    self.client.jobs.complete(self._triggerer_id)
+                except _TRANSIENT_API_ERRORS:
+                    log.warning("Failed to finalize triggerer Job via Execution API", exc_info=True)
 
     def should_stop(self) -> bool:
         """Return True when the run loop should exit."""
@@ -625,12 +701,13 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
         self.emit_metrics()
 
-    def heartbeat(self):
-        if self.job is None:
-            raise RuntimeError(
-                "TriggerRunnerSupervisor.heartbeat() requires a Job; "
-                "subclasses without a metadata-DB Job must override this method."
-            )
+    def heartbeat(self) -> None:
+        """
+        Heartbeat the Job over the API, throttled to the job heartrate.
+
+        Keeps the runner-deadlock silence check so a hung event loop still stops heartbeating
+        (which lets the scheduler reassign this triggerer's triggers).
+        """
         elapsed = time.monotonic() - self._last_runner_comms
         if self.runner_health_check_threshold > 0 and elapsed > self.runner_health_check_threshold:
             if not self._runner_comms_silence_logged:
@@ -644,80 +721,105 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 self._runner_comms_silence_logged = True
             return
         self._runner_comms_silence_logged = False
-        perform_heartbeat(self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True)
 
-    def heartbeat_callback(self, session: Session | None = None) -> None:
+        now = time.monotonic()
+        if self._heartrate > 0 and (now - self._last_heartbeat) < self._heartrate:
+            return
+        try:
+            self.client.jobs.heartbeat(self.triggerer_id)
+        except _TRANSIENT_API_ERRORS as e:
+            if not _is_transient(e):
+                raise
+            # A missed heartbeat is not fatal; the next loop retries. Crashing the loop on a
+            # transient blip would be worse (it'd tear down all running triggers).
+            log.warning("Failed to heartbeat Job via Execution API; will retry next cycle", exc_info=True)
+            return
+        self._last_heartbeat = now
         stats.incr("triggerer_heartbeat", 1, 1)
 
     def load_triggers(self) -> None:
-        """Assign triggers to this triggerer and update the runner with the IDs it should run."""
-        if self.job is None:
-            raise RuntimeError(
-                "TriggerRunnerSupervisor.load_triggers() requires a Job; "
-                "subclasses without a metadata-DB Job must override this method."
+        """Claim triggers over the API and reconcile the runner's running set."""
+        try:
+            ids = self.client.triggers.load(
+                triggerer_id=self.triggerer_id,
+                capacity=self.capacity,
+                health_check_threshold=self.health_check_threshold,
+                queues=list(self.queues) if self.queues else None,
+                team_name=self.team_name,
             )
-        Trigger.assign_unassigned(
-            self.job.id,
-            self.capacity,
-            self.health_check_threshold,
-            queues=self.queues,
-            team_name=self.team_name,
-        )
-        ids = Trigger.ids_for_triggerer(self.job.id, queues=self.queues, team_name=self.team_name)
+        except _TRANSIENT_API_ERRORS as e:
+            if not _is_transient(e):
+                raise
+            log.warning("Failed to load triggers from Execution API; skipping this cycle", exc_info=True)
+            return
+        # Reuse the base diff logic (works out adds/cancels against what we already run).
         self.update_triggers(set(ids))
 
-    def handle_events(self):
-        """Dispatch outbound events to the Trigger model which pushes them to the relevant task instances."""
+    def handle_events(self) -> None:
+        """
+        Submit fired events over the API, re-queuing on a transient blip.
+
+        Popping the event then submitting it means a raised client call would lose the popped
+        event if the loop crashed. Here a transient error re-queues the event (preserving FIFO
+        order) and stops the loop so it retries next cycle.
+        """
         while self.events:
-            # Get the event and its trigger ID
             trigger_id, event = self.events.popleft()
-            # Tell the model to wake up its tasks
-            self.on_trigger_event(trigger_id=trigger_id, event=event)
-            # Emit stat event
+            try:
+                self.on_trigger_event(trigger_id, event)
+            except _TRANSIENT_API_ERRORS as e:
+                if not _is_transient(e):
+                    raise
+                log.warning(
+                    "Failed to submit trigger event via Execution API; will retry next cycle",
+                    exc_info=True,
+                )
+                self.events.appendleft((trigger_id, event))
+                break
             stats.incr("triggers.succeeded")
 
     def on_trigger_event(self, trigger_id: int, event: TriggerEvent) -> None:
-        """Record that a trigger fired an event."""
-        Trigger.submit_event(trigger_id=trigger_id, event=event)
+        """Report a fired event over the API (the run loop guards against transient errors)."""
+        # The payload may be a non-JSON-native object (e.g. a pendulum DateTime from a temporal
+        # trigger). Serialize it with serde so it survives the HTTP hop. The server splices this
+        # serde form straight into the task instance's next_kwargs WITHOUT deserializing it -- the
+        # worker deserializes it on resume. This keeps untrusted worker payloads from being
+        # reconstructed inside the trusted api-server.
+        self.client.triggers.submit_event(trigger_id, serde_serialize(event.payload))
 
     def clean_unused(self) -> None:
-        """Remove triggers that are no longer needed."""
-        Trigger.clean_unused()
+        """Ask the server to delete orphaned triggers; tolerate a transient API blip."""
+        try:
+            self.client.triggers.cleanup()
+        except _TRANSIENT_API_ERRORS as e:
+            if not _is_transient(e):
+                raise
+            log.warning("Failed to clean up triggers via Execution API; skipping this cycle", exc_info=True)
 
-    def handle_failed_triggers(self):
-        """
-        Handle "failed" triggers. - ones that errored or exited before they sent an event.
-
-        Task Instances that depend on them need failing.
-        """
+    def handle_failed_triggers(self) -> None:
+        """Submit trigger failures over the API, re-queuing on a transient blip (see ``handle_events``)."""
         while self.failed_triggers:
-            # Tell the model to fail this trigger's deps
             trigger_id, exc = self.failed_triggers.popleft()
-            self.on_trigger_failure(trigger_id=trigger_id, exc=exc)
-            # Emit stat event
+            try:
+                self.on_trigger_failure(trigger_id, exc)
+            except _TRANSIENT_API_ERRORS as e:
+                if not _is_transient(e):
+                    raise
+                log.warning(
+                    "Failed to submit trigger failure via Execution API; will retry next cycle",
+                    exc_info=True,
+                )
+                self.failed_triggers.appendleft((trigger_id, exc))
+                break
             stats.incr("triggers.failed")
 
     def on_trigger_failure(self, trigger_id: int, exc: list[str] | None) -> None:
-        """Record that a trigger failed."""
-        Trigger.submit_failure(trigger_id=trigger_id, exc=exc)
+        """Report a trigger failure over the API (the run loop guards against transient errors)."""
+        self.client.triggers.submit_failure(trigger_id, exc)
 
     def metric_tags(self) -> dict[str, str]:
-        """
-        Return extra tags applied to gauges emitted by :meth:`emit_metrics`.
-
-        Subclasses that don't have a metadata-DB ``Job`` (e.g. AIP-92 Execution-API-backed
-        triggerers) **must** override this to supply ``hostname`` (and any other identity
-        tags) from another source. ``triggers.running`` and ``triggerer.capacity_left``
-        declare ``hostname`` as a required name variable in ``metrics_template.yaml``, so
-        an empty dict here would crash :meth:`emit_metrics` on every tick.
-        """
-        hostname = self.job.hostname if self.job is not None else None
-        if hostname is None:
-            raise RuntimeError(
-                "TriggerRunnerSupervisor.metric_tags() requires a Job with a hostname; "
-                "subclasses without a metadata-DB Job must override this method."
-            )
-        return {"hostname": hostname}
+        """Supply the ``hostname`` tag from the host (the supervisor has no metadata-DB Job row)."""
+        return {"hostname": get_hostname()}
 
     def emit_metrics(self):
         tags = self.metric_tags()
@@ -734,124 +836,58 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             tags=tags,
         )
 
-    def _create_workload(
-        self,
-        trigger: Trigger,
-        dag_bag: DBDagBag,
-        render_log_fname: Callable[..., str],
-        session: Session,
-    ) -> workloads.RunTrigger | None:
-        if trigger.task_instance is None:
-            return workloads.RunTrigger(
-                id=trigger.id,
-                classpath=trigger.classpath,
-                encrypted_kwargs=trigger.encrypted_kwargs,
-            )
+    def _trigger_log_id(self) -> int:
+        """
+        Return the id embedded in the on-disk trigger log filename.
 
-        if not trigger.task_instance.dag_version_id:
-            # This is to handle 2 to 3 upgrade where TI.dag_version_id can be none
-            log.warning(
-                "TaskInstance associated with Trigger has no associated Dag Version, skipping the trigger",
-                ti_id=trigger.task_instance.id,
-            )
-            return None
+        The reader side (``FileTaskHandler.add_triggerer_suffix``) formats the suffix from
+        ``ti.triggerer_job.id`` (an int). Use the registered Job id so the writer's filename
+        matches the reader's expectation.
+        """
+        return self.triggerer_id
 
-        log_path = render_log_fname(ti=trigger.task_instance)
-        ser_ti = TaskInstanceDTO.model_validate(trigger.task_instance, from_attributes=True)
-
+    def _register_trigger_logger(self, trigger_id: int, ser_ti: TaskInstanceDTO, log_path: str) -> None:
         # When producing logs from TIs, include the supervisor id producing the logs to disambiguate it.
-        # Note: with a Job this is an int (Job.id); without a Job it's a UUID. The reader side
-        # (FileTaskHandler.add_triggerer_suffix) currently formats the suffix from
-        # ``ti.triggerer_job.id``, which only resolves the int form — AIP-92 subclasses without a
-        # metadata Job need their own log retrieval path.
-        log_id = self.job.id if self.job is not None else self.id
-        self.logger_cache[trigger.id] = TriggerLoggingFactory(
+        log_id = self._trigger_log_id()
+        self.logger_cache[trigger_id] = TriggerLoggingFactory(
             log_path=f"{log_path}.trigger.{log_id}.log",
             ti=ser_ti,  # type: ignore
         )
 
-        serialized_dag_model = dag_bag.get_serialized_dag_model(
-            version_id=trigger.task_instance.dag_version_id,
-            session=session,
-        )
-
-        if serialized_dag_model:
-            task = serialized_dag_model.dag.get_task(trigger.task_instance.task_id)
-
-            # When a TaskInstance of a Trigger contains a task with start_from_trigger enabled,
-            # it means we need to load the SerializedDagModel so we can build a RuntimeTaskInstance later on which
-            # will allow us to build a context on which we will render the templated fields.
-            if task.start_from_trigger:
-                log.info("Start from trigger enabled for task %s", task.task_id)
-                dag_run = trigger.task_instance.get_dagrun(session=session)
-
-                return workloads.RunTrigger(
-                    id=trigger.id,
-                    classpath=trigger.classpath,
-                    encrypted_kwargs=trigger.encrypted_kwargs,
-                    ti=ser_ti,
-                    timeout_after=trigger.task_instance.trigger_timeout,
-                    dag_data=serialized_dag_model.data,
-                    dag_run_data=dag_run.dag_run_data.model_dump(exclude_unset=True),
-                )
-        return workloads.RunTrigger(
-            id=trigger.id,
-            classpath=trigger.classpath,
-            encrypted_kwargs=trigger.encrypted_kwargs,
-            ti=ser_ti,
-            timeout_after=trigger.task_instance.trigger_timeout,
-        )
-
-    def fetch_trigger_details(self, trigger_ids: set[int], *, session: Session) -> dict[int, Trigger]:
-        """Fetch trigger rows by ID."""
-        return Trigger.bulk_fetch(trigger_ids, session=session)
-
-    def fetch_non_task_trigger_ids(self, *, session: Session) -> set[int]:
-        """Fetch trigger IDs associated with non-task entities."""
-        return Trigger.fetch_trigger_ids_with_non_task_associations(session=session)
+    def _render_log_path(self, ti: TaskInstanceDTO) -> str:
+        if self._log_fname_renderer is None:
+            self._log_fname_renderer = log_filename_template_renderer()
+        return self._log_fname_renderer(ti=ti)
 
     def build_trigger_workloads(self, new_trigger_ids: set[int]) -> list[workloads.RunTrigger]:
-        """Build workloads for new trigger IDs."""
-        dag_bag = DBDagBag()
-        render_log_fname = log_filename_template_renderer()
-        with create_session() as session:
-            new_triggers = self.fetch_trigger_details(new_trigger_ids, session=session)
-            trigger_ids_with_non_task_associations = self.fetch_non_task_trigger_ids(session=session)
-            to_create: list[workloads.RunTrigger] = []
-            for new_trigger_id in new_trigger_ids:
-                # Check it didn't vanish in the meantime
-                if new_trigger_id not in new_triggers:
-                    log.warning("Trigger disappeared before we could start it", id=new_trigger_id)
-                    continue
+        """
+        Fetch workloads for newly-claimed triggers over the API and register their loggers.
 
-                new_trigger_orm = new_triggers[new_trigger_id]
+        On a transient API blip we return an empty list: the triggers stay assigned to us and get
+        re-fetched on the next load cycle, so nothing is lost.
+        """
+        try:
+            raw = self.client.triggers.workloads(list(new_trigger_ids))
+        except _TRANSIENT_API_ERRORS as e:
+            if not _is_transient(e):
+                raise
+            log.warning(
+                "Failed to fetch trigger workloads from Execution API; will retry next cycle",
+                exc_info=True,
+            )
+            return []
 
-                # If the trigger is not associated to a task, an asset, or a callback, this means the TaskInstance
-                # row was updated by either Trigger.submit_event or Trigger.submit_failure
-                # and can happen when a single trigger Job is being run on multiple TriggerRunners
-                # in a High-Availability setup.
-                if (
-                    new_trigger_orm.task_instance is None
-                    and new_trigger_id not in trigger_ids_with_non_task_associations
-                ):
-                    log.info(
-                        (
-                            "TaskInstance of Trigger is None. It was likely updated by another trigger job. "
-                            "Skipping trigger instantiation."
-                        ),
-                        id=new_trigger_id,
-                    )
-                    continue
+        # The client returns the workloads as raw dicts (it must not import the core RunTrigger
+        # type); validate them into RunTrigger objects here in airflow-core.
+        built = [workloads.RunTrigger.model_validate(w) for w in raw]
 
-                if workload := self._create_workload(
-                    trigger=new_trigger_orm,
-                    dag_bag=dag_bag,
-                    render_log_fname=render_log_fname,
-                    session=session,
-                ):
-                    to_create.append(workload)
-
-        return to_create
+        # Register a per-trigger logging factory for each task-backed workload so its logs are
+        # captured and uploaded on finish. The workloads come over HTTP, so we re-derive the log
+        # path here from the (DB-free) filename renderer and the workload's TaskInstanceDTO.
+        for workload in built:
+            if workload.ti is not None:
+                self._register_trigger_logger(workload.id, workload.ti, self._render_log_path(workload.ti))
+        return built
 
     def update_triggers(self, requested_trigger_ids: set[int]):
         """

--- a/airflow-core/src/airflow/jobs/triggerer_workloads.py
+++ b/airflow-core/src/airflow/jobs/triggerer_workloads.py
@@ -1,0 +1,188 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Shared builder that turns ``Trigger`` rows into ``RunTrigger`` workloads.
+
+This logic is used in two places that must produce identical workloads:
+
+* :class:`~airflow.jobs.triggerer_job_runner.TriggerRunnerSupervisor`, which builds
+  workloads in-process from its own metadata-DB session.
+* The Execution API ``/triggers/workloads`` endpoint (AIP-92), which builds the
+  same workloads server-side so a DB-free triggerer can fetch them over HTTP.
+
+Keeping a single implementation here avoids the two paths drifting apart.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from airflow.executors import workloads
+from airflow.executors.workloads.task import TaskInstanceDTO
+from airflow.models.trigger import Trigger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from sqlalchemy.orm import Session
+
+    from airflow.models.dagbag import DBDagBag
+
+log = logging.getLogger(__name__)
+
+
+def build_run_trigger_workload(
+    trigger: Trigger,
+    *,
+    dag_bag: DBDagBag,
+    render_log_fname: Callable[..., str],
+    session: Session,
+    on_ti_logging: Callable[[int, TaskInstanceDTO, str], None] | None = None,
+) -> workloads.RunTrigger | None:
+    """
+    Build a single :class:`~airflow.executors.workloads.RunTrigger` for ``trigger``.
+
+    :param trigger: The trigger ORM row to build a workload for.
+    :param dag_bag: DagBag used to load the serialized DAG for task-backed triggers.
+    :param render_log_fname: Callable returning the trigger log path for a task instance.
+    :param session: The database session.
+    :param on_ti_logging: Optional callback invoked for task-backed triggers with
+        ``(trigger_id, ser_ti, log_path)``. The supervisor uses this to register a
+        per-trigger logging factory; the Execution API endpoint omits it because it only
+        needs the serializable workload. Kept as a callback so the workload-building logic
+        stays in one place while the supervisor's ``self``-bound side effect lives there.
+    :return: The built workload, or ``None`` if the trigger should be skipped.
+    """
+    if trigger.task_instance is None:
+        return workloads.RunTrigger(
+            id=trigger.id,
+            classpath=trigger.classpath,
+            encrypted_kwargs=trigger.encrypted_kwargs,
+        )
+
+    if not trigger.task_instance.dag_version_id:
+        # This is to handle 2 to 3 upgrade where TI.dag_version_id can be none
+        log.warning(
+            "TaskInstance %s associated with Trigger has no associated Dag Version, skipping the trigger",
+            trigger.task_instance.id,
+        )
+        return None
+
+    log_path = render_log_fname(ti=trigger.task_instance)
+    ser_ti = TaskInstanceDTO.model_validate(trigger.task_instance, from_attributes=True)
+
+    if on_ti_logging is not None:
+        on_ti_logging(trigger.id, ser_ti, log_path)
+
+    serialized_dag_model = dag_bag.get_serialized_dag_model(
+        version_id=trigger.task_instance.dag_version_id,
+        session=session,
+    )
+
+    if serialized_dag_model:
+        task = serialized_dag_model.dag.get_task(trigger.task_instance.task_id)
+
+        # When a TaskInstance of a Trigger contains a task with start_from_trigger enabled,
+        # it means we need to load the SerializedDagModel so we can build a RuntimeTaskInstance later on
+        # which will allow us to build a context on which we will render the templated fields.
+        if task.start_from_trigger:
+            log.info("Start from trigger enabled for task %s", task.task_id)
+            dag_run = trigger.task_instance.get_dagrun(session=session)
+
+            return workloads.RunTrigger(
+                id=trigger.id,
+                classpath=trigger.classpath,
+                encrypted_kwargs=trigger.encrypted_kwargs,
+                ti=ser_ti,
+                timeout_after=trigger.task_instance.trigger_timeout,
+                dag_data=serialized_dag_model.data,
+                dag_run_data=dag_run.dag_run_data.model_dump(exclude_unset=True),
+            )
+    return workloads.RunTrigger(
+        id=trigger.id,
+        classpath=trigger.classpath,
+        encrypted_kwargs=trigger.encrypted_kwargs,
+        ti=ser_ti,
+        timeout_after=trigger.task_instance.trigger_timeout,
+    )
+
+
+def build_run_trigger_workloads(
+    trigger_ids: set[int],
+    *,
+    dag_bag: DBDagBag,
+    render_log_fname: Callable[..., str],
+    session: Session,
+    on_ti_logging: Callable[[int, TaskInstanceDTO, str], None] | None = None,
+    bulk_fetch: Callable[..., dict[int, Trigger]] | None = None,
+    fetch_non_task_ids: Callable[..., set[int]] | None = None,
+) -> list[workloads.RunTrigger]:
+    """
+    Build :class:`~airflow.executors.workloads.RunTrigger` workloads for ``trigger_ids``.
+
+    Triggers that vanished, or that are no longer associated with a task, asset, or callback
+    (e.g. resolved by another triggerer in an HA setup), are skipped.
+
+    :param trigger_ids: The trigger IDs to build workloads for.
+    :param dag_bag: DagBag used to load serialized DAGs for task-backed triggers.
+    :param render_log_fname: Callable returning the trigger log path for a task instance.
+    :param session: The database session.
+    :param on_ti_logging: Optional per-trigger callback, see :func:`build_run_trigger_workload`.
+    :param bulk_fetch: Override for fetching trigger rows; defaults to ``Trigger.bulk_fetch``. The
+        supervisor injects its own hook so it can instrument/override the fetch.
+    :param fetch_non_task_ids: Override for fetching non-task trigger IDs; defaults to
+        ``Trigger.fetch_trigger_ids_with_non_task_associations``.
+    """
+    if bulk_fetch is None:
+        bulk_fetch = Trigger.bulk_fetch
+    if fetch_non_task_ids is None:
+        fetch_non_task_ids = Trigger.fetch_trigger_ids_with_non_task_associations
+
+    new_triggers = bulk_fetch(trigger_ids, session=session)
+    trigger_ids_with_non_task_associations = fetch_non_task_ids(session=session)
+
+    to_create: list[workloads.RunTrigger] = []
+    for trigger_id in trigger_ids:
+        # Check it didn't vanish in the meantime
+        if trigger_id not in new_triggers:
+            log.warning("Trigger %s disappeared before we could start it", trigger_id)
+            continue
+
+        new_trigger_orm = new_triggers[trigger_id]
+
+        # If the trigger is not associated to a task, an asset, or a callback, this means the TaskInstance
+        # row was updated by either Trigger.submit_event or Trigger.submit_failure and can happen when a
+        # single trigger Job is being run on multiple TriggerRunners in a High-Availability setup.
+        if new_trigger_orm.task_instance is None and trigger_id not in trigger_ids_with_non_task_associations:
+            log.info(
+                "TaskInstance of Trigger %s is None. It was likely updated by another trigger job. "
+                "Skipping trigger instantiation.",
+                trigger_id,
+            )
+            continue
+
+        if workload := build_run_trigger_workload(
+            new_trigger_orm,
+            dag_bag=dag_bag,
+            render_log_fname=render_log_fname,
+            session=session,
+            on_ti_logging=on_ti_logging,
+        ):
+            to_create.append(workload)
+
+    return to_create

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -301,6 +301,52 @@ class Trigger(Base):
 
     @classmethod
     @provide_session
+    def submit_event_serialized(
+        cls, trigger_id, serialized_payload: Any, *, session: Session = NEW_SESSION
+    ) -> None:
+        """
+        Fire an event whose payload arrives already serde-serialized (AIP-92 Execution API path).
+
+        Resume all deferred tasks waiting on the trigger and notify any associated assets and
+        callbacks, like :meth:`submit_event`, but **without** deserializing the worker-supplied
+        payload on the resume path: the serialized payload is spliced straight into ``next_kwargs``
+        so the trusted api-server never runs ``import_string`` on a worker-controlled body.
+
+        Asset and callback consumers still need the live object, so on those branches the payload
+        is deserialized via ``airflow.sdk.serde.deserialize``, which is allowlist-gated by
+        ``[core] allowed_deserialization_classes`` (not the unrestricted ``BaseSerialization`` path).
+        """
+        # Resume deferred tasks -- the serialized payload is spliced in untouched (no deserialize).
+        for task_instance in session.scalars(
+            select(TaskInstance).where(
+                TaskInstance.trigger_id == trigger_id, TaskInstance.state == TaskInstanceState.DEFERRED
+            )
+        ):
+            handle_serialized_event_submit(serialized_payload, task_instance=task_instance, session=session)
+
+        trigger = session.scalars(select(cls).where(cls.id == trigger_id)).one_or_none()
+        if trigger is None:
+            # Already deleted for some reason
+            return
+        # Only the asset/callback consumers need the materialized object. Deserialize here via
+        # serde, whose allowlist ([core] allowed_deserialization_classes) is the control -- the
+        # resume path above never deserializes the worker payload.
+        if trigger.assets or trigger.callback:
+            from airflow.sdk.serde import deserialize
+            from airflow.triggers.base import TriggerEvent
+
+            payload_obj = deserialize(serialized_payload)
+            for asset in trigger.assets:
+                AssetManager.register_asset_change(
+                    asset=asset.to_serialized(),
+                    extra={"from_trigger": True, "payload": payload_obj},
+                    session=session,
+                )
+            if trigger.callback:
+                trigger.callback.handle_event(TriggerEvent(payload=payload_obj), session)
+
+    @classmethod
+    @provide_session
     def submit_failure(cls, trigger_id, exc=None, *, session: Session = NEW_SESSION) -> None:
         """
         When a trigger has failed unexpectedly, mark everything that depended on it as failed.
@@ -587,4 +633,53 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
 
     _submit_callback_if_necessary()
     _push_xcoms_if_necessary()
+    session.flush()
+
+
+def handle_serialized_event_submit(
+    serialized_payload: Any, *, task_instance: TaskInstance, session: Session
+) -> None:
+    """
+    Resume a deferred task instance with an already-serialized event payload.
+
+    Mirrors the default :func:`handle_event_submit` tail, but splices the serde-encoded
+    payload into ``next_kwargs`` *without* materializing it. The api-server therefore never
+    deserializes the worker-supplied event (no ``import_string`` gadget surface); the worker
+    deserializes the spliced ``next_kwargs`` itself when it resumes.
+
+    :param serialized_payload: The event payload as produced by ``airflow.sdk.serde.serialize``.
+    :param task_instance: The deferred task instance to resume.
+    :param session: The session to flush the state change on.
+    """
+    from airflow.sdk.serde import deserialize, serialize
+
+    next_kwargs_raw = task_instance.next_kwargs or {}
+
+    # The existing next_kwargs are the *task-authored* defer kwargs (trusted), not the worker
+    # event payload, so deserializing them here is not the gadget surface. Keep the compat
+    # try/except so a deferred task that resumes after upgrade (mixed BaseSerialization/serde
+    # data) still works.
+    try:
+        next_kwargs = deserialize(next_kwargs_raw)
+    except (ImportError, KeyError, AttributeError, TypeError):
+        from airflow.serialization.serialized_objects import BaseSerialization
+
+        next_kwargs = BaseSerialization.deserialize(next_kwargs_raw)
+
+    if TYPE_CHECKING:
+        assert isinstance(next_kwargs, dict)
+    # serialize() returns a plain dict whose values are serde-encoded; splice the already
+    # serde-encoded payload straight in so the api-server never reconstructs the worker object.
+    serialized = serialize(next_kwargs)
+    if TYPE_CHECKING:
+        assert isinstance(serialized, dict)
+    serialized["event"] = serialized_payload
+    task_instance.next_kwargs = serialized
+
+    # Remove ourselves as its trigger
+    task_instance.trigger_id = None
+
+    # Set the state of the task instance to scheduled
+    task_instance.state = TaskInstanceState.SCHEDULED
+    task_instance.scheduled_dttm = timezone.utcnow()
     session.flush()

--- a/airflow-core/tests/unit/api_fastapi/execution_api/routes/__init__.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/routes/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow-core/tests/unit/api_fastapi/execution_api/routes/test_jobs.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/routes/test_jobs.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow._shared.timezones import timezone
+from airflow.jobs.job import Job, JobState
+
+from tests_common.test_utils.db import clear_db_jobs
+
+pytestmark = pytest.mark.db_test
+
+
+class TestRegisterJob:
+    def setup_method(self):
+        clear_db_jobs()
+
+    def teardown_method(self):
+        clear_db_jobs()
+
+    def test_register_creates_running_job_and_returns_id(self, client, session):
+        response = client.post(
+            "/execution/jobs",
+            json={"job_type": "TriggererJob", "hostname": "triggerer-host"},
+        )
+
+        assert response.status_code == 201
+        job_id = response.json()["job_id"]
+        assert isinstance(job_id, int)
+
+        session.expire_all()
+        job = session.get(Job, job_id)
+        assert job is not None
+        assert job.job_type == "TriggererJob"
+        assert job.state == JobState.RUNNING
+        # Job.__init__ stamps these so the row counts as alive immediately.
+        assert job.latest_heartbeat is not None
+        assert job.start_date is not None
+        # The registering process's hostname is recorded, not the api-server's.
+        assert job.hostname == "triggerer-host"
+
+
+class TestHeartbeatJob:
+    def setup_method(self):
+        clear_db_jobs()
+
+    def teardown_method(self):
+        clear_db_jobs()
+
+    def test_heartbeat_updates_latest_heartbeat(self, client, session):
+        stale = timezone.datetime(2020, 1, 1)
+        job = Job(job_type="TriggererJob", state=JobState.RUNNING)
+        job.latest_heartbeat = stale
+        session.add(job)
+        session.commit()
+        job_id = job.id
+
+        response = client.post(f"/execution/jobs/{job_id}/heartbeat")
+
+        assert response.status_code == 204
+
+        session.expire_all()
+        refreshed = session.get(Job, job_id)
+        assert refreshed.latest_heartbeat > stale
+        assert refreshed.end_date is None
+
+    def test_heartbeat_unknown_job_returns_404(self, client):
+        response = client.post("/execution/jobs/987654/heartbeat")
+        assert response.status_code == 404
+
+
+class TestCompleteJob:
+    def setup_method(self):
+        clear_db_jobs()
+
+    def teardown_method(self):
+        clear_db_jobs()
+
+    def test_complete_stamps_end_date(self, client, session):
+        job = Job(job_type="TriggererJob", state=JobState.RUNNING)
+        session.add(job)
+        session.commit()
+        job_id = job.id
+        assert job.end_date is None
+
+        response = client.post(f"/execution/jobs/{job_id}/complete")
+
+        assert response.status_code == 204
+
+        session.expire_all()
+        refreshed = session.get(Job, job_id)
+        assert refreshed.end_date is not None
+
+    def test_complete_unknown_job_returns_404(self, client):
+        response = client.post("/execution/jobs/987654/complete")
+        assert response.status_code == 404

--- a/airflow-core/tests/unit/api_fastapi/execution_api/routes/test_triggers.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/routes/test_triggers.py
@@ -1,0 +1,261 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import func, select
+
+from airflow._shared.timezones import timezone
+from airflow.jobs.job import Job
+from airflow.jobs.triggerer_job_runner import TriggererJobRunner
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.trigger import Trigger
+from airflow.sdk.serde import deserialize as serde_deserialize, serialize as serde_serialize
+from airflow.serialization.serialized_objects import BaseSerialization
+from airflow.utils.state import State
+
+from tests_common.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
+
+pytestmark = pytest.mark.db_test
+
+HEALTH_CHECK_THRESHOLD = 30
+
+
+def _clear():
+    clear_db_runs()
+    clear_db_serialized_dags()
+    clear_db_dags()
+
+
+def _make_triggerer(session) -> Job:
+    """Create an alive TriggererJob so triggers can be assigned to it."""
+    job = Job(heartrate=10, state=State.RUNNING, latest_heartbeat=timezone.utcnow())
+    TriggererJobRunner(job)
+    session.add(job)
+    session.flush()
+    return job
+
+
+class TestLoadTriggers:
+    def setup_method(self):
+        _clear()
+
+    def teardown_method(self):
+        _clear()
+
+    def test_load_assigns_and_returns_ids(self, client, session, create_task_instance):
+        job = _make_triggerer(session)
+        trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+        session.add(trigger)
+        session.flush()
+        # assign_unassigned only picks up triggers referenced by a task, asset, or callback.
+        ti = create_task_instance(
+            session=session,
+            logical_date=timezone.utcnow(),
+            state=State.DEFERRED,
+        )
+        ti.trigger_id = trigger.id
+        session.commit()
+
+        assert trigger.triggerer_id is None
+
+        response = client.post(
+            "/execution/triggers/load",
+            json={
+                "triggerer_id": job.id,
+                "capacity": 100,
+                "health_check_threshold": HEALTH_CHECK_THRESHOLD,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"trigger_ids": [trigger.id]}
+
+        # The trigger should now be assigned to the triggerer in the DB.
+        session.expire_all()
+        assert session.get(Trigger, trigger.id).triggerer_id == job.id
+
+    def test_load_returns_empty_when_nothing_to_assign(self, client, session):
+        job = _make_triggerer(session)
+        session.commit()
+
+        response = client.post(
+            "/execution/triggers/load",
+            json={
+                "triggerer_id": job.id,
+                "capacity": 100,
+                "health_check_threshold": HEALTH_CHECK_THRESHOLD,
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"trigger_ids": []}
+
+
+class TestTriggerWorkloads:
+    def setup_method(self):
+        _clear()
+
+    def teardown_method(self):
+        _clear()
+
+    def test_workloads_for_deferred_ti(self, client, session, create_task_instance):
+        trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+        session.add(trigger)
+        session.flush()
+
+        ti = create_task_instance(
+            session=session,
+            logical_date=timezone.utcnow(),
+            state=State.DEFERRED,
+        )
+        ti.trigger_id = trigger.id
+        session.commit()
+
+        response = client.post(
+            "/execution/triggers/workloads",
+            json={"trigger_ids": [trigger.id]},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["workloads"]) == 1
+        workload = body["workloads"][0]
+        assert workload["id"] == trigger.id
+        assert workload["type"] == "RunTrigger"
+        assert workload["classpath"] == "airflow.triggers.testing.SuccessTrigger"
+        # Task-backed trigger carries the serialized task instance.
+        assert workload["ti"] is not None
+        assert workload["ti"]["task_id"] == ti.task_id
+
+    def test_workloads_empty_for_unknown_id(self, client, session):
+        response = client.post(
+            "/execution/triggers/workloads",
+            json={"trigger_ids": [123456]},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"workloads": []}
+
+
+class TestSubmitEvent:
+    def setup_method(self):
+        _clear()
+
+    def teardown_method(self):
+        _clear()
+
+    def test_event_resumes_deferred_ti(self, client, session, create_task_instance, mocker):
+        trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+        session.add(trigger)
+        session.flush()
+
+        ti = create_task_instance(
+            session=session,
+            logical_date=timezone.utcnow(),
+            state=State.DEFERRED,
+        )
+        ti.trigger_id = trigger.id
+        session.commit()
+
+        payload = serde_serialize({"result": "ok"})
+
+        # The route must never run the unrestricted BaseSerialization.deserialize on the
+        # worker-supplied body -- that would be an arbitrary import/instantiation gadget.
+        # (BaseSerialization.deserialize is still used internally by SQLAlchemy column types,
+        # so we spy as a passthrough and assert it is never handed the worker payload.)
+        spy = mocker.spy(BaseSerialization, "deserialize")
+
+        response = client.post(
+            f"/execution/triggers/{trigger.id}/event",
+            # The real client serde-serializes the payload before sending; the server stores it
+            # without deserializing and the worker deserializes it on resume.
+            json={"payload": payload},
+        )
+
+        assert response.status_code == 204
+        for call in spy.call_args_list:
+            assert payload not in call.args, "route deserialized the worker payload"
+
+        session.expire_all()
+        resumed = session.get(TaskInstance, ti.id)
+        assert resumed.state == State.SCHEDULED
+        assert resumed.trigger_id is None
+        # The stored next_kwargs holds the serde-spliced payload; deserializing it (what the
+        # worker does on resume) round-trips back to the original event.
+        assert serde_deserialize(resumed.next_kwargs) == {"event": {"result": "ok"}}
+
+
+class TestSubmitFailure:
+    def setup_method(self):
+        _clear()
+
+    def teardown_method(self):
+        _clear()
+
+    def test_failure_marks_ti_to_fail(self, client, session, create_task_instance):
+        trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+        session.add(trigger)
+        session.flush()
+
+        ti = create_task_instance(
+            session=session,
+            logical_date=timezone.utcnow(),
+            state=State.DEFERRED,
+        )
+        ti.trigger_id = trigger.id
+        session.commit()
+
+        response = client.post(
+            f"/execution/triggers/{trigger.id}/failure",
+            # The traceback is a list of lines end-to-end (not a joined string), so the worker
+            # renders it line-by-line rather than one character per line.
+            json={"error": ["Traceback (most recent call last):\n", "  boom\n"]},
+        )
+
+        assert response.status_code == 204
+
+        session.expire_all()
+        failed = session.get(TaskInstance, ti.id)
+        assert failed.state == State.SCHEDULED
+        assert failed.next_method == "__fail__"
+        assert failed.trigger_id is None
+        assert failed.next_kwargs["traceback"] == ["Traceback (most recent call last):\n", "  boom\n"]
+
+
+class TestCleanup:
+    def setup_method(self):
+        _clear()
+
+    def teardown_method(self):
+        _clear()
+
+    def test_cleanup_deletes_orphan_trigger(self, client, session):
+        trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+        session.add(trigger)
+        session.commit()
+        trigger_id = trigger.id
+
+        assert session.scalar(select(func.count()).select_from(Trigger).where(Trigger.id == trigger_id)) == 1
+
+        response = client.post("/execution/triggers/cleanup")
+
+        assert response.status_code == 204
+
+        session.expire_all()
+        assert session.get(Trigger, trigger_id) is None

--- a/airflow-core/tests/unit/cli/commands/test_triggerer_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_triggerer_command.py
@@ -70,19 +70,17 @@ class TestTriggererCommand:
         )
 
     @mock.patch("airflow.cli.commands.triggerer_command.TriggererJobRunner")
-    @mock.patch("airflow.cli.commands.triggerer_command.run_job")
     @mock.patch("airflow.cli.commands.triggerer_command.Process")
-    def test_trigger_run_serve_logs(self, mock_process, mock_run_job, mock_trigger_job_runner):
+    def test_trigger_run_serve_logs(self, mock_process, mock_trigger_job_runner):
         """Ensure that trigger runner and server log functions execute as intended"""
         triggerer_command.triggerer_run(
             skip_serve_logs=False, capacity=1, triggerer_heartrate=10.3, queues=None
         )
 
         mock_process.assert_called_once()
-        mock_run_job.assert_called_once_with(
-            job=mock_trigger_job_runner.return_value.job,
-            execute_callable=mock_trigger_job_runner.return_value._execute,
-        )
+        # AIP-92: the triggerer runs the job runner directly (no run_job, so no metadata-DB Job
+        # is written at startup); its liveness Job is registered over the Execution API instead.
+        mock_trigger_job_runner.return_value._execute.assert_called_once_with()
 
     @mock.patch("airflow.cli.hot_reload.run_with_reloader")
     def test_triggerer_with_dev_flag(self, mock_reloader):

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import datetime
-import itertools
 import os
 import random
 import selectors
@@ -28,18 +27,17 @@ import threading
 import time
 import typing
 import uuid
-from collections.abc import AsyncIterator
 from socket import socket, socketpair
-from typing import TYPE_CHECKING, Any
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import greenback
+import httpx
 import msgspec
-import pendulum
+import psutil
 import pytest
 import pytest_asyncio
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -63,22 +61,13 @@ from airflow.jobs.triggerer_job_runner import (
     _make_trigger_span,
     messages,
 )
-from airflow.models import Connection, DagModel, DagRun, Trigger, Variable
-from airflow.models.dag_version import DagVersion
-from airflow.models.dagbundle import DagBundleModel
-from airflow.models.serialized_dag import SerializedDagModel
-from airflow.models.xcom import XComModel
-from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.providers.standard.operators.python import PythonOperator
-from airflow.providers.standard.triggers.file import FileDeleteTrigger
+from airflow.models import Trigger
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
-from airflow.sdk import DAG, BaseHook, BaseOperator
 from airflow.sdk.execution_time.comms import ToSupervisor, ToTask, _RequestFrame, _ResponseFrame
-from airflow.serialization.serialized_objects import LazyDeserializedDAG
+from airflow.sdk.serde import serialize as serde_serialize
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.triggers.testing import FailureTrigger, SuccessTrigger
-from airflow.utils.state import State, TaskInstanceState
-from airflow.utils.types import DagRunType
+from airflow.utils.state import State
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
@@ -91,10 +80,6 @@ from tests_common.test_utils.db import (
     clear_db_variables,
     clear_db_xcom,
 )
-from tests_common.test_utils.taskinstance import create_task_instance
-
-if TYPE_CHECKING:
-    from kgb import SpyAgency
 
 pytestmark = pytest.mark.db_test
 
@@ -119,43 +104,6 @@ def clean_database():
     clear_db_variables()
     clear_db_triggers()
     clear_db_jobs()
-
-
-def create_trigger_in_db(session, trigger, operator=None):
-    bundle_name = "testing"
-
-    testing_bundle = DagBundleModel(name=bundle_name)
-    session.merge(testing_bundle)
-    session.flush()
-
-    date = pendulum.datetime(2023, 1, 1)
-    dag_model = DagModel(dag_id="test_dag", bundle_name=bundle_name)
-    dag = DAG(dag_id=dag_model.dag_id, schedule="@daily", start_date=date)
-    run = DagRun(
-        dag_id=dag_model.dag_id,
-        run_id="test_run",
-        logical_date=date,
-        data_interval=(date, date),
-        run_after=date,
-        run_type=DagRunType.MANUAL,
-    )
-    trigger_orm = Trigger.from_object(trigger)
-    if operator:
-        operator.dag = dag
-    else:
-        operator = BaseOperator(task_id="test_ti", dag=dag)
-    session.add(dag_model)
-
-    SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
-    session.add(run)
-    session.add(trigger_orm)
-    session.flush()
-    dag_version = DagVersion.get_latest_version(dag.dag_id)
-    task_instance = create_task_instance(operator, run_id=run.run_id, dag_version_id=dag_version.id)
-    task_instance.trigger_id = trigger_orm.id
-    session.add(task_instance)
-    session.commit()
-    return dag_model, run, trigger_orm, task_instance
 
 
 def test_is_needed(session):
@@ -208,57 +156,82 @@ def test_triggerer_job_runner_stores_team_name(team_name):
     assert runner.team_name == team_name
 
 
+def _make_remote_ti() -> TaskInstanceDTO:
+    return TaskInstanceDTO(
+        id=uuid.uuid4(),
+        dag_version_id=uuid.uuid4(),
+        task_id="task",
+        dag_id="dag",
+        run_id="run",
+        try_number=1,
+        pool_slots=1,
+        queue="default",
+        priority_weight=1,
+    )
+
+
+def _make_run_trigger(trigger_id: int, *, with_ti: bool = False) -> workloads.RunTrigger:
+    return workloads.RunTrigger(
+        id=trigger_id,
+        classpath="airflow.triggers.testing.SuccessTrigger",
+        encrypted_kwargs="x",
+        ti=_make_remote_ti() if with_ti else None,
+    )
+
+
+def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://in-process.invalid./triggers/cleanup")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("boom", request=request, response=response)
+
+
 @pytest.fixture
-def supervisor_builder(mocker, session):
-    def builder(job=None):
-        import psutil
+def supervisor_builder(mocker):
+    """Build a TriggerRunnerSupervisor (``job=None``) with a mocked client and a registered id.
 
-        if not job:
-            job = Job()
-            session.add(job)
-            session.flush()
+    AIP-92: the supervisor holds no metadata-DB access, so orchestration goes through a mocked
+    Execution API client rather than a real DB session.
+    """
 
-        process = mocker.Mock(spec=psutil.Process, pid=10 * job.id + 1)
-        # Create a mock stdin that has both write and sendall methods
+    def builder():
+        from airflow.sdk.api.client import Client
+
+        process = mocker.Mock(spec=psutil.Process, pid=42)
         mock_stdin = mocker.Mock(spec=socket)
         mock_stdin.write = mocker.Mock()
         mock_stdin.sendall = mocker.Mock()
 
         proc = TriggerRunnerSupervisor(
             process_log=mocker.Mock(spec=FilteringBoundLogger),
-            id=job.id,
-            job=job,
+            id=uuid.uuid4(),
+            job=None,
             pid=process.pid,
             stdin=mock_stdin,
             process=process,
             capacity=10,
         )
-        # Mock the selector
         mock_selector = mocker.Mock(spec=selectors.DefaultSelector)
         mock_selector.select.return_value = []
-
-        # Set the selector on the process
         proc.selector = mock_selector
+
+        # Mock the client so no HTTP/DB is touched, and pre-register the Job id.
+        mock_client = mocker.Mock(spec=Client)
+        mocker.patch.object(TriggerRunnerSupervisor, "make_client", return_value=mock_client)
+        proc._triggerer_id = 7
         return proc
 
     return builder
 
 
-def test_supervisor_stores_team_name(supervisor_builder, mocker, session):
+def test_supervisor_stores_team_name(mocker):
     """TriggerRunnerSupervisor stores team_name field."""
-    job = Job()
-    session.add(job)
-    session.flush()
-
-    import psutil
-
     process = mocker.Mock(spec=psutil.Process, pid=99)
     mock_stdin = mocker.Mock(spec=socket)
 
     proc = TriggerRunnerSupervisor(
         process_log=mocker.Mock(spec=FilteringBoundLogger),
-        id=job.id,
-        job=job,
+        id=uuid.uuid4(),
+        job=None,
         pid=process.pid,
         stdin=mock_stdin,
         process=process,
@@ -269,8 +242,8 @@ def test_supervisor_stores_team_name(supervisor_builder, mocker, session):
 
     proc_global = TriggerRunnerSupervisor(
         process_log=mocker.Mock(spec=FilteringBoundLogger),
-        id=job.id,
-        job=job,
+        id=uuid.uuid4(),
+        job=None,
         pid=process.pid,
         stdin=mock_stdin,
         process=process,
@@ -311,15 +284,23 @@ def test_run_invokes_seams_in_order(supervisor_builder, mocker):
     assert events == ["enter", "tick-1", "tick-2", "tick-3", "exit"]
 
 
-def test_client_delegates_to_make_client_and_caches_result(supervisor_builder, mocker):
-    """``supervisor.client`` delegates to ``make_client`` (the subclass-override hook)
-    and caches the result across accesses."""
-    supervisor = supervisor_builder()
+def test_client_delegates_to_make_client_and_caches_result(mocker):
+    """``supervisor.client`` delegates to ``make_client`` and caches the result across accesses."""
     make_client = mocker.patch.object(
         TriggerRunnerSupervisor,
         "make_client",
         autospec=True,
         return_value=mocker.sentinel.client,
+    )
+    process = mocker.Mock(spec=psutil.Process, pid=42)
+    supervisor = TriggerRunnerSupervisor(
+        process_log=mocker.Mock(spec=FilteringBoundLogger),
+        id=uuid.uuid4(),
+        job=None,
+        pid=process.pid,
+        stdin=mocker.Mock(spec=socket),
+        process=process,
+        capacity=10,
     )
 
     first = supervisor.client
@@ -356,8 +337,8 @@ def test_run_context_exits_when_subprocess_dies(supervisor_builder, mocker):
 
 @pytest.fixture
 def jobless_supervisor(mocker):
-    """Build a TriggerRunnerSupervisor with ``job=None`` for testing the optional-job path."""
-    import psutil
+    """Build a TriggerRunnerSupervisor (``job=None``) with a mocked client and a registered id."""
+    from airflow.sdk.api.client import Client
 
     process = mocker.Mock(spec=psutil.Process, pid=42)
     mock_stdin = mocker.Mock(spec=socket)
@@ -376,6 +357,10 @@ def jobless_supervisor(mocker):
     mock_selector = mocker.Mock(spec=selectors.DefaultSelector)
     mock_selector.select.return_value = []
     supervisor.selector = mock_selector
+
+    mock_client = mocker.Mock(spec=Client)
+    mocker.patch.object(TriggerRunnerSupervisor, "make_client", return_value=mock_client)
+    supervisor._triggerer_id = 7
     return supervisor
 
 
@@ -400,79 +385,316 @@ def test_start_without_job_generates_uuid_id(mocker):
     fake_proc.send_msg.assert_called_once()
 
 
-def test_heartbeat_raises_without_job(jobless_supervisor, mocker):
-    """heartbeat() must fail loudly when job is None so missing subclass overrides surface."""
-    perform_heartbeat = mocker.patch("airflow.jobs.triggerer_job_runner.perform_heartbeat")
+class TestRunContextRegistersJob:
+    def _build(self, mocker, register_returns=99):
+        from airflow.sdk.api.client import Client
 
-    with pytest.raises(RuntimeError, match="must override this method"):
-        jobless_supervisor.heartbeat()
+        process = mocker.Mock(spec=psutil.Process, pid=42)
+        mock_stdin = mocker.Mock(spec=socket)
+        sup = TriggerRunnerSupervisor(
+            process_log=mocker.Mock(spec=FilteringBoundLogger),
+            id=uuid.uuid4(),
+            job=None,
+            pid=process.pid,
+            stdin=mock_stdin,
+            process=process,
+            capacity=10,
+        )
+        mock_client = mocker.Mock(spec=Client)
+        mock_client.jobs.register.return_value = register_returns
+        mocker.patch.object(TriggerRunnerSupervisor, "make_client", return_value=mock_client)
+        return sup, mock_client
 
-    perform_heartbeat.assert_not_called()
+    def test_run_context_registers_job_and_sets_id(self, mocker):
+        sup, mock_client = self._build(mocker)
+        mocker.patch("airflow.jobs.triggerer_job_runner.get_hostname", return_value="triggerer-host")
+
+        with sup.run_context():
+            assert sup._triggerer_id == 99
+        # Registers with the triggerer's own hostname (not the api-server's).
+        mock_client.jobs.register.assert_called_once_with("TriggererJob", "triggerer-host")
+        # Finalizes the Job on clean exit so it isn't left looking RUNNING forever.
+        mock_client.jobs.complete.assert_called_once_with(99)
+
+    def test_run_context_completes_job_even_on_error(self, mocker):
+        sup, mock_client = self._build(mocker)
+        mocker.patch("airflow.jobs.triggerer_job_runner.get_hostname", return_value="triggerer-host")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with sup.run_context():
+                raise RuntimeError("boom")
+        mock_client.jobs.complete.assert_called_once_with(99)
+
+    def test_register_retries_until_api_server_ready(self, mocker):
+        # The triggerer can boot before the api-server is ready; a transient error means "wait".
+        sup, mock_client = self._build(mocker)
+        mocker.patch("airflow.jobs.triggerer_job_runner.get_hostname", return_value="triggerer-host")
+        mock_client.jobs.register.side_effect = [httpx.ReadTimeout("not ready yet"), 99]
+        sleep = mocker.patch("airflow.jobs.triggerer_job_runner.time.sleep")
+
+        assert sup._register_triggerer_job() == 99
+        assert mock_client.jobs.register.call_count == 2
+        sleep.assert_called_once()
+
+    def test_register_reraises_non_transient_error(self, mocker):
+        # A 4xx is a real error, not a startup race -- fail loudly without retrying.
+        sup, mock_client = self._build(mocker)
+        mocker.patch("airflow.jobs.triggerer_job_runner.get_hostname", return_value="triggerer-host")
+        request = httpx.Request("POST", "http://api/execution/jobs")
+        mock_client.jobs.register.side_effect = httpx.HTTPStatusError(
+            "bad request", request=request, response=httpx.Response(400, request=request)
+        )
+        mocker.patch("airflow.jobs.triggerer_job_runner.time.sleep")
+
+        with pytest.raises(httpx.HTTPStatusError):
+            sup._register_triggerer_job()
+        mock_client.jobs.register.assert_called_once()
+
+    def test_trigger_log_id_is_registered_job_id(self, supervisor_builder):
+        # The on-disk filename uses the int Job id so the reader (add_triggerer_suffix) finds it.
+        assert supervisor_builder()._trigger_log_id() == 7
 
 
-def test_heartbeat_watchdog(supervisor_builder, mocker):
-    """heartbeat() fires when the subprocess is active, skips when silent, and only arms the
-    silence flag once (so the error is logged once, not on every subsequent call)."""
-    supervisor = supervisor_builder()
-    perform_heartbeat_mock = mocker.patch("airflow.jobs.triggerer_job_runner.perform_heartbeat")
+class TestOverridesDelegateToClient:
+    def test_load_triggers_calls_client_and_reuses_update(self, supervisor_builder, mocker):
+        supervisor = supervisor_builder()
+        supervisor.client.triggers.load.return_value = [1, 2, 3]
+        update = mocker.patch.object(TriggerRunnerSupervisor, "update_triggers")
 
-    # Within threshold — heartbeat fires
-    supervisor._last_runner_comms = time.monotonic() - 5.0
-    supervisor.heartbeat()
-    perform_heartbeat_mock.assert_called_once()
+        supervisor.load_triggers()
 
-    # Just inside threshold (29.9s < 30s default) — still fires
-    supervisor._last_runner_comms = time.monotonic() - 29.9
-    supervisor.heartbeat()
-    assert perform_heartbeat_mock.call_count == 2
+        supervisor.client.triggers.load.assert_called_once_with(
+            triggerer_id=7,
+            capacity=supervisor.capacity,
+            health_check_threshold=supervisor.health_check_threshold,
+            queues=None,
+            team_name=None,
+        )
+        update.assert_called_once_with({1, 2, 3})
 
-    # Beyond threshold — heartbeat skips and silence flag is set
-    supervisor._last_runner_comms = time.monotonic() - 9999.0
-    supervisor.heartbeat()
-    assert perform_heartbeat_mock.call_count == 2
-    assert supervisor._runner_comms_silence_logged is True
+    def test_load_triggers_passes_team_name(self, supervisor_builder, mocker):
+        """load_triggers passes team_name/queues to client.triggers.load."""
+        supervisor = supervisor_builder()
+        supervisor.team_name = "team_x"
+        supervisor.queues = {"q1"}
+        supervisor.client.triggers.load.return_value = [1, 2]
+        mocker.patch.object(TriggerRunnerSupervisor, "update_triggers")
 
-    # Subsequent silent heartbeats don't re-arm the flag (error logged only once)
-    supervisor.heartbeat()
-    supervisor.heartbeat()
-    assert perform_heartbeat_mock.call_count == 2
-    assert supervisor._runner_comms_silence_logged is True
+        supervisor.load_triggers()
 
-    # Once the subprocess speaks again the flag resets and heartbeat resumes
-    supervisor._last_runner_comms = time.monotonic()
-    supervisor.heartbeat()
-    assert perform_heartbeat_mock.call_count == 3
-    assert supervisor._runner_comms_silence_logged is False
+        supervisor.client.triggers.load.assert_called_once_with(
+            triggerer_id=7,
+            capacity=supervisor.capacity,
+            health_check_threshold=supervisor.health_check_threshold,
+            queues=["q1"],
+            team_name="team_x",
+        )
+
+    def test_load_triggers_swallows_transient_error(self, supervisor_builder, mocker):
+        supervisor = supervisor_builder()
+        supervisor.client.triggers.load.side_effect = httpx.ConnectError("boom")
+        update = mocker.patch.object(TriggerRunnerSupervisor, "update_triggers")
+
+        # Must not raise -- a blip should skip the cycle.
+        supervisor.load_triggers()
+
+        update.assert_not_called()
+
+    def test_build_trigger_workloads_calls_client(self, supervisor_builder, mocker):
+        supervisor = supervisor_builder()
+        asset_workload = _make_run_trigger(11)
+        task_workload = _make_run_trigger(12, with_ti=True)
+        supervisor.client.triggers.workloads.return_value = [asset_workload, task_workload]
+        register = mocker.patch.object(TriggerRunnerSupervisor, "_register_trigger_logger")
+        mocker.patch.object(TriggerRunnerSupervisor, "_render_log_path", return_value="rendered.log")
+
+        result = supervisor.build_trigger_workloads({12, 11})
+
+        assert result == [asset_workload, task_workload]
+        (called_arg,), _ = supervisor.client.triggers.workloads.call_args
+        assert sorted(called_arg) == [11, 12]
+        # Only the task-backed workload gets a logger registered (asset-based has no ti).
+        register.assert_called_once_with(12, task_workload.ti, "rendered.log")
+
+    def test_build_trigger_workloads_returns_empty_on_transient_error(self, supervisor_builder, mocker):
+        supervisor = supervisor_builder()
+        supervisor.client.triggers.workloads.side_effect = httpx.ConnectError("boom")
+        register = mocker.patch.object(TriggerRunnerSupervisor, "_register_trigger_logger")
+
+        # Returns [] so the triggers stay assigned and get re-fetched next load cycle.
+        assert supervisor.build_trigger_workloads({1}) == []
+        register.assert_not_called()
+
+    def test_on_trigger_event_calls_submit_event(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.on_trigger_event(5, TriggerEvent(payload={"result": "ok"}))
+        # The payload is serde-serialized so non-JSON-native values survive the hop; the server
+        # splices it into next_kwargs without deserializing (the worker deserializes on resume).
+        supervisor.client.triggers.submit_event.assert_called_once_with(5, serde_serialize({"result": "ok"}))
+
+    def test_on_trigger_failure_calls_submit_failure(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.on_trigger_failure(5, ["trace", "back"])
+        supervisor.client.triggers.submit_failure.assert_called_once_with(5, ["trace", "back"])
+
+    def test_clean_unused_calls_cleanup(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.clean_unused()
+        supervisor.client.triggers.cleanup.assert_called_once_with()
+
+    def test_clean_unused_swallows_transient_error(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.client.triggers.cleanup.side_effect = httpx.ConnectError("boom")
+        # Must not raise.
+        supervisor.clean_unused()
+
+    def test_clean_unused_reraises_non_transient_4xx(self, supervisor_builder):
+        # A persistent 4xx is a logic bug the client never retries; it must crash loudly
+        # instead of looping forever at WARNING.
+        supervisor = supervisor_builder()
+        supervisor.client.triggers.cleanup.side_effect = _make_http_status_error(400)
+        with pytest.raises(httpx.HTTPStatusError):
+            supervisor.clean_unused()
+
+    def test_clean_unused_swallows_5xx(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.client.triggers.cleanup.side_effect = _make_http_status_error(503)
+        # 5xx is transient -- swallow it.
+        supervisor.clean_unused()
 
 
-def test_heartbeat_watchdog_disabled_when_threshold_is_zero(supervisor_builder, mocker):
-    """Setting runner_health_check_threshold=0 disables the watchdog; heartbeat always fires."""
-    supervisor = supervisor_builder()
-    mocker.patch.object(type(supervisor), "runner_health_check_threshold", new=0)
-    perform_heartbeat_mock = mocker.patch("airflow.jobs.triggerer_job_runner.perform_heartbeat")
+class TestHandleEventsReQueue:
+    def test_handle_events_submits_and_clears(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.events.append((5, TriggerEvent(payload={"result": "ok"})))
 
-    supervisor._last_runner_comms = time.monotonic() - 9999.0
+        supervisor.handle_events()
 
-    supervisor.heartbeat()
+        supervisor.client.triggers.submit_event.assert_called_once()
+        assert not supervisor.events
 
-    perform_heartbeat_mock.assert_called_once()
+    def test_handle_events_requeues_on_transient_error(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        event = TriggerEvent(payload={"result": "ok"})
+        supervisor.events.append((5, event))
+        supervisor.client.triggers.submit_event.side_effect = httpx.ConnectError("boom")
+
+        # Must not raise; the popped event is re-queued (not lost) for the next cycle.
+        supervisor.handle_events()
+
+        assert list(supervisor.events) == [(5, event)]
+
+    def test_handle_events_reraises_non_transient(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.events.append((5, TriggerEvent(payload={"result": "ok"})))
+        supervisor.client.triggers.submit_event.side_effect = _make_http_status_error(400)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            supervisor.handle_events()
+
+    def test_handle_failed_triggers_submits_and_clears(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.failed_triggers.append((5, ["trace", "back"]))
+
+        supervisor.handle_failed_triggers()
+
+        supervisor.client.triggers.submit_failure.assert_called_once_with(5, ["trace", "back"])
+        assert not supervisor.failed_triggers
+
+    def test_handle_failed_triggers_requeues_on_transient_error(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor.failed_triggers.append((5, ["trace"]))
+        supervisor.client.triggers.submit_failure.side_effect = httpx.ConnectError("boom")
+
+        supervisor.handle_failed_triggers()
+
+        assert list(supervisor.failed_triggers) == [(5, ["trace"])]
 
 
-def test_metric_tags_default_uses_job_hostname(supervisor_builder):
-    """metric_tags() defaults to {"hostname": job.hostname} when a job is present."""
-    supervisor = supervisor_builder()
+class TestHeartbeat:
+    def test_heartbeat_calls_jobs_heartbeat(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor._last_runner_comms = time.monotonic()
+        supervisor._heartrate = 0  # disable throttle so it always fires
+        supervisor.heartbeat()
+        supervisor.client.jobs.heartbeat.assert_called_once_with(7)
 
-    assert supervisor.metric_tags() == {"hostname": supervisor.job.hostname}
+    def test_heartbeat_throttled_to_heartrate(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor._last_runner_comms = time.monotonic()
+        supervisor._heartrate = 100
+        supervisor._last_heartbeat = time.monotonic()  # just beat -- within heartrate
+
+        supervisor.heartbeat()
+
+        supervisor.client.jobs.heartbeat.assert_not_called()
+
+    def test_heartbeat_swallows_transient_error(self, supervisor_builder):
+        supervisor = supervisor_builder()
+        supervisor._last_runner_comms = time.monotonic()
+        supervisor._heartrate = 0
+        supervisor.client.jobs.heartbeat.side_effect = httpx.ConnectError("boom")
+
+        # Must not raise -- a missed heartbeat retries next loop.
+        supervisor.heartbeat()
+
+    def test_heartbeat_watchdog(self, supervisor_builder):
+        """heartbeat() fires when the subprocess is active, skips when silent, and only arms the
+        silence flag once (so the error is logged once, not on every subsequent call)."""
+        supervisor = supervisor_builder()
+        supervisor._heartrate = 0  # force a beat each call; isolate the watchdog logic
+
+        # Within threshold — heartbeat fires
+        supervisor._last_runner_comms = time.monotonic() - 5.0
+        supervisor.heartbeat()
+        assert supervisor.client.jobs.heartbeat.call_count == 1
+
+        # Just inside threshold (29.9s < 30s default) — still fires
+        supervisor._last_runner_comms = time.monotonic() - 29.9
+        supervisor.heartbeat()
+        assert supervisor.client.jobs.heartbeat.call_count == 2
+
+        # Beyond threshold — heartbeat skips and silence flag is set
+        supervisor._last_runner_comms = time.monotonic() - 9999.0
+        supervisor.heartbeat()
+        assert supervisor.client.jobs.heartbeat.call_count == 2
+        assert supervisor._runner_comms_silence_logged is True
+
+        # Subsequent silent heartbeats don't re-arm the flag (error logged only once)
+        supervisor.heartbeat()
+        supervisor.heartbeat()
+        assert supervisor.client.jobs.heartbeat.call_count == 2
+        assert supervisor._runner_comms_silence_logged is True
+
+        # Once the subprocess speaks again the flag resets and heartbeat resumes
+        supervisor._last_runner_comms = time.monotonic()
+        supervisor.heartbeat()
+        assert supervisor.client.jobs.heartbeat.call_count == 3
+        assert supervisor._runner_comms_silence_logged is False
+
+    def test_heartbeat_watchdog_disabled_when_threshold_is_zero(self, supervisor_builder, mocker):
+        """Setting runner_health_check_threshold=0 disables the watchdog; heartbeat always fires."""
+        supervisor = supervisor_builder()
+        supervisor._heartrate = 0
+        mocker.patch.object(type(supervisor), "runner_health_check_threshold", new=0)
+
+        supervisor._last_runner_comms = time.monotonic() - 9999.0
+
+        supervisor.heartbeat()
+
+        supervisor.client.jobs.heartbeat.assert_called_once()
 
 
-def test_metric_tags_raises_without_job(jobless_supervisor):
-    """metric_tags() must fail loudly when job is None — empty tags would crash emit_metrics()."""
-    with pytest.raises(RuntimeError, match="must override this method"):
-        jobless_supervisor.metric_tags()
+class TestMetricTags:
+    def test_metric_tags_uses_hostname(self, supervisor_builder, mocker):
+        """metric_tags() returns {"hostname": get_hostname()} -- the supervisor has no Job row."""
+        supervisor = supervisor_builder()
+        mocker.patch("airflow.jobs.triggerer_job_runner.get_hostname", return_value="myhost")
+        assert supervisor.metric_tags() == {"hostname": "myhost"}
 
 
 def test_emit_metrics_uses_metric_tags_override(jobless_supervisor, mocker):
-    """Subclasses can supply tags by overriding metric_tags() instead of threading args."""
+    """emit_metrics() applies the tags supplied by metric_tags() to every gauge."""
     gauge = mocker.patch("airflow.jobs.triggerer_job_runner.stats.gauge")
     mocker.patch.object(
         TriggerRunnerSupervisor,
@@ -487,163 +709,6 @@ def test_emit_metrics_uses_metric_tags_override(jobless_supervisor, mocker):
         assert call.kwargs["tags"] == {"hostname": "astro-host", "deployment": "demo"}
 
 
-def test_load_triggers_raises_without_job(jobless_supervisor, mocker):
-    """load_triggers() must fail loudly when job is None so missing subclass overrides surface."""
-    assign_unassigned = mocker.patch("airflow.jobs.triggerer_job_runner.Trigger.assign_unassigned")
-    ids_for_triggerer = mocker.patch("airflow.jobs.triggerer_job_runner.Trigger.ids_for_triggerer")
-    update_triggers = mocker.patch.object(TriggerRunnerSupervisor, "update_triggers")
-
-    with pytest.raises(RuntimeError, match="must override this method"):
-        jobless_supervisor.load_triggers()
-
-    assign_unassigned.assert_not_called()
-    ids_for_triggerer.assert_not_called()
-    update_triggers.assert_not_called()
-
-
-def test_load_triggers_passes_team_name(supervisor_builder, mocker):
-    """load_triggers passes team_name to assign_unassigned and ids_for_triggerer."""
-    proc = supervisor_builder()
-    proc.team_name = "team_x"
-
-    assign_unassigned = mocker.patch("airflow.jobs.triggerer_job_runner.Trigger.assign_unassigned")
-    ids_for_triggerer = mocker.patch(
-        "airflow.jobs.triggerer_job_runner.Trigger.ids_for_triggerer", return_value=[1, 2]
-    )
-    mocker.patch.object(TriggerRunnerSupervisor, "update_triggers")
-
-    proc.load_triggers()
-
-    assign_unassigned.assert_called_once_with(
-        proc.job.id,
-        proc.capacity,
-        proc.health_check_threshold,
-        queues=proc.queues,
-        team_name="team_x",
-    )
-    ids_for_triggerer.assert_called_once_with(proc.job.id, queues=proc.queues, team_name="team_x")
-
-
-def test_create_workload_uses_supervisor_id_without_job(jobless_supervisor, mocker):
-    """_create_workload() should fall back to self.id for the log filename when job is None."""
-    trigger = mocker.Mock()
-    trigger.id = 7
-    trigger.classpath = "some.path.Trigger"
-    trigger.encrypted_kwargs = ""
-    trigger.task_instance.dag_version_id = uuid.uuid4()
-    trigger.task_instance.task_id = "t"
-    trigger.task_instance.trigger_timeout = None
-
-    mocker.patch(
-        "airflow.jobs.triggerer_job_runner.TaskInstanceDTO.model_validate",
-        return_value=mocker.Mock(spec=TaskInstanceDTO),
-    )
-
-    dag_bag = mocker.Mock()
-    serialized_dag_model = mocker.Mock()
-    task = mocker.Mock(start_from_trigger=False)
-    serialized_dag_model.dag.get_task.return_value = task
-    dag_bag.get_serialized_dag_model.return_value = serialized_dag_model
-
-    render_log_fname = mocker.Mock(return_value="/logs/ti")
-
-    jobless_supervisor._create_workload(
-        trigger=trigger,
-        dag_bag=dag_bag,
-        render_log_fname=render_log_fname,
-        session=mocker.Mock(),
-    )
-
-    factory = jobless_supervisor.logger_cache[trigger.id]
-    assert factory.log_path == f"/logs/ti.trigger.{jobless_supervisor.id}.log"
-
-
-def test_trigger_lifecycle(spy_agency: SpyAgency, session, testing_dag_bundle):
-    """
-    Checks that the triggerer will correctly see a new Trigger in the database
-    and send it to the trigger runner, and then delete it when it vanishes.
-    """
-    # Use a trigger that will not fire for the lifetime of the test
-    # (we want to avoid it firing and deleting itself)
-    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
-    dag_model, run, trigger_orm, task_instance = create_trigger_in_db(session, trigger)
-    # Make a TriggererJobRunner and have it retrieve DB tasks
-    trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=12345), capacity=10)
-
-    try:
-        # Spy on it so we can see what gets send, but also call the original.
-        message = None
-
-        @spy_agency.spy_for(TriggerRunnerSupervisor.send_msg)
-        def send_msg_spy(self, msg, *args, **kwargs):
-            nonlocal message
-            message = msg
-            TriggerRunnerSupervisor.send_msg.call_original(self, msg, *args, **kwargs)
-
-        trigger_runner_supervisor.load_triggers()
-        trigger_runner_supervisor._service_subprocess(0.1)
-
-        # Make sure it turned up in TriggerRunner's queue
-        assert trigger_runner_supervisor.running_triggers == {trigger_orm.id}
-
-        assert message is not None, "spy was not called"
-        assert len(message.to_create) == 1
-        assert message.to_create[0] == (
-            workloads.RunTrigger.model_construct(
-                id=trigger_orm.id,
-                ti=ANY,
-                classpath=trigger.serialize()[0],
-                encrypted_kwargs=trigger_orm.encrypted_kwargs,
-                kind="RunTrigger",
-                dag_data=ANY,
-            )
-        )
-        # OK, now remove it from the DB
-        session.delete(trigger_orm)
-        session.commit()
-
-        # Re-load the triggers
-        trigger_runner_supervisor.load_triggers()
-
-        # Wait for up to 10 seconds for it to vanish from the TriggerRunner's storage
-        for _ in range(100):
-            if not trigger_runner_supervisor.running_triggers:
-                break
-            trigger_runner_supervisor._service_subprocess(0.1)
-        else:
-            pytest.fail("TriggerRunnerSupervisor never deleted trigger")
-    finally:
-        # We always have to stop the runner
-        trigger_runner_supervisor.kill(force=False)
-
-
-@pytest.mark.parametrize(
-    ("trigger", "watcher_count", "trigger_count"),
-    [
-        (TimeDeltaTrigger(datetime.timedelta(days=7)), 0, 1),
-        (FileDeleteTrigger("/tmp/foo.txt", poke_interval=1), 1, 0),
-    ],
-)
-@patch("time.monotonic", side_effect=itertools.count(start=1, step=60))
-def test_trigger_log(mock_monotonic, trigger, watcher_count, trigger_count, session, capsys):
-    """
-    Checks that the triggerer will log watcher and trigger in separate lines.
-    """
-    create_trigger_in_db(session, trigger)
-
-    trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
-    trigger_runner_supervisor.load_triggers()
-
-    for _ in range(30):
-        trigger_runner_supervisor._service_subprocess(0.1)
-
-    stdout = capsys.readouterr().out
-    assert f"{trigger_count} triggers currently running" in stdout
-    assert f"{watcher_count} watchers currently running" in stdout
-
-    trigger_runner_supervisor.kill(force=False)
-
-
 def test_trigger_logger_close():
     logger = TriggerLoggingFactory(log_path="/tmp/test.log", ti=MagicMock())
 
@@ -655,28 +720,6 @@ def test_trigger_logger_close():
     logger.close()
 
     mock_fh.close.assert_called_once()
-
-
-def test_trigger_logger_fd_closed_when_removed(session):
-    trigger = TimeDeltaTrigger(datetime.timedelta(seconds=0.5))
-
-    create_trigger_in_db(session, trigger)
-
-    mock_file = MagicMock()
-    mock_file.closed = False
-
-    with patch("airflow.sdk.log.init_log_file") as mock_init_log_file:
-        mock_init_log_file.return_value.open.return_value = mock_file
-
-        trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
-        trigger_runner_supervisor.load_triggers()
-
-        for _ in range(30):
-            trigger_runner_supervisor._service_subprocess(0.1)
-
-    mock_file.close.assert_called_once()
-
-    trigger_runner_supervisor.kill(force=False)
 
 
 def test_trigger_logger_fd_closed_when_upload_to_remote_raises(jobless_supervisor):
@@ -1052,101 +1095,20 @@ class TestTriggerRunner:
         assert len(second_call.events) == 2
 
 
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("testing_dag_bundle")
-async def test_trigger_create_race_condition_38599(session, supervisor_builder):
-    """
-    This verifies the resolution of race condition documented in github issue #38599.
-    More details in the issue description.
-
-    The race condition may occur in the following scenario:
-        1. TaskInstance TI1 defers itself, which creates Trigger T1, which holds a
-            reference to TI1.
-        2. T1 gets picked up by TriggererJobRunner TJR1 and starts running T1.
-        3. TJR1 misses a heartbeat, most likely due to high host load causing delays in
-            each TriggererJobRunner._run_trigger_loop loop.
-        4. A second TriggererJobRunner TJR2 notices that T1 has missed its heartbeat,
-            so it starts the process of picking up any Triggers that TJR1 may have had,
-            including T1.
-        5. Before TJR2 starts executing T1, TJR1 finishes execution of T1 and cleans it
-            up by clearing the trigger_id of TI1.
-        6. TJR2 tries to execute T1, but it crashes (with the above error) while trying to
-            look up TI1 (because T1 no longer has a TaskInstance linked to it).
-    """
-    trigger = TimeDeltaTrigger(delta=datetime.timedelta(microseconds=1))
-    trigger_orm = Trigger.from_object(trigger)
-    session.add(trigger_orm)
-    session.flush()
-
-    bundle_name = "testing"
-    with DAG(dag_id="test-dag") as dag:
-        task = PythonOperator(task_id="dummy-task", python_callable=print)
-    dm = DagModel(dag_id="test-dag", bundle_name=bundle_name)
-    session.add(dm)
-
-    SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
-    dag_run = DagRun(dag.dag_id, run_id="abc", run_type="none", run_after=timezone.utcnow())
-    dag_version = DagVersion.get_latest_version(dag.dag_id)
-    ti = create_task_instance(
-        task,
-        run_id=dag_run.run_id,
-        state=TaskInstanceState.DEFERRED,
-        dag_version_id=dag_version.id,
-    )
-    ti.trigger_id = trigger_orm.id
-    session.add(dag_run)
-    session.add(ti)
-
-    job1 = Job()
-    job2 = Job()
-    session.add(job1)
-    session.add(job2)
-
-    session.commit()
-
-    supervisor1 = supervisor_builder(job1)
-    supervisor2 = supervisor_builder(job2)
-
-    # Assign and run the trigger on the first TriggererJobRunner
-    # Instead of running job_runner1._execute, we will run the individual methods
-    # to control the timing of the execution.
-    supervisor1.load_triggers()
-    assert {t.id for t in supervisor1.creating_triggers} == {trigger_orm.id}
-    trigger_orm = session.get(Trigger, trigger_orm.id)
-    assert trigger_orm.task_instance is not None, "Pre-condition"
-
-    # In a real execution environment, a missed heartbeat would cause the trigger to be picked up
-    # by another TriggererJobRunner.
-    # In this test, however, this is not necessary because we are controlling the execution
-    # of the TriggererJobRunner.
-    # job1.latest_heartbeat = timezone.utcnow() - datetime.timedelta(hours=1)
-    # session.commit()
-
-    # This calls Trigger.submit_event, which will unlink the trigger from the task instance
-
-    # Simulate this call: supervisor1._service_subprocess()
-    supervisor1.events.append((trigger_orm.id, TriggerEvent(True)))
-    supervisor1.handle_events()
-    trigger_orm = session.get(Trigger, trigger_orm.id)
-    # This is the "pre"-condition we need to assert to test the race condition
-    assert trigger_orm.task_instance is None
-
-    # Simulate the second TriggererJobRunner picking up the trigger
-    # The race condition happens here.
-    # AttributeError: 'NoneType' object has no attribute 'dag_id'
-    supervisor2.update_triggers({trigger_orm.id})
-    assert supervisor2.running_triggers == set()
-    # We should have not sent anything to the async runner process
-    supervisor2.stdin.write.assert_not_called()
-
-
 @pytest.mark.execution_timeout(5)
-def test_trigger_runner_exception_stops_triggerer():
+def test_trigger_runner_exception_stops_triggerer(mocker):
     """
     Checks that if an exception occurs when creating triggers, that the triggerer
     process stops
     """
     import signal
+
+    # The triggerer orchestrates through the Execution API; give its supervisor a mock client so
+    # this test exercises the runner-died -> stop behaviour without a real api-server.
+    mock_client = mocker.Mock()
+    mock_client.jobs.register.return_value = 1
+    mock_client.triggers.load.return_value = []
+    mocker.patch.object(TriggerRunnerSupervisor, "make_client", return_value=mock_client)
 
     job_runner = TriggererJobRunner(Job())
 
@@ -1243,477 +1205,32 @@ async def test_trigger_failing():
             info["task"].cancel()
 
 
-def test_failed_trigger(session, dag_maker, supervisor_builder):
+def test_update_triggers_prevents_duplicate_creation_queue_entries(supervisor_builder):
     """
-    Checks that the triggerer will correctly fail task instances that depend on
-    triggers that can't even be loaded.
+    update_triggers does not re-queue a trigger that is already queued for creation.
 
-    This is the Supervisor side of the error reported in TestTriggerRunner::test_invalid_trigger
+    The build step (``client.triggers.workloads``) is only consulted for ids not already known.
     """
-    # Create a totally invalid trigger
-    trigger_orm = Trigger(classpath="fake.classpath", kwargs={})
-    session.add(trigger_orm)
-    session.flush()
-
-    # Create the test DAG and task
-    with dag_maker(dag_id="test_invalid_trigger", session=session):
-        EmptyOperator(task_id="dummy1")
-
-    dr = dag_maker.create_dagrun()
-    task_instance = dr.task_instances[0]
-    # Make a task instance based on that and tie it to the trigger
-    task_instance.state = TaskInstanceState.DEFERRED
-    task_instance.trigger_id = trigger_orm.id
-    session.commit()
-
-    supervisor: TriggerRunnerSupervisor = supervisor_builder()
-
-    supervisor.load_triggers()
-
-    # Make sure it got picked up
-    assert {t.id for t in supervisor.creating_triggers} == {trigger_orm.id}, "Pre-condition"
-    # Simulate receiving the state update message
-
-    supervisor._handle_request(
-        messages.TriggerStateChanges(
-            events=None,
-            finished=None,
-            failures=[
-                (
-                    trigger_orm.id,
-                    [
-                        "Traceback (most recent call last):\n",
-                        'File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked\n',
-                        "ModuleNotFoundError: No module named 'fake'\n",
-                    ],
-                )
-            ],
-        ),
-        req_id=1,
-        log=MagicMock(),
-    )
-
-    # Run the failed trigger handler
-    supervisor.handle_failed_triggers()
-
-    # Make sure it marked the task instance as failed (which is actually the
-    # scheduled state with a payload to make it fail)
-    task_instance.refresh_from_db()
-    assert task_instance.state == TaskInstanceState.SCHEDULED
-    assert task_instance.next_method == "__fail__"
-    assert task_instance.next_kwargs["error"] == "Trigger failure"
-    assert task_instance.next_kwargs["traceback"][-1] == "ModuleNotFoundError: No module named 'fake'\n"
-
-
-class CustomTrigger(BaseTrigger):
-    """Custom Trigger that will access one Variable and one Connection."""
-
-    def __init__(self, dag_id, run_id, task_id, map_index):
-        self.dag_id = dag_id
-        self.run_id = run_id
-        self.task_id = task_id
-        self.map_index = map_index
-
-    async def run(self, **args) -> AsyncIterator[TriggerEvent]:
-        import attrs
-
-        from airflow.sdk import Variable
-        from airflow.sdk.execution_time.xcom import XCom
-
-        # Use sdk masker in dag processor and triggerer because those use the task sdk machinery
-        from airflow.sdk.log import mask_secret
-
-        conn = await sync_to_async(BaseHook.get_connection)("test_connection")
-        self.log.info("Loaded conn %s", conn.conn_id)
-
-        get_variable_value = await sync_to_async(Variable.get)("test_get_variable")
-        await sync_to_async(mask_secret)(get_variable_value)
-        self.log.info("Loaded variable %s", get_variable_value)
-
-        get_xcom_value = await sync_to_async(XCom.get_one)(
-            key="test_get_xcom",
-            dag_id=self.dag_id,
-            run_id=self.run_id,
-            task_id=self.task_id,
-            map_index=self.map_index,
-        )
-        self.log.info("Loaded XCom %s", get_xcom_value)
-
-        set_variable_key = "test_set_variable"
-        set_variable_value = "set_value"
-        await sync_to_async(Variable.set)(key=set_variable_key, value=set_variable_value)
-        self.log.info("Set variable with key %s and value %s", set_variable_key, set_variable_value)
-
-        set_xcom_key = "test_set_xcom"
-        set_xcom_value = "set_xcom"
-        await sync_to_async(XCom.set)(
-            key=set_xcom_key,
-            dag_id=self.dag_id,
-            run_id=self.run_id,
-            task_id=self.task_id,
-            map_index=self.map_index,
-            value=set_xcom_value,
-        )
-        self.log.info("Set xcom with key %s and value %s", set_xcom_key, set_xcom_value)
-
-        delete_variable_key = "test_delete_variable"
-        await sync_to_async(Variable.delete)(delete_variable_key)
-        self.log.info("Deleted variable with key %s", delete_variable_key)
-
-        delete_xcom_key = "test_delete_xcom"
-        await sync_to_async(XCom.delete)(
-            key=delete_xcom_key,
-            dag_id=self.dag_id,
-            run_id=self.run_id,
-            task_id=self.task_id,
-            map_index=self.map_index,
-        )
-        self.log.info("Delete xcom with key %s", delete_xcom_key)
-
-        yield TriggerEvent(
-            {
-                "connection": attrs.asdict(conn),
-                "variable": {
-                    "get_variable": get_variable_value,
-                    "set_variable": set_variable_value,
-                    "delete_variable": delete_variable_key,
-                },
-                "xcom": {
-                    "get_xcom": get_xcom_value,
-                    "set_xcom": set_xcom_value,
-                    "delete_xcom": delete_xcom_key,
-                },
-            }
-        )
-
-    def serialize(self) -> tuple[str, dict[str, Any]]:
-        return (
-            f"{type(self).__module__}.{type(self).__qualname__}",
-            {
-                "dag_id": self.dag_id,
-                "run_id": self.run_id,
-                "task_id": self.task_id,
-                "map_index": self.map_index,
-            },
-        )
-
-
-class DummyTriggerRunnerSupervisor(TriggerRunnerSupervisor):
-    """
-    Make sure that the Supervisor stops after handling the events and do not keep running forever so the
-    test can continue.
-    """
-
-    def handle_events(self):
-        self.stop = bool(self.events)
-        super().handle_events()
-
-
-@pytest.mark.asyncio
-@pytest.mark.execution_timeout(20)
-async def test_trigger_can_call_variables_connections_and_xcoms_methods(session, dag_maker):
-    """Checks that the trigger will successfully call Variables, Connections and XComs methods."""
-    # Create the test DAG and task
-    with dag_maker(dag_id="trigger_accessing_variable_connection_and_xcom", session=session):
-        EmptyOperator(task_id="dummy1")
-    dr = dag_maker.create_dagrun()
-    task_instance = dr.task_instances[0]
-    # Make a task instance based on that and tie it to the trigger
-    task_instance.state = TaskInstanceState.DEFERRED
-
-    # Create a Trigger
-    trigger = CustomTrigger(dag_id=dr.dag_id, run_id=dr.run_id, task_id=task_instance.task_id, map_index=-1)
-    trigger_orm = Trigger(
-        classpath=trigger.serialize()[0],
-        kwargs={"dag_id": dr.dag_id, "run_id": dr.run_id, "task_id": task_instance.task_id, "map_index": -1},
-    )
-    session.add(trigger_orm)
-    session.flush()
-    task_instance.trigger_id = trigger_orm.id
-
-    # Create the appropriate Connection, Variable and XCom
-    connection = Connection(
-        conn_id="test_connection",
-        conn_type="http",
-        schema="https",
-        login="user",
-        password="pass",
-        extra={"key": "value"},
-        port=443,
-        host="example.com",
-    )
-    get_variable = Variable(key="test_get_variable", val="some_variable_value")
-    delete_variable = Variable(key="test_delete_variable", val="delete_value")
-
-    session.add(connection)
-    session.add(get_variable)
-    session.add(delete_variable)
-
-    XComModel.set(
-        key="test_get_xcom",
-        value="some_xcom_value",
-        task_id=task_instance.task_id,
-        dag_id=dr.dag_id,
-        run_id=dr.run_id,
-        map_index=-1,
-        session=session,
-    )
-
-    XComModel.set(
-        key="test_delete_xcom",
-        value="some_xcom_value",
-        task_id=task_instance.task_id,
-        dag_id=dr.dag_id,
-        run_id=dr.run_id,
-        map_index=-1,
-        session=session,
-    )
-
-    job = Job()
-    session.add(job)
-    session.commit()
-
-    supervisor = DummyTriggerRunnerSupervisor.start(job=job, capacity=1, logger=None)
-    supervisor.run()
-
-    task_instance.refresh_from_db()
-    assert task_instance.state == TaskInstanceState.SCHEDULED
-    assert task_instance.next_method != "__fail__"
-    expected_event = {
-        "event": {
-            "connection": {
-                "conn_id": "test_connection",
-                "conn_type": "http",
-                "description": None,
-                "host": "example.com",
-                "schema": "https",
-                "login": "user",
-                "password": "pass",
-                "port": 443,
-                "extra": '{"key": "value"}',
-            },
-            "variable": {
-                "get_variable": "some_variable_value",
-                "set_variable": "set_value",
-                "delete_variable": "test_delete_variable",
-            },
-            "xcom": {
-                "get_xcom": '"some_xcom_value"',
-                "set_xcom": "set_xcom",
-                "delete_xcom": "test_delete_xcom",
-            },
-        }
-    }
-    assert task_instance.next_kwargs == expected_event
-
-
-class CustomTriggerDagRun(BaseTrigger):
-    def __init__(self, trigger_dag_id, run_ids, states, logical_dates):
-        self.trigger_dag_id = trigger_dag_id
-        self.run_ids = run_ids
-        self.states = states
-        self.logical_dates = logical_dates
-
-    def serialize(self) -> tuple[str, dict[str, Any]]:
-        return (
-            f"{type(self).__module__}.{type(self).__qualname__}",
-            {
-                "trigger_dag_id": self.trigger_dag_id,
-                "run_ids": self.run_ids,
-                "states": self.states,
-                "logical_dates": self.logical_dates,
-            },
-        )
-
-    async def run(self, **args) -> AsyncIterator[TriggerEvent]:
-        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
-
-        dag_run_states_count = await sync_to_async(RuntimeTaskInstance.get_dr_count)(
-            dag_id=self.trigger_dag_id,
-            run_ids=self.run_ids,
-            states=self.states,
-            logical_dates=self.logical_dates,
-        )
-        dag_run_state = await sync_to_async(RuntimeTaskInstance.get_dagrun_state)(
-            dag_id=self.trigger_dag_id,
-            run_id=self.run_ids[0],
-        )
-        yield TriggerEvent({"count": dag_run_states_count, "dag_run_state": dag_run_state})
-
-
-@pytest.mark.asyncio
-@pytest.mark.execution_timeout(20)
-async def test_trigger_can_fetch_trigger_dag_run_count_and_state_in_deferrable(session, dag_maker):
-    """Checks that the trigger will successfully fetch the count of trigger DAG runs."""
-    # Create the test DAG and task
-    with dag_maker(dag_id="trigger_can_fetch_trigger_dag_run_count_and_state_in_deferrable", session=session):
-        EmptyOperator(task_id="dummy1")
-    dr = dag_maker.create_dagrun()
-    task_instance = dr.task_instances[0]
-    task_instance.state = TaskInstanceState.DEFERRED
-
-    # Use the same dag run with states deferred to fetch the count
-    trigger = CustomTriggerDagRun(
-        trigger_dag_id=dr.dag_id, run_ids=[dr.run_id], states=[dr.state], logical_dates=[dr.logical_date]
-    )
-    trigger_orm = Trigger(
-        classpath=trigger.serialize()[0],
-        kwargs={
-            "trigger_dag_id": dr.dag_id,
-            "run_ids": [dr.run_id],
-            "states": [dr.state],
-            "logical_dates": [dr.logical_date],
-        },
-    )
-
-    session.add(trigger_orm)
-    session.commit()
-    task_instance.trigger_id = trigger_orm.id
-
-    job = Job()
-    session.add(job)
-    session.commit()
-
-    supervisor = DummyTriggerRunnerSupervisor.start(job=job, capacity=1, logger=None)
-    supervisor.run()
-
-    task_instance.refresh_from_db()
-    assert task_instance.state == TaskInstanceState.SCHEDULED
-    assert task_instance.next_method != "__fail__"
-    assert task_instance.next_kwargs == {"event": {"count": 1, "dag_run_state": "running"}}
-
-
-class CustomTriggerWorkflowStateTrigger(BaseTrigger):
-    """Custom Trigger to check the triggerer can access the get_ti_count and get_dr_count."""
-
-    def __init__(self, external_dag_id, execution_dates, external_task_ids, allowed_states, run_ids):
-        self.external_dag_id = external_dag_id
-        self.execution_dates = execution_dates
-        self.external_task_ids = external_task_ids
-        self.allowed_states = allowed_states
-        self.run_ids = run_ids
-
-    def serialize(self) -> tuple[str, dict[str, Any]]:
-        return (
-            f"{type(self).__module__}.{type(self).__qualname__}",
-            {
-                "external_dag_id": self.external_dag_id,
-                "execution_dates": self.execution_dates,
-                "external_task_ids": self.external_task_ids,
-                "allowed_states": self.allowed_states,
-                "run_ids": self.run_ids,
-            },
-        )
-
-    async def run(self, **args) -> AsyncIterator[TriggerEvent]:
-        from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
-
-        ti_count = await sync_to_async(RuntimeTaskInstance.get_ti_count)(
-            dag_id=self.external_dag_id,
-            task_ids=self.external_task_ids,
-            task_group_id=None,
-            run_ids=self.run_ids,
-            logical_dates=self.execution_dates,
-            states=self.allowed_states,
-        )
-        dr_count = await sync_to_async(RuntimeTaskInstance.get_dr_count)(
-            dag_id=self.external_dag_id,
-            run_ids=self.run_ids,
-            logical_dates=self.execution_dates,
-            states=["running"],
-        )
-        task_states = await sync_to_async(RuntimeTaskInstance.get_task_states)(
-            dag_id=self.external_dag_id,
-            task_ids=self.external_task_ids,
-            run_ids=self.run_ids,
-            task_group_id=None,
-            logical_dates=self.execution_dates,
-        )
-        yield TriggerEvent({"ti_count": ti_count, "dr_count": dr_count, "task_states": task_states})
-
-
-@pytest.mark.asyncio
-@pytest.mark.execution_timeout(20)
-async def test_trigger_can_fetch_dag_run_count_ti_count_in_deferrable(session, dag_maker):
-    """Checks that the trigger will successfully fetch the count of DAG runs, Task count and task states."""
-    # Create the test DAG and task
-    with dag_maker(dag_id="parent_dag", session=session):
-        EmptyOperator(task_id="parent_task")
-    parent_dag_run = dag_maker.create_dagrun()
-    parent_task = parent_dag_run.task_instances[0]
-    parent_task.state = TaskInstanceState.SUCCESS
-
-    with dag_maker(dag_id="trigger_can_fetch_dag_run_count_ti_count_in_deferrable", session=session):
-        EmptyOperator(task_id="dummy1")
-    dr = dag_maker.create_dagrun()
-    task_instance = dr.task_instances[0]
-    task_instance.state = TaskInstanceState.DEFERRED
-
-    # Use the same dag run with states deferred to fetch the count
-    trigger = CustomTriggerWorkflowStateTrigger(
-        external_dag_id=parent_task.dag_id,
-        execution_dates=[parent_task.logical_date],
-        external_task_ids=[parent_task.task_id],
-        allowed_states=[State.SUCCESS],
-        run_ids=[parent_task.run_id],
-    )
-    trigger_orm = Trigger(
-        classpath=trigger.serialize()[0],
-        kwargs={
-            "external_dag_id": parent_dag_run.dag_id,
-            "execution_dates": [parent_dag_run.logical_date],
-            "external_task_ids": [parent_task.task_id],
-            "allowed_states": [State.SUCCESS],
-            "run_ids": [parent_dag_run.run_id],
-        },
-    )
-    session.add(trigger_orm)
-    session.commit()
-    task_instance.trigger_id = trigger_orm.id
-
-    job = Job()
-    session.add(job)
-    session.commit()
-
-    supervisor = DummyTriggerRunnerSupervisor.start(job=job, capacity=1, logger=None)
-    supervisor.run()
-
-    parent_task.refresh_from_db()
-    task_instance.refresh_from_db()
-    assert task_instance.state == TaskInstanceState.SCHEDULED
-    assert task_instance.next_method != "__fail__"
-    assert task_instance.next_kwargs == {
-        "event": {"ti_count": 1, "dr_count": 1, "task_states": {"test": {"parent_task": "success"}}}
-    }
-
-
-def test_update_triggers_prevents_duplicate_creation_queue_entries(session, supervisor_builder):
-    """
-    Test that update_triggers prevents adding triggers to the creation queue
-    if they are already queued for creation.
-    """
-    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
-    dag_model, run, trigger_orm, task_instance = create_trigger_in_db(session, trigger)
-
     supervisor = supervisor_builder()
+    supervisor.client.triggers.workloads.return_value = [_make_run_trigger(99)]
 
-    # First call to update_triggers should add the trigger to creating_triggers
-    supervisor.update_triggers({trigger_orm.id})
+    # First call queues the trigger for creation.
+    supervisor.update_triggers({99})
     assert len(supervisor.creating_triggers) == 1
-    assert supervisor.creating_triggers[0].id == trigger_orm.id
+    assert supervisor.creating_triggers[0].id == 99
+    supervisor.client.triggers.workloads.assert_called_once_with([99])
 
-    # Second call to update_triggers with the same trigger_id should not add it again
-    supervisor.update_triggers({trigger_orm.id})
+    # Second call with the same id does not add it again (and does not re-fetch it).
+    supervisor.update_triggers({99})
     assert len(supervisor.creating_triggers) == 1
-    assert supervisor.creating_triggers[0].id == trigger_orm.id
+    assert supervisor.creating_triggers[0].id == 99
+    supervisor.client.triggers.workloads.assert_called_once_with([99])
 
-    # Verify that the trigger is not in running_triggers yet (it's still queued)
-    assert trigger_orm.id not in supervisor.running_triggers
-
-    # Verify that the trigger is not in any other tracking sets
-    assert trigger_orm.id not in supervisor.cancelling_triggers
-    assert not any(trigger_id == trigger_orm.id for trigger_id, _ in supervisor.events)
-    assert not any(trigger_id == trigger_orm.id for trigger_id, _ in supervisor.failed_triggers)
+    # The trigger is queued but not yet running or in any other tracking set.
+    assert 99 not in supervisor.running_triggers
+    assert 99 not in supervisor.cancelling_triggers
+    assert not any(tid == 99 for tid, _ in supervisor.events)
+    assert not any(tid == 99 for tid, _ in supervisor.failed_triggers)
 
 
 def test_update_triggers_delegates_workload_creation(supervisor_builder, mocker):
@@ -1731,126 +1248,26 @@ def test_update_triggers_delegates_workload_creation(supervisor_builder, mocker)
     assert supervisor.cancelling_triggers == {1}
 
 
-def test_update_triggers_uses_fetch_hooks(session, supervisor_builder, mocker):
-    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
-    _, _, trigger_orm, _ = create_trigger_in_db(session, trigger)
-
-    supervisor = supervisor_builder()
-    fetch_trigger_details_calls = []
-    fetch_non_task_trigger_ids_calls = []
-    original_fetch_trigger_details = TriggerRunnerSupervisor.fetch_trigger_details
-    original_fetch_non_task_trigger_ids = TriggerRunnerSupervisor.fetch_non_task_trigger_ids
-
-    def fetch_trigger_details(self, trigger_ids, *, session):
-        fetch_trigger_details_calls.append((trigger_ids, session))
-        return original_fetch_trigger_details(self, trigger_ids, session=session)
-
-    def fetch_non_task_trigger_ids(self, *, session):
-        fetch_non_task_trigger_ids_calls.append(session)
-        return original_fetch_non_task_trigger_ids(self, session=session)
-
-    mocker.patch.object(
-        TriggerRunnerSupervisor, "fetch_trigger_details", autospec=True, side_effect=fetch_trigger_details
-    )
-    mocker.patch.object(
-        TriggerRunnerSupervisor,
-        "fetch_non_task_trigger_ids",
-        autospec=True,
-        side_effect=fetch_non_task_trigger_ids,
-    )
-
-    supervisor.update_triggers({trigger_orm.id})
-
-    assert len(fetch_trigger_details_calls) == 1
-    assert len(fetch_non_task_trigger_ids_calls) == 1
-    assert fetch_trigger_details_calls == [({trigger_orm.id}, fetch_non_task_trigger_ids_calls[0])]
-    assert len(supervisor.creating_triggers) == 1
-    assert supervisor.creating_triggers[0].id == trigger_orm.id
-
-    supervisor.update_triggers({trigger_orm.id})
-
-    assert len(supervisor.creating_triggers) == 1
-    assert supervisor.creating_triggers[0].id == trigger_orm.id
-
-
 def test_update_triggers_prevents_duplicate_creation_queue_entries_with_multiple_triggers(
-    session, supervisor_builder, dag_maker
+    supervisor_builder,
 ):
-    """
-    Test that update_triggers prevents adding multiple triggers to the creation queue
-    if they are already queued for creation.
-    """
-    trigger1 = TimeDeltaTrigger(datetime.timedelta(days=7))
-    trigger2 = TimeDeltaTrigger(datetime.timedelta(days=14))
-
-    dag_model1, run1, trigger_orm1, task_instance1 = create_trigger_in_db(session, trigger1)
-
-    with dag_maker("test_dag_2"):
-        EmptyOperator(task_id="test_ti_2")
-
-    run2 = dag_maker.create_dagrun()
-    trigger_orm2 = Trigger.from_object(trigger2)
-    ti2 = run2.task_instances[0]
-    session.add(trigger_orm2)
-    session.flush()
-    ti2.trigger_id = trigger_orm2.id
-    session.merge(ti2)
-    session.flush()
-    # Create a supervisor
+    """update_triggers does not re-queue triggers already queued for creation, across multiple ids."""
     supervisor = supervisor_builder()
+    supervisor.client.triggers.workloads.side_effect = lambda ids: [
+        _make_run_trigger(tid) for tid in sorted(ids)
+    ]
 
-    # First call to update_triggers should add both triggers to creating_triggers
-    supervisor.update_triggers({trigger_orm1.id, trigger_orm2.id})
-    assert len(supervisor.creating_triggers) == 2
-    trigger_ids = {trigger.id for trigger in supervisor.creating_triggers}
-    assert trigger_orm1.id in trigger_ids
-    assert trigger_orm2.id in trigger_ids
+    # First call queues both triggers.
+    supervisor.update_triggers({1, 2})
+    assert {t.id for t in supervisor.creating_triggers} == {1, 2}
 
-    # Second call to update_triggers with the same trigger_ids should not add them again
-    supervisor.update_triggers({trigger_orm1.id, trigger_orm2.id})
-    assert len(supervisor.creating_triggers) == 2
-    trigger_ids = {trigger.id for trigger in supervisor.creating_triggers}
-    assert trigger_orm1.id in trigger_ids
-    assert trigger_orm2.id in trigger_ids
+    # Second call with the same ids does not add them again.
+    supervisor.update_triggers({1, 2})
+    assert {t.id for t in supervisor.creating_triggers} == {1, 2}
 
-    # Third call with just one trigger should not add duplicates
-    supervisor.update_triggers({trigger_orm1.id})
-    assert len(supervisor.creating_triggers) == 2
-    trigger_ids = {trigger.id for trigger in supervisor.creating_triggers}
-    assert trigger_orm1.id in trigger_ids
-    assert trigger_orm2.id in trigger_ids
-
-
-def test_update_triggers_skips_when_ti_has_no_dag_version(session, supervisor_builder, dag_maker):
-    """
-    Ensure supervisor skips creating a trigger when the linked TaskInstance has no dag_version_id.
-    """
-    with dag_maker(dag_id="test_no_dag_version"):
-        EmptyOperator(task_id="t1")
-    dr = dag_maker.create_dagrun()
-    ti = dr.task_instances[0]
-
-    # Create a Trigger and link it to the TaskInstance
-    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
-    trigger_orm = Trigger.from_object(trigger)
-    session.add(trigger_orm)
-    session.flush()
-
-    ti.trigger_id = trigger_orm.id
-    # Explicitly remove dag_version_id
-    ti.dag_version_id = None
-    session.merge(ti)
-    session.commit()
-
-    supervisor = supervisor_builder()
-
-    # Attempt to enqueue creation of this trigger
-    supervisor.update_triggers({trigger_orm.id})
-
-    # Assert that nothing was queued for creation and no subprocess writes happened
-    assert len(supervisor.creating_triggers) == 0
-    assert trigger_orm.id not in supervisor.running_triggers
-    supervisor.stdin.write.assert_not_called()
+    # Third call with just one already-queued id does not add duplicates.
+    supervisor.update_triggers({1})
+    assert {t.id for t in supervisor.creating_triggers} == {1, 2}
 
 
 class TestTriggererJobRunner:

--- a/airflow-core/tests/unit/jobs/test_triggerer_workloads.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_workloads.py
@@ -1,0 +1,268 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Direct tests for the shared ``RunTrigger`` workload builder.
+
+This logic used to be exercised through the (now DB-free) triggerer supervisor; it now lives only
+in :mod:`airflow.jobs.triggerer_workloads` and is consumed server-side by the Execution API
+``/triggers/workloads`` endpoint. These tests cover the build edge cases directly: the happy
+task-backed path with its ``on_ti_logging`` callback, ``start_from_trigger`` workloads carrying the
+serialized DAG, the 2->3-upgrade ``dag_version_id is None`` skip, non-task (asset/callback)
+triggers, the #38599 vanished-task-instance skip, and the fetch-hook overrides.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pendulum
+import pytest
+
+from airflow.jobs.triggerer_workloads import build_run_trigger_workload, build_run_trigger_workloads
+from airflow.models import DagModel, DagRun, Trigger
+from airflow.models.dag_version import DagVersion
+from airflow.models.dagbag import DBDagBag
+from airflow.models.dagbundle import DagBundleModel
+from airflow.models.serialized_dag import SerializedDagModel
+from airflow.providers.standard.triggers.temporal import TimeDeltaTrigger
+from airflow.sdk import DAG, BaseOperator
+from airflow.serialization.serialized_objects import LazyDeserializedDAG
+from airflow.triggers.base import StartTriggerArgs
+from airflow.utils.helpers import log_filename_template_renderer
+from airflow.utils.types import DagRunType
+
+from tests_common.test_utils.db import (
+    clear_db_dag_bundles,
+    clear_db_dags,
+    clear_db_runs,
+    clear_db_triggers,
+)
+from tests_common.test_utils.taskinstance import create_task_instance
+
+pytestmark = pytest.mark.db_test
+
+BUNDLE_NAME = "testing"
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    clear_db_runs()
+    clear_db_dags()
+    clear_db_dag_bundles()
+    clear_db_triggers()
+    yield
+    clear_db_runs()
+    clear_db_dags()
+    clear_db_dag_bundles()
+    clear_db_triggers()
+
+
+def _create_task_trigger_in_db(session, trigger, *, operator=None):
+    """Create a Trigger linked to a task instance with a serialized DAG version."""
+    session.merge(DagBundleModel(name=BUNDLE_NAME))
+    session.flush()
+
+    date = pendulum.datetime(2023, 1, 1)
+    dag_model = DagModel(dag_id="test_dag", bundle_name=BUNDLE_NAME)
+    dag = DAG(dag_id=dag_model.dag_id, schedule="@daily", start_date=date)
+    run = DagRun(
+        dag_id=dag_model.dag_id,
+        run_id="test_run",
+        logical_date=date,
+        data_interval=(date, date),
+        run_after=date,
+        run_type=DagRunType.MANUAL,
+    )
+    trigger_orm = Trigger.from_object(trigger)
+    if operator:
+        operator.dag = dag
+    else:
+        operator = BaseOperator(task_id="test_ti", dag=dag)
+    session.add(dag_model)
+    SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=BUNDLE_NAME)
+    session.add(run)
+    session.add(trigger_orm)
+    session.flush()
+    dag_version = DagVersion.get_latest_version(dag.dag_id)
+    task_instance = create_task_instance(operator, run_id=run.run_id, dag_version_id=dag_version.id)
+    task_instance.trigger_id = trigger_orm.id
+    session.add(task_instance)
+    session.commit()
+    return trigger_orm, task_instance
+
+
+def test_build_workload_for_task_trigger_invokes_on_ti_logging(session, testing_dag_bundle):
+    """A task-backed trigger yields a workload carrying its TI and fires the on_ti_logging callback."""
+    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
+    trigger_orm, ti = _create_task_trigger_in_db(session, trigger)
+
+    logged: list[tuple] = []
+    workloads = build_run_trigger_workloads(
+        {trigger_orm.id},
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+        on_ti_logging=lambda trigger_id, ser_ti, log_path: logged.append((trigger_id, log_path)),
+    )
+
+    assert len(workloads) == 1
+    workload = workloads[0]
+    assert workload.id == trigger_orm.id
+    assert workload.ti is not None
+    assert workload.ti.task_id == ti.task_id
+    # The callback fires once for the task-backed trigger so the supervisor can register a logger.
+    assert len(logged) == 1
+    assert logged[0][0] == trigger_orm.id
+
+
+class _StartFromTriggerOperator(BaseOperator):
+    """An operator that begins execution directly in the triggerer (``start_from_trigger``)."""
+
+    start_trigger_args = StartTriggerArgs(
+        trigger_cls="airflow.triggers.testing.SuccessTrigger",
+        trigger_kwargs={},
+        next_method="execute_complete",
+        next_kwargs=None,
+        timeout=None,
+    )
+    start_from_trigger = True
+
+    def execute_complete(self, *args, **kwargs):
+        pass
+
+
+def test_build_workload_start_from_trigger_carries_serialized_dag(session, testing_dag_bundle):
+    """A start_from_trigger task carries the serialized DAG + dag-run data so a context can be built."""
+    operator = _StartFromTriggerOperator(task_id="sft_task")
+    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
+    trigger_orm, _ = _create_task_trigger_in_db(session, trigger, operator=operator)
+
+    workload = build_run_trigger_workload(
+        session.get(Trigger, trigger_orm.id),
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+    )
+
+    assert workload is not None
+    assert workload.dag_data is not None
+    assert workload.dag_run_data is not None
+
+
+def test_build_workload_skips_ti_without_dag_version(session, testing_dag_bundle):
+    """A task instance with no dag_version_id (2->3 upgrade) is skipped, not built."""
+    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
+    trigger_orm, ti = _create_task_trigger_in_db(session, trigger)
+    ti.dag_version_id = None
+    session.merge(ti)
+    session.commit()
+
+    workloads = build_run_trigger_workloads(
+        {trigger_orm.id},
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+    )
+
+    assert workloads == []
+
+
+def test_build_workload_for_non_task_trigger(session):
+    """A trigger with no task instance but a non-task association builds a TI-less workload."""
+    trigger_orm = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger_orm)
+    session.commit()
+
+    # The trigger has no task instance; include it via the non-task association hook.
+    workloads = build_run_trigger_workloads(
+        {trigger_orm.id},
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+        fetch_non_task_ids=lambda *, session: {trigger_orm.id},
+    )
+
+    assert len(workloads) == 1
+    assert workloads[0].id == trigger_orm.id
+    assert workloads[0].ti is None
+
+
+def test_build_workload_skips_vanished_task_instance_38599(session, testing_dag_bundle):
+    """
+    A trigger whose task instance was unlinked by another triggerer (#38599 race) is skipped.
+
+    When ``Trigger.submit_event``/``submit_failure`` clears the TI's trigger_id in an HA setup,
+    the trigger is left with no task instance and no non-task association, so the builder must skip
+    it rather than crash dereferencing the missing TI.
+    """
+    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
+    trigger_orm, ti = _create_task_trigger_in_db(session, trigger)
+    # Simulate the other triggerer unlinking the task instance.
+    ti.trigger_id = None
+    session.merge(ti)
+    session.commit()
+
+    workloads = build_run_trigger_workloads(
+        {trigger_orm.id},
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+    )
+
+    assert workloads == []
+
+
+def test_build_workloads_uses_fetch_hooks(session, testing_dag_bundle):
+    """The bulk_fetch / fetch_non_task_ids hooks are honored (used by callers to instrument fetches)."""
+    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
+    trigger_orm, _ = _create_task_trigger_in_db(session, trigger)
+
+    bulk_fetch_calls: list = []
+    non_task_calls: list = []
+
+    def bulk_fetch(ids, *, session):
+        bulk_fetch_calls.append(set(ids))
+        return Trigger.bulk_fetch(ids, session=session)
+
+    def fetch_non_task_ids(*, session):
+        non_task_calls.append(True)
+        return Trigger.fetch_trigger_ids_with_non_task_associations(session=session)
+
+    workloads = build_run_trigger_workloads(
+        {trigger_orm.id},
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+        bulk_fetch=bulk_fetch,
+        fetch_non_task_ids=fetch_non_task_ids,
+    )
+
+    assert bulk_fetch_calls == [{trigger_orm.id}]
+    assert non_task_calls == [True]
+    assert len(workloads) == 1
+    assert workloads[0].id == trigger_orm.id
+
+
+def test_build_workloads_skips_vanished_trigger(session):
+    """A trigger id that no longer exists in the DB is skipped."""
+    workloads = build_run_trigger_workloads(
+        {999999},
+        dag_bag=DBDagBag(),
+        render_log_fname=log_filename_template_renderer(),
+        session=session,
+    )
+    assert workloads == []

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -232,6 +232,81 @@ def test_submit_event(mock_callback_handle_event, session, create_task_instance)
     mock_callback_handle_event.assert_called_once_with(event, session)
 
 
+def test_submit_event_serialized_resume_roundtrips_without_deserializing(session, create_task_instance):
+    """
+    ``submit_event_serialized`` resumes a deferred task by splicing the already serde-serialized
+    payload into ``next_kwargs`` (the api-server never materializes it). A non-JSON-native value
+    proves the splice survives a full serde round-trip when the worker deserializes on resume.
+    """
+    from airflow.sdk.serde import deserialize as serde_deserialize, serialize as serde_serialize
+
+    payload = pendulum.datetime(2024, 1, 2, 3, 4, 5, tz="UTC")
+    serialized_payload = serde_serialize(payload)
+
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(
+        session=session, logical_date=timezone.utcnow(), state=State.DEFERRED
+    )
+    task_instance.trigger_id = trigger.id
+    task_instance.next_kwargs = {"cheesecake": True}
+    session.commit()
+
+    Trigger.submit_event_serialized(trigger.id, serialized_payload, session=session)
+    session.flush()
+    session.refresh(task_instance)
+
+    assert task_instance.state == State.SCHEDULED
+    assert task_instance.trigger_id is None
+    # next_kwargs holds the spliced serde form; deserializing it (what the worker does on resume)
+    # reconstructs the original datetime alongside the pre-existing kwargs.
+    assert serde_deserialize(task_instance.next_kwargs) == {"event": payload, "cheesecake": True}
+
+
+@patch.object(TriggererCallback, "handle_event")
+def test_submit_event_serialized_notifies_assets_and_callbacks(
+    mock_callback_handle_event, session, create_task_instance
+):
+    """
+    ``submit_event_serialized`` notifies associated assets and callbacks with the *materialized*
+    payload (deserialized via serde, which is allowlist-gated), while still resuming deferred tasks.
+    """
+    from airflow.sdk.serde import serialize as serde_serialize
+
+    # JSON-native payload: the asset_event.extra column is plain JSON (the DB-path test uses a
+    # plain string for the same reason), so the materialized object must be JSON-serializable.
+    payload = {"result": "ok"}
+    serialized_payload = serde_serialize(payload)
+
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(
+        session=session, logical_date=timezone.utcnow(), state=State.DEFERRED
+    )
+    task_instance.trigger_id = trigger.id
+
+    asset = AssetModel("test_serialized")
+    asset.add_trigger(trigger, "test_asset_watcher")
+    session.add(asset)
+
+    callback = TriggererCallback(callback_def=AsyncCallback("classpath.callback"))
+    callback.trigger = trigger
+    session.add(callback)
+    session.commit()
+
+    Trigger.submit_event_serialized(trigger.id, serialized_payload, session=session)
+    session.flush()
+    session.refresh(task_instance)
+
+    assert task_instance.state == State.SCHEDULED
+
+    asset_event = session.scalar(select(AssetEvent).where(AssetEvent.asset_id == asset.id))
+    assert asset_event.extra == {"from_trigger": True, "payload": payload}
+    (called_event, called_session), _ = mock_callback_handle_event.call_args
+    assert called_event.payload == payload
+    assert called_session is session
+
+
 def test_submit_failure(session, create_task_instance):
     """
     Tests that failures submitted to a trigger fail their dependent

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -181,8 +181,10 @@ _log_retry_warning = before_log(log, logging.WARNING)
 __all__ = [
     "Client",
     "ConnectionOperations",
+    "JobOperations",
     "ServerResponseError",
     "TaskInstanceOperations",
+    "TriggerOperations",
     "get_hostname",
     "getuser",
 ]
@@ -1075,6 +1077,89 @@ class ConnectionTestOperations:
         self.client.patch(f"connection-tests/{id}", content=body.model_dump_json())
 
 
+class TriggerOperations:
+    """Operations the (DB-free) triggerer uses to orchestrate triggers over the Execution API."""
+
+    __slots__ = ("client",)
+
+    def __init__(self, client: Client):
+        self.client = client
+
+    def load(
+        self,
+        *,
+        triggerer_id: int,
+        capacity: int,
+        health_check_threshold: float,
+        queues: list[str] | None = None,
+        team_name: str | None = None,
+    ) -> list[int]:
+        """Assign unassigned triggers to this triggerer and return its assigned trigger IDs."""
+        body: dict[str, Any] = {
+            "triggerer_id": triggerer_id,
+            "capacity": capacity,
+            "health_check_threshold": health_check_threshold,
+            "queues": queues,
+            "team_name": team_name,
+        }
+        resp = self.client.post("triggers/load", json=body)
+        return resp.json()["trigger_ids"]
+
+    def workloads(self, trigger_ids: list[int]) -> list[dict[str, Any]]:
+        """
+        Fetch the runnable trigger workloads (raw RunTrigger dicts) for the given trigger IDs.
+
+        Returns the workloads as plain dicts; the caller (in airflow-core) validates them into
+        ``RunTrigger`` objects. The task SDK must not import the core ``RunTrigger`` type.
+        """
+        resp = self.client.post("triggers/workloads", json={"trigger_ids": trigger_ids})
+        return resp.json()["workloads"]
+
+    def submit_event(self, trigger_id: int, payload: JsonValue) -> None:
+        """
+        Submit an event for a trigger, resuming any deferred task instances waiting on it.
+
+        ``payload`` must be an ``airflow.sdk.serde.serialize(...)`` output, not arbitrary JSON.
+        The server stores it **without deserializing** -- it is spliced straight into the task
+        instance's ``next_kwargs`` and deserialized by the worker on resume, so the trusted
+        api-server never reconstructs this worker-supplied object.
+        """
+        self.client.post(f"triggers/{trigger_id}/event", json={"payload": payload})
+
+    def submit_failure(self, trigger_id: int, error: list[str] | None) -> None:
+        """Submit a failure for a trigger, re-scheduling dependent task instances to fail."""
+        # ``error`` is the traceback lines (traceback.format_exception output). Send the list
+        # unchanged so the worker's "\n".join(traceback) renders it line-by-line rather than
+        # one character per line.
+        self.client.post(f"triggers/{trigger_id}/failure", json={"error": error})
+
+    def cleanup(self) -> None:
+        """Delete triggers that no longer have any task, asset, or callback depending on them."""
+        self.client.post("triggers/cleanup")
+
+
+class JobOperations:
+    """Operations to register and heartbeat a ``Job`` row over the Execution API."""
+
+    __slots__ = ("client",)
+
+    def __init__(self, client: Client):
+        self.client = client
+
+    def register(self, job_type: str, hostname: str) -> int:
+        """Register a new ``Job`` row and return its id."""
+        resp = self.client.post("jobs", json={"job_type": job_type, "hostname": hostname})
+        return resp.json()["job_id"]
+
+    def heartbeat(self, job_id: int) -> None:
+        """Record a fresh heartbeat for the given ``Job`` so it stays alive."""
+        self.client.post(f"jobs/{job_id}/heartbeat")
+
+    def complete(self, job_id: int) -> None:
+        """Mark the given ``Job`` finished by stamping its end date."""
+        self.client.post(f"jobs/{job_id}/complete")
+
+
 class BearerAuth(httpx.Auth):
     def __init__(self, token: str):
         self.token: str = token
@@ -1287,6 +1372,18 @@ class Client(httpx.Client):
     def dags(self) -> DagsOperations:
         """Operations related to DAGs."""
         return DagsOperations(self)
+
+    @lru_cache()  # type: ignore[misc]
+    @property
+    def triggers(self) -> TriggerOperations:
+        """Operations related to triggerer orchestration (AIP-92)."""
+        return TriggerOperations(self)
+
+    @lru_cache()  # type: ignore[misc]
+    @property
+    def jobs(self) -> JobOperations:
+        """Operations related to Job registration/heartbeat (AIP-92)."""
+        return JobOperations(self)
 
 
 # This is only used for parsing. ServerResponseError is raised instead

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -27,7 +27,7 @@ from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, RootModel
 
-API_VERSION: Final[str] = "2026-06-30"
+API_VERSION: Final[str] = "2026-07-14"
 
 
 class AssetAliasReferenceAssetEventDagRun(BaseModel):
@@ -215,6 +215,26 @@ class IntermediateTIState(str, Enum):
     UP_FOR_RETRY = "up_for_retry"
     UP_FOR_RESCHEDULE = "up_for_reschedule"
     DEFERRED = "deferred"
+
+
+class JobRegisterBody(BaseModel):
+    """
+    Body for registering a new ``Job`` row (e.g. a DB-free triggerer claiming an identity).
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    job_type: Annotated[str, Field(title="Job Type")]
+    hostname: Annotated[str, Field(title="Hostname")]
+
+
+class JobRegisterResponse(BaseModel):
+    """
+    Response carrying the id of the freshly registered ``Job`` row.
+    """
+
+    job_id: Annotated[int, Field(title="Job Id")]
 
 
 class PrevSuccessfulDagRunResponse(BaseModel):
@@ -440,6 +460,70 @@ class TriggerDAGRunPayload(BaseModel):
     reset_dag_run: Annotated[bool | None, Field(title="Reset Dag Run")] = False
     partition_key: Annotated[str | None, Field(title="Partition Key")] = None
     note: Annotated[str | None, Field(title="Note")] = None
+
+
+class TriggerEventBody(BaseModel):
+    """
+    Body for submitting a trigger event payload.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    payload: JsonValue | None = None
+
+
+class TriggerFailureBody(BaseModel):
+    """
+    Body for submitting a trigger failure.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: Annotated[list[str] | None, Field(title="Error")] = None
+
+
+class TriggerIdsResponse(BaseModel):
+    """
+    Response listing the trigger IDs currently assigned to a triggerer.
+    """
+
+    trigger_ids: Annotated[list[int], Field(title="Trigger Ids")]
+
+
+class TriggerLoadBody(BaseModel):
+    """
+    Body for requesting triggers to be assigned to and loaded for a triggerer.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    triggerer_id: Annotated[int, Field(title="Triggerer Id")]
+    capacity: Annotated[int, Field(title="Capacity")]
+    health_check_threshold: Annotated[float, Field(title="Health Check Threshold")]
+    queues: Annotated[list[str] | None, Field(title="Queues")] = None
+    team_name: Annotated[str | None, Field(title="Team Name")] = None
+
+
+class TriggerWorkloadsBody(BaseModel):
+    """
+    Body for requesting runnable workloads for a set of trigger IDs.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    trigger_ids: Annotated[list[int], Field(title="Trigger Ids")]
+
+
+class TriggerWorkloadsResponse(BaseModel):
+    """
+    Response carrying serialized ``RunTrigger`` workloads.
+    """
+
+    workloads: Annotated[list[dict[str, Any]], Field(title="Workloads")]
 
 
 class UpdateHITLDetailPayload(BaseModel):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -2006,3 +2006,136 @@ class TestAssetStateOperations:
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.asset_store.clear(uri="s3://bucket/key")
         assert result == OKResponse(ok=True)
+
+
+class TestTriggerOperations:
+    """Exercise the AIP-92 triggerer client operations against a mock transport."""
+
+    def test_load_posts_body_and_returns_ids(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/triggers/load"
+            assert json.loads(request.content) == {
+                "triggerer_id": 7,
+                "capacity": 100,
+                "health_check_threshold": 30.0,
+                "queues": ["default"],
+                "team_name": None,
+            }
+            return httpx.Response(status_code=200, json={"trigger_ids": [1, 2, 3]})
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.triggers.load(
+            triggerer_id=7, capacity=100, health_check_threshold=30.0, queues=["default"]
+        )
+        assert result == [1, 2, 3]
+
+    def test_workloads_returns_raw_dicts(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/triggers/workloads"
+            assert json.loads(request.content) == {"trigger_ids": [9]}
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "workloads": [
+                        {
+                            "id": 9,
+                            "classpath": "airflow.triggers.testing.SuccessTrigger",
+                            "encrypted_kwargs": "x",
+                            "type": "RunTrigger",
+                        }
+                    ]
+                },
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.triggers.workloads([9])
+        # The SDK client returns the raw dicts; the core supervisor validates them into RunTrigger.
+        assert result == [
+            {
+                "id": 9,
+                "classpath": "airflow.triggers.testing.SuccessTrigger",
+                "encrypted_kwargs": "x",
+                "type": "RunTrigger",
+            }
+        ]
+
+    def test_submit_event(self):
+        from airflow.sdk.serde import serialize as serde_serialize
+
+        # The caller serde-serializes the payload; the wire body carries that serialized form
+        # verbatim. The server stores it without deserializing (the worker deserializes on resume).
+        payload = serde_serialize({"result": "ok"})
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/triggers/5/event"
+            assert json.loads(request.content) == {"payload": payload}
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.triggers.submit_event(5, payload) is None
+
+    def test_submit_failure_sends_list_unchanged(self):
+        # The traceback must stay a list end-to-end so the worker's "\n".join(traceback)
+        # renders it line-by-line rather than one character per line.
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/triggers/5/failure"
+            assert json.loads(request.content) == {"error": ["line1\n", "line2\n"]}
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.triggers.submit_failure(5, ["line1\n", "line2\n"]) is None
+
+    def test_submit_failure_none(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert json.loads(request.content) == {"error": None}
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.triggers.submit_failure(5, None) is None
+
+    def test_cleanup(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/triggers/cleanup"
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.triggers.cleanup() is None
+
+
+class TestJobOperations:
+    """Exercise the AIP-92 Job register/heartbeat client operations against a mock transport."""
+
+    def test_register_posts_to_jobs_and_returns_id(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            # No trailing slash: the route is registered at exactly /jobs so the client
+            # does not hit a 307 redirect (httpx does not follow redirects by default).
+            assert request.url.path == "/jobs"
+            assert json.loads(request.content) == {"job_type": "TriggererJob", "hostname": "triggerer-host"}
+            return httpx.Response(status_code=201, json={"job_id": 42})
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.jobs.register("TriggererJob", "triggerer-host") == 42
+
+    def test_heartbeat(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/jobs/42/heartbeat"
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.jobs.heartbeat(42) is None
+
+    def test_complete(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert request.url.path == "/jobs/42/complete"
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        assert client.jobs.complete(42) is None


### PR DESCRIPTION
The triggerer's supervisor already serves the runtime requests its triggers make (connections, variables, XComs, task states) through the Execution API, but today it does so in-process against the metadata database. This change points that client at the api-server over HTTP and moves trigger orchestration onto the API as well, so the triggerer process holds no metadata-database connection: it registers and heartbeats a liveness Job, claims triggers, fetches their `RunTrigger` workloads, and reports events, failures, and cleanup over the API. The api-server becomes the only process that touches the database. Implements the triggerer portion of AIP-92.

## What it adds

New Execution API endpoints, gated behind a new API version:

- `POST /execution/triggers/load`, `/workloads`, `/{id}/event`, `/{id}/failure`, `/cleanup`
- `POST /execution/jobs`, `/jobs/{id}/heartbeat`, `/jobs/{id}/complete`

The workload-building logic is shared between the `/workloads` endpoint and the in-process builder, so the server and the triggerer produce identical workloads.

## Design notes

- **Event payloads are not deserialized in the api-server.** A fired event's payload is serde-encoded by the triggerer and spliced into the task instance's `next_kwargs` without being deserialized server-side, so the trusted api-server never runs `import_string` on a worker-supplied body. The worker deserializes it on resume. Asset and callback consumers, which need the live object, deserialize via serde, which is allowlist-gated by `[core] allowed_deserialization_classes`.
- **Resilient run loop.** A transient API error re-queues the event or failure and retries next cycle rather than tearing down all running triggers; a non-transient 4xx surfaces loudly instead of looping silently at WARNING.
- **No metadata Job row written by the triggerer.** The command runs the job runner directly instead of through `run_job` (whose `prepare_for_execution` would write a Job row at startup) and skips the startup database checks. The liveness Job is registered, heartbeated, and finalized over the API instead.
- **Trigger logs stay retrievable.** The supervisor registers a per-trigger logging factory for each fetched workload, keys the log filename on the registered Job id so it matches what the reader looks for, and records the triggerer's own hostname on the Job.

## Gotchas

- The wire carries the event payload but not its event type, so a `start_from_trigger` trigger that emits a `BaseTaskEndEvent` is currently handled as a generic resume rather than a terminal event. Worth a follow-up.
