### PR TITLE
fix non-ASCII DAG/TaskGroup names with OTel metrics enabled

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -103,7 +103,19 @@ def name_is_otel_safe(prefix: str, name: str) -> bool:
     Legal names are defined here:
     https://opentelemetry.io/docs/reference/specification/metrics/api/#instrument-name-syntax
     """
-    return bool(stat_name_otel_handler(prefix, name, max_length=OTEL_NAME_MAX_LENGTH))
+    #return bool(stat_name_otel_handler(prefix, name, max_length=OTEL_NAME_MAX_LENGTH))
+
+    # stat_name_otel_handler() raises InvalidStatsNameException for names that
+    # contain non-ASCII characters (e.g. TaskGroup IDs with ç, ã, ö, é …).
+    # This function is declared -> bool, so it must NEVER raise; callers such
+    # as SafeOtelLogger.timing() rely on the False return to silently skip the
+    # metric emission.  Without this guard the exception propagates into the
+    # scheduler's critical section and causes CrashLoopBackOff.
+    # See: https://github.com/apache/airflow/issues/68018
+    try:
+        return bool(stat_name_otel_handler(prefix, name, max_length=OTEL_NAME_MAX_LENGTH))
+    except InvalidStatsNameException:
+        return False
 
 
 def _type_as_str(obj: Instrument) -> str:

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -43,6 +43,7 @@ from .validators import (
     get_validator,
     stat_name_otel_handler,
 )
+from ..exceptions import InvalidStatsNameException
 
 if TYPE_CHECKING:
     from opentelemetry.metrics import Instrument
@@ -103,8 +104,6 @@ def name_is_otel_safe(prefix: str, name: str) -> bool:
     Legal names are defined here:
     https://opentelemetry.io/docs/reference/specification/metrics/api/#instrument-name-syntax
     """
-    #return bool(stat_name_otel_handler(prefix, name, max_length=OTEL_NAME_MAX_LENGTH))
-
     # stat_name_otel_handler() raises InvalidStatsNameException for names that
     # contain non-ASCII characters (e.g. TaskGroup IDs with ç, ã, ö, é …).
     # This function is declared -> bool, so it must NEVER raise; callers such

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -37,6 +37,7 @@ from airflow_shared.observability.metrics.otel_logger import (
     _generate_key_name,
     _is_up_down_counter,
     full_name,
+    name_is_otel_safe,
     get_otel_logger,
 )
 from airflow_shared.observability.metrics.validators import (
@@ -541,3 +542,30 @@ def mock_service_run_reinit():
     # Second init — simulates post-fork re-initialization
     logger = get_otel_logger(debug=True)
     logger.incr("post_fork_stat")
+
+
+class TestNameIsOtelSafe:
+    """Regression tests for name_is_otel_safe() — must never raise, only return bool."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "dag.lista_preços.run_pipeline.scheduled_duration",  
+            "dag.tâche.duration",                               
+            "dag.über_dag.queued_duration",                     
+        ],
+    )
+    def test_non_ascii_name_returns_false_not_raises(self, name):
+        """Non-ASCII names must return False, never raise. Regression for #68018."""
+        assert name_is_otel_safe("airflow", name) is False
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "dag.my_dag.my_task.duration",
+            "scheduler.heartbeat",
+        ],
+    )
+    def test_valid_ascii_name_returns_true(self, name):
+        """Valid ASCII names must still return True — no regression."""
+        assert name_is_otel_safe("airflow", name) is True


### PR DESCRIPTION
Fixes #68018

Addresses all points raised in the previous review:

- Added missing `from ..exceptions import InvalidStatsNameException` so the `except` clause in `name_is_otel_safe()` correctly catches the exception instead of raising `NameError`
- Added `TestNameIsOtelSafe` regression tests — non-ASCII names return `False` without raising, valid ASCII names still return `True`
- Imported `name_is_otel_safe` in the test file so the new tests can run

<!-- pr-triage-fold: triaged=2026-06-12T09:36:35Z head=032058d action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @bujjibabukatta** · by `@potiuk` · 2026-06-12 09:36 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Unit tests** — [how to fix](https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst)
> - :x: **Pre-commit / static checks** — [how to fix](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst)
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->