### PR TITLE
fix(providers/amazon): Add missing template_fields to BedrockCreateEvaluationJobOperator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py
@@ -1592,7 +1592,14 @@ class BedrockCreateEvaluationJobOperator(AwsBaseOperator[BedrockHook]):
     """
 
     aws_hook_class = BedrockHook
-    template_fields: Sequence[str] = aws_template_fields("job_name", "role_arn", "job_description")
+    template_fields: Sequence[str] = aws_template_fields(
+        "job_name",
+        "role_arn",
+        "job_description",
+        "evaluation_config",
+        "inference_config",
+        "output_data_config",
+    )
 
     def __init__(
         self,


### PR DESCRIPTION
The `evaluation_config`, `inference_config`, and `output_data_config` parameters were documented as templated but not included in `template_fields`. This caused Jinja expressions from XCom to be passed as unrendered strings to the Bedrock API instead of being resolved to their actual values.

This broke the bedrock evaluation system test after PR #68256 changed the bucket name from a hardcoded string to one derived from `env_id`, resulting in the Bedrock API receiving a Jinja template expression instead of a valid S3 URI.