### PR TITLE
Better warning visibility for invalid JSON value when editing variables

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
@@ -1,0 +1,82 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import VariableForm, { type VariableBody } from "./VariableForm";
+
+vi.mock("src/queries/useConfig.tsx", () => ({
+  useConfig: () => false,
+}));
+
+const initialVariable: VariableBody = {
+  description: "",
+  key: "json_config",
+  team_name: "",
+  value: '{"enabled": true}',
+};
+
+const renderVariableForm = (manageMutate = vi.fn()) => {
+  render(
+    <VariableForm
+      error={undefined}
+      initialVariable={initialVariable}
+      isPending={false}
+      manageMutate={manageMutate}
+      setError={vi.fn()}
+    />,
+    { wrapper: Wrapper },
+  );
+
+  return manageMutate;
+};
+
+describe("VariableForm", () => {
+  it("blocks saving malformed JSON object values", async () => {
+    const manageMutate = renderVariableForm();
+
+    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: '{"enabled": true,' } });
+
+    await waitFor(() => expect(screen.getByText("Invalid JSON")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(manageMutate).not.toHaveBeenCalled();
+  });
+
+  it("allows saving plain string values", async () => {
+    const manageMutate = renderVariableForm();
+
+    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "plain string value" } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /save/i })).toBeEnabled());
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(manageMutate).toHaveBeenCalledWith({
+        ...initialVariable,
+        value: "plain string value",
+      }),
+    );
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
@@ -55,7 +55,7 @@ describe("VariableForm", () => {
 
     fireEvent.change(screen.getByLabelText(/value/i), { target: { value: '{"enabled": true,' } });
 
-    await waitFor(() => expect(screen.getByText("Invalid JSON")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
@@ -73,7 +73,7 @@ describe("VariableForm", () => {
 
     fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "[DRAFT] plain string value" } });
 
-    await waitFor(() => expect(screen.getByText("Invalid JSON")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
@@ -82,6 +82,24 @@ describe("VariableForm", () => {
       expect(manageMutate).toHaveBeenCalledWith({
         ...initialVariable,
         value: "[DRAFT] plain string value",
+      }),
+    );
+  });
+
+  it("allows saving Jinja template values", async () => {
+    const manageMutate = renderVariableForm();
+
+    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "{{ var.value.x }}" } });
+
+    await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(manageMutate).toHaveBeenCalledWith({
+        ...initialVariable,
+        value: "{{ var.value.x }}",
       }),
     );
   });

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
@@ -50,17 +50,40 @@ const renderVariableForm = (manageMutate = vi.fn()) => {
 };
 
 describe("VariableForm", () => {
-  it("blocks saving malformed JSON object values", async () => {
+  it("shows a prominent warning for malformed JSON object values without blocking save", async () => {
     const manageMutate = renderVariableForm();
 
     fireEvent.change(screen.getByLabelText(/value/i), { target: { value: '{"enabled": true,' } });
 
     await waitFor(() => expect(screen.getByText("Invalid JSON")).toBeInTheDocument());
-    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    expect(manageMutate).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(manageMutate).toHaveBeenCalledWith({
+        ...initialVariable,
+        value: '{"enabled": true,',
+      }),
+    );
+  });
+
+  it("allows saving non-JSON string values that start with a bracket", async () => {
+    const manageMutate = renderVariableForm();
+
+    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "[DRAFT] plain string value" } });
+
+    await waitFor(() => expect(screen.getByText("Invalid JSON")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() =>
+      expect(manageMutate).toHaveBeenCalledWith({
+        ...initialVariable,
+        value: "[DRAFT] plain string value",
+      }),
+    );
   });
 
   it("allows saving plain string values", async () => {

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.test.tsx
@@ -53,12 +53,12 @@ describe("VariableForm", () => {
   it("shows a prominent warning for malformed JSON object values without blocking save", async () => {
     const manageMutate = renderVariableForm();
 
-    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: '{"enabled": true,' } });
+    fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: '{"enabled": true,' } });
 
     await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
-    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save/iu }));
 
     await waitFor(() =>
       expect(manageMutate).toHaveBeenCalledWith({
@@ -71,12 +71,12 @@ describe("VariableForm", () => {
   it("allows saving non-JSON string values that start with a bracket", async () => {
     const manageMutate = renderVariableForm();
 
-    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "[DRAFT] plain string value" } });
+    fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: "[DRAFT] plain string value" } });
 
     await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
-    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save/iu }));
 
     await waitFor(() =>
       expect(manageMutate).toHaveBeenCalledWith({
@@ -89,12 +89,12 @@ describe("VariableForm", () => {
   it("allows saving Jinja template values", async () => {
     const manageMutate = renderVariableForm();
 
-    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "{{ var.value.x }}" } });
+    fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: "{{ var.value.x }}" } });
 
     await waitFor(() => expect(screen.getByText("variables.form.invalidJson")).toBeInTheDocument());
-    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled();
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save/iu }));
 
     await waitFor(() =>
       expect(manageMutate).toHaveBeenCalledWith({
@@ -107,11 +107,11 @@ describe("VariableForm", () => {
   it("allows saving plain string values", async () => {
     const manageMutate = renderVariableForm();
 
-    fireEvent.change(screen.getByLabelText(/value/i), { target: { value: "plain string value" } });
+    fireEvent.change(screen.getByLabelText(/value/iu), { target: { value: "plain string value" } });
 
-    await waitFor(() => expect(screen.getByRole("button", { name: /save/i })).toBeEnabled());
+    await waitFor(() => expect(screen.getByRole("button", { name: /save/iu })).toBeEnabled());
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save/iu }));
 
     await waitFor(() =>
       expect(manageMutate).toHaveBeenCalledWith({

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -16,13 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Field, HStack, Input, Spacer, Text, Textarea } from "@chakra-ui/react";
+import { Box, Button, Field, HStack, Input, Spacer, Textarea } from "@chakra-ui/react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FiSave } from "react-icons/fi";
 
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { TeamSelector } from "src/components/TeamSelector.tsx";
+import { Alert } from "src/components/ui";
 import { useConfig } from "src/queries/useConfig.tsx";
 
 export type VariableBody = {
@@ -104,18 +105,11 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
               <Field.Label fontSize="md">
                 {translate("columns.value")} <Field.RequiredIndicator />
               </Field.Label>
-              <Textarea
-                {...field}
-                borderColor={showJsonWarning ? "fg.warning" : undefined}
-                borderWidth={showJsonWarning ? "2px" : undefined}
-                size="sm"
-              />
+              <Textarea {...field} size="sm" />
               {showJsonWarning ? (
-                <Box bg="bg.warning" borderColor="fg.warning" borderRadius="md" borderWidth="1px" mt={2} px={3} py={2}>
-                  <Text color="fg.warning" fontSize="sm" fontWeight="medium">
-                    {translate("variables.form.invalidJson")}
-                  </Text>
-                </Box>
+                <Alert mt={2} status="warning">
+                  {translate("variables.form.invalidJson")}
+                </Alert>
               ) : undefined}
               {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
             </Field.Root>

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Field, HStack, Input, Spacer, Textarea } from "@chakra-ui/react";
+import { Box, Button, Field, HStack, Input, Spacer, Text, Textarea } from "@chakra-ui/react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FiSave } from "react-icons/fi";
@@ -40,12 +40,6 @@ const isJsonString = (string: string) => {
   }
 
   return true;
-};
-
-const shouldValidateAsJson = (value: string) => {
-  const trimmed = value.trimStart();
-
-  return trimmed.startsWith("{") || trimmed.startsWith("[");
 };
 
 type VariableFormProps = {
@@ -101,19 +95,34 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
       <Controller
         control={control}
         name="value"
-        render={({ field, fieldState }) => (
-          <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
-            <Field.Label fontSize="md">
-              {translate("columns.value")} <Field.RequiredIndicator />
-            </Field.Label>
-            <Textarea {...field} size="sm" />
-            {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
-          </Field.Root>
-        )}
+        render={({ field, fieldState }) => {
+          const showJsonWarning =
+            field.value.startsWith("{") || field.value.startsWith("[") ? !isJsonString(field.value) : false;
+
+          return (
+            <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
+              <Field.Label fontSize="md">
+                {translate("columns.value")} <Field.RequiredIndicator />
+              </Field.Label>
+              <Textarea
+                {...field}
+                borderColor={showJsonWarning ? "fg.warning" : undefined}
+                borderWidth={showJsonWarning ? "2px" : undefined}
+                size="sm"
+              />
+              {showJsonWarning ? (
+                <Box bg="bg.warning" borderColor="fg.warning" borderRadius="md" borderWidth="1px" mt={2} px={3} py={2}>
+                  <Text color="fg.warning" fontSize="sm" fontWeight="medium">
+                    {translate("variables.form.invalidJson")}
+                  </Text>
+                </Box>
+              ) : undefined}
+              {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
+            </Field.Root>
+          );
+        }}
         rules={{
           required: translate("variables.form.valueRequired"),
-          validate: (value) =>
-            !shouldValidateAsJson(value) || isJsonString(value) || translate("variables.form.invalidJson"),
         }}
       />
 

--- a/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Variables/ManageVariable/VariableForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Field, HStack, Input, Spacer, Text, Textarea } from "@chakra-ui/react";
+import { Box, Button, Field, HStack, Input, Spacer, Textarea } from "@chakra-ui/react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FiSave } from "react-icons/fi";
@@ -40,6 +40,12 @@ const isJsonString = (string: string) => {
   }
 
   return true;
+};
+
+const shouldValidateAsJson = (value: string) => {
+  const trimmed = value.trimStart();
+
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
 };
 
 type VariableFormProps = {
@@ -95,27 +101,19 @@ const VariableForm = ({ error, initialVariable, isPending, manageMutate, setErro
       <Controller
         control={control}
         name="value"
-        render={({ field, fieldState }) => {
-          const showJsonWarning =
-            field.value.startsWith("{") || field.value.startsWith("[") ? !isJsonString(field.value) : false;
-
-          return (
-            <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
-              <Field.Label fontSize="md">
-                {translate("columns.value")} <Field.RequiredIndicator />
-              </Field.Label>
-              <Textarea {...field} size="sm" />
-              {showJsonWarning ? (
-                <Text color="fg.warning" fontSize="xs">
-                  {translate("variables.form.invalidJson")}
-                </Text>
-              ) : undefined}
-              {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
-            </Field.Root>
-          );
-        }}
+        render={({ field, fieldState }) => (
+          <Field.Root invalid={Boolean(fieldState.error)} mt={4} required>
+            <Field.Label fontSize="md">
+              {translate("columns.value")} <Field.RequiredIndicator />
+            </Field.Label>
+            <Textarea {...field} size="sm" />
+            {fieldState.error ? <Field.ErrorText>{fieldState.error.message}</Field.ErrorText> : undefined}
+          </Field.Root>
+        )}
         rules={{
           required: translate("variables.form.valueRequired"),
+          validate: (value) =>
+            !shouldValidateAsJson(value) || isJsonString(value) || translate("variables.form.invalidJson"),
         }}
       />
 


### PR DESCRIPTION
### What

Improve the warning shown when a variable value looks like JSON but is not valid JSON.

### Why

Invalid JSON values can be easy to miss in the variable form. The form should warn clearly, while still allowing users to save non-JSON strings that intentionally start with `{` or `[`.

### How

- Keep the invalid JSON feedback as a visible warning instead of a blocking validation error.
- Preserve the save flow for malformed JSON-looking strings, bracket-prefixed plain strings, Jinja templates, and plain strings.
- Add tests covering the warning and non-blocking save behavior.