### PR TITLE
UI clear task checkboxes

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/ActionAccordion.tsx
@@ -29,24 +29,27 @@ import ReactMarkdown from "src/components/ReactMarkdown";
 import { Accordion } from "src/components/ui";
 
 import { DataTable } from "../DataTable";
-import { getColumns } from "./columns";
+import { getColumns, type RowSelection } from "./columns";
 
 type Props = {
   readonly affectedTasks?: TaskInstanceCollectionResponse;
   readonly groupByRunId?: boolean;
   readonly note: DAGRunResponse["note"];
+  readonly selection?: RowSelection;
   readonly setNote: (value: string) => void;
 };
 
 const TasksTable = ({
   noRowsMessage,
+  selection,
   tasks,
 }: {
   readonly noRowsMessage: string;
+  readonly selection?: RowSelection;
   readonly tasks: Array<TaskInstanceResponse>;
 }) => {
   const { t: translate } = useTranslation();
-  const columns = getColumns(translate);
+  const columns = getColumns(translate, selection);
 
   return (
     <DataTable
@@ -63,7 +66,7 @@ const TasksTable = ({
 
 // Table is in memory, pagination and sorting are disabled.
 // TODO: Make a front-end only unconnected table component with client side ordering and pagination
-const ActionAccordion = ({ affectedTasks, groupByRunId = false, note, setNote }: Props) => {
+const ActionAccordion = ({ affectedTasks, groupByRunId = false, note, selection, setNote }: Props) => {
   const showTaskSection = affectedTasks !== undefined;
   const { t: translate } = useTranslation();
 
@@ -121,6 +124,7 @@ const ActionAccordion = ({ affectedTasks, groupByRunId = false, note, setNote }:
                       <Accordion.ItemContent>
                         <TasksTable
                           noRowsMessage={translate("dags:runAndTaskActions.affectedTasks.noItemsFound")}
+                          selection={selection}
                           tasks={tis}
                         />
                       </Accordion.ItemContent>
@@ -130,6 +134,7 @@ const ActionAccordion = ({ affectedTasks, groupByRunId = false, note, setNote }:
               ) : (
                 <TasksTable
                   noRowsMessage={translate("dags:runAndTaskActions.affectedTasks.noItemsFound")}
+                  selection={selection}
                   tasks={affectedTasks.task_instances}
                 />
               )}

--- a/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ActionAccordion/columns.tsx
@@ -16,13 +16,72 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type { Table } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import type { MetaColumn } from "src/components/DataTable/types";
 import { StateBadge } from "src/components/StateBadge";
+import { Checkbox } from "src/components/ui/Checkbox";
 
-export const getColumns = (translate: TFunction): Array<MetaColumn<TaskInstanceResponse>> => [
+// Stable per-row key; dag_run_id keeps the same task distinct across runs (past/future
+// expansion), and map_index disambiguates the mapped instances of one task.
+export const taskInstanceKey = (ti: TaskInstanceResponse): string =>
+  `${ti.dag_run_id}:${ti.task_id}:${ti.map_index}`;
+
+// When provided, rows render a leading checkbox so the user can exclude individual
+// task instances from the action. Excluded keys are tracked by the caller.
+export type RowSelection = {
+  excludedKeys: Set<string>;
+  onToggle: (key: string, included: boolean) => void;
+};
+
+// Header "select all" checkbox that toggles every task instance in its table at once.
+const renderSelectAllHeader = (selection: RowSelection, table: Table<TaskInstanceResponse>) => {
+  const keys = table.getRowModel().rows.map((row) => taskInstanceKey(row.original));
+  const excludedCount = keys.filter((key) => selection.excludedKeys.has(key)).length;
+  const allExcluded = keys.length > 0 && excludedCount === keys.length;
+  const someExcluded = excludedCount > 0 && excludedCount < keys.length;
+
+  return (
+    <Checkbox
+      borderWidth={1}
+      checked={someExcluded ? "indeterminate" : !allExcluded}
+      onCheckedChange={(event) => {
+        const included = Boolean(event.checked);
+
+        keys.forEach((key) => selection.onToggle(key, included));
+      }}
+    />
+  );
+};
+
+export const getColumns = (
+  translate: TFunction,
+  selection?: RowSelection,
+): Array<MetaColumn<TaskInstanceResponse>> => [
+  ...(selection
+    ? [
+        {
+          accessorKey: "select",
+          cell: ({ row: { original } }: { row: { original: TaskInstanceResponse } }) => {
+            const key = taskInstanceKey(original);
+
+            return (
+              <Checkbox
+                borderWidth={1}
+                checked={!selection.excludedKeys.has(key)}
+                onCheckedChange={(event) => selection.onToggle(key, Boolean(event.checked))}
+              />
+            );
+          },
+          enableSorting: false,
+          header: ({ table }: { table: Table<TaskInstanceResponse> }) =>
+            renderSelectAllHeader(selection, table),
+          meta: { skeletonWidth: 10 },
+        } satisfies MetaColumn<TaskInstanceResponse>,
+      ]
+    : []),
   {
     accessorKey: "task_id",
     header: translate("taskId"),

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx
@@ -21,6 +21,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { GoAlertFill } from "react-icons/go";
 
+import type { ClearTaskInstancesBody } from "openapi/requests/types.gen";
 import { Dialog } from "src/components/ui";
 import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
 import { getRelativeTime } from "src/utils/datetimeUtils";
@@ -35,6 +36,7 @@ type Props = {
     onlyFailed?: boolean;
     past?: boolean;
     taskId: string;
+    taskIds?: ClearTaskInstancesBody["task_ids"];
     upstream?: boolean;
   };
   readonly onClose: () => void;
@@ -51,6 +53,7 @@ const ClearTaskInstanceConfirmationDialog = ({
   preventRunningTask,
 }: Props) => {
   const { t: translate } = useTranslation();
+  const useExplicitTaskIds = dagDetails?.taskIds !== undefined;
   const { data, isFetching } = useClearTaskInstancesDryRun({
     dagId: dagDetails?.dagId ?? "",
     options: {
@@ -62,13 +65,14 @@ const ClearTaskInstanceConfirmationDialog = ({
     },
     requestBody: {
       dag_run_id: dagDetails?.dagRunId ?? "",
-      include_downstream: dagDetails?.downstream,
+      include_downstream: useExplicitTaskIds ? false : dagDetails?.downstream,
       include_future: dagDetails?.future,
       include_past: dagDetails?.past,
-      include_upstream: dagDetails?.upstream,
+      include_upstream: useExplicitTaskIds ? false : dagDetails?.upstream,
       only_failed: dagDetails?.onlyFailed,
-      task_ids:
-        dagDetails?.mapIndex === undefined
+      task_ids: useExplicitTaskIds
+        ? dagDetails.taskIds
+        : dagDetails?.mapIndex === undefined
           ? [dagDetails?.taskId ?? ""]
           : [[dagDetails.taskId, dagDetails.mapIndex]],
     },

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearTaskInstanceDialog.tsx
@@ -17,13 +17,14 @@
  * under the License.
  */
 import { Button, Flex, Heading, useDisclosure, VStack } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CgRedo } from "react-icons/cg";
 
 import { useDagServiceGetDagDetails } from "openapi/queries";
-import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import type { ClearTaskInstancesBody, TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ActionAccordion } from "src/components/ActionAccordion";
+import { taskInstanceKey } from "src/components/ActionAccordion/columns";
 import { useRerunWithLatestVersion } from "src/components/Clear/useRerunWithLatestVersion";
 import Time from "src/components/Time";
 import { Checkbox, Dialog } from "src/components/ui";
@@ -152,6 +153,37 @@ const ClearTaskInstanceDialog = (props: Props) => {
     total_entries: 0,
   };
 
+  // Tasks the user has unticked in the affected list; excluded from the clear.
+  const [excludedKeys, setExcludedKeys] = useState<Set<string>>(new Set());
+
+  const toggleTask = (key: string, included: boolean) =>
+    setExcludedKeys((prev) => {
+      const next = new Set(prev);
+
+      if (included) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+
+      return next;
+    });
+
+  // The dry run already resolved the full affected set, so on confirm we send those
+  // task instances explicitly (minus the unticked ones) with the graph-expansion flags
+  // off, instead of re-deriving them from the selected task + upstream/downstream.
+  const keptTaskInstances = useMemo(
+    () => affectedTasks.task_instances.filter((ti) => !excludedKeys.has(taskInstanceKey(ti))),
+    [affectedTasks.task_instances, excludedKeys],
+  );
+
+  const checkedTaskIds = useMemo<ClearTaskInstancesBody["task_ids"]>(
+    () => keptTaskInstances.map((ti) => (ti.map_index < 0 ? ti.task_id : [ti.task_id, ti.map_index])),
+    [keptTaskInstances],
+  );
+
+  const hasExclusions = excludedKeys.size > 0;
+
   return (
     <>
       <Dialog.Root lazyMount onOpenChange={onCloseDialog} open={openDialog ? !open : false}>
@@ -212,7 +244,12 @@ const ClearTaskInstanceDialog = (props: Props) => {
                 ]}
               />
             </Flex>
-            <ActionAccordion affectedTasks={affectedTasks} note={note} setNote={setNote} />
+            <ActionAccordion
+              affectedTasks={affectedTasks}
+              note={note}
+              selection={{ excludedKeys, onToggle: toggleTask }}
+              setNote={setNote}
+            />
             <Flex
               {...(shouldShowRunOnLatestOption ? { alignItems: "center" } : {})}
               gap={3}
@@ -234,50 +271,95 @@ const ClearTaskInstanceDialog = (props: Props) => {
               >
                 {translate("dags:runAndTaskActions.options.preventRunningTasks")}
               </Checkbox>
-              <Button disabled={affectedTasks.total_entries === 0} loading={isPending} onClick={onOpen}>
+              <Button
+                disabled={affectedTasks.total_entries === 0 || checkedTaskIds?.length === 0}
+                loading={isPending}
+                onClick={onOpen}
+              >
                 <CgRedo /> {translate("modal.confirm")}
               </Button>
             </Flex>
           </Dialog.Body>
         </Dialog.Content>
       </Dialog.Root>
-      <ClearTaskInstanceConfirmationDialog
-        dagDetails={{
-          dagId,
-          dagRunId,
-          downstream,
-          future,
-          mapIndex,
-          onlyFailed,
-          past,
-          taskId,
-          upstream,
-        }}
-        onClose={onClose}
-        onConfirm={() => {
-          const noteChanged = note !== (taskInstance?.note ?? null);
-
-          mutate({
+      {open ? (
+        <ClearTaskInstanceConfirmationDialog
+          dagDetails={{
             dagId,
-            requestBody: {
-              dag_run_id: dagRunId,
-              dry_run: false,
-              include_downstream: downstream,
-              include_future: future,
-              include_past: past,
-              include_upstream: upstream,
-              note: noteChanged ? note : undefined,
-              only_failed: onlyFailed,
-              run_on_latest_version: runOnLatestVersion,
-              task_ids: allMapped ? [taskId] : [[taskId, mapIndex as number]],
-              ...(preventRunningTask ? { prevent_running_task: true } : {}),
-            },
-          });
-          onCloseDialog();
-        }}
-        open={open}
-        preventRunningTask={preventRunningTask}
-      />
+            dagRunId,
+            downstream,
+            future,
+            mapIndex,
+            onlyFailed,
+            past,
+            taskId,
+            ...(hasExclusions ? { taskIds: checkedTaskIds } : {}),
+            upstream,
+          }}
+          onClose={onClose}
+          onConfirm={() => {
+            const noteChanged = note !== (taskInstance?.note ?? null);
+
+            if (hasExclusions) {
+              // The affected set is already resolved across (potentially) multiple runs.
+              // The clear endpoint only targets one run per request, so group the kept
+              // instances by run and fire one run-scoped clear each, with the graph-expansion
+              // flags off. This honors per-run exclusions (e.g. keep task X in run 1 but drop
+              // it from run 2) that a single flat request cannot express.
+              const idsByRun = new Map<string, NonNullable<ClearTaskInstancesBody["task_ids"]>>();
+
+              for (const ti of keptTaskInstances) {
+                const ids = idsByRun.get(ti.dag_run_id) ?? [];
+
+                ids.push(ti.map_index < 0 ? ti.task_id : [ti.task_id, ti.map_index]);
+                idsByRun.set(ti.dag_run_id, ids);
+              }
+
+              for (const [runId, taskIds] of idsByRun) {
+                mutate({
+                  dagId,
+                  requestBody: {
+                    dag_run_id: runId,
+                    dry_run: false,
+                    include_downstream: false,
+                    include_future: false,
+                    include_past: false,
+                    include_upstream: false,
+                    note: noteChanged ? note : undefined,
+                    only_failed: onlyFailed,
+                    run_on_latest_version: runOnLatestVersion,
+                    task_ids: taskIds,
+                    ...(preventRunningTask ? { prevent_running_task: true } : {}),
+                  },
+                });
+              }
+              onCloseDialog();
+
+              return;
+            }
+
+            mutate({
+              dagId,
+              requestBody: {
+                dag_run_id: dagRunId,
+                dry_run: false,
+                include_downstream: downstream,
+                include_future: future,
+                include_past: past,
+                include_upstream: upstream,
+                note: noteChanged ? note : undefined,
+                only_failed: onlyFailed,
+                run_on_latest_version: runOnLatestVersion,
+                task_ids: allMapped ? [taskId] : [[taskId, mapIndex as number]],
+                ...(preventRunningTask ? { prevent_running_task: true } : {}),
+              },
+            });
+            onCloseDialog();
+          }}
+          open={open}
+          preventRunningTask={preventRunningTask}
+        />
+      ) : null}
     </>
   );
 };


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)


Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


## Before

<img width="669" height="538" alt="clear-task-instance-before" src="https://github.com/user-attachments/assets/7768abd6-fc01-4a2c-aa89-18c73e2e6285" />

- Selecting a task + downstream/past/future resolved full set of tasks and cleared everything
- To skip subset of downstream tasks, you had to clear it and retrigger manually

## After

<img width="503" height="304" alt="clear-task-instance-after" src="https://github.com/user-attachments/assets/6a1a17b8-ccef-4f77-82b3-0f514dc8ef70" />

- Every affected task instance renders a checkbox, ticking by default
- Per-run granularity with past/future expansions you can keep task X in run 1 while dropping it from run 2


## Effect on API

- API calls remain the exact same with no exclusions and lets backend handle set expansion
- With exclusions, UI sends the set as explicit task_ids with expansion flags off

## File by File

ActionAccordion/columns.tsx — Adds taskInstanceKey (dag_run_id:task_id:map_index) and a RowSelection type; getColumns now prepends an optional leading checkbox column when selection is passed.

ActionAccordion/ActionAccordion.tsx — Threads the optional selection prop down to the table columns. No change when omitted.

Clear/TaskInstance/ClearTaskInstanceDialog.tsx — Tracks excludedKeys state and wires checkboxes in. On confirm with exclusions, sends the kept instances explicitly, grouped per run with expansion flags off; otherwise unchanged.

Clear/TaskInstance/ClearTaskInstanceConfirmationDialog.tsx — Accepts optional explicit taskIds; when present, the dry-run preview sends those ids with upstream/downstream off so it matches the real clear.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
