### PR TITLE
Fix DagProcessor crash: add missing name_is_otel_safe() guard to gauge() and timer()

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -270,12 +270,16 @@ class SafeOtelLogger:
         if _skip_due_to_rate(rate):
             return
 
-        if back_compat_name and self.metrics_validator.test(back_compat_name):
+        if (
+            back_compat_name
+            and self.metrics_validator.test(back_compat_name)
+            and name_is_otel_safe(self.prefix, back_compat_name)
+        ):
             self.metrics_map.set_gauge_value(
                 full_name(prefix=self.prefix, name=back_compat_name), value, delta, tags
             )
 
-        if self.metrics_validator.test(stat):
+        if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
             self.metrics_map.set_gauge_value(full_name(prefix=self.prefix, name=stat), value, delta, tags)
 
     def timing(
@@ -299,7 +303,12 @@ class SafeOtelLogger:
         **kwargs,
     ) -> Timer:
         """Timer context manager returns the duration and can be cancelled."""
-        return _OtelTimer(self, stat, tags)
+        safe_stat = (
+            stat
+            if stat is not None and self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat)
+            else None
+        )
+        return _OtelTimer(self, safe_stat, tags)
 
 
 class InternalGauge:

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -200,7 +200,9 @@ class SafeOtelLogger:
         the OTel SDK, which raises and crashes the emitting process. Keeping the check in one place
         stops a new recording method from silently omitting it.
         """
-        return bool(stat) and self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat)
+        if not stat:
+            return False
+        return self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat)
 
     def incr(
         self,

--- a/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/otel_logger.py
@@ -192,6 +192,16 @@ class SafeOtelLogger:
         self.stat_name_handler = stat_name_handler
         self.statsd_influxdb_enabled = statsd_influxdb_enabled
 
+    def _is_recordable(self, stat: str | None) -> bool:
+        """
+        Return True if ``stat`` may be recorded: non-empty, allowed by the validator, and OTel-safe.
+
+        Every recording method must gate on this before emitting; otherwise an unsafe name reaches
+        the OTel SDK, which raises and crashes the emitting process. Keeping the check in one place
+        stops a new recording method from silently omitting it.
+        """
+        return bool(stat) and self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat)
+
     def incr(
         self,
         stat: str,
@@ -213,7 +223,7 @@ class SafeOtelLogger:
         if count < 0:
             raise ValueError("count must be a positive value.")
 
-        if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
+        if self._is_recordable(stat):
             counter = self.metrics_map.get_counter(full_name(prefix=self.prefix, name=stat), attributes=tags)
             counter.add(count, attributes=tags)
             return counter
@@ -239,7 +249,7 @@ class SafeOtelLogger:
         if count < 0:
             raise ValueError("count must be a positive value.")
 
-        if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
+        if self._is_recordable(stat):
             counter = self.metrics_map.get_counter(full_name(prefix=self.prefix, name=stat))
             counter.add(-count, attributes=tags)
             return counter
@@ -270,16 +280,12 @@ class SafeOtelLogger:
         if _skip_due_to_rate(rate):
             return
 
-        if (
-            back_compat_name
-            and self.metrics_validator.test(back_compat_name)
-            and name_is_otel_safe(self.prefix, back_compat_name)
-        ):
+        if self._is_recordable(back_compat_name):
             self.metrics_map.set_gauge_value(
                 full_name(prefix=self.prefix, name=back_compat_name), value, delta, tags
             )
 
-        if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
+        if self._is_recordable(stat):
             self.metrics_map.set_gauge_value(full_name(prefix=self.prefix, name=stat), value, delta, tags)
 
     def timing(
@@ -290,7 +296,7 @@ class SafeOtelLogger:
         tags: Attributes = None,
     ) -> None:
         """Record a timing observation as a Histogram to preserve distribution information."""
-        if self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat):
+        if self._is_recordable(stat):
             if isinstance(dt, datetime.timedelta):
                 dt = dt.total_seconds() * 1000.0
             self.metrics_map.record_histogram_value(full_name(prefix=self.prefix, name=stat), float(dt), tags)
@@ -303,11 +309,7 @@ class SafeOtelLogger:
         **kwargs,
     ) -> Timer:
         """Timer context manager returns the duration and can be cancelled."""
-        safe_stat = (
-            stat
-            if stat is not None and self.metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat)
-            else None
-        )
+        safe_stat = stat if self._is_recordable(stat) else None
         return _OtelTimer(self, safe_stat, tags)
 
 

--- a/shared/observability/tests/observability/metrics/test_otel_logger.py
+++ b/shared/observability/tests/observability/metrics/test_otel_logger.py
@@ -121,6 +121,31 @@ class TestOtelMetrics:
         assert result is None
         self.meter.get_meter().create_counter.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "stat",
+        [
+            "dag_processing.last_run.seconds_ago.PBI_SKU_Performance copy",  # space in filename
+            "dag_processing.last_run.seconds_ago.mein_däg_file",  # non-ASCII in filename
+        ],
+    )
+    def test_gauge_with_invalid_stat_names_skipped_without_raising(self, stat):
+        self.stats.gauge(stat, value=1)
+
+        self.meter.get_meter().create_gauge.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "stat",
+        [
+            "dag.my_dag.preço_task.duration",  # non-ASCII
+            "dag.my_dag.task copy.duration",  # space
+        ],
+    )
+    def test_timer_with_invalid_stat_name_does_not_record(self, stat):
+        with self.stats.timer(stat):
+            pass
+
+        self.meter.get_meter().create_histogram.assert_not_called()
+
     def test_old_name_exception_works(self, caplog):
         name = "task_instance_created_OperatorNameWhichIsSuperLongAndExceedsTheOpenTelemetryCharacterLimit/task_instance_created_OperatorNameWhichIsSuperLongAndExceedsTheOpenTelemetryCharacterLimit/task_instance_created_OperatorNameWhichIsSuperLongAndExceedsTheOpenTelemetryCharacterLimit"
 


### PR DESCRIPTION
## Summary

`SafeOtelLogger.gauge()` and `timer()` were missing the `name_is_otel_safe()` guard that `incr()`, `decr()`, and `timing()` all have. A DAG filename containing a space (e.g. `PBI_SKU_Performance copy.py`) caused the DagProcessor to crash on every loop iteration when OTel metrics were enabled.

## Why

The DagProcessor emits a gauge metric for every known DAG file on every parsing loop:

```python
Stats.gauge(f"dag_processing.last_run.seconds_ago.{file_name}", seconds_ago)
```

`gauge()` only validated against the allow/block list (`metrics_validator.test()`), which does not check OTel naming rules. A filename with a space passed that check and reached `meter.create_gauge()` inside the OTel SDK, which raised a plain Exception that propagated uncaught and crashed the process:

```
Exception: Expected ASCII string of maximum length 63 characters but got airflow.dag_processing.last_run.seconds_ago.PBI_SKU_Performance copy
```

Note: the OTel SDK error message says "63 characters" but this is a stale message — the actual SDK validation regex allows up to 255 characters (matching OTEL_NAME_MAX_LENGTH). The real rejection reason is the space character, which is not a valid OTel instrument name character. See [open-telemetry/opentelemetry-python#3442](https://github.com/open-telemetry/opentelemetry-python/pull/3442).

The same gap existed in `timer()`: it had no validation at all before being passed to `_OtelTimer`, which would then call `record_histogram_value()` with the invalid name at `.stop()` time.

## Fix

Added `metrics_validator.test(stat) and name_is_otel_safe(self.prefix, stat)` to `gauge()` (both the `stat` and `back_compat_name` paths) and `timer()`, making all five recording methods consistent:

| Method | Guard before | Guard after |
|--------|-------------|-------------|
| `incr()` | ✅ both checks | ✅ unchanged |
| `decr()` | ✅ both checks | ✅ unchanged |
| `timing()` | ✅ both checks | ✅ unchanged |
| `gauge()` | ❌ validator only | ✅ both checks |
| `timer()` | ❌ none | ✅ both checks |


## Testing

- `test_gauge_with_invalid_stat_names_skipped_without_raising` — covers the exact reported scenario (space in filename) and non-ASCII, both reproducing the DagProcessor crash path.
- `test_timer_with_invalid_stat_name_does_not_record` — covers non-ASCII and space for the timer path.

```
$ pytest shared/observability/tests/observability/metrics/test_otel_logger.py \
    -k "invalid_stat_names or invalid_stat_name" -v

test_gauge_with_invalid_stat_names_skipped_without_raising[...PBI_SKU_Performance copy] PASSED
test_gauge_with_invalid_stat_names_skipped_without_raising[...mein_däg_file]            PASSED
test_timer_with_invalid_stat_name_does_not_record[...preço_task.duration]              PASSED
test_timer_with_invalid_stat_name_does_not_record[...task copy.duration]               PASSED

========================= 4 passed in 0.14s =========================
```


closes: #68282

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

This PR was prepared with Gen-AI assistance (Claude). I reviewed all generated code.