### PR TITLE
Call prot_p() in FTPSHook so the FTPS data channel is protected 

### DIFF
--- a/providers/ftp/src/airflow/providers/ftp/hooks/ftp.py
+++ b/providers/ftp/src/airflow/providers/ftp/hooks/ftp.py
@@ -313,5 +313,7 @@ class FTPSHook(FTPHook):
             else:
                 self.conn = ftplib.FTP_TLS(params.host, params.login, params.password, context=context)  # nosec: B321
             self.conn.set_pasv(pasv)
+            # Without prot_p() ftplib transfers file payloads over cleartext sockets even though the control connection is TLS.
+            self.conn.prot_p()
 
         return self.conn

--- a/providers/ftp/tests/unit/ftp/hooks/test_ftp.py
+++ b/providers/ftp/tests/unit/ftp/hooks/test_ftp.py
@@ -249,3 +249,11 @@ class TestIntegrationFTPHook:
         hook = FTPSHook("ftp_encoding")
         hook.get_conn()
         assert any(call.kwargs.get("encoding") == "cp1251" for call in mock_ftp_tls.mock_calls)
+
+    @mock.patch("ftplib.FTP_TLS")
+    def test_ftps_enables_protected_data_channel(self, mock_ftp_tls):
+        from airflow.providers.ftp.hooks.ftp import FTPSHook
+
+        hook = FTPSHook("ftp_passive")
+        conn = hook.get_conn()
+        conn.prot_p.assert_called_once_with()


### PR DESCRIPTION
Some FTPS servers are configured to require a protected data channel and reject any data transfer that is not preceded by "PROT P". Against such a server, the current `FTPSHook` / `FTPSFileTransmitOperator` path fails with:                                                                                                                                             
                                                                                                                                                          
  `ftplib.error_perm: 550 SSL/TLS required on the data channel.`                                                                                        
                                                                                                                                                          
After this change, the same operator interoperates correctly with both permissive and strict FTPS servers.

This PR adds the missing `self.conn.prot_p()` call after login, matching the standard `ftplib.FTP_TLS` usage documented in the Python stdlib:                                                                                    
                                                                                                                                                          
  > The user must explicitly secure the data connection by calling the `prot_p()` method.                                                                 
  >                                                                                                                                                       
  > — https://docs.python.org/3/library/ftplib.html#ftplib.FTP_TLS  

##### Was generative AI tooling used to co-author this PR?
- [x] Yes - Claude Code (Opus 4.7)
