### PR TITLE
Docs: update FAB auth manager Flask config wording for Airflow 3

### DIFF
--- a/providers/fab/docs/auth-manager/configuring-flask-app.rst
+++ b/providers/fab/docs/auth-manager/configuring-flask-app.rst
@@ -15,12 +15,14 @@
     specific language governing permissions and limitations
     under the License.
 
-Configuring Flask Application for Airflow Webserver
-===================================================
+Configuring the Flask Application for the Airflow UI
+====================================================
 
-``FabAuthManager`` and Airflow 2 plugins uses Flask to render the web UI.When initialized, predefined configuration
-is used, based on the ``webserver`` section of the ``airflow.cfg`` file. You can override these settings
-and add any extra settings by adding flask configuration to ``webserver_config.py`` file specified in ``[fab] config_file`` (by default it is ``$AIRFLOW_HOME/webserver_config.py``). This file is automatically loaded by the webserver.
+``FabAuthManager`` uses Flask to render the Airflow UI. When initialized, it uses predefined
+configuration based on the ``webserver`` section of ``airflow.cfg``. You can override these
+settings and add extra Flask configuration in the ``webserver_config.py`` file specified by
+``[fab] config_file`` (by default ``$AIRFLOW_HOME/webserver_config.py``). This file is
+automatically loaded by the FAB auth manager.
 
 For example if you would like to change rate limit strategy to "moving window", you can set the
 ``RATELIMIT_STRATEGY`` to ``moving-window``.


### PR DESCRIPTION
## Summary

Updates the FAB auth manager Flask configuration docs to use current Airflow 3 terminology.

Specifically, this change:

- renames the page title from "Airflow Webserver" to "Airflow UI"
- removes the outdated reference to "Airflow 2 plugins"
- clarifies that `webserver_config.py` is loaded by the FAB auth manager in this setup

## Why

Airflow 3 moved away from older webserver-era wording in several places, but this page still used terminology that reads like pre-3 documentation. Tightening the wording here should make the page less confusing for users following the current auth-manager docs.

Closes #68159.
