### PR TITLE
Fix DAG parsing retry rollback for DBAPI errors

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -32,9 +32,9 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
 from sqlalchemy import delete, func, insert, select, tuple_, update
-from sqlalchemy.exc import DBAPIError
-from sqlalchemy.orm.exc import StaleDataError
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.orm import joinedload, load_only
+from sqlalchemy.orm.exc import StaleDataError
 
 from airflow._shared.timezones.timezone import utcnow
 from airflow.assets.manager import asset_manager

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -32,7 +32,8 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
 from sqlalchemy import delete, func, insert, select, tuple_, update
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.orm.exc import StaleDataError
 from sqlalchemy.orm import joinedload, load_only
 
 from airflow._shared.timezones.timezone import utcnow
@@ -507,7 +508,7 @@ def update_dag_parsing_results_in_db(
                             _prefetched=prefetched_metadata.get(dag.dag_id),
                         )
                     )
-            except OperationalError:
+            except (DBAPIError, StaleDataError):
                 session.rollback()
                 raise
             # Only now we are "complete" do we update import_errors - don't want to record errors from

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import delete, func, inspect as sa_inspect, select
-from sqlalchemy.exc import OperationalError, SAWarning
+from sqlalchemy.exc import IntegrityError, OperationalError, SAWarning
 
 import airflow.dag_processing.collection
 from airflow._shared.timezones import timezone as tz
@@ -751,6 +751,31 @@ class TestUpdateDagParsingResults:
 
         serialized_dags_count = session.scalar(select(func.count(SerializedDagModel.dag_id)))
         assert serialized_dags_count == 0
+
+    @patch.object(SerializedDagModel, "write_dag")
+    @patch("airflow.serialization.definitions.dag.SerializedDAG.bulk_write_to_db")
+    def test_sync_to_db_rolls_back_before_retrying_integrity_error(
+        self, mock_bulk_write_to_db, mock_s10n_write_dag, testing_dag_bundle
+    ):
+        """Test that retried DBAPIError subclasses roll back the failed session first."""
+        mock_dag = mock.MagicMock()
+        integrity_error = IntegrityError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
+        mock_bulk_write_to_db.side_effect = [integrity_error, integrity_error, mock.ANY]
+
+        mock_session = mock.MagicMock()
+        update_dag_parsing_results_in_db(
+            "testing",
+            None,
+            dags=[mock_dag],
+            import_errors={},
+            parse_duration=None,
+            warnings=set(),
+            session=mock_session,
+        )
+
+        assert mock_bulk_write_to_db.call_count == 3
+        mock_session.rollback.assert_has_calls([mock.call(), mock.call()])
+        mock_s10n_write_dag.assert_called_once()
 
     def test_serialized_dags_are_written_to_db_on_sync(self, testing_dag_bundle, session):
         """Test DAGs are Serialized and written to DB when parsing result is updated"""


### PR DESCRIPTION
closes: #68263

## Why

`update_dag_parsing_results_in_db` retries database work via
`run_with_db_retries`, which retries `DBAPIError` and `StaleDataError`.

However, the local retry block only rolled back the session for
`OperationalError`. If another retried DB error, such as `IntegrityError`,
occurred during DAG metadata writes, the next retry could reuse a failed
session and surface `PendingRollbackError`, hiding the original database
failure.

## What

- Roll back the session for `DBAPIError` and `StaleDataError`, matching the shared retry policy.
- Add a regression test covering rollback before retrying `IntegrityError`.

## Tests

- `git diff --check`
- `python -m compileall -q airflow-core/src/airflow/dag_processing/collection.py airflow-core/tests/unit/dag_processing/test_collection.py`

Focused pytest command prepared:

```bash
PYTHONPATH=airflow-core/src:task-sdk/src:devel-common/src python -m pytest \
  airflow-core/tests/unit/dag_processing/test_collection.py::TestUpdateDagParsingResults::test_sync_to_db_is_retried \
  airflow-core/tests/unit/dag_processing/test_collection.py::TestUpdateDagParsingResults::test_sync_to_db_rolls_back_before_retrying_integrity_error -q
```

Local pytest run was blocked by missing Airflow test/runtime dependencies in this environment.

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=4f73f00 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @BeauDevCode** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Static checks`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - **Failing test jobs**: `Low dep tests:core / All-core:LowestDeps:14:3.10:Core...Serialization`, `MySQL tests: core / DB-core:MySQL:8.0:3.10:Core...Serialization`, `Postgres tests: core / DB-core:Postgres:14:3.10:Core...Serialization`, `Sqlite tests: core / DB-core:Sqlite:3.10:Core...Serialization`. Reproduce and fix locally, then push.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->