### PR TITLE
Fix common-ai HITL Review UI bundle

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/plugins/www/vite.config.ts
+++ b/providers/common/ai/src/airflow/providers/common/ai/plugins/www/vite.config.ts
@@ -41,8 +41,6 @@ export default defineConfig(({ command }) => {
               "react",
               "react-dom",
               "react/jsx-runtime",
-              "@chakra-ui/react",
-              "@emotion/react",
             ],
             output: {
               entryFileNames: "[name].umd.cjs",
@@ -50,8 +48,6 @@ export default defineConfig(({ command }) => {
                 react: "React",
                 "react-dom": "ReactDOM",
                 "react/jsx-runtime": "ReactJSXRuntime",
-                "@chakra-ui/react": "ChakraUI",
-                "@emotion/react": "EmotionReact",
               },
             },
           },


### PR DESCRIPTION
This PR fixes the `common-ai` HITL Review UI load failure.

* closes: #68217

Changes:
- Bundle Chakra UI and Emotion inside the HITL Review plugin build.

Before
<img width="1360" height="800" alt="Screenshot 2026-06-09 at 10 50 54" src="https://github.com/user-attachments/assets/bd999f51-ef46-4160-b34f-a335e9017628" />

After
<img width="893" height="649" alt="Screenshot 2026-06-09 at 10 50 39" src="https://github.com/user-attachments/assets/79cdb974-503a-4e3d-b038-3a088bff768c" />

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=51c3be0 action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @Jie211 → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @Jie211 — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->