### PR TITLE
fix(task): refresh JWT token in middleware when execution token expires

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/tokens.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/tokens.py
@@ -351,6 +351,36 @@ class JWTValidator:
 
         return claims
 
+    async def avalidated_claims_ignoring_expiry(self, unvalidated: str) -> dict[str, Any]:
+        """
+        Decode the JWT token with signature verification but without checking expiry.
+
+        Used only in the reissue middleware to recover claims from a token that just
+        expired, so a fresh replacement can be issued. All other validations (signature,
+        audience, issuer) are still enforced.
+        """
+        try:
+            key = await self._get_validation_key(unvalidated)
+        except KeyError:
+            raise jwt.InvalidTokenError("Kid did not match any validation keys")
+        algorithms = self.algorithm
+        validation_key: str | jwt.PyJWK | Any = key
+        if algorithms == ["GUESS"] and isinstance(key, jwt.PyJWK):
+            if not key.algorithm_name:
+                raise jwt.InvalidTokenError("Missing algorithm in JWK")
+            algorithms = [key.algorithm_name]
+            validation_key = key.key
+
+        return jwt.decode(
+            unvalidated,
+            validation_key,
+            audience=self.audience,
+            issuer=self.issuer,
+            options={"require": list(self.required_claims), "verify_exp": False},
+            algorithms=algorithms,
+            leeway=self.leeway,
+        )
+
     def revoke_token(self, token: str) -> None:
         """Validate the token, extract jti and exp, and revoke it in the database."""
         try:

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -24,6 +24,8 @@ from contextlib import AsyncExitStack
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
+from jwt.exceptions import ExpiredSignatureError
+
 import attrs
 import svcs
 from cadwyn import (
@@ -141,7 +143,23 @@ class JWTReissueMiddleware(BaseHTTPMiddleware):
             try:
                 async with svcs.Container(request.app.state.svcs_registry) as services:
                     validator: JWTValidator = await services.aget(JWTValidator)
-                    claims = await validator.avalidated_claims(token, {})
+                    try:
+                        claims = await validator.avalidated_claims(token, {})
+                    except ExpiredSignatureError:
+                        # The token just expired. Re-decode it with signature verification
+                        # but without the expiry check to recover the claims and issue a
+                        # fresh replacement. The 403 from the security middleware is still
+                        # returned; the client can retry with the new token from the
+                        # Refreshed-API-Token header. Workload tokens are excluded because
+                        # they are long-lived queue credentials and must not be refreshed here.
+                        expired_claims = await validator.avalidated_claims_ignoring_expiry(token)
+                        if expired_claims.get("scope") == "workload":
+                            return response
+                        generator: JWTGenerator = await services.aget(JWTGenerator)
+                        refreshed_token = generator.generate(expired_claims)
+                        if refreshed_token:
+                            response.headers["Refreshed-API-Token"] = refreshed_token
+                        return response
 
                     # Workload tokens are long-lived and meant to survive queue
                     # wait times so avoid refreshing them. If avalidated_claims
@@ -154,7 +172,7 @@ class JWTReissueMiddleware(BaseHTTPMiddleware):
                     refresh_when_less_than = max(int(token_lifetime * 0.20), 30)
                     valid_left = int(claims.get("exp", 0)) - now
                     if valid_left <= refresh_when_less_than:
-                        generator: JWTGenerator = await services.aget(JWTGenerator)
+                        generator = await services.aget(JWTGenerator)
                         refreshed_token = generator.generate(claims)
             except Exception as err:
                 # Do not block the response if refreshing fails; log a warning for visibility

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
+from jwt.exceptions import ExpiredSignatureError
 
 from airflow.api_fastapi.auth.tokens import JWTValidator
 from airflow.api_fastapi.execution_api.app import lifespan
@@ -67,3 +68,59 @@ def test_expiring_token_is_reissued(
         assert "Refreshed-API-Token" in response.headers
     else:
         assert "Refreshed-API-Token" not in response.headers
+
+
+@pytest.mark.db_test
+def test_expired_token_is_reissued(client, exec_app: FastAPI, time_machine):
+    """
+    Expired execution tokens should still receive a Refreshed-API-Token header
+    so the client can update its token and retry the request.
+
+    Regression test for https://github.com/apache/airflow/issues/67939.
+    """
+    moment = 1743451846
+    validity = 600
+    sub = "edb09971-4e0e-4221-ad3f-800852d38085"
+
+    auth = AsyncMock(spec=JWTValidator)
+    # The token is already past its expiry so avalidated_claims raises.
+    auth.avalidated_claims.side_effect = ExpiredSignatureError("Signature has expired")
+    # avalidated_claims_ignoring_expiry succeeds and returns the original claims.
+    auth.avalidated_claims_ignoring_expiry.return_value = {
+        "sub": sub,
+        "iat": moment,
+        "exp": moment + validity,
+        "scope": "execution",
+    }
+
+    time_machine.move_to(moment + validity + 5, tick=False)
+
+    lifespan.registry.register_value(JWTValidator, auth)
+
+    response = client.get("/execution/variables/key1", headers={"Authorization": "Bearer dummy"})
+
+    assert "Refreshed-API-Token" in response.headers
+
+
+@pytest.mark.db_test
+def test_expired_workload_token_is_not_reissued(client, exec_app: FastAPI, time_machine):
+    """Workload tokens must not be refreshed by the reissue middleware, even after expiry."""
+    moment = 1743451846
+    validity = 600
+
+    auth = AsyncMock(spec=JWTValidator)
+    auth.avalidated_claims.side_effect = ExpiredSignatureError("Signature has expired")
+    auth.avalidated_claims_ignoring_expiry.return_value = {
+        "sub": "some-workload-id",
+        "iat": moment,
+        "exp": moment + validity,
+        "scope": "workload",
+    }
+
+    time_machine.move_to(moment + validity + 5, tick=False)
+
+    lifespan.registry.register_value(JWTValidator, auth)
+
+    response = client.get("/execution/variables/key1", headers={"Authorization": "Bearer dummy"})
+
+    assert "Refreshed-API-Token" not in response.headers


### PR DESCRIPTION
Fixes #67939

## Problem

Long-running tasks (running longer than `EXECUTION_API__JWT_EXPIRATION_TIME`, default 600 s) fail to send heartbeats because their execution-scoped JWT expires. When the token expires:

1. The security middleware rejects the request with 403.
2. `JWTReissueMiddleware` tries to refresh the token by calling `avalidated_claims` -- this also raises `ExpiredSignatureError`.
3. No `Refreshed-API-Token` header is set on the 403 response.
4. The client's tenacity retries all use the same expired token and keep getting 403.
5. After `MAX_FAILED_HEARTBEATS` consecutive failures the supervisor kills the task.

The proactive 80 % refresh works for tokens that are *near* expiry, but cannot help once the token has already crossed its `exp` boundary.

## Fix

Add `avalidated_claims_ignoring_expiry` to `JWTValidator`. This method verifies the signature, audience, and issuer exactly like `avalidated_claims`, but passes `"verify_exp": False` to `jwt.decode` so it does not raise on an already-expired token.

`JWTReissueMiddleware` now catches `ExpiredSignatureError` from the regular validation, calls `avalidated_claims_ignoring_expiry` to recover the claims with full signature verification, and sets `Refreshed-API-Token` on the 403 response. Workload-scoped tokens are excluded from this path (same as the existing proactive refresh).

The existing `_update_auth` response hook in the SDK client already updates the `Bearer` token from `Refreshed-API-Token` before the error is raised, so the tenacity retry fires with a fresh token and succeeds. No client-side changes are needed.

## Changes

- `airflow-core/src/airflow/api_fastapi/auth/tokens.py`: add `avalidated_claims_ignoring_expiry` to `JWTValidator`
- `airflow-core/src/airflow/api_fastapi/execution_api/app.py`: catch `ExpiredSignatureError` in `JWTReissueMiddleware` and issue a replacement token
- `airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py`: add regression tests for expired execution and workload tokens