### PR TITLE
MSSQL Asset URI: support 5-part path with optional instance name

### DIFF
--- a/providers/microsoft/mssql/src/airflow/providers/microsoft/mssql/assets/mssql.py
+++ b/providers/microsoft/mssql/src/airflow/providers/microsoft/mssql/assets/mssql.py
@@ -33,8 +33,10 @@ def sanitize_uri(uri: SplitResult) -> SplitResult:
     if uri.port is None:
         host = uri.netloc.rstrip(":")
         uri = uri._replace(netloc=f"{host}:1433")
-    if len(uri.path.split("/")) != 4:  # Leading slash, database, schema, and table names.
-        raise ValueError("URI format mssql:// must contain database, schema, and table names")
+    if len(uri.path.split("/")) not in {4, 5}:
+        raise ValueError(
+            "URI format mssql:// must contain database, schema, and table/view names with optional instance name"
+        )
     return uri
 
 
@@ -50,6 +52,10 @@ def convert_asset_to_openlineage(asset: Asset, lineage_context) -> OpenLineageDa
 
     from airflow.providers.common.compat.openlineage.facet import Dataset as OpenLineageDataset
 
-    parsed = urlsplit(asset.uri)
-    _, database, schema, table = parsed.path.split("/")  # Leading slash, database, schema, and table names.
+    parsed = sanitize_uri(urlsplit(asset.uri))
+    path_parts = parsed.path.split("/")
+    if len(path_parts) == 4:
+        _, database, schema, table = path_parts  # Leading slash, database, schema, and table names.
+    else:
+        _, _instance, database, schema, table = path_parts
     return OpenLineageDataset(namespace=f"mssql://{parsed.netloc}", name=f"{database}.{schema}.{table}")

--- a/providers/microsoft/mssql/tests/unit/microsoft/mssql/assets/test_mssql.py
+++ b/providers/microsoft/mssql/tests/unit/microsoft/mssql/assets/test_mssql.py
@@ -42,6 +42,31 @@ from airflow.providers.microsoft.mssql.assets.mssql import (
             "mssql://example.com:1433/database/schema/table",
             id="default-port",
         ),
+        pytest.param(
+            "mssql://example.com/instance/database/schema/table",
+            "mssql://example.com:1433/instance/database/schema/table",
+            id="with-instance-default-port",
+        ),
+        pytest.param(
+            "mssql://my-azure-server.database.windows.net/database/schema/table",
+            "mssql://my-azure-server.database.windows.net:1433/database/schema/table",
+            id="azure-sql-default-port",
+        ),
+        pytest.param(
+            "mssql://my-azure-server.database.windows.net/instance/database/schema/table",
+            "mssql://my-azure-server.database.windows.net:1433/instance/database/schema/table",
+            id="azure-sql-with-instance-default-port",
+        ),
+        pytest.param(
+            "mssql://my-fabric-server.my-tenant.fabric.microsoft.com/database/schema/table",
+            "mssql://my-fabric-server.my-tenant.fabric.microsoft.com:1433/database/schema/table",
+            id="fabric-default-port",
+        ),
+        pytest.param(
+            "mssql://my-fabric-server.my-tenant.fabric.microsoft.com/instance/database/schema/table",
+            "mssql://my-fabric-server.my-tenant.fabric.microsoft.com:1433/instance/database/schema/table",
+            id="fabric-with-instance-default-port",
+        ),
     ],
 )
 def test_sanitize_uri_pass(original: str, normalized: str) -> None:
@@ -53,15 +78,34 @@ def test_sanitize_uri_pass(original: str, normalized: str) -> None:
 @pytest.mark.parametrize(
     "value",
     [
-        pytest.param("mssql://", id="blank"),
-        pytest.param("mssql:///database/schema/table", id="no-host"),
-        pytest.param("mssql://example.com/database/table", id="missing-component"),
-        pytest.param("mssql://example.com/database/schema/table/column", id="extra-component"),
+        pytest.param("mssql://example.com/database", id="missing-component"),
+        pytest.param("mssql://example.com/database/schema/table/column/extra", id="extra-component"),
+        pytest.param("mssql://my-azure-server.database.windows.net/database", id="azure-missing-component"),
+        pytest.param(
+            "mssql://my-fabric-server.my-tenant.fabric.microsoft.com/database/schema/table/column/extra",
+            id="fabric-extra-component",
+        ),
     ],
 )
-def test_sanitize_uri_fail(value: str) -> None:
+def test_sanitize_uri_fail_invalid_path(value: str) -> None:
     uri_i = urllib.parse.urlsplit(value)
-    with pytest.raises(ValueError, match="URI format mssql:// must contain"):
+    with pytest.raises(
+        ValueError,
+        match="URI format mssql:// must contain database, schema, and table/view names with optional instance name",
+    ):
+        sanitize_uri(uri_i)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("mssql://", id="blank"),
+        pytest.param("mssql:///database/schema/table", id="no-host"),
+    ],
+)
+def test_sanitize_uri_fail_missing_host(value: str) -> None:
+    uri_i = urllib.parse.urlsplit(value)
+    with pytest.raises(ValueError, match="URI format mssql:// must contain a host"):
         sanitize_uri(uri_i)
 
 
@@ -115,6 +159,12 @@ def test_create_asset(
             "mssql://db-host:1434",
             "testdb.schema1.events",
             id="custom-port",
+        ),
+        pytest.param(
+            "mssql://db-host:1434/sql2019/testdb/schema1/events",
+            "mssql://db-host:1434",
+            "testdb.schema1.events",
+            id="with-instance",
         ),
     ],
 )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes (please specify the tool below)

Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

## Summary

This PR updates MSSQL asset URI sanitization to support both URI path formats (with and without SQL instance) and to properly support Azure SQL and Microsoft Fabric hosts.

Supported URI formats after this change:

1. `mssql://<host>[:port]/<database>/<schema>/<table>`
2. `mssql://<host>[:port]/<instance>/<database>/<schema>/<table>`

Examples of supported hosts include:

- Azure SQL Database: `<server-unique-identifier>.database.windows.net`
- Microsoft Fabric SQL endpoint: `<server-unique-identifier>.<tenant>.fabric.microsoft.com`

## Changes

### `sanitize_uri`

- Keeps host validation (`mssql://` must include a host).
- Keeps default port normalization to `1433` when omitted.
- Accepts both valid path shapes:
  - 4 segments (`/database/schema/table`)
  - 5 segments (`/instance/database/schema/table`)
- Rejects other path shapes with a clear `ValueError`.

### `convert_asset_to_openlineage`

- Now sanitizes/parses URI via `sanitize_uri(...)`.
- Supports both URI path variants when extracting dataset name.
- Produces consistent OpenLineage output:
  - `namespace = mssql://<host>:<port>`
  - `name = <database>.<schema>.<table>`

## Tests

Updated unit tests in  
`providers/microsoft/mssql/tests/unit/microsoft/mssql/assets/test_mssql.py`:

- Added passing cases for:
  - standard host without instance
  - standard host with instance
  - Azure SQL host
  - Fabric host
  - Fabric host with instance
- Added failing cases for invalid segment counts in both formats.
- Added OpenLineage conversion test for URI including instance.

## Outcome

MSSQL assets now accept both SQL Server-style instance paths and non-instance cloud paths (Azure SQL / Fabric) while keeping OpenLineage conversion consistent and backward compatible.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
