### PR TITLE
Fix airflowctl JSON parsing for Dag run conf

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -24,6 +24,7 @@ import argparse
 import ast
 import datetime
 import inspect
+import json
 import os
 import sys
 from argparse import Namespace
@@ -193,6 +194,19 @@ def string_lower_type(val):
     if not val:
         return
     return val.strip().lower()
+
+
+def json_dict_type(val: str | dict[str, Any]) -> dict[str, Any]:
+    """Parse JSON object argument."""
+    if isinstance(val, dict):
+        return val
+    try:
+        parsed = json.loads(val)
+    except json.JSONDecodeError as e:
+        raise argparse.ArgumentTypeError(f"invalid JSON object: {val!r}") from e
+    if not isinstance(parsed, dict):
+        raise argparse.ArgumentTypeError(f"expected JSON object: {val!r}")
+    return parsed
 
 
 def _load_help_texts_yaml() -> dict[str, dict[str, str]]:
@@ -511,11 +525,11 @@ class CommandFactory:
             "str": str,
             "bytes": bytes,
             "list": list,
-            "dict": dict,
+            "dict": json_dict_type,
             "tuple": tuple,
             "set": set,
             "datetime.datetime": datetime.datetime,
-            "dict[str, typing.Any]": dict,
+            "dict[str, typing.Any]": json_dict_type,
         }
         # Default to ``str`` to preserve previous behaviour for any unrecognised
         # type names while still allowing the CLI to function.

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -33,6 +33,7 @@ from airflowctl.ctl.cli_config import (
     CommandFactory,
     GroupCommand,
     add_auth_token_to_all_commands,
+    json_dict_type,
     merge_commands,
     safe_call_command,
 )
@@ -105,7 +106,7 @@ def test_args_create():
                 "help": "dag_run_conf for backfill operation",
                 "action": None,
                 "default": None,
-                "type": dict,
+                "type": json_dict_type,
                 "dest": None,
             },
         ),
@@ -320,6 +321,23 @@ class TestCommandFactory:
         assert is_alive_arg.kwargs["action"] == BooleanOptionalAction
         assert is_alive_arg.kwargs["default"] is None
         assert is_alive_arg.kwargs["type"] is bool
+
+    def test_command_factory_parses_json_dict_datamodel_fields(self):
+        """Dict datamodel fields should parse JSON object CLI values."""
+        command_factory = CommandFactory()
+        dags_trigger_args = []
+        for generated_group_command in command_factory.group_commands:
+            if generated_group_command.name != "dags":
+                continue
+            for sub_command in generated_group_command.subcommands:
+                if sub_command.name == "trigger":
+                    dags_trigger_args = list(sub_command.args)
+                    break
+
+        conf_arg = next(arg for arg in dags_trigger_args if arg.flags == ("--conf",))
+        parsed_conf = conf_arg.kwargs["type"]('{"my-key": "my-value"}')
+
+        assert parsed_conf == {"my-key": "my-value"}
 
     def test_command_factory_required_primitive_param_is_positional(self, tmp_path):
         """Required primitive parameters (no default, not Optional) become positional arguments.


### PR DESCRIPTION
Fixes `airflowctl dags trigger ... --conf` so JSON object values are parsed into dictionaries before validating the generated Dag run request body. Previously the generated parser used raw `dict`, which rejects JSON strings such as `{ "my-key": "my-value" }`.

closes: #67989

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI GPT-5 assisted with investigation, patch drafting, and local verification review)

Generated-by: OpenAI GPT-5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

## Local verification

- `uv run --project airflow-ctl pytest airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py::TestCommandFactory::test_command_factory_parses_json_dict_datamodel_fields -q` failed before the fix with `ValueError: dictionary update sequence element #0 has length 1; 2 is required`
- `uv run --project airflow-ctl ruff format airflow-ctl/src/airflowctl/ctl/cli_config.py airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py`
- `uv run --project airflow-ctl ruff check --fix airflow-ctl/src/airflowctl/ctl/cli_config.py airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py`
- `uv run --project airflow-ctl pytest airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py -q` passed 23 tests
- `git diff --check`

<!-- pr-triage-fold: triaged=2026-07-08T15:38:00Z head=b11f76c action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @puneetdixit200** · by `@potiuk` · 2026-07-08 15:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Unit tests** failing (`MySQL tests: core / DB-core:MySQL:8.0:3.10:API...CLI`). See the [contributor guide](https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst).
>
> Full criteria: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
