### PR TITLE
Add Helm chart 1.22.0 to bug report version dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-airflow_bug_report.yml
@@ -227,7 +227,8 @@ body:
       multiple: false
       options:
         - "Not Applicable"
-        - "1.21.0 (latest released)"
+        - "1.22.0 (latest released)"
+        - "1.21.0"
         - "1.20.0"
         - "1.19.0"
         - "1.18.0"


### PR DESCRIPTION
Post-release housekeeping for the Helm Chart 1.22.0 release: add `1.22.0
(latest released)` to the "Official Helm Chart version" dropdown in the bug
report issue template and demote `1.21.0`.