### PR TITLE
Don't force the full test matrix for large test/docs-only PRs

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -730,14 +730,13 @@ class SelectiveChecks:
         """
         Check if PR is large enough to run full tests.
 
-        The heuristics are based on number of files changed and total lines changed,
-        while excluding generated files which can be ignored.
-
-        The line-count check (``LINE_THRESHOLD``) only counts lines in production-code
-        files — tests, docs, newsfragments, generated files, translations, dev tooling,
-        and similar low-risk paths do not contribute to the line count. A 1000-line test
-        or docs PR is not the same shape of risk as a 1000-line change to scheduler
-        code, and only the latter should trigger the full test matrix.
+        Both heuristics — the count of changed files (``FILE_THRESHOLD``) and the
+        total lines changed (``LINE_THRESHOLD``) — only consider production-code
+        files. Tests, docs, newsfragments, generated files, translations, example
+        DAGs, and dev tooling are low-risk: a PR that only touches them, however
+        many files or lines, must not force the full test matrix. A 1000-line (or
+        40-file) test or docs PR is not the same shape of risk as the same churn in
+        scheduler code, and only the latter should trigger the full test matrix.
         """
         FILE_THRESHOLD = 25
         LINE_THRESHOLD = 500
@@ -745,34 +744,12 @@ class SelectiveChecks:
         if not self._files:
             return False
 
-        exclude_patterns = [
-            r"/newsfragments/",
-            r"^uv\.lock$",
-            r"pnpm-lock\.yaml$",
-            r"package-lock\.json$",
-        ]
-
-        relevant_files = [
-            f for f in self._files if not any(re.search(pattern, f) for pattern in exclude_patterns)
-        ]
-
-        files_changed = len(relevant_files)
-        if files_changed >= FILE_THRESHOLD:
-            console_print(
-                f"[warning]Running full set of tests because PR touches {files_changed} files "
-                f"(≥25 threshold)[/]"
-            )
-            return True
-
-        if not self._commit_ref:
-            console_print("[warning]Cannot determine if PR is big enough, skipping the check[/]")
-            return False
-
-        # The line-count gate only counts churn in production code. We compose
-        # the existing `*_PRODUCTION_FILES` and helm groups rather than rolling
-        # a bespoke pattern set, so the definition of "production code" stays
-        # in lockstep with the rest of CI (e.g. SAST scans targeted by
-        # `run_python_scans` / `run_javascript_scans`).
+        # Both gates count churn in production code only. We compose the existing
+        # `*_PRODUCTION_FILES` and helm groups rather than rolling a bespoke pattern
+        # set, so the definition of "production code" stays in lockstep with the rest
+        # of CI (e.g. SAST scans targeted by `run_python_scans` /
+        # `run_javascript_scans`). These groups already exclude tests, docs,
+        # generated files, translations, and example DAGs.
         production_files = list(
             dict.fromkeys(
                 self._matching_files(FileGroupForCi.PYTHON_PRODUCTION_FILES, CI_FILE_GROUP_MATCHES)
@@ -781,6 +758,18 @@ class SelectiveChecks:
             )
         )
         if not production_files:
+            return False
+
+        files_changed = len(production_files)
+        if files_changed >= FILE_THRESHOLD:
+            console_print(
+                f"[warning]Running full set of tests because PR touches {files_changed} "
+                f"production files (≥{FILE_THRESHOLD} threshold)[/]"
+            )
+            return True
+
+        if not self._commit_ref:
+            console_print("[warning]Cannot determine if PR is big enough, skipping the check[/]")
             return False
 
         try:
@@ -807,8 +796,7 @@ class SelectiveChecks:
                 if total_lines >= LINE_THRESHOLD:
                     console_print(
                         f"[warning]Running full set of tests because PR changes {total_lines} lines "
-                        f"of production code in {len(production_files)} file(s) "
-                        f"(of {files_changed} relevant file(s))[/]"
+                        f"of production code in {len(production_files)} file(s)[/]"
                     )
                     return True
         except Exception:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3520,6 +3520,42 @@ def test_provider_dependency_bump_check_in_optional_dependencies(mock_run_comman
             },
             id="PR with only lock files changed",
         ),
+        # The file-count gate, like the line-count gate, only counts production
+        # code. A PR that touches many test, docs, or example-DAG files — and no
+        # production code — must not force the full matrix on its file count alone.
+        pytest.param(
+            tuple(f"airflow-core/tests/unit/models/test_file{i}.py" for i in range(30)),
+            {
+                "full-tests-needed": "false",
+            },
+            id="Large test-only PR (30 files) does not trigger full tests",
+        ),
+        pytest.param(
+            tuple(f"airflow-core/docs/page_{i}.rst" for i in range(30)),
+            {
+                "full-tests-needed": "false",
+            },
+            id="Large docs-only PR (30 files) does not trigger full tests",
+        ),
+        pytest.param(
+            tuple(f"airflow-core/src/airflow/example_dags/example_{i}.py" for i in range(30)),
+            {
+                "full-tests-needed": "false",
+            },
+            id="Large example_dags-only PR (30 files) does not trigger full tests",
+        ),
+        # A mix below the production-file threshold (20 production + 20 test files)
+        # must not trip the file-count gate on the combined count of 40.
+        pytest.param(
+            tuple(
+                [f"airflow-core/src/airflow/models/file{i}.py" for i in range(20)]
+                + [f"airflow-core/tests/unit/models/test_file{i}.py" for i in range(20)]
+            ),
+            {
+                "full-tests-needed": "false",
+            },
+            id="Mixed PR with 20 production files (of 40) does not trigger on file count",
+        ),
     ],
 )
 def test_large_pr_by_file_count(files, expected_outputs: dict[str, str]):


### PR DESCRIPTION
The "large PR" heuristic in selective checks escalates a PR to the full test
matrix on two gates: number of changed files (≥25) and lines of production
code changed (≥500).

The **line-count** gate was already narrowed to count production code only, so
a large test/docs/translation/example-DAG diff does not trigger it (#68042 and
the test-line-exclusion work). The **file-count** gate, however, still counted
*every* changed file (minus newsfragments and lockfiles) — so a PR touching
25+ test, docs, or example-DAG files alone still forced the full ~135-job
matrix.

This change bases the file-count gate on the same production-file set the
line-count gate uses (`PYTHON_PRODUCTION_FILES` + `JAVASCRIPT_PRODUCTION_FILES`
+ helm), so both heuristics agree on what "production code" means. A PR that
only touches tests, docs, translations, or example DAGs no longer forces the
full matrix on its file count. Production-heavy PRs are unaffected.

Added parametrized tests for large test-only, docs-only, example_dags-only, and
mixed (20-production-of-40) PRs.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)