### PR TITLE
Fix `example_asset_store` consumer crash and test comment typos

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_asset_store.py
+++ b/airflow-core/src/airflow/example_dags/example_asset_store.py
@@ -87,7 +87,7 @@ with DAG(
     @task(inlets=[ORDERS])
     def consume(asset_store=None):
         state = asset_store[ORDERS]
-        summary = state.get("last_run_summary") or "{}"
+        summary = state.get("last_run_summary") or {}
         print(
             f"Processing {summary.get('rows_loaded', '?')} rows "
             f"up to watermark {state.get('watermark')}. "

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -387,7 +387,7 @@ class TestCurrentContext:
         for i in range(max_stack_depth):
             # Create all contexts in ascending order
             new_context = {"ContextId": i}
-            # Like 15 nested with Storements
+            # Like 15 nested with statements
             ctx_obj = set_current_context(new_context)
             ctx_obj.__enter__()
             ctx_list.append(ctx_obj)
@@ -395,7 +395,7 @@ class TestCurrentContext:
             # Iterate over contexts in reverse order - stack is LIFO
             ctx = get_current_context()
             assert ctx["ContextId"] == i
-            # End of with Storement
+            # End of with statement
             ctx_list[i].__exit__(None, None, None)
 
 


### PR DESCRIPTION
Fallout from the task_state->task_store rename (#67833):

- example_asset_store consume() fell back to the string "{}" when the asset had no last_run_summary yet, then called .get() on it, raising AttributeError. Fall back to an empty dict so .get() works.
- A eager find-replace turned "statement(s)" into "Storement(s)" in two comments in test_context.py. Restored the original words.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
