### PR TITLE
Fix IMAP attachment filename collisions

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite_file: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,8 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite_file: If True, overwrite existing files with the same name.
+            If False, preserve existing files by adding an incremental suffix before the extension.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +222,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +290,16 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, overwrite_file: bool = True
+    ) -> None:
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                self._create_file(name, payload, local_output_directory, overwrite_file)
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -311,11 +316,27 @@ class ImapHook(BaseHook):
             else local_output_directory + os.sep + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _create_file(
+        self, name: str, payload: Any, local_output_directory: str, overwrite_file: bool = True
+    ) -> None:
         file_path = self._correct_path(name, local_output_directory)
 
-        with open(file_path, "wb") as file:
-            file.write(payload)
+        if overwrite_file:
+            with open(file_path, "wb") as file:
+                file.write(payload)
+            return
+
+        stem, suffix = os.path.splitext(name)
+        counter = 1
+        while True:
+            try:
+                with open(file_path, "xb") as file:
+                    file.write(payload)
+                return
+            except FileExistsError:
+                candidate = f"{stem}_{counter}{suffix}"
+                file_path = self._correct_path(candidate, local_output_directory)
+                counter += 1
 
 
 class Mail(LoggingMixin):

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -33,7 +33,13 @@ imaplib_string = "airflow.providers.imap.hooks.imap.imaplib"
 open_string = "airflow.providers.imap.hooks.imap.open"
 
 
-def _create_fake_imap(mock_imaplib, with_mail=False, attachment_name="test1.csv", use_ssl=True):
+def _create_fake_imap(
+    mock_imaplib,
+    with_mail=False,
+    attachment_name="test1.csv",
+    use_ssl=True,
+    payload="SWQsTmFtZQoxLEZlbGl4",
+):
     if use_ssl:
         mock_conn = Mock(spec=imaplib.IMAP4_SSL)
         mock_imaplib.IMAP4_SSL.return_value = mock_conn
@@ -51,7 +57,7 @@ def _create_fake_imap(mock_imaplib, with_mail=False, attachment_name="test1.csv"
             f"boundary=123\r\n--123\r\n"
             f"Content-Disposition: attachment; "
             f'filename="{attachment_name}";'
-            f"Content-Transfer-Encoding: base64\r\nSWQsTmFtZQoxLEZlbGl4\r\n--123--"
+            f"Content-Transfer-Encoding: base64\r\n{payload}\r\n--123--"
         )
         mock_conn.fetch.return_value = ("OK", [(b"", mail_string.encode("utf-8"))])
         mock_conn.close.return_value = ("OK", [])
@@ -407,6 +413,55 @@ class TestImapHook:
 
         mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
         assert mock_open_method.call_count == 1
+
+    @pytest.mark.parametrize(
+        ("attachment_name", "unexpected_files"),
+        [
+            ("test1.csv", ["test1_1.csv", "test1_2.csv"]),
+            ("README", ["README_1", "README_2"]),
+            ("test.tar.gz", ["test.tar_1.gz", "test.tar_2.gz"]),
+        ],
+    )
+    @patch(imaplib_string)
+    def test_download_mail_attachments_overwrites_existing_file(
+        self, mock_imaplib, tmp_path, attachment_name, unexpected_files
+    ):
+        for payload in ("first", "second", "third"):
+            _create_fake_imap(
+                mock_imaplib, with_mail=True, attachment_name=attachment_name, payload=payload
+            )
+            with ImapHook() as imap_hook:
+                imap_hook.download_mail_attachments(attachment_name, str(tmp_path))
+
+        assert (tmp_path / attachment_name).read_bytes() == b"third"
+        for unexpected_file in unexpected_files:
+            assert not (tmp_path / unexpected_file).exists()
+        assert len(list(tmp_path.iterdir())) == 1
+
+    @pytest.mark.parametrize(
+        ("attachment_name", "expected_files"),
+        [
+            ("test1.csv", ["test1.csv", "test1_1.csv", "test1_2.csv"]),
+            ("README", ["README", "README_1", "README_2"]),
+            ("test.tar.gz", ["test.tar.gz", "test.tar_1.gz", "test.tar_2.gz"]),
+        ],
+    )
+    @patch(imaplib_string)
+    def test_download_mail_attachments_without_overwrite_preserves_existing_files(
+        self, mock_imaplib, tmp_path, attachment_name, expected_files
+    ):
+        _create_fake_imap(mock_imaplib, with_mail=True, attachment_name=attachment_name)
+
+        with ImapHook() as imap_hook:
+            for _ in range(3):
+                imap_hook.download_mail_attachments(
+                    attachment_name, str(tmp_path), overwrite_file=False
+                )
+
+        payload = b"SWQsTmFtZQoxLEZlbGl4"
+        for expected_file in expected_files:
+            assert (tmp_path / expected_file).read_bytes() == payload
+        assert len(list(tmp_path.iterdir())) == 3
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_with_max_mails(self, mock_imaplib):


### PR DESCRIPTION
Closes #65870

This PR adds an `overwrite_file` option to `ImapHook.download_mail_attachments` so callers can choose whether duplicate attachment filenames overwrite existing files or are preserved with incremental suffixes.

By default, `overwrite_file=True` keeps the current behavior. With `overwrite_file=False`, existing files are preserved using suffixes such as `report_1.xlsx`.

Tests cover:
- default overwrite behavior, including verifying the file content is replaced
- preserving duplicate filenames when `overwrite_file=False`
- filenames with a normal extension, no extension, and multiple extensions

Tested locally:
- `python -m py_compile providers/imap/src/airflow/providers/imap/hooks/imap.py providers/imap/tests/unit/imap/hooks/test_imap.py`
- `git diff --check`

I could not run the targeted pytest file locally from this sparse checkout because `airflow` is not installed in this environment.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: GPT-5.5 following the Airflow pull request guidelines.

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=15f1903 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Abdeltoto** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Static checks`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->