### PR TITLE
Reuse a session-scoped FastAPI app across api_fastapi tests

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_dagbag.py
@@ -59,7 +59,7 @@ class TestDagBagSingleton:
             purge_cached_app()
             yield
 
-    def test_dagbag_used_as_singleton_in_dependency(self, session, dag_maker, test_client):
+    def test_dagbag_used_as_singleton_in_dependency(self, session, dag_maker, fresh_test_client):
         """
         Ensure DagBag is created only once and reused across multiple API requests.
 
@@ -76,10 +76,10 @@ class TestDagBagSingleton:
             BaseOperator(task_id="test_task")
         session.commit()
 
-        resp1 = test_client.get(f"/api/v2/dags/{dag_id}")
+        resp1 = fresh_test_client.get(f"/api/v2/dags/{dag_id}")
         assert resp1.status_code == 200
 
-        resp2 = test_client.get(f"/api/v2/dags/{dag_id}")
+        resp2 = fresh_test_client.get(f"/api/v2/dags/{dag_id}")
         assert resp2.status_code == 200
 
         assert self.dagbag_call_counter["count"] == 1

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -27,7 +27,7 @@ from fastapi import FastAPI
 from fastapi.routing import Mount
 from fastapi.testclient import TestClient
 
-from airflow.api_fastapi.app import create_app, create_auth_manager
+from airflow.api_fastapi.app import create_app
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models import Connection
@@ -77,31 +77,45 @@ def _shared_api_app():
         return create_app()
 
 
-def _reset_shared_app(app: FastAPI) -> None:
-    """
-    Reset mutable state on the session-shared app before each test.
-
-    The app object is reused for the whole session, so any per-test mutation of its ``state`` or
-    ``dependency_overrides`` would leak into later tests. These mutations exist today and were
-    harmless only because each test used to build its own app:
-
-    * the auth endpoint tests swap ``app.state.auth_manager`` for a mock without restoring it;
-    * several route tests (extra links, tasks, logs) install a ``dag_bag_from_app`` dependency
-      override in their per-test setup and never pop it;
-    * ``app.state.dag_bag`` carries an LRU/TTL cache of deserialized Dags keyed by
-      ``dag_version_id``. A warm entry from an earlier test would let a later test skip the
-      serialized-Dag DB read, which silently breaks query-count assertions (e.g. the grid
-      ``ti_summaries`` stream tests) depending on execution order.
-
-    Restore the canonical auth manager, drop leftover overrides (including on mounted sub-apps),
-    and empty the Dag cache so each test starts from the pristine app and re-applies its own state.
-    """
-    app.state.auth_manager = create_auth_manager()
-    app.state.dag_bag.clear_cache()
-    app.dependency_overrides.clear()
+def _mounted_fastapi_apps(app: FastAPI) -> list[FastAPI]:
+    """Return ``app`` and every FastAPI app mounted under it, recursively (``/execution``, ``/auth``, ...)."""
+    apps = [app]
     for route in app.routes:
         if isinstance(route, Mount) and isinstance(route.app, FastAPI):
-            route.app.dependency_overrides.clear()
+            apps.extend(_mounted_fastapi_apps(route.app))
+    return apps
+
+
+@pytest.fixture
+def _isolated_shared_app(_shared_api_app):
+    """
+    Yield the session-shared app with its mutable state snapshotted and restored around each test.
+
+    The app is built once per session, so a test that rebinds something on ``app.state`` (the auth
+    endpoint tests swap ``auth_manager`` for a mock) or installs a ``dependency_overrides`` entry
+    (extra-links/tasks/logs install a ``dag_bag_from_app`` override) would leak into later tests.
+    Snapshotting ``state`` and ``dependency_overrides`` on the root app and every mounted sub-app on
+    entry and restoring them on exit keeps the reset resilient to future mutations without having to
+    enumerate them.
+
+    ``app.state.dag_bag`` is the exception: tests mutate the DagBag object *in place* (its cache of
+    deserialized Dags fills as requests resolve them), which a state snapshot can't undo, so its
+    cache is cleared explicitly. A leaked warm entry would otherwise let a later test skip a
+    serialized-Dag DB read and break query-count assertions (e.g. the grid ``ti_summaries`` stream
+    tests) depending on execution order.
+    """
+    apps = _mounted_fastapi_apps(_shared_api_app)
+    # ``app.state._state`` is Starlette's backing dict for ``State`` -- the only way to enumerate it.
+    saved = [(app, dict(app.state._state), dict(app.dependency_overrides)) for app in apps]
+    _shared_api_app.state.dag_bag.clear_cache()
+    try:
+        yield _shared_api_app
+    finally:
+        for app, state, overrides in saved:
+            app.state._state.clear()
+            app.state._state.update(state)
+            app.dependency_overrides.clear()
+            app.dependency_overrides.update(overrides)
 
 
 def _authed_test_client(app: FastAPI, request):
@@ -127,9 +141,8 @@ def _authed_test_client(app: FastAPI, request):
 
 
 @pytest.fixture
-def test_client(request, _shared_api_app):
-    _reset_shared_app(_shared_api_app)
-    yield from _authed_test_client(_shared_api_app, request)
+def test_client(request, _isolated_shared_app):
+    yield from _authed_test_client(_isolated_shared_app, request)
 
 
 @pytest.fixture
@@ -153,15 +166,13 @@ def fresh_test_client(request):
 
 
 @pytest.fixture
-def unauthenticated_test_client(request, _shared_api_app):
-    _reset_shared_app(_shared_api_app)
-    return TestClient(_shared_api_app, base_url=f"{BASE_URL}{get_api_path(request)}")
+def unauthenticated_test_client(request, _isolated_shared_app):
+    return TestClient(_isolated_shared_app, base_url=f"{BASE_URL}{get_api_path(request)}")
 
 
 @pytest.fixture
-def unauthorized_test_client(request, _shared_api_app):
-    app = _shared_api_app
-    _reset_shared_app(app)
+def unauthorized_test_client(request, _isolated_shared_app):
+    app = _isolated_shared_app
     auth_manager: SimpleAuthManager = app.state.auth_manager
     token = auth_manager._get_token_signer().generate(
         auth_manager.serialize_user(SimpleAuthManagerUser(username="dummy", role=None))

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -23,9 +23,11 @@ from unittest import mock
 
 import pytest
 import time_machine
+from fastapi import FastAPI
+from fastapi.routing import Mount
 from fastapi.testclient import TestClient
 
-from airflow.api_fastapi.app import create_app
+from airflow.api_fastapi.app import create_app, create_auth_manager
 from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.models import Connection
@@ -54,8 +56,16 @@ def get_api_path(request):
     return API_PATHS.get(subdirectory_name, "/")
 
 
-@pytest.fixture
-def test_client(request):
+@pytest.fixture(scope="session")
+def _shared_api_app():
+    """
+    Build the FastAPI app once per test session.
+
+    ``create_app()`` rebuilds two full FastAPI apps (core + execution), registers every route and
+    builds the OpenAPI schema -- ~0.5s. The default ``test_client`` always uses the same config
+    (SimpleAuthManager), so the app structure is identical across tests; only per-test DB state and
+    request data differ. Building it once and reusing it removes that per-test rebuild cost.
+    """
     with conf_vars(
         {
             (
@@ -64,54 +74,76 @@ def test_client(request):
             ): "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager",
         }
     ):
-        app = create_app()
-        auth_manager: SimpleAuthManager = app.state.auth_manager
-        # set time_very_before to 2014-01-01 00:00:00 and time_very_after to tomorrow
-        # to make the JWT token always valid for all test cases with time_machine
-        time_very_before = datetime.datetime(2014, 1, 1, 0, 0, 0)
-        time_after = datetime.datetime.now() + datetime.timedelta(days=1)
-        with time_machine.travel(time_very_before, tick=False):
-            token = auth_manager._get_token_signer(
-                expiration_time_in_seconds=(time_after - time_very_before).total_seconds()
-            ).generate(
-                auth_manager.serialize_user(
-                    SimpleAuthManagerUser(username="test", role="admin", teams=["team1"])
-                ),
-            )
-        with mock.patch("airflow.models.revoked_token.RevokedToken.is_revoked", return_value=False):
-            yield TestClient(
-                app,
-                headers={"Authorization": f"Bearer {token}"},
-                base_url=f"{BASE_URL}{get_api_path(request)}",
-            )
+        return create_app()
+
+
+def _reset_shared_app(app: FastAPI) -> None:
+    """
+    Reset mutable state on the session-shared app before each test.
+
+    The app object is reused for the whole session, so any per-test mutation of its ``state`` or
+    ``dependency_overrides`` would leak into later tests. Two such mutations exist today and were
+    harmless only because each test used to build its own app:
+
+    * the auth endpoint tests swap ``app.state.auth_manager`` for a mock without restoring it;
+    * several route tests (extra links, tasks, logs) install a ``dag_bag_from_app`` dependency
+      override in their per-test setup and never pop it.
+
+    Restore the canonical auth manager and drop any leftover overrides (including on mounted
+    sub-apps) so each test starts from the pristine app and re-applies its own overrides.
+    """
+    app.state.auth_manager = create_auth_manager()
+    app.dependency_overrides.clear()
+    for route in app.routes:
+        if isinstance(route, Mount) and isinstance(route.app, FastAPI):
+            route.app.dependency_overrides.clear()
 
 
 @pytest.fixture
-def unauthenticated_test_client(request):
-    return TestClient(create_app(), base_url=f"{BASE_URL}{get_api_path(request)}")
-
-
-@pytest.fixture
-def unauthorized_test_client(request):
-    with conf_vars(
-        {
-            (
-                "core",
-                "auth_manager",
-            ): "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager",
-        }
-    ):
-        app = create_app()
-        auth_manager: SimpleAuthManager = app.state.auth_manager
-        token = auth_manager._get_token_signer().generate(
-            auth_manager.serialize_user(SimpleAuthManagerUser(username="dummy", role=None))
+def test_client(request, _shared_api_app):
+    app = _shared_api_app
+    _reset_shared_app(app)
+    auth_manager: SimpleAuthManager = app.state.auth_manager
+    # set time_very_before to 2014-01-01 00:00:00 and time_very_after to tomorrow
+    # to make the JWT token always valid for all test cases with time_machine
+    time_very_before = datetime.datetime(2014, 1, 1, 0, 0, 0)
+    time_after = datetime.datetime.now() + datetime.timedelta(days=1)
+    with time_machine.travel(time_very_before, tick=False):
+        token = auth_manager._get_token_signer(
+            expiration_time_in_seconds=(time_after - time_very_before).total_seconds()
+        ).generate(
+            auth_manager.serialize_user(
+                SimpleAuthManagerUser(username="test", role="admin", teams=["team1"])
+            ),
         )
-        with mock.patch("airflow.models.revoked_token.RevokedToken.is_revoked", return_value=False):
-            yield TestClient(
-                app,
-                headers={"Authorization": f"Bearer {token}"},
-                base_url=f"{BASE_URL}{get_api_path(request)}",
-            )
+    with mock.patch("airflow.models.revoked_token.RevokedToken.is_revoked", return_value=False):
+        yield TestClient(
+            app,
+            headers={"Authorization": f"Bearer {token}"},
+            base_url=f"{BASE_URL}{get_api_path(request)}",
+        )
+
+
+@pytest.fixture
+def unauthenticated_test_client(request, _shared_api_app):
+    _reset_shared_app(_shared_api_app)
+    return TestClient(_shared_api_app, base_url=f"{BASE_URL}{get_api_path(request)}")
+
+
+@pytest.fixture
+def unauthorized_test_client(request, _shared_api_app):
+    app = _shared_api_app
+    _reset_shared_app(app)
+    auth_manager: SimpleAuthManager = app.state.auth_manager
+    token = auth_manager._get_token_signer().generate(
+        auth_manager.serialize_user(SimpleAuthManagerUser(username="dummy", role=None))
+    )
+    with mock.patch("airflow.models.revoked_token.RevokedToken.is_revoked", return_value=False):
+        yield TestClient(
+            app,
+            headers={"Authorization": f"Bearer {token}"},
+            base_url=f"{BASE_URL}{get_api_path(request)}",
+        )
 
 
 @pytest.fixture

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -99,10 +99,7 @@ def _reset_shared_app(app: FastAPI) -> None:
             route.app.dependency_overrides.clear()
 
 
-@pytest.fixture
-def test_client(request, _shared_api_app):
-    app = _shared_api_app
-    _reset_shared_app(app)
+def _authed_test_client(app: FastAPI, request):
     auth_manager: SimpleAuthManager = app.state.auth_manager
     # set time_very_before to 2014-01-01 00:00:00 and time_very_after to tomorrow
     # to make the JWT token always valid for all test cases with time_machine
@@ -122,6 +119,32 @@ def test_client(request, _shared_api_app):
             headers={"Authorization": f"Bearer {token}"},
             base_url=f"{BASE_URL}{get_api_path(request)}",
         )
+
+
+@pytest.fixture
+def test_client(request, _shared_api_app):
+    _reset_shared_app(_shared_api_app)
+    yield from _authed_test_client(_shared_api_app, request)
+
+
+@pytest.fixture
+def fresh_test_client(request):
+    """
+    Like ``test_client`` but backed by a freshly built app instead of the session-shared one.
+
+    For the rare tests that patch app construction (e.g. counting ``DBDagBag`` instantiation) and
+    so need the app built *after* their patch is applied.
+    """
+    with conf_vars(
+        {
+            (
+                "core",
+                "auth_manager",
+            ): "airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager",
+        }
+    ):
+        app = create_app()
+    yield from _authed_test_client(app, request)
 
 
 @pytest.fixture

--- a/airflow-core/tests/unit/api_fastapi/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/conftest.py
@@ -82,17 +82,22 @@ def _reset_shared_app(app: FastAPI) -> None:
     Reset mutable state on the session-shared app before each test.
 
     The app object is reused for the whole session, so any per-test mutation of its ``state`` or
-    ``dependency_overrides`` would leak into later tests. Two such mutations exist today and were
+    ``dependency_overrides`` would leak into later tests. These mutations exist today and were
     harmless only because each test used to build its own app:
 
     * the auth endpoint tests swap ``app.state.auth_manager`` for a mock without restoring it;
     * several route tests (extra links, tasks, logs) install a ``dag_bag_from_app`` dependency
-      override in their per-test setup and never pop it.
+      override in their per-test setup and never pop it;
+    * ``app.state.dag_bag`` carries an LRU/TTL cache of deserialized Dags keyed by
+      ``dag_version_id``. A warm entry from an earlier test would let a later test skip the
+      serialized-Dag DB read, which silently breaks query-count assertions (e.g. the grid
+      ``ti_summaries`` stream tests) depending on execution order.
 
-    Restore the canonical auth manager and drop any leftover overrides (including on mounted
-    sub-apps) so each test starts from the pristine app and re-applies its own overrides.
+    Restore the canonical auth manager, drop leftover overrides (including on mounted sub-apps),
+    and empty the Dag cache so each test starts from the pristine app and re-applies its own state.
     """
     app.state.auth_manager = create_auth_manager()
+    app.state.dag_bag.clear_cache()
     app.dependency_overrides.clear()
     for route in app.routes:
         if isinstance(route, Mount) and isinstance(route.app, FastAPI):


### PR DESCRIPTION
## Summary

The `api_fastapi` test fixtures (`test_client`, `unauthenticated_test_client`,
`unauthorized_test_client`) rebuilt the entire FastAPI app via `create_app()` on every test.
Each rebuild constructs two mounted apps (core + execution), registers every route, and builds
the OpenAPI schema, costing roughly 0.55s of setup per test. With thousands of api_fastapi tests
that setup dominated the suite, and the MySQL core API shard had crept to ~62 min against the
65-min job timeout, so PR runs were getting cancelled mid-suite.

The app structure is identical for the default client (the fixture pins `[core] auth_manager` to
`SimpleAuthManager`), so this builds it once in a session-scoped fixture and reuses it. Only
per-test DB state and request data differ.

## Impact

| Measurement | Before | After |
|---|---|---|
| `test_variables + test_pools + test_connections` — 289 tests, breeze | 183s | 70s (-62%) |
| Per-test setup, breeze | ~0.55s | ~0.17s (-70%) |
| MySQL `8.0:3.10:API...CLI` shard — full CI matrix | ~62 min (cancelled at the 65-min wall) | 29 min (-53%) |

The first two rows are a controlled A/B (same tests, backend, and machine); for those files the
`--durations` table is almost entirely `setup` phases, so the saving scales across the whole API
test type. The CI row is the same `API...CLI` bucket as the baseline (full matrix via the
`full tests needed` label); Postgres and sqlite see the same effect (25 min and 20 min).

## Keeping tests isolated

A shared app means per-test mutations are no longer discarded with the app, so
`_reset_shared_app()` runs on every client-fixture entry and restores everything a test can mutate:

- **`app.state.auth_manager`** — the auth endpoint tests swap it for a mock without restoring.
  Load-bearing: reverting just this reset turns a passing subset into 64 failures (leaked mock ->
  invalid tokens -> 401s).
- **`app.dependency_overrides`** (app and mounted sub-apps) — extra-links/tasks/logs tests install
  a `dag_bag_from_app` override in their per-test setup and never pop it.
- **`app.state.dag_bag` cache** — the DagBag caches deserialized Dags keyed by `dag_version_id`. A
  warm entry would let a later test skip the serialized-Dag DB read, silently breaking query-count
  assertions (e.g. the grid `ti_summaries` stream tests) by execution order. `clear_cache()` empties
  it per test.

DB isolation is unchanged (each test sets up and clears its own rows). Same-`dag_id` tests are safe:
`get_latest_version_of_dag` resolves the version with a fresh `SerializedDagModel.get` query per
request, and the cache is keyed by the immutable `dag_version_id`, so a recreated DAG gets a new
version id and a cache miss.

## Why a session fixture and not `cached_app()`

`cached_app()` is the process-global production app (served from `api_fastapi/main.py`) memoized
with `functools.cache`. A session fixture is preferable for the core test client because:

- it is built under the fixture's pinned `SimpleAuthManager` config rather than ambient config;
- `purge_cached_app()` is called by other tests and by migrations, so the global instance's lifetime
  across a session is not under the fixture's control;
- the fixture needs one owned instance to reset per test; resetting the global would touch the
  production-path object.

`execution_api` tests reuse `cached_app(apps="execution")` because that sub-app takes no such config
override and they manage their overrides explicitly.

## Escape hatch

`fresh_test_client` builds a per-test app for the rare test that patches app construction
(`test_dagbag_used_as_singleton_in_dependency` counts `DBDagBag` instantiation, which must happen
after its patch). Tests needing a non-default app config keep using `client`.

## Tradeoffs

- Shared state is a footgun: a future test that mutates the app in a new way and doesn't restore it
  fails order-dependently. `_reset_shared_app` is the single place to add new resets.
- A leaked mutation now surfaces as an order-dependent failure rather than being silently isolated.
