### PR TITLE
Improve the default SMTP task failure email template

### DIFF
--- a/providers/smtp/src/airflow/providers/smtp/notifications/templates/email.html
+++ b/providers/smtp/src/airflow/providers/smtp/notifications/templates/email.html
@@ -4,57 +4,97 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="viewport" content="width=device-width">
     </head>
-<body>
-    <table role="presentation">
-        {% if ti is defined %}
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#1f2937;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f4f4f5;padding:24px 0;">
         <tr>
-            <td>Run ID:</td>
-            <td>{{ ti.run_id }}</td>
+            <td align="center">
+                <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background-color:#ffffff;border:1px solid #e5e7eb;border-radius:6px;">
+                    {% if ti is defined %}
+                    <tr>
+                        <td style="padding:16px 24px;background-color:#dc2626;color:#ffffff;font-size:18px;font-weight:bold;border-top-left-radius:6px;border-top-right-radius:6px;">
+                            Airflow Task Failed
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:24px;">
+                            <table role="presentation" width="100%" cellpadding="6" cellspacing="0" border="0" style="font-size:14px;color:#1f2937;">
+                                <tr>
+                                    <td style="width:140px;color:#6b7280;font-weight:bold;vertical-align:top;">DAG:</td>
+                                    <td style="vertical-align:top;">{{ ti.dag_id }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:140px;color:#6b7280;font-weight:bold;vertical-align:top;">Task:</td>
+                                    <td style="vertical-align:top;">{{ ti.task_id }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:140px;color:#6b7280;font-weight:bold;vertical-align:top;">Run ID:</td>
+                                    <td style="vertical-align:top;">{{ ti.run_id }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:140px;color:#6b7280;font-weight:bold;vertical-align:top;">Try:</td>
+                                    <td style="vertical-align:top;">{{ ti.try_number }} of {{ ti.max_tries + 1 }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:140px;color:#6b7280;font-weight:bold;vertical-align:top;">State:</td>
+                                    <td style="vertical-align:top;">{{ ti.state }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:140px;color:#6b7280;font-weight:bold;vertical-align:top;">Host:</td>
+                                    <td style="vertical-align:top;">{{ ti.hostname }}</td>
+                                </tr>
+                            </table>
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:20px;">
+                                <tr>
+                                    <td align="left">
+                                        <a href="{{ ti.log_url }}" style="display:inline-block;padding:10px 18px;background-color:#2563eb;color:#ffffff;text-decoration:none;font-weight:bold;font-size:14px;border-radius:4px;">View Logs</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td style="padding-top:10px;font-size:12px;color:#6b7280;word-break:break-all;">
+                                        <a href="{{ ti.log_url }}" style="color:#2563eb;text-decoration:underline;">{{ ti.log_url }}</a>
+                                    </td>
+                                </tr>
+                                {% if ti.mark_success_url is defined %}
+                                <tr>
+                                    <td style="padding-top:14px;font-size:12px;color:#6b7280;word-break:break-all;">
+                                        Mark Success: <a href="{{ ti.mark_success_url }}" style="color:#2563eb;text-decoration:underline;">{{ ti.mark_success_url }}</a>
+                                    </td>
+                                </tr>
+                                {% endif %}
+                            </table>
+                        </td>
+                    </tr>
+                    {% elif slas is defined %}
+                    <tr>
+                        <td style="padding:24px;">
+                            <table role="presentation" width="100%" cellpadding="6" cellspacing="0" border="0" style="font-size:14px;color:#1f2937;">
+                                <tr>
+                                    <td style="width:160px;color:#6b7280;font-weight:bold;vertical-align:top;">Dag:</td>
+                                    <td style="vertical-align:top;">{{ dag.dag_id }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:160px;color:#6b7280;font-weight:bold;vertical-align:top;">Task List:</td>
+                                    <td style="vertical-align:top;">{{ task_list }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:160px;color:#6b7280;font-weight:bold;vertical-align:top;">Blocking Task List:</td>
+                                    <td style="vertical-align:top;">{{ blocking_task_list }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:160px;color:#6b7280;font-weight:bold;vertical-align:top;">SLAs:</td>
+                                    <td style="vertical-align:top;">{{ slas }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="width:160px;color:#6b7280;font-weight:bold;vertical-align:top;">Blocking TI's</td>
+                                    <td style="vertical-align:top;">{{ blocking_tis }}</td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </td>
         </tr>
-        <tr>
-            <td>Try:</td>
-            <td>{{ ti.try_number }} of {{ ti.max_tries + 1 }}</td>
-        </tr>
-        <tr>
-            <td>Task State:</td>
-            <td>{{ ti.state }}</td>
-        </tr>
-        <tr>
-            <td>Host:</td>
-            <td>{{ ti.hostname }}</td>
-        </tr>
-        <tr>
-            <td>Log Link:</td>
-            <td><a href="{{ ti.log_url }}" style="text-decoration:underline;">{{ ti.log_url }}</a></td>
-        </tr>
-        {% if ti.mark_success_url is defined %}
-        <tr>
-            <td>Mark Success Link:</td>
-            <td><a href="{{ ti.mark_success_url }}" style="text-decoration:underline;">{{ ti.mark_success_url }}</a></td>
-        </tr>
-        {% endif %}
-        {% elif slas is defined %}
-        <tr>
-            <td>Dag:</td>
-            <td>{{ dag.dag_id }}</td>
-        </tr>
-        <tr>
-            <td>Task List:</td>
-            <td>{{ task_list }}</td>
-        </tr>
-        <tr>
-            <td>Blocking Task List:</td>
-            <td>{{ blocking_task_list }}</td>
-        </tr>
-        <tr>
-            <td>SLAs:</td>
-            <td>{{ slas }}</td>
-        </tr>
-        <tr>
-            <td>Blocking TI's</td>
-            <td>{{ blocking_tis }}</td>
-        </tr>
-        {% endif %}
     </table>
 </body>
 </html>

--- a/providers/smtp/src/airflow/providers/smtp/notifications/templates/email_subject.jinja2
+++ b/providers/smtp/src/airflow/providers/smtp/notifications/templates/email_subject.jinja2
@@ -17,7 +17,7 @@
  under the License.
 #}
 {% if ti is defined %}
-DAG {{ ti.dag_id }} - Task {{ ti.task_id }} - Run ID {{ ti.run_id }} in State {{ ti.state }}
+[Airflow] {{ ti.dag_id }}.{{ ti.task_id }} {{ ti.state }} - Run {{ ti.run_id }}
 {% elif slas is defined %}
 SLA Missed for DAG {{ dag.dag_id }} - Task {{ slas[0].task_id }}
 {% endif %}

--- a/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/notifications/test_smtp.py
@@ -163,7 +163,7 @@ class TestSmtpNotifier:
         mock_smtphook_hook.return_value.__enter__().send_email_smtp.assert_called_once_with(
             from_email=TEST_SENDER,
             to=TEST_RECEIVER,
-            subject=f"DAG {TEST_DAG_ID} - Task {TEST_TASK_ID} - Run ID {TEST_RUN_ID} in State {TEST_TASK_STATE}",
+            subject=f"[Airflow] {TEST_DAG_ID}.{TEST_TASK_ID} {TEST_TASK_STATE} - Run {TEST_RUN_ID}",
             html_content=mock.ANY,
             smtp_conn_id=SMTP_CONN_ID,
             **DEFAULT_EMAIL_PARAMS,


### PR DESCRIPTION
Resolves #61667.

The default email that `SmtpNotifier` sends on task failure does not show which DAG or task failed, so it is hard to triage at a glance. This restyles the default templates for readability, keeping the change minimal and backward compatible.

### What changed
- `templates/email.html`: add **DAG** and **Task** rows (previously missing) alongside the existing Run ID, Try, State, Host and log link, and lay the body out as a scannable table. Layout uses a plain `<table>` with inline cell styles only (no `<style>` or `<head>` styling, no CSS grid or flexbox), so it renders consistently in Gmail and Outlook.
- `templates/email_subject.jinja2`: a more scannable subject, `[Airflow] {{ ti.dag_id }}.{{ ti.task_id }} {{ ti.state }} - Run {{ ti.run_id }}`. The SLA branch is unchanged.
- `tests/unit/smtp/notifications/test_smtp.py`: update the one assertion that pins the default subject.

### Scope and compatibility
- Only the SMTP provider default templates are touched. airflow-core and task-sdk are left alone, since email integration is moving out of core (PR #30531).
- Backward compatible: a user-provided `subject_template` or `html_content_template` (connection extras) still takes precedence over the bundled defaults.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code

<!-- pr-triage-fold: triaged=2026-07-28T16:10:44Z head=f39ed66 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @wilmerdooley** · by `@potiuk` · 2026-07-28 16:10 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Unit tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **1310 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
