### PR TITLE
Fix IMAP attachment downloads with duplicate filenames

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -187,6 +187,7 @@ class ImapHook(BaseHook):
         name: str,
         local_output_directory: str,
         *,
+        overwrite_file: bool = True,
         check_regex: bool = False,
         latest_only: bool = False,
         max_mails: int | None = None,
@@ -200,6 +201,9 @@ class ImapHook(BaseHook):
         :param name: The name of the attachment that will be downloaded.
         :param local_output_directory: The output directory on the local machine
             where the files will be downloaded to.
+        :param overwrite_file: Whether to overwrite an existing local file when an
+            attachment with the same name is downloaded. When set to False, duplicate
+            filenames are suffixed with a counter to preserve all attachments.
         :param check_regex: Checks the name for a regular expression.
         :param latest_only: If set to True it will only download the first matched attachment.
         :param max_mails: Maximum number of latest emails to process. Must be a positive integer, or None when unlimited. Defaults to None.
@@ -219,7 +223,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file=overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +291,23 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, *, overwrite_file: bool = True
+    ) -> None:
+        created_file_paths: set[str] = set()
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                file_path = self._correct_path(name, local_output_directory)
+                if not overwrite_file:
+                    file_path = self._find_available_file_path(
+                        name, local_output_directory, created_file_paths
+                    )
+                self._create_file(file_path, payload)
+                created_file_paths.add(file_path)
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -311,9 +324,22 @@ class ImapHook(BaseHook):
             else local_output_directory + os.sep + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _find_available_file_path(
+        self, name: str, local_output_directory: str, created_file_paths: set[str]
+    ) -> str:
         file_path = self._correct_path(name, local_output_directory)
+        if file_path not in created_file_paths and not os.path.exists(file_path):
+            return file_path
 
+        base_name, extension = os.path.splitext(name)
+        counter = 1
+        while True:
+            file_path = self._correct_path(f"{base_name}_{counter}{extension}", local_output_directory)
+            if file_path not in created_file_paths and not os.path.exists(file_path):
+                return file_path
+            counter += 1
+
+    def _create_file(self, file_path: str, payload: Any) -> None:
         with open(file_path, "wb") as file:
             file.write(payload)
 

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import imaplib
 import json
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, call, mock_open, patch
 
 import pytest
 
@@ -315,6 +315,56 @@ class TestImapHook:
 
         mock_open_method.assert_called_once_with("test_directory/test1.csv", "wb")
         mock_open_method.return_value.write.assert_called_once_with(b"SWQsTmFtZQoxLEZlbGl4")
+
+    @patch(open_string, new_callable=mock_open)
+    def test_download_mail_attachments_overwrites_duplicate_names_by_default(self, mock_open_method):
+        with patch.object(
+            ImapHook,
+            "_retrieve_mails_attachments_by_name",
+            return_value=[("test1.csv", b"first"), ("test1.csv", b"second")],
+        ):
+            ImapHook().download_mail_attachments("test1.csv", "test_directory")
+
+        assert mock_open_method.call_args_list == [
+            call("test_directory/test1.csv", "wb"),
+            call("test_directory/test1.csv", "wb"),
+        ]
+        assert mock_open_method.return_value.write.call_args_list == [call(b"first"), call(b"second")]
+
+    @patch("airflow.providers.imap.hooks.imap.os.path.exists", return_value=False)
+    @patch(open_string, new_callable=mock_open)
+    def test_download_mail_attachments_preserves_duplicate_names(self, mock_open_method, mock_path_exists):
+        with patch.object(
+            ImapHook,
+            "_retrieve_mails_attachments_by_name",
+            return_value=[("test1.csv", b"first"), ("test1.csv", b"second")],
+        ):
+            ImapHook().download_mail_attachments("test1.csv", "test_directory", overwrite_file=False)
+
+        assert mock_path_exists.call_args_list == [
+            call("test_directory/test1.csv"),
+            call("test_directory/test1_1.csv"),
+        ]
+        assert mock_open_method.call_args_list == [
+            call("test_directory/test1.csv", "wb"),
+            call("test_directory/test1_1.csv", "wb"),
+        ]
+        assert mock_open_method.return_value.write.call_args_list == [call(b"first"), call(b"second")]
+
+    @patch("airflow.providers.imap.hooks.imap.os.path.exists")
+    @patch(open_string, new_callable=mock_open)
+    def test_download_mail_attachments_avoids_existing_file(self, mock_open_method, mock_path_exists):
+        mock_path_exists.side_effect = lambda file_path: file_path == "test_directory/test1.csv"
+
+        with patch.object(
+            ImapHook,
+            "_retrieve_mails_attachments_by_name",
+            return_value=[("test1.csv", b"payload")],
+        ):
+            ImapHook().download_mail_attachments("test1.csv", "test_directory", overwrite_file=False)
+
+        assert mock_open_method.call_args_list == [call("test_directory/test1_1.csv", "wb")]
+        assert mock_open_method.return_value.write.call_args_list == [call(b"payload")]
 
     @patch(open_string, new_callable=mock_open)
     @patch(imaplib_string)


### PR DESCRIPTION
Fixes #65870.

This adds an overwrite_file option to ImapHook.download_mail_attachments.

By default, existing behavior is preserved and duplicate filenames overwrite the same local path. When overwrite_file=False, downloaded attachments with duplicate filenames are saved with a numeric suffix, preserving each attachment.

Added unit coverage for:
- default overwrite behavior
- preserving duplicate attachment names
- avoiding collision with an existing local file