### PR TITLE
Only run testable integrations relevant to the change in selective checks

### DIFF
--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -101,6 +101,25 @@ DISABLE_TESTABLE_INTEGRATIONS_FROM_ARM = [
     "trino",
     "ydb",
 ]
+# Maps each testable provider integration to the provider distribution (dotted id)
+# that "owns" it. Used by selective checks to only run a provider integration when
+# its owning provider is among the affected providers of a change.
+TESTABLE_PROVIDERS_INTEGRATION_OWNERS = {
+    "celery": "celery",
+    "cassandra": "apache.cassandra",
+    "drill": "apache.drill",
+    "elasticsearch": "elasticsearch",
+    "tinkerpop": "apache.tinkerpop",
+    "kafka": "apache.kafka",
+    "localstack": "amazon",
+    "mongo": "mongo",
+    "mssql": "microsoft.mssql",
+    "pinot": "apache.pinot",
+    "qdrant": "qdrant",
+    "redis": "redis",
+    "trino": "trino",
+    "ydb": "ydb",
+}
 KEYCLOAK_INTEGRATION = "keycloak"
 STATSD_INTEGRATION = "statsd"
 OTEL_INTEGRATION = "otel"

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -52,6 +52,7 @@ from airflow_breeze.global_constants import (
     PUBLIC_ARM_RUNNERS,
     RUNNERS_TYPE_CROSS_MAPPING,
     TESTABLE_CORE_INTEGRATIONS,
+    TESTABLE_PROVIDERS_INTEGRATION_OWNERS,
     TESTABLE_PROVIDERS_INTEGRATIONS,
     GithubEvents,
     SelectiveAirflowCtlTestType,
@@ -147,6 +148,9 @@ class FileGroupForCi(Enum):
     DEVEL_TOML_FILES = auto()
     SCRIPTS_FILES = auto()
     UV_LOCK_FILE = auto()
+    KERBEROS_FILES = auto()
+    OTEL_FILES = auto()
+    CELERY_FILES = auto()
 
 
 class AllProvidersSentinel:
@@ -430,8 +434,30 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
         FileGroupForCi.UV_LOCK_FILE: [
             r"^uv\.lock$",
         ],
+        FileGroupForCi.KERBEROS_FILES: [
+            r"^airflow-core/src/airflow/security/kerberos\.py$",
+            r"^airflow-core/src/airflow/cli/commands/kerberos_command\.py$",
+        ],
+        FileGroupForCi.OTEL_FILES: [
+            r"^airflow-core/src/airflow/observability/.*",
+            r"^shared/observability/src/airflow_shared/observability/.*",
+            r"^airflow-core/src/airflow/utils/span_status\.py$",
+        ],
+        FileGroupForCi.CELERY_FILES: [
+            # Core executor sources - redis is celery's broker/result backend, so the
+            # core "redis" integration is exercised when the executor framework changes.
+            r"^airflow-core/src/airflow/executors/.*",
+        ],
     }
 )
+
+# Maps each testable core integration to the file group whose change should trigger it.
+# "redis" maps to celery/core-executor sources (redis is celery's broker/result backend).
+TESTABLE_CORE_INTEGRATION_FILE_GROUPS = {
+    "kerberos": FileGroupForCi.KERBEROS_FILES,
+    "otel": FileGroupForCi.OTEL_FILES,
+    "redis": FileGroupForCi.CELERY_FILES,
+}
 
 PYTHON_OPERATOR_FILES = [
     r"^providers/tests/standard/operators/test_python.py",
@@ -1839,21 +1865,41 @@ class SelectiveChecks:
     def testable_core_integrations(self) -> list[str]:
         if not self.run_unit_tests:
             return []
-        return [
-            integration
-            for integration in TESTABLE_CORE_INTEGRATIONS
-            if not self._is_disabled_integration(integration)
-        ]
+        if self.full_tests_needed or self._is_canary_run():
+            # All tests are running - exercise every core integration.
+            selected = list(TESTABLE_CORE_INTEGRATIONS)
+        else:
+            # Otherwise only run a core integration when its corresponding core sources changed.
+            selected = [
+                integration
+                for integration in TESTABLE_CORE_INTEGRATIONS
+                if self._should_be_run(TESTABLE_CORE_INTEGRATION_FILE_GROUPS[integration])
+            ]
+        return [integration for integration in selected if not self._is_disabled_integration(integration)]
 
     @cached_property
     def testable_providers_integrations(self) -> list[str]:
         if not self.run_unit_tests:
             return []
-        return [
-            integration
-            for integration in TESTABLE_PROVIDERS_INTEGRATIONS
-            if not self._is_disabled_integration(integration)
-        ]
+        if self.full_tests_needed or self._is_canary_run():
+            # All tests are running - exercise every provider integration.
+            selected = list(TESTABLE_PROVIDERS_INTEGRATIONS)
+        else:
+            # Otherwise only run a provider integration when its owning provider is affected.
+            affected_providers = self._find_all_providers_affected(include_docs=False)
+            if isinstance(affected_providers, AllProvidersSentinel):
+                selected = list(TESTABLE_PROVIDERS_INTEGRATIONS)
+            elif affected_providers:
+                affected_set = set(affected_providers)
+                selected = [
+                    integration
+                    for integration in TESTABLE_PROVIDERS_INTEGRATIONS
+                    if TESTABLE_PROVIDERS_INTEGRATION_OWNERS.get(integration) in affected_set
+                ]
+            else:
+                # No providers affected by the change.
+                selected = []
+        return [integration for integration in selected if not self._is_disabled_integration(integration)]
 
     @cached_property
     def is_committer_build(self):

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3223,8 +3223,13 @@ def test_testable_core_integrations_excludes_disabled():
             commit_ref=NEUTRAL_COMMIT,
             github_event=GithubEvents.PULL_REQUEST,
         )
-        with patch.object(
-            SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+        with (
+            patch.object(
+                SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+            ),
+            patch.object(
+                SelectiveChecks, "full_tests_needed", new_callable=lambda: property(lambda self: True)
+            ),
         ):
             result = selective_checks_amd.testable_core_integrations
             assert "postgres" in result
@@ -3242,8 +3247,15 @@ def test_testable_core_integrations_excludes_arm_disabled_on_arm():
             github_event=GithubEvents.SCHEDULE,
             github_context_dict={"ref_name": "main"},
         )
-        with patch.object(
-            SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: '["ubuntu-22.04-arm"]')
+        with (
+            patch.object(
+                SelectiveChecks,
+                "runner_type",
+                new_callable=lambda: property(lambda self: '["ubuntu-22.04-arm"]'),
+            ),
+            patch.object(
+                SelectiveChecks, "full_tests_needed", new_callable=lambda: property(lambda self: True)
+            ),
         ):
             result = selective_checks_arm.testable_core_integrations
             assert "postgres" in result
@@ -3263,8 +3275,13 @@ def test_testable_providers_integrations_excludes_disabled():
             commit_ref=NEUTRAL_COMMIT,
             github_event=GithubEvents.PULL_REQUEST,
         )
-        with patch.object(
-            SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+        with (
+            patch.object(
+                SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+            ),
+            patch.object(
+                SelectiveChecks, "full_tests_needed", new_callable=lambda: property(lambda self: True)
+            ),
         ):
             result = selective_checks_amd.testable_providers_integrations
             assert "postgres" in result
@@ -3283,13 +3300,72 @@ def test_testable_providers_integrations_excludes_arm_disabled_on_arm():
             github_event=GithubEvents.SCHEDULE,
             github_context_dict={"ref_name": "main"},
         )
-        with patch.object(
-            SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: '["ubuntu-22.04-arm"]')
+        with (
+            patch.object(
+                SelectiveChecks,
+                "runner_type",
+                new_callable=lambda: property(lambda self: '["ubuntu-22.04-arm"]'),
+            ),
+            patch.object(
+                SelectiveChecks, "full_tests_needed", new_callable=lambda: property(lambda self: True)
+            ),
         ):
             result = selective_checks_arm.testable_providers_integrations
             assert "postgres" in result
             assert "trino" not in result
             assert "ydb" not in result
+
+
+@pytest.mark.parametrize(
+    ("changed_file", "expected_integration"),
+    [
+        pytest.param("airflow-core/src/airflow/security/kerberos.py", "kerberos", id="kerberos-source"),
+        pytest.param("airflow-core/src/airflow/observability/stats.py", "otel", id="otel-source"),
+        pytest.param("airflow-core/src/airflow/executors/executor_loader.py", "redis", id="celery-source"),
+    ],
+)
+def test_testable_core_integrations_gated_by_source(changed_file, expected_integration):
+    """A core integration is only emitted when its corresponding core source group changed."""
+    selective_checks = SelectiveChecks(
+        files=(changed_file,),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+    )
+    with patch.object(
+        SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+    ):
+        result = selective_checks.testable_core_integrations
+        assert result == [expected_integration]
+
+
+def test_testable_core_integrations_empty_when_unrelated_source():
+    """Unrelated core changes emit no core integrations (no full-tests / canary trigger)."""
+    selective_checks = SelectiveChecks(
+        files=("airflow-core/src/airflow/models/taskinstance.py",),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+    )
+    with patch.object(
+        SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+    ):
+        assert selective_checks.testable_core_integrations == []
+
+
+def test_testable_providers_integrations_gated_by_affected_provider():
+    """A provider integration is only emitted when its owning provider is affected."""
+    selective_checks = SelectiveChecks(
+        files=("providers/apache/cassandra/src/airflow/providers/apache/cassandra/hooks/cassandra.py",),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+    )
+    with patch.object(
+        SelectiveChecks, "runner_type", new_callable=lambda: property(lambda self: PUBLIC_AMD_RUNNERS)
+    ):
+        result = selective_checks.testable_providers_integrations
+        assert "cassandra" in result
+        # Unrelated integrations whose providers are not affected must be absent.
+        assert "mongo" not in result
+        assert "ydb" not in result
 
 
 def test_individual_providers_excludes_platform_excluded_on_arm():


### PR DESCRIPTION
Previously breeze `selective-checks` emitted the **full** list of testable core
and provider integrations on any run where unit tests run, so a PR touching a
single provider still spun up every integration-system-test service (kerberos,
otel, redis, celery, mongo, trino, ...), wasting CI capacity.

This narrows the emitted integrations:

- **All-tests / canary runs** (full tests needed, scheduled, push, workflow
  dispatch) still emit every testable integration — no change.
- **Provider integrations** are emitted only when the integration's owning
  provider is among the affected providers of the change (new
  `TESTABLE_PROVIDERS_INTEGRATION_OWNERS` mapping).
- **Core integrations** `kerberos` / `otel` / `redis` are emitted only when their
  corresponding core source group changed — new `KERBEROS_FILES`, `OTEL_FILES`
  and `CELERY_FILES` file groups. `redis` maps to the core executor sources
  (redis is celery's broker/result backend).

CI-disabled and ARM-disabled filtering is preserved across all branches.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)