### PR TITLE
Don't force full test matrix for large example_dags-only changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -220,10 +220,18 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
             # `run_python_scans` (SAST/SCA target) and the line-threshold check
             # in `_is_large_enough_pr` to decide whether a PR's diff is large
             # enough to force the full test matrix.
-            r"^airflow-core/src/airflow/(?!.*/(?:openapi-gen|i18n/locales)/).*\.py$",
+            #
+            # `example_dags/` are illustrative, not shipped runtime code, so a large
+            # example-DAG diff must not force the full matrix. They are still selected
+            # for their own tests via the broader `ALL_AIRFLOW_PYTHON_FILES` /
+            # `ALL_PROVIDERS_PYTHON_FILES` groups, so excluding them here only affects
+            # the line-count gate (and SAST target), not test selection. The
+            # `(?:.*/)?` covers both airflow-core's top-level `airflow/example_dags/`
+            # and the nested `providers/<name>/.../example_dags/` layout.
+            r"^airflow-core/src/airflow/(?!(?:.*/)?example_dags/)(?!.*/(?:openapi-gen|i18n/locales)/).*\.py$",
             r"^task-sdk/src/airflow/(?!.*_generated\.py$).*\.py$",
             r"^airflow-ctl/src/airflowctl/(?!.*generated\.py$).*\.py$",
-            r"^providers/(?:[^/]+/)+src/.*\.py$",
+            r"^providers/(?:[^/]+/)+src/(?!(?:.*/)?example_dags/).*\.py$",
             r"^shared/[^/]+/src/.*\.py$",
             r"^pyproject\.toml$",
             r"^hatch_build\.py$",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3619,6 +3619,37 @@ def test_large_pr_by_file_count(files, expected_outputs: dict[str, str]):
             },
             id="Mixed PR with only 200 production lines does not trigger (test lines excluded)",
         ),
+        # A large example-DAG diff in a "plain" provider (not standard/git, which
+        # have their own full-tests rule) must NOT force the full matrix. This is
+        # the exact shape of apache/airflow#68037.
+        pytest.param(
+            (
+                "providers/common/ai/src/airflow/providers/common/ai/example_dags/example_aip_progress_tracker.py",
+            ),
+            "600\t600\tproviders/common/ai/src/airflow/providers/common/ai/example_dags/example_aip_progress_tracker.py",
+            {
+                "full-tests-needed": "false",
+            },
+            id="Large provider example_dags-only PR does not trigger full tests",
+        ),
+        pytest.param(
+            ("airflow-core/src/airflow/example_dags/example_complex.py",),
+            "600\t600\tairflow-core/src/airflow/example_dags/example_complex.py",
+            {
+                "full-tests-needed": "false",
+            },
+            id="Large airflow-core example_dags-only PR does not trigger full tests",
+        ),
+        # Regression guard: a large *non-example* file in the same plain provider
+        # must still count as production code and trigger the full matrix.
+        pytest.param(
+            ("providers/arangodb/src/airflow/providers/arangodb/operators/arangodb.py",),
+            "600\t600\tproviders/arangodb/src/airflow/providers/arangodb/operators/arangodb.py",
+            {
+                "full-tests-needed": "true",
+            },
+            id="Large provider production (non-example) PR still triggers full tests",
+        ),
     ],
 )
 def test_large_pr_by_line_count(files, git_diff_output, expected_outputs: dict[str, str]):


### PR DESCRIPTION
### What

Exclude `example_dags/` from `PYTHON_PRODUCTION_FILES` — the "production code" definition that drives the large-PR line-count gate (`_is_large_enough_pr`). Covers both layouts:
- airflow-core top-level `airflow/example_dags/`
- nested `providers/<name>/.../example_dags/`

### Why

A large diff to **example DAGs** currently trips the line-count heuristic (>500 "production" lines) and sets `full-tests-needed = true`, fanning out the **entire** matrix — core DB tests (MySQL/Postgres/Sqlite), Kubernetes, Helm, PROD image builds + all PROD image e2e tests, all-provider distribution-compat and special tests — for what is illustrative, non-shipped code.

Real example: [#68037](https://github.com/apache/airflow/pull/68037) changed a single provider example DAG (`providers/common/ai/.../example_dags/example_aip_progress_tracker.py`, +667/−119) and ran ~130 jobs; the Build info log shows `full-tests-needed=true` was the sole reason, triggered by the line gate (`all-versions=false`, so no other rule fired). That's a lot of CI capacity spent on a docs-style change.

### Why it's safe

`PYTHON_PRODUCTION_FILES` only feeds the line-count gate and the (currently consumer-less) `run-python-scans` output. Test **selection** uses different groups that still match example DAGs:
- airflow-core example → still selected by `ALL_AIRFLOW_PYTHON_FILES` (`^airflow-core/.*\.py$`)
- provider example → still selected by `ALL_PROVIDERS_PYTHON_FILES` (`^providers/.*\.py$`)

So an example-DAG change **still runs its own core/provider tests** (incl. the example-import checks) — it just no longer forces the full matrix.

Note: `standard`/`git` providers have their own `full-tests-needed` rule (core tests depend on them), so a large example change *there* still runs full tests via that separate rule — this change only removes the **line-count** over-trigger.

### Tests

Added to `test_large_pr_by_line_count`:
- Large provider `example_dags`-only PR (the real `common.ai` path) → `full-tests-needed=false`
- Large airflow-core `example_dags`-only PR → `full-tests-needed=false`
- Regression guard: large provider **non-example** file (`arangodb`) → `full-tests-needed=true`

Full `test_selective_checks.py` suite passes (168), `mypy for dev` + ruff clean.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
