### PR TITLE
UI: Fix wrong language auto-detected from browser preferences

### DIFF
--- a/airflow-core/src/airflow/ui/src/i18n/config.test.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.test.ts
@@ -1,0 +1,91 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { createInstance } from "i18next";
+import { describe, expect, it } from "vitest";
+
+import { convertDetectedLanguage, i18nBaseOptions } from "./config";
+
+// getBestMatchFromCodes is the resolver i18next runs on the array the
+// LanguageDetector returns. It is not part of i18next's public types
+// (services.languageUtils is `any`), so we pin the one method we use.
+type LanguageUtils = { getBestMatchFromCodes: (codes: ReadonlyArray<string>) => string };
+
+// Resolve a language exactly as the running app does: the detector maps
+// convertDetectedLanguage over navigator.languages (preserving order), then
+// i18next picks the best match. Uses the production init options so the test
+// guards the real config rather than a copy.
+const resolveLanguage = async (navigatorLanguages: ReadonlyArray<string>): Promise<string> => {
+  const instance = createInstance();
+
+  await instance.init({ ...i18nBaseOptions, initImmediate: false, resources: {} });
+
+  const languageUtils = instance.services.languageUtils as LanguageUtils;
+
+  return languageUtils.getBestMatchFromCodes(navigatorLanguages.map(convertDetectedLanguage));
+};
+
+describe("i18n language resolution", () => {
+  it.each([
+    // The reported bug: real UK Chrome with Hindi added. Before the fix this
+    // resolved to "hi" because "en-GB"/"en-US" are not exact members of
+    // supportedLngs but "hi" is, so the first bare supported code won.
+    { expected: "en", languages: ["en-GB", "hi-IN", "hi", "en-US", "en", "gu"] },
+    { expected: "en", languages: ["en-GB", "hi"] },
+    { expected: "en", languages: ["en-GB"] },
+    // Browsers may emit non-canonical casing.
+    { expected: "en", languages: ["EN-GB", "hi"] },
+    // Other region-qualified base languages were affected the same way.
+    { expected: "pt", languages: ["pt-BR", "en"] },
+    { expected: "de", languages: ["de-AT", "de", "en"] },
+    { expected: "fr", languages: ["fr-FR", "fr", "en"] },
+  ])(
+    "resolves $languages to $expected (region variant of a base language)",
+    async ({ expected, languages }) => {
+      expect(await resolveLanguage(languages)).toBe(expected);
+    },
+  );
+
+  it.each([
+    // Region-specific supported locales must stay intact even when English
+    // follows them -- this is what nonExplicitSupportedLngs/load:"languageOnly"
+    // would break by collapsing "zh-CN"/"zh-TW" to the unsupported "zh".
+    { expected: "zh-CN", languages: ["zh-CN"] },
+    { expected: "zh-CN", languages: ["zh-CN", "zh", "en"] },
+    { expected: "zh-CN", languages: ["zh-CN", "en-US"] },
+    { expected: "zh-TW", languages: ["zh-TW", "zh", "en"] },
+    { expected: "zh-TW", languages: ["zh-TW", "en"] },
+    // Traditional Chinese via script/region subtags (e.g. macOS Safari) must
+    // resolve to zh-TW, not be collapsed to Simplified by a generic "zh-*" match.
+    { expected: "zh-TW", languages: ["zh-Hant-TW", "en"] },
+    { expected: "zh-TW", languages: ["zh-Hant", "en"] },
+    { expected: "zh-TW", languages: ["zh-HK", "en"] },
+    { expected: "zh-TW", languages: ["zh-MO", "en"] },
+    // Simplified markers and a bare "zh" map to zh-CN.
+    { expected: "zh-CN", languages: ["zh-Hans-CN", "en"] },
+    { expected: "zh-CN", languages: ["zh-SG", "en"] },
+    { expected: "zh-CN", languages: ["zh", "en"] },
+  ])("keeps Chinese locale $expected for $languages", async ({ expected, languages }) => {
+    expect(await resolveLanguage(languages)).toBe(expected);
+  });
+
+  it("still honors a genuinely preferred non-English language", async () => {
+    expect(await resolveLanguage(["hi"])).toBe("hi");
+    expect(await resolveLanguage(["hi-IN", "en"])).toBe("hi");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/i18n/config.ts
+++ b/airflow-core/src/airflow/ui/src/i18n/config.ts
@@ -63,6 +63,72 @@ const baseHref = document.querySelector("head > base")?.getAttribute("href") ?? 
 const baseUrl = new URL(baseHref, globalThis.location.origin);
 const basePath = new URL(baseUrl).pathname.replace(/\/$/u, "");
 
+const supportedCodes: Array<string> = supportedLanguages.map((lang) => lang.code);
+
+// i18next resolves navigator.languages with two global passes: it only reduces
+// a region code ("en-GB") to its base ("en") when NO exact match exists anywhere
+// in the list. So a browser list like ["en-GB", "hi-IN", "hi", "en-US", "en"]
+// matched the exact "hi" before "en-GB" was ever reduced to "en", and the UI
+// loaded in Hindi. The detector maps this function over each navigator.languages
+// entry (preserving order), so normalising per code makes the base-language
+// match happen in priority order. Preferred over nonExplicitSupportedLngs /
+// load:"languageOnly", which strip the region from every code and so collapse
+// "zh-CN"/"zh-TW" to the unsupported "zh".
+export const convertDetectedLanguage = (lng: string): string => {
+  let locale: Intl.Locale;
+
+  try {
+    locale = new Intl.Locale(lng);
+  } catch {
+    // Not a well-formed BCP-47 tag (e.g. a stale "zh_TW" cache value). Leave it
+    // for i18next to fall back rather than guess.
+    return lng;
+  }
+
+  // Exact supported code, tolerating browser casing ("ZH-CN" -> "zh-CN").
+  if (supportedCodes.includes(locale.baseName)) {
+    return locale.baseName;
+  }
+
+  // Region/script variant of a supported base language: "en-GB" -> "en", "pt-BR" -> "pt".
+  if (supportedCodes.includes(locale.language)) {
+    return locale.language;
+  }
+
+  // For a language whose base code isn't supported but which has region-specific
+  // supported locales, match by language + resolved script. maximize() derives
+  // the script from the region via CLDR data, so "zh-HK"/"zh-Hant" (Hant) map to
+  // "zh-TW" and "zh"/"zh-SG" (Hans) map to "zh-CN". A Chinese tag thus prefers
+  // Chinese over a lower-priority language.
+  const wanted = locale.maximize();
+
+  return (
+    supportedCodes.find((code) => {
+      const candidate = new Intl.Locale(code).maximize();
+
+      return candidate.language === wanted.language && candidate.script === wanted.script;
+    }) ?? lng
+  );
+};
+
+export const i18nBaseOptions = {
+  defaultNS: "common",
+  detection: {
+    caches: ["localStorage"],
+    convertDetectedLanguage,
+    order: ["localStorage", "navigator", "htmlTag"],
+  },
+  fallbackLng: defaultLanguage,
+  interpolation: {
+    escapeValue: false,
+  },
+  ns: namespaces,
+  react: {
+    useSuspense: false,
+  },
+  supportedLngs: supportedCodes,
+};
+
 const initI18n = (version: string) => {
   const queryString = version ? `?v=${version}` : "";
 
@@ -71,23 +137,10 @@ const initI18n = (version: string) => {
     .use(LanguageDetector)
     .use(initReactI18next)
     .init({
+      ...i18nBaseOptions,
       backend: {
         loadPath: `${basePath}/static/i18n/locales/{{lng}}/{{ns}}.json${queryString}`,
       },
-      defaultNS: "common",
-      detection: {
-        caches: ["localStorage"],
-        order: ["localStorage", "navigator", "htmlTag"],
-      },
-      fallbackLng: defaultLanguage,
-      interpolation: {
-        escapeValue: false,
-      },
-      ns: namespaces,
-      react: {
-        useSuspense: false,
-      },
-      supportedLngs: supportedLanguages.map((lang) => lang.code),
     });
 };
 


### PR DESCRIPTION
The web UI auto-detects its display language from the browser. For users whose `navigator.languages` lists a region-qualified primary locale (for example `en-GB`) ahead of other languages, the UI loads in the wrong language. My case: a UK English browser that also lists Hindi loads the UI in Hindi instead of English! The detected language is cached in `localStorage` (`i18nextLng`), so it persists across reloads until changed manually.

My Browser setting as an example:

<img width="1480" height="770" alt="image" src="https://github.com/user-attachments/assets/1620ba85-c251-4632-a84f-840018f38675" />


## Root cause

i18next resolves the detected list with `getBestMatchFromCodes`, which runs two global passes. The first pass selects the first code that is an exact member of `supportedLngs`; only if that finds nothing does the second pass reduce a region code to its base language. `supportedLngs` mixes base codes (`en`) with region codes (`zh-CN`, `zh-TW`), so `en-GB`/`en-US` are not exact matches and get skipped, while a later exact match such as `hi` wins before `en-GB` is ever reduced to `en`.

This affects any user whose top browser language is a region variant of a base-supported locale (`en-GB`, `pt-BR`, `de-AT`, ...) followed by another exactly-supported language. It surfaced in 3.1 as the locale set grew to include bare codes like `hi`; the original two-locale set (`en`, `zh_TW`) could not trigger it.

## Fix

Add a `convertDetectedLanguage` hook to the detector. i18next maps it over each `navigator.languages` entry in order, before matching, so the base-language reduction happens per code in priority order. Each tag is parsed with the platform's native `Intl.Locale` (matching the UI's existing `Intl.*` usage):

- region variant of a supported base language folds to the base (`en-GB` -> `en`)
- region-specific supported locales stay exact (`zh-CN`, `zh-TW`)
- Chinese without an exact match picks Traditional vs Simplified from `Intl.Locale(...).maximize().script` (CLDR data): `zh-Hant-TW`/`zh-HK`/`zh-MO` -> `zh-TW`, `zh`/`zh-Hans`/`zh-SG` -> `zh-CN`

## Why this approach

`nonExplicitSupportedLngs: true` and `load: "languageOnly"` strip the region from every code, which collapses the supported `zh-CN`/`zh-TW` to the unsupported `zh` and flips Chinese users to English. `convertDetectedLanguage` is the mechanism i18next recommends for a `supportedLngs` that mixes base and region codes ([i18next #2365](https://github.com/i18next/i18next/issues/2365), [#2354](https://github.com/i18next/i18next/issues/2354)), applied at the array layer where the limitation lives ([#2299](https://github.com/i18next/i18next/issues/2299)). The behavior is unchanged through the latest i18next (26.x), so a version bump does not address it.

## Notes

- Region variants resolve to the base locale (`en`), so no request is made for nonexistent `en-GB` translation files.
- A previously cached wrong language stays until the user changes it or clears `localStorage`; fresh detections resolve correctly.


## Resolved language (before/after)

Resolved UI locale for representative `navigator.languages`, against the real i18next resolver (also encoded as tests in `config.test.ts`):

| `navigator.languages` | Before | After |
|---|---|---|
| `["en-GB","hi-IN","hi","en-US","en"]` | `hi` | `en` |
| `["pt-BR","en"]` | `en` | `pt` |
| `["zh-TW","zh","en"]` | `zh-TW` | `zh-TW` (unchanged) |
| `["zh-Hant-TW","en"]` | `en` | `zh-TW` |

