### PR TITLE
SimpleAuthManager: preserve deep-link next URL on first login

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py
@@ -27,6 +27,7 @@ from enum import Enum
 from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -215,11 +216,17 @@ class SimpleAuthManager(BaseAuthManager[SimpleAuthManagerUser]):
 
     def get_url_login(self, **kwargs) -> str:
         """Return the login page url."""
+        next_url = kwargs.get("next_url")
         is_simple_auth_manager_all_admins = conf.getboolean("core", "simple_auth_manager_all_admins")
         if is_simple_auth_manager_all_admins:
-            return AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token/login"
+            login_url = AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token/login"
+        else:
+            login_url = AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login"
 
-        return AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login"
+        if next_url:
+            return f"{login_url}?{urlencode({'next': next_url})}"
+
+        return login_url
 
     def deserialize_user(self, token: dict[str, Any]) -> SimpleAuthManagerUser:
         return SimpleAuthManagerUser(

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/test_simple_auth_manager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 from unittest import mock
+from urllib.parse import urlencode
 
 import pytest
 
@@ -230,6 +231,17 @@ class TestSimpleAuthManager:
         with conf_vars({("core", "simple_auth_manager_all_admins"): "true"}):
             result = auth_manager.get_url_login()
             assert result == AUTH_MANAGER_FASTAPI_APP_PREFIX + "/token/login"
+
+    def test_get_url_login_with_next_url(self, auth_manager):
+        next_url = "http://localhost:8080/dags/example_dag/runs/manual__2026-05-20/tasks/example_task"
+        result = auth_manager.get_url_login(next_url=next_url)
+        assert result == f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/login?{urlencode({'next': next_url})}"
+
+    def test_get_url_login_with_next_url_all_admins(self, auth_manager):
+        with conf_vars({("core", "simple_auth_manager_all_admins"): "true"}):
+            next_url = "http://localhost:8080/dags/example_dag/runs/manual__2026-05-20/tasks/example_task"
+            result = auth_manager.get_url_login(next_url=next_url)
+            assert result == f"{AUTH_MANAGER_FASTAPI_APP_PREFIX}/token/login?{urlencode({'next': next_url})}"
 
     def test_deserialize_user(self, auth_manager):
         result = auth_manager.deserialize_user({"sub": "test", "role": "admin"})


### PR DESCRIPTION
Fixes #67476

When unauthenticated users opened a deep link, some login paths called `get_url_login(next_url=...)`. `SimpleAuthManager` ignored this kwarg, so it always redirected to `/auth/login` or `/auth/token/login` without preserving `next`, which caused users to land on the homepage after their first login.

This change makes `SimpleAuthManager.get_url_login` honor the optional `next_url` argument by appending a URL-encoded `next` query parameter for both regular and all-admin login endpoints.

Added unit tests for:

* Regular login with `next_url`
* All-admin login with `next_url`

Validation:

* `/opt/homebrew/bin/ruff format + check --fix` passed
* Local `pytest` run failed in this workspace due to a missing test dependency: `tests_common`
