### PR TITLE
Run spotless against Java files in static checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1229,3 +1229,10 @@ repos:
         language: system
         pass_filenames: false
         files: ^java-sdk/.*$
+      - id: spotless
+        name: Run spotless apply
+        description: "Use spotless (via Gradle) to format Java files"
+        entry: ./java-sdk/gradlew -p ./java-sdk spotlessApply
+        language: system
+        pass_filenames: false
+        files: ^java-sdk/.*\.java$

--- a/java-sdk/example/src/java/org/apache/airflow/example/AnnotationExample.java
+++ b/java-sdk/example/src/java/org/apache/airflow/example/AnnotationExample.java
@@ -19,11 +19,10 @@
 
 package org.apache.airflow.example;
 
+import java.util.Date;
 import org.apache.airflow.sdk.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Date;
 
 @SuppressWarnings("DuplicatedCode")
 @Builder.Dag(id = "java_annotation_example")

--- a/java-sdk/example/src/java/org/apache/airflow/example/ExampleBundleBuilder.java
+++ b/java-sdk/example/src/java/org/apache/airflow/example/ExampleBundleBuilder.java
@@ -19,9 +19,9 @@
 
 package org.apache.airflow.example;
 
+import java.util.List;
 import org.apache.airflow.sdk.*;
 import org.jetbrains.annotations.NotNull;
-import java.util.List;
 
 public class ExampleBundleBuilder implements BundleBuilder {
   @NotNull


### PR DESCRIPTION
See #68205. This ensures the Java code is formatted correctly.