### PR TITLE
UI: Fix task instance state badge staying stale after Mark-as action

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/usePatchTaskInstance.ts
+++ b/airflow-core/src/airflow/ui/src/queries/usePatchTaskInstance.ts
@@ -20,7 +20,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
 import {
-  UseTaskInstanceServiceGetMappedTaskInstanceKeyFn,
   useTaskInstanceServiceGetMappedTaskInstanceKey,
   UseTaskInstanceServiceGetTaskInstanceKeyFn,
   useTaskInstanceServiceGetTaskInstancesKey,
@@ -65,36 +64,13 @@ export const usePatchTaskInstance = ({
       [useTaskInstanceServiceGetTaskInstancesKey],
       [usePatchTaskInstanceDryRunKey, dagId, dagRunId, { mapIndex, taskId }],
       [useClearTaskInstancesDryRunKey, dagId],
+      [useTaskInstanceServiceGetMappedTaskInstanceKey, { dagId, dagRunId, taskId }],
       ...tiPerAttemptQueryKeys,
     ];
-
-    if (mapIndex !== undefined) {
-      queryKeys.push(UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({ dagId, dagRunId, mapIndex, taskId }));
-    }
 
     await Promise.all([
       ...gridQueryKeys(dagId).map((key) => queryClient.invalidateQueries({ queryKey: key })),
       ...queryKeys.map((key) => queryClient.invalidateQueries({ queryKey: key })),
-      // Wildcard match when patching every mapped TI (mapIndex undefined):
-      // invalidate the mapped-TI cache for every map_index of this task.
-      // The mapped-TI key embeds its params as a single object, so prefix
-      // matching on a partial key doesn't catch them — match via predicate.
-      ...(mapIndex === undefined
-        ? [
-            queryClient.invalidateQueries({
-              predicate: ({ queryKey }) => {
-                if (queryKey[0] !== useTaskInstanceServiceGetMappedTaskInstanceKey) {
-                  return false;
-                }
-                const params = queryKey[1] as
-                  | { dagId?: string; dagRunId?: string; taskId?: string }
-                  | undefined;
-
-                return params?.dagId === dagId && params.dagRunId === dagRunId && params.taskId === taskId;
-              },
-            }),
-          ]
-        : []),
     ]);
 
     if (onSuccess) {


### PR DESCRIPTION
closes: #67883


After marking a task instance as success/failed/skipped, the state badge
on the task instance detail page does not update until a manual page reload.

The root cause is in `usePatchTaskInstance`: the `GetMappedTaskInstance`
query was invalidated using the full 4-field key
`UseTaskInstanceServiceGetMappedTaskInstanceKeyFn({ dagId, dagRunId, mapIndex, taskId })`.
While this exact key should theoretically match, TanStack Query's
`partialDeepEqual` matching is more reliable when the search key is a
**subset** of the cached key rather than an exact match.

`usePatchDagRun` already uses the partial-key pattern for the same query:
```ts
[useTaskInstanceServiceGetMappedTaskInstanceKey, { dagId, dagRunId }]
```

This PR aligns `usePatchTaskInstance` to the same approach, using
`[useTaskInstanceServiceGetMappedTaskInstanceKey, { dagId, dagRunId, taskId }]`
as a partial key that matches any `mapIndex` for the given task. This also
eliminates the separate predicate-based invalidation that was needed for the
"patch all mapped TIs" case (`mapIndex === undefined`), simplifying the code.

