### PR TITLE
Add team_name as option for dag_bundle_config_list in Helm Chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1075,6 +1075,9 @@ Usage:
     {{- $bundles := list -}}
     {{- range .Values.dagProcessor.dagBundleConfigList -}}
       {{- $bundle := dict "name" .name "classpath" .classpath "kwargs" (.kwargs | default dict) -}}
+      {{- if .team_name -}}
+      {{- $_ := set $bundle "team_name" .team_name -}}
+      {{- end -}}
       {{- $bundles = append $bundles $bundle -}}
     {{- end -}}
     {{- $bundles | toJson -}}

--- a/chart/tests/helm_tests/airflow_aux/test_configmap.py
+++ b/chart/tests/helm_tests/airflow_aux/test_configmap.py
@@ -320,6 +320,16 @@ metadata:
                             "classpath": "airflow.dag_processing.bundles.local.LocalDagBundle",
                             "kwargs": {},
                         },
+                        {
+                            "name": "team-bundle",
+                            "team_name": "team-a",
+                            "classpath": "airflow.providers.git.bundles.git.GitDagBundle",
+                            "kwargs": {
+                                "git_conn_id": "GITHUB__team_repo",
+                                "subdir": "team-dags",
+                                "tracking_ref": "main",
+                            },
+                        },
                     ],
                 },
             },
@@ -337,7 +347,7 @@ metadata:
         # Parse and validate JSON structure
         bundles = json.loads(json_str)
         assert isinstance(bundles, list), "dag_bundle_config_list should be a list"
-        assert len(bundles) == 3, f"Expected 3 bundles, got {len(bundles)}"
+        assert len(bundles) == 4, f"Expected 4 bundles, got {len(bundles)}"
 
         # Verify bundle1
         bundle1 = next((b for b in bundles if b["name"] == "bundle1"), None)
@@ -362,3 +372,12 @@ metadata:
         assert dags_folder is not None, "dags-folder not found"
         assert dags_folder["classpath"] == "airflow.dag_processing.bundles.local.LocalDagBundle"
         assert dags_folder["kwargs"] == {}
+
+        # Verify team-bundle
+        team_bundle = next((b for b in bundles if b["name"] == "team-bundle"), None)
+        assert team_bundle is not None, "team-bundle not found"
+        assert team_bundle["team_name"] == "team-a"
+        assert team_bundle["classpath"] == "airflow.providers.git.bundles.git.GitDagBundle"
+        assert team_bundle["kwargs"]["git_conn_id"] == "GITHUB__team_repo"
+        assert team_bundle["kwargs"]["subdir"] == "team-dags"
+        assert team_bundle["kwargs"]["tracking_ref"] == "main"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5764,6 +5764,10 @@
                                 "description": "Name of the Dag bundle.",
                                 "type": "string"
                             },
+                            "team_name": {
+                                "description": "Team name for the Dag bundle.",
+                                "type": "string"
+                            },
                             "classpath": {
                                 "description": "Class path of the Dag bundle class.",
                                 "type": "string"


### PR DESCRIPTION
Since the addition of multi team,  support the kwarg team_name.

This change will allow the helm chart to support team_name as an option for airflow.config.dag_processor.dag_bundle_config_list

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Codex (GPT-5)

<!--
Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
