### PR TITLE
Fix secrets backend connection errors silently swallowed at DEBUG level

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -212,6 +212,7 @@ def _get_connection(conn_id: str) -> Connection:
                 "Unable to retrieve connection from secrets backend (%s). "
                 "Checking subsequent secrets backend.",
                 type(secrets_backend).__name__,
+                exc_info=True,
             )
 
     # If no backend found the connection, raise an error
@@ -269,6 +270,7 @@ async def _async_get_connection(conn_id: str) -> Connection:
                 "Unable to retrieve connection from secrets backend (%s). "
                 "Checking subsequent secrets backend.",
                 type(secrets_backend).__name__,
+                exc_info=True,
             )
 
     # If no backend found the connection, raise an error


### PR DESCRIPTION
## What does this PR do?

When a secrets backend raises an exception during `get_connection()`, the exception is caught and logged at `DEBUG` without `exc_info`, making the actual error completely invisible — even with `DEBUG` logging enabled. Only the backend class name is logged, not the error itself.

This PR adds `exc_info=True` to both the sync (`_get_connection`) and async (`_async_get_connection`) lookup loops in `context.py`.

**Before:** only the backend name is visible at DEBUG:
```
DEBUG - Unable to retrieve connection from secrets backend (VaultBackend). Checking subsequent secrets backend.
```

**After:** the full traceback is included, so the actual cause (e.g. a `KeyError` during deserialization, an auth failure, a missing dependency) is visible when DEBUG logging is enabled.

The exception stays at `DEBUG` to avoid log spam in normal multi-backend setups where fallthrough is expected. This brings `_get_connection` in line with `_get_variable`, which already uses `log.exception()`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Claude Code (claude-sonnet-4-6); reviewed by @seanmuth before posting