### PR TITLE
Fix Grid Gantt tooltip showing wrong start date on queued/scheduled segments

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -86,7 +86,7 @@ const toTooltipSummary = (
   return {
     child_states: null,
     max_end_date: dayjs(segment.x[1]).toISOString(),
-    min_start_date: dayjs(segment.x[0]).toISOString(),
+    min_start_date: segment.start_when ?? dayjs(segment.x[0]).toISOString(),
     state: segment.state ?? null,
     task_display_name: segment.y,
     task_id: segment.taskId,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -33,6 +33,8 @@ export type GanttDataItem = {
   /** Source try times for tooltips (matches TaskInstance `*_when` fields). */
   queued_when?: string | null;
   scheduled_when?: string | null;
+  /** Actual task execution start_date — consistent across all segments of the same try. */
+  start_when?: string | null;
   state?: TaskInstanceState | null;
   taskId: string;
   tryNumber?: number;
@@ -133,10 +135,11 @@ export const transformGanttData = ({
             const queuedMs = queuedDttm === null ? undefined : dayjs(queuedDttm).valueOf();
             const scheduledMs = scheduledDttm === null ? undefined : dayjs(scheduledDttm).valueOf();
 
-            // Include scheduled/queued times in tooltip data whenever the timestamps exist.
+            // Include scheduled/queued/start times in tooltip data whenever the timestamps exist.
             const tryWhenForTooltip = {
               ...(scheduledMs === undefined ? {} : { scheduled_when: scheduledDttm }),
               ...(queuedMs === undefined ? {} : { queued_when: queuedDttm }),
+              ...(startDate === null ? {} : { start_when: startDate }),
             };
 
             let endMs: number;


### PR DESCRIPTION
Closes #68174
The Gantt bar tooltip was showing a wrong "Start Date" when hovering over the queued part of a task. It was picking up the queued time as the start date instead of the actual execution start date. Hovering over the execution part showed the correct time.
The issue was in 'toTooltipSummary' ,it was using 'segment.x[0]' (left edge of the hovered segment) for 'min_start_date'. For the queued segment that's the queued time, not the actual start date.
Fixed by storing the real 'start_date' as 'start_when' on every 'GanttDataItem' and using that in 'toTooltipSummary' instead of 'segment.x[0]'. Now hovering any segment shows the same correct start date.

I used Claude (claude.ai) as an AI assistant for parts of this implementation.
