### PR TITLE
Fix common.ai 10-K example DAGs for Pydantic XCom output change

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_langchain_10k.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_langchain_10k.py
@@ -461,8 +461,8 @@ def example_langchain_10k_analysis():
     # [END 10k_langchain_decompose]
 
     @task
-    def extract_sub_questions(decomposed: dict) -> list[dict]:
-        return decomposed["sub_questions"]
+    def extract_sub_questions(decomposed: DecomposedQuestion) -> list[SubQuestion]:
+        return decomposed.sub_questions
 
     sub_questions = extract_sub_questions(decomposed)
 
@@ -471,12 +471,12 @@ def example_langchain_10k_analysis():
     # Each sub-question targets a specific company's FAISS index.
     # ------------------------------------------------------------------
     @task
-    def build_retrieval_kwargs(sub_questions: list[dict]) -> list[dict]:
+    def build_retrieval_kwargs(sub_questions: list[SubQuestion]) -> list[dict]:
         return [
             {
-                "query": sq["sub_question"],
-                "ticker": sq["ticker"],
-                "index_dir": f"{INDEX_BASE_DIR}/{sq['ticker'].lower()}",
+                "query": sq.sub_question,
+                "ticker": sq.ticker,
+                "index_dir": f"{INDEX_BASE_DIR}/{sq.ticker.lower()}",
             }
             for sq in sub_questions
         ]
@@ -523,13 +523,13 @@ def example_langchain_10k_analysis():
     # Step 5: Collect all retrieval results into a single context.
     # ------------------------------------------------------------------
     @task
-    def collect_results(sub_questions: list[dict], results: list[dict]) -> str:
+    def collect_results(sub_questions: list[SubQuestion], results: list[dict]) -> str:
         sections = []
         for sq, r in zip(sub_questions, results):
             chunks_text = "\n".join(
                 f"  [{i + 1}] (score {c['score']:.2f}) {c['text']}" for i, c in enumerate(r["chunks"])
             )
-            sections.append(f"## {sq['ticker']} -- {sq['sub_question']}\n{chunks_text}")
+            sections.append(f"## {sq.ticker} -- {sq.sub_question}\n{chunks_text}")
         return "\n\n".join(sections)
 
     collected = collect_results(sub_questions, retrieval_results)
@@ -561,30 +561,30 @@ Cite specific data points and scores.
 
     # ------------------------------------------------------------------
     # Step 7: Format the structured report into readable text for the
-    # human reviewer.  The LLM produced a dict (via output_type=
-    # AnalysisReport); this task renders it as clean prose.
+    # human reviewer.  The LLM produced an AnalysisReport instance (via
+    # output_type=AnalysisReport); this task renders it as clean prose.
     # ------------------------------------------------------------------
     @task
-    def format_report(report: dict) -> str:
-        lines = [f"# Executive Summary\n\n{report['executive_summary']}"]
+    def format_report(report: AnalysisReport) -> str:
+        lines = [f"# Executive Summary\n\n{report.executive_summary}"]
 
-        if report.get("company_findings"):
+        if report.company_findings:
             lines.append("\n# Company Findings")
-            for finding in report["company_findings"]:
+            for finding in report.company_findings:
                 company = finding.get("company") or finding.get("ticker", "Unknown")
                 lines.append(f"\n## {company}")
                 for key, value in finding.items():
                     if key not in ("company", "ticker"):
                         lines.append(f"- **{key}**: {value}")
 
-        if report.get("key_risks"):
+        if report.key_risks:
             lines.append("\n# Key Risks")
-            for risk in report["key_risks"]:
+            for risk in report.key_risks:
                 lines.append(f"- {risk}")
 
-        if report.get("recommendations"):
+        if report.recommendations:
             lines.append("\n# Recommendations")
-            for rec in report["recommendations"]:
+            for rec in report.recommendations:
                 lines.append(f"- {rec}")
 
         return "\n".join(lines)

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llamaindex_10k.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llamaindex_10k.py
@@ -418,8 +418,8 @@ def example_llamaindex_10k_analysis():
     # [END 10k_decompose]
 
     @task
-    def extract_sub_questions(decomposed: dict) -> list[dict]:
-        return decomposed["sub_questions"]
+    def extract_sub_questions(decomposed: DecomposedQuestion) -> list[SubQuestion]:
+        return decomposed.sub_questions
 
     sub_questions = extract_sub_questions(decomposed)
 
@@ -428,11 +428,11 @@ def example_llamaindex_10k_analysis():
     # Each sub-question targets a specific company's pre-built index.
     # ------------------------------------------------------------------
     @task
-    def build_retrieval_kwargs(sub_questions: list[dict]) -> list[dict]:
+    def build_retrieval_kwargs(sub_questions: list[SubQuestion]) -> list[dict]:
         return [
             {
-                "query": sq["sub_question"],
-                "index_persist_dir": f"{INDEX_BASE_DIR}/{sq['ticker'].lower()}",
+                "query": sq.sub_question,
+                "index_persist_dir": f"{INDEX_BASE_DIR}/{sq.ticker.lower()}",
             }
             for sq in sub_questions
         ]
@@ -459,14 +459,14 @@ def example_llamaindex_10k_analysis():
     # re-associates each result with its company.
     # ------------------------------------------------------------------
     @task
-    def collect_results(sub_questions: list[dict], results: list[dict]) -> str:
+    def collect_results(sub_questions: list[SubQuestion], results: list[dict]) -> str:
         sections = []
         for sq, r in zip(sub_questions, results):
             chunks_text = "\n".join(
                 f"  [{i + 1}] (score {c.get('score') or 0.0:.2f}) {c['text']}"
                 for i, c in enumerate(r["chunks"])
             )
-            sections.append(f"## {sq['ticker']} -- {sq['sub_question']}\n{chunks_text}")
+            sections.append(f"## {sq.ticker} -- {sq.sub_question}\n{chunks_text}")
         return "\n\n".join(sections)
 
     collected = collect_results(sub_questions, retrieval_results.output)
@@ -498,30 +498,30 @@ Cite specific data points and scores.
 
     # ------------------------------------------------------------------
     # Step 7: Format the structured report into readable text for the
-    # human reviewer.  The LLM produced a dict (via output_type=
-    # AnalysisReport); this task renders it as clean prose.
+    # human reviewer.  The LLM produced an AnalysisReport instance (via
+    # output_type=AnalysisReport); this task renders it as clean prose.
     # ------------------------------------------------------------------
     @task
-    def format_report(report: dict) -> str:
-        lines = [f"# Executive Summary\n\n{report['executive_summary']}"]
+    def format_report(report: AnalysisReport) -> str:
+        lines = [f"# Executive Summary\n\n{report.executive_summary}"]
 
-        if report.get("company_findings"):
+        if report.company_findings:
             lines.append("\n# Company Findings")
-            for finding in report["company_findings"]:
+            for finding in report.company_findings:
                 company = finding.get("company") or finding.get("ticker", "Unknown")
                 lines.append(f"\n## {company}")
                 for key, value in finding.items():
                     if key not in ("company", "ticker"):
                         lines.append(f"- **{key}**: {value}")
 
-        if report.get("key_risks"):
+        if report.key_risks:
             lines.append("\n# Key Risks")
-            for risk in report["key_risks"]:
+            for risk in report.key_risks:
                 lines.append(f"- {risk}")
 
-        if report.get("recommendations"):
+        if report.recommendations:
             lines.append("\n# Recommendations")
-            for rec in report["recommendations"]:
+            for rec in report.recommendations:
                 lines.append(f"- {rec}")
 
         return "\n".join(lines)


### PR DESCRIPTION
## Summary

Commit 9318bd6250 (#67644) stopped the common.ai LLM operators from calling `model_dump()` on Pydantic `output_type` results before pushing to XCom. Downstream tasks now receive the model instance instead of a dict. The [`example_langchain_10k`](https://github.com/apache/airflow/blob/main/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_langchain_10k.py) and [`example_llamaindex_10k`](https://github.com/apache/airflow/blob/main/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_llamaindex_10k.py) DAGs were never updated, so their consumer tasks still subscripted the result as a dict (`decomposed["sub_questions"]`, `report["executive_summary"]`, `sq["ticker"]`) and now fail with `TypeError: '...' object is not subscriptable` on current main.

## What changed

Switched the four consumer tasks in each example DAG to attribute access and typed their parameters with the model classes:

- `extract_sub_questions(decomposed: DecomposedQuestion)` returns `decomposed.sub_questions`
- `build_retrieval_kwargs(sub_questions: list[SubQuestion])` uses `sq.sub_question`, `sq.ticker`
- `collect_results(...)` uses `sq.ticker`, `sq.sub_question`
- `format_report(report: AnalysisReport)` uses `report.executive_summary`, `report.company_findings`, `report.key_risks`, `report.recommendations`

This is the access pattern #67644 was built to enable, so the examples now demonstrate it.

## Left as dict access (intentional)

- `finding` inside `company_findings`, which is typed `list[dict]` on `AnalysisReport`, so each finding stays a plain dict
- retrieval chunks (`r["chunks"]`, `c["score"]`, `c["text"]`) produced by the retrieval operators as plain dicts
- `hitl_response` and the SEC EDGAR filing dicts

## Why the cross-task round-trip works

The consuming tasks are plain `@task` functions, not LLM operators, but the worker-side operator walk added in #67875 registers `decompose_question`'s `output_type=DecomposedQuestion` plus the reachable `SubQuestion`, so those workers can deserialize the model instances handed down through XCom.
