### PR TITLE
Don't auto-add Java SDK Javadoc to provider-list doc publishes

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -366,12 +366,22 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
-      - name: "Check whether the Java SDK exists at this ref"
+      - name: "Decide whether to build the Java SDK Javadoc"
         id: sdk-present
         env:
           REF: ${{ inputs.ref }}
+          INCLUDE_DOCS: ${{ inputs.include-docs }}
         run: |
-          if [[ -f "java-sdk/gradlew" ]]; then
+          # The Java SDK Javadoc is only built (and later published) for full doc
+          # builds (include-docs == 'all') or when 'java-sdk' is explicitly listed.
+          # When a specific list of packages is passed (e.g. a provider release
+          # wave like "amazon cncf.kubernetes ..."), the Java SDK must NOT be added
+          # automatically — otherwise the publish step drags java-sdk into a
+          # providers-only publish and the S3 publish fails.
+          if [[ "${INCLUDE_DOCS}" != "all" && " ${INCLUDE_DOCS} " != *" java-sdk "* ]]; then
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+            echo "include-docs='${INCLUDE_DOCS}' is a specific package list without 'java-sdk' — skipping Javadoc build."
+          elif [[ -f "java-sdk/gradlew" ]]; then
             echo "exists=true" >> "${GITHUB_OUTPUT}"
           else
             echo "exists=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
When a specific list of packages is passed to the `publish-docs-to-s3`
workflow (for example a provider release wave like
`amazon cncf.kubernetes edge3 apache.spark clickhousedb`), the Java SDK
Javadoc was still built and appended to the S3 publish set whenever
`java-sdk/` existed at the ref. That dragged `java-sdk` into a
providers-only publish and made the **Publish documentation to S3** job
fail (e.g. [run 27138260700](https://github.com/apache/airflow/actions/runs/27138260700)).

The `sdk-present` decision step now also looks at `include-docs`: it skips
building (and therefore publishing) the Java SDK Javadoc unless this is a
full docs build (`include-docs == 'all'`) or `java-sdk` is explicitly
listed. The gate lives at the step level (setting `built=false`) rather
than the job level, so the `publish-docs-to-s3` job's `needs` stays
satisfied and GitHub's skipped-dependency propagation does not skip the
publish job.

Verified against the real workflow on `apache/airflow`:
[run 27141569441](https://github.com/apache/airflow/actions/runs/27141569441)
re-published the 2026-06-08 provider wave to staging — the Java SDK
Javadoc job completed in 12s (skipped the build) and **Publish
documentation to S3** passed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
