### PR TITLE
Fix custom timetables silently failing to schedule on Airflow 3.2

### DIFF
--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -143,15 +143,8 @@ class DagRunInfo(NamedTuple):
     data_interval: DataInterval | None
     """The data interval this DagRun to operate over."""
 
-    # partition_date/partition_key are for partition-oriented scheduling (AIP-76).
-    # They default to None so custom timetables written for Airflow 3.1.x and
-    # earlier — which build DagRunInfo with only run_after and data_interval —
-    # keep working on 3.2+.
     partition_date: DateTime | None = None
-    """The partition date for partition-oriented scheduling (AIP-76)."""
-
     partition_key: str | None = None
-    """The partition key for partition-oriented scheduling (AIP-76)."""
 
     @classmethod
     def exact(cls, at: DateTime) -> DagRunInfo:

--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -143,8 +143,15 @@ class DagRunInfo(NamedTuple):
     data_interval: DataInterval | None
     """The data interval this DagRun to operate over."""
 
-    partition_date: DateTime | None
-    partition_key: str | None
+    # partition_date/partition_key are for partition-oriented scheduling (AIP-76).
+    # They default to None so custom timetables written for Airflow 3.1.x and
+    # earlier — which build DagRunInfo with only run_after and data_interval —
+    # keep working on 3.2+.
+    partition_date: DateTime | None = None
+    """The partition date for partition-oriented scheduling (AIP-76)."""
+
+    partition_key: str | None = None
+    """The partition key for partition-oriented scheduling (AIP-76)."""
 
     @classmethod
     def exact(cls, at: DateTime) -> DagRunInfo:

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -184,14 +184,13 @@ def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
 
 
 # ---------------------------------------------------------------------------
-# DagRunInfo backward compatibility
+# DagRunInfo partition fields
 # ---------------------------------------------------------------------------
 
 
 def test_dagruninfo_partition_fields_default_to_none():
-    """Custom timetables written for 3.1.x construct ``DagRunInfo`` with only
-    ``run_after`` and ``data_interval``; the partition fields added in 3.2
-    (AIP-76) must default to *None* so those timetables keep scheduling."""
+    """``DagRunInfo`` can be constructed with only ``run_after`` and
+    ``data_interval``; the partition fields are optional and default to *None*."""
     from airflow.timetables.base import DagRunInfo, DataInterval
 
     start = pendulum.datetime(2026, 1, 1, tz="UTC")

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -22,6 +22,7 @@ import pendulum
 import pytest
 
 from airflow._shared.module_loading import qualname
+from airflow.timetables.base import DagRunInfo, DataInterval
 from airflow.timetables.simple import NullTimetable
 
 
@@ -183,44 +184,33 @@ def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
     assert expected_key in fp
 
 
-# ---------------------------------------------------------------------------
-# DagRunInfo partition fields
-# ---------------------------------------------------------------------------
-
-
-def test_dagruninfo_partition_fields_default_to_none():
-    """``DagRunInfo`` can be constructed with only ``run_after`` and
-    ``data_interval``; the partition fields are optional and default to *None*."""
-    from airflow.timetables.base import DagRunInfo, DataInterval
-
+@pytest.mark.parametrize(
+    ("extra_kwargs", "expected_partition_date", "expected_partition_key"),
+    [
+        pytest.param({}, None, None, id="omitted-default-to-none"),
+        pytest.param(
+            {
+                "partition_date": pendulum.datetime(2026, 1, 1, tz="UTC"),
+                "partition_key": "2026-01-01",
+            },
+            pendulum.datetime(2026, 1, 1, tz="UTC"),
+            "2026-01-01",
+            id="set-explicitly",
+        ),
+    ],
+)
+def test_dagruninfo_partition_fields(extra_kwargs, expected_partition_date, expected_partition_key):
+    """The partition fields are optional: omitting them defaults to *None* (so timetables
+    built the pre-3.2 way keep working), and partitioned timetables can still set them."""
     start = pendulum.datetime(2026, 1, 1, tz="UTC")
     end = pendulum.datetime(2026, 1, 2, tz="UTC")
 
-    info = DagRunInfo(run_after=end, data_interval=DataInterval(start=start, end=end))
+    info = DagRunInfo(run_after=end, data_interval=DataInterval(start=start, end=end), **extra_kwargs)
 
-    assert info.partition_date is None
-    assert info.partition_key is None
+    assert info.partition_date == expected_partition_date
+    assert info.partition_key == expected_partition_key
     assert info.run_after == end
     assert info.data_interval == DataInterval(start=start, end=end)
-
-
-def test_dagruninfo_partition_fields_can_be_set_explicitly():
-    """Partitioned timetables still set the partition fields explicitly."""
-    from airflow.timetables.base import DagRunInfo, DataInterval
-
-    start = pendulum.datetime(2026, 1, 1, tz="UTC")
-    end = pendulum.datetime(2026, 1, 2, tz="UTC")
-    partition_date = pendulum.datetime(2026, 1, 1, tz="UTC")
-
-    info = DagRunInfo(
-        run_after=end,
-        data_interval=DataInterval(start=start, end=end),
-        partition_date=partition_date,
-        partition_key="2026-01-01",
-    )
-
-    assert info.partition_date == partition_date
-    assert info.partition_key == "2026-01-01"
 
 
 def test_base_resolve_day_bound_returns_midnight_utc():

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -183,6 +183,47 @@ def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
     assert expected_key in fp
 
 
+# ---------------------------------------------------------------------------
+# DagRunInfo backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_dagruninfo_partition_fields_default_to_none():
+    """Custom timetables written for 3.1.x construct ``DagRunInfo`` with only
+    ``run_after`` and ``data_interval``; the partition fields added in 3.2
+    (AIP-76) must default to *None* so those timetables keep scheduling."""
+    from airflow.timetables.base import DagRunInfo, DataInterval
+
+    start = pendulum.datetime(2026, 1, 1, tz="UTC")
+    end = pendulum.datetime(2026, 1, 2, tz="UTC")
+
+    info = DagRunInfo(run_after=end, data_interval=DataInterval(start=start, end=end))
+
+    assert info.partition_date is None
+    assert info.partition_key is None
+    assert info.run_after == end
+    assert info.data_interval == DataInterval(start=start, end=end)
+
+
+def test_dagruninfo_partition_fields_can_be_set_explicitly():
+    """Partitioned timetables still set the partition fields explicitly."""
+    from airflow.timetables.base import DagRunInfo, DataInterval
+
+    start = pendulum.datetime(2026, 1, 1, tz="UTC")
+    end = pendulum.datetime(2026, 1, 2, tz="UTC")
+    partition_date = pendulum.datetime(2026, 1, 1, tz="UTC")
+
+    info = DagRunInfo(
+        run_after=end,
+        data_interval=DataInterval(start=start, end=end),
+        partition_date=partition_date,
+        partition_key="2026-01-01",
+    )
+
+    assert info.partition_date == partition_date
+    assert info.partition_key == "2026-01-01"
+
+
 def test_base_resolve_day_bound_returns_midnight_utc():
     """Base default returns midnight UTC as a pendulum DateTime for any calendar day."""
     tt = NullTimetable()


### PR DESCRIPTION
Airflow 3.2 extended `DagRunInfo` with two new fields for partition-oriented scheduling (AIP-76, #61167):

```python
class DagRunInfo(NamedTuple):
    run_after: DateTime
    data_interval: DataInterval | None
    partition_date: DateTime | None   # new in 3.2
    partition_key: str | None         # new in 3.2
```

Both were added **without defaults**, making them required positional fields. Custom timetables written for 3.1.x and earlier — including the pattern shown in the [official custom-timetable how-to](https://airflow.apache.org/docs/apache-airflow/stable/howto/timetable.html) — construct `DagRunInfo` with only two arguments:

```python
return DagRunInfo(
    run_after=run_after,
    data_interval=DataInterval(start=start, end=end),
)
```

On 3.2 this raises `TypeError: DagRunInfo.__new__() missing 2 required positional arguments: 'partition_date' and 'partition_key'`. The exception is swallowed by the error handling around `DAG.next_dagrun_info()`, so `next_dagrun` / `next_dagrun_create_after` stay `NULL`, the **Next Run** column is empty, and no scheduled runs are created — with no import error or other visible failure. Built-in timetables are unaffected because they build `DagRunInfo` via helpers (`DagRunInfo.interval(...)`, `DagRunInfo.exact(...)`, etc.) that already pass the partition fields explicitly.

## Fix

Default the two partition fields to `None`. They are the trailing fields of the `NamedTuple`, so the change is purely additive and restores the documented two-argument construction. Every internal call site already passes all four fields explicitly, so their behaviour is unchanged.

## Design notes

- Defaulting trailing `NamedTuple` fields is the idiomatic approach already used in this codebase — e.g. `TaskInstanceKey` (`try_number: int = 1`, `map_index: int = -1`). No `__new__` override or dataclass conversion is needed.
- Partitioned timetables continue to set `partition_date` / `partition_key` explicitly; the defaults only affect callers that omit them, which is exactly the pre-3.2 custom-timetable contract.

## Tests

Added two unit tests in `test_base_timetable.py`: the backward-compatible two-argument construction (partition fields default to `None`) and the explicit four-argument construction (partition fields still settable). Full `airflow-core/tests/unit/timetables/` suite passes (220 passed).

closes: #68315


