### PR TITLE
Coerce missing HTTP(S) scheme into aws endpoint_url

### DIFF
--- a/providers/amazon/docs/connections/aws.rst
+++ b/providers/amazon/docs/connections/aws.rst
@@ -122,8 +122,12 @@ Extra (optional)
     * ``config_kwargs``: Additional **kwargs** used to construct a
       `botocore.config.Config <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`__.
       To anonymously access public AWS resources (equivalent of `signature_version=botocore.UNSGINED`), set `"signature_version"="unsigned"` within `config_kwargs`.
-    * ``endpoint_url``: Global Endpoint URL for the connection. You could specify endpoint url per AWS service by utilize
-      ``service_config``, for more details please refer to :ref:`howto/connection:aws:per-service-endpoint-configuration`
+    * ``endpoint_url``: Global Endpoint URL for the connection. Can be specified with or without the http scheme.
+      You could specify endpoint url per AWS service by utilize ``service_config``,
+      for more details please refer to :ref:`howto/connection:aws:per-service-endpoint-configuration`
+
+    * ``use_https``: If the HTTP scheme is not provided for any endpoint_url, the https (if true) or http (if false) scheme will be prepended.
+      This can be specified in the ``service_config`` as well (see :ref:`howto/connection:aws:per-service-endpoint-configuration`).
 
     * ``verify``: Whether or not to verify SSL certificates.
 
@@ -339,6 +343,7 @@ AWS Service Endpoint URL configuration
 
 To use ``endpoint_url`` per specific AWS service in the single connection you might setup it in service config.
 For enforce to default ``botocore``/``boto3`` behaviour you might set value to ``null``.
+If not provided in the ``endpoint_url``, you can set the http scheme to https using ``use_https``
 The precedence rules are as follows:
 
   1. ``endpoint_url`` specified per service level.
@@ -350,7 +355,8 @@ The precedence rules are as follows:
 .. code-block:: json
 
     {
-      "endpoint_url": "s3.amazonaws.com"
+      "endpoint_url": "s3.amazonaws.com",
+      "use_https": true
       "service_config": {
         "s3": {
           "endpoint_url": "https://s3.eu-west-1.amazonaws.com"
@@ -360,6 +366,10 @@ The precedence rules are as follows:
         },
         "ec2": {
           "endpoint_url": null
+        },
+        "eks": {
+          "endpoint_url": "localhost",
+          "use_https": false
         }
       }
     }

--- a/providers/amazon/src/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -72,6 +72,29 @@ class _ConnectionMetadata:
             raise TypeError(f"Expected JSON-Object or dict, got {type(extra).__name__}.")
         return extra
 
+def _parse_service_endpoint(endpoint_url: str | None, use_https: bool | None = None) -> str | None:
+    """
+    Add the HTTP scheme to the endpoint_url if it is missing.
+
+    :param endpoint_url: URL string to parse
+    :param use_https: use https instead of http as the scheme
+
+    Returns
+    --------
+    endpoint_url with the http(s) scheme appended if it is missing.
+    """
+    if endpoint_url is None:
+        return endpoint_url
+    if use_https is None:
+        use_https = True
+
+    if endpoint_url.startswith("http"):
+        return endpoint_url
+    if "://" in endpoint_url:
+        raise ValueError(f"Invalid endpoint_url: {endpoint_url}")
+
+    scheme = "https" if use_https else "http"
+    return f"{scheme}://{endpoint_url}"
 
 @dataclass
 class AwsConnectionWrapper(LoggingMixin):
@@ -117,6 +140,8 @@ class AwsConnectionWrapper(LoggingMixin):
     profile_name: str | None = field(init=False, default=None)
     # Custom endpoint_url for boto3.client and boto3.resource
     endpoint_url: str | None = field(init=False, default=None)
+    # Use https or http with endpoint URL. Ignored if scheme is specified in url.
+    use_https: bool | None = field(init=False, default=None)
 
     # Assume Role Configurations
     role_arn: str | None = field(init=False, default=None)
@@ -143,6 +168,7 @@ class AwsConnectionWrapper(LoggingMixin):
     ) -> str | None:
         service_config = self.get_service_config(service_name=service_name)
         global_endpoint_url = self.endpoint_url
+        global_use_https = self.use_https
 
         if service_name == "sts" and True in (sts_connection_assume, sts_test_connection):
             # There are different logics exists historically for STS Client
@@ -156,7 +182,10 @@ class AwsConnectionWrapper(LoggingMixin):
                     "`sts_connection` and `sts_test_connection` set to True."
                 )
 
-        return service_config.get("endpoint_url", global_endpoint_url)
+        return _parse_service_endpoint(
+            service_config.get("endpoint_url", global_endpoint_url),
+            service_config.get("use_https", global_use_https),
+        )
 
     def __post_init__(self, conn: Connection | AwsConnectionWrapper | _ConnectionMetadata | None) -> None:
         """Initialize the AwsConnectionWrapper object after instantiation."""

--- a/providers/amazon/tests/unit/amazon/aws/utils/test_connection_wrapper.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_connection_wrapper.py
@@ -404,9 +404,13 @@ class TestAwsConnectionWrapper:
             conn_id="foo-bar",
             extra={
                 "endpoint_url": "https://spam.egg",
+                "use_https": False,
                 "service_config": {
                     "sns": {"endpoint_url": "https://foo.bar"},
                     "ec2": {"endpoint_url": None},  # Enforce to boto3
+                    "s3": {"endpoint_url": "bar.baz", "use_https":True}, # Coerce HTTPS scheme
+                    "eks": {"endpoint_url": "baz.bip"},  # Coerce HTTP scheme (global use_https)
+                    "athena": {"endpoint_url": "ftp://foo.bar"},  # Invalid endpoint_url
                 },
             },
         )
@@ -414,6 +418,10 @@ class TestAwsConnectionWrapper:
         assert wrap_conn.get_service_endpoint_url("sns") == "https://foo.bar"
         assert wrap_conn.get_service_endpoint_url("sts") == "https://spam.egg"
         assert wrap_conn.get_service_endpoint_url("ec2") is None
+        assert wrap_conn.get_service_endpoint_url("s3") == "https://bar.baz"
+        assert wrap_conn.get_service_endpoint_url("eks") == "http://baz.bip"
+        with pytest.raises(ValueError, match=r"Invalid endpoint_url: ftp://foo\.bar"):
+            wrap_conn.get_service_endpoint_url("athena")
 
     @pytest.mark.parametrize(
         ("global_endpoint_url", "sts_service_endpoint_url", "expected_endpoint_url"),


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Coerce HTTP scheme into aws endpoint_url if it is not provided
---

if the `endpoint_url` does not contain a URL scheme (e.g. `mys3.example.com`) then `_parse_service_endpoint` will prepend a https or http scheme to it when providing the `endpoint_url` to boto3 (e.g. `https://mys3.example.com`)

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

<!-- pr-triage-fold: triaged=2026-07-28T17:12:17Z head=a2d374e action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @stephen-bracken** · by `@potiuk` · 2026-07-28 17:12 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
