### PR TITLE
Fix flaky e2e remote-logging tests (LocalStack bucket creation)

### DIFF
--- a/airflow-e2e-tests/scripts/init-aws.sh
+++ b/airflow-e2e-tests/scripts/init-aws.sh
@@ -16,6 +16,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
-aws --endpoint-url=http://localstack:4566 s3 mb s3://test-airflow-logs
-aws --endpoint-url=http://localstack:4566 s3 mb s3://test-xcom-objectstorage-backend
-aws --endpoint-url=http://localstack:4566 s3 ls
+set -euo pipefail
+
+# This script runs as a LocalStack READY init hook *inside* the localstack
+# container, so it must reach the gateway over loopback (localhost), not via the
+# docker compose service name "localstack" — the service-name endpoint is not
+# reliably resolvable/connectable from within the container at the READY stage
+# and intermittently caused "Could not connect to the endpoint URL" failures,
+# leaving the buckets uncreated and remote-logging tests failing with NoSuchBucket.
+endpoint_url="http://localhost:4566"
+
+# The READY hook fires when LocalStack reports ready, but guard against a
+# transient gateway delay so bucket creation never silently fails.
+for _ in $(seq 1 30); do
+  if aws --endpoint-url="${endpoint_url}" s3 ls >/dev/null 2>&1; then
+    break
+  fi
+  echo "Waiting for LocalStack S3 gateway at ${endpoint_url} ..."
+  sleep 1
+done
+
+aws --endpoint-url="${endpoint_url}" s3 mb s3://test-airflow-logs
+aws --endpoint-url="${endpoint_url}" s3 mb s3://test-xcom-objectstorage-backend
+aws --endpoint-url="${endpoint_url}" s3 ls


### PR DESCRIPTION
The remote-logging and XCom object-storage e2e tests (Additional PROD image
tests) intermittently fail with `NoSuchBucket` because the LocalStack init
hook never creates the buckets.

`airflow-e2e-tests/scripts/init-aws.sh` runs as a LocalStack READY init hook
*inside* the localstack container, but it connected to the docker-compose
service name `http://localstack:4566`. That endpoint is not reliably
connectable from within the container at the READY stage, so both `aws s3 mb`
calls failed (`Could not connect to the endpoint URL`, script exit 255), the
`test-airflow-logs` / `test-xcom-objectstorage-backend` buckets were never
created, and worker `PutObject` calls returned `NoSuchBucket`.

Fix: connect over loopback (`http://localhost:4566`) from inside the container,
add a short readiness wait, and `set -euo pipefail` so a transient gateway
delay cannot silently leave the buckets uncreated.

Observed on the v3-2-test branch:
https://github.com/apache/airflow/actions/runs/26889226071/job/79325331114

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)