### PR TITLE
Speed up Trigger.clean_unused query to prevent Triggerer crashes 

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -250,15 +250,12 @@ class Trigger(Base):
                 )
 
         # Get all triggers that have no task instances, assets, or callbacks depending on them and delete them
-        ids = (
-            select(cls.id)
-            .where(
-                ~cls.assets.any(),
-                ~cls.callback.has(),
-                ~cls.task_instance.has(),
-            )
-            .with_for_update(skip_locked=True)
+        ids = select(cls.id).where(
+            ~cls.assets.any(),
+            ~cls.callback.has(),
+            ~cls.task_instance.has(),
         )
+        ids = with_row_locks(ids, session, of=cls, skip_locked=True, key_share=False)
         if get_dialect_name(session) == "mysql":
             # MySQL doesn't support DELETE with JOIN, so we need to do it in two steps
             ids_list = list(session.scalars(ids).all())

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -250,10 +250,14 @@ class Trigger(Base):
                 )
 
         # Get all triggers that have no task instances, assets, or callbacks depending on them and delete them
-        ids = select(cls.id).where(
-            ~cls.assets.any(),
-            ~cls.callback.has(),
-            ~cls.task_instance.has(),
+        ids = (
+            select(cls.id)
+            .where(
+                ~cls.assets.any(),
+                ~cls.callback.has(),
+                ~cls.task_instance.has(),
+            )
+            .with_for_update(skip_locked=True)
         )
         if get_dialect_name(session) == "mysql":
             # MySQL doesn't support DELETE with JOIN, so we need to do it in two steps

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -250,12 +250,10 @@ class Trigger(Base):
                 )
 
         # Get all triggers that have no task instances, assets, or callbacks depending on them and delete them
-        ids = (
-            select(cls.id)
-            .where(~cls.assets.any(), ~cls.callback.has())
-            .join(TaskInstance, cls.id == TaskInstance.trigger_id, isouter=True)
-            .group_by(cls.id)
-            .having(func.count(TaskInstance.trigger_id) == 0)
+        ids = select(cls.id).where(
+            ~cls.assets.any(),
+            ~cls.callback.has(),
+            ~cls.task_instance.has(),
         )
         if get_dialect_name(session) == "mysql":
             # MySQL doesn't support DELETE with JOIN, so we need to do it in two steps


### PR DESCRIPTION


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
### Description
Changed the query that checks for triggers that have no more callbacks, assets or task instances associated to them from count + aggregate to anti join on task_instance. 
The result is the same (we are checking for non existence) but the query is more efficient. Also added skip locked since we run multiple triggerers and the different queries interfere with each other. 

I did not add tests since I'm not introducing a new functionality, so the [current one](https://github.com/apache/airflow/blob/main/airflow-core/tests/unit/models/test_trigger.py#L122) should cover the code change. If you think additional tests are needed, please let me know.  

### Testing

<details>
<summary>Plans of the queries</summary>
OLD QUERY:

```
EXPLAIN
DELETE
FROM trigger
WHERE trigger.id IN (SELECT trigger.id
                     FROM trigger
                              LEFT OUTER JOIN task_instance ON trigger.id = task_instance.trigger_id
                     WHERE NOT (EXISTS (SELECT 1
                                        FROM asset_watcher
                                        WHERE trigger.id = asset_watcher.trigger_id
                                          AND (EXISTS (SELECT 1
                                                       FROM asset
                                                       WHERE asset.id = asset_watcher.asset_id)))
                         )
                       AND NOT (EXISTS (SELECT 1
                                        FROM callback
                                        WHERE trigger.id = callback.trigger_id))
                     GROUP BY trigger.id
                     HAVING count(task_instance.trigger_id) = 0);
```
yields
```
-[ RECORD 1 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN | Delete on trigger  (cost=49.31..93458.14 rows=0 width=0)
-[ RECORD 2 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |   ->  Nested Loop  (cost=49.31..93458.14 rows=1 width=34)
-[ RECORD 3 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |         ->  Subquery Scan on "ANY_subquery"  (cost=49.04..93455.59 rows=1 width=32)
-[ RECORD 4 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |               ->  GroupAggregate  (cost=49.04..93455.58 rows=1 width=4)
-[ RECORD 5 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                     Group Key: trigger_1.id
-[ RECORD 6 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                     Filter: (count(task_instance.trigger_id) = 0)
-[ RECORD 7 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                     ->  Nested Loop Left Join  (cost=49.04..192.44 rows=18652448 width=8)
-[ RECORD 8 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                           ->  Nested Loop Anti Join  (cost=48.61..72.06 rows=72 width=4)
-[ RECORD 9 ]---------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                 ->  Merge Anti Join  (cost=48.46..48.83 rows=72 width=4)
-[ RECORD 10 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       Merge Cond: (trigger_1.id = asset_watcher.trigger_id)
-[ RECORD 11 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       ->  Sort  (cost=45.94..46.12 rows=72 width=4)
-[ RECORD 12 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             Sort Key: trigger_1.id
-[ RECORD 13 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             ->  Seq Scan on trigger trigger_1  (cost=0.00..43.72 rows=72 width=4)
-[ RECORD 14 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       ->  Sort  (cost=2.52..2.52 rows=1 width=4)
-[ RECORD 15 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             Sort Key: asset_watcher.trigger_id
-[ RECORD 16 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             ->  Nested Loop  (cost=0.29..2.51 rows=1 width=4)
-[ RECORD 17 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                   ->  Seq Scan on asset_watcher  (cost=0.00..0.00 rows=1 width=8)
-[ RECORD 18 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                   ->  Index Only Scan using asset_pkey on asset  (cost=0.29..2.51 rows=1 width=4)
-[ RECORD 19 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                         Index Cond: (id = asset_watcher.asset_id)
-[ RECORD 20 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                 ->  Index Only Scan using idx_callback_trigger_id on callback  (cost=0.15..0.32 rows=1 width=4)
-[ RECORD 21 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       Index Cond: (trigger_id = trigger_1.id)
-[ RECORD 22 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                           ->  Index Only Scan using ti_trigger_id on task_instance  (cost=0.44..1.66 rows=1 width=4)
-[ RECORD 23 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                 Index Cond: (trigger_id = trigger_1.id)
-[ RECORD 24 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |         ->  Index Scan using trigger_pkey on trigger  (cost=0.27..2.49 rows=1 width=10)
-[ RECORD 25 ]--------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |               Index Cond: (id = "ANY_subquery".id)
```
NEW QUERY:
```
EXPLAIN
DELETE
FROM trigger
WHERE trigger.id IN (SELECT trigger.id
                     FROM trigger
                     WHERE NOT (EXISTS (SELECT 1
                                        FROM asset_watcher

                                        WHERE trigger.id = asset_watcher.trigger_id
                                          AND (EXISTS (SELECT 1
                                                       FROM asset
                                                       WHERE asset.id = asset_watcher.asset_id)))
                         )
                       AND NOT (EXISTS (SELECT 1
                                        FROM callback

                                        WHERE trigger.id = callback.trigger_id))
                       AND NOT (EXISTS (SELECT 1
                                        FROM task_instance

                                        WHERE trigger.id = task_instance.trigger_id)) FOR
UPDATE SKIP LOCKED
    );
```
yields
```
-[ RECORD 1 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN | Delete on trigger  (cost=328.23..372.97 rows=0 width=0)
-[ RECORD 2 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |   ->  Hash Semi Join  (cost=328.23..372.97 rows=73 width=34)
-[ RECORD 3 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |         Hash Cond: (trigger.id = "ANY_subquery".id)
-[ RECORD 4 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |         ->  Seq Scan on trigger  (cost=0.00..43.73 rows=73 width=10)
-[ RECORD 5 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |         ->  Hash  (cost=327.32..327.32 rows=73 width=32)
-[ RECORD 6 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |               ->  Subquery Scan on "ANY_subquery"  (cost=0.88..327.32 rows=73 width=32)
-[ RECORD 7 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                     ->  LockRows  (cost=0.88..326.59 rows=73 width=34)
-[ RECORD 8 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                           ->  Nested Loop Anti Join  (cost=0.88..325.86 rows=73 width=34)
-[ RECORD 9 ]-----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                 ->  Nested Loop Anti Join  (cost=0.44..129.83 rows=73 width=28)
-[ RECORD 10 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       ->  Nested Loop Anti Join  (cost=0.29..47.33 rows=73 width=22)
-[ RECORD 11 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             Join Filter: (trigger_1.id = asset_watcher.trigger_id)
-[ RECORD 12 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             ->  Seq Scan on trigger trigger_1  (cost=0.00..43.73 rows=73 width=10)
-[ RECORD 13 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             ->  Materialize  (cost=0.29..2.51 rows=1 width=16)
-[ RECORD 14 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                   ->  Nested Loop  (cost=0.29..2.51 rows=1 width=16)
-[ RECORD 15 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                         ->  Seq Scan on asset_watcher  (cost=0.00..0.00 rows=1 width=14)
-[ RECORD 16 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                         ->  Index Scan using asset_pkey on asset  (cost=0.29..2.51 rows=1 width=10)
-[ RECORD 17 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                                               Index Cond: (id = asset_watcher.asset_id)
-[ RECORD 18 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       ->  Index Scan using idx_callback_trigger_id on callback  (cost=0.15..1.12 rows=1 width=10)
-[ RECORD 19 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                             Index Cond: (trigger_id = trigger_1.id)
-[ RECORD 20 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                 ->  Index Scan using ti_trigger_id on task_instance  (cost=0.44..2.66 rows=1 width=10)
-[ RECORD 21 ]----------------------------------------------------------------------------------------------------------------------------------
QUERY PLAN |                                       Index Cond: (trigger_id = trigger_1.id)

```

</details>
Also we stopped having queries that crashed the triggerer
<img width="1001" height="179" alt="image" src="https://github.com/user-attachments/assets/c4d03de6-812c-4015-8a26-d1b4646944d4" />


---
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Sonnet 1M
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
