### PR TITLE
Emit scheduler.executor_events_duration per executor

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1851,9 +1851,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 with create_session() as session:
                     num_finished_events = 0
                     for executor in self.executors:
-                        num_finished_events += self._process_executor_events(
-                            executor=executor, session=session
-                        )
+                        with stats.timer(
+                            "scheduler.executor_events_duration",
+                            tags={"executor": type(executor).__name__},
+                        ):
+                            num_finished_events += self._process_executor_events(
+                                executor=executor, session=session
+                            )
 
                 for executor in self.executors:
                     try:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -1387,6 +1387,22 @@ class TestSchedulerJob:
             for executor, timer_call in zip(self.job_runner.executors, heartbeat_calls):
                 assert timer_call.kwargs.get("tags") == {"executor": type(executor).__name__}
 
+    def test_process_executor_events_emits_timer(self, mock_executors, configure_testing_dag_bundle):
+        with configure_testing_dag_bundle(os.devnull):
+            scheduler_job = Job()
+            self.job_runner = SchedulerJobRunner(job=scheduler_job, num_runs=1)
+            with patch("airflow.jobs.scheduler_job_runner.stats.timer") as mock_timer:
+                self.job_runner._execute()
+
+            event_calls = [
+                timer_call
+                for timer_call in mock_timer.call_args_list
+                if timer_call.args and timer_call.args[0] == "scheduler.executor_events_duration"
+            ]
+            assert len(event_calls) == len(self.job_runner.executors)
+            for executor, timer_call in zip(self.job_runner.executors, event_calls):
+                assert timer_call.kwargs.get("tags") == {"executor": type(executor).__name__}
+
     def test_executor_events_processed(self, mock_executors, configure_testing_dag_bundle):
         with configure_testing_dag_bundle(os.devnull):
             scheduler_job = Job()

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -736,6 +736,13 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "scheduler.executor_events_duration"
+    description: "Milliseconds spent in ``_process_executor_events()`` per scheduler loop iteration,
+      tagged by executor class name so each configured executor is reported separately."
+    type: "timer"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "dagrun.first_task_scheduling_delay"
     description: "Milliseconds elapsed between first task start_date and dagrun expected start"
     type: "timer"


### PR DESCRIPTION
## Summary

Wrap `_process_executor_events()` in a per-executor `stats.timer` named `scheduler.executor_events_duration`, tagged by executor class name. In multi-executor deployments, operators can now attribute per-loop event-processing cost to each configured executor instead of seeing it only in the aggregate `scheduler.scheduler_loop_duration`.

This mirrors #66808, which added `scheduler.executor_heartbeat_duration` for `executor.heartbeat()`. The two timers sit side-by-side, so operators can localise which stage of the scheduler loop a given executor is slowing down.

## Why

When the scheduler loop runs long in a multi-executor deployment, `scheduler.scheduler_loop_duration` alone does not tell you which executor's event processing is to blame. A per-executor timer around `_process_executor_events` gives the same granular signal the heartbeat timer already provides — additive, zero-cost when metrics are disabled.

## Test plan

- New unit test `test_process_executor_events_emits_timer` asserts the timer is emitted once per executor with the expected tag.
- Existing `test_executor_heartbeat_emits_timer` still passes.
- `prek run --from-ref main --stage pre-commit` and `--stage manual` clean (excluding host-only mypy/breeze hooks; CI will run them).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Used Cursor
