### PR TITLE
Remove automated backporting to v3-2-test

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -356,24 +356,6 @@ labelPRBasedOnFilePath:
     - .rat-excludes
     - .readthedocs.yml
 
-  # This should be copy of the "area:dev-tools" above minus contributing docs and some files that should
-  # only make sense in main - it should be updated when we switch maintenance branch.
-  # Scoped to PRs targeting `main` only — a PR opened directly against v3-2-test
-  # does not need a backport-to-v3-2-test label.
-  backport-to-v3-2-test:
-    paths:
-      - scripts/**/*
-      - dev/**/*
-      - .github/**/*
-      - Dockerfile.ci
-      - yamllint-config.yml
-      - .dockerignore
-      - .hadolint.yaml
-      - .pre-commit-config.yaml
-      - .rat-excludes
-    targetBranchFilter:
-      - ^main$
-
   # Apply to PRs touching airflow-ctl code so the release manager notices when a
   # fix should land on the airflow-ctl/v0-1-test maintenance branch.
   # Scoped to PRs targeting `main` only.


### PR DESCRIPTION
Removes the `backport-to-v3-2-test` auto-label rule from `.github/boring-cyborg.yml`.

PRs merged to `main` that touch dev-tools paths (`scripts/`, `dev/`, `.github/`, `Dockerfile.ci`, etc.) will no longer be automatically labelled `backport-to-v3-2-test` and therefore no longer trigger automatic cherry-picks to the `v3-2-test` maintenance branch.

The generic label-driven backport machinery (`automatic-backport.yml` / `backport-cli.yml`) is left intact, so maintainers can still backport manually by applying a `backport-to-*` label or running the `workflow_dispatch`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8 1M context)

Generated-by: Claude Code (Opus 4.8 1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)