### PR TITLE
Fix Stackdriver log read filter to use task_instance_id with backward compatibility

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -78,6 +78,7 @@ LABEL_TASK_ID = "task_id"
 LABEL_DAG_ID = "dag_id"
 LABEL_LOGICAL_DATE = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 LABEL_TRY_NUMBER = "try_number"
+LABEL_TASK_INSTANCE_ID = "task_instance_id"
 
 
 @attrs.define(kw_only=True)
@@ -232,8 +233,24 @@ class StackdriverRemoteLogIO(LoggingMixin):
         for key, value in self.resource.labels.items():
             log_filters.append(f"resource.labels.{escape_label_key(key)}={escape_label_value(value)}")
 
-        for key, value in ti_labels.items():
-            log_filters.append(f"labels.{escape_label_key(key)}={escape_label_value(value)}")
+        ti_id_val = ti_labels.get(LABEL_TASK_INSTANCE_ID)
+        legacy_filters = [
+            f"labels.{escape_label_key(k)}={escape_label_value(v)}"
+            for k, v in ti_labels.items()
+            if k != LABEL_TASK_INSTANCE_ID
+        ]
+
+        if ti_id_val:
+            ti_id_filter = (
+                f"labels.{escape_label_key(LABEL_TASK_INSTANCE_ID)}={escape_label_value(ti_id_val)}"
+            )
+            if legacy_filters:
+                log_filters.append(f"({ti_id_filter} OR ({' AND '.join(legacy_filters)}))")
+            else:
+                log_filters.append(ti_id_filter)
+        else:
+            log_filters.extend(legacy_filters)
+
         return "\n".join(log_filters)
 
     def read_logs(
@@ -280,14 +297,17 @@ class StackdriverRemoteLogIO(LoggingMixin):
 
 def _task_instance_to_labels(ti) -> dict[str, str]:
     """Convert a task instance to Stackdriver labels."""
-    return {
-        LABEL_TASK_ID: ti.task_id,
-        LABEL_DAG_ID: ti.dag_id,
+    labels = {
+        LABEL_TASK_ID: str(ti.task_id),
+        LABEL_DAG_ID: str(ti.dag_id),
         LABEL_LOGICAL_DATE: str(ti.logical_date.isoformat())
         if AIRFLOW_V_3_0_PLUS
         else str(ti.execution_date.isoformat()),
         LABEL_TRY_NUMBER: str(ti.try_number),
     }
+    if getattr(ti, "id", None):
+        labels[LABEL_TASK_INSTANCE_ID] = str(ti.id)
+    return labels
 
 
 class StackdriverTaskHandler(logging.Handler):
@@ -326,6 +346,7 @@ class StackdriverTaskHandler(logging.Handler):
     LABEL_DAG_ID = LABEL_DAG_ID
     LABEL_LOGICAL_DATE = LABEL_LOGICAL_DATE
     LABEL_TRY_NUMBER = LABEL_TRY_NUMBER
+    LABEL_TASK_INSTANCE_ID = LABEL_TASK_INSTANCE_ID
     LOG_VIEWER_BASE_URL = "https://console.cloud.google.com/logs/viewer"
     LOG_NAME = "Google Stackdriver"
 
@@ -463,14 +484,17 @@ class StackdriverTaskHandler(logging.Handler):
 
     @classmethod
     def _task_instance_to_labels(cls, ti: TaskInstance) -> dict[str, str]:
-        return {
-            cls.LABEL_TASK_ID: ti.task_id,
-            cls.LABEL_DAG_ID: ti.dag_id,
+        labels = {
+            cls.LABEL_TASK_ID: str(ti.task_id),
+            cls.LABEL_DAG_ID: str(ti.dag_id),
             cls.LABEL_LOGICAL_DATE: str(ti.logical_date.isoformat())
             if AIRFLOW_V_3_0_PLUS
             else str(ti.execution_date.isoformat()),
             cls.LABEL_TRY_NUMBER: str(ti.try_number),
         }
+        if getattr(ti, "id", None):
+            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti.id)
+        return labels
 
     @property
     def log_name(self):

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -493,9 +493,6 @@ class StackdriverTaskHandler(logging.Handler):
             else str(ti.execution_date.isoformat()),
             cls.LABEL_TRY_NUMBER: str(ti.try_number),
         }
-        ti_id = getattr(ti, "id", None)
-        if ti_id:
-            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti_id)
         return labels
 
     @property

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -305,8 +305,9 @@ def _task_instance_to_labels(ti) -> dict[str, str]:
         else str(ti.execution_date.isoformat()),
         LABEL_TRY_NUMBER: str(ti.try_number),
     }
-    if getattr(ti, "id", None):
-        labels[LABEL_TASK_INSTANCE_ID] = str(ti.id)
+    ti_id = getattr(ti, "id", None)
+    if ti_id:
+        labels[LABEL_TASK_INSTANCE_ID] = str(ti_id)
     return labels
 
 
@@ -492,8 +493,9 @@ class StackdriverTaskHandler(logging.Handler):
             else str(ti.execution_date.isoformat()),
             cls.LABEL_TRY_NUMBER: str(ti.try_number),
         }
-        if getattr(ti, "id", None):
-            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti.id)
+        ti_id = getattr(ti, "id", None)
+        if ti_id:
+            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti_id)
         return labels
 
     @property

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -79,6 +79,7 @@ LABEL_DAG_ID = "dag_id"
 LABEL_LOGICAL_DATE = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 LABEL_TRY_NUMBER = "try_number"
 LABEL_TASK_INSTANCE_ID = "task_instance_id"
+LABEL_RUN_ID = "run_id"
 
 
 @attrs.define(kw_only=True)
@@ -178,7 +179,7 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 if task_id := event.get("task_id"):
                     labels[LABEL_TASK_ID] = str(task_id)
                 if run_id := event.get("run_id"):
-                    labels["run_id"] = str(run_id)
+                    labels[LABEL_RUN_ID] = str(run_id)
                 if try_number := event.get("try_number"):
                     labels[LABEL_TRY_NUMBER] = str(try_number)
                 if map_index := event.get("map_index"):
@@ -302,14 +303,18 @@ def _task_instance_to_labels(ti) -> dict[str, str]:
     labels = {
         LABEL_TASK_ID: str(ti.task_id),
         LABEL_DAG_ID: str(ti.dag_id),
-        LABEL_LOGICAL_DATE: str(ti.logical_date.isoformat())
-        if AIRFLOW_V_3_0_PLUS
-        else str(ti.execution_date.isoformat()),
         LABEL_TRY_NUMBER: str(ti.try_number),
     }
+
     ti_id = getattr(ti, "id", None)
     if ti_id:
         labels[LABEL_TASK_INSTANCE_ID] = str(ti_id)
+
+    if logical_date := getattr(ti, LABEL_LOGICAL_DATE, None):
+        labels[LABEL_LOGICAL_DATE] = str(logical_date.isoformat())
+    elif run_id := getattr(ti, "run_id", None):
+        labels[LABEL_RUN_ID] = str(run_id)
+
     return labels
 
 

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -184,6 +184,8 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 if map_index := event.get("map_index"):
                     labels["map_index"] = str(map_index)
 
+            if ti_id := event.get("ti_id"):
+                labels[StackdriverTaskHandler.LABEL_TASK_INSTANCE_ID] = str(ti_id)
             _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
             return event
 

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -82,6 +82,7 @@ LABEL_DAG_ID = "dag_id"
 LABEL_LOGICAL_DATE = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 LABEL_TRY_NUMBER = "try_number"
 LABEL_TASK_INSTANCE_ID = "task_instance_id"
+LABEL_RUN_ID = "run_id"
 
 
 @attrs.define(kw_only=True)
@@ -214,7 +215,7 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 if task_id := event.get("task_id"):
                     labels[LABEL_TASK_ID] = str(task_id)
                 if run_id := event.get("run_id"):
-                    labels["run_id"] = str(run_id)
+                    labels[LABEL_RUN_ID] = str(run_id)
                 if try_number := event.get("try_number"):
                     labels[LABEL_TRY_NUMBER] = str(try_number)
                 if map_index := event.get("map_index"):
@@ -338,14 +339,18 @@ def _task_instance_to_labels(ti) -> dict[str, str]:
     labels = {
         LABEL_TASK_ID: str(ti.task_id),
         LABEL_DAG_ID: str(ti.dag_id),
-        LABEL_LOGICAL_DATE: str(ti.logical_date.isoformat())
-        if AIRFLOW_V_3_0_PLUS
-        else str(ti.execution_date.isoformat()),
         LABEL_TRY_NUMBER: str(ti.try_number),
     }
+
     ti_id = getattr(ti, "id", None)
     if ti_id:
         labels[LABEL_TASK_INSTANCE_ID] = str(ti_id)
+
+    if logical_date := getattr(ti, LABEL_LOGICAL_DATE, None):
+        labels[LABEL_LOGICAL_DATE] = str(logical_date.isoformat())
+    elif run_id := getattr(ti, "run_id", None):
+        labels[LABEL_RUN_ID] = str(run_id)
+
     return labels
 
 

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -81,6 +81,7 @@ LABEL_TASK_ID = "task_id"
 LABEL_DAG_ID = "dag_id"
 LABEL_LOGICAL_DATE = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 LABEL_TRY_NUMBER = "try_number"
+LABEL_TASK_INSTANCE_ID = "task_instance_id"
 
 
 @attrs.define(kw_only=True)
@@ -268,8 +269,24 @@ class StackdriverRemoteLogIO(LoggingMixin):
         for key, value in self.resource.labels.items():
             log_filters.append(f"resource.labels.{escape_label_key(key)}={escape_label_value(value)}")
 
-        for key, value in ti_labels.items():
-            log_filters.append(f"labels.{escape_label_key(key)}={escape_label_value(value)}")
+        ti_id_val = ti_labels.get(LABEL_TASK_INSTANCE_ID)
+        legacy_filters = [
+            f"labels.{escape_label_key(k)}={escape_label_value(v)}"
+            for k, v in ti_labels.items()
+            if k != LABEL_TASK_INSTANCE_ID
+        ]
+
+        if ti_id_val:
+            ti_id_filter = (
+                f"labels.{escape_label_key(LABEL_TASK_INSTANCE_ID)}={escape_label_value(ti_id_val)}"
+            )
+            if legacy_filters:
+                log_filters.append(f"({ti_id_filter} OR ({' AND '.join(legacy_filters)}))")
+            else:
+                log_filters.append(ti_id_filter)
+        else:
+            log_filters.extend(legacy_filters)
+
         return "\n".join(log_filters)
 
     def read_logs(
@@ -316,14 +333,17 @@ class StackdriverRemoteLogIO(LoggingMixin):
 
 def _task_instance_to_labels(ti) -> dict[str, str]:
     """Convert a task instance to Stackdriver labels."""
-    return {
-        LABEL_TASK_ID: ti.task_id,
-        LABEL_DAG_ID: ti.dag_id,
+    labels = {
+        LABEL_TASK_ID: str(ti.task_id),
+        LABEL_DAG_ID: str(ti.dag_id),
         LABEL_LOGICAL_DATE: str(ti.logical_date.isoformat())
         if AIRFLOW_V_3_0_PLUS
         else str(ti.execution_date.isoformat()),
         LABEL_TRY_NUMBER: str(ti.try_number),
     }
+    if getattr(ti, "id", None):
+        labels[LABEL_TASK_INSTANCE_ID] = str(ti.id)
+    return labels
 
 
 class StackdriverTaskHandler(logging.Handler):
@@ -362,6 +382,7 @@ class StackdriverTaskHandler(logging.Handler):
     LABEL_DAG_ID = LABEL_DAG_ID
     LABEL_LOGICAL_DATE = LABEL_LOGICAL_DATE
     LABEL_TRY_NUMBER = LABEL_TRY_NUMBER
+    LABEL_TASK_INSTANCE_ID = LABEL_TASK_INSTANCE_ID
     LOG_VIEWER_BASE_URL = "https://console.cloud.google.com/logs/viewer"
     LOG_NAME = "Google Stackdriver"
 
@@ -499,14 +520,17 @@ class StackdriverTaskHandler(logging.Handler):
 
     @classmethod
     def _task_instance_to_labels(cls, ti: TaskInstance) -> dict[str, str]:
-        return {
-            cls.LABEL_TASK_ID: ti.task_id,
-            cls.LABEL_DAG_ID: ti.dag_id,
+        labels = {
+            cls.LABEL_TASK_ID: str(ti.task_id),
+            cls.LABEL_DAG_ID: str(ti.dag_id),
             cls.LABEL_LOGICAL_DATE: str(ti.logical_date.isoformat())
             if AIRFLOW_V_3_0_PLUS
             else str(ti.execution_date.isoformat()),
             cls.LABEL_TRY_NUMBER: str(ti.try_number),
         }
+        if getattr(ti, "id", None):
+            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti.id)
+        return labels
 
     @property
     def log_name(self):

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -220,6 +220,8 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 if map_index := event.get("map_index"):
                     labels["map_index"] = str(map_index)
 
+            if ti_id := event.get("ti_id"):
+                labels[StackdriverTaskHandler.LABEL_TASK_INSTANCE_ID] = str(ti_id)
             _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
             return event
 

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -529,9 +529,6 @@ class StackdriverTaskHandler(logging.Handler):
             else str(ti.execution_date.isoformat()),
             cls.LABEL_TRY_NUMBER: str(ti.try_number),
         }
-        ti_id = getattr(ti, "id", None)
-        if ti_id:
-            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti_id)
         return labels
 
     @property

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -341,8 +341,9 @@ def _task_instance_to_labels(ti) -> dict[str, str]:
         else str(ti.execution_date.isoformat()),
         LABEL_TRY_NUMBER: str(ti.try_number),
     }
-    if getattr(ti, "id", None):
-        labels[LABEL_TASK_INSTANCE_ID] = str(ti.id)
+    ti_id = getattr(ti, "id", None)
+    if ti_id:
+        labels[LABEL_TASK_INSTANCE_ID] = str(ti_id)
     return labels
 
 
@@ -528,8 +529,9 @@ class StackdriverTaskHandler(logging.Handler):
             else str(ti.execution_date.isoformat()),
             cls.LABEL_TRY_NUMBER: str(ti.try_number),
         }
-        if getattr(ti, "id", None):
-            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti.id)
+        ti_id = getattr(ti, "id", None)
+        if ti_id:
+            labels[cls.LABEL_TASK_INSTANCE_ID] = str(ti_id)
         return labels
 
     @property

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -449,7 +449,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
-            "task_instance_id": str(self.ti.id),
+            **({"task_instance_id": str(self.ti.id)} if hasattr(self.ti, "id") else {}),
         }
         resource = Resource(type="global", labels={})
         self.transport_mock.return_value.send.assert_called_once_with(
@@ -475,7 +475,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
-            "task_instance_id": str(self.ti.id),
+            **({"task_instance_id": str(self.ti.id)} if hasattr(self.ti, "id") else {}),
             "product.googleapis.com/task_id": "test-value",
         }
         resource = Resource(type="global", labels={})
@@ -496,14 +496,23 @@ class TestStackdriverLoggingHandlerTask:
 
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -529,14 +538,23 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata = stackdriver_task_handler.read(self.ti)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="K\\"OT" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="K\\"OT" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="K\\"OT"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -560,15 +578,25 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata = stackdriver_task_handler.read(self.ti, 3)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-            'labels.try_number="3"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+                'labels.try_number="3"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
+                'labels.try_number="3"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -593,15 +621,25 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata1 = stackdriver_task_handler.read(self.ti, 3)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-            'labels.try_number="3"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+                'labels.try_number="3"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
+                'labels.try_number="3"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -620,15 +658,7 @@ class TestStackdriverLoggingHandlerTask:
         mock_client.return_value.list_log_entries.assert_called_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
-                filter=(
-                    'resource.type="global"\n'
-                    'logName="projects/project_id/logs/airflow"\n'
-                    f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-                    'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-                    'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-                    f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-                    'labels.try_number="3"))'
-                ),
+                filter=filter_str,
                 order_by="timestamp asc",
                 page_size=1000,
                 page_token="TOKEN1",
@@ -672,17 +702,29 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata = stackdriver_task_handler.read(self.ti)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="cloud_composer_environment"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            'resource.labels."environment.name"="test-instance"\n'
-            'resource.labels.location="europe-west-3"\n'
-            'resource.labels.project_id="project_id"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="cloud_composer_environment"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'resource.labels."environment.name"="test-instance"\n'
+                'resource.labels.location="europe-west-3"\n'
+                'resource.labels.project_id="project_id"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="cloud_composer_environment"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'resource.labels."environment.name"="test-instance"\n'
+                'resource.labels.location="europe-west-3"\n'
+                'resource.labels.project_id="project_id"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -734,14 +776,24 @@ class TestStackdriverLoggingHandlerTask:
 
         filter_params = parsed_qs["advancedFilter"][0].splitlines()
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        expected_filter = [
-            'resource.type="global"',
-            'logName="projects/project_id/logs/airflow"',
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
-            f'labels.dag_id="{self.DAG_ID}" AND '
-            f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
-            f'labels.try_number="{self.ti.try_number}"))',
-        ]
+        if hasattr(self.ti, "id"):
+            expected_filter = [
+                'resource.type="global"',
+                'logName="projects/project_id/logs/airflow"',
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
+                f'labels.dag_id="{self.DAG_ID}" AND '
+                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
+                f'labels.try_number="{self.ti.try_number}"))',
+            ]
+        else:
+            expected_filter = [
+                'resource.type="global"',
+                'logName="projects/project_id/logs/airflow"',
+                f'labels.task_id="{self.ti.task_id}"',
+                f'labels.dag_id="{self.DAG_ID}"',
+                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}"',
+                f'labels.try_number="{self.ti.try_number}"',
+            ]
         assert set(expected_filter) == set(filter_params)
 
 

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -74,14 +74,21 @@ class TestStackdriverRemoteLogIO:
         )
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
 
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = timezone.datetime(2016, 1, 1)
+
         ti.task_id = "test_task"
         ti.dag_id = "test_dag"
         ti.try_number = 1
-        if AIRFLOW_V_3_0_PLUS:
-            ti.logical_date = timezone.datetime(2016, 1, 1)
-        else:
-            ti.execution_date = timezone.datetime(2016, 1, 1)
 
         messages, logs = self.io.read("dag_id=test_dag/run_id=run1/task_id=test_task/attempt=1.log", ti)
 
@@ -97,14 +104,21 @@ class TestStackdriverRemoteLogIO:
         )
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
 
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = timezone.datetime(2016, 1, 1)
+
         ti.task_id = "test_task"
         ti.dag_id = "test_dag"
         ti.try_number = 1
-        if AIRFLOW_V_3_0_PLUS:
-            ti.logical_date = timezone.datetime(2016, 1, 1)
-        else:
-            ti.execution_date = timezone.datetime(2016, 1, 1)
 
         messages, logs = self.io.read("test/path", ti)
 
@@ -585,8 +599,8 @@ class TestStackdriverLoggingHandlerTask:
                 f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
                 'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-                'labels.try_number="3"))'
+                'labels.try_number="3" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
             )
         else:
             filter_str = (
@@ -594,8 +608,8 @@ class TestStackdriverLoggingHandlerTask:
                 'logName="projects/project_id/logs/airflow"\n'
                 'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-                'labels.try_number="3"'
+                'labels.try_number="3"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
             )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -628,8 +642,8 @@ class TestStackdriverLoggingHandlerTask:
                 f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
                 'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-                'labels.try_number="3"))'
+                'labels.try_number="3" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
             )
         else:
             filter_str = (
@@ -637,8 +651,8 @@ class TestStackdriverLoggingHandlerTask:
                 'logName="projects/project_id/logs/airflow"\n'
                 'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-                'labels.try_number="3"'
+                'labels.try_number="3"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
             )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -782,8 +796,8 @@ class TestStackdriverLoggingHandlerTask:
                 'logName="projects/project_id/logs/airflow"',
                 f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
                 f'labels.dag_id="{self.DAG_ID}" AND '
-                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
-                f'labels.try_number="{self.ti.try_number}"))',
+                f'labels.try_number="{self.ti.try_number}" AND '
+                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}"))',
             ]
         else:
             expected_filter = [
@@ -819,12 +833,21 @@ class TestStackdriverTaskHandlerExceptionHandling:
         )
 
         handler = StackdriverTaskHandler()
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
+
         ti.task_id = "t"
         ti.dag_id = "d"
         ti.try_number = 1
-        ti.logical_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
-        ti.execution_date = ti.logical_date
 
         with caplog.at_level(logging.ERROR):
             logs, metadata = handler.read(ti, try_number=1)
@@ -855,12 +878,21 @@ class TestStackdriverTaskHandlerExceptionHandling:
         )
 
         handler = StackdriverTaskHandler()
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
+
         ti.task_id = "t"
         ti.dag_id = "d"
         ti.try_number = 1
-        ti.logical_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
-        ti.execution_date = ti.logical_date
 
         logs, _ = handler.read(ti, try_number=1)
 

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -242,6 +242,23 @@ class TestStackdriverRemoteLogIO:
             "task_id": "test_task",
             "dag_id": "test_dag",
             "try_number": "1",
+            "task_instance_id": "test_ti_id",
+        }
+        log_filter = self.io.prepare_log_filter(ti_labels)
+
+        assert 'resource.type="global"' in log_filter
+        assert 'logName="projects/project_id/logs/airflow"' in log_filter
+        expected_or = '(labels.task_instance_id="test_ti_id" OR (labels.task_id="test_task" AND labels.dag_id="test_dag" AND labels.try_number="1"))'
+        assert expected_or in log_filter
+
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
+    def test_prepare_log_filter_legacy(self, mock_get_creds_and_project_id):
+        mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+
+        ti_labels = {
+            "task_id": "test_task",
+            "dag_id": "test_dag",
+            "try_number": "1",
         }
         log_filter = self.io.prepare_log_filter(ti_labels)
 
@@ -249,6 +266,7 @@ class TestStackdriverRemoteLogIO:
         assert 'logName="projects/project_id/logs/airflow"' in log_filter
         assert 'labels.task_id="test_task"' in log_filter
         assert 'labels.dag_id="test_dag"' in log_filter
+        assert " OR " not in log_filter
 
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     def test_prepare_log_filter_with_custom_resource(self, mock_get_creds_and_project_id):
@@ -431,6 +449,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
+            "task_instance_id": str(self.ti.id),
         }
         resource = Resource(type="global", labels={})
         self.transport_mock.return_value.send.assert_called_once_with(
@@ -456,6 +475,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
+            "task_instance_id": str(self.ti.id),
             "product.googleapis.com/task_id": "test-value",
         }
         resource = Resource(type="global", labels={})
@@ -479,9 +499,10 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -511,9 +532,10 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="K\\"OT"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="K\\"OT" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -541,10 +563,11 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-            'labels.try_number="3"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+            'labels.try_number="3"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -573,10 +596,11 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-            'labels.try_number="3"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+            'labels.try_number="3"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -599,10 +623,11 @@ class TestStackdriverLoggingHandlerTask:
                 filter=(
                     'resource.type="global"\n'
                     'logName="projects/project_id/logs/airflow"\n'
-                    'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-                    'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-                    f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-                    'labels.try_number="3"'
+                    f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                    'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                    'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                    f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+                    'labels.try_number="3"))'
                 ),
                 order_by="timestamp asc",
                 page_size=1000,
@@ -653,9 +678,10 @@ class TestStackdriverLoggingHandlerTask:
             'resource.labels."environment.name"="test-instance"\n'
             'resource.labels.location="europe-west-3"\n'
             'resource.labels.project_id="project_id"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -711,10 +737,10 @@ class TestStackdriverLoggingHandlerTask:
         expected_filter = [
             'resource.type="global"',
             'logName="projects/project_id/logs/airflow"',
-            f'labels.task_id="{self.ti.task_id}"',
-            f'labels.dag_id="{self.DAG_ID}"',
-            f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}"',
-            f'labels.try_number="{self.ti.try_number}"',
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
+            f'labels.dag_id="{self.DAG_ID}" AND '
+            f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
+            f'labels.try_number="{self.ti.try_number}"))',
         ]
         assert set(expected_filter) == set(filter_params)
 

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -512,7 +512,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
-            "task_instance_id": str(self.ti.id),
+            **({"task_instance_id": str(self.ti.id)} if hasattr(self.ti, "id") else {}),
         }
         resource = Resource(type="global", labels={})
         self.transport_mock.return_value.send.assert_called_once_with(
@@ -538,7 +538,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
-            "task_instance_id": str(self.ti.id),
+            **({"task_instance_id": str(self.ti.id)} if hasattr(self.ti, "id") else {}),
             "product.googleapis.com/task_id": "test-value",
         }
         resource = Resource(type="global", labels={})
@@ -559,14 +559,23 @@ class TestStackdriverLoggingHandlerTask:
 
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
 
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -592,14 +601,23 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata = stackdriver_task_handler.read(self.ti)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="K\\"OT" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="K\\"OT" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="K\\"OT"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -623,15 +641,25 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata = stackdriver_task_handler.read(self.ti, 3)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-            'labels.try_number="3"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+                'labels.try_number="3"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
+                'labels.try_number="3"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -656,15 +684,25 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata1 = stackdriver_task_handler.read(self.ti, 3)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="global"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-            'labels.try_number="3"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+                'labels.try_number="3"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="global"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
+                'labels.try_number="3"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -683,15 +721,7 @@ class TestStackdriverLoggingHandlerTask:
         mock_client.return_value.list_log_entries.assert_called_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
-                filter=(
-                    'resource.type="global"\n'
-                    'logName="projects/project_id/logs/airflow"\n'
-                    f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-                    'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-                    'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-                    f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-                    'labels.try_number="3"))'
-                ),
+                filter=filter_str,
                 order_by="timestamp asc",
                 page_size=1000,
                 page_token="TOKEN1",
@@ -735,17 +765,29 @@ class TestStackdriverLoggingHandlerTask:
 
         logs, metadata = stackdriver_task_handler.read(self.ti)
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        filter_str = (
-            'resource.type="cloud_composer_environment"\n'
-            'logName="projects/project_id/logs/airflow"\n'
-            'resource.labels."environment.name"="test-instance"\n'
-            'resource.labels.location="europe-west-3"\n'
-            'resource.labels.project_id="project_id"\n'
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
-            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
-        )
+        if hasattr(self.ti, "id"):
+            filter_str = (
+                'resource.type="cloud_composer_environment"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'resource.labels."environment.name"="test-instance"\n'
+                'resource.labels.location="europe-west-3"\n'
+                'resource.labels.project_id="project_id"\n'
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
+            )
+        else:
+            filter_str = (
+                'resource.type="cloud_composer_environment"\n'
+                'logName="projects/project_id/logs/airflow"\n'
+                'resource.labels."environment.name"="test-instance"\n'
+                'resource.labels.location="europe-west-3"\n'
+                'resource.labels.project_id="project_id"\n'
+                'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
+                'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
                 resource_names=["projects/project_id"],
@@ -797,14 +839,24 @@ class TestStackdriverLoggingHandlerTask:
 
         filter_params = parsed_qs["advancedFilter"][0].splitlines()
         date_label = "logical_date" if AIRFLOW_V_3_0_PLUS else "execution_date"
-        expected_filter = [
-            'resource.type="global"',
-            'logName="projects/project_id/logs/airflow"',
-            f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
-            f'labels.dag_id="{self.DAG_ID}" AND '
-            f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
-            f'labels.try_number="{self.ti.try_number}"))',
-        ]
+        if hasattr(self.ti, "id"):
+            expected_filter = [
+                'resource.type="global"',
+                'logName="projects/project_id/logs/airflow"',
+                f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
+                f'labels.dag_id="{self.DAG_ID}" AND '
+                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
+                f'labels.try_number="{self.ti.try_number}"))',
+            ]
+        else:
+            expected_filter = [
+                'resource.type="global"',
+                'logName="projects/project_id/logs/airflow"',
+                f'labels.task_id="{self.ti.task_id}"',
+                f'labels.dag_id="{self.DAG_ID}"',
+                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}"',
+                f'labels.try_number="{self.ti.try_number}"',
+            ]
         assert set(expected_filter) == set(filter_params)
 
 

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -305,6 +305,23 @@ class TestStackdriverRemoteLogIO:
             "task_id": "test_task",
             "dag_id": "test_dag",
             "try_number": "1",
+            "task_instance_id": "test_ti_id",
+        }
+        log_filter = self.io.prepare_log_filter(ti_labels)
+
+        assert 'resource.type="global"' in log_filter
+        assert 'logName="projects/project_id/logs/airflow"' in log_filter
+        expected_or = '(labels.task_instance_id="test_ti_id" OR (labels.task_id="test_task" AND labels.dag_id="test_dag" AND labels.try_number="1"))'
+        assert expected_or in log_filter
+
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
+    def test_prepare_log_filter_legacy(self, mock_get_creds_and_project_id):
+        mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+
+        ti_labels = {
+            "task_id": "test_task",
+            "dag_id": "test_dag",
+            "try_number": "1",
         }
         log_filter = self.io.prepare_log_filter(ti_labels)
 
@@ -312,6 +329,7 @@ class TestStackdriverRemoteLogIO:
         assert 'logName="projects/project_id/logs/airflow"' in log_filter
         assert 'labels.task_id="test_task"' in log_filter
         assert 'labels.dag_id="test_dag"' in log_filter
+        assert " OR " not in log_filter
 
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     def test_prepare_log_filter_with_custom_resource(self, mock_get_creds_and_project_id):
@@ -494,6 +512,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
+            "task_instance_id": str(self.ti.id),
         }
         resource = Resource(type="global", labels={})
         self.transport_mock.return_value.send.assert_called_once_with(
@@ -519,6 +538,7 @@ class TestStackdriverLoggingHandlerTask:
             "dag_id": self.DAG_ID,
             date_key: "2016-01-01T00:00:00+00:00",
             "try_number": "1",
+            "task_instance_id": str(self.ti.id),
             "product.googleapis.com/task_id": "test-value",
         }
         resource = Resource(type="global", labels={})
@@ -542,9 +562,10 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -574,9 +595,10 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="K\\"OT"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="K\\"OT" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -604,10 +626,11 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-            'labels.try_number="3"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+            'labels.try_number="3"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -636,10 +659,11 @@ class TestStackdriverLoggingHandlerTask:
         filter_str = (
             'resource.type="global"\n'
             'logName="projects/project_id/logs/airflow"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-            'labels.try_number="3"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+            'labels.try_number="3"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -662,10 +686,11 @@ class TestStackdriverLoggingHandlerTask:
                 filter=(
                     'resource.type="global"\n'
                     'logName="projects/project_id/logs/airflow"\n'
-                    'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-                    'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-                    f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-                    'labels.try_number="3"'
+                    f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+                    'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+                    'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+                    f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
+                    'labels.try_number="3"))'
                 ),
                 order_by="timestamp asc",
                 page_size=1000,
@@ -716,9 +741,10 @@ class TestStackdriverLoggingHandlerTask:
             'resource.labels."environment.name"="test-instance"\n'
             'resource.labels.location="europe-west-3"\n'
             'resource.labels.project_id="project_id"\n'
-            'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
-            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-            f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
+            'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
+            'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
+            f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
         )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -774,10 +800,10 @@ class TestStackdriverLoggingHandlerTask:
         expected_filter = [
             'resource.type="global"',
             'logName="projects/project_id/logs/airflow"',
-            f'labels.task_id="{self.ti.task_id}"',
-            f'labels.dag_id="{self.DAG_ID}"',
-            f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}"',
-            f'labels.try_number="{self.ti.try_number}"',
+            f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
+            f'labels.dag_id="{self.DAG_ID}" AND '
+            f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
+            f'labels.try_number="{self.ti.try_number}"))',
         ]
         assert set(expected_filter) == set(filter_params)
 

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -137,14 +137,21 @@ class TestStackdriverRemoteLogIO:
         )
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
 
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = timezone.datetime(2016, 1, 1)
+
         ti.task_id = "test_task"
         ti.dag_id = "test_dag"
         ti.try_number = 1
-        if AIRFLOW_V_3_0_PLUS:
-            ti.logical_date = timezone.datetime(2016, 1, 1)
-        else:
-            ti.execution_date = timezone.datetime(2016, 1, 1)
 
         messages, logs = self.io.read("dag_id=test_dag/run_id=run1/task_id=test_task/attempt=1.log", ti)
 
@@ -160,14 +167,21 @@ class TestStackdriverRemoteLogIO:
         )
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
 
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = timezone.datetime(2016, 1, 1)
+
         ti.task_id = "test_task"
         ti.dag_id = "test_dag"
         ti.try_number = 1
-        if AIRFLOW_V_3_0_PLUS:
-            ti.logical_date = timezone.datetime(2016, 1, 1)
-        else:
-            ti.execution_date = timezone.datetime(2016, 1, 1)
 
         messages, logs = self.io.read("test/path", ti)
 
@@ -648,8 +662,8 @@ class TestStackdriverLoggingHandlerTask:
                 f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
                 'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-                'labels.try_number="3"))'
+                'labels.try_number="3" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
             )
         else:
             filter_str = (
@@ -657,8 +671,8 @@ class TestStackdriverLoggingHandlerTask:
                 'logName="projects/project_id/logs/airflow"\n'
                 'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-                'labels.try_number="3"'
+                'labels.try_number="3"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
             )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -691,8 +705,8 @@ class TestStackdriverLoggingHandlerTask:
                 f'(labels.task_instance_id="{str(self.ti.id)}" OR ('
                 'labels.task_id="task_for_testing_stackdriver_task_handler" AND '
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler" AND '
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00" AND '
-                'labels.try_number="3"))'
+                'labels.try_number="3" AND '
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"))'
             )
         else:
             filter_str = (
@@ -700,8 +714,8 @@ class TestStackdriverLoggingHandlerTask:
                 'logName="projects/project_id/logs/airflow"\n'
                 'labels.task_id="task_for_testing_stackdriver_task_handler"\n'
                 'labels.dag_id="dag_for_testing_stackdriver_file_task_handler"\n'
-                f'labels.{date_label}="2016-01-01T00:00:00+00:00"\n'
-                'labels.try_number="3"'
+                'labels.try_number="3"\n'
+                f'labels.{date_label}="2016-01-01T00:00:00+00:00"'
             )
         mock_client.return_value.list_log_entries.assert_called_once_with(
             request=ListLogEntriesRequest(
@@ -845,8 +859,8 @@ class TestStackdriverLoggingHandlerTask:
                 'logName="projects/project_id/logs/airflow"',
                 f'(labels.task_instance_id="{str(self.ti.id)}" OR (labels.task_id="{self.ti.task_id}" AND '
                 f'labels.dag_id="{self.DAG_ID}" AND '
-                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}" AND '
-                f'labels.try_number="{self.ti.try_number}"))',
+                f'labels.try_number="{self.ti.try_number}" AND '
+                f'labels.{date_label}="{self.ti.logical_date.isoformat() if AIRFLOW_V_3_0_PLUS else self.ti.execution_date.isoformat()}"))',
             ]
         else:
             expected_filter = [
@@ -882,12 +896,21 @@ class TestStackdriverTaskHandlerExceptionHandling:
         )
 
         handler = StackdriverTaskHandler()
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
+
         ti.task_id = "t"
         ti.dag_id = "d"
         ti.try_number = 1
-        ti.logical_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
-        ti.execution_date = ti.logical_date
 
         with caplog.at_level(logging.ERROR):
             logs, metadata = handler.read(ti, try_number=1)
@@ -918,12 +941,21 @@ class TestStackdriverTaskHandlerExceptionHandling:
         )
 
         handler = StackdriverTaskHandler()
-        ti = mock.MagicMock()
+        if AIRFLOW_V_3_0_PLUS:
+            from airflow.sdk.types import RuntimeTaskInstanceProtocol
+
+            ti = mock.MagicMock(spec=RuntimeTaskInstanceProtocol)
+            ti.id = "test_ti_id"
+            ti.run_id = "run1"
+        else:
+            from airflow.models.taskinstance import TaskInstance
+
+            ti = mock.MagicMock(spec=TaskInstance)
+            ti.execution_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
+
         ti.task_id = "t"
         ti.dag_id = "d"
         ti.try_number = 1
-        ti.logical_date = mock.MagicMock(isoformat=lambda: "2020-01-01T00:00:00+00:00")
-        ti.execution_date = ti.logical_date
 
         logs, _ = handler.read(ti, try_number=1)
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This PR resolves the Stackdriver supervisor read crash (**Bug 2** described in #68240) by adopting `ti.id` as the primary log filter while ensuring backward compatibility.

## Description
Following @ashb's guidance, this PR transitions the Stackdriver log filter to use `task_instance_id` (`ti.id`). This removes the supervisor's dependency on `logical_date`.

### Key changes
* **Write Path:** Extracted `ti_id` from the `event` dict in `processors` to stamp the `task_instance_id` label on supervisor logs.
* **Read Path & Fallback:** 
  * Prevented `AttributeError` on `RuntimeTaskInstance` by safely fetching `logical_date`.
  * Generates an `OR` query: prioritizes `task_instance_id`, falling back to `run_id` (for AF3 logs) or `logical_date` (for legacy logs).
* **Tests:** Updated `test_read_logs` to use `spec=RuntimeTaskInstanceProtocol` in AF3+, ensuring missing attribute crashes are caught.

**Generated Filter Example:**
```text
(labels.task_instance_id="<uuid>" OR (labels.task_id="..." AND labels.dag_id="..." AND labels.run_id="..."))
```

## Verification Results
I have verified the changes using `prek` and `breeze`.
* **Static Checks (Prek):** Passed
* **Unit Tests (Breeze):** Passed

---

related: #68240

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=dbca0b3 action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @23tae → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @23tae — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->