### PR TITLE
fix: swallow OperationalError in TriggerRunnerSupervisor.clean_unused() to prevent triggerer CLBO

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -43,7 +43,7 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import BaseModel, Field, TypeAdapter
-from sqlalchemy import func, select
+from sqlalchemy import exc, func, select
 from structlog.contextvars import bind_contextvars as bind_log_contextvars
 
 from airflow._shared.module_loading import import_string
@@ -692,7 +692,14 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
     def clean_unused(self) -> None:
         """Remove triggers that are no longer needed."""
-        Trigger.clean_unused()
+        try:
+            Trigger.clean_unused()
+        except exc.OperationalError as e:
+            self.log.warning(
+                "Trigger.clean_unused() failed with a database error and will be retried "
+                "on the next heartbeat. error=%s",
+                e,
+            )
 
     def handle_failed_triggers(self):
         """


### PR DESCRIPTION
## Motivation

`TriggerRunnerSupervisor.clean_unused()` calls `Trigger.clean_unused()`, which executes a `DELETE FROM trigger WHERE ...` that joins against `task_instance`. Under row-level lock contention — specifically when the triggerer's own `SELECT ... FOR UPDATE` queries hold locks on trigger rows while async coroutine work is in progress — the DELETE blocks waiting for those locks. If the wait exceeds the database `statement_timeout`, PostgreSQL raises `QueryCanceled`, which SQLAlchemy surfaces as `OperationalError`.

This exception propagates unhandled up through `TriggerRunnerSupervisor.run()`, crashing the triggerer process into CrashLoopBackOff.

This was observed in production (PostgreSQL metaDB, Airflow 3.2.1) across multiple workergroup deployments with 20–32 triggerer restarts over 3 days.

## Changes

- Wrap `Trigger.clean_unused()` in `TriggerRunnerSupervisor.clean_unused()` to catch `OperationalError` and log a warning instead of propagating the exception
- Add `sqlalchemy.exc` to the existing `sqlalchemy` import

## Why this is safe

`clean_unused()` is best-effort periodic housekeeping. Orphaned trigger rows sitting in the database for one extra heartbeat cycle (~1s) have no functional impact — triggers still fire, deferrable tasks still run. The cleanup retries on the next heartbeat. Crashing the triggerer over a transient DB error is strictly worse than skipping one cleanup cycle.

## Alternatives considered

- Fixing the lock contention directly: the triggerer's `SELECT ... FOR UPDATE` pattern is intentional for claiming triggers. Reducing contention via `idle_in_transaction_session_timeout` on the DB side helps but doesn't eliminate the race window.
- Re-raising after N consecutive failures: adds complexity for limited benefit — a persistent DB outage would surface through other signals (heartbeat failures, liveness probes) before the retry count mattered.