### PR TITLE
Add regression tests for pools API with unlimited (-1) slots

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py
@@ -178,6 +178,27 @@ class TestGetPool(TestPoolsEndpoint):
             "team_name": None,
         }
 
+    def test_get_unlimited_pool_should_respond_200(self, test_client, session):
+        """Regression for #65377: an unlimited (-1 slots) pool has open_slots == inf internally; the
+        response must serialize open_slots as -1 and return 200, not 500."""
+        session.add(Pool(pool="unlimited_pool", slots=-1, include_deferred=False))
+        session.commit()
+        response = test_client.get("/pools/unlimited_pool")
+        assert response.status_code == 200
+        assert response.json() == {
+            "deferred_slots": 0,
+            "description": None,
+            "include_deferred": False,
+            "name": "unlimited_pool",
+            "occupied_slots": 0,
+            "open_slots": -1,
+            "queued_slots": 0,
+            "running_slots": 0,
+            "scheduled_slots": 0,
+            "slots": -1,
+            "team_name": None,
+        }
+
 
 class TestGetPools(TestPoolsEndpoint):
     @pytest.mark.parametrize(
@@ -237,6 +258,17 @@ class TestGetPools(TestPoolsEndpoint):
 
         assert body["total_entries"] == 2
         assert [pool["name"] for pool in body["pools"]] == [Pool.DEFAULT_POOL_NAME, POOL1_NAME]
+
+    def test_get_pools_with_unlimited_pool_should_respond_200(self, test_client, session):
+        """Regression for #65377: listing pools that include an unlimited (-1 slots) pool must serialize
+        open_slots as -1 through the collection serializer and return 200, not 500."""
+        session.add(Pool(pool="unlimited_pool", slots=-1, include_deferred=False))
+        session.commit()
+        response = test_client.get("/pools")
+        assert response.status_code == 200
+        pools = {pool["name"]: pool for pool in response.json()["pools"]}
+        assert pools["unlimited_pool"]["slots"] == -1
+        assert pools["unlimited_pool"]["open_slots"] == -1
 
 
 class TestPatchPool(TestPoolsEndpoint):


### PR DESCRIPTION
## What

Adds two regression tests to `airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_pools.py` covering the **GET single** (`GET /pools/{name}`) and **GET list** (`GET /pools`) paths for a pool with unlimited (`-1`) slots. Test-only change — no production code is modified.

## Why

The pools REST endpoints used to 500 when a pool had unlimited/infinite slots (#65377): internally `open_slots` is `inf`, which fails the response-schema `integer` validation. That bug is already fixed on `main` by #61140, which added a `_sanitize_open_slots` validator (`airflow-core/src/airflow/api_fastapi/core_api/datamodels/pools.py`) that maps `open_slots` from `inf` to `-1` on `PoolResponse`.

However, the only existing test for that conversion (`test_post_pool_allows_unlimited_slots`) exercises the **POST** (create) path. The scenario the issue actually reports — *listing pre-existing unlimited pools* — was untested. These tests cover the DB-read (GET single) and collection-serializer (GET list) paths so the conversion cannot silently regress there.

## Impact

No behavior change and no production code change on `main`; this only adds test coverage. The endpoints continue to serialize `open_slots` as `-1` and return `200` for unlimited pools.

## Testing

Two tests added (both seed `Pool(pool="unlimited_pool", slots=-1, include_deferred=False)`):

- `TestGetPool.test_get_unlimited_pool_should_respond_200` — `GET /pools/unlimited_pool` returns `200` and the response body serializes both `slots` and `open_slots` as `-1` (rather than `inf` / a 500).
- `TestGetPools.test_get_pools_with_unlimited_pool_should_respond_200` — `GET /pools` returns `200` and the unlimited pool in the collection has `slots == -1` and `open_slots == -1`, exercising the collection serializer.

closes: #65377

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
