### PR TITLE
Add better logging to ResumableJobMixin for crash recovery observability

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
@@ -103,31 +103,48 @@ class ResumableJobMixin:
         """
         task_store = context.get("task_store")
 
-        if task_store is not None:
+        if task_store is None:
+            self.log.warning("task_store not available in context, crash recovery is disabled for this run")
+        else:
             external_id = task_store.get(self.external_id_key)
             if external_id:
                 status = self.get_job_status(external_id, context)
                 if self.is_job_active(status):
                     self.log.info(
-                        "Reconnecting to existing job identified by: %s (status: %s)", external_id, status
+                        "Reconnecting to existing job",
+                        external_id_key=self.external_id_key,
+                        external_id=external_id,
+                        status=status,
                     )
                     return self.poll_until_complete(external_id, context)
                 if self.is_job_succeeded(status):
                     self.log.info(
-                        "Job with identifier: %s already completed successfully, skipping resubmission",
-                        external_id,
+                        "Job already completed successfully, skipping resubmission",
+                        external_id_key=self.external_id_key,
+                        external_id=external_id,
                     )
                     return self.get_job_result(external_id, context)
-                self.log.info(
-                    "Prior job with identifier: %s in terminal state %s, resubmitting fresh",
-                    external_id,
-                    status,
+                self.log.warning(
+                    "Prior job in terminal state, resubmitting fresh",
+                    external_id_key=self.external_id_key,
+                    external_id=external_id,
+                    status=status,
+                )
+            else:
+                self.log.debug(
+                    "No stored external ID found; submitting fresh job",
+                    external_id_key=self.external_id_key,
                 )
 
         external_id = self.submit_job(context)
 
         if task_store is not None and external_id is not None:
             task_store.set(self.external_id_key, external_id)
+            self.log.debug(
+                "Persisted external ID to task store",
+                external_id_key=self.external_id_key,
+                external_id=external_id,
+            )
 
         self.poll_until_complete(external_id, context)
         return self.get_job_result(external_id, context)

--- a/task-sdk/tests/task_sdk/bases/test_resumablemixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablemixin.py
@@ -208,36 +208,22 @@ class TestLogging:
         warnings = [entry for entry in logs if entry["log_level"] == "warning"]
         assert any("crash recovery is disabled" in entry["event"] for entry in warnings)
 
-    def test_info_reconnect_with_structured_fields(self):
+    @pytest.mark.parametrize(
+        ("status", "event_fragment", "log_level", "extra_fields"),
+        [
+            ("RUNNING", "Reconnecting", "info", {"external_id_key": "test_job_id", "status": "RUNNING"}),
+            ("SUCCEEDED", "already completed", "info", {"external_id_key": "test_job_id"}),
+            ("FAILED", "terminal state", "warning", {"status": "FAILED"}),
+        ],
+    )
+    def test_log_fields_for_stored_job(self, status, event_fragment, log_level, extra_fields):
         op = ConcreteResumableOperator(task_id="test_task")
-        op._status_map["job-001"] = "RUNNING"
+        op._status_map["job-001"] = status
         with structlog.testing.capture_logs() as logs:
             op.execute_resumable(make_context(FakeTaskState({"test_job_id": "job-001"})))
-        reconnect = next((entry for entry in logs if "Reconnecting" in entry["event"]), None)
-        assert reconnect is not None
-        assert reconnect["log_level"] == "info"
-        assert reconnect["external_id"] == "job-001"
-        assert reconnect["external_id_key"] == "test_job_id"
-        assert reconnect["status"] == "RUNNING"
-
-    def test_info_already_succeeded(self):
-        op = ConcreteResumableOperator(task_id="test_task")
-        op._status_map["job-001"] = "SUCCEEDED"
-        with structlog.testing.capture_logs() as logs:
-            op.execute_resumable(make_context(FakeTaskState({"test_job_id": "job-001"})))
-        succeeded = next((entry for entry in logs if "already completed" in entry["event"]), None)
-        assert succeeded is not None
-        assert succeeded["log_level"] == "info"
-        assert succeeded["external_id"] == "job-001"
-        assert succeeded["external_id_key"] == "test_job_id"
-
-    def test_warning_on_terminal_state_fallback(self):
-        op = ConcreteResumableOperator(task_id="test_task")
-        op._status_map["job-001"] = "FAILED"
-        with structlog.testing.capture_logs() as logs:
-            op.execute_resumable(make_context(FakeTaskState({"test_job_id": "job-001"})))
-        terminal = next((entry for entry in logs if "terminal state" in entry["event"]), None)
-        assert terminal is not None
-        assert terminal["log_level"] == "warning"
-        assert terminal["external_id"] == "job-001"
-        assert terminal["status"] == "FAILED"
+        entry = next((e for e in logs if event_fragment in e["event"]), None)
+        assert entry is not None
+        assert entry["log_level"] == log_level
+        assert entry["external_id"] == "job-001"
+        for key, val in extra_fields.items():
+            assert entry[key] == val

--- a/task-sdk/tests/task_sdk/bases/test_resumablemixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablemixin.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+import structlog.testing
 
 from airflow.sdk import ResumableJobMixin
 from airflow.sdk.bases.operator import BaseOperator
@@ -197,3 +198,46 @@ class TestExternalIdKey:
         op.execute_resumable(make_context(task_state))
 
         assert task_state.get("my_custom_key") == "job-001"
+
+
+class TestLogging:
+    def test_warning_when_task_store_unavailable(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        with structlog.testing.capture_logs() as logs:
+            op.execute_resumable(make_context(task_store=None))
+        warnings = [entry for entry in logs if entry["log_level"] == "warning"]
+        assert any("crash recovery is disabled" in entry["event"] for entry in warnings)
+
+    def test_info_reconnect_with_structured_fields(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "RUNNING"
+        with structlog.testing.capture_logs() as logs:
+            op.execute_resumable(make_context(FakeTaskState({"test_job_id": "job-001"})))
+        reconnect = next((entry for entry in logs if "Reconnecting" in entry["event"]), None)
+        assert reconnect is not None
+        assert reconnect["log_level"] == "info"
+        assert reconnect["external_id"] == "job-001"
+        assert reconnect["external_id_key"] == "test_job_id"
+        assert reconnect["status"] == "RUNNING"
+
+    def test_info_already_succeeded(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "SUCCEEDED"
+        with structlog.testing.capture_logs() as logs:
+            op.execute_resumable(make_context(FakeTaskState({"test_job_id": "job-001"})))
+        succeeded = next((entry for entry in logs if "already completed" in entry["event"]), None)
+        assert succeeded is not None
+        assert succeeded["log_level"] == "info"
+        assert succeeded["external_id"] == "job-001"
+        assert succeeded["external_id_key"] == "test_job_id"
+
+    def test_warning_on_terminal_state_fallback(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        op._status_map["job-001"] = "FAILED"
+        with structlog.testing.capture_logs() as logs:
+            op.execute_resumable(make_context(FakeTaskState({"test_job_id": "job-001"})))
+        terminal = next((entry for entry in logs if "terminal state" in entry["event"]), None)
+        assert terminal is not None
+        assert terminal["log_level"] == "warning"
+        assert terminal["external_id"] == "job-001"
+        assert terminal["status"] == "FAILED"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes: claude sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---


### What

If/When `ResumableJobMixin` fails in a running cluster in production, for reasons such as: stale state, a resume that silently falls back to a fresh submit, or a wrong external job ID, there is not enough signal in the logs to diagnose the failure from telemetry alone. Support and engineering will have to reproduce the issue to understand what happened.

### Current behaviour

`execute_resumable()` emits three `INFO` log lines using positional `%s` formatting. None of them include the external ID key, and the terminal-state fallback (where the operator silently resubmits fresh instead of reconnecting) is logged at `INFO` which indistinguishable from the normal path. When `task_store` is absent from context (pre-3.3 workers or misconfigured environments), nothing is logged.

### Proposed change

- Enhance existing log lines to use structlog keyword args for logging (`external_id=`, `external_id_key=`, `status=`) so the fields are queryable in structured log systems.
- Some edits to the terminal-state fallback log from `INFO` to `WARNING`,  this is a degraded path that warrants attention.
- Added a `WARNING` when `task_store` is not available in context, making it visible when crash recovery is silently disabled.
- Added `DEBUG` logs for the fresh-submit and post-persist paths (internal mechanics, off by default in production).

### Testing

Tested with this dag
```python

class MockBatchOperator(BaseOperator, ResumableJobMixin):
    """
    Submits a mock batch job and polls until completion.

    Demonstrates how ``ResumableJobMixin`` handles a worker crash between
    submission and the start of polling: on retry the job ID is read from
    ``task_store`` and the operator reconnects rather than resubmitting.
    """

    external_id_key = "job_id"

    def execute(self, context: Context) -> Any:
        return self.execute_resumable(context)

    def submit_job(self, context: Context) -> JsonValue:
        job_id = _generate_job_id()
        _submit(job_id)
        self.log.info("Submitted batch job", job_id=job_id)
        return job_id

    def get_job_status(self, external_id: JsonValue, context: Context) -> str:
        # Default to RUNNING if the ID is not in the local cache — this simulates
        # a real external system that keeps running after a worker crash.
        return _JOBS.get(str(external_id), "RUNNING")

    def is_job_active(self, status: str) -> bool:
        return status == "RUNNING"

    def is_job_succeeded(self, status: str) -> bool:
        return status == "SUCCEEDED"

    def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
        self.log.info("Polling job — kill the worker now to trigger a retry", job_id=external_id)
        time.sleep(60)
        self.log.info("Polling job until complete", job_id=external_id)
        _poll(str(external_id))

    def get_job_result(self, external_id: JsonValue, context: Context) -> str:
        return f"Job {external_id} finished with status {_get_status(str(external_id))}"


with DAG(
    dag_id="example_resumable_job",
    schedule=None,
    start_date=datetime(2026, 1, 1),
    catchup=False,
    tags=["example", "resumable", "task-store"],
    doc_md=__doc__,
):
    MockBatchOperator(
        task_id="run_batch_job",
        retries=2,
        retry_delay=timedelta(seconds=5),
    )

```

Try 1:
<img width="2312" height="893" alt="image" src="https://github.com/user-attachments/assets/cf4fd202-ca10-4a21-8e28-d417affae085" />


Try 2:
<img width="2312" height="893" alt="image" src="https://github.com/user-attachments/assets/26631b8d-6de9-4d4f-ba74-13dc942952b8" />



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
