### PR TITLE
Bump Helm chart version to 1.23.0 after 1.22.0 release

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: airflow
-version: 1.22.0
+version: 1.23.0
 appVersion: 3.2.2
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows


### PR DESCRIPTION
Routine post-release version bump of the Helm chart on the `chart/v1-2x-test`
maintenance branch following the 1.22.0 release.

`chart/Chart.yaml` version 1.22.0 -> 1.23.0 (no `-dev` suffix, per the Helm
chart release process).