### PR TITLE
Add asset partition sensor

### DIFF
--- a/airflow-core/newsfragments/67941.feature.rst
+++ b/airflow-core/newsfragments/67941.feature.rst
@@ -1,0 +1,1 @@
+Deferred triggers can now look up asset events through the triggerer, so a trigger may wait for an asset event (optionally filtered by ``partition_key``) instead of holding a worker slot.

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -73,6 +73,8 @@ from airflow.sdk.execution_time.comms import (
     DeleteXCom,
     DRCount,
     ErrorResponse,
+    GetAssetEventByAsset,
+    GetAssetEventByAssetAlias,
     GetAssetStateStoreByName,
     GetAssetStateStoreByUri,
     GetConnection,
@@ -108,6 +110,8 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_delete_asset_state_store_by_uri,
     handle_delete_variable,
     handle_delete_xcom,
+    handle_get_asset_event_by_asset,
+    handle_get_asset_event_by_asset_alias,
     handle_get_asset_state_store_by_name,
     handle_get_asset_state_store_by_uri,
     handle_get_connection,
@@ -396,6 +400,8 @@ ToTriggerSupervisor = Annotated[
     | SetXCom
     | GetTICount
     | GetTaskStates
+    | GetAssetEventByAsset
+    | GetAssetEventByAssetAlias
     | ClearAssetStateStoreByName
     | ClearAssetStateStoreByUri
     | DeleteAssetStateStoreByName
@@ -641,6 +647,10 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             resp, dump_opts = handle_get_dr_count(self.client, msg)
         elif isinstance(msg, GetDagRunState):
             resp, dump_opts = handle_get_dag_run_state(self.client, msg)
+        elif isinstance(msg, GetAssetEventByAsset):
+            resp, dump_opts = handle_get_asset_event_by_asset(self.client, msg)
+        elif isinstance(msg, GetAssetEventByAssetAlias):
+            resp, dump_opts = handle_get_asset_event_by_asset_alias(self.client, msg)
 
         elif isinstance(msg, GetTICount):
             resp, dump_opts = handle_get_ti_count(self.client, msg)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -77,16 +77,19 @@ from airflow.providers.standard.triggers.file import FileDeleteTrigger
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, Asset, BaseHook, BaseOperator
 from airflow.sdk.api.client import Client
-from airflow.sdk.api.datamodels._generated import AssetStateStoreResponse
+from airflow.sdk.api.datamodels._generated import AssetEventsResponse, AssetStateStoreResponse
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time import supervisor
 from airflow.sdk.execution_time.comms import (
+    AssetEventsResult,
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
     ErrorResponse,
+    GetAssetEventByAsset,
+    GetAssetEventByAssetAlias,
     GetAssetStateStoreByName,
     GetAssetStateStoreByUri,
     OKResponse,
@@ -1011,6 +1014,73 @@ class TestTriggerSupervisorAssetStateStore:
 
         supervisor.client.asset_state_store.clear.assert_called_once_with(uri="s3://bucket/a")
         supervisor.send_msg.assert_called_once_with(OKResponse(ok=True), request_id=7, error=None)
+
+
+class TestTriggerSupervisorAssetEvents:
+    """Supervisor side of asset-event lookups made by deferred triggers.
+
+    A trigger that queries asset events reaches the supervisor twice: the frame is first
+    validated against the ``ToTriggerSupervisor`` union, then dispatched by
+    ``_handle_request``. Both are asserted here — a message missing from the union fails
+    to decode long before any handler branch runs.
+    """
+
+    @pytest.fixture
+    def supervisor(self, jobless_supervisor, mocker):
+        jobless_supervisor.client = mocker.MagicMock(spec=Client)
+        mocker.patch.object(TriggerRunnerSupervisor, "send_msg")
+        return jobless_supervisor
+
+    @pytest.mark.parametrize(
+        ("msg", "expected_kwargs"),
+        [
+            pytest.param(
+                GetAssetEventByAsset(
+                    name="orders",
+                    uri="s3://warehouse/orders",
+                    partition_key="2024-01-01",
+                    ascending=False,
+                    limit=1,
+                ),
+                {
+                    "uri": "s3://warehouse/orders",
+                    "name": "orders",
+                    "after": None,
+                    "before": None,
+                    "ascending": False,
+                    "limit": 1,
+                    "partition_key": "2024-01-01",
+                    "partition_key_regexp_pattern": None,
+                    "extra": None,
+                },
+                id="by_asset",
+            ),
+            pytest.param(
+                GetAssetEventByAssetAlias(alias_name="orders_alias", partition_key="2024-01-01"),
+                {
+                    "alias_name": "orders_alias",
+                    "after": None,
+                    "before": None,
+                    "ascending": True,
+                    "limit": None,
+                    "partition_key": "2024-01-01",
+                    "partition_key_regexp_pattern": None,
+                    "extra": None,
+                },
+                id="by_asset_alias",
+            ),
+        ],
+    )
+    def test_asset_event_lookup_is_decodable_and_replies(self, supervisor, msg, expected_kwargs):
+        assert TriggerRunnerSupervisor.decoder.validate_python(msg.model_dump()) == msg
+
+        supervisor.client.asset_events.get.return_value = AssetEventsResponse(asset_events=[])
+        supervisor._handle_request(msg, log=MagicMock(spec=FilteringBoundLogger), req_id=7)
+
+        supervisor.client.asset_events.get.assert_called_once_with(**expected_kwargs)
+        supervisor.send_msg.assert_called_once_with(
+            AssetEventsResult(asset_events=[]), request_id=7, error=None, exclude_unset=True
+        )
 
 
 def test_trigger_lifecycle(spy_agency: SpyAgency, session, testing_dag_bundle):

--- a/devel-common/src/tests_common/test_utils/version_compat.py
+++ b/devel-common/src/tests_common/test_utils/version_compat.py
@@ -42,6 +42,7 @@ AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
 AIRFLOW_V_3_2_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 2)
 AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
+AIRFLOW_V_3_4_PLUS = get_base_airflow_version_tuple() >= (3, 4, 0)
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import PokeReturnValue, timezone
@@ -64,6 +65,7 @@ __all__ = [
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
     "AIRFLOW_V_3_3_PLUS",
+    "AIRFLOW_V_3_4_PLUS",
     "NOTSET",
     "XCOM_RETURN_KEY",
     "ArgNotSet",

--- a/providers/standard/docs/sensors/asset.rst
+++ b/providers/standard/docs/sensors/asset.rst
@@ -1,0 +1,73 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/operator:AssetPartitionSensor:
+
+AssetPartitionSensor
+====================
+
+Use the :class:`~airflow.providers.standard.sensors.asset.AssetPartitionSensor` to wait for an asset
+event carrying a specific partition key.
+
+A Dag scheduled with :class:`~airflow.sdk.PartitionedAssetTimetable` is triggered *by* matching asset
+partitions. This sensor covers the opposite direction: a **time-scheduled** Dag that needs to block
+until one named partition of an upstream asset has been produced.
+
+Requires Airflow 3.4 or newer — partition-key filtering of asset events is not available on earlier
+versions.
+
+.. exampleinclude:: /../src/airflow/providers/standard/example_dags/example_asset_partition_sensor.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_sensor_asset_partition]
+    :end-before: [END howto_sensor_asset_partition]
+
+Bounding the lookup with ``after``
+----------------------------------
+
+By default the sensor succeeds on *any* event that carries ``partition_key``, including one produced
+long before the current run. That is what you want when the key is unique per event — a timestamp
+such as ``2024-01-01T05``. It is not what you want when keys repeat across runs, for example a region
+code like ``us``: an event from last week would satisfy the wait immediately.
+
+Pass ``after`` to scope the lookup to the current interval. Both ``partition_key`` and ``after`` are
+templated, so they can be derived from the run:
+
+.. code-block:: python
+
+    AssetPartitionSensor(
+        task_id="wait_for_region",
+        asset=regional_sales,
+        partition_key="us",
+        after="{{ data_interval_start }}",
+    )
+
+Deferrable mode
+---------------
+
+Waiting for an upstream partition can take a long time, so prefer ``deferrable=True`` to release the
+worker slot while waiting. The sensor pokes once up front and only defers when the partition has not
+arrived yet. Deferral is also the default when ``[operators] default_deferrable`` is set.
+
+Lineage
+-------
+
+The waited-for ``asset`` is registered as a task inlet, so the data dependency appears in the asset
+and lineage graph even though the Dag remains time-scheduled. Inlets are declarative only: they make
+the dependency visible without scheduling or gating the Dag run on the asset.

--- a/providers/standard/provider.yaml
+++ b/providers/standard/provider.yaml
@@ -82,6 +82,7 @@ integrations:
       - /docs/apache-airflow-providers-standard/sensors/datetime.rst
       - /docs/apache-airflow-providers-standard/sensors/file.rst
       - /docs/apache-airflow-providers-standard/sensors/external_task_sensor.rst
+      - /docs/apache-airflow-providers-standard/sensors/asset.rst
 
 operators:
   - integration-name: Standard
@@ -107,6 +108,7 @@ sensors:
       - airflow.providers.standard.sensors.python
       - airflow.providers.standard.sensors.filesystem
       - airflow.providers.standard.sensors.external_task
+      - airflow.providers.standard.sensors.asset
 hooks:
   - integration-name: Standard
     python-modules:
@@ -121,6 +123,7 @@ triggers:
       - airflow.providers.standard.triggers.file
       - airflow.providers.standard.triggers.temporal
       - airflow.providers.standard.triggers.hitl
+      - airflow.providers.standard.triggers.asset
 
 extra-links:
   - airflow.providers.standard.operators.trigger_dagrun.TriggerDagRunLink

--- a/providers/standard/src/airflow/providers/standard/example_dags/example_asset_partition_sensor.py
+++ b/providers/standard/src/airflow/providers/standard/example_dags/example_asset_partition_sensor.py
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.providers.standard.sensors.asset import AssetPartitionSensor
+from airflow.sdk import DAG, Asset, timezone
+
+hourly_sales = Asset(uri="s3://warehouse/sales/hourly", name="hourly_sales")
+
+with DAG(
+    dag_id="example_asset_partition_sensor",
+    start_date=timezone.datetime(2026, 1, 1),
+    schedule="@hourly",
+    catchup=False,
+    tags=["example", "asset", "partition"],
+) as dag:
+    # [START howto_sensor_asset_partition]
+    # ``after`` scopes the lookup to this run's interval. Without it, an event carrying the same
+    # partition key from an earlier run would satisfy the wait — harmless for keys that are unique
+    # per event (a timestamp), but wrong for keys that repeat (a region code).
+    wait_for_hourly_partition = AssetPartitionSensor(
+        task_id="wait_for_hourly_partition",
+        asset=hourly_sales,
+        partition_key="{{ data_interval_start.strftime('%Y-%m-%dT%H') }}",
+        after="{{ data_interval_start }}",
+        deferrable=True,
+    )
+    # [END howto_sensor_asset_partition]
+
+    summarize = EmptyOperator(task_id="summarize_hourly_sales")
+
+    wait_for_hourly_partition >> summarize

--- a/providers/standard/src/airflow/providers/standard/exceptions.py
+++ b/providers/standard/src/airflow/providers/standard/exceptions.py
@@ -67,3 +67,7 @@ class HITLTimeoutError(HITLTriggerEventError):
 
 class HITLRejectException(AirflowException):
     """Raised when an ApprovalOperator receives a "Reject" response when fail_on_reject is set to True."""
+
+
+class AssetPartitionTriggerEventError(AirflowException):
+    """Raised when AssetPartitionTrigger reports an error event."""

--- a/providers/standard/src/airflow/providers/standard/get_provider_info.py
+++ b/providers/standard/src/airflow/providers/standard/get_provider_info.py
@@ -43,6 +43,7 @@ def get_provider_info():
                     "/docs/apache-airflow-providers-standard/sensors/datetime.rst",
                     "/docs/apache-airflow-providers-standard/sensors/file.rst",
                     "/docs/apache-airflow-providers-standard/sensors/external_task_sensor.rst",
+                    "/docs/apache-airflow-providers-standard/sensors/asset.rst",
                 ],
             }
         ],
@@ -75,6 +76,7 @@ def get_provider_info():
                     "airflow.providers.standard.sensors.python",
                     "airflow.providers.standard.sensors.filesystem",
                     "airflow.providers.standard.sensors.external_task",
+                    "airflow.providers.standard.sensors.asset",
                 ],
             }
         ],
@@ -96,6 +98,7 @@ def get_provider_info():
                     "airflow.providers.standard.triggers.file",
                     "airflow.providers.standard.triggers.temporal",
                     "airflow.providers.standard.triggers.hitl",
+                    "airflow.providers.standard.triggers.asset",
                 ],
             }
         ],

--- a/providers/standard/src/airflow/providers/standard/sensors/asset.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/asset.py
@@ -1,0 +1,129 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.common.compat.sdk import (
+    AirflowOptionalProviderFeatureException,
+    BaseSensorOperator,
+    conf,
+    timezone,
+)
+from airflow.providers.standard.version_compat import AIRFLOW_V_3_4_PLUS
+
+if not AIRFLOW_V_3_4_PLUS:
+    raise AirflowOptionalProviderFeatureException("Asset partition sensor needs Airflow 3.4+.")
+
+from airflow.providers.standard.exceptions import AssetPartitionTriggerEventError
+from airflow.providers.standard.triggers.asset import AssetPartitionTrigger
+
+if TYPE_CHECKING:
+    from airflow.providers.common.compat.sdk import Asset, Context
+
+
+class AssetPartitionSensor(BaseSensorOperator):
+    """
+    Wait for an asset event with the given partition key.
+
+    :param asset: asset to wait for.
+    :param partition_key: partition key for the asset event to wait for.
+    :param after: only match events whose timestamp is at or after this (timezone-aware)
+        datetime. When unset, any historical event with the partition key satisfies the
+        wait. Bound it (e.g. ``after="{{ data_interval_start }}"``) when the partition key
+        can be reused across events, so a stale event from an earlier run is not matched.
+    :param deferrable: If waiting for completion, whether to defer the task until done.
+
+    The waited-for ``asset`` is registered as an inlet, so the dependency shows up in the
+    asset/lineage graph even though the Dag stays time-scheduled and is not asset-triggered.
+    """
+
+    template_fields: Sequence[str] = ("partition_key", "after")
+    ui_color = "#e6f1f2"
+
+    def __init__(
+        self,
+        *,
+        asset: Asset,
+        partition_key: str,
+        after: datetime.datetime | str | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.asset = asset
+        self.partition_key = partition_key
+        self.after = after
+        self.deferrable = deferrable
+        # Declare the waited-for asset as an inlet so the data dependency is visible in the
+        # lineage graph. Inlets are declarative only — they do not schedule or gate the run.
+        self.add_inlets([asset])
+
+    def poke(self, context: Context) -> bool:
+        from airflow.sdk.exceptions import AirflowRuntimeError
+        from airflow.sdk.execution_time.comms import AssetEventsResult, ErrorResponse, GetAssetEventByAsset
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+        self.log.info("Poking for asset event: asset=%s, partition_key=%s", self.asset, self.partition_key)
+        after = timezone.parse(self.after) if isinstance(self.after, str) else self.after
+        response = SUPERVISOR_COMMS.send(
+            GetAssetEventByAsset(
+                name=self.asset.name,
+                uri=self.asset.uri,
+                partition_key=self.partition_key,
+                after=after,
+                ascending=False,
+                limit=1,
+            )
+        )
+        if isinstance(response, ErrorResponse):
+            raise AirflowRuntimeError(response)
+        if TYPE_CHECKING:
+            assert isinstance(response, AssetEventsResult)
+        return bool(response and response.asset_events)
+
+    def execute(self, context: Context) -> None:
+        if not self.deferrable:
+            super().execute(context=context)
+            return
+
+        if not self.poke(context=context):
+            self.defer(
+                timeout=datetime.timedelta(seconds=self.timeout),
+                trigger=AssetPartitionTrigger(
+                    asset_name=self.asset.name,
+                    asset_uri=self.asset.uri,
+                    partition_key=self.partition_key,
+                    after=self.after,
+                    poke_interval=self.poke_interval,
+                ),
+                method_name="execute_complete",
+            )
+
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> None:
+        if event and event.get("status") == "success":
+            self.log.info(
+                "Asset partition event found: asset=%s, partition_key=%s",
+                self.asset,
+                self.partition_key,
+            )
+            return
+        message = event.get("message") if event else "Trigger completed without an event"
+        raise AssetPartitionTriggerEventError(message)

--- a/providers/standard/src/airflow/providers/standard/triggers/asset.py
+++ b/providers/standard/src/airflow/providers/standard/triggers/asset.py
@@ -1,0 +1,107 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException, timezone
+from airflow.providers.standard.version_compat import AIRFLOW_V_3_4_PLUS
+
+if not AIRFLOW_V_3_4_PLUS:
+    raise AirflowOptionalProviderFeatureException("Asset partition sensor needs Airflow 3.4+.")
+
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+if TYPE_CHECKING:
+    import datetime
+
+
+class AssetPartitionTrigger(BaseTrigger):
+    """
+    Trigger when an asset event exists for the given partition key.
+
+    :param asset_name: name of the asset to wait for.
+    :param asset_uri: URI of the asset to wait for.
+    :param partition_key: partition key for the asset event to wait for.
+    :param after: only match events whose timestamp is at or after this (timezone-aware)
+        datetime. Leave unset to match any event with the partition key.
+    :param poke_interval: polling interval in seconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        asset_name: str | None,
+        asset_uri: str | None,
+        partition_key: str,
+        after: datetime.datetime | str | None = None,
+        poke_interval: float = 5.0,
+    ) -> None:
+        super().__init__()
+        self.asset_name = asset_name
+        self.asset_uri = asset_uri
+        self.partition_key = partition_key
+        self.after = after
+        self.poke_interval = poke_interval
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize AssetPartitionTrigger arguments and classpath."""
+        return (
+            "airflow.providers.standard.triggers.asset.AssetPartitionTrigger",
+            {
+                "asset_name": self.asset_name,
+                "asset_uri": self.asset_uri,
+                "partition_key": self.partition_key,
+                "after": self.after,
+                "poke_interval": self.poke_interval,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """Poll until the requested asset partition event exists."""
+        from airflow.sdk.execution_time.comms import AssetEventsResult, ErrorResponse, GetAssetEventByAsset
+        from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
+
+        after = timezone.parse(self.after) if isinstance(self.after, str) else self.after
+        while True:
+            response = await SUPERVISOR_COMMS.asend(
+                GetAssetEventByAsset(
+                    name=self.asset_name,
+                    uri=self.asset_uri,
+                    partition_key=self.partition_key,
+                    after=after,
+                    ascending=False,
+                    limit=1,
+                )
+            )
+            if isinstance(response, ErrorResponse):
+                yield TriggerEvent(
+                    {
+                        "status": "error",
+                        "message": f"{response.error.value}: {response.detail}",
+                    }
+                )
+                return
+            if TYPE_CHECKING:
+                assert isinstance(response, AssetEventsResult)
+            if response and response.asset_events:
+                yield TriggerEvent({"status": "success"})
+                return
+            await asyncio.sleep(self.poke_interval)

--- a/providers/standard/src/airflow/providers/standard/version_compat.py
+++ b/providers/standard/src/airflow/providers/standard/version_compat.py
@@ -37,6 +37,7 @@ AIRFLOW_V_3_1_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_1_3_PLUS: bool = get_base_airflow_version_tuple() >= (3, 1, 3)
 AIRFLOW_V_3_2_PLUS: bool = get_base_airflow_version_tuple() >= (3, 2, 0)
 AIRFLOW_V_3_3_PLUS: bool = get_base_airflow_version_tuple() >= (3, 3, 0)
+AIRFLOW_V_3_4_PLUS: bool = get_base_airflow_version_tuple() >= (3, 4, 0)
 
 # BaseOperator: Use 3.1+ due to xcom_push method missing in SDK BaseOperator 3.0.x
 # This is needed for DecoratedOperator compatibility
@@ -60,6 +61,7 @@ __all__ = [
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
     "AIRFLOW_V_3_3_PLUS",
+    "AIRFLOW_V_3_4_PLUS",
     "ArgNotSet",
     "BaseOperator",
     "is_arg_set",

--- a/providers/standard/tests/unit/standard/sensors/test_asset.py
+++ b/providers/standard/tests/unit/standard/sensors/test_asset.py
@@ -1,0 +1,243 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_4_PLUS
+
+if not AIRFLOW_V_3_4_PLUS:
+    pytest.skip(
+        "Asset event partition_key filtering is only available in Airflow >= 3.4.0",
+        allow_module_level=True,
+    )
+
+from airflow.providers.common.compat.sdk import AirflowException, Asset, TaskDeferred
+from airflow.providers.standard.sensors.asset import AssetPartitionSensor
+from airflow.providers.standard.triggers.asset import AssetPartitionTrigger
+from airflow.sdk import timezone
+from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.execution_time import task_runner
+from airflow.sdk.execution_time.comms import (
+    AssetEventsResult,
+    ErrorResponse,
+    GetAssetEventByAsset,
+)
+
+
+class TestAssetPartitionSensor:
+    def test_template_fields(self):
+        assert AssetPartitionSensor.template_fields == ("partition_key", "after")
+
+    def test_waited_asset_is_registered_as_inlet(self):
+        asset = Asset(name="orders", uri="s3://warehouse/orders")
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=asset,
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.inlets == [asset]
+
+    def test_user_supplied_inlets_are_preserved(self):
+        asset = Asset(name="orders", uri="s3://warehouse/orders")
+        other = Asset(name="other", uri="s3://warehouse/other")
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=asset,
+            partition_key="2024-01-01",
+            inlets=[other],
+        )
+
+        assert sensor.inlets == [other, asset]
+
+    def test_poke_returns_true_when_partition_event_exists(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(
+            asset_events=[
+                AssetEventResponse(
+                    id=1,
+                    timestamp=timezone.utcnow(),
+                    asset=AssetResponse(name="orders", uri="s3://warehouse/orders", group="asset"),
+                    partition_key="2024-01-01",
+                    created_dagruns=[],
+                )
+            ],
+        )
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.poke({}) is True
+        comms.send.assert_called_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    def test_poke_forwards_after_bound(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        after = timezone.datetime(2024, 1, 1)
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+            after=after,
+        )
+
+        assert sensor.poke({}) is False
+        comms.send.assert_called_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                after=after,
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    def test_poke_parses_string_after(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+            after="2024-01-01T00:00:00+00:00",
+        )
+
+        assert sensor.poke({}) is False
+        comms.send.assert_called_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                after=timezone.parse("2024-01-01T00:00:00+00:00"),
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    def test_poke_returns_false_when_partition_event_is_missing(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.poke({}) is False
+
+    def test_poke_raises_runtime_error_for_supervisor_error(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = ErrorResponse(error=ErrorType.ASSET_NOT_FOUND)
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            sensor.poke({})
+
+    def test_execute_pokes_and_succeeds_when_not_deferrable(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(
+            asset_events=[
+                AssetEventResponse(
+                    id=1,
+                    timestamp=timezone.utcnow(),
+                    asset=AssetResponse(name="orders", uri="s3://warehouse/orders", group="asset"),
+                    partition_key="2024-01-01",
+                    created_dagruns=[],
+                )
+            ],
+        )
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.execute({}) is None
+        comms.send.assert_called_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    def test_execute_defers_when_partition_event_is_missing(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        after = timezone.datetime(2024, 1, 1)
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+            after=after,
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            sensor.execute({})
+
+        assert isinstance(exc.value.trigger, AssetPartitionTrigger)
+        assert exc.value.trigger.asset_name == "orders"
+        assert exc.value.trigger.asset_uri == "s3://warehouse/orders"
+        assert exc.value.trigger.partition_key == "2024-01-01"
+        assert exc.value.trigger.after == after
+
+    def test_execute_complete_raises_for_trigger_error(self):
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        with pytest.raises(AirflowException, match="failed"):
+            sensor.execute_complete({}, {"status": "error", "message": "failed"})

--- a/providers/standard/tests/unit/standard/sensors/test_asset.py
+++ b/providers/standard/tests/unit/standard/sensors/test_asset.py
@@ -1,0 +1,187 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_4_PLUS
+
+if not AIRFLOW_V_3_4_PLUS:
+    pytest.skip(
+        "Asset event partition_key filtering is only available in Airflow >= 3.4.0",
+        allow_module_level=True,
+    )
+
+from airflow.providers.common.compat.sdk import AirflowException, Asset, TaskDeferred
+from airflow.providers.standard.sensors.asset import AssetPartitionSensor
+from airflow.providers.standard.triggers.asset import AssetPartitionTrigger
+from airflow.sdk import timezone
+from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.execution_time import task_runner
+from airflow.sdk.execution_time.comms import (
+    AssetEventsResult,
+    ErrorResponse,
+    GetAssetEventByAsset,
+)
+
+
+class TestAssetPartitionSensor:
+    def test_template_fields(self):
+        assert AssetPartitionSensor.template_fields == ("partition_key", "after")
+
+    def test_waited_asset_is_registered_as_inlet(self):
+        asset = Asset(name="orders", uri="s3://warehouse/orders")
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=asset,
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.inlets == [asset]
+
+    def test_user_supplied_inlets_are_preserved(self):
+        asset = Asset(name="orders", uri="s3://warehouse/orders")
+        other = Asset(name="other", uri="s3://warehouse/other")
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=asset,
+            partition_key="2024-01-01",
+            inlets=[other],
+        )
+
+        assert sensor.inlets == [other, asset]
+
+    def test_poke_returns_true_when_partition_event_exists(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(
+            asset_events=[
+                AssetEventResponse(
+                    id=1,
+                    timestamp=timezone.utcnow(),
+                    asset=AssetResponse(name="orders", uri="s3://warehouse/orders", group="asset"),
+                    partition_key="2024-01-01",
+                    created_dagruns=[],
+                )
+            ],
+        )
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.poke({}) is True
+        comms.send.assert_called_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    def test_poke_forwards_after_bound(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        after = timezone.datetime(2024, 1, 1)
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+            after=after,
+        )
+
+        assert sensor.poke({}) is False
+        comms.send.assert_called_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                after=after,
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    def test_poke_returns_false_when_partition_event_is_missing(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        assert sensor.poke({}) is False
+
+    def test_poke_raises_runtime_error_for_supervisor_error(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = ErrorResponse(error=ErrorType.ASSET_NOT_FOUND)
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            sensor.poke({})
+
+    def test_execute_defers_when_partition_event_is_missing(self, monkeypatch):
+        comms = mock.Mock()
+        comms.send.return_value = AssetEventsResult(asset_events=[])
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+
+        after = timezone.datetime(2024, 1, 1)
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+            after=after,
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            sensor.execute({})
+
+        assert isinstance(exc.value.trigger, AssetPartitionTrigger)
+        assert exc.value.trigger.asset_name == "orders"
+        assert exc.value.trigger.asset_uri == "s3://warehouse/orders"
+        assert exc.value.trigger.partition_key == "2024-01-01"
+        assert exc.value.trigger.after == after
+
+    def test_execute_complete_raises_for_trigger_error(self):
+        sensor = AssetPartitionSensor(
+            task_id="wait_orders",
+            asset=Asset(name="orders", uri="s3://warehouse/orders"),
+            partition_key="2024-01-01",
+        )
+
+        with pytest.raises(AirflowException, match="failed"):
+            sensor.execute_complete({}, {"status": "error", "message": "failed"})

--- a/providers/standard/tests/unit/standard/triggers/test_asset.py
+++ b/providers/standard/tests/unit/standard/triggers/test_asset.py
@@ -1,0 +1,112 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_4_PLUS
+
+if not AIRFLOW_V_3_4_PLUS:
+    pytest.skip(
+        "Asset event partition_key filtering is only available in Airflow >= 3.4.0",
+        allow_module_level=True,
+    )
+
+from airflow.providers.standard.triggers.asset import AssetPartitionTrigger
+from airflow.sdk import timezone
+from airflow.sdk.api.datamodels._generated import AssetEventResponse, AssetResponse
+from airflow.sdk.exceptions import ErrorType
+from airflow.sdk.execution_time import task_runner
+from airflow.sdk.execution_time.comms import AssetEventsResult, ErrorResponse, GetAssetEventByAsset
+from airflow.triggers.base import TriggerEvent
+
+
+class TestAssetPartitionTrigger:
+    def test_serialization(self):
+        after = timezone.datetime(2024, 1, 1)
+        trigger = AssetPartitionTrigger(
+            asset_name="orders",
+            asset_uri="s3://warehouse/orders",
+            partition_key="2024-01-01",
+            after=after,
+            poke_interval=10,
+        )
+
+        classpath, kwargs = trigger.serialize()
+
+        assert classpath == "airflow.providers.standard.triggers.asset.AssetPartitionTrigger"
+        assert kwargs == {
+            "asset_name": "orders",
+            "asset_uri": "s3://warehouse/orders",
+            "partition_key": "2024-01-01",
+            "after": after,
+            "poke_interval": 10,
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_yields_success_when_partition_event_exists(self, monkeypatch):
+        comms = mock.Mock()
+        comms.asend = mock.AsyncMock(
+            return_value=AssetEventsResult(
+                asset_events=[
+                    AssetEventResponse(
+                        id=1,
+                        timestamp=timezone.utcnow(),
+                        asset=AssetResponse(name="orders", uri="s3://warehouse/orders", group="asset"),
+                        partition_key="2024-01-01",
+                        created_dagruns=[],
+                    )
+                ],
+            )
+        )
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+        trigger = AssetPartitionTrigger(
+            asset_name="orders",
+            asset_uri="s3://warehouse/orders",
+            partition_key="2024-01-01",
+            poke_interval=0,
+        )
+
+        assert await trigger.run().__anext__() == TriggerEvent({"status": "success"})
+        comms.asend.assert_awaited_once_with(
+            GetAssetEventByAsset(
+                name="orders",
+                uri="s3://warehouse/orders",
+                partition_key="2024-01-01",
+                ascending=False,
+                limit=1,
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_yields_error_for_supervisor_error(self, monkeypatch):
+        comms = mock.Mock()
+        comms.asend = mock.AsyncMock(return_value=ErrorResponse(error=ErrorType.ASSET_NOT_FOUND))
+        monkeypatch.setattr(task_runner, "SUPERVISOR_COMMS", comms, raising=False)
+        trigger = AssetPartitionTrigger(
+            asset_name="orders",
+            asset_uri="s3://warehouse/orders",
+            partition_key="2024-01-01",
+            poke_interval=0,
+        )
+
+        assert await trigger.run().__anext__() == TriggerEvent(
+            {"status": "error", "message": "ASSET_NOT_FOUND: None"}
+        )

--- a/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
+++ b/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
@@ -41,6 +41,7 @@ from airflow.sdk.api.datamodels._generated import (
     XComSequenceSliceResponse,
 )
 from airflow.sdk.execution_time.comms import (
+    AssetEventsResult,
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
@@ -50,6 +51,8 @@ from airflow.sdk.execution_time.comms import (
     DeleteAssetStateStoreByUri,
     DeleteVariable,
     DeleteXCom,
+    GetAssetEventByAsset,
+    GetAssetEventByAssetAlias,
     GetAssetStateStoreByName,
     GetAssetStateStoreByUri,
     GetConnection,
@@ -215,6 +218,41 @@ def handle_get_dag_run_state(client: Client, msg: GetDagRunState) -> tuple[BaseM
     if isinstance(dr_resp, DagRunStateResponse):
         return DagRunStateResult.from_api_response(dr_resp), {}
     return dr_resp, {}
+
+
+def handle_get_asset_event_by_asset(
+    client: Client, msg: GetAssetEventByAsset
+) -> tuple[BaseModel | None, dict[str, bool]]:
+    """Fetch asset events for an asset, optionally filtered by partition key."""
+    resp = client.asset_events.get(
+        uri=msg.uri,
+        name=msg.name,
+        after=msg.after,
+        before=msg.before,
+        ascending=msg.ascending,
+        limit=msg.limit,
+        partition_key=msg.partition_key,
+        partition_key_regexp_pattern=msg.partition_key_regexp_pattern,
+        extra=msg.extra,
+    )
+    return AssetEventsResult.from_asset_events_response(resp), {"exclude_unset": True}
+
+
+def handle_get_asset_event_by_asset_alias(
+    client: Client, msg: GetAssetEventByAssetAlias
+) -> tuple[BaseModel | None, dict[str, bool]]:
+    """Fetch asset events for an asset alias, optionally filtered by partition key."""
+    resp = client.asset_events.get(
+        alias_name=msg.alias_name,
+        after=msg.after,
+        before=msg.before,
+        ascending=msg.ascending,
+        limit=msg.limit,
+        partition_key=msg.partition_key,
+        partition_key_regexp_pattern=msg.partition_key_regexp_pattern,
+        extra=msg.extra,
+    )
+    return AssetEventsResult.from_asset_events_response(resp), {"exclude_unset": True}
 
 
 def handle_get_previous_dag_run(

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -61,7 +61,6 @@ from airflow.sdk.configuration import conf
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time import comms
 from airflow.sdk.execution_time.comms import (
-    AssetEventsResult,
     AssetResult,
     AssetStateStoreResult,
     AwaitInputTask,
@@ -136,6 +135,8 @@ from airflow.sdk.execution_time.coordinator import get_coordinator_manager
 from airflow.sdk.execution_time.request_handlers import (
     handle_delete_variable,
     handle_delete_xcom,
+    handle_get_asset_event_by_asset,
+    handle_get_asset_event_by_asset_alias,
     handle_get_connection,
     handle_get_dag_run_state,
     handle_get_dr_count,
@@ -1767,34 +1768,9 @@ class ActivitySubprocess(WatchedSubprocess):
         elif isinstance(msg, GetAssetsByAlias):
             resp = self.client.assets.get_by_alias(alias_name=msg.alias_name)
         elif isinstance(msg, GetAssetEventByAsset):
-            asset_event_resp = self.client.asset_events.get(
-                uri=msg.uri,
-                name=msg.name,
-                after=msg.after,
-                before=msg.before,
-                ascending=msg.ascending,
-                limit=msg.limit,
-                partition_key=msg.partition_key,
-                partition_key_regexp_pattern=msg.partition_key_regexp_pattern,
-                extra=msg.extra,
-            )
-            asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)
-            resp = asset_event_result
-            dump_opts = {"exclude_unset": True}
+            resp, dump_opts = handle_get_asset_event_by_asset(self.client, msg)
         elif isinstance(msg, GetAssetEventByAssetAlias):
-            asset_event_resp = self.client.asset_events.get(
-                alias_name=msg.alias_name,
-                after=msg.after,
-                before=msg.before,
-                ascending=msg.ascending,
-                limit=msg.limit,
-                partition_key=msg.partition_key,
-                partition_key_regexp_pattern=msg.partition_key_regexp_pattern,
-                extra=msg.extra,
-            )
-            asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)
-            resp = asset_event_result
-            dump_opts = {"exclude_unset": True}
+            resp, dump_opts = handle_get_asset_event_by_asset_alias(self.client, msg)
         elif isinstance(msg, GetPrevSuccessfulDagRun):
             resp, dump_opts = handle_get_prev_successful_dag_run(self.client, self.id)
         elif isinstance(msg, GetXComCount):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -61,7 +61,6 @@ from airflow.sdk.configuration import conf
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time import comms
 from airflow.sdk.execution_time.comms import (
-    AssetEventsResult,
     AssetResult,
     AssetStateStoreResult,
     AwaitInputTask,
@@ -136,6 +135,8 @@ from airflow.sdk.execution_time.coordinator import get_coordinator_manager
 from airflow.sdk.execution_time.request_handlers import (
     handle_delete_variable,
     handle_delete_xcom,
+    handle_get_asset_event_by_asset,
+    handle_get_asset_event_by_asset_alias,
     handle_get_connection,
     handle_get_dag_run_state,
     handle_get_dr_count,
@@ -1830,34 +1831,9 @@ class ActivitySubprocess(WatchedSubprocess):
         elif isinstance(msg, GetAssetsByAlias):
             resp = self.client.assets.get_by_alias(alias_name=msg.alias_name)
         elif isinstance(msg, GetAssetEventByAsset):
-            asset_event_resp = self.client.asset_events.get(
-                uri=msg.uri,
-                name=msg.name,
-                after=msg.after,
-                before=msg.before,
-                ascending=msg.ascending,
-                limit=msg.limit,
-                partition_key=msg.partition_key,
-                partition_key_regexp_pattern=msg.partition_key_regexp_pattern,
-                extra=msg.extra,
-            )
-            asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)
-            resp = asset_event_result
-            dump_opts = {"exclude_unset": True}
+            resp, dump_opts = handle_get_asset_event_by_asset(self.client, msg)
         elif isinstance(msg, GetAssetEventByAssetAlias):
-            asset_event_resp = self.client.asset_events.get(
-                alias_name=msg.alias_name,
-                after=msg.after,
-                before=msg.before,
-                ascending=msg.ascending,
-                limit=msg.limit,
-                partition_key=msg.partition_key,
-                partition_key_regexp_pattern=msg.partition_key_regexp_pattern,
-                extra=msg.extra,
-            )
-            asset_event_result = AssetEventsResult.from_asset_events_response(asset_event_resp)
-            resp = asset_event_result
-            dump_opts = {"exclude_unset": True}
+            resp, dump_opts = handle_get_asset_event_by_asset_alias(self.client, msg)
         elif isinstance(msg, GetPrevSuccessfulDagRun):
             resp, dump_opts = handle_get_prev_successful_dag_run(self.client, self.id)
         elif isinstance(msg, GetXComCount):

--- a/task-sdk/tests/task_sdk/execution_time/test_request_handlers.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_request_handlers.py
@@ -20,16 +20,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from airflow.sdk import timezone
 from airflow.sdk.api import client as sdk_client
-from airflow.sdk.api.datamodels._generated import AssetStateStoreResponse
+from airflow.sdk.api.datamodels._generated import AssetEventsResponse, AssetStateStoreResponse
 from airflow.sdk.exceptions import ErrorType
 from airflow.sdk.execution_time.comms import (
+    AssetEventsResult,
     AssetStateStoreResult,
     ClearAssetStateStoreByName,
     ClearAssetStateStoreByUri,
     DeleteAssetStateStoreByName,
     DeleteAssetStateStoreByUri,
     ErrorResponse,
+    GetAssetEventByAsset,
+    GetAssetEventByAssetAlias,
     GetAssetStateStoreByName,
     GetAssetStateStoreByUri,
     SetAssetStateStoreByName,
@@ -40,6 +44,8 @@ from airflow.sdk.execution_time.request_handlers import (
     handle_clear_asset_state_store_by_uri,
     handle_delete_asset_state_store_by_name,
     handle_delete_asset_state_store_by_uri,
+    handle_get_asset_event_by_asset,
+    handle_get_asset_event_by_asset_alias,
     handle_get_asset_state_store_by_name,
     handle_get_asset_state_store_by_uri,
     handle_set_asset_state_store_by_name,
@@ -98,6 +104,58 @@ def test_get_asset_state_store_by_uri_passes_through_error_response(client):
 
     assert result is err
     assert dump_opts == {}
+
+
+def test_get_asset_event_by_asset_delegates_and_wraps(client):
+    client.asset_events.get.return_value = AssetEventsResponse(asset_events=[])
+
+    result, dump_opts = handle_get_asset_event_by_asset(
+        client,
+        GetAssetEventByAsset(
+            name="orders",
+            uri="s3://warehouse/orders",
+            partition_key="2024-01-01",
+            after=timezone.datetime(2024, 1, 1),
+            limit=1,
+            ascending=False,
+        ),
+    )
+
+    client.asset_events.get.assert_called_once_with(
+        uri="s3://warehouse/orders",
+        name="orders",
+        after=timezone.datetime(2024, 1, 1),
+        before=None,
+        ascending=False,
+        limit=1,
+        partition_key="2024-01-01",
+        partition_key_regexp_pattern=None,
+        extra=None,
+    )
+    assert isinstance(result, AssetEventsResult)
+    assert dump_opts == {"exclude_unset": True}
+
+
+def test_get_asset_event_by_asset_alias_delegates_and_wraps(client):
+    client.asset_events.get.return_value = AssetEventsResponse(asset_events=[])
+
+    result, dump_opts = handle_get_asset_event_by_asset_alias(
+        client,
+        GetAssetEventByAssetAlias(alias_name="orders_alias", partition_key="2024-01-01"),
+    )
+
+    client.asset_events.get.assert_called_once_with(
+        alias_name="orders_alias",
+        after=None,
+        before=None,
+        ascending=True,
+        limit=None,
+        partition_key="2024-01-01",
+        partition_key_regexp_pattern=None,
+        extra=None,
+    )
+    assert isinstance(result, AssetEventsResult)
+    assert dump_opts == {"exclude_unset": True}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds an `AssetPartitionSensor` (and backing `AssetPartitionTrigger`) to the standard provider so a **time-scheduled** Dag can wait, at the task level, for a specific asset **partition** produced by another Dag — the use case from #67375.

### What it does

- `AssetPartitionSensor(asset=..., partition_key=..., after=..., deferrable=...)` succeeds once an asset event with the given `partition_key` exists.
- `after` (templated) bounds the lookup to the run's interval, so a stale event carrying a reused key from an earlier run doesn't satisfy the wait. `partition_key` is templated too.
- Deferrable mode releases the worker slot while waiting.
- The waited-for asset is registered as a task **inlet**, so the dependency stays visible in the asset/lineage graph even though the Dag stays time-scheduled (it is not asset-triggered).

### Core change

The only `airflow-core` change wires the triggerer so a deferred trigger can look up asset events: `GetAssetEventByAsset` / `GetAssetEventByAssetAlias` are added to the `ToTriggerSupervisor` union and dispatched through a shared request handler (also adopted by the worker supervisor, which becomes a net reduction). A trigger has no metadata-DB or Execution API access of its own, so this is required for deferrable mode — without it the deferred lookup fails the supervisor's frame validation. A regression test covers both the union membership and the dispatch.

Builds on the asset-event `partition_key` filters from #64610; this PR adds no API, DB, OpenAPI, or UI changes of its own.

### Tests & docs

- Unit tests for the sensor, trigger, shared request handlers, and the triggerer supervisor path.
- How-to guide (`sensors/asset.rst`) and an example Dag.

related: #67375

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5) and Claude Code (Opus 4.8)

Generated-by: Codex (GPT-5) and Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
