### PR TITLE
Register nested Pydantic models for XCom deserialization

### DIFF
--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -130,9 +130,11 @@ def iter_pydantic_models(annotation: Any) -> Iterator[type]:
 
     Handles a bare model class, ``Optional`` / ``Union`` of models, and
     parameterized containers such as ``list[MyModel]`` -- the shapes accepted as
-    an operator ``output_type``. The agent (or operator) may emit an instance of
-    any model reachable from the annotation, so each must be registered for XCom
-    deserialization, not just the top-level type.
+    an operator ``output_type`` -- and recurses into a model's own fields so
+    models nested inside it (e.g. ``SubQuestion`` reachable via
+    ``DecomposedQuestion.sub_questions``) are yielded too. A task may push a
+    nested model on to XCom by itself, so each reachable model must be registered
+    for deserialization, not just the top-level type.
     """
     seen: set[Any] = set()
     stack: list[Any] = [annotation]
@@ -151,6 +153,13 @@ def iter_pydantic_models(annotation: Any) -> Iterator[type]:
             seen.add(tp)
             if is_pydantic_model(tp):
                 yield tp
+                # A model's fields may reference further models; walk them so a
+                # value nested inside the declared type is deserializable too.
+                # ``seen`` makes self-referential models terminate. ``getattr``
+                # because ``is_pydantic_model`` guarantees ``model_fields`` exists
+                # but does not narrow ``tp`` (typed ``type``) for the type checker.
+                for field in getattr(tp, "model_fields", {}).values():
+                    stack.append(field.annotation)
 
 
 def decode(d: dict[str, Any]) -> tuple[str, int, Any]:

--- a/task-sdk/tests/task_sdk/serde/test_serde.py
+++ b/task-sdk/tests/task_sdk/serde/test_serde.py
@@ -199,6 +199,27 @@ class C:
         return None
 
 
+class NestedLeaf(BaseModel):
+    value: int
+
+
+class NestedMid(BaseModel):
+    leaves: list[NestedLeaf]
+
+
+class NestedRoot(BaseModel):
+    mid: NestedMid
+    maybe: NestedLeaf | None
+
+
+class SelfRefNode(BaseModel):
+    name: str
+    children: list[SelfRefNode] = []
+
+
+SelfRefNode.model_rebuild()
+
+
 @pytest.mark.usefixtures("recalculate_patterns")
 class TestSerDe:
     def test_ser_primitives(self):
@@ -474,6 +495,16 @@ class TestSerDe:
         # Non-model annotations yield nothing.
         assert set(iter_pydantic_models(str)) == set()
         assert set(iter_pydantic_models(list[int])) == set()
+
+    def test_iter_pydantic_models_recurses_into_fields(self):
+        """Models nested inside a model's fields are yielded, not just the top-level type."""
+        assert set(iter_pydantic_models(NestedRoot)) == {NestedRoot, NestedMid, NestedLeaf}
+        # Holds when the declared type is a container of the root model.
+        assert set(iter_pydantic_models(list[NestedRoot])) == {NestedRoot, NestedMid, NestedLeaf}
+
+    def test_iter_pydantic_models_terminates_on_self_reference(self):
+        """A self-referential model must not loop forever."""
+        assert set(iter_pydantic_models(SelfRefNode)) == {SelfRefNode}
 
     def test_incompatible_version(self):
         data = dict(


### PR DESCRIPTION
The worker-side walk that registers an operator's structured-output classes for XCom deserialization (`_register_deserialization_allowed_classes`, reading each operator's `output_type`) only registers the top-level declared type. `iter_pydantic_models` walks the *annotation shape* (`Optional` / `Union` / `list[...]`) but never recurses into a model's own fields, so a model nested inside the declared type is never added to the per-process deserialization allow-list.

With a model that nests another model:

```python
class SubQuestion(BaseModel): ...
class DecomposedQuestion(BaseModel):
    sub_questions: list[SubQuestion]

@task.llm(output_type=DecomposedQuestion)
def decompose(...): ...
```

a downstream task that emits the nested model to XCom (`return decomposed.sub_questions` -> `list[SubQuestion]`) fails when its input is resolved on the consumer:

```
ImportError: ...SubQuestion was not found in allow list for deserialization imports.
```

`DecomposedQuestion` is registered (it is the declared `output_type`), but `SubQuestion`, reachable only through its field, is not.

## Fix

After yielding a model, push its field annotations onto the walk stack so every reachable model is yielded and registered. The existing `seen` set makes self-referential and mutually recursive model graphs terminate.

Behavior on the example above, exercising the real walk:

- before: allow-list = `{DecomposedQuestion}`; deserializing `list[SubQuestion]` raises the ImportError
- after: allow-list = `{DecomposedQuestion, SubQuestion}`; both hops deserialize

New unit tests cover field recursion (including container-typed fields) and self-reference termination; the rest of the serde suite passes unchanged.

## Context

Surfaced while fixing the common.ai 10-K example DAGs (#67930). Those examples now side-step it by pushing dicts (`serialize_output=True`), but the underlying gap affects any DAG that passes a nested Pydantic model between tasks, so it is worth fixing in core.
