### PR TITLE
Fix missing task.duration metric for tasks that get skipped after starting.

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1719,27 +1719,22 @@ def _handle_trigger_dag_run(
     )
 
     if isinstance(comms_msg, ErrorResponse) and comms_msg.error == ErrorType.DAGRUN_ALREADY_EXISTS:
+        ti.end_date = datetime.now(tz=timezone.utc)
         if drte.skip_when_already_exists:
             log.info(
                 "Dag Run already exists, skipping task as skip_when_already_exists is set to True.",
                 dag_id=drte.trigger_dag_id,
             )
-            ti.end_date = datetime.now(tz=timezone.utc)
-            msg = TaskState(
-                state=TaskInstanceState.SKIPPED,
-                end_date=ti.end_date,
-                rendered_map_index=ti.rendered_map_index,
-            )
             state = TaskInstanceState.SKIPPED
         else:
             log.error("Dag Run already exists, marking task as failed.", dag_id=drte.trigger_dag_id)
-            msg = TaskState(
-                state=TaskInstanceState.FAILED,
-                end_date=datetime.now(tz=timezone.utc),
-                rendered_map_index=ti.rendered_map_index,
-            )
             state = TaskInstanceState.FAILED
 
+        msg = TaskState(
+            state=state,
+            end_date=ti.end_date,
+            rendered_map_index=ti.rendered_map_index,
+        )
         return msg, state
 
     log.info("Dag Run triggered successfully.", trigger_dag_id=drte.trigger_dag_id)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1474,9 +1474,10 @@ def run(
         log.info("::group::Post Execute")
         if e.args:
             log.info("Skipping task.", reason=e.args[0])
+        ti.end_date = datetime.now(tz=timezone.utc)
         msg = TaskState(
             state=TaskInstanceState.SKIPPED,
-            end_date=datetime.now(tz=timezone.utc),
+            end_date=ti.end_date,
             rendered_map_index=ti.rendered_map_index,
         )
         state = TaskInstanceState.SKIPPED
@@ -1723,9 +1724,10 @@ def _handle_trigger_dag_run(
                 "Dag Run already exists, skipping task as skip_when_already_exists is set to True.",
                 dag_id=drte.trigger_dag_id,
             )
+            ti.end_date = datetime.now(tz=timezone.utc)
             msg = TaskState(
                 state=TaskInstanceState.SKIPPED,
-                end_date=datetime.now(tz=timezone.utc),
+                end_date=ti.end_date,
                 rendered_map_index=ti.rendered_map_index,
             )
             state = TaskInstanceState.SKIPPED

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1720,6 +1720,7 @@ def _handle_trigger_dag_run(
 
     if isinstance(comms_msg, ErrorResponse) and comms_msg.error == ErrorType.DAGRUN_ALREADY_EXISTS:
         ti.end_date = datetime.now(tz=timezone.utc)
+        state: Literal[TaskInstanceState.FAILED, TaskInstanceState.SKIPPED]
         if drte.skip_when_already_exists:
             log.info(
                 "Dag Run already exists, skipping task as skip_when_already_exists is set to True.",

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1632,9 +1632,10 @@ def _run_task_and_map_outcome(
         log.info("::group::Post Execute")
         if e.args:
             log.info("Skipping task.", reason=e.args[0])
+        ti.end_date = datetime.now(tz=timezone.utc)
         msg = TaskState(
             state=TaskInstanceState.SKIPPED,
-            end_date=datetime.now(tz=timezone.utc),
+            end_date=ti.end_date,
             rendered_map_index=ti.rendered_map_index,
         )
         state = TaskInstanceState.SKIPPED
@@ -1962,9 +1963,10 @@ def _handle_trigger_dag_run(
                 "Dag Run already exists, skipping task as skip_when_already_exists is set to True.",
                 dag_id=drte.trigger_dag_id,
             )
+            ti.end_date = datetime.now(tz=timezone.utc)
             msg = TaskState(
                 state=TaskInstanceState.SKIPPED,
-                end_date=datetime.now(tz=timezone.utc),
+                end_date=ti.end_date,
                 rendered_map_index=ti.rendered_map_index,
             )
             state = TaskInstanceState.SKIPPED

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1959,6 +1959,7 @@ def _handle_trigger_dag_run(
 
     if isinstance(comms_msg, ErrorResponse) and comms_msg.error == ErrorType.DAGRUN_ALREADY_EXISTS:
         ti.end_date = datetime.now(tz=timezone.utc)
+        state: Literal[TaskInstanceState.FAILED, TaskInstanceState.SKIPPED]
         if drte.skip_when_already_exists:
             log.info(
                 "Dag Run already exists, skipping task as skip_when_already_exists is set to True.",

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1958,27 +1958,22 @@ def _handle_trigger_dag_run(
     )
 
     if isinstance(comms_msg, ErrorResponse) and comms_msg.error == ErrorType.DAGRUN_ALREADY_EXISTS:
+        ti.end_date = datetime.now(tz=timezone.utc)
         if drte.skip_when_already_exists:
             log.info(
                 "Dag Run already exists, skipping task as skip_when_already_exists is set to True.",
                 dag_id=drte.trigger_dag_id,
             )
-            ti.end_date = datetime.now(tz=timezone.utc)
-            msg = TaskState(
-                state=TaskInstanceState.SKIPPED,
-                end_date=ti.end_date,
-                rendered_map_index=ti.rendered_map_index,
-            )
             state = TaskInstanceState.SKIPPED
         else:
             log.error("Dag Run already exists, marking task as failed.", dag_id=drte.trigger_dag_id)
-            msg = TaskState(
-                state=TaskInstanceState.FAILED,
-                end_date=datetime.now(tz=timezone.utc),
-                rendered_map_index=ti.rendered_map_index,
-            )
             state = TaskInstanceState.FAILED
 
+        msg = TaskState(
+            state=state,
+            end_date=ti.end_date,
+            rendered_map_index=ti.rendered_map_index,
+        )
         return msg, state
 
     log.info("Dag Run triggered successfully.", trigger_dag_id=drte.trigger_dag_id)

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5137,6 +5137,44 @@ class TestTaskInstanceMetrics:
                 tags={"dag_id": ti.dag_id, "task_id": ti.task_id, "state": expected_state},
             )
 
+    @pytest.mark.parametrize(
+        ("task_callable", "expected_state"),
+        [
+            pytest.param(lambda: "success", "success", id="success"),
+            pytest.param(lambda: (_ for _ in ()).throw(AirflowSkipException()), "skipped", id="skipped"),
+            pytest.param(lambda: (_ for _ in ()).throw(AirflowFailException("fail")), "failed", id="failed"),
+        ],
+    )
+    def test_task_duration_metric_emitted_for_terminal_states(
+        self, task_callable, expected_state, create_runtime_ti, mock_supervisor_comms
+    ):
+        """task.duration is emitted for every terminal state — success, skipped, failed."""
+        task = PythonOperator(task_id="test", python_callable=task_callable)
+        ti = create_runtime_ti(task=task)
+
+        context = ti.get_template_context()
+        with mock.patch("airflow.sdk._shared.observability.metrics.stats._get_backend") as mock_get_backend:
+            backend = mock.MagicMock(spec=StatsLogger)
+            mock_get_backend.return_value = backend
+            state, _, error = run(ti, context=context, log=mock.MagicMock())
+            finalize(ti, state=state, context=context, log=mock.MagicMock(), error=error)
+
+            # verify task.duration was emitted in tagged format
+            task_duration_calls = [
+                c for c in backend.timing.call_args_list if c.args and c.args[0] == "task.duration"
+            ]
+            assert len(task_duration_calls) == 1, (
+                f"Expected exactly 1 task.duration emit for state={expected_state}, "
+                f"got {len(task_duration_calls)}"
+            )
+            assert task_duration_calls[0].kwargs.get("tags") == {
+                "dag_id": ti.dag_id,
+                "task_id": ti.task_id,
+            }
+            # verify task.duration was also emitted in legacy dotted format via the
+            # registry's legacy_name derivation in metrics_template.yaml
+            backend.timing.assert_any_call(f"dag.{ti.dag_id}.{ti.task_id}.duration", mock.ANY)
+
     def test_operator_successes_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
         """Test that operator_successes and ti_successes metrics are emitted on task success."""
         task = PythonOperator(task_id="test", python_callable=lambda: "success")

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -4891,6 +4891,10 @@ class TestTriggerDagRunOperator:
 
         assert state == expected_state
         assert msg.state == expected_state
+        # end_date must be set on the local instance (not just the outbound
+        # message) so finalize() emits the task.duration metric
+        assert ti.end_date is not None
+        assert msg.end_date == ti.end_date
 
         expected_calls = [
             mock.call.send(

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5174,10 +5174,14 @@ class TestTaskInstanceMetrics:
             assert task_duration_calls[0].kwargs.get("tags") == {
                 "dag_id": ti.dag_id,
                 "task_id": ti.task_id,
+                "run_type": "manual",
             }
             # verify task.duration was also emitted in legacy dotted format via the
-            # registry's legacy_name derivation in metrics_template.yaml
-            backend.timing.assert_any_call(f"dag.{ti.dag_id}.{ti.task_id}.duration", mock.ANY)
+            # registry's legacy_name derivation in metrics_template.yaml. dag_id and
+            # task_id are consumed by the legacy name, leaving run_type as a tag.
+            backend.timing.assert_any_call(
+                f"dag.{ti.dag_id}.{ti.task_id}.duration", mock.ANY, tags={"run_type": "manual"}
+            )
 
     def test_operator_successes_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
         """Test that operator_successes and ti_successes metrics are emitted on task success."""

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5871,6 +5871,44 @@ class TestTaskInstanceMetrics:
                 },
             )
 
+    @pytest.mark.parametrize(
+        ("task_callable", "expected_state"),
+        [
+            pytest.param(lambda: "success", "success", id="success"),
+            pytest.param(lambda: (_ for _ in ()).throw(AirflowSkipException()), "skipped", id="skipped"),
+            pytest.param(lambda: (_ for _ in ()).throw(AirflowFailException("fail")), "failed", id="failed"),
+        ],
+    )
+    def test_task_duration_metric_emitted_for_terminal_states(
+        self, task_callable, expected_state, create_runtime_ti, mock_supervisor_comms
+    ):
+        """task.duration is emitted for every terminal state — success, skipped, failed."""
+        task = PythonOperator(task_id="test", python_callable=task_callable)
+        ti = create_runtime_ti(task=task)
+
+        context = ti.get_template_context()
+        with mock.patch("airflow.sdk._shared.observability.metrics.stats._get_backend") as mock_get_backend:
+            backend = mock.MagicMock(spec=StatsLogger)
+            mock_get_backend.return_value = backend
+            state, _, error = run(ti, context=context, log=mock.MagicMock())
+            finalize(ti, state=state, context=context, log=mock.MagicMock(), error=error)
+
+            # verify task.duration was emitted in tagged format
+            task_duration_calls = [
+                c for c in backend.timing.call_args_list if c.args and c.args[0] == "task.duration"
+            ]
+            assert len(task_duration_calls) == 1, (
+                f"Expected exactly 1 task.duration emit for state={expected_state}, "
+                f"got {len(task_duration_calls)}"
+            )
+            assert task_duration_calls[0].kwargs.get("tags") == {
+                "dag_id": ti.dag_id,
+                "task_id": ti.task_id,
+            }
+            # verify task.duration was also emitted in legacy dotted format via the
+            # registry's legacy_name derivation in metrics_template.yaml
+            backend.timing.assert_any_call(f"dag.{ti.dag_id}.{ti.task_id}.duration", mock.ANY)
+
     def test_operator_successes_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
         """Test that operator_successes and ti_successes metrics are emitted on task success."""
         task = PythonOperator(task_id="test", python_callable=lambda: "success")

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5908,10 +5908,14 @@ class TestTaskInstanceMetrics:
             assert task_duration_calls[0].kwargs.get("tags") == {
                 "dag_id": ti.dag_id,
                 "task_id": ti.task_id,
+                "run_type": "manual",
             }
             # verify task.duration was also emitted in legacy dotted format via the
-            # registry's legacy_name derivation in metrics_template.yaml
-            backend.timing.assert_any_call(f"dag.{ti.dag_id}.{ti.task_id}.duration", mock.ANY)
+            # registry's legacy_name derivation in metrics_template.yaml. dag_id and
+            # task_id are consumed by the legacy name, leaving run_type as a tag.
+            backend.timing.assert_any_call(
+                f"dag.{ti.dag_id}.{ti.task_id}.duration", mock.ANY, tags={"run_type": "manual"}
+            )
 
     def test_operator_successes_metrics_emitted(self, create_runtime_ti, mock_supervisor_comms):
         """Test that operator_successes and ti_successes metrics are emitted on task success."""

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5355,6 +5355,10 @@ class TestTriggerDagRunOperator:
 
         assert state == expected_state
         assert msg.state == expected_state
+        # end_date must be set on the local instance (not just the outbound
+        # message) so finalize() emits the task.duration metric
+        assert ti.end_date is not None
+        assert msg.end_date == ti.end_date
 
         expected_calls = [
             mock.call.send(


### PR DESCRIPTION
## Summary

`task.duration` (and its registry-derived legacy name `dag.<dag_id>.<task_id>.duration`) was emitted for tasks ending in `SUCCESS` or `FAILED` but missing entirely for `SKIPPED` tasks, despite the metric being documented as available for all terminal states. Reproducible with `ShortCircuitOperator`, `BranchPythonOperator`, and `BashOperator` with `skip_on_exit_code` (narrowed in #61849 by @shivaam).

## Fix

The metric is emitted from `finalize()` in the Task SDK `task_runner`, gated on `if ti.start_date and ti.end_date:`. The `SUCCESS` and `FAILED` exception handlers set `ti.end_date` on the local `RuntimeTaskInstance` before constructing the outbound `TaskState` message, so the guard passes. The two `SKIPPED` handlers (`AirflowSkipException`, and the `SKIPPED` branch of `DagRunTriggerException` with `skip_when_already_exists=True`) set `end_date` only on the outbound `TaskState` message, leaving `ti.end_date` as `None` — so `finalize()`'s guard failed for skipped tasks.

Set `ti.end_date` on the local instance in both handlers, mirroring the `AirflowFailException` and `_handle_current_task_success` patterns. The `TaskState` message references `ti.end_date` to keep the local instance and the outbound message in sync.

**Update:** the fix now also covers the `FAILED` branch of the same `DAGRUN_ALREADY_EXISTS` handling (when `skip_when_already_exists=False`), which had the identical bug — `end_date` was set only on the outbound message. `ti.end_date` is now set once before the branch and shared by both outcomes.

## Test plan

- [x] New parametrized `test_task_duration_metric_emitted_for_terminal_states` covers `success` / `skipped` / `failed` — verifies `stats.timing("task.duration", ...)` is called with the correct tags and that the legacy dotted form is also emitted via the `metrics_template.yaml` registry.
- [x] Extended `test_handle_trigger_dag_run_conflict` (parametrized over both conflict outcomes) to assert `ti.end_date` is set on the local instance and matches the outbound message.
- [x] Self-verified by stashing the production change: the `[skipped]` parametrize case fails without the fix and passes with it; `[success]` and `[failed]` pass in both cases.
- [x] Existing SKIPPED-related tests (`test_run_basic_skipped`, `test_task_runner_calls_listeners_skipped`, etc.) still pass — no regression.
- [x] `ruff format` / `ruff check` / `mypy-task-sdk` / `prek run --from-ref upstream/main --stage pre-commit` all green.

closes: #61849

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7, Fable 5)

Generated-by: Claude Code (Opus 4.7, Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=e0f6813 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @myps6415** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Other failing CI checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
