### PR TITLE
Test connections via workers instead of the API server

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -53,9 +53,6 @@
     "testError": {
       "title": "Test Connection Failed"
     },
-    "testInProgress": {
-      "title": "A connection test is already in progress"
-    },
     "testSuccess": {
       "title": "Test Connection Successful"
     },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/admin.json
@@ -53,6 +53,9 @@
     "testError": {
       "title": "Test Connection Failed"
     },
+    "testInProgress": {
+      "title": "A connection test is already in progress"
+    },
     "testSuccess": {
       "title": "Test Connection Successful"
     },

--- a/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.test.tsx
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConnectionResponse } from "openapi/requests/types.gen";
 import type * as ComponentsUi from "src/components/ui";
+import type * as Utils from "src/utils";
 import { Wrapper } from "src/utils/Wrapper";
 
 import TestConnectionButton from "./TestConnectionButton";
@@ -44,6 +45,12 @@ vi.mock("openapi/queries", () => ({
 vi.mock("src/queries/useConfig", () => ({
   useConfig: vi.fn(() => configValue),
 }));
+
+vi.mock("src/utils", async () => {
+  const actual = await vi.importActual<typeof Utils>("src/utils");
+
+  return { ...actual, useAutoRefresh: vi.fn(() => 2000) };
+});
 
 vi.mock("src/components/ui", async () => {
   const actual = await vi.importActual<typeof ComponentsUi>("src/components/ui");
@@ -120,14 +127,21 @@ describe("TestConnectionButton", () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it("shows an in-progress toast when an active test already exists (409)", () => {
+  it("shows the server error message when enqueuing fails", () => {
     renderButton();
 
     fireEvent.click(screen.getByRole("button"));
-    enqueueOptions.onError({ status: 409 });
+    enqueueOptions.onError({
+      message: "An active connection test already exists for connection_id `my_conn`.",
+      status: 409,
+    });
 
     expect(create).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "connections.testInProgress.title", type: "error" }),
+      expect.objectContaining({
+        description: "An active connection test already exists for connection_id `my_conn`.",
+        title: "connections.testError.title",
+        type: "error",
+      }),
     );
   });
 

--- a/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.test.tsx
@@ -1,0 +1,140 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ConnectionResponse } from "openapi/requests/types.gen";
+import type * as ComponentsUi from "src/components/ui";
+import { Wrapper } from "src/utils/Wrapper";
+
+import TestConnectionButton from "./TestConnectionButton";
+
+const { create, mutate } = vi.hoisted(() => ({ create: vi.fn(), mutate: vi.fn() }));
+
+let enqueueOptions: { onError: (error: unknown) => void; onSuccess: (response: { token: string }) => void };
+let testStatus: { result_message?: string | null; state: string } | undefined;
+let configValue = "Enabled";
+
+vi.mock("openapi/queries", () => ({
+  useConnectionServiceEnqueueConnectionTest: vi.fn((options: typeof enqueueOptions) => {
+    enqueueOptions = options;
+
+    return { isPending: false, mutate };
+  }),
+  useConnectionServiceGetConnectionTest: vi.fn(() => ({ data: testStatus })),
+}));
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: vi.fn(() => configValue),
+}));
+
+vi.mock("src/components/ui", async () => {
+  const actual = await vi.importActual<typeof ComponentsUi>("src/components/ui");
+
+  return { ...actual, toaster: { create } };
+});
+
+const connection = {
+  conn_type: "http",
+  connection_id: "my_conn",
+  description: "",
+  extra: "{}",
+  host: "example.com",
+  login: "",
+  password: "",
+  port: 443,
+  schema: "",
+} as ConnectionResponse;
+
+const renderButton = () => render(<TestConnectionButton connection={connection} />, { wrapper: Wrapper });
+
+describe("TestConnectionButton", () => {
+  beforeEach(() => {
+    testStatus = undefined;
+    configValue = "Enabled";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues a worker test on click", () => {
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(mutate).toHaveBeenCalledWith({
+      requestBody: {
+        conn_type: "http",
+        connection_id: "my_conn",
+        description: "",
+        extra: "{}",
+        host: "example.com",
+        login: "",
+        password: "",
+        port: 443,
+        schema: "",
+      },
+    });
+  });
+
+  it("shows a success toast when the test reaches a success state", () => {
+    testStatus = { result_message: "It works", state: "success" };
+    renderButton();
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "It works", type: "success" }),
+    );
+  });
+
+  it("shows an error toast when the test reaches a failed state", () => {
+    testStatus = { result_message: "Connection refused", state: "failed" };
+    renderButton();
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Connection refused", type: "error" }),
+    );
+  });
+
+  it("does not toast while the test is still running", () => {
+    testStatus = { state: "running" };
+    renderButton();
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("shows an in-progress toast when an active test already exists (409)", () => {
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button"));
+    enqueueOptions.onError({ status: 409 });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "connections.testInProgress.title", type: "error" }),
+    );
+  });
+
+  it("is disabled when the feature is turned off", () => {
+    configValue = "Disabled";
+    renderButton();
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.tsx
@@ -60,7 +60,7 @@ const TestConnectionButton = ({ connection }: Props) => {
     schema: connection.schema ?? "",
   };
 
-  const { isPending, test } = useTestConnection((result) => {
+  const { isPending, mutate } = useTestConnection((result) => {
     if (result === undefined) {
       setIcon(defaultIcon);
     } else if (result) {
@@ -79,7 +79,7 @@ const TestConnectionButton = ({ connection }: Props) => {
       label={label}
       loading={isPending}
       onClick={() => {
-        test(connectionBody);
+        mutate(connectionBody);
       }}
     >
       {icon}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/TestConnectionButton.tsx
@@ -60,10 +60,10 @@ const TestConnectionButton = ({ connection }: Props) => {
     schema: connection.schema ?? "",
   };
 
-  const { isPending, mutate } = useTestConnection((result) => {
+  const { isPending, test } = useTestConnection((result) => {
     if (result === undefined) {
       setIcon(defaultIcon);
-    } else if (result === true) {
+    } else if (result) {
       setIcon(connectedIcon);
     } else {
       setIcon(disconnectedIcon);
@@ -79,7 +79,7 @@ const TestConnectionButton = ({ connection }: Props) => {
       label={label}
       loading={isPending}
       onClick={() => {
-        mutate({ requestBody: connectionBody });
+        test(connectionBody);
       }}
     >
       {icon}

--- a/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
@@ -23,31 +23,25 @@ import {
   useConnectionServiceEnqueueConnectionTest,
   useConnectionServiceGetConnectionTest,
 } from "openapi/queries";
-import type { ApiError } from "openapi/requests";
 import type { ConnectionTestRequestBody } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
+import { createErrorToaster, useAutoRefresh } from "src/utils";
 
 type ConnectionStatus = boolean | undefined;
 
 const ACTIVE_STATES = new Set(["pending", "queued", "running"]);
-const POLL_INTERVAL = 2000;
 
 const isActive = (state: string | undefined) => state !== undefined && ACTIVE_STATES.has(state);
 
 export const useTestConnection = (setConnected: (status: ConnectionStatus) => void) => {
   const { t: translate } = useTranslation("admin");
   const [token, setToken] = useState<string | undefined>(undefined);
+  const refetchInterval = useAutoRefresh({});
 
   const enqueue = useConnectionServiceEnqueueConnectionTest({
     onError: (error) => {
       setConnected(false);
-      toaster.create({
-        title:
-          (error as ApiError).status === 409
-            ? translate("connections.testInProgress.title")
-            : translate("connections.testError.title"),
-        type: "error",
-      });
+      createErrorToaster(error, { titleKey: "connections.testError.title" }, translate);
     },
     onSuccess: (response) => {
       setToken(response.token);
@@ -59,7 +53,7 @@ export const useTestConnection = (setConnected: (status: ConnectionStatus) => vo
     undefined,
     {
       enabled: token !== undefined,
-      refetchInterval: (query) => (isActive(query.state.data?.state) ? POLL_INTERVAL : false),
+      refetchInterval: (query) => isActive(query.state.data?.state) && refetchInterval,
     },
   );
 
@@ -85,12 +79,12 @@ export const useTestConnection = (setConnected: (status: ConnectionStatus) => vo
     setToken(undefined);
   }, [state, resultMessage, setConnected, translate]);
 
-  const test = (requestBody: ConnectionTestRequestBody) => {
+  const mutate = (requestBody: ConnectionTestRequestBody) => {
     setConnected(undefined);
     enqueue.mutate({ requestBody });
   };
 
   const isPending = enqueue.isPending || (token !== undefined && (state === undefined || isActive(state)));
 
-  return { isPending, test };
+  return { isPending, mutate };
 };

--- a/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useTestConnection.ts
@@ -16,39 +16,81 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useConnectionServiceTestConnection } from "openapi/queries";
-import type { ConnectionTestResponse } from "openapi/requests/types.gen";
+import {
+  useConnectionServiceEnqueueConnectionTest,
+  useConnectionServiceGetConnectionTest,
+} from "openapi/queries";
+import type { ApiError } from "openapi/requests";
+import type { ConnectionTestRequestBody } from "openapi/requests/types.gen";
 import { toaster } from "src/components/ui";
 
-export const useTestConnection = (setConnected: Dispatch<SetStateAction<boolean | undefined>>) => {
-  const { t: translate } = useTranslation("admin");
+type ConnectionStatus = boolean | undefined;
 
-  const onSuccess = (res: ConnectionTestResponse) => {
-    setConnected(res.status);
-    if (res.status) {
+const ACTIVE_STATES = new Set(["pending", "queued", "running"]);
+const POLL_INTERVAL = 2000;
+
+const isActive = (state: string | undefined) => state !== undefined && ACTIVE_STATES.has(state);
+
+export const useTestConnection = (setConnected: (status: ConnectionStatus) => void) => {
+  const { t: translate } = useTranslation("admin");
+  const [token, setToken] = useState<string | undefined>(undefined);
+
+  const enqueue = useConnectionServiceEnqueueConnectionTest({
+    onError: (error) => {
+      setConnected(false);
       toaster.create({
-        description: res.message,
-        title: translate("connections.testSuccess.title"),
-        type: "success",
-      });
-    } else {
-      toaster.create({
-        description: res.message,
-        title: translate("connections.testError.title"),
+        title:
+          (error as ApiError).status === 409
+            ? translate("connections.testInProgress.title")
+            : translate("connections.testError.title"),
         type: "error",
       });
-    }
-  };
-
-  const onError = () => {
-    setConnected(false);
-  };
-
-  return useConnectionServiceTestConnection({
-    onError,
-    onSuccess,
+    },
+    onSuccess: (response) => {
+      setToken(response.token);
+    },
   });
+
+  const { data } = useConnectionServiceGetConnectionTest(
+    { airflowConnectionTestToken: token ?? "" },
+    undefined,
+    {
+      enabled: token !== undefined,
+      refetchInterval: (query) => (isActive(query.state.data?.state) ? POLL_INTERVAL : false),
+    },
+  );
+
+  const state = data?.state;
+  const resultMessage = data?.result_message;
+
+  useEffect(() => {
+    if (state === undefined || isActive(state)) {
+      return;
+    }
+
+    const succeeded = state === "success";
+
+    setConnected(succeeded);
+    toaster.create({
+      description: resultMessage ?? undefined,
+      title: succeeded
+        ? translate("connections.testSuccess.title")
+        : translate("connections.testError.title"),
+      type: succeeded ? "success" : "error",
+    });
+
+    setToken(undefined);
+  }, [state, resultMessage, setConnected, translate]);
+
+  const test = (requestBody: ConnectionTestRequestBody) => {
+    setConnected(undefined);
+    enqueue.mutate({ requestBody });
+  };
+
+  const isPending = enqueue.isPending || (token !== undefined && (state === undefined || isActive(state)));
+
+  return { isPending, test };
 };


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Follow-up to #62343, which moved connection testing to workers but left the UI on the old sync endpoint.

This wires the Connections "Test" button to the new worker flow: enqueue the test, then poll until it finishes. The result shows up as a toast (with the worker's message) and the usual green/red icon. Clicking Test while one is already running shows an "already in progress" message.

related: #62343

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=af35cfc action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @anishgirianish → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @anishgirianish — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->