### PR TITLE
Fix empty labels in Stackdriver log IO for Airflow 3 Supervisor

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -171,6 +171,18 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 labels.update(self.labels)
             if ti:
                 labels.update(_task_instance_to_labels(ti))
+            else:
+                if dag_id := event.get("dag_id"):
+                    labels[LABEL_DAG_ID] = str(dag_id)
+                if task_id := event.get("task_id"):
+                    labels[LABEL_TASK_ID] = str(task_id)
+                if run_id := event.get("run_id"):
+                    labels["run_id"] = str(run_id)
+                if try_number := event.get("try_number"):
+                    labels[LABEL_TRY_NUMBER] = str(try_number)
+                if map_index := event.get("map_index"):
+                    labels["map_index"] = str(map_index)
+
             _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
             return event
 

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -189,6 +189,50 @@ class TestStackdriverRemoteLogIO:
 
         mock_transport.flush.assert_called_once()
 
+    @mock.patch(
+        "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverRemoteLogIO.transport",
+        new_callable=PropertyMock,
+    )
+    def test_processors_fallback_to_event_labels(self, mock_transport_prop):
+        mock_transport = mock.MagicMock()
+        mock_transport_prop.return_value = mock_transport
+
+        io = StackdriverRemoteLogIO(
+            base_log_folder=self.local_log_location,
+            gcp_log_name="airflow",
+        )
+        logger = mock.MagicMock()
+        # Mock relative_path_from_logger to return something truthy
+        with mock.patch(
+            "airflow.sdk.log.relative_path_from_logger",
+            return_value="some/path.py",
+        ):
+            proc = io.processors[0]
+            event = {
+                "event": "Test message",
+                "dag_id": "test_dag_id",
+                "task_id": "test_task_id",
+                "run_id": "test_run_id",
+                "try_number": 2,
+                "map_index": -1,
+            }
+
+            result = proc(logger, "info", event)
+
+            assert result == event
+
+            mock_transport.send.assert_called_once()
+            _, kwargs = mock_transport.send.call_args
+
+            labels = kwargs.get("labels", {})
+            assert labels == {
+                "dag_id": "test_dag_id",
+                "task_id": "test_task_id",
+                "run_id": "test_run_id",
+                "try_number": "2",
+                "map_index": "-1",
+            }
+
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     def test_prepare_log_filter(self, mock_get_creds_and_project_id):
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -189,6 +189,7 @@ class TestStackdriverRemoteLogIO:
 
         mock_transport.flush.assert_called_once()
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="airflow.sdk.log only exists in Airflow 3+")
     @mock.patch(
         "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverRemoteLogIO.transport",
         new_callable=PropertyMock,


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This PR adds fallback logic to `StackdriverRemoteLogIO` to extract task labels directly from the `structlog` context dictionary when `record.task_instance` is missing, addressing the empty labels issue in the Airflow 3 Supervisor.

## Description
This PR addresses **Bug 1** described in #68240.

In the Airflow 3 Task SDK Supervisor environment, the `task_instance` object may be stripped from log records. Without it, the Stackdriver handler failed to attach identifying labels, resulting in untraceable "empty label" logs in Google Cloud.

As suggested by @ashb in the issue, rather than manually parsing log file paths, this PR leverages the `structlog` context variables. The Task SDK inherently binds task details to the structlog context, making them naturally available in the `event` dictionary.

### Key changes
* **Fallback Label Extraction**: Added fallback logic in `StackdriverRemoteLogIO.processors.proc`. If `record.task_instance` is missing, it safely extracts `dag_id`, `task_id`, `run_id`, `try_number`, and `map_index` directly from the `event` dictionary and applies them as labels.

## Verification Results
I have verified the changes using `prek` and `breeze`.
* **Static Checks (Prek):** Passed
* **Unit Tests (Breeze):** Passed

---

related: #68240

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
