### PR TITLE
Document supported `databricks_retry_args` usage for deferrable Databricks operators

### DIFF
--- a/providers/databricks/docs/changelog.rst
+++ b/providers/databricks/docs/changelog.rst
@@ -62,6 +62,7 @@ Features
 ~~~~~~~~
 
 * ``Fail fast for non-serializable retry_args in deferrable operators and triggers (#64960)``
+* ``Document supported retry_args shapes for deferrable Databricks operators``
 * ``Forward Airflow Dag params to Databricks job parameters in CreateJobs/SubmitRun/RunNow (#66613)``
 * ``Add session-level query tags to Databricks SQL operators (#66895)``
 

--- a/providers/databricks/docs/changelog.rst
+++ b/providers/databricks/docs/changelog.rst
@@ -62,7 +62,6 @@ Features
 ~~~~~~~~
 
 * ``Fail fast for non-serializable retry_args in deferrable operators and triggers (#64960)``
-* ``Document supported retry_args shapes for deferrable Databricks operators``
 * ``Forward Airflow Dag params to Databricks job parameters in CreateJobs/SubmitRun/RunNow (#66613)``
 * ``Add session-level query tags to Databricks SQL operators (#66895)``
 

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -119,3 +119,38 @@ DatabricksRunNowDeferrableOperator
 Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` operator.
 
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_
+
+.. _howto/operator:DatabricksRunNowDeferrableOperator:retry-args:
+
+Retry args in deferrable mode
+-----------------------------
+
+When ``deferrable=True``, the ``databricks_retry_args`` dictionary is serialized across the
+trigger boundary and must contain only Airflow-serializable values (plain Python primitives
+such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list``).
+
+**Supported** (serialization-safe):
+
+.. code-block:: python
+
+    # Integer / float primitives
+    databricks_retry_args = {"stop_after_attempt": 3, "wait_fixed": 30}
+
+    # Nested plain-dict form
+    databricks_retry_args = {"stop": {"type": "stop_after_attempt", "value": 3}}
+
+**Not supported** in deferrable mode (will raise ``ValueError`` at task submission):
+
+.. code-block:: python
+
+    from tenacity import stop_after_attempt, wait_incrementing
+
+    # Tenacity strategy objects — NOT serializable
+    databricks_retry_args = {"stop": stop_after_attempt(3)}
+    databricks_retry_args = {"wait": wait_incrementing(start=30, increment=30)}
+
+    # Arbitrary callables — NOT serializable
+    databricks_retry_args = {"retry": my_custom_retry_callable}
+
+If you need a custom callable retry strategy, use the non-deferrable
+:class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` (``deferrable=False``).

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -123,21 +123,24 @@ It allows to utilize Airflow workers more effectively using `new functionality i
 .. _howto/operator:DatabricksRunNowDeferrableOperator:retry-args:
 
 Retry args in deferrable mode
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When ``deferrable=True``, the ``databricks_retry_args`` dictionary is serialized across the
 trigger boundary and must contain only Airflow-serializable values (plain Python primitives
 such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list``).
 
-**Supported** (serialization-safe):
+**Supported** (serialization-safe and runtime-valid):
 
 .. code-block:: python
 
-    # Integer / float primitives
-    databricks_retry_args = {"stop_after_attempt": 3, "wait_fixed": 30}
+    # Only plain-primitive Retrying kwarg: reraise
+    databricks_retry_args = {"reraise": True}
 
-    # Nested plain-dict form
-    databricks_retry_args = {"stop": {"type": "stop_after_attempt", "value": 3}}
+For controlling attempt count and delay, prefer the dedicated operator
+parameters ``retry_limit`` and ``retry_delay`` rather than
+``databricks_retry_args``. Custom tenacity strategy objects (``stop``,
+``wait``, ``retry``, ``before``, ``after``, etc.) require tenacity
+callable objects, which are not serialization-safe in deferrable mode.
 
 **Not supported** in deferrable mode (will raise ``ValueError`` at task submission):
 

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -20,7 +20,7 @@
 DatabricksRunNowOperator
 ========================
 
-Use the :class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` to trigger a run of an existing Databricks job
+Use the :class:`~airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator` to trigger a run of an existing Databricks job
 via `api/2.2/jobs/run-now <https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow>`_ API endpoint.
 
 
@@ -116,7 +116,7 @@ effect.
 DatabricksRunNowDeferrableOperator
 ==================================
 
-Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` operator.
+Deferrable version of the :class:`~airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator` operator.
 
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_
 
@@ -126,23 +126,23 @@ Retry args in deferrable mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When ``deferrable=True``, the ``databricks_retry_args`` dictionary is serialized across the
-trigger boundary and must contain only Airflow-serializable values (plain Python primitives
-such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list``).
+trigger boundary and must contain only values that Airflow serde can serialize. Primitive
+values such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list`` are
+the common safe choices.
 
-**Supported** (serialization-safe and runtime-valid):
+For controlling attempt count and delay in deferrable mode, leave
+``databricks_retry_args`` unset and use the dedicated operator parameters
+``retry_limit`` and ``retry_delay``. When ``databricks_retry_args`` is set,
+these dedicated parameters are ignored for the hook retry policy.
 
-.. code-block:: python
+Serialization validation only verifies that values can cross the trigger boundary; it does
+not verify that the supplied keys and values are valid or meaningful ``tenacity.Retrying``
+keyword arguments. Custom tenacity strategy objects (``stop``, ``wait``, ``retry``,
+``before``, ``after``, etc.) require callable objects, which are not serialization-safe in
+deferrable mode.
 
-    # Only plain-primitive Retrying kwarg: reraise
-    databricks_retry_args = {"reraise": True}
-
-For controlling attempt count and delay, prefer the dedicated operator
-parameters ``retry_limit`` and ``retry_delay`` rather than
-``databricks_retry_args``. Custom tenacity strategy objects (``stop``,
-``wait``, ``retry``, ``before``, ``after``, etc.) require tenacity
-callable objects, which are not serialization-safe in deferrable mode.
-
-**Not supported** in deferrable mode (will raise ``ValueError`` at task submission):
+**Not supported** in deferrable mode (will raise ``ValueError`` when the task defers; the
+Databricks run has already been submitted at that point):
 
 .. code-block:: python
 
@@ -156,4 +156,4 @@ callable objects, which are not serialization-safe in deferrable mode.
     databricks_retry_args = {"retry": my_custom_retry_callable}
 
 If you need a custom callable retry strategy, use the non-deferrable
-:class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` (``deferrable=False``).
+:class:`~airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator` (``deferrable=False``).

--- a/providers/databricks/docs/operators/run_now.rst
+++ b/providers/databricks/docs/operators/run_now.rst
@@ -120,7 +120,7 @@ Deferrable version of the :class:`~airflow.providers.databricks.operators.databr
 
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_
 
-.. _howto/operator:DatabricksRunNowDeferrableOperator:retry-args:
+.. _howto/operator:DatabricksRunNowOperator:retry-args:
 
 Retry args in deferrable mode
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,9 +137,9 @@ these dedicated parameters are ignored for the hook retry policy.
 
 Serialization validation only verifies that values can cross the trigger boundary; it does
 not verify that the supplied keys and values are valid or meaningful ``tenacity.Retrying``
-keyword arguments. Custom tenacity strategy objects (``stop``, ``wait``, ``retry``,
-``before``, ``after``, etc.) require callable objects, which are not serialization-safe in
-deferrable mode.
+keyword arguments. Custom tenacity strategy objects (``stop``, ``wait``, ``before``, etc.)
+require callable objects, which are not serialization-safe in deferrable mode. The hook always
+replaces supplied ``retry`` and ``after`` values, so setting them has no effect in either mode.
 
 **Not supported** in deferrable mode (will raise ``ValueError`` when the task defers; the
 Databricks run has already been submitted at that point):
@@ -152,8 +152,9 @@ Databricks run has already been submitted at that point):
     databricks_retry_args = {"stop": stop_after_attempt(3)}
     databricks_retry_args = {"wait": wait_incrementing(start=30, increment=30)}
 
-    # Arbitrary callables — NOT serializable
-    databricks_retry_args = {"retry": my_custom_retry_callable}
-
-If you need a custom callable retry strategy, use the non-deferrable
+If you need custom ``stop`` or ``wait`` strategies, use the non-deferrable
 :class:`~airflow.providers.databricks.operators.databricks.DatabricksRunNowOperator` (``deferrable=False``).
+Setting non-empty ``databricks_retry_args`` replaces the hook's default retry policy rather
+than merging with it, so supply both ``stop`` and ``wait``. Otherwise, Tenacity defaults to
+``stop_never`` and ``wait_none()``, which retries persistently retryable API errors forever
+without backoff.

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -23,7 +23,7 @@
 DatabricksSubmitRunOperator
 ===========================
 
-Use the :class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` to submit
+Use the :class:`~airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator` to submit
 a new Databricks job via Databricks `api/2.2/jobs/runs/submit <https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsSubmit>`_ API endpoint.
 
 
@@ -202,7 +202,7 @@ Triggerer already tracks the run across the wait, so deferrable mode takes prece
 DatabricksSubmitRunDeferrableOperator
 =====================================
 
-Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` operator.
+Deferrable version of the :class:`~airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator` operator.
 
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_
 
@@ -212,23 +212,23 @@ Retry args in deferrable mode
 -----------------------------
 
 When ``deferrable=True``, the ``databricks_retry_args`` dictionary is serialized across the
-trigger boundary and must contain only Airflow-serializable values (plain Python primitives
-such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list``).
+trigger boundary and must contain only values that Airflow serde can serialize. Primitive
+values such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list`` are
+the common safe choices.
 
-**Supported** (serialization-safe and runtime-valid):
+For controlling attempt count and delay in deferrable mode, leave
+``databricks_retry_args`` unset and use the dedicated operator parameters
+``retry_limit`` and ``retry_delay``. When ``databricks_retry_args`` is set,
+these dedicated parameters are ignored for the hook retry policy.
 
-.. code-block:: python
+Serialization validation only verifies that values can cross the trigger boundary; it does
+not verify that the supplied keys and values are valid or meaningful ``tenacity.Retrying``
+keyword arguments. Custom tenacity strategy objects (``stop``, ``wait``, ``retry``,
+``before``, ``after``, etc.) require callable objects, which are not serialization-safe in
+deferrable mode.
 
-    # Only plain-primitive Retrying kwarg: reraise
-    databricks_retry_args = {"reraise": True}
-
-For controlling attempt count and delay, prefer the dedicated operator
-parameters ``retry_limit`` and ``retry_delay`` rather than
-``databricks_retry_args``. Custom tenacity strategy objects (``stop``,
-``wait``, ``retry``, ``before``, ``after``, etc.) require tenacity
-callable objects, which are not serialization-safe in deferrable mode.
-
-**Not supported** in deferrable mode (will raise ``ValueError`` at task submission):
+**Not supported** in deferrable mode (will raise ``ValueError`` when the task defers; the
+Databricks run has already been submitted at that point):
 
 .. code-block:: python
 
@@ -242,4 +242,4 @@ callable objects, which are not serialization-safe in deferrable mode.
     databricks_retry_args = {"retry": my_custom_retry_callable}
 
 If you need a custom callable retry strategy, use the non-deferrable
-:class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` (``deferrable=False``).
+:class:`~airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator` (``deferrable=False``).

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -215,15 +215,18 @@ When ``deferrable=True``, the ``databricks_retry_args`` dictionary is serialized
 trigger boundary and must contain only Airflow-serializable values (plain Python primitives
 such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list``).
 
-**Supported** (serialization-safe):
+**Supported** (serialization-safe and runtime-valid):
 
 .. code-block:: python
 
-    # Integer / float primitives
-    databricks_retry_args = {"stop_after_attempt": 3, "wait_fixed": 30}
+    # Only plain-primitive Retrying kwarg: reraise
+    databricks_retry_args = {"reraise": True}
 
-    # Nested plain-dict form
-    databricks_retry_args = {"stop": {"type": "stop_after_attempt", "value": 3}}
+For controlling attempt count and delay, prefer the dedicated operator
+parameters ``retry_limit`` and ``retry_delay`` rather than
+``databricks_retry_args``. Custom tenacity strategy objects (``stop``,
+``wait``, ``retry``, ``before``, ``after``, etc.) require tenacity
+callable objects, which are not serialization-safe in deferrable mode.
 
 **Not supported** in deferrable mode (will raise ``ValueError`` at task submission):
 

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -205,3 +205,38 @@ DatabricksSubmitRunDeferrableOperator
 Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` operator.
 
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_
+
+.. _howto/operator:DatabricksSubmitRunDeferrableOperator:retry-args:
+
+Retry args in deferrable mode
+-----------------------------
+
+When ``deferrable=True``, the ``databricks_retry_args`` dictionary is serialized across the
+trigger boundary and must contain only Airflow-serializable values (plain Python primitives
+such as ``int``, ``float``, ``str``, ``bool``, ``None``, ``dict``, and ``list``).
+
+**Supported** (serialization-safe):
+
+.. code-block:: python
+
+    # Integer / float primitives
+    databricks_retry_args = {"stop_after_attempt": 3, "wait_fixed": 30}
+
+    # Nested plain-dict form
+    databricks_retry_args = {"stop": {"type": "stop_after_attempt", "value": 3}}
+
+**Not supported** in deferrable mode (will raise ``ValueError`` at task submission):
+
+.. code-block:: python
+
+    from tenacity import stop_after_attempt, wait_incrementing
+
+    # Tenacity strategy objects — NOT serializable
+    databricks_retry_args = {"stop": stop_after_attempt(3)}
+    databricks_retry_args = {"wait": wait_incrementing(start=30, increment=30)}
+
+    # Arbitrary callables — NOT serializable
+    databricks_retry_args = {"retry": my_custom_retry_callable}
+
+If you need a custom callable retry strategy, use the non-deferrable
+:class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` (``deferrable=False``).

--- a/providers/databricks/docs/operators/submit_run.rst
+++ b/providers/databricks/docs/operators/submit_run.rst
@@ -206,7 +206,7 @@ Deferrable version of the :class:`~airflow.providers.databricks.operators.databr
 
 It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_
 
-.. _howto/operator:DatabricksSubmitRunDeferrableOperator:retry-args:
+.. _howto/operator:DatabricksSubmitRunOperator:retry-args:
 
 Retry args in deferrable mode
 -----------------------------
@@ -223,9 +223,9 @@ these dedicated parameters are ignored for the hook retry policy.
 
 Serialization validation only verifies that values can cross the trigger boundary; it does
 not verify that the supplied keys and values are valid or meaningful ``tenacity.Retrying``
-keyword arguments. Custom tenacity strategy objects (``stop``, ``wait``, ``retry``,
-``before``, ``after``, etc.) require callable objects, which are not serialization-safe in
-deferrable mode.
+keyword arguments. Custom tenacity strategy objects (``stop``, ``wait``, ``before``, etc.)
+require callable objects, which are not serialization-safe in deferrable mode. The hook always
+replaces supplied ``retry`` and ``after`` values, so setting them has no effect in either mode.
 
 **Not supported** in deferrable mode (will raise ``ValueError`` when the task defers; the
 Databricks run has already been submitted at that point):
@@ -238,8 +238,9 @@ Databricks run has already been submitted at that point):
     databricks_retry_args = {"stop": stop_after_attempt(3)}
     databricks_retry_args = {"wait": wait_incrementing(start=30, increment=30)}
 
-    # Arbitrary callables — NOT serializable
-    databricks_retry_args = {"retry": my_custom_retry_callable}
-
-If you need a custom callable retry strategy, use the non-deferrable
+If you need custom ``stop`` or ``wait`` strategies, use the non-deferrable
 :class:`~airflow.providers.databricks.operators.databricks.DatabricksSubmitRunOperator` (``deferrable=False``).
+Setting non-empty ``databricks_retry_args`` replaces the hook's default retry policy rather
+than merging with it, so supply both ``stop`` and ``wait``. Otherwise, Tenacity defaults to
+``stop_never`` and ``wait_none()``, which retries persistently retryable API errors forever
+without backoff.


### PR DESCRIPTION

* Part of #64609

### What does this PR do?

Follow up for #64960 

Adds documentation clarifying which `databricks_retry_args` configurations are supported when using Databricks operators in deferrable mode.

The new documentation:

* Explains that `databricks_retry_args` must be serialization-safe because it is serialized across the trigger boundary when `deferrable=True`.
* Documents supported value types (plain Python primitives and collections of primitives).
* Provides examples of supported configurations, such as `{"reraise": True}`.
* Explains that retry count and delay should be configured through the dedicated `retry_limit` and `retry_delay` operator parameters.
* Documents unsupported configurations, including Tenacity strategy objects (`stop_after_attempt`, `wait_incrementing`, etc.) and arbitrary callables.
* Recommends using the non-deferrable Databricks operators when custom callable retry strategies are required.
* Adds a Databricks provider changelog entry describing the documentation update.

### Does this PR introduce any user-facing change?

Yes. Documentation now explicitly describes the serialization requirements and supported shapes for `databricks_retry_args` in deferrable Databricks operators, helping users avoid unsupported retry configurations. 

### How was this patch tested?

No tests were added or modified. This PR contains documentation and changelog updates only. 

---

##### Was generative AI tooling used to co-author this PR?

* [x] Yes (please specify the tool below)
  ChatGPT

