### PR TITLE
Fix CI/CD running full matrix on push to release branches (v3-X-test)

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -649,6 +649,10 @@ class SelectiveChecks:
                     f"[warning]Only text non doc files changed in {self._github_event}, skip full tests[/]"
                 )
                 return False
+            # On push to release branches (v3-X-test, etc), only run selective tests.
+            # Canaries (SCHEDULE) and manual triggers (WORKFLOW_DISPATCH) still run full matrix.
+            if self._github_event == GithubEvents.PUSH and self._default_branch != "main":
+                return False
             console_print(f"[warning]Running everything because event is {self._github_event}[/]")
             return True
         if not self._commit_ref:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3909,3 +3909,59 @@ def test_helm_test_kubernetes_versions(
         default_branch="main",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
+
+
+@pytest.mark.parametrize(
+    ("github_event", "default_branch", "expected_all_versions"),
+    [
+        pytest.param(
+            GithubEvents.PUSH,
+            "v3-2-test",
+            "false",
+            id="Push to release branch does not force all versions",
+        ),
+        pytest.param(
+            GithubEvents.SCHEDULE,
+            "main",
+            "true",
+            id="Schedule (canary) forces all versions",
+        ),
+        pytest.param(
+            GithubEvents.WORKFLOW_DISPATCH,
+            "main",
+            "true",
+            id="Workflow dispatch forces all versions",
+        ),
+    ],
+)
+@patch.dict("os.environ", {"GITHUB_TOKEN": "test_token"})
+@patch("requests.get")
+def test_push_to_release_branch_does_not_force_full_tests(
+    mock_get, github_event, default_branch, expected_all_versions
+):
+    """Test that push to release branches (v3-X-test) does not force full test matrix,
+    while canaries (SCHEDULE) and manual triggers still do."""
+    # Mock GitHub API calls for runner_type property (used in PUSH/SCHEDULE events)
+    workflow_response = Mock()
+    workflow_response.status_code = 200
+    workflow_response.json.return_value = {"workflow_runs": [{"jobs_url": "https://api.github.com/jobs/123"}]}
+    jobs_response = Mock()
+    jobs_response.status_code = 200
+    jobs_response.json.return_value = {
+        "jobs": [{"name": "Basic tests (ubuntu-22.04)", "labels": ["ubuntu-22.04"]}]
+    }
+    mock_get.side_effect = [workflow_response, jobs_response]
+
+    stderr = SelectiveChecks(
+        files=("airflow-core/src/airflow/models/dag.py",),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=github_event,
+        pr_labels=(),
+        default_branch=default_branch,
+    )
+    assert_outputs_are_printed(
+        {
+            "all-versions": expected_all_versions,
+        },
+        str(stderr),
+    )


### PR DESCRIPTION
On push to release branches like v3-2-test, the full test matrix was unconditionally running because `_should_run_all_tests_and_versions()` didn't distinguish between push events to main vs release branches.

Release branch pushes should only run selective tests (based on changed files), while canaries (SCHEDULE) and manual triggers (WORKFLOW_DISPATCH) still get the full matrix.

Added branch-aware gating: push to release branches now returns False from `_should_run_all_tests_and_versions()` unless other conditions (pyproject.toml changes, etc.) require full tests.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Haiku 4.5

Generated-by: Claude Haiku 4.5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)