### PR TITLE
Fix IDC domain S3 path resolution

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio_notebook.py
@@ -262,11 +262,7 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
         :param project_id: The ID of the DataZone project.
         :return: A ``(bucket, prefix)`` tuple. ``bucket`` is the S3 bucket name.
             ``prefix`` is the path component of the project's
-            ``s3BucketPath`` (with no leading or trailing ``/``) — typically
-            ``""`` for IAM domains and
-            ``"<domain_id>/<project_id>/<scope>"`` for IDC domains.
-            Callers should prepend ``prefix`` to any S3 key they construct so
-            writes/reads stay within the IAM scope of the project's role.
+            ``s3BucketPath`` (with no leading or trailing ``/``).
         :raises RuntimeError: If the default tooling environment or the
             ``s3BucketPath`` provisioned resource cannot be found.
         """
@@ -282,8 +278,8 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
                         f"environment {environment_id} for project {project_id} in domain "
                         f"{domain_identifier}"
                     )
-                # value looks like "s3://<bucket>" (IAM) or
-                # "s3://<bucket>/<domain>/<project>/<scope>" (IDC). Return both
+                # value looks like "s3://<bucket>/shared/<suffix>" (IAM) or
+                # "s3://<bucket>/<domain>/<project>/dev/<suffix>" (IDC). Return both
                 # parts so callers can construct project-scoped keys.
                 parts = urlparse(value, allow_fragments=False)
                 bucket = parts.netloc

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio_notebook.py
@@ -247,21 +247,26 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
             error_message = execution_message
         raise RuntimeError(error_message)
 
-    def get_project_s3_path(self, domain_identifier: str, project_id: str) -> str:
+    def get_project_s3_path(self, domain_identifier: str, project_id: str) -> tuple[str, str]:
         """
-        Look up the S3 bucket path for a SageMaker Unified Studio project.
+        Look up the S3 location for a SageMaker Unified Studio project.
 
-        The bucket path is read from the ``s3BucketPath`` provisioned resource of
-        the project's default ("Tooling") environment via the DataZone APIs:
-        ``GetEnvironment(GetProjectDefaultEnvironment(...))``. This mirrors how
-        SageMaker Unified Studio resolves the project bucket, and accommodates projects
-        whose bucket name does not follow the
-        ``amazon-sagemaker-{account_id}-{region}-{project_id}`` template (for
-        example, BYOR-bucket projects).
+        The bucket and key prefix are read from the ``s3BucketPath`` provisioned
+        resource of the project's default ("Tooling") environment via the
+        DataZone APIs. This mirrors how SageMaker Unified Studio resolves the
+        project bucket and accommodates projects whose bucket name does not
+        follow the ``amazon-sagemaker-{account_id}-{region}-{project_id}``
+        template (for example, BYOR-bucket projects).
 
         :param domain_identifier: The ID of the DataZone domain.
         :param project_id: The ID of the DataZone project.
-        :return: The S3 bucket name for the project.
+        :return: A ``(bucket, prefix)`` tuple. ``bucket`` is the S3 bucket name.
+            ``prefix`` is the path component of the project's
+            ``s3BucketPath`` (with no leading or trailing ``/``) — typically
+            ``""`` for IAM domains and
+            ``"<domain_id>/<project_id>/<scope>"`` for IDC domains.
+            Callers should prepend ``prefix`` to any S3 key they construct so
+            writes/reads stay within the IAM scope of the project's role.
         :raises RuntimeError: If the default tooling environment or the
             ``s3BucketPath`` provisioned resource cannot be found.
         """
@@ -277,7 +282,9 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
                         f"environment {environment_id} for project {project_id} in domain "
                         f"{domain_identifier}"
                     )
-                # value looks like "s3://<bucket>/<prefix>"; return the bucket name only.
+                # value looks like "s3://<bucket>" (IAM) or
+                # "s3://<bucket>/<domain>/<project>/<scope>" (IDC). Return both
+                # parts so callers can construct project-scoped keys.
                 parts = urlparse(value, allow_fragments=False)
                 bucket = parts.netloc
                 if not bucket:
@@ -286,7 +293,8 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
                         f"'{value}' in default tooling environment {environment_id} for "
                         f"project {project_id} in domain {domain_identifier}"
                     )
-                return bucket
+                prefix = parts.path.strip("/")
+                return bucket, prefix
 
         raise RuntimeError(
             f"s3BucketPath provisioned resource not found in default tooling environment "
@@ -419,10 +427,10 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
         """
         log = logging.getLogger(__name__)
         try:
-            bucket = self.get_project_s3_path(domain_identifier, owning_project_identifier)
+            bucket, prefix = self.get_project_s3_path(domain_identifier, owning_project_identifier)
         except Exception:
             log.warning(
-                "Failed to resolve project S3 bucket for project %s in domain %s, "
+                "Failed to resolve project S3 location for project %s in domain %s, "
                 "skipping notebook outputs read.",
                 owning_project_identifier,
                 domain_identifier,
@@ -430,7 +438,12 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
             )
             return {}
 
-        key = f"sys/notebooks/{notebook_identifier}/runs/{notebook_run_id}/notebook_outputs.json"
+        # IDC domains have a non-empty prefix (e.g. "<domain>/<project>/<scope>")
+        # and the project role's IAM policy only allows S3 reads under that prefix.
+        # IAM domains have prefix == "" and the key is unchanged from the
+        # legacy bucket-root layout.
+        run_key = f"sys/notebooks/{notebook_identifier}/runs/{notebook_run_id}/notebook_outputs.json"
+        key = f"{prefix}/{run_key}" if prefix else run_key
 
         log.info("Reading notebook outputs from s3://%s/%s", bucket, key)
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/sagemaker_unified_studio_notebook.py
@@ -442,7 +442,7 @@ class SageMakerUnifiedStudioNotebookHook(AwsBaseHook):
         # and the project role's IAM policy only allows S3 reads under that prefix.
         # IAM domains have prefix == "" and the key is unchanged from the
         # legacy bucket-root layout.
-        run_key = f"sys/notebooks/{notebook_identifier}/runs/{notebook_run_id}/notebook_outputs.json"
+        run_key = f".sys/notebooks/{notebook_identifier}/runs/{notebook_run_id}/notebook_outputs.json"
         key = f"{prefix}/{run_key}" if prefix else run_key
 
         log.info("Reading notebook outputs from s3://%s/%s", bucket, key)

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
@@ -57,7 +57,7 @@ DOMAIN_ID_KEY = "DOMAIN_ID"
 PROJECT_ID_KEY = "PROJECT_ID"
 NOTEBOOK_ID_KEY = "NOTEBOOK_ID"
 NOTEBOOK_B_ID_KEY = "NOTEBOOK_B_ID"
-# DATAZONE_ROLE_ARN_KEY = "DATAZONE_ROLE_ARN"
+DATAZONE_ROLE_ARN_KEY = "DATAZONE_ROLE_ARN"
 
 sys_test_context_task = (
     SystemTestContextBuilder()
@@ -65,11 +65,11 @@ sys_test_context_task = (
     .add_variable(PROJECT_ID_KEY)
     .add_variable(NOTEBOOK_ID_KEY)
     .add_variable(NOTEBOOK_B_ID_KEY)
-    # .add_variable(DATAZONE_ROLE_ARN_KEY)
+    .add_variable(DATAZONE_ROLE_ARN_KEY)
     .build()
 )
 
-# DATAZONE_CONN_ID = "aws_datazone_notebook"
+DATAZONE_CONN_ID = "aws_datazone_notebook"
 
 
 @task
@@ -101,39 +101,39 @@ with DAG(
     project_id = test_context[PROJECT_ID_KEY]
     notebook_id = test_context[NOTEBOOK_ID_KEY]
     notebook_b_id = test_context[NOTEBOOK_B_ID_KEY]
-    # configure_conn = setup_datazone_connection(test_context[DATAZONE_ROLE_ARN_KEY])
+    configure_conn = setup_datazone_connection(test_context[DATAZONE_ROLE_ARN_KEY])
 
     # [START howto_operator_sagemaker_unified_studio_notebook]
     client_token = f"idempotency-token-{int(time.time())}"
 
-    # run_notebook = SageMakerUnifiedStudioNotebookOperator(
-    #     task_id="notebook-task",
-    #     aws_conn_id=DATAZONE_CONN_ID,
-    #     notebook_identifier=notebook_id,
-    #     domain_identifier=domain_id,
-    #     owning_project_identifier=project_id,
-    #     client_token=client_token,  # optional
-    #     notebook_parameters={
-    #         "param1": "value1",
-    #         "param2": "value2",
-    #     },  # optional
-    #     compute_configuration={"instanceType": "sc.m5.large"},  # optional
-    #     timeout_configuration={"runTimeoutInMinutes": 1440},  # optional
-    #     wait_for_completion=True,  # optional
-    #     waiter_delay=30,  # optional
-    #     deferrable=False,  # optional
-    # )
+    run_notebook = SageMakerUnifiedStudioNotebookOperator(
+        task_id="notebook-task",
+        aws_conn_id=DATAZONE_CONN_ID,
+        notebook_identifier=notebook_id,
+        domain_identifier=domain_id,
+        owning_project_identifier=project_id,
+        client_token=client_token,  # optional
+        notebook_parameters={
+            "param1": "value1",
+            "param2": "value2",
+        },  # optional
+        compute_configuration={"instanceType": "sc.m5.large"},  # optional
+        timeout_configuration={"runTimeoutInMinutes": 1440},  # optional
+        wait_for_completion=True,  # optional
+        waiter_delay=30,  # optional
+        deferrable=False,  # optional
+    )
     # [END howto_operator_sagemaker_unified_studio_notebook]
 
     # [START howto_sensor_sagemaker_unified_studio_notebook]
-    # run_sensor = SageMakerUnifiedStudioNotebookSensor(
-    #     task_id="notebook-sensor-task",
-    #     aws_conn_id=DATAZONE_CONN_ID,
-    #     domain_identifier=domain_id,
-    #     owning_project_identifier=project_id,
-    #     notebook_identifier=notebook_id,
-    #     notebook_run_id=run_notebook.output["notebook_run_id"],
-    # )
+    run_sensor = SageMakerUnifiedStudioNotebookSensor(
+        task_id="notebook-sensor-task",
+        aws_conn_id=DATAZONE_CONN_ID,
+        domain_identifier=domain_id,
+        owning_project_identifier=project_id,
+        notebook_identifier=notebook_id,
+        notebook_run_id=run_notebook.output["notebook_run_id"],
+    )
     # [END howto_sensor_sagemaker_unified_studio_notebook]
 
     # [START howto_operator_sagemaker_unified_studio_notebook_pass_outputs]
@@ -141,7 +141,7 @@ with DAG(
     # Notebook B consumes those outputs via Jinja templating in notebook_parameters.
     run_notebook_a = SageMakerUnifiedStudioNotebookOperator(
         task_id="notebook-a-task",
-        # aws_conn_id=DATAZONE_CONN_ID,
+        aws_conn_id=DATAZONE_CONN_ID,
         notebook_identifier=notebook_id,
         domain_identifier=domain_id,
         owning_project_identifier=project_id,
@@ -151,13 +151,13 @@ with DAG(
 
     run_notebook_b = SageMakerUnifiedStudioNotebookOperator(
         task_id="notebook-b-task",
-        # aws_conn_id=DATAZONE_CONN_ID,
+        aws_conn_id=DATAZONE_CONN_ID,
         notebook_identifier=notebook_b_id,
         domain_identifier=domain_id,
         owning_project_identifier=project_id,
         notebook_parameters={
-            "name": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.name') }}",
-            "age": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.age') }}",
+            "employee_name": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.name') }}",
+            "employee_age": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.age') }}",
         },
         wait_for_completion=True,
         deferrable=False,
@@ -166,9 +166,9 @@ with DAG(
 
     chain(
         test_context,
-        # configure_conn,
-        # run_notebook,
-        # run_sensor,
+        configure_conn,
+        run_notebook,
+        run_sensor,
         run_notebook_a,
         run_notebook_b,
     )

--- a/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sagemaker_unified_studio_notebook.py
@@ -57,7 +57,7 @@ DOMAIN_ID_KEY = "DOMAIN_ID"
 PROJECT_ID_KEY = "PROJECT_ID"
 NOTEBOOK_ID_KEY = "NOTEBOOK_ID"
 NOTEBOOK_B_ID_KEY = "NOTEBOOK_B_ID"
-DATAZONE_ROLE_ARN_KEY = "DATAZONE_ROLE_ARN"
+# DATAZONE_ROLE_ARN_KEY = "DATAZONE_ROLE_ARN"
 
 sys_test_context_task = (
     SystemTestContextBuilder()
@@ -65,11 +65,11 @@ sys_test_context_task = (
     .add_variable(PROJECT_ID_KEY)
     .add_variable(NOTEBOOK_ID_KEY)
     .add_variable(NOTEBOOK_B_ID_KEY)
-    .add_variable(DATAZONE_ROLE_ARN_KEY)
+    # .add_variable(DATAZONE_ROLE_ARN_KEY)
     .build()
 )
 
-DATAZONE_CONN_ID = "aws_datazone_notebook"
+# DATAZONE_CONN_ID = "aws_datazone_notebook"
 
 
 @task
@@ -101,39 +101,39 @@ with DAG(
     project_id = test_context[PROJECT_ID_KEY]
     notebook_id = test_context[NOTEBOOK_ID_KEY]
     notebook_b_id = test_context[NOTEBOOK_B_ID_KEY]
-    configure_conn = setup_datazone_connection(test_context[DATAZONE_ROLE_ARN_KEY])
+    # configure_conn = setup_datazone_connection(test_context[DATAZONE_ROLE_ARN_KEY])
 
     # [START howto_operator_sagemaker_unified_studio_notebook]
     client_token = f"idempotency-token-{int(time.time())}"
 
-    run_notebook = SageMakerUnifiedStudioNotebookOperator(
-        task_id="notebook-task",
-        aws_conn_id=DATAZONE_CONN_ID,
-        notebook_identifier=notebook_id,
-        domain_identifier=domain_id,
-        owning_project_identifier=project_id,
-        client_token=client_token,  # optional
-        notebook_parameters={
-            "param1": "value1",
-            "param2": "value2",
-        },  # optional
-        compute_configuration={"instanceType": "sc.m5.large"},  # optional
-        timeout_configuration={"runTimeoutInMinutes": 1440},  # optional
-        wait_for_completion=True,  # optional
-        waiter_delay=30,  # optional
-        deferrable=False,  # optional
-    )
+    # run_notebook = SageMakerUnifiedStudioNotebookOperator(
+    #     task_id="notebook-task",
+    #     aws_conn_id=DATAZONE_CONN_ID,
+    #     notebook_identifier=notebook_id,
+    #     domain_identifier=domain_id,
+    #     owning_project_identifier=project_id,
+    #     client_token=client_token,  # optional
+    #     notebook_parameters={
+    #         "param1": "value1",
+    #         "param2": "value2",
+    #     },  # optional
+    #     compute_configuration={"instanceType": "sc.m5.large"},  # optional
+    #     timeout_configuration={"runTimeoutInMinutes": 1440},  # optional
+    #     wait_for_completion=True,  # optional
+    #     waiter_delay=30,  # optional
+    #     deferrable=False,  # optional
+    # )
     # [END howto_operator_sagemaker_unified_studio_notebook]
 
     # [START howto_sensor_sagemaker_unified_studio_notebook]
-    run_sensor = SageMakerUnifiedStudioNotebookSensor(
-        task_id="notebook-sensor-task",
-        aws_conn_id=DATAZONE_CONN_ID,
-        domain_identifier=domain_id,
-        owning_project_identifier=project_id,
-        notebook_identifier=notebook_id,
-        notebook_run_id=run_notebook.output["notebook_run_id"],
-    )
+    # run_sensor = SageMakerUnifiedStudioNotebookSensor(
+    #     task_id="notebook-sensor-task",
+    #     aws_conn_id=DATAZONE_CONN_ID,
+    #     domain_identifier=domain_id,
+    #     owning_project_identifier=project_id,
+    #     notebook_identifier=notebook_id,
+    #     notebook_run_id=run_notebook.output["notebook_run_id"],
+    # )
     # [END howto_sensor_sagemaker_unified_studio_notebook]
 
     # [START howto_operator_sagemaker_unified_studio_notebook_pass_outputs]
@@ -141,7 +141,7 @@ with DAG(
     # Notebook B consumes those outputs via Jinja templating in notebook_parameters.
     run_notebook_a = SageMakerUnifiedStudioNotebookOperator(
         task_id="notebook-a-task",
-        aws_conn_id=DATAZONE_CONN_ID,
+        # aws_conn_id=DATAZONE_CONN_ID,
         notebook_identifier=notebook_id,
         domain_identifier=domain_id,
         owning_project_identifier=project_id,
@@ -151,13 +151,13 @@ with DAG(
 
     run_notebook_b = SageMakerUnifiedStudioNotebookOperator(
         task_id="notebook-b-task",
-        aws_conn_id=DATAZONE_CONN_ID,
+        # aws_conn_id=DATAZONE_CONN_ID,
         notebook_identifier=notebook_b_id,
         domain_identifier=domain_id,
         owning_project_identifier=project_id,
         notebook_parameters={
-            "employee_name": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.name') }}",
-            "employee_age": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.age') }}",
+            "name": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.name') }}",
+            "age": "{{ task_instance.xcom_pull(task_ids='notebook-a-task', key='NOTEBOOK_OUTPUT.age') }}",
         },
         wait_for_completion=True,
         deferrable=False,
@@ -166,9 +166,9 @@ with DAG(
 
     chain(
         test_context,
-        configure_conn,
-        run_notebook,
-        run_sensor,
+        # configure_conn,
+        # run_notebook,
+        # run_sensor,
         run_notebook_a,
         run_notebook_b,
     )

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_sagemaker_unified_studio_notebook.py
@@ -334,7 +334,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
 
         result = self.hook.get_project_s3_path(DOMAIN_ID, PROJECT_ID)
 
-        assert result == bucket
+        assert result == (bucket, f"dzd_x/{PROJECT_ID}/dev")
         self.mock_client.list_environment_blueprints.assert_any_call(
             domainIdentifier=DOMAIN_ID,
             managed=True,
@@ -368,7 +368,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
 
         result = self.hook.get_project_s3_path(DOMAIN_ID, PROJECT_ID)
 
-        assert result == bucket
+        assert result == (bucket, "p")
         self.mock_client.get_environment.assert_called_once_with(
             domainIdentifier=DOMAIN_ID,
             identifier=env_id,
@@ -389,7 +389,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
 
         result = self.hook.get_project_s3_path(DOMAIN_ID, PROJECT_ID)
 
-        assert result == bucket
+        assert result == (bucket, "p")
         # Both blueprint lookups happened.
         assert self.mock_client.list_environment_blueprints.call_count == 2
         self.mock_client.get_environment.assert_called_once_with(
@@ -414,7 +414,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
 
         result = self.hook.get_project_s3_path(DOMAIN_ID, PROJECT_ID)
 
-        assert result == bucket
+        assert result == (bucket, "p")
         self.mock_client.get_environment.assert_called_once_with(
             domainIdentifier=DOMAIN_ID,
             identifier=env_id,
@@ -498,6 +498,34 @@ class TestSageMakerUnifiedStudioNotebookHook:
         outputs = {"name": "Alice", "age": 42}
         bucket = "test-bucket"
         self._stub_project_bucket(bucket)
+
+        with patch(f"{HOOK_MODULE}.S3Hook") as mock_s3_hook_cls:
+            mock_s3_hook_cls.return_value.read_key.return_value = json.dumps(outputs)
+            result = self.hook.get_notebook_outputs(
+                notebook_identifier=NOTEBOOK_ID,
+                notebook_run_id=NOTEBOOK_RUN_ID,
+                domain_identifier=DOMAIN_ID,
+                owning_project_identifier=PROJECT_ID,
+            )
+
+        assert result == outputs
+        expected_key = (
+            f"dzd_x/{PROJECT_ID}/dev/sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
+        )
+        mock_s3_hook_cls.return_value.read_key.assert_called_once_with(key=expected_key, bucket_name=bucket)
+
+    def test_get_notebook_outputs_iam_mode_no_prefix(self):
+        """IAM-mode projects (s3BucketPath is bucket-only) read from the bucket root."""
+        outputs = {"name": "Alice"}
+        bucket = "iam-mode-bucket"
+        # Tooling env returns s3BucketPath without a path component.
+        self._stub_tooling_blueprint_lookup(
+            environments=[{"id": "env-1", "name": "Tooling", "deploymentOrder": 1}]
+        )
+        self.mock_client.get_environment.return_value = {
+            "id": "env-1",
+            "provisionedResources": [{"name": "s3BucketPath", "value": f"s3://{bucket}"}],
+        }
 
         with patch(f"{HOOK_MODULE}.S3Hook") as mock_s3_hook_cls:
             mock_s3_hook_cls.return_value.read_key.return_value = json.dumps(outputs)

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_sagemaker_unified_studio_notebook.py
@@ -509,9 +509,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
             )
 
         assert result == outputs
-        expected_key = (
-            f"dzd_x/{PROJECT_ID}/dev/.sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
-        )
+        expected_key = f"dzd_x/{PROJECT_ID}/dev/.sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
         mock_s3_hook_cls.return_value.read_key.assert_called_once_with(key=expected_key, bucket_name=bucket)
 
     def test_get_notebook_outputs_iam_mode_no_prefix(self):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_sagemaker_unified_studio_notebook.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_sagemaker_unified_studio_notebook.py
@@ -510,7 +510,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
 
         assert result == outputs
         expected_key = (
-            f"dzd_x/{PROJECT_ID}/dev/sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
+            f"dzd_x/{PROJECT_ID}/dev/.sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
         )
         mock_s3_hook_cls.return_value.read_key.assert_called_once_with(key=expected_key, bucket_name=bucket)
 
@@ -537,7 +537,7 @@ class TestSageMakerUnifiedStudioNotebookHook:
             )
 
         assert result == outputs
-        expected_key = f"sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
+        expected_key = f".sys/notebooks/{NOTEBOOK_ID}/runs/{NOTEBOOK_RUN_ID}/notebook_outputs.json"
         mock_s3_hook_cls.return_value.read_key.assert_called_once_with(key=expected_key, bucket_name=bucket)
 
     def test_get_notebook_outputs_no_such_key(self):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

TLDR: Scoping notebook output reads to project S3 prefix

The hook reads notebook outputs from a fixed bucket-root key:
```
s3://<prefix>/.sys/notebooks/<notebook_id>/runs/<run_id>/notebook_outputs.json
```
That works for IAM domains (the bucket has no per-project prefix) but fails for IDC domains, whose project role only grants S3 access under the project's own scope:
```
s3:PutObject / s3:GetObject on <bucket>/${aws:PrincipalTag/AmazonDataZoneDomain}/${aws:PrincipalTag/AmazonDataZoneProject}/*
```
The kernel that writes the file is moving to use the project's full `ProjectS3Path` as the prefix, matching the role's allowed key space. Mirror that on the read side here:

  - `get_project_s3_path` now returns `(bucket, prefix)`. `prefix` is the path component of the `s3BucketPath` provisioned resource.
  - `get_notebook_outputs` prepends `prefix` when constructing the output key, so reads target the same path the kernel writes to.

#### Testing

Tested by invoking the DAGs both IAM and IDC domains.

```
IAM

2026-06-04T01:59:02.203146Z [info     ] Exiting notebook run 51i8t94t6mq974. Status: SUCCEEDED [airflow.task.hooks.airflow.providers.amazon.aws.hooks.sagemaker_unified_studio_notebook.SageMakerUnifiedStudioNotebookHook]
2026-06-04T01:59:04.213415Z [info     ] Reading notebook outputs from s3://amazon-sagemaker-377228489309-us-west-2-bisglciuqpgv0w/shared/.sys/notebooks/bvnn0s06pp42a8/runs/51i8t94t6mq974/notebook_outputs.json [airflow.providers.amazon.aws.hooks.sagemaker_unified_studio_notebook]

IDC

2026-06-04T01:49:05.124510Z [info     ] Exiting notebook run cx2c783193fr8n. Status: SUCCEEDED [airflow.task.hooks.airflow.providers.amazon.aws.hooks.sagemaker_unified_studio_notebook.SageMakerUnifiedStudioNotebookHook]
2026-06-04T01:49:06.004935Z [info     ] Reading notebook outputs from s3://amazon-maxdome-430606112922-us-east-1-805540179/dzd-bkzf6ldy3hpbs7/d3f93aknrykrs7/dev/.sys/notebooks/4h1klahfqowoiv/runs/cx2c783193fr8n/notebook_outputs.json [airflow.providers.amazon.aws.hooks.sagemaker_unified_studio_notebook]

PASSED

=================== 1 passed, 1 warning in 443.18s (0:07:23) ===================
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---