### PR TITLE
Require generated request body flags in airflowctl

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -531,6 +531,7 @@ class CommandFactory:
         arg_action: argparse.BooleanOptionalAction | None,
         arg_dest: str | None = None,
         arg_default: Any | None = None,
+        arg_required: bool | None = None,
     ) -> Arg:
         return Arg(
             flags=arg_flags,
@@ -538,6 +539,7 @@ class CommandFactory:
             dest=arg_dest,
             help=arg_help,
             default=arg_default,
+            required=arg_required if arg_required is not None else _UNSET,
             action=arg_action,
         )
 
@@ -583,6 +585,7 @@ class CommandFactory:
                         arg_action=argparse.BooleanOptionalAction if field_type.annotation is bool else None,  # type: ignore
                         arg_help=f"{field} for {parameter_key} operation",
                         arg_default=False if field_type.annotation is bool else None,
+                        arg_required=True if field_type.is_required() else None,
                     )
                 )
             else:
@@ -598,6 +601,7 @@ class CommandFactory:
                         arg_action=argparse.BooleanOptionalAction if annotation is bool else None,  # type: ignore
                         arg_help=f"{field} for {parameter_key} operation",
                         arg_default=False if annotation is bool else None,
+                        arg_required=True if field_type.is_required() else None,
                     )
                 )
         return commands

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -412,6 +412,38 @@ class TestCommandFactory:
         assert limit_arg.flags == ("--limit",)
         assert limit_arg.kwargs["type"] is int
 
+    def test_command_factory_required_datamodel_fields_are_required_flags(self, tmp_path):
+        temp_file = self._save_temp_operations_py(
+            tmp_path=tmp_path,
+            file_content="""
+                class ConnectionsOperations(BaseOperations):
+                    def create(self, connection: ConnectionBody) -> ConnectionResponse | ServerResponseError:
+                        self.response = self.client.post(
+                            "connections",
+                            json=connection.model_dump(mode="json"),
+                        )
+                        return ConnectionResponse.model_validate_json(self.response.content)
+            """,
+        )
+
+        command_factory = CommandFactory(file_path=str(temp_file))
+        create_args = []
+        for generated_group_command in command_factory.group_commands:
+            if generated_group_command.name != "connections":
+                continue
+            for sub_command in generated_group_command.subcommands:
+                if sub_command.name == "create":
+                    create_args = list(sub_command.args)
+                    break
+
+        connection_id_arg = next(arg for arg in create_args if arg.flags == ("--connection-id",))
+        conn_type_arg = next(arg for arg in create_args if arg.flags == ("--conn-type",))
+        description_arg = next(arg for arg in create_args if arg.flags == ("--description",))
+
+        assert connection_id_arg.kwargs["required"] is True
+        assert conn_type_arg.kwargs["required"] is True
+        assert "required" not in description_arg.kwargs
+
 
 class TestCliConfigMethods:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Generated airflowctl commands expand request-body models into CLI flags, but required Pydantic fields were still optional to argparse. That let the command reach request-body validation before telling the user what was missing.

This passes `field_info.is_required()` through when building those flags, so commands like `connections create` report missing required fields as normal CLI arguments.

closes: #57721

Tests:
- `.venv\Scripts\python.exe -m pytest airflow-ctl\tests\airflow_ctl\ctl\test_cli_config.py -q --confcutdir=airflow-ctl\tests\airflow_ctl\ctl`
- `.venv\Scripts\python.exe -m py_compile airflow-ctl\src\airflowctl\ctl\cli_config.py airflow-ctl\tests\airflow_ctl\ctl\test_cli_config.py`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.