### PR TITLE
Batch triggerer unused trigger cleanup deletes

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2889,6 +2889,17 @@ triggerer:
       type: integer
       example: ~
       default: "50"
+    unreferenced_triggers_cleanup_batch_size:
+      description: |
+        Maximum number of unreferenced ``trigger`` rows the triggerer removes per transaction
+        when running trigger cleanup. Batching avoids holding row locks on the ``trigger`` table
+        for the duration of a single large delete, which would otherwise stall the triggerer loop
+        while many rows are removed. Set to ``0`` to disable batching and delete all matching
+        rows in a single transaction.
+      version_added: 3.3.0
+      type: integer
+      example: ~
+      default: "500"
     on_kill_timeout:
       description: |
         Maximum number of seconds the triggerer will wait for ``BaseTrigger.on_kill()`` to complete

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -39,7 +39,7 @@ from airflow.serialization.enums import stringify_encoding_keys as _stringify_en
 from airflow.triggers.base import BaseTaskEndEvent
 from airflow.utils.retries import run_with_db_retries
 from airflow.utils.session import NEW_SESSION, provide_session
-from airflow.utils.sqlalchemy import UtcDateTime, get_dialect_name, with_row_locks
+from airflow.utils.sqlalchemy import UtcDateTime, with_row_locks
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
@@ -250,23 +250,29 @@ class Trigger(Base):
                 )
 
         # Get all triggers that have no task instances, assets, or callbacks depending on them and delete them
-        ids = (
+        ids_query = (
             select(cls.id)
             .where(~cls.assets.any(), ~cls.callback.has())
             .join(TaskInstance, cls.id == TaskInstance.trigger_id, isouter=True)
             .group_by(cls.id)
             .having(func.count(TaskInstance.trigger_id) == 0)
         )
-        if get_dialect_name(session) == "mysql":
-            # MySQL doesn't support DELETE with JOIN, so we need to do it in two steps
-            ids_list = list(session.scalars(ids).all())
-            session.execute(
-                delete(Trigger).where(Trigger.id.in_(ids_list)).execution_options(synchronize_session=False)
-            )
-        else:
+        batch_size = conf.getint("triggerer", "unreferenced_triggers_cleanup_batch_size", fallback=500)
+
+        while True:
+            limited_ids_query = ids_query.limit(batch_size) if batch_size > 0 else ids_query
+            ids = list(session.scalars(limited_ids_query).all())
+
+            if not ids:
+                break
+
             session.execute(
                 delete(Trigger).where(Trigger.id.in_(ids)).execution_options(synchronize_session=False)
             )
+            session.commit()
+
+            if batch_size <= 0 or len(ids) < batch_size:
+                break
 
     @classmethod
     @provide_session

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -177,6 +177,28 @@ def test_clean_unused(session, dag_maker):
     assert {result.id for result in results} == {trigger1.id, trigger4.id, trigger5.id, trigger6.id}
 
 
+@conf_vars({("triggerer", "unreferenced_triggers_cleanup_batch_size"): "2"})
+def test_clean_unused_batches_deletes(session, monkeypatch):
+    for index in range(5):
+        session.add(Trigger(classpath=f"airflow.triggers.testing.SuccessTrigger{index}", kwargs={}))
+    session.flush()
+
+    commit_calls = 0
+    original_commit = session.commit
+
+    def _counting_commit():
+        nonlocal commit_calls
+        commit_calls += 1
+        original_commit()
+
+    monkeypatch.setattr(session, "commit", _counting_commit)
+
+    Trigger.clean_unused(session=session)
+
+    assert session.scalar(select(func.count()).select_from(Trigger)) == 0
+    assert commit_calls == 3
+
+
 @patch.object(TriggererCallback, "handle_event")
 def test_submit_event(mock_callback_handle_event, session, create_task_instance):
     """

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1789,6 +1789,7 @@ unpause
 unpaused
 unpausing
 unpredicted
+unreferenced
 unsanitized
 unscoped
 untestable


### PR DESCRIPTION
closes: #68243

## Why

`Trigger.clean_unused()` currently removes all unreferenced trigger rows in one unbounded delete. On busy deployments this can hold locks on the `trigger` table for the duration of a large cleanup and stall the triggerer loop.

## What changed

- Select unused trigger IDs before deleting, preserving the existing unused-trigger criteria.
- Delete matching trigger rows in configurable batches, committing between batches.
- Add `[triggerer] unreferenced_triggers_cleanup_batch_size`, defaulting to `500`; setting it to `0` keeps single-transaction cleanup behavior.
- Add a unit test that uses a batch size of `2` and verifies five unused triggers are removed across three committed delete batches.

Related context: PR #68244 changes the anti-join shape in the same method, but does not add bounded delete batches. This PR intentionally focuses on the batching behavior requested in #68243.

## Tests

- `git diff --check`
- `python3 -m compileall -q airflow-core/src/airflow/models/trigger.py airflow-core/tests/unit/models/test_trigger.py`
- Parsed `airflow-core/src/airflow/config_templates/config.yml` with PyYAML and verified the new option shape

Not run locally: focused pytest/config validation could not complete because this environment lacks parts of Airflow's development dependency set (`pathspec` during test collection; `requests` for `dev/validate_version_added_fields_in_config.py`).

<!-- pr-triage-fold: triaged=2026-06-17T14:51:56Z head=6343f06 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @BeauDevCode** · by `@potiuk` · 2026-06-17 14:51 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Static / docs checks failing** (`CI image checks / Build documentation (--spellcheck-only)`). Run them locally with `prek run --all-files` (or `pre-commit run --all-files`) and push the fixes.
> - See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->