### PR TITLE
Fix JWT token not refreshed when token expires mid-request

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -42,6 +42,7 @@ from airflow.api_fastapi.auth.tokens import (
     get_sig_validation_args,
     get_signing_args,
 )
+from airflow.api_fastapi.execution_api.security import _REQUEST_SCOPE_TOKEN_KEY
 
 if TYPE_CHECKING:
     import httpx
@@ -135,25 +136,22 @@ class JWTReissueMiddleware(BaseHTTPMiddleware):
         response: Response = await call_next(request)
 
         refreshed_token: str | None = None
-        auth_header = request.headers.get("authorization")
-        if auth_header and auth_header.lower().startswith("bearer "):
-            token = auth_header.split(" ", 1)[1]
+        token = request.scope.get(_REQUEST_SCOPE_TOKEN_KEY)
+        if token:
             try:
-                async with svcs.Container(request.app.state.svcs_registry) as services:
-                    validator: JWTValidator = await services.aget(JWTValidator)
-                    claims = await validator.avalidated_claims(token, {})
+                claims = {"sub": str(token.id), **token.claims.model_dump()}
 
-                    # Workload tokens are long-lived and meant to survive queue
-                    # wait times so avoid refreshing them. If avalidated_claims
-                    # raises for a workload token, the outer except handles it.
-                    if claims.get("scope") == "workload":
-                        return response
+                # Workload tokens are long-lived and meant to survive queue
+                # wait times so avoid refreshing them.
+                if claims.get("scope") == "workload":
+                    return response
 
-                    now = int(time.time())
-                    token_lifetime = int(claims.get("exp", 0)) - int(claims.get("iat", 0))
-                    refresh_when_less_than = max(int(token_lifetime * 0.20), 30)
-                    valid_left = int(claims.get("exp", 0)) - now
-                    if valid_left <= refresh_when_less_than:
+                now = int(time.time())
+                token_lifetime = int(claims.get("exp", 0)) - int(claims.get("iat", 0))
+                refresh_when_less_than = max(int(token_lifetime * 0.20), 30)
+                valid_left = int(claims.get("exp", 0)) - now
+                if valid_left <= refresh_when_less_than:
+                    async with svcs.Container(request.app.state.svcs_registry) as services:
                         generator: JWTGenerator = await services.aget(JWTGenerator)
                         refreshed_token = generator.generate(claims)
             except Exception as err:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -136,7 +136,7 @@ def test_token_expiring_mid_request_is_reissued_without_revalidation(client, exe
 
     Regression test for the TOCTOU race in JWTReissueMiddleware: a heartbeat arrives with a
     token that has ~0s left, JWTBearer validates it (still technically valid at that moment),
-    the request completes, and the middleware runs. In the old code the middleware would call
+    the request starts, and the middleware runs. In the old code the middleware would call
     avalidated_claims a second time and get ExpiredSignatureError — no Refreshed-API-Token
     header would be set, and the task would die on the next heartbeat.
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -71,8 +71,8 @@ def test_expiring_token_is_reissued(
 
 
 @pytest.mark.db_test
-def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: FastAPI, time_machine):
-    """Token that expires mid-request is still reissued by the middleware.
+def test_token_expiring_mid_request_is_reissued_without_revalidation(client, exec_app: FastAPI, time_machine):
+    """Middleware reissues from cached JWTBearer claims without re-validating the token.
 
     Regression test for the TOCTOU race in JWTReissueMiddleware: a heartbeat arrives with a
     token that has ~0s left, JWTBearer validates it (still technically valid at that moment),
@@ -81,7 +81,8 @@ def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: Fa
     header would be set, and the task would die on the next heartbeat.
 
     With the fix the middleware reads claims from request.scope (set by JWTBearer) instead of
-    re-validating, so it still issues a fresh token even when the original has since expired.
+    calling avalidated_claims again, so it still issues a fresh token even when the original
+    has since expired.
     """
     moment = 1743451846
     auth = AsyncMock(spec=JWTValidator)
@@ -91,9 +92,9 @@ def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: Fa
         "exp": moment + 600,
     }
 
-    # Move time to 1 second past the token's expiry — simulates the middleware running after
-    # the token boundary. JWTBearer already accepted the token (mocked); the middleware must
-    # still issue a refresh rather than silently dropping it.
+    # Move time to 1 second past the token's expiry. JWTBearer already accepted the token
+    # (mocked); the middleware must still issue a refresh using the cached claims rather than
+    # silently dropping it.
     time_machine.move_to(moment + 601, tick=False)
 
     lifespan.registry.register_value(JWTValidator, auth)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -67,3 +67,39 @@ def test_expiring_token_is_reissued(
         assert "Refreshed-API-Token" in response.headers
     else:
         assert "Refreshed-API-Token" not in response.headers
+    auth.avalidated_claims.assert_awaited_once_with("dummy", {})
+
+
+@pytest.mark.db_test
+def test_just_expired_token_is_reissued_within_grace_period(client, exec_app: FastAPI, time_machine):
+    """Token that expires mid-request is still reissued by the middleware.
+
+    Regression test for the TOCTOU race in JWTReissueMiddleware: a heartbeat arrives with a
+    token that has ~0s left, JWTBearer validates it (still technically valid at that moment),
+    the request completes, and the middleware runs. In the old code the middleware would call
+    avalidated_claims a second time and get ExpiredSignatureError — no Refreshed-API-Token
+    header would be set, and the task would die on the next heartbeat.
+
+    With the fix the middleware reads claims from request.scope (set by JWTBearer) instead of
+    re-validating, so it still issues a fresh token even when the original has since expired.
+    """
+    moment = 1743451846
+    auth = AsyncMock(spec=JWTValidator)
+    auth.avalidated_claims.return_value = {
+        "sub": "edb09971-4e0e-4221-ad3f-800852d38085",
+        "iat": moment,
+        "exp": moment + 600,
+    }
+
+    # Move time to 1 second past the token's expiry — simulates the middleware running after
+    # the token boundary. JWTBearer already accepted the token (mocked); the middleware must
+    # still issue a refresh rather than silently dropping it.
+    time_machine.move_to(moment + 601, tick=False)
+
+    lifespan.registry.register_value(JWTValidator, auth)
+
+    response = client.get("/execution/variables/key1", headers={"Authorization": "Bearer dummy"})
+
+    assert "Refreshed-API-Token" in response.headers
+    # avalidated_claims must be called exactly once — by JWTBearer only.
+    auth.avalidated_claims.assert_awaited_once_with("dummy", {})

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_router.py
@@ -20,17 +20,76 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import FastAPI
+import svcs
+from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.security import HTTPBearer
+from fastapi.testclient import TestClient
 
 from airflow.api_fastapi.auth.tokens import JWTValidator
 from airflow.api_fastapi.execution_api.app import lifespan
+from airflow.api_fastapi.execution_api.datamodels.token import TIClaims, TIToken
+from airflow.api_fastapi.execution_api.security import (
+    _REQUEST_SCOPE_TOKEN_KEY,
+    _jwt_bearer,
+)
+
+
+@pytest.fixture
+def client():
+    """Test client that exercises JWTBearer so request.scope is populated for the middleware."""
+    from starlette.routing import Mount
+
+    from airflow.api_fastapi.app import cached_app
+
+    app = cached_app(apps="execution")
+
+    exec_app: FastAPI | None = None
+    for route in app.routes:
+        if isinstance(route, Mount) and route.path == "/execution" and isinstance(route.app, FastAPI):
+            exec_app = route.app
+            break
+    if exec_app is None:
+        raise RuntimeError("Execution API sub-app not found")
+
+    _http_bearer = HTTPBearer(auto_error=False)
+
+    async def mock_jwt_bearer(request: Request):
+        """Drop-in for _jwt_bearer that uses the registered JWTValidator mock and sets scope."""
+        if cached := request.scope.get(_REQUEST_SCOPE_TOKEN_KEY):
+            return cached
+
+        creds = await _http_bearer(request)
+        if not creds:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing auth token")
+
+        async with svcs.Container(request.app.state.svcs_registry) as services:
+            validator: JWTValidator = await services.aget(JWTValidator)
+            try:
+                claims = await validator.avalidated_claims(creds.credentials, {})
+            except Exception:
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid auth token")
+
+        claims.setdefault("scope", "execution")
+        token = TIToken(id=claims["sub"], claims=TIClaims(**claims))
+        request.scope[_REQUEST_SCOPE_TOKEN_KEY] = token
+        return token
+
+    exec_app.dependency_overrides[_jwt_bearer] = mock_jwt_bearer
+
+    with TestClient(app) as c:
+        yield c
+
+    exec_app.dependency_overrides.pop(_jwt_bearer, None)
 
 
 @pytest.fixture
 def exec_app(client):
-    last_route = client.app.routes[-1]
-    assert isinstance(last_route.app, FastAPI)
-    return last_route.app
+    from starlette.routing import Mount
+
+    for route in client.app.routes:
+        if isinstance(route, Mount) and route.path == "/execution" and isinstance(route.app, FastAPI):
+            return route.app
+    raise RuntimeError("Execution API sub-app not found")
 
 
 @pytest.mark.parametrize(
@@ -67,6 +126,7 @@ def test_expiring_token_is_reissued(
         assert "Refreshed-API-Token" in response.headers
     else:
         assert "Refreshed-API-Token" not in response.headers
+    # avalidated_claims must be called exactly once — by JWTBearer only, not by the middleware.
     auth.avalidated_claims.assert_awaited_once_with("dummy", {})
 
 


### PR DESCRIPTION
closes: #67939

## Problem

Long-running tasks fail with repeated 403 errors when a heartbeat arrives with a JWT token that has only milliseconds of validity left. The race:

1. `JWTBearer` validates the token — still valid at that instant
2. Handler completes (heartbeat → 200)
3. `JWTReissueMiddleware` calls `avalidated_claims` a **second time** on the same token
4. Token has now crossed its expiry boundary → `ExpiredSignatureError`
5. Exception is swallowed, no `Refreshed-API-Token` header is set
6. Client's next heartbeat (30 s later) arrives with a fully-expired token → 403
7. After `MAX_FAILED_HEARTBEATS` the supervisor kills the task

The race is rare (only triggers when a heartbeat lands with < 1 s left on the token), which explains why tasks run fine for ~100 minutes and then suddenly die.

## Fix

`JWTBearer` already validates the token and caches the resulting `TIToken` on `request.scope`. `JWTReissueMiddleware` now reads directly from `request.scope` instead of re-parsing the `Authorization` header and calling `avalidated_claims` again. This avoids a second validation pass and does not add any expiry leeway.

If the token crosses its expiry boundary during request processing, `valid_left` will be ≤ `refresh_when_less_than` and a fresh token is still issued from the already-validated claims. If the token crosses its expiry boundary during request processing, `valid_left` will be ≤ `refresh_when_less_than`, so a fresh token can still be issued from the claims that were already validated for this request. The reissued token uses the same `sub`, `scope`, and `ti_id`, and no expiry leeway is added.


## Changes

- `app.py`: read `TIToken` from `request.scope[_REQUEST_SCOPE_TOKEN_KEY]` (cached by `JWTBearer`) instead of re-parsing the `Authorization` header and calling `avalidated_claims` a second time
- `test_router.py`: assert `avalidated_claims` is called exactly once per request; add a regression test verifying that the middleware reissues from cached `JWTBearer` claims without re-validating the token