### PR TITLE
Fix older and custom secrets backends breaking on Airflow 3.2

### DIFF
--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -31,6 +31,7 @@ from sqlalchemy import ForeignKey, Integer, String, Text, select
 from sqlalchemy.orm import Mapped, mapped_column, reconstructor
 
 from airflow._shared.module_loading import import_string
+from airflow._shared.secrets_backend.base import call_secrets_backend_method
 from airflow._shared.secrets_masker import mask_secret
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models.base import ID_LEN, Base
@@ -517,7 +518,9 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         # iterate over backends if not in cache (or expired)
         for secrets_backend in ensure_secrets_loaded():
             try:
-                conn = secrets_backend.get_connection(conn_id=conn_id, team_name=team_name)
+                conn = call_secrets_backend_method(
+                    secrets_backend.get_connection, team_name=team_name, conn_id=conn_id
+                )
                 if conn:
                     SecretCache.save_connection_uri(conn_id, conn.get_uri(), team_name=team_name)
                     return conn

--- a/airflow-core/src/airflow/models/variable.py
+++ b/airflow-core/src/airflow/models/variable.py
@@ -28,6 +28,7 @@ from sqlalchemy import Boolean, ForeignKey, Integer, String, Text, delete, or_, 
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, reconstructor, synonym
 
+from airflow._shared.secrets_backend.base import call_secrets_backend_method
 from airflow._shared.secrets_masker import mask_secret
 from airflow.configuration import conf, ensure_secrets_loaded
 from airflow.models.base import ID_LEN, Base
@@ -479,7 +480,9 @@ class Variable(Base, LoggingMixin):
         # iterate over backends if not in cache (or expired)
         for secrets_backend in ensure_secrets_loaded():
             try:
-                var_val = secrets_backend.get_variable(key=key, team_name=team_name)
+                var_val = call_secrets_backend_method(
+                    secrets_backend.get_variable, team_name=team_name, key=key
+                )
                 if var_val is not None:
                     break
             except AirflowSecretsBackendAccessDenied:

--- a/airflow-core/tests/unit/always/test_secrets.py
+++ b/airflow-core/tests/unit/always/test_secrets.py
@@ -25,6 +25,7 @@ from airflow.configuration import ensure_secrets_loaded, initialize_secrets_back
 from airflow.models import Connection, Variable
 from airflow.sdk import SecretCache
 from airflow.sdk.exceptions import AirflowNotFoundException
+from airflow.secrets import BaseSecretsBackend
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_variables
@@ -225,6 +226,55 @@ class TestVariableFromSecrets:
     )
     def test_variable_env_var_do_not_access_team_specific(self):
         assert Variable.get_variable_from_secrets(key="_team___myvar") is None
+
+
+class _LegacyGetConnectionBackend(BaseSecretsBackend):
+    """Backend overriding ``get_connection`` with the pre-3.2 ``(self, conn_id)`` signature (e.g. Vault)."""
+
+    def __init__(self, conns: dict[str, Connection]):
+        self._conns = conns
+
+    def get_connection(self, conn_id):
+        return self._conns.get(conn_id)
+
+
+class _LegacyGetVariableBackend(BaseSecretsBackend):
+    """Backend overriding ``get_variable`` with the pre-3.2 ``(self, key)`` signature."""
+
+    def __init__(self, variables: dict[str, str]):
+        self._vars = variables
+
+    def get_variable(self, key):
+        return self._vars.get(key)
+
+
+@skip_if_force_lowest_dependencies_marker
+class TestLegacyBackendSignatureCompat:
+    """Backends whose overrides predate the ``team_name`` keyword must keep working (issue #1333)."""
+
+    def setup_method(self) -> None:
+        SecretCache.reset()
+
+    @pytest.mark.parametrize("team_name", [None, "team_a"])
+    @conf_vars({("core", "multi_team"): "True"})
+    @mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.task_runner": None})
+    def test_get_connection_with_legacy_get_connection_override(self, team_name):
+        backend = _LegacyGetConnectionBackend(
+            {"legacy_conn": Connection(conn_id="legacy_conn", conn_type="mysql", host="h")}
+        )
+        with mock.patch("airflow.configuration.ensure_secrets_loaded", return_value=[backend]):
+            conn = Connection.get_connection_from_secrets("legacy_conn", team_name=team_name)
+
+        assert conn.conn_id == "legacy_conn"
+        assert conn.conn_type == "mysql"
+
+    @pytest.mark.parametrize("team_name", [None, "team_a"])
+    def test_get_variable_with_legacy_get_variable_override(self, team_name):
+        backend = _LegacyGetVariableBackend({"legacy_var": "secret_value"})
+        with mock.patch("airflow.models.variable.ensure_secrets_loaded", return_value=[backend]):
+            value = Variable.get_variable_from_secrets("legacy_var", team_name=team_name)
+
+        assert value == "secret_value"
 
 
 @skip_if_force_lowest_dependencies_marker

--- a/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
+++ b/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
@@ -16,7 +16,45 @@
 # under the License.
 from __future__ import annotations
 
+import inspect
 from abc import ABC
+from collections.abc import Callable
+
+
+def _accepts_team_name(method: Callable) -> bool:
+    """
+    Return whether a secrets-backend method accepts the ``team_name`` keyword.
+
+    Backends written before Airflow 3.2 override ``get_conn_value`` / ``get_variable`` /
+    ``get_connection`` with the legacy ``(self, conn_id)`` / ``(self, key)`` signature.
+    AIP-67 (multi-team) added a ``team_name`` keyword; forwarding it to those raises
+    ``TypeError``. A method accepts it if it declares a ``team_name`` parameter or a
+    ``**kwargs`` catch-all.
+    """
+    try:
+        parameters = inspect.signature(method).parameters
+    except (TypeError, ValueError):
+        # Un-introspectable callable (e.g. C-implemented): assume the 3.2+ signature.
+        return True
+    return "team_name" in parameters or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+    )
+
+
+def call_secrets_backend_method(method: Callable, *, team_name: str | None, **kwargs):
+    """
+    Call a secrets-backend lookup ``method``, forwarding ``team_name`` only when supported.
+
+    Forward ``team_name`` to backends that accept it (3.2+ overrides) and omit it for
+    pre-3.2 overrides, so older bundled providers and custom backends keep working --
+    in both single-team and multi-team deployments -- without being forced to add the
+    parameter. A ``TypeError`` raised inside an accepting backend is left to propagate
+    rather than retried without ``team_name``, which could mask the error and resolve a
+    team-scoped lookup against the global scope.
+    """
+    if _accepts_team_name(method):
+        return method(team_name=team_name, **kwargs)
+    return method(**kwargs)
 
 
 class BaseSecretsBackend(ABC):
@@ -113,7 +151,7 @@ class BaseSecretsBackend(ABC):
         :param team_name: Team name associated to the task trying to access the connection (if any)
         :return: Connection object or None
         """
-        value = self.get_conn_value(conn_id=conn_id, team_name=team_name)
+        value = call_secrets_backend_method(self.get_conn_value, team_name=team_name, conn_id=conn_id)
         if value:
             return self.deserialize_connection(conn_id=conn_id, value=value)
         return None

--- a/shared/secrets_backend/tests/secrets_backend/test_base.py
+++ b/shared/secrets_backend/tests/secrets_backend/test_base.py
@@ -133,3 +133,98 @@ class TestBaseSecretsBackend:
         assert isinstance(conn, MockConnection)
         assert conn.conn_id == "test_conn"
         assert conn.uri == sample_conn_uri
+
+
+class _LegacyConnValueBackend(BaseSecretsBackend):
+    """Backend overriding ``get_conn_value`` with the pre-3.2 ``(self, conn_id)`` signature."""
+
+    def __init__(self, conn_values: dict[str, str]):
+        self.conn_values = conn_values
+        self._set_connection_class(MockConnection)
+
+    def get_conn_value(self, conn_id: str) -> str | None:
+        return self.conn_values.get(conn_id)
+
+
+class _TeamAwareConnValueBackend(BaseSecretsBackend):
+    """Backend whose ``get_conn_value`` accepts ``team_name`` (3.2+ signature)."""
+
+    def __init__(self, conn_values: dict[str, str]):
+        self.conn_values = conn_values
+        self.received_team_name: str | None = None
+        self._set_connection_class(MockConnection)
+
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
+        self.received_team_name = team_name
+        return self.conn_values.get(conn_id)
+
+
+class _KwargsConnValueBackend(BaseSecretsBackend):
+    """Backend whose ``get_conn_value`` swallows extra kwargs via ``**kwargs``."""
+
+    def __init__(self, conn_values: dict[str, str]):
+        self.conn_values = conn_values
+        self.received_kwargs: dict = {}
+        self._set_connection_class(MockConnection)
+
+    def get_conn_value(self, conn_id: str, **kwargs) -> str | None:
+        self.received_kwargs = kwargs
+        return self.conn_values.get(conn_id)
+
+
+class _TeamAwareRaisingBackend(BaseSecretsBackend):
+    """``get_conn_value`` declares ``team_name`` but its body raises ``TypeError``."""
+
+    def __init__(self):
+        self.call_count = 0
+        self._set_connection_class(MockConnection)
+
+    def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
+        self.call_count += 1
+        raise TypeError("boom from inside the backend body")
+
+
+class TestTeamNameBackwardCompat:
+    """``get_connection`` must not forward ``team_name`` to overrides that predate it (issue #1333)."""
+
+    @pytest.mark.parametrize("team_name", [None, "team_a"])
+    def test_legacy_get_conn_value_signature_does_not_break(self, sample_conn_uri, team_name):
+        backend = _LegacyConnValueBackend(conn_values={"test_conn": sample_conn_uri})
+
+        conn = backend.get_connection(conn_id="test_conn", team_name=team_name)
+
+        assert isinstance(conn, MockConnection)
+        assert conn.conn_id == "test_conn"
+
+    def test_team_name_forwarded_when_override_accepts_it(self, sample_conn_uri):
+        backend = _TeamAwareConnValueBackend(conn_values={"test_conn": sample_conn_uri})
+
+        conn = backend.get_connection(conn_id="test_conn", team_name="team_a")
+
+        assert isinstance(conn, MockConnection)
+        assert backend.received_team_name == "team_a"
+
+    def test_team_name_forwarded_to_kwargs_override(self, sample_conn_uri):
+        backend = _KwargsConnValueBackend(conn_values={"test_conn": sample_conn_uri})
+
+        conn = backend.get_connection(conn_id="test_conn", team_name="team_a")
+
+        assert isinstance(conn, MockConnection)
+        assert backend.received_kwargs == {"team_name": "team_a"}
+
+    def test_team_aware_backend_typeerror_not_masked(self):
+        # A TypeError from inside a team_name-aware backend must propagate, not be
+        # retried without team_name (which would hide the error and could resolve the
+        # lookup against the global scope instead of the requested team).
+        backend = _TeamAwareRaisingBackend()
+
+        with pytest.raises(TypeError, match="boom from inside the backend body"):
+            backend.get_connection(conn_id="test_conn", team_name="team_a")
+
+        assert backend.call_count == 1
+
+    @pytest.mark.parametrize("team_name", [None, "team_a"])
+    def test_legacy_backend_missing_conn_returns_none(self, team_name):
+        backend = _LegacyConnValueBackend(conn_values={})
+
+        assert backend.get_connection(conn_id="missing", team_name=team_name) is None


### PR DESCRIPTION
Airflow 3.2 (AIP-67 multi-team) added a `team_name` keyword to the secrets backend API. `BaseSecretsBackend.get_connection()` forwarded `team_name` to `get_conn_value()` unconditionally, and `Connection.get_connection_from_secrets()` / `Variable.get_variable_from_secrets()` passed it straight to the backend's `get_connection()` / `get_variable()`.

Any secrets backend whose override predates the `team_name` keyword (the old `(self, conn_id)` / `(self, key)` signature) raises, on every connection and variable lookup:

```
TypeError: get_conn_value() got an unexpected keyword argument 'team_name'
```

The backend-iteration loop catches this in its broad `except Exception` and treats it as "secret not found", so the real cause never surfaces. Users instead see `AirflowNotFoundException: The conn_id '<id>' isn't defined`, or a downstream auth failure when a connection silently isn't applied (for example boto3 falling back to an instance profile and getting `403`). It presents as "all my connections and variables disappeared after upgrading to 3.2."

This breaks two groups:

- Bundled provider backends pinned below the version that added `team_name`: Amazon `SecretsManagerBackend` / `SystemsManagerParameterStoreBackend`, Google `CloudSecretManagerBackend`, Azure `AzureKeyVaultBackend`, cncf-kubernetes `KubernetesSecretsBackend`, Hashicorp `VaultBackend`, Yandex `LockboxSecretBackend`.
- Custom and third-party secrets backends with the pre-3.2 signature, which cannot be fixed by a provider bump.

Introduced in 3.2.0 by the multi-team work (apache/airflow#59476 for connections, apache/airflow#58905 for variables), which updated the bundled providers in lockstep. Providers that version independently, and custom backends, were not (and cannot be) updated in lockstep.

## Fix

`BaseSecretsBackend` now introspects whether an override accepts `team_name` and forwards it only when the override accepts it, or has a `**kwargs` catch-all; otherwise it calls the legacy signature. This is applied in:

- [`get_connection`'s forward to `get_conn_value`](https://github.com/apache/airflow/blob/main/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py) -- covers the common case across every call path (core models, worker, supervisor), all of which reach the override through the base method.
- The core call sites [`Connection.get_connection_from_secrets`](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/connection.py) and [`Variable.get_variable_from_secrets`](https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/variable.py), which pass `team_name` explicitly. This covers backends that override `get_connection` / `get_variable` directly (for example Vault), and the variable path generally.

## Design rationale

- **Signature introspection over a blanket `try/except TypeError` retry.** Retrying without `team_name` on any `TypeError` would also mask a genuine `TypeError` raised inside a backend (a real bug), re-running it as if it were a signature mismatch. Worse, in multi-team it could resolve a team-scoped lookup against the global scope. Introspecting the signature targets exactly the legacy-signature case.
- **`**kwargs` counts as accepting `team_name`.** Backends that forward `**kwargs` already handle the extra keyword.

Backward compatibility for custom secrets backends is the constraint: a core minor upgrade should not require every third-party backend to add a parameter in lockstep.

## Gotchas

- Backends that override `get_connection` / `get_variable` directly (rather than `get_conn_value`) are handled at the model call sites, not in the base class, because such overrides bypass the base method entirely. Both override styles are covered.

