### PR TITLE
Refactor Teradata provider tests to remove legacy unittest imports

### DIFF
--- a/providers/teradata/tests/unit/teradata/operators/test_bteq.py
+++ b/providers/teradata/tests/unit/teradata/operators/test_bteq.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import logging
 import tempfile
-import unittest
 from unittest import mock
 
 import pytest
@@ -288,7 +287,3 @@ class TestBteqOperator:
         )
         result = op.execute({})
         assert result == 42  # still returns, but caller can fail on RC if desired
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/providers/teradata/tests/unit/teradata/utils/test_bteq_util.py
+++ b/providers/teradata/tests/unit/teradata/utils/test_bteq_util.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import os
 import stat
-import unittest
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -348,7 +347,3 @@ class TestBteqUtils:
         ssh_client = MagicMock()
         result = is_valid_remote_bteq_script_file(ssh_client, None)
         assert result is False
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py
+++ b/providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import string
-import unittest
 from unittest.mock import MagicMock, patch
 
 from airflow.providers.teradata.utils.encryption_utils import (
@@ -102,7 +101,3 @@ class TestEncryptionUtils:
         assert exit_status == 0
         assert output == "decrypted output"
         assert err == ""
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR refactors the test files for the Teradata provider to fully align with Airflow's pytest migration guidelines. 

Specifically, it removes:
- Unused `import unittest` statements
- The legacy `if __name__ == "__main__": unittest.main()` execution blocks from the bottom of the files

These files already utilize standard `pytest` decorators, asserts, and mocks, making the legacy `unittest` remnants obsolete.

### Modified Files:
- `providers/teradata/tests/unit/teradata/operators/test_bteq.py`
- `providers/teradata/tests/unit/teradata/utils/test_bteq_util.py`
- `providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py`

### Tests Run
Executed the full Teradata provider test suite inside the local Breeze environment:
```bash
breeze testing providers-tests --test-type "Providers[teradata]"
```


##### Was generative AI tooling used to co-author this PR?
- [X] Yes — Antigravity (Gemini 3.5 Flash)
Generated-by: Antigravity (Gemini 3.5 Flash) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
EOF

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=8a222ba action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @RyukR1 → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @RyukR1 — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->