### PR TITLE
UI: Fix laggy multi-selection checkboxes in tables

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/DataTable/useRowSelection.tsx
+++ b/airflow-core/src/airflow/ui/src/components/DataTable/useRowSelection.tsx
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { useState } from "react";
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+import { Checkbox } from "src/components/ui/Checkbox";
 
 type UseRowSelectionProps<T> = {
   data?: Array<T>;
@@ -24,14 +26,84 @@ type UseRowSelectionProps<T> = {
 };
 
 export type GetColumnsParams = {
-  allRowsSelected: boolean;
   multiTeam: boolean;
+};
+
+type SelectionContextValue = {
+  allRowsSelected: boolean;
   onRowSelect: (key: string, isChecked: boolean) => void;
   onSelectAll: (isChecked: boolean) => void;
   selectedRows: Map<string, boolean>;
 };
 
-export const useRowSelection = <T>({ data = [], getKey }: UseRowSelectionProps<T>) => {
+const SelectionContext = createContext<SelectionContextValue | undefined>(undefined);
+
+const useSelectionContext = () => {
+  const ctx = useContext(SelectionContext);
+
+  if (ctx === undefined) {
+    throw new Error("SelectionRowCheckbox / SelectionHeaderCheckbox must be used inside <SelectionProvider>");
+  }
+
+  return ctx;
+};
+
+type SelectionProviderProps = {
+  readonly allRowsSelected: boolean;
+  readonly children: ReactNode;
+  readonly onRowSelect: (key: string, isChecked: boolean) => void;
+  readonly onSelectAll: (isChecked: boolean) => void;
+  readonly selectedRows: Map<string, boolean>;
+};
+
+export const SelectionProvider = ({
+  allRowsSelected,
+  children,
+  onRowSelect,
+  onSelectAll,
+  selectedRows,
+}: SelectionProviderProps) => {
+  const value: SelectionContextValue = { allRowsSelected, onRowSelect, onSelectAll, selectedRows };
+
+  return <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>;
+};
+
+type SelectionRowCheckboxProps = {
+  readonly colorPalette?: string;
+  readonly rowKey: string;
+};
+
+export const SelectionRowCheckbox = ({ colorPalette, rowKey }: SelectionRowCheckboxProps) => {
+  const { onRowSelect, selectedRows } = useSelectionContext();
+
+  return (
+    <Checkbox
+      borderWidth={1}
+      checked={selectedRows.has(rowKey)}
+      colorPalette={colorPalette}
+      onCheckedChange={(event) => onRowSelect(rowKey, Boolean(event.checked))}
+    />
+  );
+};
+
+type SelectionHeaderCheckboxProps = {
+  readonly colorPalette?: string;
+};
+
+export const SelectionHeaderCheckbox = ({ colorPalette }: SelectionHeaderCheckboxProps) => {
+  const { allRowsSelected, onSelectAll } = useSelectionContext();
+
+  return (
+    <Checkbox
+      borderWidth={1}
+      checked={allRowsSelected}
+      colorPalette={colorPalette}
+      onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
+    />
+  );
+};
+
+export const useRowSelection = <T,>({ data = [], getKey }: UseRowSelectionProps<T>) => {
   const [selectedRows, setSelectedRows] = useState<Map<string, boolean>>(new Map());
 
   const handleRowSelect = (key: string, isChecked: boolean) => {

--- a/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/Connections.tsx
@@ -26,13 +26,18 @@ import { useSearchParams } from "react-router-dom";
 import { useConnectionServiceGetConnections } from "openapi/queries";
 import type { ConnectionResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
-import { useRowSelection, type GetColumnsParams } from "src/components/DataTable/useRowSelection";
+import {
+  SelectionHeaderCheckbox,
+  SelectionProvider,
+  SelectionRowCheckbox,
+  useRowSelection,
+  type GetColumnsParams,
+} from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { SearchBar } from "src/components/SearchBar";
 import { Tooltip } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
-import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearch } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig.tsx";
@@ -59,32 +64,20 @@ export type ConnectionBody = {
 };
 
 const getColumns = ({
-  allRowsSelected,
+  hasSelection,
   multiTeam,
-  onRowSelect,
-  onSelectAll,
-  selectedRows,
   translate,
-}: { translate: TFunction } & GetColumnsParams): Array<ColumnDef<ConnectionResponse>> => {
+}: {
+  hasSelection: boolean;
+  translate: TFunction;
+} & GetColumnsParams): Array<ColumnDef<ConnectionResponse>> => {
   const columns: Array<ColumnDef<ConnectionResponse>> = [
     {
       accessorKey: "select",
-      cell: ({ row }) => (
-        <Checkbox
-          borderWidth={1}
-          checked={selectedRows.get(row.original.connection_id)}
-          onCheckedChange={(event) => onRowSelect(row.original.connection_id, Boolean(event.checked))}
-        />
-      ),
+      cell: ({ row }) => <SelectionRowCheckbox rowKey={row.original.connection_id} />,
       enableHiding: false,
       enableSorting: false,
-      header: () => (
-        <Checkbox
-          borderWidth={1}
-          checked={allRowsSelected}
-          onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
-        />
-      ),
+      header: () => <SelectionHeaderCheckbox />,
       meta: {
         skeletonWidth: 10,
       },
@@ -122,8 +115,8 @@ const getColumns = ({
       cell: ({ row: { original } }) => (
         <Flex justifyContent="end">
           <TestConnectionButton connection={original} />
-          <EditConnectionButton connection={original} disabled={selectedRows.size > 0} />
-          <DeleteConnectionButton connectionId={original.connection_id} disabled={selectedRows.size > 0} />
+          <EditConnectionButton connection={original} disabled={hasSelection} />
+          <DeleteConnectionButton connectionId={original.connection_id} disabled={hasSelection} />
         </Flex>
       ),
       enableSorting: false,
@@ -166,11 +159,8 @@ export const Connections = () => {
     });
 
   const columns = getColumns({
-    allRowsSelected,
+    hasSelection: selectedRows.size > 0,
     multiTeam: multiTeamEnabled,
-    onRowSelect: handleRowSelect,
-    onSelectAll: handleSelectAll,
-    selectedRows,
     translate,
   });
 
@@ -190,7 +180,12 @@ export const Connections = () => {
   };
 
   return (
-    <>
+    <SelectionProvider
+      allRowsSelected={allRowsSelected}
+      onRowSelect={handleRowSelect}
+      onSelectAll={handleSelectAll}
+      selectedRows={selectedRows}
+    >
       <VStack alignItems="none">
         <SearchBar
           advancedSearch={advancedSearch}
@@ -231,6 +226,6 @@ export const Connections = () => {
           <ActionBar.CloseTrigger onClick={clearSelections} />
         </ActionBar.Content>
       </ActionBar.Root>
-    </>
+    </SelectionProvider>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
@@ -27,7 +27,13 @@ import type { DAGRunResponse } from "openapi/requests/types.gen";
 import { ClearRunButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
 import { DataTable } from "src/components/DataTable";
-import { useRowSelection, type GetColumnsParams } from "src/components/DataTable/useRowSelection";
+import {
+  SelectionHeaderCheckbox,
+  SelectionProvider,
+  SelectionRowCheckbox,
+  useRowSelection,
+  type GetColumnsParams,
+} from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { LimitedItemsList } from "src/components/LimitedItemsList";
@@ -39,7 +45,6 @@ import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
 import { RouterLink } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
-import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { renderDuration, useAutoRefresh, isStatePending } from "src/utils";
@@ -82,34 +87,13 @@ type ColumnProps = {
   readonly translate: TFunction;
 } & GetColumnsParams;
 
-const runColumns = ({
-  allRowsSelected,
-  dagId,
-  onRowSelect,
-  onSelectAll,
-  selectedRows,
-  translate,
-}: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
+const runColumns = ({ dagId, translate }: ColumnProps): Array<ColumnDef<DAGRunResponse>> => [
   {
     accessorKey: "select",
-    cell: ({ row }) => (
-      <Checkbox
-        borderWidth={1}
-        checked={selectedRows.get(getRowKey(row.original))}
-        colorPalette="brand"
-        onCheckedChange={(event) => onRowSelect(getRowKey(row.original), Boolean(event.checked))}
-      />
-    ),
+    cell: ({ row }) => <SelectionRowCheckbox colorPalette="brand" rowKey={getRowKey(row.original)} />,
     enableHiding: false,
     enableSorting: false,
-    header: () => (
-      <Checkbox
-        borderWidth={1}
-        checked={allRowsSelected}
-        colorPalette="brand"
-        onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
-      />
-    ),
+    header: () => <SelectionHeaderCheckbox colorPalette="brand" />,
     meta: {
       skeletonWidth: 10,
     },
@@ -345,17 +329,18 @@ export const DagRuns = () => {
   const selectedDagRuns = (data?.dag_runs ?? []).filter((dagRun) => selectedRows.has(getRowKey(dagRun)));
 
   const columns = runColumns({
-    allRowsSelected,
     dagId,
     multiTeam: false,
-    onRowSelect: handleRowSelect,
-    onSelectAll: handleSelectAll,
-    selectedRows,
     translate,
   });
 
   return (
-    <>
+    <SelectionProvider
+      allRowsSelected={allRowsSelected}
+      onRowSelect={handleRowSelect}
+      onSelectAll={handleSelectAll}
+      selectedRows={selectedRows}
+    >
       <DagRunsFilters dagId={dagId} />
       <DataTable
         columns={columns}
@@ -379,6 +364,6 @@ export const DagRuns = () => {
           <ActionBar.CloseTrigger onClick={clearSelections} />
         </ActionBar.Content>
       </ActionBar.Root>
-    </>
+    </SelectionProvider>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -27,7 +27,13 @@ import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
 import { DagVersion } from "src/components/DagVersion";
 import { DataTable } from "src/components/DataTable";
-import { useRowSelection, type GetColumnsParams } from "src/components/DataTable/useRowSelection";
+import {
+  SelectionHeaderCheckbox,
+  SelectionProvider,
+  SelectionRowCheckbox,
+  useRowSelection,
+  type GetColumnsParams,
+} from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
@@ -36,7 +42,6 @@ import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
 import { RouterLink } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
-import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { useAutoRefresh, isStatePending, renderDuration } from "src/utils";
@@ -83,33 +88,17 @@ type ColumnProps = {
 };
 
 const taskInstanceColumns = ({
-  allRowsSelected,
   dagId,
-  onRowSelect,
-  onSelectAll,
   runId,
-  selectedRows,
   taskId,
   translate,
 }: ColumnProps & GetColumnsParams): Array<ColumnDef<TaskInstanceResponse>> => [
   {
     accessorKey: "select",
-    cell: ({ row }) => (
-      <Checkbox
-        borderWidth={1}
-        checked={selectedRows.get(getRowKey(row.original))}
-        onCheckedChange={(event) => onRowSelect(getRowKey(row.original), Boolean(event.checked))}
-      />
-    ),
+    cell: ({ row }) => <SelectionRowCheckbox rowKey={getRowKey(row.original)} />,
     enableHiding: false,
     enableSorting: false,
-    header: () => (
-      <Checkbox
-        borderWidth={1}
-        checked={allRowsSelected}
-        onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
-      />
-    ),
+    header: () => <SelectionHeaderCheckbox />,
     meta: {
       skeletonWidth: 10,
     },
@@ -381,19 +370,20 @@ export const TaskInstances = () => {
   const selectedTaskInstances = (data?.task_instances ?? []).filter((ti) => selectedRows.has(getRowKey(ti)));
 
   const columns = taskInstanceColumns({
-    allRowsSelected,
     dagId,
     multiTeam: false,
-    onRowSelect: handleRowSelect,
-    onSelectAll: handleSelectAll,
     runId,
-    selectedRows,
     taskId: Boolean(groupId) ? undefined : taskId,
     translate,
   });
 
   return (
-    <>
+    <SelectionProvider
+      allRowsSelected={allRowsSelected}
+      onRowSelect={handleRowSelect}
+      onSelectAll={handleSelectAll}
+      selectedRows={selectedRows}
+    >
       <TaskInstancesFilter />
       <DataTable
         columns={columns}
@@ -427,6 +417,6 @@ export const TaskInstances = () => {
           <ActionBar.CloseTrigger onClick={clearSelections} />
         </ActionBar.Content>
       </ActionBar.Root>
-    </>
+    </SelectionProvider>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/Variables.tsx
@@ -26,14 +26,19 @@ import { useSearchParams } from "react-router-dom";
 import { useVariableServiceGetVariables } from "openapi/queries";
 import type { VariableResponse } from "openapi/requests/types.gen";
 import { DataTable } from "src/components/DataTable";
-import { useRowSelection, type GetColumnsParams } from "src/components/DataTable/useRowSelection";
+import {
+  SelectionHeaderCheckbox,
+  SelectionProvider,
+  SelectionRowCheckbox,
+  useRowSelection,
+  type GetColumnsParams,
+} from "src/components/DataTable/useRowSelection";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { ExpandCollapseButtons } from "src/components/ExpandCollapseButtons";
 import { SearchBar } from "src/components/SearchBar";
 import { Tooltip } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
-import { Checkbox } from "src/components/ui/Checkbox";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearch } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig.tsx";
@@ -51,33 +56,18 @@ type ColumnProps = {
 };
 
 const getColumns = ({
-  allRowsSelected,
+  hasSelection,
   multiTeam,
-  onRowSelect,
-  onSelectAll,
   open,
-  selectedRows,
   translate,
-}: ColumnProps & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
+}: { hasSelection: boolean } & ColumnProps & GetColumnsParams): Array<ColumnDef<VariableResponse>> => {
   const columns: Array<ColumnDef<VariableResponse>> = [
     {
       accessorKey: "select",
-      cell: ({ row }) => (
-        <Checkbox
-          borderWidth={1}
-          checked={selectedRows.get(row.original.key)}
-          onCheckedChange={(event) => onRowSelect(row.original.key, Boolean(event.checked))}
-        />
-      ),
+      cell: ({ row }) => <SelectionRowCheckbox rowKey={row.original.key} />,
       enableHiding: false,
       enableSorting: false,
-      header: () => (
-        <Checkbox
-          borderWidth={1}
-          checked={allRowsSelected}
-          onCheckedChange={(event) => onSelectAll(Boolean(event.checked))}
-        />
-      ),
+      header: () => <SelectionHeaderCheckbox />,
       meta: {
         skeletonWidth: 10,
       },
@@ -129,8 +119,8 @@ const getColumns = ({
       accessorKey: "actions",
       cell: ({ row: { original } }) => (
         <Flex justifyContent="end">
-          <EditVariableButton disabled={selectedRows.size > 0} variable={original} />
-          <DeleteVariableButton deleteKey={original.key} disabled={selectedRows.size > 0} />
+          <EditVariableButton disabled={hasSelection} variable={original} />
+          <DeleteVariableButton deleteKey={original.key} disabled={hasSelection} />
         </Flex>
       ),
       enableSorting: false,
@@ -176,12 +166,9 @@ export const Variables = () => {
     });
 
   const columns = getColumns({
-    allRowsSelected,
+    hasSelection: selectedRows.size > 0,
     multiTeam: multiTeamEnabled,
-    onRowSelect: handleRowSelect,
-    onSelectAll: handleSelectAll,
     open,
-    selectedRows,
     translate,
   });
 
@@ -201,7 +188,12 @@ export const Variables = () => {
   };
 
   return (
-    <>
+    <SelectionProvider
+      allRowsSelected={allRowsSelected}
+      onRowSelect={handleRowSelect}
+      onSelectAll={handleSelectAll}
+      selectedRows={selectedRows}
+    >
       <VStack alignItems="none">
         <SearchBar
           advancedSearch={advancedSearch}
@@ -246,6 +238,6 @@ export const Variables = () => {
           <ActionBar.CloseTrigger onClick={clearSelections} />
         </ActionBar.Content>
       </ActionBar.Root>
-    </>
+    </SelectionProvider>
   );
 };


### PR DESCRIPTION
Clicking a row checkbox in the Task Instances / Dag Runs / Variables / Connections tables had a visible (~500ms) delay before the checked state appeared.

### Cause

The `select` column cells read `selectedRows` directly, so the columns array depended on it. Each click replaces `selectedRows` with a new `Map`, recomputing the columns — and TanStack then re-renders every cell, including the heavy ones (`Time`, `RouterLink`, `StateBadge`, `DagVersion`, action buttons). At 30–50 rows that reaches hundreds of ms.

### Fix

Move selection out of the column definitions into a `SelectionContext`; the new `SelectionRowCheckbox` / `SelectionHeaderCheckbox` read it from context. The columns array no longer depends on `selectedRows`, so it stays stable across clicks and only the checkboxes re-render.

Also use `selectedRows.has(key)` (`boolean`) instead of `.get(key)` (`boolean | undefined`) to keep the checkbox controlled.

Applied to all four multi-selection tables: TaskInstances, DagRuns, Variables, Connections.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
