### PR TITLE
[v3-2-test] Updated verbiage for backfill runs being deprioritized (#67338)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -14,6 +14,7 @@
     "permissionDenied": "Dry Run Failed: User does not have permission to create backfills.",
     "reprocessBehavior": "Reprocess Behavior",
     "run": "Run Backfill",
+    "schedulerPriorityHint": "Backfill Dag runs are ordered after non-backfill Dag runs in each scheduler cycle. Backfill runs may remain queued longer if other non-backfill runs are present.",
     "selectDescription": "Run this Dag for a range of dates",
     "selectLabel": "Backfill",
     "title": "Run Backfill",

--- a/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Banner/BackfillBanner.tsx
@@ -19,7 +19,7 @@
 import { Box, Button, HStack, Spacer, Text, type ButtonProps } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { MdPause, MdPlayArrow, MdStop } from "react-icons/md";
+import { MdInfo, MdPause, MdPlayArrow, MdStop } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 
 import {
@@ -30,6 +30,7 @@ import {
   useBackfillServiceUnpauseBackfill,
 } from "openapi/queries";
 import type { BackfillResponse } from "openapi/requests/types.gen";
+import { Tooltip } from "src/components/ui";
 import { useAutoRefresh } from "src/utils";
 
 import Time from "../Time";
@@ -107,6 +108,11 @@ const BackfillBanner = ({ dagId }: Props) => {
       <HStack alignItems="center" ml={3}>
         <RiArrowGoBackFill />
         <Text key="backfill">{translate("banner.backfillInProgress")}:</Text>
+        <Tooltip content={translate("backfill.schedulerPriorityHint")} showArrow>
+          <span>
+            <MdInfo />
+          </span>
+        </Tooltip>
         <Text fontSize="sm">
           {" "}
           <Time datetime={backfill.from_date} /> - <Time datetime={backfill.to_date} />

--- a/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DagActions/RunBackfillForm.tsx
@@ -149,6 +149,7 @@ const RunBackfillForm = ({ dag, onClose }: RunBackfillFormProps) => {
         <ErrorAlert error={errors.date ?? dryRunError ?? error} />
       )}
       <VStack alignItems="stretch" gap={2} pt={4}>
+        <Alert status="info">{translate("backfill.schedulerPriorityHint")}</Alert>
         <Box>
           <Text fontSize="md" fontWeight="semibold" mb={3}>
             {translate("backfill.dateRange")}


### PR DESCRIPTION
Backport of #67338 to `v3-2-test`.

The automatic backport failed due to a cherry-pick conflict in `en/components.json`: the `scheduleNotBackfillable` translation key that anchors the change on `main` does not exist on `v3-2-test`. Resolved by adding only the `schedulerPriorityHint` key introduced by this PR (the `.tsx` changes reference only that key). Resulting diff is identical to the original PR (3 files, +9/-1).

cherry picked from commit d9d7a568796496eb334c546f2e8a3c8bb8cb3736

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)