### PR TITLE
API: fix /importErrors total_entries overcount for multi-Dag files

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/import_error.py
@@ -31,6 +31,7 @@ from airflow.api_fastapi.auth.managers.models.resource_details import (
 )
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
+    apply_filters_to_select,
     paginated_select,
 )
 from airflow.api_fastapi.common.parameters import (
@@ -53,6 +54,7 @@ from airflow.api_fastapi.core_api.security import (
 )
 from airflow.models import DagModel
 from airflow.models.errors import ParseImportError
+from airflow.utils.db import get_query_count
 
 REDACTED_STACKTRACE = "REDACTED - you do not have read permission on all Dags in the file"
 import_error_router = AirflowRouter(tags=["Import Error"], prefix="/importErrors")
@@ -208,14 +210,21 @@ def get_import_errors(
         .order_by(ParseImportError.id)
     )
 
+    count_statement = apply_filters_to_select(
+        statement=import_errors_stmt.with_only_columns(ParseImportError.id).distinct(),
+        filters=[filename_pattern, filename_prefix_pattern],
+    )
+    total_entries = get_query_count(count_statement, session=session)
+
     # Paginate the import errors query
-    import_errors_select, total_entries = paginated_select(
+    import_errors_select, _ = paginated_select(
         statement=import_errors_stmt,
         filters=[filename_pattern, filename_prefix_pattern],
         order_by=order_by,
         offset=offset,
         limit=limit,
         session=session,
+        return_total_entries=False,
     )
     import_errors_result: Iterable[tuple[ParseImportError, Iterable]] = groupby(
         session.execute(import_errors_select), itemgetter(0)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_import_error.py
@@ -387,6 +387,39 @@ class TestGetImportErrors:
             import_error["filename"] for import_error in response_json["import_errors"]
         ] == expected_filenames
 
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.import_error.get_auth_manager")
+    def test_total_entries_counts_distinct_import_errors_when_file_maps_to_multiple_dags(
+        self,
+        mock_get_auth_manager,
+        test_client,
+        permitted_dag_model_all,
+        session,
+    ):
+        session.add(
+            DagModel(
+                fileloc=FILENAME1,
+                relative_fileloc=FILENAME1,
+                dag_id="dag_id1_colocated",
+                is_paused=False,
+                bundle_name=BUNDLE_NAME,
+            )
+        )
+        session.commit()
+
+        set_mock_auth_manager__get_authorized_dag_ids(
+            mock_get_auth_manager,
+            permitted_dag_model_all | {"dag_id1_colocated"},
+        )
+        set_mock_auth_manager__batch_is_authorized_dag(mock_get_auth_manager, True)
+
+        response = test_client.get("/importErrors")
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["total_entries"] == 3
+        assert len(response_json["import_errors"]) == 3
+        assert [entry["filename"] for entry in response_json["import_errors"]].count(FILENAME1) == 1
+
     def test_should_raises_401_unauthenticated(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get("/importErrors")
         assert response.status_code == 401


### PR DESCRIPTION
Fixes #67525

When one ParseImportError file maps to multiple DagModel rows, the
`/api/v2/importErrors` endpoint returned grouped import error objects but
computed `total_entries` from raw joined rows. This inflated the Dashboard
Dag Import Errors badge.

This change makes `total_entries` count distinct `ParseImportError.id`
after applying the same filename filters used by the endpoint.
Pagination and authorization/redaction behavior are unchanged.

Added regression test:
- verifies `total_entries` remains equal to distinct import-error objects
  when one file maps to multiple DAGs.

Validation:
- ruff check passed for touched files
- targeted pytest is blocked in this workspace due missing `tests_common`
  dependency in local runtime (`ModuleNotFoundError: tests_common`)

 
