### PR TITLE
API: Add bulk update to mark Dag runs as success/failed

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dag_run.py
@@ -51,10 +51,12 @@ class DAGRunPatchBody(StrictBaseModel):
 
 
 class BulkDAGRunBody(StrictBaseModel):
-    """Request body for bulk delete operations on Dag Runs."""
+    """Request body for bulk operations on Dag Runs."""
 
     dag_run_id: str
     dag_id: str | None = None
+    state: DagRunMutableStates | None = None
+    note: str | None = Field(None, max_length=1000)
 
 
 class BaseDAGRunClear(StrictBaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -2057,7 +2057,7 @@ paths:
       tags:
       - DagRun
       summary: Bulk Dag Runs
-      description: Bulk delete Dag Runs.
+      description: Bulk update or delete Dag Runs.
       operationId: bulk_dag_runs
       security:
       - OAuth2PasswordBearer: []
@@ -11940,12 +11940,22 @@ components:
           - type: string
           - type: 'null'
           title: Dag Id
+        state:
+          anyOf:
+          - $ref: '#/components/schemas/DagRunMutableStates'
+          - type: 'null'
+        note:
+          anyOf:
+          - type: string
+            maxLength: 1000
+          - type: 'null'
+          title: Note
       additionalProperties: false
       type: object
       required:
       - dag_run_id
       title: BulkDAGRunBody
-      description: Request body for bulk delete operations on Dag Runs.
+      description: Request body for bulk operations on Dag Runs.
     BulkDAGRunClearBody:
       properties:
         dry_run:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -98,10 +98,10 @@ from airflow.api_fastapi.core_api.security import (
 from airflow.api_fastapi.core_api.services.public.dag_run import (
     BulkDagRunService,
     DagRunWaiter,
-    _patch_dag_run_note,
-    _patch_dag_run_state,
     dry_run_clear_dag_run,
     get_dag_run_and_dag_for_clear,
+    patch_dag_run_note,
+    patch_dag_run_state,
     perform_clear_dag_run,
 )
 from airflow.api_fastapi.logging.decorators import action_logging
@@ -221,11 +221,11 @@ def patch_dag_run(
 
     for attr_name, attr_value_raw in data.items():
         if attr_name == "state" and patch_body.state is not None:
-            _patch_dag_run_state(dag=dag, dag_run=dag_run, state=patch_body.state, session=session)
+            patch_dag_run_state(dag=dag, dag_run=dag_run, state=patch_body.state, session=session)
         elif attr_name == "note":
             updated_dag_run = session.get(DagRun, dag_run.id)
             if updated_dag_run is not None:
-                _patch_dag_run_note(dag_run=updated_dag_run, note=attr_value_raw, user=user)
+                patch_dag_run_note(dag_run=updated_dag_run, note=attr_value_raw, user=user)
 
     final_dag_run = session.get(DagRun, dag_run.id)
     if not final_dag_run:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -270,9 +270,13 @@ def bulk_dag_runs(
     request: BulkBody[BulkDAGRunBody],
     session: SessionDep,
     dag_id: str,
+    dag_bag: DagBagDep,
+    user: GetUserDep,
 ) -> BulkResponse:
-    """Bulk delete Dag Runs."""
-    return BulkDagRunService(session=session, request=request, dag_id=dag_id).handle_request()
+    """Bulk update or delete Dag Runs."""
+    return BulkDagRunService(
+        session=session, request=request, dag_id=dag_id, dag_bag=dag_bag, user=user
+    ).handle_request()
 
 
 @dag_run_router.get(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import textwrap
 from typing import Annotated, Literal, cast
 
-import structlog
 from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
@@ -28,11 +27,6 @@ from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
-from airflow.api.common.mark_tasks import (
-    set_dag_run_state_to_failed,
-    set_dag_run_state_to_queued,
-    set_dag_run_state_to_success,
-)
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.cursors import (
@@ -104,20 +98,19 @@ from airflow.api_fastapi.core_api.security import (
 from airflow.api_fastapi.core_api.services.public.dag_run import (
     BulkDagRunService,
     DagRunWaiter,
+    _patch_dag_run_note,
+    _patch_dag_run_state,
     dry_run_clear_dag_run,
     get_dag_run_and_dag_for_clear,
     perform_clear_dag_run,
 )
 from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.exceptions import ParamValidationError
-from airflow.listeners.listener import get_listener_manager
 from airflow.models import DagModel, DagRun
 from airflow.models.asset import AssetEvent
 from airflow.models.dag_version import DagVersion
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
-
-log = structlog.get_logger(__name__)
 
 dag_run_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}/dagRuns")
 dag_run_at_dag_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}")
@@ -227,33 +220,12 @@ def patch_dag_run(
     data = patch_body.model_dump(include=fields_to_update, by_alias=True)
 
     for attr_name, attr_value_raw in data.items():
-        if attr_name == "state":
-            attr_value = getattr(patch_body, "state")
-            if attr_value == DagRunMutableStates.SUCCESS:
-                set_dag_run_state_to_success(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
-                try:
-                    get_listener_manager().hook.on_dag_run_success(dag_run=dag_run, msg="")
-                except Exception:
-                    log.exception("error calling listener")
-
-            # TODO AIP-103: https://github.com/apache/airflow/issues/66755
-            # Handle clearing states for all task instances in a dagrun when cleared
-            elif attr_value == DagRunMutableStates.QUEUED:
-                set_dag_run_state_to_queued(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
-                # Not notifying on queued - only notifying on RUNNING, this is happening in scheduler
-            elif attr_value == DagRunMutableStates.FAILED:
-                set_dag_run_state_to_failed(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
-                try:
-                    get_listener_manager().hook.on_dag_run_failed(dag_run=dag_run, msg="")
-                except Exception:
-                    log.exception("error calling listener")
+        if attr_name == "state" and patch_body.state is not None:
+            _patch_dag_run_state(dag=dag, dag_run=dag_run, state=patch_body.state, session=session)
         elif attr_name == "note":
             updated_dag_run = session.get(DagRun, dag_run.id)
-            if updated_dag_run and updated_dag_run.dag_run_note is None:
-                updated_dag_run.note = (attr_value_raw, user.get_id())
-            elif updated_dag_run:
-                updated_dag_run.dag_run_note.content = attr_value_raw
-                updated_dag_run.dag_run_note.user_id = user.get_id()
+            if updated_dag_run is not None:
+                _patch_dag_run_note(dag_run=updated_dag_run, note=attr_value_raw, user=user)
 
     final_dag_run = session.get(DagRun, dag_run.id)
     if not final_dag_run:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -146,12 +146,44 @@ def perform_clear_dag_run(
     if not dag_run_cleared:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Dag run not found after clearing")
     if note is not None:
-        if dag_run_cleared.dag_run_note is None:
-            dag_run_cleared.note = (note, user.get_id())
-        else:
-            dag_run_cleared.dag_run_note.content = note
-            dag_run_cleared.dag_run_note.user_id = user.get_id()
+        _patch_dag_run_note(dag_run=dag_run_cleared, note=note, user=user)
     return dag_run_cleared
+
+
+def _patch_dag_run_state(
+    *,
+    dag: SerializedDAG,
+    dag_run: DagRun,
+    state: DagRunMutableStates,
+    session: Session,
+) -> None:
+    """Set a Dag Run's state (success/queued/failed), firing the matching listener hooks."""
+    if state == DagRunMutableStates.SUCCESS:
+        set_dag_run_state_to_success(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
+        try:
+            get_listener_manager().hook.on_dag_run_success(dag_run=dag_run, msg="")
+        except Exception:
+            log.exception("error calling listener")
+    elif state == DagRunMutableStates.QUEUED:
+        # TODO AIP-103: https://github.com/apache/airflow/issues/66755
+        # Handle clearing states for all task instances in a dagrun when cleared.
+        # Not notifying on queued - only notifying on RUNNING, which happens in the scheduler.
+        set_dag_run_state_to_queued(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
+    elif state == DagRunMutableStates.FAILED:
+        set_dag_run_state_to_failed(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
+        try:
+            get_listener_manager().hook.on_dag_run_failed(dag_run=dag_run, msg="")
+        except Exception:
+            log.exception("error calling listener")
+
+
+def _patch_dag_run_note(*, dag_run: DagRun, note: str | None, user: BaseUser) -> None:
+    """Set or update a Dag Run's note."""
+    if dag_run.dag_run_note is None:
+        dag_run.note = (note, user.get_id())
+    else:
+        dag_run.dag_run_note.content = note
+        dag_run.dag_run_note.user_id = user.get_id()
 
 
 @attrs.define
@@ -233,159 +265,129 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
             }
         )
 
+    def _resolve_entity_key(
+        self, entity: str | BulkDAGRunBody, results: BulkActionResponse
+    ) -> tuple[str, str] | None:
+        """
+        Resolve the ``(dag_id, dag_run_id)`` for an entity.
+
+        Records a 400 error and returns ``None`` when a wildcard ``~`` leaves the
+        dag_id unresolved. Shared by the bulk update and delete handlers.
+        """
+        if isinstance(entity, str):
+            dag_id, dag_run_id = self.dag_id, entity
+        else:
+            dag_id = entity.dag_id or self.dag_id
+            dag_run_id = entity.dag_run_id
+
+        if dag_id == "~" or dag_run_id == "~":
+            if isinstance(entity, str):
+                error_msg = (
+                    "When using wildcard in path, dag_id must be specified in BulkDAGRunBody"
+                    f" object, not as string for dag_run_id: {entity}"
+                )
+            else:
+                error_msg = (
+                    "When using wildcard in path, dag_id must be specified in request body for"
+                    f" dag_run_id: {entity.dag_run_id}"
+                )
+            results.errors.append({"error": error_msg, "status_code": status.HTTP_400_BAD_REQUEST})
+            return None
+
+        return (dag_id, dag_run_id)
+
     def handle_bulk_update(
         self, action: BulkUpdateAction[BulkDAGRunBody], results: BulkActionResponse
     ) -> None:
-        """Bulk update Dag Runs (e.g. mark as success/failed/queued)."""
+        """Bulk update Dag Runs (mark as success/failed/queued and/or set a note)."""
         entities_by_key: dict[tuple[str, str], BulkDAGRunBody] = {}
-
         for entity in action.entities:
             if isinstance(entity, str):
                 results.errors.append(
                     {
                         "error": (
-                            "Bulk update requires a BulkDAGRunBody object carrying the target state,"
+                            "Bulk update requires a BulkDAGRunBody object,"
                             f" not a string for dag_run_id: {entity}"
                         ),
                         "status_code": status.HTTP_400_BAD_REQUEST,
                     }
                 )
                 continue
-
-            dag_id = entity.dag_id or self.dag_id
-            dag_run_id = entity.dag_run_id
-
-            if dag_id == "~" or dag_run_id == "~":
-                results.errors.append(
-                    {
-                        "error": (
-                            "When using wildcard in path, dag_id must be specified in request body for"
-                            f" dag_run_id: {entity.dag_run_id}"
-                        ),
-                        "status_code": status.HTTP_400_BAD_REQUEST,
-                    }
-                )
-                continue
-
-            if entity.state is None:
-                results.errors.append(
-                    {
-                        "error": f"A target state is required to update dag_run_id: {dag_run_id}",
-                        "status_code": status.HTTP_400_BAD_REQUEST,
-                    }
-                )
-                continue
-
-            entities_by_key[(dag_id, dag_run_id)] = entity
+            key = self._resolve_entity_key(entity, results)
+            if key is not None:
+                entities_by_key[key] = entity
 
         if not entities_by_key:
             return
 
-        dag_runs = self.session.scalars(
-            select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(entities_by_key.keys())))
-        ).all()
-        dag_run_map = {(dr.dag_id, dr.run_id): dr for dr in dag_runs}
-        not_found = entities_by_key.keys() - dag_run_map.keys()
+        dag_run_map = {
+            (dr.dag_id, dr.run_id): dr
+            for dr in self.session.scalars(
+                select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(entities_by_key.keys())))
+            )
+        }
 
-        if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
-            for dag_id, run_id in sorted(not_found):
-                results.errors.append(
-                    {
-                        "error": (f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found"),
-                        "status_code": status.HTTP_404_NOT_FOUND,
-                    }
-                )
+        for (dag_id, run_id), entity in entities_by_key.items():
+            try:
+                dag_run = dag_run_map.get((dag_id, run_id))
+                if dag_run is None:
+                    if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
+                        raise HTTPException(
+                            status.HTTP_404_NOT_FOUND,
+                            f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found",
+                        )
+                    continue
 
-        for (dag_id, run_id), dag_run in dag_run_map.items():
-            entity = entities_by_key[(dag_id, run_id)]
-            dag = get_dag_for_run(self.dag_bag, dag_run, session=self.session)
+                if entity.state is not None:
+                    dag = get_dag_for_run(self.dag_bag, dag_run, session=self.session)
+                    _patch_dag_run_state(dag=dag, dag_run=dag_run, state=entity.state, session=self.session)
+                if entity.note is not None:
+                    _patch_dag_run_note(dag_run=dag_run, note=entity.note, user=self.user)
 
-            if entity.state == DagRunMutableStates.SUCCESS:
-                set_dag_run_state_to_success(dag=dag, run_id=run_id, commit=True, session=self.session)
-                try:
-                    get_listener_manager().hook.on_dag_run_success(dag_run=dag_run, msg="")
-                except Exception:
-                    log.exception("error calling listener")
-            elif entity.state == DagRunMutableStates.QUEUED:
-                set_dag_run_state_to_queued(dag=dag, run_id=run_id, commit=True, session=self.session)
-            elif entity.state == DagRunMutableStates.FAILED:
-                set_dag_run_state_to_failed(dag=dag, run_id=run_id, commit=True, session=self.session)
-                try:
-                    get_listener_manager().hook.on_dag_run_failed(dag_run=dag_run, msg="")
-                except Exception:
-                    log.exception("error calling listener")
-
-            if entity.note is not None:
-                updated_dag_run = self.session.get(DagRun, dag_run.id)
-                if updated_dag_run and updated_dag_run.dag_run_note is None:
-                    updated_dag_run.note = (entity.note, self.user.get_id())
-                elif updated_dag_run:
-                    updated_dag_run.dag_run_note.content = entity.note
-                    updated_dag_run.dag_run_note.user_id = self.user.get_id()
-
-            results.success.append(f"{dag_id}.{run_id}")
+                results.success.append(f"{dag_id}.{run_id}")
+            except HTTPException as e:
+                results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})
 
     def handle_bulk_delete(
         self, action: BulkDeleteAction[BulkDAGRunBody], results: BulkActionResponse
     ) -> None:
         """Bulk delete Dag Runs."""
         keys: set[tuple[str, str]] = set()
-
         for entity in action.entities:
-            if isinstance(entity, str):
-                dag_id, dag_run_id = self.dag_id, entity
-            else:
-                dag_id = entity.dag_id or self.dag_id
-                dag_run_id = entity.dag_run_id
-
-            if dag_id == "~" or dag_run_id == "~":
-                if isinstance(entity, str):
-                    error_msg = (
-                        "When using wildcard in path, dag_id must be specified in BulkDAGRunBody"
-                        f" object, not as string for dag_run_id: {entity}"
-                    )
-                else:
-                    error_msg = (
-                        "When using wildcard in path, dag_id must be specified in request body for"
-                        f" dag_run_id: {entity.dag_run_id}"
-                    )
-                results.errors.append(
-                    {"error": error_msg, "status_code": status.HTTP_400_BAD_REQUEST},
-                )
-                continue
-
-            keys.add((dag_id, dag_run_id))
+            key = self._resolve_entity_key(entity, results)
+            if key is not None:
+                keys.add(key)
 
         if not keys:
             return
 
-        dag_runs = self.session.scalars(
-            select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(keys)))
-        ).all()
-        dag_run_map = {(dr.dag_id, dr.run_id): dr for dr in dag_runs}
-        not_found = keys - dag_run_map.keys()
-
-        if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
-            for dag_id, run_id in sorted(not_found):
-                results.errors.append(
-                    {
-                        "error": (f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found"),
-                        "status_code": status.HTTP_404_NOT_FOUND,
-                    }
-                )
-
+        dag_run_map = {
+            (dr.dag_id, dr.run_id): dr
+            for dr in self.session.scalars(
+                select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(keys)))
+            )
+        }
         deletable_states = {s.value for s in DagRunMutableStates}
-        for (dag_id, run_id), dag_run in dag_run_map.items():
-            if dag_run.state not in deletable_states:
-                results.errors.append(
-                    {
-                        "error": (
-                            f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` "
-                            f"cannot be deleted in {dag_run.state} state"
-                        ),
-                        "status_code": status.HTTP_409_CONFLICT,
-                    }
-                )
-                continue
-            self.session.delete(dag_run)
-            results.success.append(f"{dag_id}.{run_id}")
+
+        for dag_id, run_id in sorted(keys):
+            try:
+                dag_run = dag_run_map.get((dag_id, run_id))
+                if dag_run is None:
+                    if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
+                        raise HTTPException(
+                            status.HTTP_404_NOT_FOUND,
+                            f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found",
+                        )
+                    continue
+
+                if dag_run.state not in deletable_states:
+                    raise HTTPException(
+                        status.HTTP_409_CONFLICT,
+                        f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` "
+                        f"cannot be deleted in {dag_run.state} state",
+                    )
+
+                self.session.delete(dag_run)
+                results.success.append(f"{dag_id}.{run_id}")
+            except HTTPException as e:
+                results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -29,8 +29,13 @@ from fastapi import HTTPException, status
 from sqlalchemy import select, tuple_
 from sqlalchemy.orm import Session, joinedload
 
+from airflow.api.common.mark_tasks import (
+    set_dag_run_state_to_failed,
+    set_dag_run_state_to_queued,
+    set_dag_run_state_to_success,
+)
 from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
-from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
+from airflow.api_fastapi.common.dagbag import DagBagDep, get_dag_for_run, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.task_instances import eager_load_TI_and_TIH_for_validation
 from airflow.api_fastapi.core_api.datamodels.common import (
     BulkActionNotOnExistence,
@@ -43,6 +48,7 @@ from airflow.api_fastapi.core_api.datamodels.common import (
 from airflow.api_fastapi.core_api.datamodels.dag_run import BulkDAGRunBody, DagRunMutableStates
 from airflow.api_fastapi.core_api.datamodels.task_instances import NewTaskResponse
 from airflow.api_fastapi.core_api.services.public.common import BulkService, resolve_run_on_latest_version
+from airflow.listeners.listener import get_listener_manager
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.xcom import XCOM_RETURN_KEY, XComModel
@@ -209,9 +215,13 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
         session: Session,
         request: BulkBody[BulkDAGRunBody],
         dag_id: str,
+        dag_bag: DagBagDep,
+        user: BaseUser,
     ):
         super().__init__(session, request)
         self.dag_id = dag_id
+        self.dag_bag = dag_bag
+        self.user = user
 
     def handle_bulk_create(
         self, action: BulkCreateAction[BulkDAGRunBody], results: BulkActionResponse
@@ -226,12 +236,94 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
     def handle_bulk_update(
         self, action: BulkUpdateAction[BulkDAGRunBody], results: BulkActionResponse
     ) -> None:
-        results.errors.append(
-            {
-                "error": "Dag Runs bulk update is not supported yet. Use the patch Dag Run endpoint per run instead.",
-                "status_code": status.HTTP_405_METHOD_NOT_ALLOWED,
-            }
-        )
+        """Bulk update Dag Runs (e.g. mark as success/failed/queued)."""
+        entities_by_key: dict[tuple[str, str], BulkDAGRunBody] = {}
+
+        for entity in action.entities:
+            if isinstance(entity, str):
+                results.errors.append(
+                    {
+                        "error": (
+                            "Bulk update requires a BulkDAGRunBody object carrying the target state,"
+                            f" not a string for dag_run_id: {entity}"
+                        ),
+                        "status_code": status.HTTP_400_BAD_REQUEST,
+                    }
+                )
+                continue
+
+            dag_id = entity.dag_id or self.dag_id
+            dag_run_id = entity.dag_run_id
+
+            if dag_id == "~" or dag_run_id == "~":
+                results.errors.append(
+                    {
+                        "error": (
+                            "When using wildcard in path, dag_id must be specified in request body for"
+                            f" dag_run_id: {entity.dag_run_id}"
+                        ),
+                        "status_code": status.HTTP_400_BAD_REQUEST,
+                    }
+                )
+                continue
+
+            if entity.state is None:
+                results.errors.append(
+                    {
+                        "error": f"A target state is required to update dag_run_id: {dag_run_id}",
+                        "status_code": status.HTTP_400_BAD_REQUEST,
+                    }
+                )
+                continue
+
+            entities_by_key[(dag_id, dag_run_id)] = entity
+
+        if not entities_by_key:
+            return
+
+        dag_runs = self.session.scalars(
+            select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(entities_by_key.keys())))
+        ).all()
+        dag_run_map = {(dr.dag_id, dr.run_id): dr for dr in dag_runs}
+        not_found = entities_by_key.keys() - dag_run_map.keys()
+
+        if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
+            for dag_id, run_id in sorted(not_found):
+                results.errors.append(
+                    {
+                        "error": (f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found"),
+                        "status_code": status.HTTP_404_NOT_FOUND,
+                    }
+                )
+
+        for (dag_id, run_id), dag_run in dag_run_map.items():
+            entity = entities_by_key[(dag_id, run_id)]
+            dag = get_dag_for_run(self.dag_bag, dag_run, session=self.session)
+
+            if entity.state == DagRunMutableStates.SUCCESS:
+                set_dag_run_state_to_success(dag=dag, run_id=run_id, commit=True, session=self.session)
+                try:
+                    get_listener_manager().hook.on_dag_run_success(dag_run=dag_run, msg="")
+                except Exception:
+                    log.exception("error calling listener")
+            elif entity.state == DagRunMutableStates.QUEUED:
+                set_dag_run_state_to_queued(dag=dag, run_id=run_id, commit=True, session=self.session)
+            elif entity.state == DagRunMutableStates.FAILED:
+                set_dag_run_state_to_failed(dag=dag, run_id=run_id, commit=True, session=self.session)
+                try:
+                    get_listener_manager().hook.on_dag_run_failed(dag_run=dag_run, msg="")
+                except Exception:
+                    log.exception("error calling listener")
+
+            if entity.note is not None:
+                updated_dag_run = self.session.get(DagRun, dag_run.id)
+                if updated_dag_run and updated_dag_run.dag_run_note is None:
+                    updated_dag_run.note = (entity.note, self.user.get_id())
+                elif updated_dag_run:
+                    updated_dag_run.dag_run_note.content = entity.note
+                    updated_dag_run.dag_run_note.user_id = self.user.get_id()
+
+            results.success.append(f"{dag_id}.{run_id}")
 
     def handle_bulk_delete(
         self, action: BulkDeleteAction[BulkDAGRunBody], results: BulkActionResponse

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -146,11 +146,11 @@ def perform_clear_dag_run(
     if not dag_run_cleared:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Dag run not found after clearing")
     if note is not None:
-        _patch_dag_run_note(dag_run=dag_run_cleared, note=note, user=user)
+        patch_dag_run_note(dag_run=dag_run_cleared, note=note, user=user)
     return dag_run_cleared
 
 
-def _patch_dag_run_state(
+def patch_dag_run_state(
     *,
     dag: SerializedDAG,
     dag_run: DagRun,
@@ -177,7 +177,7 @@ def _patch_dag_run_state(
             log.exception("error calling listener")
 
 
-def _patch_dag_run_note(*, dag_run: DagRun, note: str | None, user: BaseUser) -> None:
+def patch_dag_run_note(*, dag_run: DagRun, note: str | None, user: BaseUser) -> None:
     """Set or update a Dag Run's note."""
     if dag_run.dag_run_note is None:
         dag_run.note = (note, user.get_id())
@@ -361,9 +361,9 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
                 dag_run = dag_run_map[key]
                 if entity.state is not None:
                     dag = get_dag_for_run(self.dag_bag, dag_run, session=self.session)
-                    _patch_dag_run_state(dag=dag, dag_run=dag_run, state=entity.state, session=self.session)
+                    patch_dag_run_state(dag=dag, dag_run=dag_run, state=entity.state, session=self.session)
                 if entity.note is not None:
-                    _patch_dag_run_note(dag_run=dag_run, note=entity.note, user=self.user)
+                    patch_dag_run_note(dag_run=dag_run, note=entity.note, user=self.user)
                 results.success.append(f"{dag_id}.{run_id}")
         except HTTPException as e:
             results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})
@@ -372,16 +372,16 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
         self, action: BulkDeleteAction[BulkDAGRunBody], results: BulkActionResponse
     ) -> None:
         """Bulk delete Dag Runs."""
-        keys: set[tuple[str, str]] = set()
+        to_delete_keys: set[tuple[str, str]] = set()
         for entity in action.entities:
             key = self._resolve_entity_key(entity, results)
             if key is not None:
-                keys.add(key)
+                to_delete_keys.add(key)
 
-        if not keys:
+        if not to_delete_keys:
             return
 
-        dag_run_map, matched_keys, not_found_keys = self._categorize_dag_runs(keys)
+        dag_run_map, matched_keys, not_found_keys = self._categorize_dag_runs(to_delete_keys)
         deletable_states = {s.value for s in DagRunMutableStates}
 
         try:
@@ -391,7 +391,9 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
                     f"The DagRuns with these identifiers: {sorted(not_found_keys)} were not found",
                 )
             delete_keys = (
-                matched_keys if action.action_on_non_existence == BulkActionNotOnExistence.SKIP else keys
+                matched_keys
+                if action.action_on_non_existence == BulkActionNotOnExistence.SKIP
+                else to_delete_keys
             )
 
             for dag_id, run_id in sorted(delete_keys):

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -296,6 +296,25 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
 
         return (dag_id, dag_run_id)
 
+    def _categorize_dag_runs(
+        self, keys: set[tuple[str, str]]
+    ) -> tuple[dict[tuple[str, str], DagRun], set[tuple[str, str]], set[tuple[str, str]]]:
+        """
+        Split the requested ``(dag_id, dag_run_id)`` keys into existing and missing ones.
+
+        :return: tuple of (dag_run_map, matched_keys, not_found_keys). Shared by the bulk
+            update and delete handlers.
+        """
+        dag_run_map = {
+            (dr.dag_id, dr.run_id): dr
+            for dr in self.session.scalars(
+                select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(keys)))
+            )
+        }
+        matched_keys = set(dag_run_map.keys())
+        not_found_keys = keys - matched_keys
+        return dag_run_map, matched_keys, not_found_keys
+
     def handle_bulk_update(
         self, action: BulkUpdateAction[BulkDAGRunBody], results: BulkActionResponse
     ) -> None:
@@ -320,33 +339,34 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
         if not entities_by_key:
             return
 
-        dag_run_map = {
-            (dr.dag_id, dr.run_id): dr
-            for dr in self.session.scalars(
-                select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(entities_by_key.keys())))
+        to_update_keys = set(entities_by_key.keys())
+        dag_run_map, matched_keys, not_found_keys = self._categorize_dag_runs(to_update_keys)
+
+        try:
+            if action.action_on_non_existence == BulkActionNotOnExistence.FAIL and not_found_keys:
+                raise HTTPException(
+                    status.HTTP_404_NOT_FOUND,
+                    f"The DagRuns with these identifiers: {sorted(not_found_keys)} were not found",
+                )
+            update_keys = (
+                matched_keys
+                if action.action_on_non_existence == BulkActionNotOnExistence.SKIP
+                else to_update_keys
             )
-        }
 
-        for (dag_id, run_id), entity in entities_by_key.items():
-            try:
-                dag_run = dag_run_map.get((dag_id, run_id))
-                if dag_run is None:
-                    if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
-                        raise HTTPException(
-                            status.HTTP_404_NOT_FOUND,
-                            f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found",
-                        )
+            for key, entity in entities_by_key.items():
+                if key not in update_keys:
                     continue
-
+                dag_id, run_id = key
+                dag_run = dag_run_map[key]
                 if entity.state is not None:
                     dag = get_dag_for_run(self.dag_bag, dag_run, session=self.session)
                     _patch_dag_run_state(dag=dag, dag_run=dag_run, state=entity.state, session=self.session)
                 if entity.note is not None:
                     _patch_dag_run_note(dag_run=dag_run, note=entity.note, user=self.user)
-
                 results.success.append(f"{dag_id}.{run_id}")
-            except HTTPException as e:
-                results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})
+        except HTTPException as e:
+            results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})
 
     def handle_bulk_delete(
         self, action: BulkDeleteAction[BulkDAGRunBody], results: BulkActionResponse
@@ -361,33 +381,33 @@ class BulkDagRunService(BulkService[BulkDAGRunBody]):
         if not keys:
             return
 
-        dag_run_map = {
-            (dr.dag_id, dr.run_id): dr
-            for dr in self.session.scalars(
-                select(DagRun).where(tuple_(DagRun.dag_id, DagRun.run_id).in_(list(keys)))
-            )
-        }
+        dag_run_map, matched_keys, not_found_keys = self._categorize_dag_runs(keys)
         deletable_states = {s.value for s in DagRunMutableStates}
 
-        for dag_id, run_id in sorted(keys):
-            try:
-                dag_run = dag_run_map.get((dag_id, run_id))
-                if dag_run is None:
-                    if action.action_on_non_existence == BulkActionNotOnExistence.FAIL:
-                        raise HTTPException(
-                            status.HTTP_404_NOT_FOUND,
-                            f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` was not found",
-                        )
-                    continue
+        try:
+            if action.action_on_non_existence == BulkActionNotOnExistence.FAIL and not_found_keys:
+                raise HTTPException(
+                    status.HTTP_404_NOT_FOUND,
+                    f"The DagRuns with these identifiers: {sorted(not_found_keys)} were not found",
+                )
+            delete_keys = (
+                matched_keys if action.action_on_non_existence == BulkActionNotOnExistence.SKIP else keys
+            )
 
+            for dag_id, run_id in sorted(delete_keys):
+                dag_run = dag_run_map[(dag_id, run_id)]
                 if dag_run.state not in deletable_states:
-                    raise HTTPException(
-                        status.HTTP_409_CONFLICT,
-                        f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` "
-                        f"cannot be deleted in {dag_run.state} state",
+                    results.errors.append(
+                        {
+                            "error": (
+                                f"The DagRun with dag_id: `{dag_id}` and run_id: `{run_id}` "
+                                f"cannot be deleted in {dag_run.state} state"
+                            ),
+                            "status_code": status.HTTP_409_CONFLICT,
+                        }
                     )
-
+                    continue
                 self.session.delete(dag_run)
                 results.success.append(f"{dag_id}.{run_id}")
-            except HTTPException as e:
-                results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})
+        except HTTPException as e:
+            results.errors.append({"error": f"{e.detail}", "status_code": e.status_code})

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -2499,7 +2499,7 @@ export const useDagRunServicePatchDagRun = <TData = Common.DagRunServicePatchDag
 }, TContext>({ mutationFn: ({ dagId, dagRunId, requestBody, updateMask }) => DagRunService.patchDagRun({ dagId, dagRunId, requestBody, updateMask }) as unknown as Promise<TData>, ...options });
 /**
 * Bulk Dag Runs
-* Bulk delete Dag Runs.
+* Bulk update or delete Dag Runs.
 * @param data The data for the request.
 * @param data.dagId
 * @param data.requestBody

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -962,13 +962,35 @@ export const $BulkDAGRunBody = {
                 }
             ],
             title: 'Dag Id'
+        },
+        state: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/DagRunMutableStates'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        note: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 1000
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Note'
         }
     },
     additionalProperties: false,
     type: 'object',
     required: ['dag_run_id'],
     title: 'BulkDAGRunBody',
-    description: 'Request body for bulk delete operations on Dag Runs.'
+    description: 'Request body for bulk operations on Dag Runs.'
 } as const;
 
 export const $BulkDAGRunClearBody = {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -938,7 +938,7 @@ export class DagRunService {
     
     /**
      * Bulk Dag Runs
-     * Bulk delete Dag Runs.
+     * Bulk update or delete Dag Runs.
      * @param data The data for the request.
      * @param data.dagId
      * @param data.requestBody

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -294,11 +294,13 @@ export type BulkCreateAction_VariableBody_ = {
 };
 
 /**
- * Request body for bulk delete operations on Dag Runs.
+ * Request body for bulk operations on Dag Runs.
  */
 export type BulkDAGRunBody = {
     dag_run_id: string;
     dag_id?: string | null;
+    state?: DagRunMutableStates | null;
+    note?: string | null;
 };
 
 /**

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -3060,7 +3060,60 @@ class TestBulkDagRuns:
         assert len(body["create"]["errors"]) == 1
         assert body["create"]["errors"][0]["status_code"] == 405
 
-    def test_bulk_update_not_supported(self, test_client):
+    def test_bulk_update_marks_state(self, test_client, session):
+        """Bulk update marks the selected Dag Runs to the requested state in a single call."""
+        response = test_client.patch(
+            self.ENDPOINT_URL,
+            json={
+                "actions": [
+                    {
+                        "action": "update",
+                        "entities": [
+                            {"dag_run_id": DAG1_RUN1_ID, "state": "failed"},
+                            {"dag_run_id": DAG1_RUN2_ID, "state": "failed"},
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert sorted(body["update"]["success"]) == sorted(
+            [f"{DAG1_ID}.{DAG1_RUN1_ID}", f"{DAG1_ID}.{DAG1_RUN2_ID}"]
+        )
+        assert body["update"]["errors"] == []
+        session.expire_all()
+        for run_id in (DAG1_RUN1_ID, DAG1_RUN2_ID):
+            dag_run = session.scalar(select(DagRun).where(DagRun.dag_id == DAG1_ID, DagRun.run_id == run_id))
+            assert dag_run.state == DagRunState.FAILED
+
+    def test_bulk_update_across_dags_with_wildcard(self, test_client, session):
+        """``~`` URL with per-entity dag_id marks runs across Dags in one call."""
+        response = test_client.patch(
+            self.WILDCARD_ENDPOINT,
+            json={
+                "actions": [
+                    {
+                        "action": "update",
+                        "entities": [
+                            {"dag_id": DAG1_ID, "dag_run_id": DAG1_RUN1_ID, "state": "success"},
+                            {"dag_id": DAG2_ID, "dag_run_id": DAG2_RUN1_ID, "state": "success"},
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert sorted(body["update"]["success"]) == sorted(
+            [f"{DAG1_ID}.{DAG1_RUN1_ID}", f"{DAG2_ID}.{DAG2_RUN1_ID}"]
+        )
+        session.expire_all()
+        for run_id in (DAG1_RUN1_ID, DAG2_RUN1_ID):
+            assert session.scalar(select(DagRun).where(DagRun.run_id == run_id)).state == DagRunState.SUCCESS
+
+    def test_bulk_update_requires_state(self, test_client):
+        """An entity without a target state is reported as a 400 error rather than silently skipped."""
         response = test_client.patch(
             self.ENDPOINT_URL,
             json={
@@ -3076,7 +3129,29 @@ class TestBulkDagRuns:
         body = response.json()
         assert body["update"]["success"] == []
         assert len(body["update"]["errors"]) == 1
-        assert body["update"]["errors"][0]["status_code"] == 405
+        assert body["update"]["errors"][0]["status_code"] == 400
+
+    def test_bulk_update_not_found_fails(self, test_client, session):
+        """When FAIL semantics, a missing run is reported and matched runs still get updated."""
+        response = test_client.patch(
+            self.ENDPOINT_URL,
+            json={
+                "actions": [
+                    {
+                        "action": "update",
+                        "entities": [
+                            {"dag_run_id": DAG1_RUN1_ID, "state": "failed"},
+                            {"dag_run_id": "non_existent_run", "state": "failed"},
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["update"]["success"] == [f"{DAG1_ID}.{DAG1_RUN1_ID}"]
+        assert len(body["update"]["errors"]) == 1
+        assert body["update"]["errors"][0]["status_code"] == 404
 
     def test_bulk_delete_rejects_unauthorized_dag_ids_from_request_body(self, test_client, session):
         """A 403 at the route level if any entity references a Dag the user can't access."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -3112,24 +3112,29 @@ class TestBulkDagRuns:
         for run_id in (DAG1_RUN1_ID, DAG2_RUN1_ID):
             assert session.scalar(select(DagRun).where(DagRun.run_id == run_id)).state == DagRunState.SUCCESS
 
-    def test_bulk_update_requires_state(self, test_client):
-        """An entity without a target state is reported as a 400 error rather than silently skipped."""
+    def test_bulk_update_note_only(self, test_client, session):
+        """A bulk update may set only the note, without a target state."""
         response = test_client.patch(
             self.ENDPOINT_URL,
             json={
                 "actions": [
                     {
                         "action": "update",
-                        "entities": [{"dag_run_id": DAG1_RUN1_ID}],
+                        "entities": [{"dag_run_id": DAG1_RUN1_ID, "note": "bulk note"}],
                     }
                 ]
             },
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["update"]["success"] == []
-        assert len(body["update"]["errors"]) == 1
-        assert body["update"]["errors"][0]["status_code"] == 400
+        assert body["update"]["success"] == [f"{DAG1_ID}.{DAG1_RUN1_ID}"]
+        assert body["update"]["errors"] == []
+        session.expire_all()
+        dag_run = session.scalar(
+            select(DagRun).where(DagRun.dag_id == DAG1_ID, DagRun.run_id == DAG1_RUN1_ID)
+        )
+        assert dag_run.note == "bulk note"
+        assert dag_run.state == DAG1_RUN1_STATE
 
     def test_bulk_update_not_found_fails(self, test_client, session):
         """When FAIL semantics, a missing run is reported and matched runs still get updated."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -2957,7 +2957,7 @@ class TestBulkDagRuns:
         assert session.scalar(select(DagRun).where(DagRun.run_id == "running_run")) is not None
 
     def test_bulk_delete_not_found_fails(self, test_client, session):
-        """When FAIL semantics, each missing run is reported individually and matched runs still get deleted."""
+        """FAIL semantics: a single missing run fails the whole action and nothing is deleted."""
         response = test_client.patch(
             self.ENDPOINT_URL,
             json={
@@ -2971,16 +2971,15 @@ class TestBulkDagRuns:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["delete"]["success"] == [f"{DAG1_ID}.{DAG1_RUN1_ID}"]
+        assert body["delete"]["success"] == []
         errors = body["delete"]["errors"]
-        assert len(errors) == 2
-        assert all(err["status_code"] == 404 for err in errors)
-        assert {err["error"] for err in errors} == {
-            f"The DagRun with dag_id: `{DAG1_ID}` and run_id: `another_missing_run` was not found",
-            f"The DagRun with dag_id: `{DAG1_ID}` and run_id: `non_existent_run` was not found",
-        }
+        assert len(errors) == 1
+        assert errors[0]["status_code"] == 404
+        assert "non_existent_run" in errors[0]["error"]
+        assert "another_missing_run" in errors[0]["error"]
         session.expire_all()
-        assert session.scalar(select(DagRun).where(DagRun.run_id == DAG1_RUN1_ID)) is None
+        # The matched run must not be deleted when another entity is missing.
+        assert session.scalar(select(DagRun).where(DagRun.run_id == DAG1_RUN1_ID)) is not None
 
     def test_bulk_delete_not_found_skip(self, test_client, session):
         response = test_client.patch(
@@ -3137,7 +3136,7 @@ class TestBulkDagRuns:
         assert dag_run.state == DAG1_RUN1_STATE
 
     def test_bulk_update_not_found_fails(self, test_client, session):
-        """When FAIL semantics, a missing run is reported and matched runs still get updated."""
+        """FAIL semantics: a single missing run fails the whole action and nothing is updated."""
         response = test_client.patch(
             self.ENDPOINT_URL,
             json={
@@ -3154,9 +3153,39 @@ class TestBulkDagRuns:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["update"]["success"] == [f"{DAG1_ID}.{DAG1_RUN1_ID}"]
+        assert body["update"]["success"] == []
         assert len(body["update"]["errors"]) == 1
         assert body["update"]["errors"][0]["status_code"] == 404
+        assert "non_existent_run" in body["update"]["errors"][0]["error"]
+        session.expire_all()
+        # The matched run must keep its original state when another entity is missing.
+        dag_run = session.scalar(select(DagRun).where(DagRun.run_id == DAG1_RUN1_ID))
+        assert dag_run.state == DAG1_RUN1_STATE
+
+    def test_bulk_update_not_found_skip(self, test_client, session):
+        """SKIP semantics: missing runs are ignored and matched runs are still updated."""
+        response = test_client.patch(
+            self.ENDPOINT_URL,
+            json={
+                "actions": [
+                    {
+                        "action": "update",
+                        "action_on_non_existence": "skip",
+                        "entities": [
+                            {"dag_run_id": DAG1_RUN1_ID, "state": "failed"},
+                            {"dag_run_id": "non_existent_run", "state": "failed"},
+                        ],
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["update"]["success"] == [f"{DAG1_ID}.{DAG1_RUN1_ID}"]
+        assert body["update"]["errors"] == []
+        session.expire_all()
+        dag_run = session.scalar(select(DagRun).where(DagRun.run_id == DAG1_RUN1_ID))
+        assert dag_run.state == DagRunState.FAILED
 
     def test_bulk_delete_rejects_unauthorized_dag_ids_from_request_body(self, test_client, session):
         """A 403 at the route level if any entity references a Dag the user can't access."""

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -108,62 +108,8 @@ class BulkActionResponse(BaseModel):
     ] = []
 
 
-class BulkDAGRunBody(BaseModel):
-    """
-    Request body for bulk delete operations on Dag Runs.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dag_run_id: Annotated[str, Field(title="Dag Run Id")]
-    dag_id: Annotated[str | None, Field(title="Dag Id")] = None
-
-
 class Note(RootModel[str]):
     root: Annotated[str, Field(max_length=1000, title="Note")]
-
-
-class BulkDAGRunClearBody(BaseModel):
-    """
-    Request body for the bulk clear Dag Runs endpoint.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dry_run: Annotated[bool | None, Field(title="Dry Run")] = True
-    only_failed: Annotated[bool | None, Field(title="Only Failed")] = False
-    only_new: Annotated[
-        bool | None,
-        Field(
-            description="Only queue newly added tasks in the latest Dag version without clearing existing tasks.",
-            title="Only New",
-        ),
-    ] = False
-    run_on_latest_version: Annotated[
-        bool | None,
-        Field(
-            description="(Experimental) Run on the latest bundle version of the Dag after clearing. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False``.",
-            title="Run On Latest Version",
-        ),
-    ] = None
-    note: Annotated[Note | None, Field(title="Note")] = None
-    dag_runs: Annotated[list[BulkDAGRunBody], Field(min_length=1, title="Dag Runs")]
-
-
-class BulkDeleteActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | BulkDAGRunBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class BulkResponse(BaseModel):
@@ -187,26 +133,6 @@ class BulkResponse(BaseModel):
         BulkActionResponse | None,
         Field(description="Details of the bulk delete operation, including successful keys and errors."),
     ] = None
-
-
-class BulkUpdateActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["update"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[BulkDAGRunBody], Field(description="A list of entities to be updated.", title="Entities")
-    ]
-    update_mask: Annotated[
-        list[str] | None,
-        Field(
-            description="A list of field names to update for each entity.Only these fields will be applied from the request body to the database model.Any extra fields provided will be ignored.",
-            title="Update Mask",
-        ),
-    ] = None
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class TaskIds(RootModel[list]):
@@ -1317,19 +1243,6 @@ class BackfillResponse(BaseModel):
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
 
 
-class BulkCreateActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["create"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[BulkDAGRunBody], Field(description="A list of entities to be created.", title="Entities")
-    ]
-    action_on_existence: BulkActionOnExistence | None = "fail"
-
-
 class BulkCreateActionConnectionBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -1367,6 +1280,62 @@ class BulkCreateActionVariableBody(BaseModel):
         list[VariableBody], Field(description="A list of entities to be created.", title="Entities")
     ]
     action_on_existence: BulkActionOnExistence | None = "fail"
+
+
+class BulkDAGRunBody(BaseModel):
+    """
+    Request body for bulk operations on Dag Runs.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dag_run_id: Annotated[str, Field(title="Dag Run Id")]
+    dag_id: Annotated[str | None, Field(title="Dag Id")] = None
+    state: DagRunMutableStates | None = None
+    note: Annotated[Note | None, Field(title="Note")] = None
+
+
+class BulkDAGRunClearBody(BaseModel):
+    """
+    Request body for the bulk clear Dag Runs endpoint.
+    """
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dry_run: Annotated[bool | None, Field(title="Dry Run")] = True
+    only_failed: Annotated[bool | None, Field(title="Only Failed")] = False
+    only_new: Annotated[
+        bool | None,
+        Field(
+            description="Only queue newly added tasks in the latest Dag version without clearing existing tasks.",
+            title="Only New",
+        ),
+    ] = False
+    run_on_latest_version: Annotated[
+        bool | None,
+        Field(
+            description="(Experimental) Run on the latest bundle version of the Dag after clearing. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False``.",
+            title="Run On Latest Version",
+        ),
+    ] = None
+    note: Annotated[Note | None, Field(title="Note")] = None
+    dag_runs: Annotated[list[BulkDAGRunBody], Field(min_length=1, title="Dag Runs")]
+
+
+class BulkDeleteActionBulkDAGRunBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[str | BulkDAGRunBody],
+        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
+    ]
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class BulkDeleteActionConnectionBody(BaseModel):
@@ -1429,6 +1398,26 @@ class BulkTaskInstanceBody(BaseModel):
     map_index: Annotated[int | None, Field(title="Map Index")] = None
     dag_id: Annotated[str | None, Field(title="Dag Id")] = None
     dag_run_id: Annotated[str | None, Field(title="Dag Run Id")] = None
+
+
+class BulkUpdateActionBulkDAGRunBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["update"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[BulkDAGRunBody], Field(description="A list of entities to be updated.", title="Entities")
+    ]
+    update_mask: Annotated[
+        list[str] | None,
+        Field(
+            description="A list of field names to update for each entity.Only these fields will be applied from the request body to the database model.Any extra fields provided will be ignored.",
+            title="Update Mask",
+        ),
+    ] = None
+    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class BulkUpdateActionBulkTaskInstanceBody(BaseModel):
@@ -2075,18 +2064,6 @@ class BackfillCollectionResponse(BaseModel):
     total_entries: Annotated[int, Field(title="Total Entries")]
 
 
-class BulkBodyBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[
-            BulkCreateActionBulkDAGRunBody | BulkUpdateActionBulkDAGRunBody | BulkDeleteActionBulkDAGRunBody
-        ],
-        Field(title="Actions"),
-    ]
-
-
 class BulkBodyConnectionBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -2117,6 +2094,19 @@ class BulkBodyVariableBody(BaseModel):
         list[BulkCreateActionVariableBody | BulkUpdateActionVariableBody | BulkDeleteActionVariableBody],
         Field(title="Actions"),
     ]
+
+
+class BulkCreateActionBulkDAGRunBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    action: Annotated[
+        Literal["create"], Field(description="The action to be performed on the entities.", title="Action")
+    ]
+    entities: Annotated[
+        list[BulkDAGRunBody], Field(description="A list of entities to be created.", title="Entities")
+    ]
+    action_on_existence: BulkActionOnExistence | None = "fail"
 
 
 class BulkCreateActionBulkTaskInstanceBody(BaseModel):
@@ -2330,6 +2320,18 @@ class TaskInstanceHistoryCollectionResponse(BaseModel):
 
     task_instances: Annotated[list[TaskInstanceHistoryResponse], Field(title="Task Instances")]
     total_entries: Annotated[int, Field(title="Total Entries")]
+
+
+class BulkBodyBulkDAGRunBody(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    actions: Annotated[
+        list[
+            BulkCreateActionBulkDAGRunBody | BulkUpdateActionBulkDAGRunBody | BulkDeleteActionBulkDAGRunBody
+        ],
+        Field(title="Actions"),
+    ]
 
 
 class BulkBodyBulkTaskInstanceBody(BaseModel):


### PR DESCRIPTION
Implements the `update` action of the bulk Dag-run endpoint (`PATCH /dags/{dag_id}/dagRuns`) so multiple Dag runs can be marked as `success` / `failed` / `queued` in a single request, instead of one PATCH per run. Previously this action returned 405 ("not supported").

This is the **backend** for issue #63854 (bulk "mark as" for Dag runs); the UI wiring will follow in a separate PR.

related: #63854

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)