### PR TITLE
magpie-setup: refresh committed bootstrap from airflow-steward main (#442, #443)

### DIFF
--- a/.github/skills/magpie-setup/SKILL.md
+++ b/.github/skills/magpie-setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup
+name: magpie-setup
 description: |
   Adopt and maintain the apache-steward framework in a project
   repo via the snapshot-based adoption mechanism. The only
@@ -93,6 +93,21 @@ copy):
   [`overrides.md`](overrides.md) for the contract and
   [`docs/setup/agentic-overrides.md`](../../docs/setup/agentic-overrides.md)
   for the design rationale.
+
+**Local self-adoption (the framework checkout only).** The one
+repo that cannot be adopted via the snapshot mechanism is the
+Apache Magpie framework checkout itself — a remote snapshot of the
+framework into itself would be circular. Instead it **self-adopts**
+with `method:local`: each `magpie-<skill>` is a **committed**
+symlink into the in-repo `../../skills/<skill>/` source — written
+under both `.claude/skills/` (Claude Code) and `.github/skills/`
+(GitHub's skill loader) — with no snapshot, no remote fetch, and
+no copy. This makes
+the framework's own skills callable while developing the framework,
+and every contributor gets them active on a fresh clone with no
+setup step. `adopt` detects the framework checkout structurally and
+routes there automatically (see
+[`adopt.md` → Local self-adoption](adopt.md#local-self-adoption-methodlocal)).
 
 ## The two lock files
 
@@ -342,7 +357,7 @@ first, then continue.
 | Flag | Effect |
 |---|---|
 | `from:<git-ref>` / `from:<version>` | Adopt or upgrade from a specific framework ref or version. Used during `adopt` (overrides the user prompt) and `upgrade` (overrides the committed lock for *this run only* — does NOT update the committed lock). |
-| `method:<git-branch\|git-tag\|svn-zip>` | Pick the install method explicitly. Default during `adopt`: prompt the user. |
+| `method:<git-branch\|git-tag\|svn-zip\|local>` | Pick the install method explicitly. Default during `adopt`: prompt the user. **`local`** is **framework-checkout only** — it self-adopts by linking the in-repo `skills/` source directly instead of fetching a snapshot (see [`adopt.md` → Local self-adoption](adopt.md#local-self-adoption-methodlocal)). |
 | `skill-families:<list>` | Comma-separated **opt-in** families to symlink (`security`, `pr-management`, `issue`). Default on `adopt`: prompt. Default on `upgrade`: read the families list from `<committed-lock>` / `<local-lock>`, **auto-include any opt-in family the framework has introduced since the lock was written** (recorded back into the lock), and **ensure every framework skill in the effective family set has a valid symlink** — create or repair missing / broken symlinks, not just add new ones. The flag never accepts the always-on families (`setup-*` minus `setup` itself, and `list-*`); per [Golden rule 8](#golden-rules) those are wired up unconditionally on every run and there is no way to ask for them or opt out. |
 | `--purge-overrides` | *(unadopt only)* Also `git rm -r` `.apache-magpie-overrides/`. Default: preserve. |
 | `dry-run` | Show what the skill would do without writing anything. |

--- a/.github/skills/magpie-setup/adopt.md
+++ b/.github/skills/magpie-setup/adopt.md
@@ -63,9 +63,31 @@ between automatically:
    `$(dirname "$(cd "$(git rev-parse --git-common-dir)" && pwd)")` —
    surface it explicitly in the error message so the operator
    can `cd` there without guessing.
-3. Confirm we are **not** in `apache/airflow-steward` itself
-   (read `git remote get-url origin` and refuse if it
-   resolves to the framework).
+3. Detect whether we are **in the Apache Magpie framework
+   checkout itself** rather than an adopter repo. The framework
+   checkout is the one place self-adoption is possible — it
+   links its own `skills/` source directly instead of fetching a
+   snapshot (see
+   [Local self-adoption](#local-self-adoption-methodlocal)).
+
+   Detect it **structurally** — do *not* rely on the `origin`
+   URL, which on a contributor's fork points at
+   `<user>/airflow-steward`, not `apache/`. The repo is the
+   framework checkout when `skills/setup/SKILL.md` exists at the
+   repo root with `name: magpie-setup` in its frontmatter **and**
+   `skills/list-skills/` is present.
+
+   - **Framework checkout** → self-adoption is available. If the
+     user passed `method:local`, go straight to
+     [Local self-adoption](#local-self-adoption-methodlocal).
+     Otherwise offer it — the only non-circular adoption for the
+     framework repo is the local one (a remote snapshot of the
+     framework into itself would shadow the live `skills/`
+     source with a stale copy). On confirmation, follow that
+     section; a remote `method:` against the framework checkout
+     is refused.
+   - **Adopter repo** (the structural markers are absent) →
+     continue with the normal remote-snapshot flow below.
 4. Detect the adopter's existing skills-dir convention by
    following [`conventions.md`](conventions.md). Pin the
    result as `<adopter-skills-dir>` for the rest of this
@@ -104,6 +126,100 @@ between automatically:
    The consolidation is a one-time, deliberate layout
    change; the adopt flow surfaces every step before
    writing.
+
+## Local self-adoption (`method:local`)
+
+**Framework checkout only.** When `/magpie-setup` runs inside the
+Apache Magpie framework checkout (detected in
+[Step 0](#step-0--pre-flight)), it adopts the framework *into
+itself* by linking the live `skills/` source directly — **no
+remote URL, no snapshot fetch, no repo copy**. This is how a
+maintainer makes the framework's own skills callable while
+developing the framework. An adopter repo never reaches this
+section; it runs Steps 1–12 below.
+
+How it differs from a remote adoption:
+
+- **No `<snapshot-dir>`.** Nothing is fetched — the skill sources
+  already live in `skills/` at the repo root.
+- **No remote lock.** A single committed marker file
+  `.apache-magpie.lock` records `method: local` (no
+  `url`/`ref`/`commit`/`sha512`), and there is no
+  `.apache-magpie.local.lock`.
+- **Symlinks are committed, not gitignored.** Each
+  `magpie-<skill>` symlink targets `../../skills/<skill>/` — an
+  in-repo path that always resolves on a fresh clone — so the
+  links are committed. They are written under **both**
+  `.claude/skills/` (Claude Code) and `.github/skills/` (GitHub's
+  skill loader), so the framework's own skills are discoverable
+  by either harness; `.gitignore` un-ignores `magpie-*` in both
+  dirs. Every contributor gets the skills active with no setup
+  step.
+- **All skills, no family prompt.** Self-adoption links *every*
+  skill under `skills/`, so the opt-in family prompt of
+  [Step 5](#step-5--pick-the-skill-families) is skipped.
+  `skill-families:` is still honoured if the maintainer wants to
+  narrow the set.
+- **`magpie-setup` is itself a symlink** (→ `../../skills/setup/`),
+  not a committed copy. The copy-vs-symlink rule of
+  [`SKILL.md` Golden rule 6](SKILL.md#golden-rules) exists only
+  because adopter snapshots disappear on clone; the framework's
+  own source is always present, so the bootstrap is linked like
+  every other skill.
+
+### Steps
+
+1. **Pre-flight** ([Step 0](#step-0--pre-flight)) has confirmed
+   we are in the framework checkout and in the main checkout (not
+   a worktree).
+2. **Refuse a remote method.** If the user passed
+   `method:git-branch|git-tag|svn-zip`, stop: a remote snapshot
+   of the framework into itself is circular and would shadow the
+   live `skills/` source.
+3. **Enumerate skills.** List every directory under
+   `<repo-root>/skills/` that contains a `SKILL.md`. Apply
+   `skill-families:` as a filter if it was passed; otherwise take
+   all of them.
+4. **Write the marker lock** at `<repo-root>/.apache-magpie.lock`:
+
+   ```text
+   # .apache-magpie.lock — committed. Local self-adoption marker.
+   # The framework checkout links its own skills/ source; there is
+   # no remote snapshot. Edited only by /magpie-setup.
+
+   method: local
+   source: skills/
+   ```
+
+5. **`.gitignore`.** Ensure each skills dir glob is ignored with
+   the `magpie-*` set un-ignored, in **both** locations
+   (idempotent — add any missing line):
+
+   ```text
+   .claude/skills/*
+   !/.claude/skills/magpie-*
+   .github/skills/*
+   !/.github/skills/magpie-*
+   ```
+
+6. **Create the symlinks.** For each enumerated skill `<n>`,
+   create the relative symlink `magpie-<n>` → `../../skills/<n>`
+   under **both** `<repo-root>/.claude/skills/` and
+   `<repo-root>/.github/skills/`. Idempotent: re-point a
+   pre-existing `magpie-<n>` symlink only if it targets something
+   else; never overwrite a non-symlink (surface the conflict and
+   stop). Show the full list and confirm before writing.
+7. **Verify + stage.** Confirm every `magpie-<n>` symlink (in
+   both dirs) resolves to a directory containing `SKILL.md`, then
+   suggest the user `git add` the symlinks, `.apache-magpie.lock`,
+   and `.gitignore`.
+
+Self-adoption skips the adopter-only steps entirely: no snapshot
+fetch (Step 3), no committed-`setup` reconcile (Step 3b), no
+fit-signal probe (Step 4b), no family prompt (Step 5), no
+`.apache-magpie-overrides/` scaffold (Step 9), no `user.md`
+(Step 9b), no comdev MCP prereqs (Step 9c), no project-doc
+updates (Step 11) — the framework repo *is* the documentation.
 
 ## Step 1 — Detect adoption shape
 

--- a/.github/skills/magpie-setup/upgrade.md
+++ b/.github/skills/magpie-setup/upgrade.md
@@ -59,27 +59,30 @@ Both paths run the same flow.
 
 ## Step 0a — Pre-Magpie leftovers safety check
 
-A repo that adopted the framework before it was renamed from
-**apache-steward** to **Apache Magpie** migrates via the
-one-shot transition shim at `.claude/skills/setup-steward/`
-(a frozen `/setup-steward upgrade` lands there automatically;
-see that skill's [`upgrade.md`](../../.claude/skills/setup-steward/upgrade.md)).
-A fully-migrated repo never reaches *this* file with legacy
-artefacts present.
+The framework was once named **apache-steward** before it was
+renamed to **Apache Magpie**. The framework **no longer ships an
+automated pre-Magpie migration** — a repo still on the old layout
+must be migrated by hand.
 
-If you nonetheless detect **any** legacy artefact here —
+If you detect **any** legacy artefact here —
 `.apache-steward.lock`, `.apache-steward/`,
 `.apache-steward-overrides/`, a committed
 `<adopter-skills-dir>/setup-steward/`, or a framework symlink
-**without** the `magpie-` prefix — a prior migration did not
-finish. Do **not** continue the normal upgrade against the
-half-migrated state. Run the transition migration to
-completion first (follow
-[`.claude/skills/setup-steward/upgrade.md`](../../.claude/skills/setup-steward/upgrade.md),
-which is idempotent and safe to re-run), then resume this
-upgrade. `~/.config/apache-steward/` alone (per-user, no
-in-repo artefacts) just needs the dir + sandbox-allowlist
-move from that file's Step 7.
+**without** the `magpie-` prefix — do **not** continue the normal
+upgrade against the half-migrated state. Stop and surface the
+manual remediation:
+
+1. Remove the legacy in-repo artefacts (`.apache-steward*`, any
+   un-prefixed framework symlinks, a committed `setup-steward`
+   skill).
+2. Re-adopt from scratch with `/magpie-setup` so the current
+   `.apache-magpie*` layout and `magpie-`-prefixed symlinks are
+   written fresh.
+3. Move `~/.config/apache-steward/` (per-user) to
+   `~/.config/apache-magpie/` and update any sandbox-allowlist
+   entry that referenced the old path.
+
+Then resume this upgrade against the clean Magpie layout.
 
 ## Step 1 — Compute drift
 

--- a/.github/skills/magpie-setup/verify.md
+++ b/.github/skills/magpie-setup/verify.md
@@ -21,12 +21,50 @@ default — surfaces gaps and remediation commands.
 ## Pre-flight
 
 1. `git rev-parse --show-toplevel` — must succeed.
-2. `git remote get-url origin` — refuse if it resolves to
-   `apache/airflow-steward` itself (this skill is for
-   adopters, not the framework).
+2. **Framework checkout?** Detect structurally (as in
+   [`adopt.md` Step 0](adopt.md#step-0--pre-flight)):
+   `skills/setup/SKILL.md` exists at the repo root with
+   `name: magpie-setup` and `skills/list-skills/` is present. If
+   so **and** `.apache-magpie.lock` records `method: local`, the
+   repo is **self-adopted** — run the
+   [Local self-adoption checks](#local-self-adoption-checks)
+   instead of the snapshot checks below, then stop. A framework
+   checkout with no `method: local` lock is simply not adopted
+   yet — point at `/magpie-setup`.
 3. If `<repo-root>/.apache-magpie.lock` is missing, the
    repo is not adopted. Surface and stop with a pointer at
    `/magpie-setup adopt`.
+
+## Local self-adoption checks
+
+Run these (and only these) when pre-flight detected a framework
+checkout self-adopted with `method: local`. There is no snapshot,
+no remote lock, and no per-machine lock to drift against — the
+committed symlinks into the in-repo `skills/` source *are* the
+adoption state.
+
+1. **Marker lock.** `.apache-magpie.lock` parses and records
+   `method: local`. ✓ when present; ✗ with a pointer at
+   `/magpie-setup` otherwise.
+2. **Symlinks resolve into `skills/`.** In **both**
+   `.claude/skills/` and `.github/skills/`, every `magpie-<n>` is
+   a symlink whose target (`../../skills/<n>/`) resolves to a
+   directory containing `SKILL.md`. ✗ list any dangling or
+   non-symlink entry; remediation: re-run `/magpie-setup`
+   (idempotent).
+3. **Coverage.** Every `skills/<n>/` with a `SKILL.md` has a
+   matching `magpie-<n>` symlink in **both** dirs (unless a
+   `skill-families:` filter was deliberately applied). ⚠ list any
+   source skill with no link; remediation: `/magpie-setup`.
+4. **`.gitignore`.** `.claude/skills/*` and `.github/skills/*` are
+   ignored, with `!/.claude/skills/magpie-*` and
+   `!/.github/skills/magpie-*` un-ignoring the committed symlinks.
+   ✗ if either un-ignore line is missing (those symlinks would not
+   be tracked).
+5. **No remote leftovers.** No `.apache-magpie/` snapshot dir and
+   no `.apache-magpie.local.lock` — local self-adoption uses
+   neither. ⚠ surface either if found (a stale remote adoption was
+   not cleaned up).
 
 ## The checks
 


### PR DESCRIPTION
Refreshes the committed Apache Magpie bootstrap skill (`/.github/skills/magpie-setup`, surfaced as `.claude/skills/magpie-setup`) to apache/airflow-steward `main` via `/magpie-setup upgrade` (snapshot `0990284` → `fd382b2`):

- **#442** — prefix skill `name:` frontmatter with `magpie-`
- **#443** — add the `method:local` self-adoption path and drop the `setup-steward` migration shim (no pre-Magpie artefacts remain in this repo, so the removal is a no-op here)

Bootstrap-only change (4 files). The committed lock (`git-branch` / `main`) is unchanged — `git-branch` carries no commit pin. The gitignored snapshot and skill symlinks are not part of the diff.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)