### PR TITLE
Update providers metadata 2026-06-07

### DIFF
--- a/generated/provider_metadata.json
+++ b/generated/provider_metadata.json
@@ -157,18 +157,26 @@
             "date_released": "2026-04-12T14:24:40Z"
         },
         "5.4.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "5.5.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-27T12:45:31Z"
+        },
+        "5.5.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:01Z"
         }
     },
     "akeyless": {
         "0.1.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-01T21:24:16Z"
+        },
+        "0.2.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:02Z"
         }
     },
     "alibaba": {
@@ -345,7 +353,7 @@
             "date_released": "2026-04-12T14:25:15Z"
         },
         "3.3.8": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -715,19 +723,19 @@
             "date_released": "2026-04-14T00:38:50Z"
         },
         "9.26.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "9.27.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-01T21:24:16Z"
         },
         "9.28.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "9.29.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -1073,6 +1081,10 @@
         "3.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:30Z"
+        },
+        "3.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:03Z"
         }
     },
     "apache.drill": {
@@ -1227,6 +1239,10 @@
         "3.3.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:50Z"
+        },
+        "3.3.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:04Z"
         }
     },
     "apache.druid": {
@@ -1519,6 +1535,10 @@
         "1.8.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-03-28T11:03:25Z"
+        },
+        "1.8.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:05Z"
         }
     },
     "apache.hdfs": {
@@ -1703,7 +1723,7 @@
             "date_released": "2026-04-12T14:24:32Z"
         },
         "4.12.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -1977,7 +1997,7 @@
             "date_released": "2026-04-12T14:24:33Z"
         },
         "9.5.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -2037,6 +2057,10 @@
         "2.0.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:06Z"
+        },
+        "2.0.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:06Z"
         }
     },
     "apache.impala": {
@@ -2143,6 +2167,10 @@
         "1.9.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:29Z"
+        },
+        "1.9.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:07Z"
         }
     },
     "apache.kafka": {
@@ -2271,11 +2299,11 @@
             "date_released": "2026-04-12T14:25:23Z"
         },
         "1.13.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "1.14.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -2403,6 +2431,10 @@
         "3.10.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:45Z"
+        },
+        "3.10.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:08Z"
         }
     },
     "apache.livy": {
@@ -2595,7 +2627,7 @@
             "date_released": "2026-04-12T14:25:25Z"
         },
         "4.5.6": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -2715,6 +2747,10 @@
         "4.8.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:37Z"
+        },
+        "4.8.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:09Z"
         }
     },
     "apache.pinot": {
@@ -2873,6 +2909,10 @@
         "4.10.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:49Z"
+        },
+        "4.10.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:10Z"
         }
     },
     "apache.spark": {
@@ -3101,7 +3141,7 @@
             "date_released": "2026-04-12T14:25:37Z"
         },
         "6.0.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -3145,6 +3185,10 @@
         "1.1.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:09Z"
+        },
+        "1.1.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:11Z"
         }
     },
     "apprise": {
@@ -3243,6 +3287,10 @@
         "2.3.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:36Z"
+        },
+        "2.3.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:11Z"
         }
     },
     "arangodb": {
@@ -3353,6 +3401,10 @@
         "2.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:54Z"
+        },
+        "2.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:12Z"
         }
     },
     "asana": {
@@ -3471,6 +3523,10 @@
         "2.11.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:48Z"
+        },
+        "2.11.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:13Z"
         }
     },
     "atlassian.jira": {
@@ -3581,6 +3637,10 @@
         "3.3.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:24Z"
+        },
+        "3.3.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:14Z"
         }
     },
     "celery": {
@@ -3825,11 +3885,11 @@
             "date_released": "2026-04-12T14:24:14Z"
         },
         "3.19.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-01T21:24:16Z"
         },
         "3.20.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -3965,6 +4025,10 @@
         "4.3.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:15Z"
+        },
+        "4.3.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:15Z"
         }
     },
     "cncf.kubernetes": {
@@ -4353,15 +4417,15 @@
             "date_released": "2026-04-12T14:25:07Z"
         },
         "10.16.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:50Z"
         },
         "10.17.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "10.17.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -4453,6 +4517,10 @@
         "1.6.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:05Z"
+        },
+        "1.6.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:16Z"
         }
     },
     "common.ai": {
@@ -4461,16 +4529,20 @@
             "date_released": "2026-04-14T00:38:52Z"
         },
         "0.1.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "0.2.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "0.3.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "0.4.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:17Z"
         }
     },
     "common.compat": {
@@ -4583,7 +4655,7 @@
             "date_released": "2026-04-14T00:38:49Z"
         },
         "1.15.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -4683,6 +4755,10 @@
         "1.7.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-03-28T11:03:25Z"
+        },
+        "1.7.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:18Z"
         }
     },
     "common.messaging": {
@@ -4725,6 +4801,10 @@
         "2.0.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-03-28T11:03:25Z"
+        },
+        "2.0.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:19Z"
         }
     },
     "common.sql": {
@@ -4977,16 +5057,20 @@
             "date_released": "2026-03-28T11:03:25Z"
         },
         "1.35.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "1.36.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "2.0.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "2.0.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:20Z"
         }
     },
     "databricks": {
@@ -5275,16 +5359,20 @@
             "date_released": "2026-04-12T14:25:11Z"
         },
         "7.13.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:50Z"
         },
         "7.14.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "7.15.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "7.16.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:21Z"
         }
     },
     "datadog": {
@@ -5415,6 +5503,10 @@
         "3.10.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:34Z"
+        },
+        "3.10.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:22Z"
         }
     },
     "dbt.cloud": {
@@ -5631,12 +5723,16 @@
             "date_released": "2026-04-12T14:24:17Z"
         },
         "4.8.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "4.9.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-27T12:45:31Z"
+        },
+        "4.9.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:23Z"
         }
     },
     "dingding": {
@@ -5755,6 +5851,10 @@
         "3.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:43Z"
+        },
+        "3.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:24Z"
         }
     },
     "discord": {
@@ -5895,7 +5995,7 @@
             "date_released": "2026-04-12T14:24:28Z"
         },
         "3.12.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         }
     },
@@ -6153,8 +6253,12 @@
             "date_released": "2026-04-12T14:24:31Z"
         },
         "4.5.6": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "4.5.7": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:25Z"
         }
     },
     "edge3": {
@@ -6243,15 +6347,15 @@
             "date_released": "2026-04-12T14:24:52Z"
         },
         "3.5.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "3.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "3.7.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -6501,12 +6605,16 @@
             "date_released": "2026-04-12T14:24:38Z"
         },
         "6.5.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "6.5.4": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "6.6.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:26Z"
         }
     },
     "exasol": {
@@ -6713,6 +6821,10 @@
         "4.10.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:20Z"
+        },
+        "4.10.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:27Z"
         }
     },
     "fab": {
@@ -6885,16 +6997,20 @@
             "date_released": "2026-04-12T14:24:46Z"
         },
         "3.6.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "3.6.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "3.6.4": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "3.6.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:28Z"
         }
     },
     "facebook": {
@@ -7033,6 +7149,10 @@
         "3.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:09Z"
+        },
+        "3.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:29Z"
         }
     },
     "ftp": {
@@ -7197,7 +7317,7 @@
             "date_released": "2026-04-12T14:25:27Z"
         },
         "3.15.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -7275,11 +7395,11 @@
             "date_released": "2026-04-12T14:24:37Z"
         },
         "0.3.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "0.4.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -7411,6 +7531,10 @@
         "2.11.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:34Z"
+        },
+        "2.11.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:30Z"
         }
     },
     "google": {
@@ -7763,16 +7887,20 @@
             "date_released": "2026-04-12T14:24:58Z"
         },
         "21.2.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "21.3.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "22.0.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "22.1.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:31Z"
         }
     },
     "grpc": {
@@ -7903,6 +8031,10 @@
         "3.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:03Z"
+        },
+        "3.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:32Z"
         }
     },
     "hashicorp": {
@@ -8087,8 +8219,12 @@
             "date_released": "2026-04-12T14:24:55Z"
         },
         "4.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
+        },
+        "4.7.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:33Z"
         }
     },
     "http": {
@@ -8311,6 +8447,10 @@
         "6.0.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:33Z"
+        },
+        "6.0.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:34Z"
         }
     },
     "imap": {
@@ -8467,7 +8607,7 @@
             "date_released": "2026-04-12T14:24:47Z"
         },
         "3.11.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -8601,7 +8741,7 @@
             "date_released": "2026-04-12T14:24:29Z"
         },
         "2.11.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -8617,6 +8757,10 @@
         "0.1.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:10Z"
+        },
+        "0.1.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:35Z"
         }
     },
     "jdbc": {
@@ -8797,8 +8941,12 @@
             "date_released": "2026-04-12T14:25:01Z"
         },
         "5.4.4": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
+        },
+        "5.5.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:36Z"
         }
     },
     "jenkins": {
@@ -8973,6 +9121,10 @@
         "4.2.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:04Z"
+        },
+        "4.2.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:37Z"
         }
     },
     "keycloak": {
@@ -9029,8 +9181,12 @@
             "date_released": "2026-04-12T14:24:18Z"
         },
         "0.7.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "0.7.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:38Z"
         }
     },
     "microsoft.azure": {
@@ -9375,16 +9531,20 @@
             "date_released": "2026-04-12T14:24:26Z"
         },
         "13.1.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "13.2.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "13.3.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "13.4.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:39Z"
         }
     },
     "microsoft.mssql": {
@@ -9557,8 +9717,12 @@
             "date_released": "2026-04-12T14:24:23Z"
         },
         "4.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "4.6.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:40Z"
         }
     },
     "microsoft.psrp": {
@@ -9701,6 +9865,10 @@
         "3.2.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:13Z"
+        },
+        "3.2.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:41Z"
         }
     },
     "microsoft.winrm": {
@@ -9859,6 +10027,10 @@
         "3.14.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:02Z"
+        },
+        "3.14.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:42Z"
         }
     },
     "mongo": {
@@ -10027,7 +10199,7 @@
             "date_released": "2026-04-12T14:25:22Z"
         },
         "5.4.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -10273,12 +10445,16 @@
             "date_released": "2026-04-12T14:25:32Z"
         },
         "6.5.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         },
         "6.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "6.6.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:43Z"
         }
     },
     "neo4j": {
@@ -10433,6 +10609,10 @@
         "3.11.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:19Z"
+        },
+        "3.11.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:44Z"
         }
     },
     "odbc": {
@@ -10599,6 +10779,10 @@
         "4.12.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:51Z"
+        },
+        "4.12.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:45Z"
         }
     },
     "openai": {
@@ -10693,6 +10877,10 @@
         "1.7.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:25Z"
+        },
+        "1.7.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:46Z"
         }
     },
     "openfaas": {
@@ -10807,6 +10995,10 @@
         "3.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:14Z"
+        },
+        "3.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:47Z"
         }
     },
     "openlineage": {
@@ -11011,16 +11203,20 @@
             "date_released": "2026-04-14T00:38:51Z"
         },
         "2.15.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "2.16.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "2.17.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "2.18.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:48Z"
         }
     },
     "opensearch": {
@@ -11129,12 +11325,16 @@
             "date_released": "2026-04-12T14:25:08Z"
         },
         "1.9.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "1.9.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "1.9.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:49Z"
         }
     },
     "opsgenie": {
@@ -11269,6 +11469,10 @@
         "5.10.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:27Z"
+        },
+        "5.10.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:50Z"
         }
     },
     "oracle": {
@@ -11477,8 +11681,12 @@
             "date_released": "2026-04-12T14:25:18Z"
         },
         "4.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "4.6.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:50Z"
         }
     },
     "pagerduty": {
@@ -11637,6 +11845,10 @@
         "5.2.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:42Z"
+        },
+        "5.2.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:51Z"
         }
     },
     "papermill": {
@@ -11801,8 +12013,12 @@
             "date_released": "2026-04-12T14:25:26Z"
         },
         "3.13.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
+        },
+        "3.13.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:52Z"
         }
     },
     "pgvector": {
@@ -11873,6 +12089,10 @@
         "1.7.1": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-03-28T11:03:25Z"
+        },
+        "1.7.2": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:53Z"
         }
     },
     "pinecone": {
@@ -11965,7 +12185,7 @@
             "date_released": "2026-04-12T14:24:56Z"
         },
         "2.4.5": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -12215,8 +12435,12 @@
             "date_released": "2026-04-12T14:24:24Z"
         },
         "6.7.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "6.7.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:54Z"
         }
     },
     "presto": {
@@ -12429,7 +12653,7 @@
             "date_released": "2026-04-12T14:25:19Z"
         },
         "5.12.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -12509,6 +12733,10 @@
         "1.5.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:44Z"
+        },
+        "1.5.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:55Z"
         }
     },
     "redis": {
@@ -12659,6 +12887,10 @@
         "4.4.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:21Z"
+        },
+        "4.4.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:56Z"
         }
     },
     "salesforce": {
@@ -12841,6 +13073,10 @@
         "5.14.0": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:53Z"
+        },
+        "5.14.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:57Z"
         }
     },
     "samba": {
@@ -12983,6 +13219,10 @@
         "4.12.5": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:21Z"
+        },
+        "4.12.6": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:58Z"
         }
     },
     "segment": {
@@ -13097,6 +13337,10 @@
         "3.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:00Z"
+        },
+        "3.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:04:59Z"
         }
     },
     "sendgrid": {
@@ -13217,8 +13461,12 @@
             "date_released": "2026-03-28T11:03:26Z"
         },
         "4.2.3": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
+        },
+        "4.2.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:00Z"
         }
     },
     "sftp": {
@@ -13467,12 +13715,16 @@
             "date_released": "2026-04-12T14:24:36Z"
         },
         "5.7.4": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "5.8.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "5.8.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:01Z"
         }
     },
     "singularity": {
@@ -13587,6 +13839,10 @@
         "3.9.3": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-03-28T11:03:26Z"
+        },
+        "3.9.4": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:03Z"
         }
     },
     "slack": {
@@ -13821,6 +14077,10 @@
         "9.10.0": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:16Z"
+        },
+        "9.10.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:04Z"
         }
     },
     "smtp": {
@@ -13965,11 +14225,11 @@
             "date_released": "2026-04-12T14:25:17Z"
         },
         "3.0.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "3.0.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -14291,11 +14551,11 @@
             "date_released": "2026-04-12T14:24:41Z"
         },
         "6.12.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:50Z"
         },
         "6.13.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -14463,6 +14723,10 @@
         "4.3.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:24:16Z"
+        },
+        "4.3.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:05Z"
         }
     },
     "ssh": {
@@ -14679,11 +14943,11 @@
             "date_released": "2026-04-12T14:25:12Z"
         },
         "5.0.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
         },
         "5.0.2": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -14813,12 +15077,16 @@
             "date_released": "2026-04-12T14:25:31Z"
         },
         "1.13.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:10Z"
         },
         "1.13.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "1.14.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:06Z"
         }
     },
     "tableau": {
@@ -14987,8 +15255,12 @@
             "date_released": "2026-04-12T14:24:22Z"
         },
         "5.4.1": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "5.5.0": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:07Z"
         }
     },
     "telegram": {
@@ -15131,6 +15403,10 @@
         "4.9.4": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:17Z"
+        },
+        "4.9.5": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:08Z"
         }
     },
     "teradata": {
@@ -15243,7 +15519,7 @@
             "date_released": "2026-04-12T14:24:59Z"
         },
         "3.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -15473,7 +15749,7 @@
             "date_released": "2026-04-12T14:25:35Z"
         },
         "6.6.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -15635,14 +15911,18 @@
             "date_released": "2026-04-12T14:24:35Z"
         },
         "4.4.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
     "vespa": {
         "0.1.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-04-26T19:27:51Z"
+        },
+        "0.1.1": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:09Z"
         }
     },
     "weaviate": {
@@ -15755,7 +16035,7 @@
             "date_released": "2026-04-12T14:25:20Z"
         },
         "3.3.4": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     },
@@ -15917,7 +16197,7 @@
             "date_released": "2026-04-12T14:24:39Z"
         },
         "4.5.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
         }
     },
@@ -15997,6 +16277,10 @@
         "2.5.2": {
             "associated_airflow_version": "3.2.1",
             "date_released": "2026-04-12T14:25:30Z"
+        },
+        "2.5.3": {
+            "associated_airflow_version": "3.2.2",
+            "date_released": "2026-06-07T10:05:10Z"
         }
     },
     "zendesk": {
@@ -16125,7 +16409,7 @@
             "date_released": "2026-04-12T14:25:28Z"
         },
         "4.12.0": {
-            "associated_airflow_version": "3.2.1",
+            "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
         }
     }


### PR DESCRIPTION
Routine refresh of providers metadata following the 2026-06-02 providers release — associates the released provider versions with the Airflow versions they shipped against, and refreshes the constraints / Airflow-releases data.

Generated by `breeze release-management generate-providers-metadata --refresh-constraints-and-airflow-releases`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
