### PR TITLE
Add comment hint about pandas 3.0.0

### DIFF
--- a/providers/databricks/pyproject.toml
+++ b/providers/databricks/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "apache-airflow-providers-common-compat>=1.13.0",
     "apache-airflow-providers-common-sql>=1.32.0",
     "requests>=2.32.0,<3",
-    "databricks-sql-connector>=4.0.0",
+    "databricks-sql-connector>=4.0.0", # use >=4.2.7 for pandas 3.0.0. See https://github.com/databricks/databricks-sql-python/pull/768
     "aiohttp>=3.9.2, <4",
     "mergedeep>=1.3.4",
     'pandas>=2.1.2; python_version <"3.13"',


### PR DESCRIPTION
pandas 3.0.0 will be automatically supported when databricks release 4.2.7 
https://github.com/databricks/databricks-sql-python/pull/768

I added a comment just to hint about that. There is no need to change any of the dependencies. 
I don't want to force upgrade to 4.2.7 there is no need for that now.
closes : https://github.com/apache/airflow/issues/52543