### PR TITLE
Use paths to fix baseUrl deprecation warning in tsconfig which helps in using typescript 7 preview.

### DIFF
--- a/airflow-core/src/airflow/ui/tsconfig.app.json
+++ b/airflow-core/src/airflow/ui/tsconfig.app.json
@@ -21,12 +21,12 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "baseUrl": ".",
     "ignoreDeprecations": "6.0",
     "paths": {
       "src/*": ["./src/*"],
       "openapi/*": ["./openapi-gen/*"],
-      "tests/*": ["./tests/*"]
+      "tests/*": ["./tests/*"],
+      "*": ["./*"]
     },
     "types": ["node"]
   },

--- a/airflow-core/src/airflow/ui/tsconfig.app.json
+++ b/airflow-core/src/airflow/ui/tsconfig.app.json
@@ -21,7 +21,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "ignoreDeprecations": "6.0",
     "paths": {
       "src/*": ["./src/*"],
       "openapi/*": ["./openapi-gen/*"],


### PR DESCRIPTION
Trying to use the TypeScript preview go builds results in below error. With this change it's possible to use the preview build which is faster for development.

Ref : https://github.com/microsoft/TypeScript/issues/62207

```
npx tsgo --p tsconfig.app.json
tsconfig.app.json:24:5 - error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
  Use '"paths": {"*": ["./*"]}' instead.

24     "baseUrl": ".",
       ~~~~~~~~~

Found 1 error in tsconfig.app.json:24
```

```
time node_modules/typescript/bin/tsc --p tsconfig.app.json
node_modules/typescript/bin/tsc --p tsconfig.app.json  44.17s user 1.73s system 184% cpu 24.939 total

time npx tsgo --p tsconfig.app.json                       
npx tsgo --p tsconfig.app.json  24.71s user 2.54s system 457% cpu 5.955 total
```

https://github.com/microsoft/typescript-go#preview

##### Was generative AI tooling used to co-author this PR?

No
