### PR TITLE
Fix mapped task instance links without start date

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.test.tsx
@@ -1,0 +1,168 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type * as ReactI18Next from "react-i18next";
+import type * as ReactRouterDom from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as OpenapiQueries from "openapi/queries";
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { TaskInstances } from "./TaskInstances";
+
+let mockParams: Record<string, string | undefined> = {
+  dagId: "example_dag",
+  runId: "manual__2026-06-07T00:00:00+00:00",
+  taskId: "mapped_task",
+};
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18Next>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      // eslint-disable-next-line id-length
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouterDom>();
+
+  return {
+    ...actual,
+    useParams: () => mockParams,
+    useSearchParams: () => [mockSearchParams, vi.fn()] as const,
+  };
+});
+
+vi.mock("openapi/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenapiQueries>();
+
+  return {
+    ...actual,
+    useTaskInstanceServiceGetTaskInstances: vi.fn(),
+  };
+});
+
+vi.mock("./TaskInstancesFilter", () => ({
+  TaskInstancesFilter: () => null,
+}));
+
+vi.mock("src/components/DataTable", () => ({
+  DataTable: ({
+    columns,
+    data,
+  }: {
+    readonly columns: ReadonlyArray<{
+      accessorKey?: string;
+      cell?: (props: { row: { original: TaskInstanceResponse } }) => ReactNode;
+    }>;
+    readonly data: ReadonlyArray<TaskInstanceResponse>;
+  }) => {
+    const renderedMapIndexColumn = columns.find((column) => column.accessorKey === "rendered_map_index");
+
+    return (
+      <table>
+        <tbody>
+          {data.map((taskInstance) => (
+            <tr key={`${taskInstance.task_id}-${taskInstance.map_index}`}>
+              <td>{renderedMapIndexColumn?.cell?.({ row: { original: taskInstance } })}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  },
+}));
+
+const { useTaskInstanceServiceGetTaskInstances } = await import("openapi/queries");
+
+const getTaskInstancesResponse = (taskInstances: Array<TaskInstanceResponse>) =>
+  ({
+    data: {
+      task_instances: taskInstances,
+    },
+    error: null,
+    isLoading: false,
+  }) as ReturnType<typeof useTaskInstanceServiceGetTaskInstances>;
+
+const mappedTaskInstance = {
+  dag_display_name: "example_dag",
+  dag_id: "example_dag",
+  dag_run_id: "manual__2026-06-07T00:00:00+00:00",
+  map_index: 1,
+  rendered_map_index: "1",
+  start_date: null,
+  state: "queued",
+  task_display_name: "mapped_task",
+  task_id: "mapped_task",
+} as TaskInstanceResponse;
+
+describe("TaskInstances", () => {
+  beforeEach(() => {
+    mockParams = {
+      dagId: "example_dag",
+      runId: "manual__2026-06-07T00:00:00+00:00",
+      taskId: "mapped_task",
+    };
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it.each([
+    {
+      description: "with a selected task but no run",
+      params: {
+        dagId: "example_dag",
+        taskId: "mapped_task",
+      },
+    },
+    {
+      description: "without a selected task or run",
+      params: {},
+    },
+  ])("links mapped task instances from the map index column $description", ({ params }) => {
+    mockParams = params;
+    vi.mocked(useTaskInstanceServiceGetTaskInstances).mockReturnValue(
+      getTaskInstancesResponse([mappedTaskInstance]),
+    );
+
+    render(<TaskInstances />, { wrapper: Wrapper });
+
+    expect(screen.getByRole("link", { name: "1" })).toHaveAttribute(
+      "href",
+      "/dags/example_dag/runs/manual__2026-06-07T00:00:00+00:00/tasks/mapped_task/mapped/1",
+    );
+  });
+
+  it("does not link non-mapped task instances from the map index column", () => {
+    vi.mocked(useTaskInstanceServiceGetTaskInstances).mockReturnValue(
+      getTaskInstancesResponse([{ ...mappedTaskInstance, map_index: -1, rendered_map_index: null }]),
+    );
+
+    render(<TaskInstances />, { wrapper: Wrapper });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -160,9 +160,7 @@ const taskInstanceColumns = ({
       ]),
   {
     accessorKey: "rendered_map_index",
-    // Always link a mapped instance to its own detail page. Unlike start date,
-    // map index is present before the task starts, so this is the reliable
-    // navigation target for queued/scheduled mapped instances. See #68177.
+    // Map index remains visible before a mapped task instance starts.
     cell: ({ row: { original } }) =>
       original.map_index >= 0 ? (
         <RouterLink fontWeight="bold" to={getTaskInstanceLink(original)}>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -160,6 +160,17 @@ const taskInstanceColumns = ({
       ]),
   {
     accessorKey: "rendered_map_index",
+    // Always link a mapped instance to its own detail page. Unlike start date,
+    // map index is present before the task starts, so this is the reliable
+    // navigation target for queued/scheduled mapped instances. See #68177.
+    cell: ({ row: { original } }) =>
+      original.map_index >= 0 ? (
+        <RouterLink fontWeight="bold" to={getTaskInstanceLink(original)}>
+          {original.rendered_map_index ?? original.map_index}
+        </RouterLink>
+      ) : (
+        original.rendered_map_index
+      ),
     header: translate("mapIndex"),
   },
   {


### PR DESCRIPTION
The Task Instances table only let you reach a mapped task instance through the **Start Date** column. When an instance had not started yet (`queued`/`scheduled`), Start Date was empty, so the row had no clickable target and those instances were hard to reach — you had to go up to the run and click through the task list instead.

The **Map Index** cell now links to the mapped task instance details page for mapped rows (`map_index >= 0`), built from the row's own task instance identity. Because Map Index is always present (even before the task starts), queued/scheduled mapped instances are now reachable directly. Non-mapped rows (`map_index == -1`) stay plain text, and the link renders in every context the table is used in (mapped-task view, run task list, and the Browse view).

closes: #68177

## Manual verification
- Reproduced with a mapped task whose queued mapped instances had no start date.
- Before: Map Index was plain text.
- After: Map Index linked to the mapped task instance details page.

### Before
<img width="1512" height="830" alt="before_fix" src="https://github.com/user-attachments/assets/2d59e4e4-8d20-4716-a4c8-642461300c5d" />

### After
<img width="1510" height="737" alt="after_fix1" src="https://github.com/user-attachments/assets/85505aa8-bc96-48db-851c-44bf6ed9469a" />
<img width="1511" height="626" alt="after_fix2" src="https://github.com/user-attachments/assets/b3aa6cd6-ac86-45e4-a44b-1501b07a2fb7" />


## Tests
- `pnpm vitest run src/pages/TaskInstances/TaskInstances.test.tsx` 
- `pnpm eslint --quiet src/pages/TaskInstances/TaskInstances.tsx src/pages/TaskInstances/TaskInstances.test.tsx`
- `pnpm tsc -p tsconfig.app.json --noEmit`


##### Was generative AI tooling used to co-author this PR?

- [X] Yes — (GPT-5.5)