### PR TITLE
Add scheduler observability metrics

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1265,6 +1265,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             stats.incr("scheduler.executor_events.failed", tags={"exception_class": type(exc).__name__})
             raise
 
+    @staticmethod
+    def _emit_executor_events_batch_metrics(num_events: int) -> None:
+        stats.gauge("scheduler.executor_events.batch_size", num_events)
+        stats.incr("scheduler.executor_events.processed", num_events)
+
     @classmethod
     def process_executor_events(
         cls, executor: BaseExecutor, job_id: int | None, scheduler_dag_bag: DBDagBag, session: Session
@@ -1363,15 +1368,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # Return if no finished tasks
         if not tis_with_right_state:
-            stats.gauge("scheduler.executor_events.batch_size", num_events)
-            stats.incr("scheduler.executor_events.processed", num_events)
+            cls._emit_executor_events_batch_metrics(num_events)
             return len(event_buffer)
 
         # Check state of finished tasks
         filter_for_tis = TI.filter_for_tis(tis_with_right_state)
         if filter_for_tis is None:
-            stats.gauge("scheduler.executor_events.batch_size", num_events)
-            stats.incr("scheduler.executor_events.processed", num_events)
+            cls._emit_executor_events_batch_metrics(num_events)
             return len(event_buffer)
         asset_loader, alias_loader = _eager_load_dag_run_for_validation()
         query = (
@@ -1595,8 +1598,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Update task state - emails are handled by DAG processor now
                 ti.handle_failure(error=msg, session=session)
 
-        stats.gauge("scheduler.executor_events.batch_size", num_events)
-        stats.incr("scheduler.executor_events.processed", num_events)
+        cls._emit_executor_events_batch_metrics(num_events)
         return len(event_buffer)
 
     def _execute(self) -> int | None:

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1254,12 +1254,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         return conf.getboolean("traces", "otel_on")
 
     def _process_executor_events(self, executor: BaseExecutor, session: Session) -> int:
-        return SchedulerJobRunner.process_executor_events(
-            executor=executor,
-            job_id=self.job.id,
-            scheduler_dag_bag=self.scheduler_dag_bag,
-            session=session,
-        )
+        try:
+            return SchedulerJobRunner.process_executor_events(
+                executor=executor,
+                job_id=self.job.id,
+                scheduler_dag_bag=self.scheduler_dag_bag,
+                session=session,
+            )
+        except Exception as exc:
+            stats.incr("scheduler.executor_events.failed", tags={"reason": type(exc).__name__})
+            raise
 
     @classmethod
     def process_executor_events(
@@ -1297,6 +1301,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         """
         ti_primary_key_to_try_number_map: dict[tuple[str, str, str, int], int] = {}
         event_buffer = executor.get_event_buffer()
+        num_events = len(event_buffer)
         tis_with_right_state: list[TaskInstanceKey] = []
         callback_keys_with_events: list[CallbackKey] = []
 
@@ -1358,12 +1363,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # Return if no finished tasks
         if not tis_with_right_state:
-            return len(event_buffer)
+            stats.gauge("scheduler.executor_events.batch_size", num_events)
+            stats.incr("scheduler.executor_events.processed", num_events)
+            return num_events
 
         # Check state of finished tasks
         filter_for_tis = TI.filter_for_tis(tis_with_right_state)
         if filter_for_tis is None:
-            return len(event_buffer)
+            stats.gauge("scheduler.executor_events.batch_size", num_events)
+            stats.incr("scheduler.executor_events.processed", num_events)
+            return num_events
         asset_loader, alias_loader = _eager_load_dag_run_for_validation()
         query = (
             select(TI)
@@ -1586,7 +1595,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Update task state - emails are handled by DAG processor now
                 ti.handle_failure(error=msg, session=session)
 
-        return len(event_buffer)
+        stats.gauge("scheduler.executor_events.batch_size", num_events)
+        stats.incr("scheduler.executor_events.processed", num_events)
+        return num_events
 
     def _execute(self) -> int | None:
         import os
@@ -1621,7 +1632,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             if settings.Session is not None:
                 settings.Session.remove()
-        except Exception:
+        except Exception as exc:
+            stats.incr("scheduler.loop_exceptions", tags={"exception_class": type(exc).__name__})
             self.log.exception("Exception when executing SchedulerJob._run_scheduler_loop")
             raise
         finally:
@@ -1861,6 +1873,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     loop_count,
                 )
                 break
+
 
     def _do_scheduling(self, session: Session) -> int:
         """
@@ -3347,6 +3360,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
                     stats.incr("scheduler.orphaned_tasks.cleared", len(to_reset))
                     stats.incr("scheduler.orphaned_tasks.adopted", len(tis_to_adopt_or_reset) - len(to_reset))
+                    if to_reset:
+                        stats.incr(
+                            "scheduler.zombies.detected",
+                            len(to_reset),
+                            tags={"reason": "adopt_failure"},
+                        )
 
                     if to_reset:
                         task_instance_str = "\n\t".join(reset_tis_message)
@@ -3495,6 +3514,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             if task_instances_without_heartbeats := self._find_task_instances_without_heartbeats(
                 session=session
             ):
+                stats.incr(
+                    "scheduler.zombies.detected",
+                    len(task_instances_without_heartbeats),
+                    tags={"reason": "heartbeat_timeout"},
+                )
                 self._purge_task_instances_without_heartbeats(
                     task_instances_without_heartbeats, session=session
                 )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1365,14 +1365,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if not tis_with_right_state:
             stats.gauge("scheduler.executor_events.batch_size", num_events)
             stats.incr("scheduler.executor_events.processed", num_events)
-            return num_events
+            return len(event_buffer)
 
         # Check state of finished tasks
         filter_for_tis = TI.filter_for_tis(tis_with_right_state)
         if filter_for_tis is None:
             stats.gauge("scheduler.executor_events.batch_size", num_events)
             stats.incr("scheduler.executor_events.processed", num_events)
-            return num_events
+            return len(event_buffer)
         asset_loader, alias_loader = _eager_load_dag_run_for_validation()
         query = (
             select(TI)
@@ -1597,7 +1597,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         stats.gauge("scheduler.executor_events.batch_size", num_events)
         stats.incr("scheduler.executor_events.processed", num_events)
-        return num_events
+        return len(event_buffer)
 
     def _execute(self) -> int | None:
         import os
@@ -3365,8 +3365,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                             len(to_reset),
                             tags={"reason": "adopt_failure"},
                         )
-
-                    if to_reset:
                         task_instance_str = "\n\t".join(reset_tis_message)
                         self.log.info(
                             "Reset the following %s orphaned TaskInstances:\n\t%s",

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1262,7 +1262,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 session=session,
             )
         except Exception as exc:
-            stats.incr("scheduler.executor_events.failed", tags={"reason": type(exc).__name__})
+            stats.incr("scheduler.executor_events.failed", tags={"exception_class": type(exc).__name__})
             raise
 
     @classmethod
@@ -3360,11 +3360,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     stats.incr("scheduler.orphaned_tasks.cleared", len(to_reset))
                     stats.incr("scheduler.orphaned_tasks.adopted", len(tis_to_adopt_or_reset) - len(to_reset))
                     if to_reset:
-                        stats.incr(
-                            "scheduler.zombies.detected",
-                            len(to_reset),
-                            tags={"reason": "adopt_failure"},
-                        )
                         task_instance_str = "\n\t".join(reset_tis_message)
                         self.log.info(
                             "Reset the following %s orphaned TaskInstances:\n\t%s",

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1874,7 +1874,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 break
 
-
     def _do_scheduling(self, session: Session) -> int:
         """
         Make the main scheduling decisions.

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12773,3 +12773,157 @@ def test_resolve_partition_date(mappers, partition_key, carried_partition_date, 
         carried_partition_date=carried_partition_date,
     )
     assert result == expected
+
+
+class TestSchedulerObservabilityMetrics:
+    """Tests for the scheduler observability metrics emitted in scheduler_job_runner.py."""
+
+    @pytest.fixture(autouse=True)
+    def per_test(self) -> Generator:
+        _clean_db()
+        self.job_runner: SchedulerJobRunner | None = None
+        yield
+        _clean_db()
+
+    # --- scheduler.loop_exceptions ---
+
+    def test_loop_exceptions_incr_on_scheduler_loop_failure(self):
+        """scheduler.loop_exceptions is emitted with exception_class tag when _run_scheduler_loop raises."""
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with (
+            mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats,
+            mock.patch.object(self.job_runner, "register_signals", return_value=MagicMock()),
+            mock.patch.object(self.job_runner.executor, "start"),
+            mock.patch.object(self.job_runner.executor, "end"),
+            mock.patch.object(self.job_runner, "_run_scheduler_loop", side_effect=RuntimeError("loop crash")),
+            pytest.raises(RuntimeError, match="loop crash"),
+        ):
+            self.job_runner._execute()
+
+        mock_stats.incr.assert_any_call("scheduler.loop_exceptions", tags={"exception_class": "RuntimeError"})
+
+    def test_loop_exceptions_not_emitted_on_clean_exit(self):
+        """scheduler.loop_exceptions is NOT emitted when _run_scheduler_loop returns normally."""
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with (
+            mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats,
+            mock.patch.object(self.job_runner, "register_signals", return_value=MagicMock()),
+            mock.patch.object(self.job_runner.executor, "start"),
+            mock.patch.object(self.job_runner.executor, "end"),
+            mock.patch.object(self.job_runner, "_run_scheduler_loop"),
+        ):
+            self.job_runner._execute()
+
+        emitted_names = [c.args[0] for c in mock_stats.incr.call_args_list]
+        assert "scheduler.loop_exceptions" not in emitted_names
+
+    # --- scheduler.executor_events.{batch_size,processed,failed} ---
+
+    def test_executor_events_batch_metrics_emitted_on_success(self):
+        """batch_size gauge and processed counter are emitted via the early-return path."""
+        # Empty event buffer → tis_with_right_state is empty → early return with num_events=0
+        mock_executor = MagicMock()
+        mock_executor.get_event_buffer.return_value = {}
+
+        with mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats:
+            result = SchedulerJobRunner.process_executor_events(
+                executor=mock_executor, job_id=1, scheduler_dag_bag=MagicMock(), session=MagicMock()
+            )
+
+        assert result == 0
+        mock_stats.gauge.assert_called_once_with("scheduler.executor_events.batch_size", 0)
+        mock_stats.incr.assert_called_once_with("scheduler.executor_events.processed", 0)
+
+    def test_executor_events_failed_metric_emitted_on_exception(self):
+        """failed counter is emitted in _process_executor_events when process_executor_events raises."""
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        with (
+            mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats,
+            mock.patch.object(
+                SchedulerJobRunner, "process_executor_events", side_effect=ValueError("executor boom")
+            ),
+            pytest.raises(ValueError, match="executor boom"),
+        ):
+            self.job_runner._process_executor_events(executor=MagicMock(), session=MagicMock())
+
+        mock_stats.incr.assert_called_once_with(
+            "scheduler.executor_events.failed", tags={"reason": "ValueError"}
+        )
+        mock_stats.gauge.assert_not_called()
+
+    # --- scheduler.zombies.detected ---
+
+    def test_zombies_detected_heartbeat_timeout_emitted(self):
+        """scheduler.zombies.detected{reason:heartbeat_timeout} is emitted when zombies are found."""
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+        fake_tis = [MagicMock(), MagicMock(), MagicMock()]
+
+        mock_session = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        with (
+            mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats,
+            mock.patch("airflow.jobs.scheduler_job_runner.create_session", return_value=mock_ctx),
+            mock.patch.object(
+                self.job_runner, "_find_task_instances_without_heartbeats", return_value=fake_tis
+            ),
+            mock.patch.object(self.job_runner, "_purge_task_instances_without_heartbeats"),
+        ):
+            self.job_runner._find_and_purge_task_instances_without_heartbeats()
+
+        mock_stats.incr.assert_called_once_with(
+            "scheduler.zombies.detected", 3, tags={"reason": "heartbeat_timeout"}
+        )
+
+    def test_zombies_detected_not_emitted_when_no_heartbeat_timeout(self):
+        """scheduler.zombies.detected is NOT emitted when no zombie task instances are found."""
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        mock_session = MagicMock()
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_session)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        with (
+            mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats,
+            mock.patch("airflow.jobs.scheduler_job_runner.create_session", return_value=mock_ctx),
+            mock.patch.object(self.job_runner, "_find_task_instances_without_heartbeats", return_value=[]),
+        ):
+            self.job_runner._find_and_purge_task_instances_without_heartbeats()
+
+        mock_stats.incr.assert_not_called()
+
+    def test_zombies_detected_adopt_failure_emitted(self, dag_maker, session):
+        """scheduler.zombies.detected{reason:adopt_failure} is emitted for tasks that can't be adopted."""
+        with dag_maker(dag_id="test_zombie_adopt_failure", schedule="@daily"):
+            EmptyOperator(task_id="task1")
+
+        old_job = Job()
+        session.add(old_job)
+        session.commit()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job)
+
+        dr = dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
+        ti = dr.get_task_instances(session=session)[0]
+        ti.state = TaskInstanceState.QUEUED
+        ti.queued_by_job_id = old_job.id
+        session.merge(ti)
+        session.commit()
+
+        with mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats:
+            num_reset = self.job_runner.adopt_or_reset_orphaned_tasks(session=session)
+
+        assert num_reset == 1
+        mock_stats.incr.assert_any_call("scheduler.zombies.detected", 1, tags={"reason": "adopt_failure"})

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12859,7 +12859,7 @@ class TestSchedulerObservabilityMetrics:
             self.job_runner._process_executor_events(executor=MagicMock(), session=MagicMock())
 
         mock_stats.incr.assert_called_once_with(
-            "scheduler.executor_events.failed", tags={"reason": "ValueError"}
+            "scheduler.executor_events.failed", tags={"exception_class": "ValueError"}
         )
         mock_stats.gauge.assert_not_called()
 
@@ -12909,27 +12909,3 @@ class TestSchedulerObservabilityMetrics:
 
         mock_stats.incr.assert_not_called()
 
-    def test_zombies_detected_adopt_failure_emitted(self, dag_maker, session):
-        """scheduler.zombies.detected{reason:adopt_failure} is emitted for tasks that can't be adopted."""
-        with dag_maker(dag_id="test_zombie_adopt_failure", schedule="@daily"):
-            EmptyOperator(task_id="task1")
-
-        old_job = Job()
-        session.add(old_job)
-        session.commit()
-
-        scheduler_job = Job()
-        self.job_runner = SchedulerJobRunner(job=scheduler_job)
-
-        dr = dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
-        ti = dr.get_task_instances(session=session)[0]
-        ti.state = TaskInstanceState.QUEUED
-        ti.queued_by_job_id = old_job.id
-        session.merge(ti)
-        session.commit()
-
-        with mock.patch("airflow.jobs.scheduler_job_runner.stats") as mock_stats:
-            num_reset = self.job_runner.adopt_or_reset_orphaned_tasks(session=session)
-
-        assert num_reset == 1
-        mock_stats.incr.assert_any_call("scheduler.zombies.detected", 1, tags={"reason": "adopt_failure"})

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -863,7 +863,12 @@ class TestSchedulerJob:
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.QUEUED
         self.job_runner.executor.callback_sink.send.assert_not_called()
-        mock_stats.incr.assert_not_called()
+        # Only the processed-events counter should have fired across all three sub-tests;
+        # no killed_externally mismatch metric should appear.
+        assert all(
+            c.args[0] == "scheduler.executor_events.processed"
+            for c in mock_stats.incr.call_args_list
+        )
 
     @mock.patch("airflow.jobs.scheduler_job_runner.TaskCallbackRequest")
     @mock.patch("airflow._shared.observability.metrics.stats._get_backend")
@@ -908,7 +913,9 @@ class TestSchedulerJob:
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.SCHEDULED
         self.job_runner.executor.callback_sink.send.assert_not_called()
-        mock_stats.incr.assert_not_called()
+        # Stale success from defer exit must not trigger a mismatch metric —
+        # only the standard processed-events counter should fire.
+        mock_stats.incr.assert_called_once_with("scheduler.executor_events.processed", count=1)
 
         # Without next_method, scheduled + stale success is still a mismatch (e.g. external kill).
         ti1.next_method = None
@@ -1020,7 +1027,9 @@ class TestSchedulerJob:
             for rec in caplog.records
         )
         mock_task_callback.assert_not_called()
-        mock_stats.incr.assert_not_called()
+        # Only the processed-events counter should fire; duplicate try_number events
+        # must not trigger any error/mismatch metrics.
+        mock_stats.incr.assert_called_once_with("scheduler.executor_events.processed", count=2)
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_process_executor_events_with_asset_events(self, session, dag_maker):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -972,7 +972,9 @@ class TestSchedulerJob:
         ti1.refresh_from_db(session=session)
         assert ti1.state == State.QUEUED
         self.job_runner.executor.callback_sink.send.assert_not_called()
-        mock_stats.incr.assert_not_called()
+        # Stale success from defer exit must not trigger a mismatch metric —
+        # only the standard processed-events counter should fire.
+        mock_stats.incr.assert_called_once_with("scheduler.executor_events.processed", count=1)
 
         # Without next_method, queued + stale success is still a mismatch (e.g. external kill).
         ti1.next_method = None

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -865,10 +865,7 @@ class TestSchedulerJob:
         self.job_runner.executor.callback_sink.send.assert_not_called()
         # Only the processed-events counter should have fired across all three sub-tests;
         # no killed_externally mismatch metric should appear.
-        assert all(
-            c.args[0] == "scheduler.executor_events.processed"
-            for c in mock_stats.incr.call_args_list
-        )
+        assert all(c.args[0] == "scheduler.executor_events.processed" for c in mock_stats.incr.call_args_list)
 
     @mock.patch("airflow.jobs.scheduler_job_runner.TaskCallbackRequest")
     @mock.patch("airflow._shared.observability.metrics.stats._get_backend")

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12908,4 +12908,3 @@ class TestSchedulerObservabilityMetrics:
             self.job_runner._find_and_purge_task_instances_without_heartbeats()
 
         mock_stats.incr.assert_not_called()
-

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -208,7 +208,7 @@ metrics:
 
   - name: "scheduler.zombies.detected"
     description: "Number of zombie task instances detected by the Scheduler.
-    Metric with reason tagging (``heartbeat_timeout`` or ``adopt_failure``)."
+    Metric with reason tagging (``heartbeat_timeout``)."
     type: "counter"
     legacy_name: "-"
     name_variables: []

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -186,6 +186,33 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "scheduler.loop_exceptions"
+    description: "Number of times the scheduler loop exited with an unhandled exception.
+    Metric with exception_class tagging."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.executor_events.processed"
+    description: "Number of executor events processed per ``process_executor_events`` call."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.executor_events.failed"
+    description: "Number of times ``process_executor_events`` raised an exception.
+    Metric with reason tagging."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.zombies.detected"
+    description: "Number of zombie task instances detected by the Scheduler.
+    Metric with reason tagging (``heartbeat_timeout`` or ``adopt_failure``)."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "scheduler.critical_section_busy"
     description: "Count of times a scheduler process tried to get a lock on the critical
     section (needed to send tasks to the executor) and found it locked by another process."
@@ -414,6 +441,12 @@ metrics:
 
   - name: "scheduler.tasks.starving"
     description: "Number of tasks that cannot be scheduled because of no open slot in pool"
+    type: "gauge"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.executor_events.batch_size"
+    description: "Number of executor events in the batch processed per ``process_executor_events`` call."
     type: "gauge"
     legacy_name: "-"
     name_variables: []

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -201,7 +201,7 @@ metrics:
 
   - name: "scheduler.executor_events.failed"
     description: "Number of times ``process_executor_events`` raised an exception.
-    Metric with reason tagging."
+    Metric with exception_class tagging."
     type: "counter"
     legacy_name: "-"
     name_variables: []


### PR DESCRIPTION
Emit three new metrics from \`SchedulerJobRunner\` to improve visibility into scheduler health. These metrics have been running in production at Datadog via local monkey-patches and are contributed upstream so the patches can eventually be removed.

## New metrics

- **\`scheduler.loop_exceptions{exception_class}\`** — counter incremented when the scheduler loop exits with an unhandled exception, tagged with the exception class. Emitted from the existing \`except Exception\` block in \`_execute\`.

- **\`scheduler.executor_events.batch_size\`** (gauge) and **\`scheduler.executor_events.processed\`** (counter) — emitted on every successful call to \`process_executor_events\` with the size of the event batch. **\`scheduler.executor_events.failed{exception_class}\`** is incremented when the call raises, tagged with the exception class.

- **\`scheduler.zombies.detected{reason}\`** — counter incremented when zombie task instances are detected, tagged by detection path:
  - \`heartbeat_timeout\`: task exceeded the heartbeat threshold

## Tests

New test class \`TestSchedulerObservabilityMetrics\` in \`airflow-core/tests/unit/jobs/test_scheduler_job.py\` covers all three metrics (success and failure paths):

```
pytest airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerObservabilityMetrics -v
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below) : Claude

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=97dc10c action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @safaehar** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@hussein-awala` is waiting on you:
> - 1 unresolved review thread(s) from `@hussein-awala` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
