### PR TITLE
Add Zomato to INTHEWILD.md

### DIFF
--- a/INTHEWILD.md
+++ b/INTHEWILD.md
@@ -594,6 +594,7 @@ Currently, **officially** using Airflow:
 1. [Zendesk](https://www.github.com/zendesk)
 1. [Zenly](https://zen.ly) [[@cerisier](https://github.com/cerisier) & [@jbdalido](https://github.com/jbdalido)]
 1. [Zerodha](https://zerodha.com/) [[@johnnybravo-xyz](https://github.com/johnnybravo-xyz)]
+1. [Zomato](https://www.zomato.com/) [[@zomato](https://github.com/zomato)]
 1. [Zymergen](https://www.zymergen.com/)
 1. [Zynga](https://www.zynga.com)
 1. [Ørsted](https://orsted.com/en) [[@arjunanan6](https://github.com/arjunanan6)]


### PR DESCRIPTION
Adds Zomato to the list of organizations using Apache Airflow in INTHEWILD.md.

Entry is placed alphabetically between Zerodha and Zymergen.

Closes #12012