### PR TITLE
Docs: fix removed `airflow webserver` command in FAB SSO guide for Airflow 3

### DIFF
--- a/providers/fab/docs/auth-manager/sso.rst
+++ b/providers/fab/docs/auth-manager/sso.rst
@@ -145,11 +145,11 @@ Configuration Steps
 
    Adjust these values according to your provider's documentation.
 
-5. **Restart Airflow Webserver**
+5. **Restart Airflow API Server**
 
    .. code-block:: bash
 
-      airflow webserver --reload
+      airflow api-server
 
 6. **Test SSO Login**
 


### PR DESCRIPTION
## Summary

Updates the FAB auth manager SSO configuration guide to use current Airflow 3 terminology.

Specifically, this change:

- replaces the outdated `airflow webserver --reload` command (removed in Airflow 3) with `airflow api-server`
- renames the step title from "Restart Airflow Webserver" to "Restart Airflow API Server"

## Why

A user following the SSO setup guide step-by-step would complete all the OAuth2 configuration steps and then fail at the very last step (Step 5) when running `airflow webserver --reload`, which no longer exists in Airflow 3. This is a documentation inconsistency left over from the Airflow 2 era.

This is similar to the fix already applied to `configuring-flask-app.rst` in PR #68162.

Closes #68165.