### PR TITLE
Harden Java process exit

### DIFF
--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Comm.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Comm.kt
@@ -29,7 +29,6 @@ import org.apache.airflow.sdk.execution.comm.ErrorResponse
 import org.apache.airflow.sdk.execution.comm.StartupDetails
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.system.exitProcess
 
 data class IncomingFrame(
   val id: Int,
@@ -101,12 +100,9 @@ class CoordinatorComm(
   suspend fun handleIncoming(frame: IncomingFrame) {
     when (val request = frame.body) {
       null -> {}
-      is ErrorResponse -> {
-        println("Error!! id=${frame.id} [${request.error}] ${request.detail}") // TODO: Handle error.
-        exitProcess(1)
-      }
+      is ErrorResponse -> throw ApiError("[${request.error}] ${request.detail}")
       is StartupDetails -> {
-        sendMessage(frame.id, runTask(bundle, request, this))
+        communicate<Unit>(runTask(bundle, request, this))
         shutDownRequested = true
       }
     }


### PR DESCRIPTION
Instead of printing to stdout, use the conventional ApiError to surface error sent in the initial supervisor message, like any other messages.

When exiting after task execution, instead of fire-and-forget with sendMessage(), use communicate() to also wait for the supervisor's (empty) response so we are sure the supervisor has received it.

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: [Clause] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

(Clause used for debugging the integration test error that surfaced the bug. I wrote the fix.)