### PR TITLE
UI: Fix Dag code highlighting for escaped f-string braces

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.test.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.test.ts
@@ -1,0 +1,72 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { describe, expect, it } from "vitest";
+
+import { patchPythonFStringEscapedBraces } from "./configureMonaco";
+
+type Rule = [RegExp | string, string, string?];
+
+const interpolationRule: Rule = [/\{[^\}':!=]+/, "identifier", "@fStringDetail"];
+
+const buildLanguage = () => ({
+  tokenizer: {
+    fDblStringBody: [
+      [/[^"]+/, "string"],
+      interpolationRule,
+      [/"/, "string.escape", "@popall"],
+    ] as Array<Rule>,
+    fStringBody: [
+      [/[^']+/, "string"],
+      interpolationRule,
+      [/'/, "string.escape", "@popall"],
+    ] as Array<Rule>,
+  },
+});
+
+describe("patchPythonFStringEscapedBraces", () => {
+  it("inserts escaped brace rules before interpolation in both f-string states", () => {
+    const patched = patchPythonFStringEscapedBraces(buildLanguage());
+
+    for (const stateName of ["fStringBody", "fDblStringBody"]) {
+      const rules = patched.tokenizer[stateName] ?? [];
+      const sources = rules.map((rule) => (rule[0] instanceof RegExp ? rule[0].source : String(rule[0])));
+      const escapedOpenIndex = sources.indexOf("\\{\\{");
+      const escapedCloseIndex = sources.indexOf("\\}\\}");
+      const interpolationIndex = sources.indexOf("\\{[^\\}':!=]+");
+
+      expect(escapedOpenIndex).toBeGreaterThanOrEqual(0);
+      expect(escapedCloseIndex).toBeGreaterThan(escapedOpenIndex);
+      expect(interpolationIndex).toBeGreaterThan(escapedCloseIndex);
+    }
+  });
+
+  it("is idempotent when called multiple times", () => {
+    const once = patchPythonFStringEscapedBraces(buildLanguage());
+    const twice = patchPythonFStringEscapedBraces(once);
+
+    for (const stateName of ["fStringBody", "fDblStringBody"]) {
+      const sources = (twice.tokenizer[stateName] ?? []).map((rule) =>
+        rule[0] instanceof RegExp ? rule[0].source : String(rule[0]),
+      );
+
+      expect(sources.filter((source) => source === "\\{\\{")).toHaveLength(1);
+      expect(sources.filter((source) => source === "\\}\\}")).toHaveLength(1);
+    }
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -22,7 +22,45 @@ type MonacoEnvironment = {
   readonly getWorker: (_moduleId: string, label: string) => Worker;
 };
 
+type MonarchRule = [RegExp | string, string, string?];
+
+type PythonTokenizerLanguage = {
+  readonly tokenizer: Record<string, Array<MonarchRule>>;
+};
+
 let configurationPromise: Promise<void> | undefined;
+
+const ESCAPED_OPEN_BRACE_RULE: MonarchRule = [/\{\{/, "string"];
+const ESCAPED_CLOSE_BRACE_RULE: MonarchRule = [/\}\}/, "string"];
+
+const hasRule = (rules: Array<MonarchRule>, regexSource: string) =>
+  rules.some((rule) => rule[0] instanceof RegExp && rule[0].source === regexSource);
+
+export const patchPythonFStringEscapedBraces = (
+  language: PythonTokenizerLanguage,
+): PythonTokenizerLanguage => {
+  const tokenizer = { ...language.tokenizer };
+
+  for (const stateName of ["fStringBody", "fDblStringBody"]) {
+    const stateRules = [...(tokenizer[stateName] ?? [])];
+
+    if (!hasRule(stateRules, ESCAPED_OPEN_BRACE_RULE[0].source)) {
+      const interpolationIndex = stateRules.findIndex(
+        (rule) => rule[0] instanceof RegExp && rule[0].source === "\\{[^\\}':!=]+",
+      );
+      const insertIndex = interpolationIndex === -1 ? 0 : interpolationIndex;
+
+      stateRules.splice(insertIndex, 0, ESCAPED_OPEN_BRACE_RULE, ESCAPED_CLOSE_BRACE_RULE);
+    }
+
+    tokenizer[stateName] = stateRules;
+  }
+
+  return {
+    ...language,
+    tokenizer,
+  };
+};
 
 const loadMonacoModules = async () => {
   // `editor.api` is API-only — the contribs/styles below must be side-effect imported
@@ -53,13 +91,19 @@ const loadMonacoModules = async () => {
   const languageContributions = Promise.all([
     import("monaco-editor/esm/vs/basic-languages/python/python.contribution"),
     import("monaco-editor/esm/vs/language/json/monaco.contribution"),
+    import("monaco-editor/esm/vs/basic-languages/python/python"),
   ]);
 
-  const [monaco, [editorWorkerUrl, jsonWorkerUrl]] = await Promise.all([
+  const [monaco, [editorWorkerUrl, jsonWorkerUrl], [, , pythonLanguageModule]] = await Promise.all([
     monacoApi,
     workerUrls,
     languageContributions,
   ]);
+
+  monaco.languages.setMonarchTokensProvider(
+    "python",
+    patchPythonFStringEscapedBraces(pythonLanguageModule.language as PythonTokenizerLanguage),
+  );
 
   return { editorWorkerUrl, jsonWorkerUrl, monaco };
 };


### PR DESCRIPTION
closes #67986

Fix Dag code Monaco Python tokenization for escaped braces inside f-strings (for example Jinja templates like '{{{{ ds }}}}' inside an f-string). The patch adds escaped-brace rules before interpolation matching so highlighting no longer leaks past the string boundary.

Also adds a unit test that verifies the tokenizer patch is applied to both f-string states and remains idempotent.

 

 