### PR TITLE
Document Airflow 3 UI browser requirements

### DIFF
--- a/airflow-core/docs/ui.rst
+++ b/airflow-core/docs/ui.rst
@@ -29,6 +29,11 @@ experienced users alike.
 .. note::
    Screenshots in this guide use **dark theme** by default. Select views are also shown in **light theme** for comparison. You can toggle themes from user settings located at the bottom corner of the Airflow UI.
 
+.. note::
+   The Airflow 3 UI uses modern browser and CSS features. Use a current version of Chrome, Edge, Firefox, or
+   Safari. Older browser versions that do not support modern CSS color functions such as ``oklch()`` or
+   ``color-mix()`` may render the UI incorrectly.
+
 .. _ui-home:
 
 Home Page


### PR DESCRIPTION
## Why

Older Chromium-based Edge versions can render the Airflow 3 UI incorrectly when they do not support modern CSS color functions. This was reported in #68312, and the UI documentation did not state the browser expectation.

## What

- Adds a note to the UI Overview recommending current versions of Chrome, Edge, Firefox, or Safari.
- Calls out unsupported modern CSS color functions such as `oklch()` and `color-mix()` as a possible reason for incorrect UI rendering in older browsers.

## Testing

- `git diff --check`

Related to #68312

Disclosure: This PR was prepared with Codex assistance and manually reviewed before submission.