### PR TITLE
Fix Typo in HTTP Connection Example

### DIFF
--- a/providers/http/docs/connections/http.rst
+++ b/providers/http/docs/connections/http.rst
@@ -74,4 +74,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_HTTP_DEFAULT='http://username:password@servvice.com:80/https?headers=header'
+   export AIRFLOW_CONN_HTTP_DEFAULT='http://username:password@service.com:80/https?headers=header'


### PR DESCRIPTION
## Description

One-character fix. `service` was improperly spelled `servvice` (two v's) in the Connection example. This PR fixes that typo.

## Testing

No testing was done, as this was a simple docs fix.