### PR TITLE
Enhance `ResumableJobMixin.get_job_status` with context for better job status tracking

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -269,7 +269,7 @@ class SparkSubmitOperator(ResumableJobMixin, BaseOperator):
         self.log.info("Spark driver submitted: %s", driver_id)
         return driver_id
 
-    def get_job_status(self, external_id: JsonValue) -> str:
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
         # called from submit_job which always returns a str (Spark driver IDs are strings)
         external_id = cast("str", external_id)
         if self._hook is None:

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -555,7 +555,7 @@ class TestSparkSubmitOperatorResumable:
         operator._hook.submit.return_value = "driver-new"
         task_store = FakeTaskState({"spark_job_id": "driver-001"})
 
-        operator.get_job_status = lambda external_id: prior_status
+        operator.get_job_status = lambda external_id, context: prior_status
         polled = []
         operator.poll_until_complete = lambda external_id, context: polled.append(external_id)
 
@@ -639,9 +639,9 @@ class TestSparkSubmitOperatorResumable:
         with mock.patch("requests.get", return_value=mock_response):
             if expected_error:
                 with pytest.raises(RuntimeError, match=expected_error):
-                    operator.get_job_status("driver-001")
+                    operator.get_job_status("driver-001", {})
             else:
-                assert operator.get_job_status("driver-001") == expected_status
+                assert operator.get_job_status("driver-001", {}) == expected_status
 
     def test_get_job_status_ha_tries_next_master(self):
         operator = self._make_operator()
@@ -661,7 +661,7 @@ class TestSparkSubmitOperatorResumable:
             return good_response
 
         with mock.patch("requests.get", side_effect=side_effect):
-            assert operator.get_job_status("driver-001") == "RUNNING"
+            assert operator.get_job_status("driver-001", {}) == "RUNNING"
 
         assert all(":6066/" in url for url in captured_urls), "REST API must use port 6066, not the RPC port"
 
@@ -683,7 +683,7 @@ class TestSparkSubmitOperatorResumable:
             return good_response
 
         with mock.patch("requests.get", side_effect=side_effect):
-            assert operator.get_job_status("driver-001") == "RUNNING"
+            assert operator.get_job_status("driver-001", {}) == "RUNNING"
 
     def test_get_job_status_ha_raises_when_all_masters_unreachable(self):
         operator = self._make_operator()
@@ -693,7 +693,7 @@ class TestSparkSubmitOperatorResumable:
 
         with mock.patch("requests.get", side_effect=ConnectionError("unreachable")):
             with pytest.raises(ConnectionError):
-                operator.get_job_status("driver-001")
+                operator.get_job_status("driver-001", {})
 
     def test_get_job_status_uses_rest_scheme_from_connection(self):
         operator = self._make_operator()
@@ -710,7 +710,7 @@ class TestSparkSubmitOperatorResumable:
             return mock_response
 
         with mock.patch("requests.get", side_effect=capture):
-            operator.get_job_status("driver-001")
+            operator.get_job_status("driver-001", {})
 
         assert len(captured_urls) == 1
         assert captured_urls[0].startswith("https://")

--- a/task-sdk/src/airflow/sdk/bases/resumablemixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablemixin.py
@@ -59,7 +59,7 @@ class ResumableJobMixin:
             def submit_job(self, context) -> JsonValue:
                 return self.hook.submit(...)
 
-            def get_job_status(self, external_id: JsonValue) -> str:
+            def get_job_status(self, external_id: JsonValue, context: Context) -> str:
                 return self.hook.get_status(external_id)
 
             def is_job_active(self, status: str) -> bool:
@@ -106,7 +106,7 @@ class ResumableJobMixin:
         if task_store is not None:
             external_id = task_store.get(self.external_id_key)
             if external_id:
-                status = self.get_job_status(external_id)
+                status = self.get_job_status(external_id, context)
                 if self.is_job_active(status):
                     self.log.info(
                         "Reconnecting to existing job identified by: %s (status: %s)", external_id, status
@@ -141,8 +141,15 @@ class ResumableJobMixin:
         """
         raise NotImplementedError
 
-    def get_job_status(self, external_id: JsonValue) -> str:
-        """Query the external system for the current job status."""
+    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
+        """
+        Query the external system for the current job status.
+
+        ``context`` is provided so implementations can use it if needed to implement advanced features such as:
+
+        - cache terminal status to ``task_store`` when the remote resource may be
+          ephemeral (e.g. a K8s driver pod that gets garbage-collected after completion),
+        """
         raise NotImplementedError
 
     def is_job_active(self, status: str) -> bool:

--- a/task-sdk/tests/task_sdk/bases/test_resumablemixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablemixin.py
@@ -45,7 +45,7 @@ class ConcreteResumableOperator(ResumableJobMixin, BaseOperator):
         self.submitted_ids.append(self._next_id)
         return self._next_id
 
-    def get_job_status(self, external_id: JsonValue) -> str:
+    def get_job_status(self, external_id: JsonValue, context) -> str:
         return self._status_map.get(str(external_id), "UNKNOWN")
 
     def is_job_active(self, status: str) -> bool:


### PR DESCRIPTION

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What?

`ResumableJobMixin.get_job_status` had no access to `context`, making it impossible to handle backends where the remote resource carrying job state can disappear after completion.  I encountered this problem when running Spark with Kubernetes driver pods which after a run get garbage collected, where without context an implementation cannot distinguish "SUCCEEDED but pod gone" from "FAILED but pod gone". The only workaround was `deleteOnTermination=false`, which accumulates pods indefinitely.

The same gap will also appear in another form in cases when a job is tracked by external IDs (e.g. EMR `(cluster_id, step_id)`, Glue `(job_name, run_id)`).

### Current behaviour

`get_job_status(self, external_id)` has no context, no access to `task_store`, no way to cache terminal status before the remote resource disappears.

### Proposed change

Add `context: Context` as a second parameter to `get_job_status` throughout the interface.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
