### PR TITLE
Import ldap.filter in security_manager override

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -1929,6 +1929,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
         # Ensure python-ldap is installed
         try:
             import ldap
+            import ldap.filter
         except ImportError:
             log.error("python-ldap library is not installed")
             return None


### PR DESCRIPTION
### Fix LDAP login failure caused by missing `ldap.filter` import

closes: #68224

When LDAP authentication is enabled, Airflow may return a 500 Internal Server Error during login.

The failure occurs in the LDAP search path where `ldap.filter.escape_filter_chars()` is called without importing the `ldap.filter` submodule first. With recent versions of `python-ldap`, importing `ldap` alone does not automatically expose the `filter` module, resulting in:

```python
AttributeError: module 'ldap' has no attribute 'filter'
```

This change explicitly imports `ldap.filter` before it is used by the LDAP authentication flow.

### Reproduction

1. Configure Airflow with LDAP authentication.
2. Install a recent version of `python-ldap` (e.g. 3.4.7).
3. Attempt to log in using an LDAP user.
4. Airflow returns HTTP 500 with:

```python
AttributeError: module 'ldap' has no attribute 'filter'
```

### Root Cause

`ldap.filter.escape_filter_chars()` is referenced during LDAP user lookup, but the `ldap.filter` module is not imported. Recent versions of `python-ldap` require the submodule to be imported explicitly.

### Fix

Import `ldap.filter` before using `ldap.filter.escape_filter_chars()`.

### Testing

* Reproduced the issue on:

  * Apache Airflow 3.2.2
  * apache-airflow-providers-fab 3.6.5
  * python-ldap 3.4.7
  * Python 3.12

* Verified that LDAP authentication succeeds after the change.

* Verified that the 500 Internal Server Error no longer occurs during login.
