### PR TITLE
[Hashicorp] Fix Vault GCP auth for GCE metadata credentials

### DIFF
--- a/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/providers/hashicorp/src/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -349,9 +349,9 @@ class _VaultClient(LoggingMixin):
         import time
 
         # Determine service account email
-        service_account_email = getattr(credentials, "service_account_email", None) or getattr(
-            credentials, "client_email", None
-        )
+        service_account_email = getattr(credentials, "service_account_email", None)
+        if service_account_email in (None, "default"):
+            service_account_email = getattr(credentials, "client_email", None) or None
 
         if service_account_email is None:
             # Fallback for Compute Engine credentials if email is not yet populated
@@ -373,6 +373,8 @@ class _VaultClient(LoggingMixin):
                 f"Could not determine service account email from credentials. "
                 f"Expected string, got {type(service_account_email).__name__}"
             )
+        if service_account_email == "default":
+            raise VaultError("Could not determine service account email from Compute Engine credentials.")
 
         # Generate a payload for subsequent "signJwt()" call.
         # The 'sub' claim must be the service account email.

--- a/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
+++ b/providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py
@@ -371,6 +371,61 @@ class TestVaultClient:
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac.Client")
     @mock.patch("googleapiclient.discovery.build")
     @mock.patch("time.time")
+    def test_gcp_adc_compute_engine_default_email_refresh(
+        self, mock_time, mock_google_build, mock_hvac_client, mock_get_credentials, mock_get_scopes
+    ):
+        from google.auth import compute_engine
+
+        mock_client = mock.MagicMock()
+        mock_hvac_client.return_value = mock_client
+        mock_get_scopes.return_value = ["scope1", "scope2"]
+
+        mock_credentials = mock.MagicMock(spec=compute_engine.Credentials)
+        mock_credentials.service_account_email = "default"
+
+        def refresh(_request):
+            mock_credentials.service_account_email = "service_account_email"
+
+        mock_credentials.refresh.side_effect = refresh
+        mock_get_credentials.return_value = (mock_credentials, "project_id")
+
+        mock_sign_jwt = (
+            mock_google_build.return_value.projects.return_value.serviceAccounts.return_value.signJwt
+        )
+        mock_sign_jwt.return_value.execute.return_value = {"signedJwt": "mocked_jwt"}
+
+        mock_time.return_value = 1234567890.0
+        iat = 1234567890
+        exp = iat + 900
+
+        vault_client = _VaultClient(
+            auth_type="gcp",
+            gcp_scopes="scope1,scope2",
+            role_id="role",
+            url="http://localhost:8180",
+            session=None,
+        )
+
+        client = vault_client.client
+
+        mock_credentials.refresh.assert_called_once()
+        args, kwargs = mock_sign_jwt.call_args
+        payload = json.loads(kwargs["body"]["payload"])
+
+        assert kwargs["name"] == "projects/project_id/serviceAccounts/service_account_email"
+        assert payload["iat"] == iat
+        assert payload["exp"] == exp
+        assert payload["sub"] == "service_account_email"
+
+        client.auth.gcp.login.assert_called_with(role="role", jwt="mocked_jwt")
+        client.is_authenticated.assert_called_with()
+        assert vault_client.kv_engine_version == 2
+
+    @mock.patch("airflow.providers.google.cloud.utils.credentials_provider._get_scopes")
+    @mock.patch("airflow.providers.google.cloud.utils.credentials_provider.get_credentials_and_project_id")
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac.Client")
+    @mock.patch("googleapiclient.discovery.build")
+    @mock.patch("time.time")
     def test_gcp_different_auth_mount_point(
         self,
         mock_time,


### PR DESCRIPTION
## What

Fix HashiCorp Vault GCP authentication when Application Default Credentials come from Compute Engine metadata credentials and initially expose the service account email as `default`.

## Why

In GCE-based environments such as Cloud Composer, `google.auth.compute_engine.Credentials` may start with `service_account_email == "default"` until the credentials are refreshed from the metadata server. The Vault client used that value directly in the IAM `signJwt` request, producing an invalid resource name like `projects/<project>/serviceAccounts/default`.

Sanitized task log excerpt:

```text
{connection.py:531} ERROR - Unable to retrieve connection from secrets backend (VaultBackend). Checking subsequent secrets backend.
googleapiclient.errors.HttpError: <HttpError 400 when requesting https://iam.googleapis.com/v1/projects/<project-id>/serviceAccounts/default:signJwt?alt=json returned "Invalid form of account ID default. Should be [Gaia ID |Email |Unique ID |] of the account". Details: "Invalid form of account ID default. Should be [Gaia ID |Email |Unique ID |] of the account">
airflow.exceptions.AirflowNotFoundException: The conn_id `<conn-id>` isn't defined
```

## Context

- Observed while testing `apache-airflow-providers-hashicorp==4.7.0rc1` from PyPI: https://pypi.org/project/apache-airflow-providers-hashicorp/4.7.0rc1/
- Follow-up fix for the ADC support added in https://github.com/apache/airflow/pull/53801.
- Provider testing context: https://github.com/apache/airflow/issues/67957 for rc1 wave

## How

- Resolve GCP service account email before building the IAM `signJwt` request.
- Treat missing or `default` service account email values as unresolved.
- Refresh Compute Engine credentials so the metadata server populates the real service account email.
- Preserve key-file behavior by using `client_email` when available.
- Add a regression test for the Compute Engine/Composer ADC case.

## Tests

```bash
.venv/bin/python -m pytest providers/hashicorp/tests/unit/hashicorp/_internal_client/test_vault_client.py -q --with-db-init
```

## AI assistance

This PR was prepared with help from GPT-5 / Codex.
