### PR TITLE
Extend CodeQL language gating to push events (main + release branches)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,10 +63,13 @@ jobs:
           if [[ "${EVENT_NAME}" == "push" ]]; then
             changed_files="$(gh api "repos/${REPOSITORY}/compare/${BEFORE_SHA}...${AFTER_SHA}" \
               --jq '.files[].filename')" || true
-            # Fall back to a full scan if the compare API call failed or returned nothing —
-            # e.g. a force-push, or a newly created release branch whose before SHA is all
-            # zeros (no base commit to diff against).
-            if [[ -z "${changed_files}" ]]; then
+            num_files="$(printf '%s\n' "${changed_files}" | grep -c . || true)"
+            # Fall back to a full scan if the compare call failed, returned nothing, or hit the
+            # API's 300-file cap. The compare API does not paginate files (only commits), so a
+            # merge of >300 files truncates the list and could under-detect a changed language;
+            # release branches have no daily schedule full-scan to back them up. Empty also covers
+            # a force-push or a newly created branch whose before SHA is all zeros (no base commit).
+            if [[ -z "${changed_files}" || "${num_files}" -ge 300 ]]; then
               echo "languages=${all_languages}" >> "${GITHUB_OUTPUT}"
               exit 0
             fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable']
   push:
-    branches: [main]
+    branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable']
   schedule:
     - cron: '0 2 * * *'
 
@@ -48,18 +48,33 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
           REPOSITORY: ${{ github.repository }}
-        # On `pull_request` we only scan the languages whose files actually changed in the PR.
-        # On `push` (to main) and `schedule` we always scan every language to keep full main coverage.
+        # On `pull_request` and `push` we only scan the languages whose files actually changed.
+        # On `schedule` we always scan every language to keep full periodic coverage.
         run: |
           set -euo pipefail
           all_languages='["python","javascript","actions","go","java"]'
-          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+          if [[ "${EVENT_NAME}" == "schedule" ]]; then
             echo "languages=${all_languages}" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
-          pr_files_path="repos/${REPOSITORY}/pulls/${PR_NUMBER}/files"
-          changed_files="$(gh api --paginate "${pr_files_path}" --jq '.[].filename')"
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            changed_files="$(gh api "repos/${REPOSITORY}/compare/${BEFORE_SHA}...${AFTER_SHA}" \
+              --jq '.files[].filename')" || true
+            # Fall back to a full scan if the compare API call failed or returned nothing —
+            # e.g. a force-push, or a newly created release branch whose before SHA is all
+            # zeros (no base commit to diff against).
+            if [[ -z "${changed_files}" ]]; then
+              echo "languages=${all_languages}" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          else
+            # pull_request
+            changed_files="$(gh api --paginate \
+              "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
+          fi
           languages=()
           grep -Eiq '\.(py|pyi)$'                        <<< "${changed_files}" && languages+=("python")
           grep -Eiq '\.(js|jsx|mjs|cjs|ts|tsx|vue)$'     <<< "${changed_files}" && languages+=("javascript")


### PR DESCRIPTION
### What

Extends the language-gating logic from #67972 — which only applied to `pull_request` — to `push` events as well, and brings the `push` trigger to parity with `pull_request` so it also fires on release branches.

Two changes:

1. **Gate the matrix on push.** The `detect-languages` job now uses the GitHub compare API (`repos/{repo}/compare/{before}...{after}`) to find which languages actually changed in a push, and builds the analysis matrix from that — the same way it already does for PRs. A docs-only or single-language merge no longer fans out all five CodeQL jobs.
2. **Run push CodeQL on release branches too.** The `push` trigger now matches the `pull_request` trigger (`main`, `v[0-9]+-[0-9]+-test`, `v[0-9]+-[0-9]+-stable`) instead of `main` only.

`schedule` runs are unchanged: they still scan all five languages.

### Why

#67972 intentionally left `push` scanning all languages, reasoning that full coverage on `main` was the goal. But the daily `schedule` run already provides that full-coverage guarantee — and it only runs on the **default branch** (`main`). That left two gaps:

- **`main`:** every merge commit fanned out five CodeQL jobs even when nothing relevant changed (the daily schedule already covers full-branch scanning).
- **Release branches:** merges to `v*-test` / `v*-stable` got **no** push-time CodeQL at all (only PRs targeting them were scanned, and `schedule` doesn't run there). Adding gated push runs gives maintained release branches the same security coverage cheaply.

The detect logic is branch-agnostic, so the same compare-based gating works for every push branch.

### Edge cases handled

The compare call is followed by a fallback to a **full scan** when it fails or returns nothing — covering a force-push, or a newly created release branch whose `before` SHA is all zeros (no base commit to diff against).

### Behaviour summary

| Event | Before | After |
|---|---|---|
| `pull_request` (main / release) | changed languages only (#67972) | unchanged |
| `push` to `main` | all 5 languages | changed languages only |
| `push` to `v*-test` / `v*-stable` | not triggered | changed languages only |
| `schedule` (daily, main) | all 5 languages | all 5 languages (unchanged) |

related: #67972

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-opus-4-8)

Generated-by: Claude Code (claude-opus-4-8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
