### PR TITLE
Fix Supervisor crash in Stackdriver remote log IO

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -183,7 +183,10 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 if map_index := event.get("map_index"):
                     labels["map_index"] = str(map_index)
 
-            _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
+            try:
+                _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
+            except Exception:
+                _logger.warning("Failed to send log to Cloud Logging", exc_info=True)
             return event
 
         return (proc,)

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -325,6 +325,38 @@ class TestStackdriverRemoteLogIO:
         assert result is event
         mock_transport_type.return_value.send.assert_not_called()
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="airflow.sdk.log only exists in Airflow 3+")
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.gcp_logging.Client")
+    def test_processors_survives_transport_send_failure(
+        self, mock_client, mock_get_creds_and_project_id, caplog
+    ):
+        """Test that transport.send() failure does not crash the logging processor."""
+        mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+
+        mock_transport_type = mock.MagicMock()
+        mock_transport_type.return_value.send.side_effect = RuntimeError("IAM permission denied")
+        with mock.patch("airflow.sdk.log.relative_path_from_logger", return_value="dag/task/1.log"):
+            io = StackdriverRemoteLogIO(
+                base_log_folder=self.local_log_location,
+                gcp_log_name="airflow",
+                transport_type=mock_transport_type,
+            )
+            proc = io.processors[0]
+
+            event = {
+                "event": "log message test",
+                "logger_name": "airflow.task",
+                "timestamp": "2026-06-30T00:00:00+09:00",
+            }
+            with caplog.at_level(logging.WARNING):
+                result = proc(mock.MagicMock(), "info", event)
+
+        # Ensure that it still returns the event
+        assert result is event
+        # Ensure that the error is logged
+        assert "Failed to send log to Cloud Logging" in caplog.text
+
 
 @pytest.mark.usefixtures("clean_stackdriver_handlers")
 @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This PR prevents the Airflow 3 Supervisor process from crashing entirely when transient network or IAM errors occur during Stackdriver log transmission.

## Description
This PR addresses **Bug 3** described in #68240.

In the new Airflow 3 Task SDK architecture, the `StackdriverRemoteLogIO` handler runs within the Supervisor process rather than the task process itself. If an exception is raised during `_transport.send()`, it propagates upwards and crashes the entire Supervisor process, disrupting task monitoring.

### Key changes
* **Exception Handling**: Wrapped the `_transport.send()` call in a `try...except Exception` block. When a transmission fails, the exception is safely caught, and a warning is logged using the internal `_logger`. This ensures the Supervisor process remains highly resilient.

## Verification Results
I have verified the changes using `prek` and `breeze`.
* **Static Checks (Prek):** Passed
* **Unit Tests (Breeze):** Passed

---

related: #68240

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=baa54c6 action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @23tae → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @23tae — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->