### PR TITLE
Exclude auto-generated REST API reference from docs spell-check

### DIFF
--- a/airflow-core/docs/conf.py
+++ b/airflow-core/docs/conf.py
@@ -350,7 +350,11 @@ redirects_file = "redirects.txt"
 
 # -- Options for sphinxcontrib-spelling ----------------------------------------
 spelling_word_list_filename = [SPELLING_WORDLIST_PATH.as_posix()]
-spelling_exclude_patterns = ["project.rst", "changelog.rst"]
+# ``stable-rest-api-ref.rst`` renders the OpenAPI spec via the ``swagger-plugin``
+# directive. Its content is machine-generated (camelCase URL path segments,
+# operationIds, JSON-Schema keywords such as ``oneOf``), not prose, so spell-checking
+# it only produces false positives that re-break the build on every new endpoint.
+spelling_exclude_patterns = ["project.rst", "changelog.rst", "stable-rest-api-ref.rst"]
 
 spelling_ignore_contributor_names = False
 spelling_ignore_importable_modules = True


### PR DESCRIPTION
The `stable-rest-api-ref` page renders the OpenAPI spec via the `swagger-plugin` directive (recently migrated from redoc). Spell-checking the rendered output flags machine-generated tokens — camelCase URL path segments (`dagRuns`, `taskInstances`, `hitlDetails`, …), operationIds, and JSON-Schema keywords like `oneOf` — as misspellings (127 false positives), breaking the docs build whenever new endpoints are added.

Exclude the page from spell-check, the same way the other generated pages (`project.rst`, `changelog.rst`) already are.

This surfaced in the full docs build on the CI-upgrade PR #68062; this fix unblocks it.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)