### PR TITLE
Sync apache-magpie setup bootstrap skill from framework

### DIFF
--- a/.agents/skills/magpie-setup/SKILL.md
+++ b/.agents/skills/magpie-setup/SKILL.md
@@ -3,25 +3,15 @@ name: magpie-setup
 description: |
   Adopt and maintain the apache-steward framework in a project
   repo via the snapshot-based adoption mechanism. The only
-  framework skill committed in an adopter's repo — every other
+  framework skill committed in an adopter's repo; every other
   skill is a symlink the adopt sub-action wires up.
   Sub-actions:
-    `/magpie-setup`         — first-time adoption (default;
-                                main-checkout only)
-    `/magpie-setup upgrade` — refresh the gitignored snapshot
-                                per the committed lock
-                                (main-checkout only)
-    `/magpie-setup worktree-init` — symlink a worktree's
-                                snapshot to the main's
-    `/magpie-setup verify`  — health check + drift detection
-    `/magpie-setup override <skill>` — open or scaffold an
-                                agentic override in
-                                `.apache-magpie-overrides/`
-    `/magpie-setup unadopt` — reverse the adoption (snapshot,
-                               locks, symlinks, hook, doc
-                               sections); preserves
-                               `.apache-magpie-overrides/` by
-                               default (main-checkout only)
+    `/magpie-setup` - first-time adoption (default; main-checkout only)
+    `/magpie-setup upgrade` - refresh the gitignored snapshot per the committed lock (main-checkout only)
+    `/magpie-setup worktree-init` - symlink a worktree's snapshot to the main's
+    `/magpie-setup verify` - health check + drift detection
+    `/magpie-setup override <skill>` - open or scaffold an agentic override in `.apache-magpie-overrides/`
+    `/magpie-setup unadopt` - reverse the adoption (snapshot, locks, symlinks, hook, doc sections); preserves `.apache-magpie-overrides/` by default (main-checkout only)
 when_to_use: |
   Invoke when the user says "adopt apache-steward", "adopt
   apache/airflow-steward", "set up steward in this repo",


### PR DESCRIPTION
Syncs the committed apache-magpie `setup` bootstrap skill with the upstream `apache/airflow-steward` framework (snapshot `dc98175cd`), picked up by `/magpie-setup upgrade`.

The only change is a cosmetic shortening of the skill's frontmatter `description` (steward #464). No behavior change — the sub-action logic is unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8 1M context)

Generated-by: Claude Code (Opus 4.8 1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)