### PR TITLE
Add `task_store` table to `airflow db clean` mechanism

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -140,7 +140,7 @@ config_list: list[_TableConfig] = [
         keep_last=True,
         keep_last_filters=[column("run_type") != DagRunType.MANUAL],
         keep_last_group_by=["dag_id"],
-        dependent_tables=["task_instance", "deadline"],
+        dependent_tables=["task_instance", "task_store", "deadline"],
     ),
     _TableConfig(table_name="asset_event", recency_column_name="timestamp", dag_id_column_name="dag_id"),
     _TableConfig(table_name="import_error", recency_column_name="timestamp"),
@@ -154,6 +154,11 @@ config_list: list[_TableConfig] = [
     ),
     _TableConfig(
         table_name="task_instance_history", recency_column_name="start_date", dag_id_column_name="dag_id"
+    ),
+    _TableConfig(
+        table_name="task_store",
+        recency_column_name="expires_at",
+        dag_id_column_name="dag_id",
     ),
     _TableConfig(table_name="task_reschedule", recency_column_name="start_date", dag_id_column_name="dag_id"),
     _TableConfig(table_name="xcom", recency_column_name="timestamp", dag_id_column_name="dag_id"),

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -882,8 +882,6 @@ def create_tis(base_date, num_tis, run_type=DagRunType.SCHEDULED):
 @pytest.mark.db_test
 class TestTaskStoreCleanup:
     def test_expired_rows_deleted(self):
-        from datetime import timezone as dt_timezone
-
         cfg = config_dict["task_store"]
         now = pendulum.now(tz="UTC")
         past = now.subtract(days=30)
@@ -916,8 +914,8 @@ class TestTaskStoreCleanup:
                 dag_id="ts_test_dag",
                 run_id="ts_test_run",
                 value="job-expired",
-                updated_at=past.in_timezone(dt_timezone.utc),
-                expires_at=past.subtract(days=1).in_timezone(dt_timezone.utc),
+                updated_at=past,
+                expires_at=past.subtract(days=1),
             )
             never_expire = TaskStoreModel(
                 dag_run_id=dag_run.id,
@@ -927,7 +925,7 @@ class TestTaskStoreCleanup:
                 dag_id="ts_test_dag",
                 run_id="ts_test_run",
                 value="job-never-expire",
-                updated_at=past.in_timezone(dt_timezone.utc),
+                updated_at=past,
                 expires_at=None,
             )
             not_yet_expired = TaskStoreModel(
@@ -938,22 +936,23 @@ class TestTaskStoreCleanup:
                 dag_id="ts_test_dag",
                 run_id="ts_test_run",
                 value="job-future",
-                updated_at=past.in_timezone(dt_timezone.utc),
-                expires_at=future.in_timezone(dt_timezone.utc),
+                updated_at=past,
+                expires_at=future,
             )
             session.add_all([expired, never_expire, not_yet_expired])
             session.commit()
 
         cutoff = now.subtract(hours=1)
-        _cleanup_table(
-            **cfg.__dict__,
-            clean_before_timestamp=cutoff,
-            dry_run=False,
-            verbose=False,
-            confirm=False,
-            skip_archive=True,
-            session=create_session().__enter__(),
-        )
+        with create_session() as session:
+            _cleanup_table(
+                **cfg.__dict__,
+                clean_before_timestamp=cutoff,
+                dry_run=False,
+                verbose=False,
+                confirm=False,
+                skip_archive=True,
+                session=session,
+            )
 
         with create_session() as session:
             not_deleted = {
@@ -1007,15 +1006,16 @@ class TestConnectionTestRequestCleanup:
 
         # Run cleanup with a cutoff well past every seeded row.
         cutoff = pendulum.now(tz="UTC").subtract(days=1)
-        _cleanup_table(
-            **cfg.__dict__,
-            clean_before_timestamp=cutoff,
-            dry_run=False,
-            verbose=False,
-            confirm=False,
-            skip_archive=True,
-            session=create_session().__enter__(),
-        )
+        with create_session() as session:
+            _cleanup_table(
+                **cfg.__dict__,
+                clean_before_timestamp=cutoff,
+                dry_run=False,
+                verbose=False,
+                confirm=False,
+                skip_archive=True,
+                session=session,
+            )
 
         with create_session() as s:
             survivors = {

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -37,6 +37,7 @@ from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models.task_store import TaskStoreModel
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.utils.db_cleanup import (
@@ -876,6 +877,95 @@ def create_tis(base_date, num_tis, run_type=DagRunType.SCHEDULED):
             session.add(dag_run)
             session.add(ti)
         session.commit()
+
+
+@pytest.mark.db_test
+class TestTaskStoreCleanup:
+    def test_expired_rows_deleted(self):
+        from datetime import timezone as dt_timezone
+
+        cfg = config_dict["task_store"]
+        now = pendulum.now(tz="UTC")
+        past = now.subtract(days=30)
+        future = now.add(days=30)
+
+        with create_session() as session:
+            bundle = DagBundleModel(name="ts_test_bundle")
+            session.add(bundle)
+            session.flush()
+
+            dag = DAG(dag_id="ts_test_dag")
+            dm = DagModel(dag_id="ts_test_dag", bundle_name="ts_test_bundle")
+            session.add(dm)
+            SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="ts_test_bundle")
+
+            dag_run = DagRun(
+                "ts_test_dag",
+                run_id="ts_test_run",
+                run_type=DagRunType.SCHEDULED,
+                start_date=past,
+            )
+            session.add(dag_run)
+            session.flush()
+
+            expired = TaskStoreModel(
+                dag_run_id=dag_run.id,
+                task_id="t1",
+                map_index=-1,
+                key="job_id",
+                dag_id="ts_test_dag",
+                run_id="ts_test_run",
+                value="job-expired",
+                updated_at=past.in_timezone(dt_timezone.utc),
+                expires_at=past.subtract(days=1).in_timezone(dt_timezone.utc),
+            )
+            never_expire = TaskStoreModel(
+                dag_run_id=dag_run.id,
+                task_id="t1",
+                map_index=-1,
+                key="result",
+                dag_id="ts_test_dag",
+                run_id="ts_test_run",
+                value="job-never-expire",
+                updated_at=past.in_timezone(dt_timezone.utc),
+                expires_at=None,
+            )
+            not_yet_expired = TaskStoreModel(
+                dag_run_id=dag_run.id,
+                task_id="t1",
+                map_index=-1,
+                key="future_key",
+                dag_id="ts_test_dag",
+                run_id="ts_test_run",
+                value="job-future",
+                updated_at=past.in_timezone(dt_timezone.utc),
+                expires_at=future.in_timezone(dt_timezone.utc),
+            )
+            session.add_all([expired, never_expire, not_yet_expired])
+            session.commit()
+
+        cutoff = now.subtract(hours=1)
+        _cleanup_table(
+            **cfg.__dict__,
+            clean_before_timestamp=cutoff,
+            dry_run=False,
+            verbose=False,
+            confirm=False,
+            skip_archive=True,
+            session=create_session().__enter__(),
+        )
+
+        with create_session() as session:
+            not_deleted = {
+                row.key
+                for row in session.scalars(
+                    select(TaskStoreModel).where(TaskStoreModel.dag_id == "ts_test_dag")
+                ).all()
+            }
+
+        assert "job_id" not in not_deleted, "expired row should be deleted"
+        assert "result" in not_deleted, "NEVER_EXPIRE row (expires_at=NULL) must survive"
+        assert "future_key" in not_deleted, "not-yet-expired row must survive"
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What

`task_store` rows have an `expires_at` column for per-key TTL, but they also need to be included in `airflow db clean`, so they can be both removed manually via `airflow state-store cleanup-task-store` and by db clean. This PR wires `task_store` into the standard cleanup infrastructure.

`asset_store` was intentionally excluded cos it has no `expires_at` column because it holds long lived current state for assets (not ephemeral per-run data). Rows are cleaned implicitly via `ON DELETE CASCADE` when the asset itself is deleted.

### Current behaviour

`task_store` rows are never pruned by `airflow db clean`. The only removal path is the manual CLI command `airflow state-store cleanup-task-store`, which is easy to miss sometimes and mainly so for people using the cleanup dags like this one: https://www.astronomer.io/docs/learn/2.x/cleanup-dag-tutorial

### Proposed change

- Added `task_store` to `dag_run`'s `dependent_tables` list so it is cascaded when a DAG run row is cleaned.
- Added a `_TableConfig` entry for `task_store` using `expires_at` as the recency column (not `updated_at`) so that `NULL` (`expires_at` = NEVER_EXPIRE) rows are correctly skipped — SQL evaluates `NULL < timestamp` as `NULL`, not `TRUE`, so they are never matched by the `WHERE` clause.
- Added `TestTaskStoreCleanup` verifying: expired rows are deleted, NEVER_EXPIRE rows (`expires_at=NULL`) survive, and not-yet-expired rows survive.

### Changes of Note

`expires_at` is the correct recency column here. Using `updated_at` would incorrectly delete NEVER_EXPIRE rows because those rows are regularly updated when retries write state. `expires_at=NULL` means "keep until the DAG run is cleaned up via FK cascade", which is what we want.

### Testing

Staged this data:
```json
{
    "task_store": [
        {
            "key": "dict-value",
            "value": {
                "example-key": "example-value"
            },
            "updated_at": "2026-06-08T10:16:25.405376Z",
            "expires_at": "2026-06-08T10:12:57.402464Z"
        },
        {
            "key": "job_id",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-6778-716a-b3b8-269103d0a9d1/job_id.json"
            },
            "updated_at": "2026-06-08T10:12:48.456699Z",
            "expires_at": null
        },
        {
            "key": "result",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-7b0c-7ee7-9897-cfbd7fa5f8fb/result.json"
            },
            "updated_at": "2026-06-08T10:12:56.464603Z",
            "expires_at": "2026-07-08T10:12:56.432594Z"
        },
        {
            "key": "status",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-7b0c-7ee7-9897-cfbd7fa5f8fb/status.json"
            },
            "updated_at": "2026-06-08T10:12:56.402464Z",
            "expires_at": "2026-07-08T10:12:56.268889Z"
        },
        {
            "key": "submitted_at",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-6778-716a-b3b8-269103d0a9d1/submitted_at.json"
            },
            "updated_at": "2026-06-08T10:12:48.481900Z",
            "expires_at": "2026-07-08T10:12:48.462541Z"
        }
    ],
    "total_entries": 5
}
```

Tested using:
```shell
[Breeze:3.10.20] root@bbaeb5c4452f:/opt/airflow$ airflow db clean --tables task_store --clean-before-timestamp 2026-06-09
You have requested that we purge all data prior to 2026-06-09 00:00:00+00:00 for tables ['task_store'].
This is irreversible.  Consider backing up the tables first and / or doing a dry run with option --dry-run.
Enter 'delete rows' (without quotes) to proceed.
delete rows

Checking table task_store
Found 1 rows meeting deletion criteria.
Performing Delete...
Moving data to table _airflow_deleted__task_store__20260608101839
Finished Performing Delete
```


After:

```json
{
    "task_store": [
        {
            "key": "job_id",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-6778-716a-b3b8-269103d0a9d1/job_id.json"
            },
            "updated_at": "2026-06-08T10:12:48.456699Z",
            "expires_at": null
        },
        {
            "key": "result",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-7b0c-7ee7-9897-cfbd7fa5f8fb/result.json"
            },
            "updated_at": "2026-06-08T10:12:56.464603Z",
            "expires_at": "2026-07-08T10:12:56.432594Z"
        },
        {
            "key": "status",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-7b0c-7ee7-9897-cfbd7fa5f8fb/status.json"
            },
            "updated_at": "2026-06-08T10:12:56.402464Z",
            "expires_at": "2026-07-08T10:12:56.268889Z"
        },
        {
            "key": "submitted_at",
            "value": {
                "__airflow_state_ref__": "/tmp/airflow_state/ti_019ea6b8-6778-716a-b3b8-269103d0a9d1/submitted_at.json"
            },
            "updated_at": "2026-06-08T10:12:48.481900Z",
            "expires_at": "2026-07-08T10:12:48.462541Z"
        }
    ],
    "total_entries": 4
}
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
