### PR TITLE
Fix JWT token not refreshed when token expires between auth check and reissue middleware

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -311,12 +311,12 @@ class JWTValidator:
         return await self.jwks.get_key(kid)
 
     def validated_claims(
-        self, unvalidated: str, required_claims: dict[str, Any] | None = None
+        self, unvalidated: str, required_claims: dict[str, Any] | None = None, *, extra_leeway: float = 0
     ) -> dict[str, Any]:
-        return async_to_sync(self.avalidated_claims)(unvalidated, required_claims)
+        return async_to_sync(self.avalidated_claims)(unvalidated, required_claims, extra_leeway=extra_leeway)
 
     async def avalidated_claims(
-        self, unvalidated: str, required_claims: dict[str, Any] | None = None
+        self, unvalidated: str, required_claims: dict[str, Any] | None = None, *, extra_leeway: float = 0
     ) -> dict[str, Any]:
         """Decode the JWT token, returning the validated claims or raising an exception."""
         try:
@@ -338,7 +338,7 @@ class JWTValidator:
             issuer=self.issuer,
             options={"require": list(self.required_claims)},
             algorithms=algorithms,
-            leeway=self.leeway,
+            leeway=self.leeway + extra_leeway,
         )
 
         # Validate additional claims if provided

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -25,7 +25,6 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 import attrs
-import jwt as pyjwt
 import svcs
 from cadwyn import (
     Cadwyn,
@@ -43,6 +42,7 @@ from airflow.api_fastapi.auth.tokens import (
     get_sig_validation_args,
     get_signing_args,
 )
+from airflow.api_fastapi.execution_api.security import _jwt_bearer
 
 if TYPE_CHECKING:
     import httpx
@@ -132,37 +132,20 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
 
 
 class JWTReissueMiddleware(BaseHTTPMiddleware):
-    # Grace period (in seconds) for refreshing tokens that have just expired.
-    # This handles the race condition where a token expires between the security
-    # middleware's auth check and this middleware's reissue validation.
-    # The signature and all other claims are still fully verified.
-    REISSUE_GRACE_LEEWAY: int = 60
-
     async def dispatch(self, request: Request, call_next):
         response: Response = await call_next(request)
 
         refreshed_token: str | None = None
         auth_header = request.headers.get("authorization")
         if auth_header and auth_header.lower().startswith("bearer "):
-            token = auth_header.split(" ", 1)[1]
             try:
                 async with svcs.Container(request.app.state.svcs_registry) as services:
-                    validator: JWTValidator = await services.aget(JWTValidator)
-                    try:
-                        claims = await validator.avalidated_claims(token, {})
-                    except pyjwt.ExpiredSignatureError:
-                        # Token may have expired between the auth check and here
-                        # (e.g. token lifetime boundary crossed during request
-                        # processing). Re-validate with a short grace period so
-                        # the client receives a fresh replacement token and can
-                        # retry automatically. The signature and all other
-                        # claims are still fully verified.
-                        claims = await validator.avalidated_claims(
-                            token, {}, extra_leeway=self.REISSUE_GRACE_LEEWAY
-                        )
+                    validated_token = await _jwt_bearer(request, services)
+                    claims = validated_token.claims.model_dump()
+                    claims["sub"] = str(validated_token.id)
 
                     # Workload tokens are long-lived and meant to survive queue
-                    # wait times so avoid refreshing them. If avalidated_claims
+                    # wait times so avoid refreshing them. If JWTBearer
                     # raises for a workload token, the outer except handles it.
                     if claims.get("scope") == "workload":
                         return response

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -141,6 +141,8 @@ class JWTReissueMiddleware(BaseHTTPMiddleware):
             try:
                 async with svcs.Container(request.app.state.svcs_registry) as services:
                     validated_token = await _jwt_bearer(request, services)
+                    if validated_token is None:
+                        return response
                     claims = validated_token.claims.model_dump()
                     claims["sub"] = str(validated_token.id)
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -25,6 +25,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 import attrs
+import jwt as pyjwt
 import svcs
 from cadwyn import (
     Cadwyn,
@@ -131,6 +132,12 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
 
 
 class JWTReissueMiddleware(BaseHTTPMiddleware):
+    # Grace period (in seconds) for refreshing tokens that have just expired.
+    # This handles the race condition where a token expires between the security
+    # middleware's auth check and this middleware's reissue validation.
+    # The signature and all other claims are still fully verified.
+    REISSUE_GRACE_LEEWAY: int = 60
+
     async def dispatch(self, request: Request, call_next):
         response: Response = await call_next(request)
 
@@ -141,7 +148,18 @@ class JWTReissueMiddleware(BaseHTTPMiddleware):
             try:
                 async with svcs.Container(request.app.state.svcs_registry) as services:
                     validator: JWTValidator = await services.aget(JWTValidator)
-                    claims = await validator.avalidated_claims(token, {})
+                    try:
+                        claims = await validator.avalidated_claims(token, {})
+                    except pyjwt.ExpiredSignatureError:
+                        # Token may have expired between the auth check and here
+                        # (e.g. token lifetime boundary crossed during request
+                        # processing). Re-validate with a short grace period so
+                        # the client receives a fresh replacement token and can
+                        # retry automatically. The signature and all other
+                        # claims are still fully verified.
+                        claims = await validator.avalidated_claims(
+                            token, {}, extra_leeway=self.REISSUE_GRACE_LEEWAY
+                        )
 
                     # Workload tokens are long-lived and meant to survive queue
                     # wait times so avoid refreshing them. If avalidated_claims

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock
 
+import jwt
 import pytest
 from fastapi import FastAPI
 
@@ -67,3 +68,39 @@ def test_expiring_token_is_reissued(
         assert "Refreshed-API-Token" in response.headers
     else:
         assert "Refreshed-API-Token" not in response.headers
+
+
+@pytest.mark.db_test
+def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: FastAPI, time_machine):
+    """A token that expired just before JWTReissueMiddleware runs is still refreshed.
+
+    Covers the race where a token expires between the security middleware's auth
+    check and this middleware's own validation, causing tasks to die even though
+    heartbeats were being sent on time.
+    """
+    moment = 1743451846  # A "random" unix epoch timestamp.
+    validity = 600
+    claims = {
+        "sub": "edb09971-4e0e-4221-ad3f-800852d38085",
+        "iat": moment,
+        "exp": moment + validity,
+    }
+
+    auth = AsyncMock(spec=JWTValidator)
+    # First call (strict validation, no extra_leeway) fails because the token just expired.
+    # Second call (with REISSUE_GRACE_LEEWAY) succeeds, allowing a fresh token to be issued.
+    auth.avalidated_claims.side_effect = [
+        jwt.ExpiredSignatureError("Signature has expired"),
+        claims,
+    ]
+
+    # Move time to 5 seconds past token expiry to simulate the race condition.
+    time_machine.move_to(moment + validity + 5, tick=False)
+
+    lifespan.registry.register_value(JWTValidator, auth)
+
+    response = client.get("/execution/variables/key1", headers={"Authorization": "Bearer dummy"})
+
+    # The Refreshed-API-Token header must be present so the client can update its token
+    # and recover on the next retry, even though the original token had just expired.
+    assert "Refreshed-API-Token" in response.headers

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -71,15 +71,14 @@ def test_expiring_token_is_reissued(
 
 
 @pytest.mark.db_test
-def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: FastAPI, time_machine):
-    """A token that expired just before JWTReissueMiddleware runs is still refreshed.
+def test_reissue_reuses_cached_claims_from_jwt_bearer(client, exec_app: FastAPI, time_machine):
+    """Ensure reissue uses claims already validated by JWTBearer.
 
-    Covers the race where a token expires between the security middleware's auth
-    check and this middleware's own validation, causing tasks to die even though
-    heartbeats were being sent on time.
+    If middleware validates the JWT again, this test would fail because the mocked
+    second validation call raises ExpiredSignatureError.
     """
     moment = 1743451846  # A "random" unix epoch timestamp.
-    validity = 600
+    validity = 60
     claims = {
         "sub": "edb09971-4e0e-4221-ad3f-800852d38085",
         "iat": moment,
@@ -87,20 +86,16 @@ def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: Fa
     }
 
     auth = AsyncMock(spec=JWTValidator)
-    # First call (strict validation, no extra_leeway) fails because the token just expired.
-    # Second call (with REISSUE_GRACE_LEEWAY) succeeds, allowing a fresh token to be issued.
     auth.avalidated_claims.side_effect = [
-        jwt.ExpiredSignatureError("Signature has expired"),
         claims,
+        jwt.ExpiredSignatureError("Signature has expired"),
     ]
 
-    # Move time to 5 seconds past token expiry to simulate the race condition.
-    time_machine.move_to(moment + validity + 5, tick=False)
+    time_machine.move_to(moment + 31, tick=False)
 
     lifespan.registry.register_value(JWTValidator, auth)
 
     response = client.get("/execution/variables/key1", headers={"Authorization": "Bearer dummy"})
 
-    # The Refreshed-API-Token header must be present so the client can update its token
-    # and recover on the next retry, even though the original token had just expired.
     assert "Refreshed-API-Token" in response.headers
+    assert auth.avalidated_claims.await_count == 1


### PR DESCRIPTION
closes: #67939


## Problem

Long-running tasks fail with repeated 403 errors when their JWT token expires while a heartbeat request is in-flight. The race condition is:

1. Security middleware validates the token — it is still valid (or within its leeway).
2. Request processing starts.
3. The token's `exp` boundary is crossed during processing.
4. `JWTReissueMiddleware.dispatch` calls `avalidated_claims(token, {})` — this now raises `ExpiredSignatureError`.
5. The exception is caught by the outer `except Exception` block, logged as a warning, and **no `Refreshed-API-Token` header is set**.
6. The client receives a 403 with no refreshed token, so it cannot update its `Bearer` token.
7. After `MAX_FAILED_HEARTBEATS` consecutive failures the supervisor kills the task.

## Fix

When `avalidated_claims` raises `ExpiredSignatureError` inside `JWTReissueMiddleware`, retry the validation with a 60-second grace leeway (`REISSUE_GRACE_LEEWAY`). If the token is within that grace window its claims are extracted and a fresh replacement token is issued and returned in the `Refreshed-API-Token` response header.

The signature and all other claims are still fully verified; only the expiry window is relaxed in this specific code path. The new token is generated from the same claims (same `sub`, `scope`, `ti_id`), so there is no privilege escalation.

The client's `_update_auth` hook already updates the `Bearer` token from `Refreshed-API-Token` before raising on 4xx/5xx, so the next retry uses the fresh token and succeeds.

## Changes

- `airflow-core/src/airflow/api_fastapi/auth/tokens.py`: add `extra_leeway: float = 0` keyword argument to `validated_claims` and `avalidated_claims`; pass it on top of `self.leeway` to `jwt.decode`.
- `airflow-core/src/airflow/api_fastapi/execution_api/app.py`: add `REISSUE_GRACE_LEEWAY = 60` class constant; catch `ExpiredSignatureError` on the inner `avalidated_claims` call and retry with the grace leeway.
- `airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py`: add regression test `test_just_expired_token_is_reissued_within_grace_period`.

