### PR TITLE
Fix LatestBoto CI stuck at boto3 1.38.2 (below provider minimum)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1400,11 +1400,11 @@ function check_boto_upgrade() {
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs || true
 
-    # Urllib 2.6.0 breaks kubernetes client because kubernetes client uses deprecated in 2.0.0 and
-    # removed in 2.6.0 `getheaders()` call (instead of `headers` property.
+    # Urllib 2.6.0 broke kubernetes client by removing getheaders() (restored in 2.6.1+).
+    # Exclude exactly 2.6.0; any other version is fine.
     # Tracked in https://github.com/kubernetes-client/python/issues/2477
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade "boto3<1.38.3" "botocore<1.38.3" "urllib3<2.6.0"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade "boto3" "botocore" "urllib3!=2.6.0"
 }
 
 function check_upgrade_sqlalchemy() {

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -324,11 +324,11 @@ function check_boto_upgrade() {
     # shellcheck disable=SC2086
     ${PACKAGING_TOOL_CMD} uninstall ${EXTRA_UNINSTALL_FLAGS} aiobotocore s3fs || true
 
-    # Urllib 2.6.0 breaks kubernetes client because kubernetes client uses deprecated in 2.0.0 and
-    # removed in 2.6.0 `getheaders()` call (instead of `headers` property.
+    # Urllib 2.6.0 broke kubernetes client by removing getheaders() (restored in 2.6.1+).
+    # Exclude exactly 2.6.0; any other version is fine.
     # Tracked in https://github.com/kubernetes-client/python/issues/2477
     # shellcheck disable=SC2086
-    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade "boto3<1.38.3" "botocore<1.38.3" "urllib3<2.6.0"
+    ${PACKAGING_TOOL_CMD} install ${EXTRA_INSTALL_FLAGS} --upgrade "boto3" "botocore" "urllib3!=2.6.0"
 }
 
 # Upgrade sqlalchemy to the latest version to run tests with it


### PR DESCRIPTION
The `check_boto_upgrade()` function in `scripts/docker/entrypoint_ci.sh` was capping
boto3/botocore at `<1.38.3` to avoid urllib3 2.6.0 being pulled in (it had removed
`getheaders()`, breaking the kubernetes client).

Since then:
- urllib3 2.6.1+ restored `getheaders()` — the bug was only in exactly 2.6.0
- `kubernetes-tests/pyproject.toml` and `providers/cncf/kubernetes/pyproject.toml` were
  already updated to `urllib3!=2.6.0` (PR #59203)
- The amazon provider minimum was bumped to `boto3>=1.41.0`

But `entrypoint_ci.sh` was not updated, leaving the LatestBoto CI job installing
**boto3 1.38.2**, which:
1. Is **below** the amazon provider's declared minimum (`boto3>=1.41.0`)
2. Predates the `bedrock-agentcore-control` / `bedrock-agentcore` services being added
   to botocore, causing spurious test failures for any operators that use those services
   (e.g. PR #67984, spotted via run https://github.com/apache/airflow/actions/runs/27028907135/job/79778239095)

## Change

Remove the `boto3<1.38.3` / `botocore<1.38.3` upper bounds and change
`urllib3<2.6.0` → `urllib3!=2.6.0`, consistent with what the rest of the repo
already does.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

Generated-by: Claude Code (Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)