### PR TITLE
feat(dag_command.py): change to use bulk clear

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -56,7 +56,7 @@ from airflow.utils.cli import (
     validate_dag_bundle_arg,
 )
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
-from airflow.utils.helpers import ask_yesno
+from airflow.utils.helpers import ask_yesno, chunks
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState, TaskInstanceState
@@ -211,15 +211,14 @@ def _bulk_clear_runs(
     session: Session,
 ) -> int:
     """Clear task instances for the given run_ids in chunks instead of one transaction per run."""
-    state_filter: list = []
+    state_filter: list[TaskInstanceState] = []
     if only_failed:
         state_filter += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
     if only_running:
         state_filter += [TaskInstanceState.RUNNING]
 
     cleared = 0
-    for chunk_start in range(0, len(run_ids), _RUN_CHUNK_SIZE):
-        chunk_run_ids = run_ids[chunk_start : chunk_start + _RUN_CHUNK_SIZE]
+    for chunk_run_ids in chunks(run_ids, _RUN_CHUNK_SIZE):
         ti_query = select(TaskInstance).where(
             TaskInstance.dag_id == dag_id,
             TaskInstance.run_id.in_(chunk_run_ids),

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -46,6 +46,7 @@ from airflow.jobs.job import Job
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.models.errors import ParseImportError
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models.taskinstance import clear_task_instances
 from airflow.timetables.base import TimeRestriction
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import (
@@ -74,6 +75,9 @@ if TYPE_CHECKING:
 DAG_DETAIL_FIELDS = {*DAGResponse.model_fields, *DAGResponse.model_computed_fields}
 
 log = logging.getLogger(__name__)
+
+# Chunk size for bulk delete.
+_RUN_CHUNK_SIZE = 500
 
 
 @cli_utils.action_cli
@@ -189,15 +193,44 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
             print("Cancelled, nothing was cleared.")
             return
 
-    cleared = 0
-    for run_id in run_ids:
-        cleared += dag.clear(
-            run_id=run_id,
-            only_failed=args.only_failed,
-            only_running=args.only_running,
-            session=session,
-        )
+    cleared = _bulk_clear_runs(
+        run_ids,
+        only_failed=args.only_failed,
+        only_running=args.only_running,
+        session=session,
+    )
     print(f"Cleared {cleared} task instance(s) across {len(run_ids)} Dag run(s).")
+
+
+def _bulk_clear_runs(
+    run_ids: list[str],
+    only_failed: bool,
+    only_running: bool,
+    session: Session,
+) -> int:
+    """Clear task instances for the given run_ids in chunks instead of one transaction per run."""
+    from airflow.utils.state import TaskInstanceState
+
+    state_filter: list = []
+    if only_failed:
+        state_filter += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
+    if only_running:
+        state_filter += [TaskInstanceState.RUNNING]
+
+    cleared = 0
+    for chunk_start in range(0, len(run_ids), _RUN_CHUNK_SIZE):
+        chunk_run_ids = run_ids[chunk_start : chunk_start + _RUN_CHUNK_SIZE]
+        ti_query = select(TaskInstance).where(TaskInstance.run_id.in_(chunk_run_ids))
+        if state_filter:
+            ti_query = ti_query.where(TaskInstance.state.in_(state_filter))
+        tis = session.scalars(ti_query).all()
+        if not tis:
+            continue
+        clear_task_instances(list(tis), session=session)
+        session.flush()
+        cleared += len(tis)
+
+    return cleared
 
 
 @cli_utils.action_cli

--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -59,7 +59,7 @@ from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.helpers import ask_yesno
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
-from airflow.utils.state import DagRunState
+from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 if TYPE_CHECKING:
@@ -194,6 +194,7 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
             return
 
     cleared = _bulk_clear_runs(
+        args.dag_id,
         run_ids,
         only_failed=args.only_failed,
         only_running=args.only_running,
@@ -203,14 +204,13 @@ def dag_clear(args, *, session: Session = NEW_SESSION) -> None:
 
 
 def _bulk_clear_runs(
+    dag_id: str,
     run_ids: list[str],
     only_failed: bool,
     only_running: bool,
     session: Session,
 ) -> int:
     """Clear task instances for the given run_ids in chunks instead of one transaction per run."""
-    from airflow.utils.state import TaskInstanceState
-
     state_filter: list = []
     if only_failed:
         state_filter += [TaskInstanceState.FAILED, TaskInstanceState.UPSTREAM_FAILED]
@@ -220,7 +220,10 @@ def _bulk_clear_runs(
     cleared = 0
     for chunk_start in range(0, len(run_ids), _RUN_CHUNK_SIZE):
         chunk_run_ids = run_ids[chunk_start : chunk_start + _RUN_CHUNK_SIZE]
-        ti_query = select(TaskInstance).where(TaskInstance.run_id.in_(chunk_run_ids))
+        ti_query = select(TaskInstance).where(
+            TaskInstance.dag_id == dag_id,
+            TaskInstance.run_id.in_(chunk_run_ids),
+        )
         if state_filter:
             ti_query = ti_query.where(TaskInstance.state.in_(state_filter))
         tis = session.scalars(ti_query).all()

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -42,7 +42,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagModel, DagRun
 from airflow.models.dagbag import DBDagBag
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger, TimeDeltaTrigger
 from airflow.sdk import DAG, Asset, BaseOperator, CronPartitionTimetable, PartitionedAssetTimetable, task
@@ -1766,49 +1766,20 @@ class TestCliDagsClear:
         assert states["asset_non_part"] == DagRunState.SUCCESS
 
     @pytest.mark.usefixtures("seeded_partitioned_runs")
-    def test_clears_multiple_runs_in_one_batch(self, parser):
-        """3 runs fit in one chunk, so clear_task_instances is called once (not N times)."""
-        from airflow.models.taskinstance import clear_task_instances
+    @pytest.mark.parametrize(
+        ("chunk_size", "expected_calls"),
+        [
+            pytest.param(500, 1, id="single-chunk"),
+            pytest.param(2, 2, id="multiple-chunks"),
+        ],
+    )
+    def test_clears_each_matching_run_once_across_chunks(self, parser, chunk_size, expected_calls):
+        """Every matching run is cleared exactly once, however run_ids split into chunks.
 
-        call_count = 0
-
-        def counting_clear(tis, session, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            return clear_task_instances(tis, session, **kwargs)
-
-        args = parser.parse_args(
-            [
-                "dags",
-                "clear",
-                self.DAG_ID,
-                "--partition-date-start",
-                "2026-03-08T00:00:00",
-                "--partition-date-end",
-                "2026-03-14T00:00:00",
-                "--yes",
-            ]
-        )
-        with mock.patch(
-            "airflow.cli.commands.dag_command.clear_task_instances",
-            side_effect=counting_clear,
-        ):
-            dag_command.dag_clear(args)
-
-        # 3 partitioned runs all fit in a single run-id chunk.
-        assert call_count == 1
-
-        states = self._get_run_states()
-        assert states["part_2026_03_08"] == DagRunState.QUEUED
-        assert states["part_2026_03_10"] == DagRunState.QUEUED
-        assert states["part_2026_03_14"] == DagRunState.QUEUED
-        assert states["non_partitioned"] == DagRunState.SUCCESS
-
-    @pytest.mark.usefixtures("seeded_partitioned_runs")
-    def test_chunks_on_run_boundaries_clears_each_run_once(self, parser):
-        """Across multiple chunks, each run is cleared once"""
-        from airflow.models.taskinstance import clear_task_instances
-
+        clear_task_instances is called once per chunk (not once per run), every matching
+        run is re-queued, and each run's clear_number advances by exactly 1 — proving a
+        run's TIs are never split across chunks.
+        """
         call_count = 0
 
         def counting_clear(tis, session, **kwargs):
@@ -1829,7 +1800,7 @@ class TestCliDagsClear:
             ]
         )
         with (
-            mock.patch.object(dag_command, "_RUN_CHUNK_SIZE", 2),
+            mock.patch.object(dag_command, "_RUN_CHUNK_SIZE", chunk_size),
             mock.patch(
                 "airflow.cli.commands.dag_command.clear_task_instances",
                 side_effect=counting_clear,
@@ -1837,8 +1808,13 @@ class TestCliDagsClear:
         ):
             dag_command.dag_clear(args)
 
-        # 3 runs with chunk size 2 → 2 calls.
-        assert call_count == 2
+        assert call_count == expected_calls
+
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.QUEUED
+        assert states["part_2026_03_10"] == DagRunState.QUEUED
+        assert states["part_2026_03_14"] == DagRunState.QUEUED
+        assert states["non_partitioned"] == DagRunState.SUCCESS
 
         clear_numbers = self._get_run_clear_numbers()
         assert clear_numbers["part_2026_03_08"] == 1

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -1846,6 +1846,62 @@ class TestCliDagsClear:
         assert clear_numbers["part_2026_03_14"] == 1
         assert clear_numbers["non_partitioned"] == 0
 
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_does_not_clear_runs_of_other_dags(self, parser, dag_maker):
+        """A run_id collision across DAGs must not clear the other DAG's task instances."""
+        other_dag_id = "test_dags_clear_other_dag"
+        with dag_maker(
+            other_dag_id,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone=pendulum.UTC),
+            start_date=datetime(2026, 3, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        # Same run_id and partition_date as a run cleared below, but a different DAG.
+        dag_maker.create_dagrun(
+            run_id="part_2026_03_08",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2026, 3, 8, tzinfo=pendulum.UTC),
+            partition_key="2026-03-08T00:00:00",
+        )
+        dag_maker.sync_dagbag_to_db()
+        # If dag_id is not filtered, clearing the other DAG would reset this TI to None.
+        with create_session() as session:
+            session.execute(
+                TaskInstance.__table__.update()
+                .where(TaskInstance.dag_id == other_dag_id)
+                .values(state=TaskInstanceState.SUCCESS)
+            )
+
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-03-08T00:00:00",
+                "--partition-date-end",
+                "2026-03-14T00:00:00",
+                "--yes",
+            ]
+        )
+        dag_command.dag_clear(args)
+
+        # The target DAG's same-named run must be cleared.
+        assert self._get_run_states()["part_2026_03_08"] == DagRunState.QUEUED
+
+        # The other DAG's same-named run must be left untouched.
+        with create_session() as session:
+            other_run = session.scalars(
+                select(DagRun).where(DagRun.dag_id == other_dag_id, DagRun.run_id == "part_2026_03_08")
+            ).one()
+            assert other_run.state == DagRunState.SUCCESS
+            assert other_run.clear_number == 0
+            other_ti = session.scalars(select(TaskInstance).where(TaskInstance.dag_id == other_dag_id)).one()
+            assert other_ti.state == TaskInstanceState.SUCCESS
+
 
 class TestDagDetailsIsBackfillable:
     """Tests for the is_backfillable computation in _get_dagbag_dag_details."""

--- a/airflow-core/tests/unit/cli/commands/test_dag_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_dag_command.py
@@ -1066,6 +1066,13 @@ class TestCliDagsClear:
                 for row in session.scalars(select(DagRun).where(DagRun.dag_id == self.DAG_ID)).all()
             }
 
+    def _get_run_clear_numbers(self):
+        with create_session() as session:
+            return {
+                row.run_id: row.clear_number
+                for row in session.scalars(select(DagRun).where(DagRun.dag_id == self.DAG_ID)).all()
+            }
+
     def test_requires_a_selector(self, parser):
         args = parser.parse_args(["dags", "clear", self.DAG_ID, "--yes"])
         with pytest.raises(SystemExit, match="One of --run-id, --partition-key"):
@@ -1757,6 +1764,87 @@ class TestCliDagsClear:
         assert states["asset_2026_04_14"] == DagRunState.SUCCESS
         assert states["asset_2026_04_15"] == DagRunState.SUCCESS
         assert states["asset_non_part"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_clears_multiple_runs_in_one_batch(self, parser):
+        """3 runs fit in one chunk, so clear_task_instances is called once (not N times)."""
+        from airflow.models.taskinstance import clear_task_instances
+
+        call_count = 0
+
+        def counting_clear(tis, session, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return clear_task_instances(tis, session, **kwargs)
+
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-03-08T00:00:00",
+                "--partition-date-end",
+                "2026-03-14T00:00:00",
+                "--yes",
+            ]
+        )
+        with mock.patch(
+            "airflow.cli.commands.dag_command.clear_task_instances",
+            side_effect=counting_clear,
+        ):
+            dag_command.dag_clear(args)
+
+        # 3 partitioned runs all fit in a single run-id chunk.
+        assert call_count == 1
+
+        states = self._get_run_states()
+        assert states["part_2026_03_08"] == DagRunState.QUEUED
+        assert states["part_2026_03_10"] == DagRunState.QUEUED
+        assert states["part_2026_03_14"] == DagRunState.QUEUED
+        assert states["non_partitioned"] == DagRunState.SUCCESS
+
+    @pytest.mark.usefixtures("seeded_partitioned_runs")
+    def test_chunks_on_run_boundaries_clears_each_run_once(self, parser):
+        """Across multiple chunks, each run is cleared once"""
+        from airflow.models.taskinstance import clear_task_instances
+
+        call_count = 0
+
+        def counting_clear(tis, session, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return clear_task_instances(tis, session, **kwargs)
+
+        args = parser.parse_args(
+            [
+                "dags",
+                "clear",
+                self.DAG_ID,
+                "--partition-date-start",
+                "2026-03-08T00:00:00",
+                "--partition-date-end",
+                "2026-03-14T00:00:00",
+                "--yes",
+            ]
+        )
+        with (
+            mock.patch.object(dag_command, "_RUN_CHUNK_SIZE", 2),
+            mock.patch(
+                "airflow.cli.commands.dag_command.clear_task_instances",
+                side_effect=counting_clear,
+            ),
+        ):
+            dag_command.dag_clear(args)
+
+        # 3 runs with chunk size 2 → 2 calls.
+        assert call_count == 2
+
+        clear_numbers = self._get_run_clear_numbers()
+        assert clear_numbers["part_2026_03_08"] == 1
+        assert clear_numbers["part_2026_03_10"] == 1
+        assert clear_numbers["part_2026_03_14"] == 1
+        assert clear_numbers["non_partitioned"] == 0
 
 
 class TestDagDetailsIsBackfillable:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #67484
* related: #ISSUE
-->
closes: #67484

---

##### Why

`airflow dags clear` (#66004) loops `dag.clear(run_id=...)` once per matched run, issuing a separate SELECT + flush for each. A wide `--partition-date-*` window or broad `--partition-key` therefore costs N independent transactions.

---

##### How

Replace the per-run loop with a `_bulk_clear_runs` helper:

- Iterates `run_ids` in chunks of `_RUN_CHUNK_SIZE (500)`, fetching all matching TIs for each chunk with a single query.
- Passes the entire chunk's TIs to `clear_task_instances` in one call.

Two new tests:

- `test_clears_multiple_runs_in_one_batch`: asserts that 3 runs fitting in one chunk result in exactly one `clear_task_instances` call.
- `test_chunks_on_run_boundaries_clears_each_run_once`: patches `_RUN_CHUNK_SIZE` to 2. 3 runs span 2 chunks.
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude Code with Claude Opus 4.8
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
