### PR TITLE
Fix deferred soft-fail sensor being skipped instead of rescheduled

### DIFF
--- a/airflow-core/newsfragments/68327.bugfix.rst
+++ b/airflow-core/newsfragments/68327.bugfix.rst
@@ -1,0 +1,1 @@
+Fix deferred ``soft_fail`` / ``never_fail`` sensors being marked ``SKIPPED`` instead of ``UP_FOR_RESCHEDULE`` when they request a reschedule on trigger resume.

--- a/task-sdk/src/airflow/sdk/bases/sensor.py
+++ b/task-sdk/src/airflow/sdk/bases/sensor.py
@@ -258,6 +258,13 @@ class BaseSensorOperator(BaseOperator):
                 return super().resume_execution(next_method, next_kwargs, context)
             except TaskDeferralTimeout as e:
                 raise AirflowSensorTimeout(*e.args) from e
+        except AirflowRescheduleException:
+            # A reschedule request must propagate so the task goes UP_FOR_RESCHEDULE.
+            # soft_fail/never_fail must not swallow it into a skip (this mirrors the
+            # poke loop in execute(), which never converts a reschedule to a skip).
+            # AirflowRescheduleException subclasses AirflowException, so this more
+            # specific handler must come before the broad one below.
+            raise
         except (AirflowException, TaskDeferralError) as e:
             if self.soft_fail:
                 raise AirflowSkipException("Skipping due to soft_fail is set to True.") from e

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -756,10 +756,19 @@ class TestAsyncSensor:
                 context={},
             )
 
-    @pytest.mark.parametrize("sensor_kwargs", [{}, {"soft_fail": True}, {"never_fail": True}])
+    @pytest.mark.parametrize(
+        "sensor_kwargs",
+        [
+            {},  # control: passes with or without the fix (only soft_fail/never_fail were broken)
+            {"soft_fail": True},
+            {"never_fail": True},
+        ],
+    )
     def test_reschedule_after_resuming_deferred_sensor_propagates(self, sensor_kwargs):
-        """A deferred sensor that requests a reschedule on resume must go
-        UP_FOR_RESCHEDULE; soft_fail / never_fail must not convert it into a skip."""
+        """A deferred sensor that requests a reschedule on resume must propagate
+        AirflowRescheduleException; soft_fail / never_fail must not convert it into a skip.
+        The runtime mapping of that exception to UP_FOR_RESCHEDULE is covered by
+        test_ok_with_reschedule / test_fail_with_reschedule."""
         reschedule_date = DEFAULT_DATE + timedelta(minutes=5)
 
         class RescheduleAsyncSensor(BaseSensorOperator):

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -755,3 +755,18 @@ class TestAsyncSensor:
                 next_kwargs={"error": TriggerFailureReason.TRIGGER_FAILURE},
                 context={},
             )
+
+    @pytest.mark.parametrize("sensor_kwargs", [{}, {"soft_fail": True}, {"never_fail": True}])
+    def test_reschedule_after_resuming_deferred_sensor_propagates(self, sensor_kwargs):
+        """A deferred sensor that requests a reschedule on resume must go
+        UP_FOR_RESCHEDULE; soft_fail / never_fail must not convert it into a skip."""
+        reschedule_date = DEFAULT_DATE + timedelta(minutes=5)
+
+        class RescheduleAsyncSensor(BaseSensorOperator):
+            def execute_complete(self, context, event=None):
+                raise AirflowRescheduleException(reschedule_date)
+
+        sensor = RescheduleAsyncSensor(task_id="reschedule_async_sensor", **sensor_kwargs)
+        with pytest.raises(AirflowRescheduleException) as exc_info:
+            sensor.resume_execution("execute_complete", None, {})
+        assert exc_info.value.reschedule_date == reschedule_date


### PR DESCRIPTION
A soft-fail (or never-fail) sensor that **defers** (uses a trigger) and then requests a **reschedule** on resume is wrongly marked `SKIPPED` instead of going `UP_FOR_RESCHEDULE`.

`BaseSensorOperator.resume_execution` wraps the resumed call in a broad `except (AirflowException, TaskDeferralError)` that converts the exception into `AirflowSkipException` when `soft_fail` / `never_fail` is set. Because `AirflowRescheduleException` subclasses `AirflowException`, a reschedule request raised on resume is caught by that handler and turned into a skip — so the task silently finishes instead of rescheduling.

The non-deferred poke loop in `execute()` does not have this problem: it raises `AirflowRescheduleException` outside the `soft_fail`/`never_fail` handling, so a reschedule always propagates. `resume_execution` was simply inconsistent with `execute()`.

## Fix

Re-raise `AirflowRescheduleException` from `resume_execution` before the `soft_fail` / `never_fail` conversion. The runtime already handles a propagated `AirflowRescheduleException` by marking the task `UP_FOR_RESCHEDULE` (`task_runner.py`), so the reschedule now takes effect on the deferred path too.

## Design notes

- The new `except AirflowRescheduleException: raise` must come **before** the broad `except (AirflowException, TaskDeferralError)` because `AirflowRescheduleException` is a subclass of `AirflowException`; Python matches the first compatible handler.
- This mirrors `execute()`, which never converts a reschedule into a skip — so behaviour is now consistent between the poke and deferred paths.
- Genuine failures and trigger timeouts are unchanged: they still skip under `soft_fail` / `never_fail` (covered by the existing tests, which continue to pass).

## Tests

Added `test_reschedule_after_resuming_deferred_sensor_propagates`, parametrized over default / `soft_fail=True` / `never_fail=True`, asserting that a reschedule raised on resume propagates as `AirflowRescheduleException` in every mode. Before the fix the `soft_fail` / `never_fail` cases raised `AirflowSkipException`. Full `test_sensor.py` suite passes (52 passed).

closes: #49329

<!-- pr-triage-fold: triaged=2026-07-28T16:11:42Z head=1dae34a action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Abdulrehman-PIAIC80387** · by `@potiuk` · 2026-07-28 16:11 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **531 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
