### PR TITLE
Fix Spark K8s driver pod tracking confusion

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -53,6 +53,9 @@ DEFAULT_SPARK_BINARY = "spark-submit"
 ALLOWED_SPARK_BINARIES = [DEFAULT_SPARK_BINARY, "spark2-submit", "spark3-submit"]
 
 _K8S_WAIT_APP_COMPLETION_CONF = "spark.kubernetes.submission.waitAppCompletion"
+_K8S_DRIVER_POD_NAME_REGEX = re.compile(
+    r"(?:^|\s)submission ID spark:([a-z0-9](?:[-a-z0-9]*[a-z0-9])?-driver)(?=\s|$)"
+)
 
 
 class SparkSubmitHook(BaseHook, LoggingMixin):
@@ -841,7 +844,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     self._kubernetes_driver_pod = match_driver_pod.group(1)
                     self.log.info("Identified spark driver pod: %s", self._kubernetes_driver_pod)
                 if not self._kubernetes_driver_pod:
-                    match_submission_id = re.search(r"submission ID spark:(.+?-driver)", line)
+                    match_submission_id = _K8S_DRIVER_POD_NAME_REGEX.search(line)
                     if match_submission_id:
                         self._kubernetes_driver_pod = match_submission_id.group(1)
                         self.log.info("Identified spark driver pod: %s", self._kubernetes_driver_pod)
@@ -1141,11 +1144,10 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     consecutive_api_errors = 0
                 except kube_client.ApiException as e:
                     if e.status == 404:
-                        self.log.info(
-                            "Driver pod %s not found (404); pod was likely deleted by on_kill. Exiting poll loop.",
-                            pod_name,
-                        )
-                        return
+                        raise RuntimeError(
+                            f"K8s driver pod {pod_name} was not found while polling {app_id}; "
+                            "cannot determine Spark application status."
+                        ) from e
                     consecutive_api_errors += 1
                     self.log.warning(
                         "ApiException polling pod %s (%d/%d): %s",

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -1144,10 +1144,11 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     consecutive_api_errors = 0
                 except kube_client.ApiException as e:
                     if e.status == 404:
-                        raise RuntimeError(
-                            f"K8s driver pod {pod_name} was not found while polling {app_id}; "
-                            "cannot determine Spark application status."
-                        ) from e
+                        self.log.info(
+                            "Driver pod %s not found (404); pod was likely deleted by on_kill. Exiting poll loop.",
+                            pod_name,
+                        )
+                        return
                     consecutive_api_errors += 1
                     self.log.warning(
                         "ApiException polling pod %s (%d/%d): %s",

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -941,17 +941,24 @@ class TestSparkSubmitHook:
         # Then
         assert hook._spark_exit_code == 999
 
-    def test_process_spark_submit_log_k8s_submission_id_format(self):
+    @pytest.mark.parametrize(
+        "pod_name",
+        [
+            "arrow-spark-c8e2e29e73db9c93-driver",
+            "victim-driver-foo-abc-driver",
+        ],
+    )
+    def test_process_spark_submit_log_k8s_submission_id_format(self, pod_name):
         hook = SparkSubmitHook(conn_id="spark_k8s_cluster")
         log_lines = [
-            "INFO Client: Deployed Spark application arrow-spark with application ID "
+            f"INFO Client: Deployed Spark application {pod_name.removesuffix('-driver')} with application ID "
             "spark-1e22d65826b74ac2927249b0e607ed54 and submission ID "
-            "spark:arrow-spark-c8e2e29e73db9c93-driver into Kubernetes",
+            f"spark:{pod_name} into Kubernetes",
         ]
 
         hook._process_spark_submit_log(log_lines)
 
-        assert hook._kubernetes_driver_pod == "arrow-spark-c8e2e29e73db9c93-driver"
+        assert hook._kubernetes_driver_pod == pod_name
 
     def test_process_spark_client_mode_submit_log_k8s(self):
         # Given
@@ -1589,8 +1596,8 @@ class TestSparkSubmitHook:
         assert mock_client.read_namespaced_pod.call_count == 3
 
     @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
-    def test_poll_k8s_driver_exits_cleanly_on_404(self, mock_get_client):
-        """404 from read_namespaced_pod means pod was deleted by on_kill — should return cleanly, not raise."""
+    def test_poll_k8s_driver_raises_on_404(self, mock_get_client):
+        """404 from read_namespaced_pod means the submitted driver cannot be tracked."""
         hook = SparkSubmitHook(conn_id="spark_k8s_cluster", track_driver_via_k8s_api=True)
         hook._kubernetes_driver_pod = "spark-app-abc-driver"
         hook._kubernetes_application_id = "spark-abc"
@@ -1598,7 +1605,8 @@ class TestSparkSubmitHook:
         mock_client = mock_get_client.return_value
         mock_client.read_namespaced_pod.side_effect = kube_client.ApiException(status=404, reason="Not Found")
 
-        hook._poll_k8s_driver_via_api()
+        with pytest.raises(RuntimeError, match="was not found"):
+            hook._poll_k8s_driver_via_api()
 
         mock_client.delete_namespaced_pod.assert_not_called()
 

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -1596,8 +1596,8 @@ class TestSparkSubmitHook:
         assert mock_client.read_namespaced_pod.call_count == 3
 
     @patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
-    def test_poll_k8s_driver_raises_on_404(self, mock_get_client):
-        """404 from read_namespaced_pod means the submitted driver cannot be tracked."""
+    def test_poll_k8s_driver_exits_cleanly_on_404(self, mock_get_client):
+        """404 from read_namespaced_pod means pod was deleted by on_kill — should return cleanly, not raise."""
         hook = SparkSubmitHook(conn_id="spark_k8s_cluster", track_driver_via_k8s_api=True)
         hook._kubernetes_driver_pod = "spark-app-abc-driver"
         hook._kubernetes_application_id = "spark-abc"
@@ -1605,8 +1605,7 @@ class TestSparkSubmitHook:
         mock_client = mock_get_client.return_value
         mock_client.read_namespaced_pod.side_effect = kube_client.ApiException(status=404, reason="Not Found")
 
-        with pytest.raises(RuntimeError, match="was not found"):
-            hook._poll_k8s_driver_via_api()
+        hook._poll_k8s_driver_via_api()
 
         mock_client.delete_namespaced_pod.assert_not_called()
 


### PR DESCRIPTION
Harden Kubernetes Spark driver pod tracking by strictly parsing the full driver pod name from submission ID spark:... output, so an app name containing -driver is not truncated. For example, spark:my-driver-app-abc-driver now resolves to the full my-driver-app-abc-driver pod name instead of incorrectly stopping at my-driver. Polling also now fails on pod 404 instead of treating the missing pod as a clean exit, preventing false success and unintended pod operations.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
- copilot

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
