### PR TITLE
Improve providers release docs: carry over testing-issue checkmarks + tag-providers --release-date

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -653,7 +653,7 @@ twine upload -r pypi ${AIRFLOW_REPO_ROOT}/dist/*
 Earlier, we pushed the date tag, now that the RC(s) are ready we can push the tags for them.
 
 ```shell script
-breeze release-management tag-providers
+breeze release-management tag-providers --release-date ${RELEASE_DATE}
 ```
 
 ## Prepare documentation in Staging
@@ -763,6 +763,31 @@ creating the issue:
 breeze release-management generate-issue-content-providers --only-available-in-dist \
     --output-file files/provider_issue.md --answer no
 ```
+
+#### Always carry over checkmarks from the previous wave's testing issue
+
+Whenever a provider in this wave is a **re-cut** of one that already appeared in
+an earlier wave's testing issue — providers held back from the previous wave and
+released again at `rc2`/`rc3`, or any provider whose previous RC was cancelled —
+the PRs that were already ticked `[x]` (verified) in that earlier issue must stay
+ticked in the new one. Testers should not be asked to re-verify unchanged code;
+only the genuinely new commits in the re-cut are left unchecked. **Do this every
+time** before creating the issue.
+
+Extract the checked PRs from the previous issue and carry them over to the
+generated body:
+
+```shell script
+# PREV_ISSUE = the previous wave's testing-status issue number
+gh issue view PREV_ISSUE --repo apache/airflow --json body -q .body > /tmp/prev_issue.md
+checked=$(grep -E '^\s*- \[x\]' /tmp/prev_issue.md | grep -oE '#[0-9]+' | tr -d '#' | sort -u | paste -sd '|' -)
+# macOS sed: `sed -i ''`; GNU/Linux sed: `sed -i`
+sed -i '' -E "s/- \[ \] (.*\(#(${checked})\))/- [x] \1/" files/provider_issue.md
+```
+
+Review the resulting `[x]` lines (PRs only present in the new wave stay
+unchecked), then create the issue as below. If the issue was already created,
+apply the same edit to the file and run `gh issue edit <ISSUE> --body-file ...`.
 
 then create it from the file:
 
@@ -1515,7 +1540,7 @@ and lead to annoying errors. The default behavior would be to clean such local t
 If you want to disable this behavior, set the env **CLEAN_LOCAL_TAGS** to false.
 
 ```shell script
-breeze release-management tag-providers
+breeze release-management tag-providers --release-date ${RELEASE_DATE}
 ```
 
 ## Publish documentation

--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -764,7 +764,7 @@ breeze release-management generate-issue-content-providers --only-available-in-d
     --output-file files/provider_issue.md --answer no
 ```
 
-#### Always carry over checkmarks from the previous wave's testing issue
+### Always carry over checkmarks from the previous wave's testing issue
 
 Whenever a provider in this wave is a **re-cut** of one that already appeared in
 an earlier wave's testing issue — providers held back from the previous wave and


### PR DESCRIPTION
Small improvements to the providers release process docs (`dev/README_RELEASE_PROVIDERS.md`), found while running the 2026-06-08 wave:

1. **Carry over testing-issue checkmarks for re-cuts.** When a provider is re-cut — held back from a previous wave and released again at `rc2`/`rc3`, or a cancelled RC — the PRs already verified (`[x]`) in the previous wave's testing issue should stay checked in the new issue, so testers don't re-verify unchanged code; only genuinely new commits are left unchecked. Documents the extract-and-carry-over commands as a standard "always do this" step. (Applied live for 2026-06-08: issue carried the verified PRs over from the 2026-06-02 issue.)

2. **`tag-providers --release-date`.** The command requires `--release-date`, but both examples showed it bare (`breeze release-management tag-providers`), which fails with `Missing option '--release-date'`. Fixed both examples.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
