### PR TITLE
Persist dashboard alert collapse state and clamp long alerts

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dashboard.json
@@ -1,4 +1,10 @@
 {
+  "alerts": {
+    "seeLessContext": "See less",
+    "seeMoreContext": "See more",
+    "showMoreAlerts_one": "+{{count}} more alert",
+    "showMoreAlerts_other": "+{{count}} more alerts"
+  },
   "deadlines": {
     "pending": {
       "empty": "No upcoming deadlines",

--- a/airflow-core/src/airflow/ui/src/constants/localStorage.ts
+++ b/airflow-core/src/airflow/ui/src/constants/localStorage.ts
@@ -27,6 +27,7 @@ export const LOG_WRAP_KEY = "log_wrap";
 export const LOG_SHOW_TIMESTAMP_KEY = "log_show_timestamp";
 export const LOG_SHOW_SOURCE_KEY = "log_show_source";
 export const VERSION_INDICATOR_DISPLAY_MODE_KEY = "version_indicator_display_mode";
+export const COLLAPSED_UI_ALERTS_KEY = "collapsed_ui_alerts";
 
 // Dag-scoped keys
 export const dagRunsLimitKey = (dagId: string) => `dag_runs_limit-${dagId}`;

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/AlertContent.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/AlertContent.test.tsx
@@ -1,0 +1,130 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UIAlert } from "openapi/requests/types.gen";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { AlertContent } from "./AlertContent";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    // eslint-disable-next-line id-length
+    t: (key: string) =>
+      key === "alerts.seeMoreContext" ? "See more" : key === "alerts.seeLessContext" ? "See less" : key,
+  }),
+}));
+
+// happy-dom reports 0 for all layout dimensions, so overflow is driven by
+// stubbing scrollHeight and clientHeight to simulate clamped vs. full height.
+const CLAMPED_HEIGHT = 100;
+const OVERFLOW_HEIGHT = 200;
+
+const stubScrollHeight = (height: number) => {
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => height,
+  });
+};
+
+const stubClientHeight = (height: number) => {
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get: () => height,
+  });
+};
+
+const renderAlert = (alert: UIAlert) => render(<AlertContent alert={alert} />, { wrapper: Wrapper });
+
+describe("AlertContent", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class MockResizeObserver {
+        // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+        public disconnect() {
+          /* empty */
+        }
+        // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+        public observe() {
+          /* empty */
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+    Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
+  });
+
+  it("shows no See more toggle when the alert fits within the clamp", () => {
+    stubScrollHeight(CLAMPED_HEIGHT);
+    stubClientHeight(CLAMPED_HEIGHT);
+
+    renderAlert({ category: "info", text: "Short alert text" });
+
+    expect(screen.getByText("Short alert text")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "See more" })).not.toBeInTheDocument();
+  });
+
+  it("clamps a tall alert and toggles between See more and See less", () => {
+    stubScrollHeight(OVERFLOW_HEIGHT);
+    stubClientHeight(CLAMPED_HEIGHT);
+
+    renderAlert({ category: "info", text: "Long alert text" });
+
+    const seeMore = screen.getByRole("button", { name: "See more" });
+
+    expect(seeMore).toBeVisible();
+    expect(screen.queryByRole("button", { name: "See less" })).not.toBeInTheDocument();
+
+    fireEvent.click(seeMore);
+
+    expect(screen.getByRole("button", { name: "See less" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "See more" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "See less" }));
+
+    expect(screen.getByRole("button", { name: "See more" })).toBeVisible();
+  });
+
+  it("stops the toggle click from bubbling to a surrounding accordion trigger", () => {
+    stubScrollHeight(OVERFLOW_HEIGHT);
+    stubClientHeight(CLAMPED_HEIGHT);
+
+    const onParentClick = vi.fn();
+
+    render(
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+      <div onClick={onParentClick}>
+        <AlertContent alert={{ category: "info", text: "Long alert text" }} />
+      </div>,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "See more" }));
+
+    expect(screen.getByRole("button", { name: "See less" })).toBeVisible();
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/AlertContent.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/AlertContent.tsx
@@ -1,0 +1,98 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, Button } from "@chakra-ui/react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { UIAlert } from "openapi/requests/types.gen";
+import ReactMarkdown from "src/components/ReactMarkdown";
+import { Alert } from "src/components/ui";
+
+const MAX_VISIBLE_LINES = 5;
+
+export const AlertContent = ({ alert }: { readonly alert: UIAlert }) => {
+  const { t: translate } = useTranslation("dashboard");
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const isExpandedRef = useRef(isExpanded);
+
+  // Sync before effects run so the ResizeObserver sees the current value.
+  isExpandedRef.current = isExpanded;
+
+  useLayoutEffect(() => {
+    const element = contentRef.current;
+
+    if (element === null) {
+      return undefined;
+    }
+
+    const checkOverflow = () => {
+      if (!isExpandedRef.current) {
+        setIsOverflowing(element.scrollHeight > element.clientHeight);
+      }
+    };
+
+    const observer = new ResizeObserver(checkOverflow);
+
+    observer.observe(element);
+    checkOverflow();
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Alert status={alert.category}>
+      <Box
+        ref={contentRef}
+        style={
+          isExpanded
+            ? undefined
+            : {
+                display: "-webkit-box",
+                overflow: "hidden",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: MAX_VISIBLE_LINES,
+              }
+        }
+        width="100%"
+      >
+        <ReactMarkdown>{alert.text}</ReactMarkdown>
+      </Box>
+      {isOverflowing ? (
+        <Button
+          _hover={{ textDecoration: "underline" }}
+          alignSelf="flex-start"
+          color="fg.muted"
+          mt={1}
+          onClick={(event) => {
+            // Stop the click from toggling the surrounding accordion trigger.
+            event.stopPropagation();
+            setIsExpanded((prev) => !prev);
+          }}
+          px={0}
+          size="sm"
+          variant="plain"
+        >
+          {isExpanded ? translate("alerts.seeLessContext") : translate("alerts.seeMoreContext")}
+        </Button>
+      ) : undefined}
+    </Alert>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.test.tsx
@@ -1,0 +1,204 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UIAlert } from "openapi/requests/types.gen";
+import { COLLAPSED_UI_ALERTS_KEY } from "src/constants/localStorage";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { Dashboard } from "./Dashboard";
+
+const mockConfig: Record<string, unknown> = {};
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => mockConfig[key],
+}));
+
+vi.mock("openapi/queries", () => ({
+  usePluginServiceGetPlugins: () => ({ data: { plugins: [] } }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    // eslint-disable-next-line id-length
+    t: (key: string, options?: { count?: number }) =>
+      key === "alerts.showMoreAlerts"
+        ? `+${options?.count} more ${options?.count === 1 ? "alert" : "alerts"}`
+        : key,
+  }),
+}));
+
+vi.mock("./AlertContent", () => ({
+  AlertContent: ({ alert }: { readonly alert: UIAlert }) => <div>{alert.text}</div>,
+}));
+
+// Ark UI's accordion machine does not respond to synthetic clicks under happy-dom, so this
+// stand-in wires the controlled value/onValueChange contract manually.
+vi.mock("src/components/ui", async () => {
+  const { createContext, useContext } = await import("react");
+
+  type AccordionContextValue = {
+    onValueChange: (details: { value: Array<string> }) => void;
+    value: Array<string>;
+  };
+  const AccordionContext = createContext<AccordionContextValue>({
+    onValueChange: () => undefined,
+    value: [],
+  });
+
+  type RootProps = { readonly children: React.ReactNode } & AccordionContextValue;
+  const passthrough = ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>;
+
+  return {
+    Accordion: {
+      Item: passthrough,
+      ItemContent: passthrough,
+      ItemTrigger: ({ children }: { readonly children: React.ReactNode }) => {
+        const { onValueChange, value } = useContext(AccordionContext);
+        const isOpen = value.includes("ui_alerts");
+
+        return (
+          <button
+            data-part="item-trigger"
+            data-state={isOpen ? "open" : "closed"}
+            onClick={() => onValueChange({ value: isOpen ? [] : ["ui_alerts"] })}
+            type="button"
+          >
+            {children}
+          </button>
+        );
+      },
+      Root: ({ children, onValueChange, value }: RootProps) => (
+        <AccordionContext.Provider value={{ onValueChange, value }}>{children}</AccordionContext.Provider>
+      ),
+    },
+  };
+});
+
+vi.mock("./Deadlines", () => ({ DashboardDeadlines: () => null }));
+vi.mock("./FavoriteDags", () => ({ FavoriteDags: () => null }));
+vi.mock("./Health", () => ({ Health: () => null }));
+vi.mock("./HistoricalMetrics", () => ({ HistoricalMetrics: () => null }));
+vi.mock("./PoolSummary", () => ({ PoolSummary: () => null }));
+vi.mock("./Stats", () => ({ Stats: () => null }));
+vi.mock("src/components/TimeRangeSelector", () => ({ default: () => null }));
+vi.mock("../ReactPlugin", () => ({ ReactPlugin: () => null }));
+
+const setAlerts = (alerts: Array<UIAlert>) => {
+  mockConfig.dashboard_alert = alerts;
+  mockConfig.instance_name = "Airflow";
+};
+
+const accordionState = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>('[data-part="item-trigger"]')?.dataset.state;
+
+describe("Dashboard alerts accordion", () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it("does not write the collapsed key when no alerts are configured", () => {
+    setAlerts([]);
+
+    render(<Dashboard />, { wrapper: Wrapper });
+
+    expect(globalThis.localStorage.getItem(COLLAPSED_UI_ALERTS_KEY)).toBeNull();
+  });
+
+  it("shows every alert expanded by default with no show-more button", () => {
+    setAlerts([
+      { category: "info", text: "Alert one" },
+      { category: "warning", text: "Alert two" },
+      { category: "error", text: "Alert three" },
+    ]);
+
+    const { container } = render(<Dashboard />, { wrapper: Wrapper });
+
+    expect(screen.getByText("Alert one")).toBeInTheDocument();
+    expect(screen.getByText("Alert two")).toBeInTheDocument();
+    expect(screen.getByText("Alert three")).toBeInTheDocument();
+    expect(accordionState(container)).toBe("open");
+    expect(screen.queryByRole("button", { name: /more alerts/u })).not.toBeInTheDocument();
+  });
+
+  it("persists the collapsed state to localStorage when the accordion is collapsed", () => {
+    setAlerts([
+      { category: "info", text: "Alert one" },
+      { category: "warning", text: "Alert two" },
+      { category: "error", text: "Alert three" },
+    ]);
+
+    const { container } = render(<Dashboard />, { wrapper: Wrapper });
+
+    expect(accordionState(container)).toBe("open");
+
+    fireEvent.click(container.querySelector('[data-part="item-trigger"]') as HTMLElement);
+
+    expect(globalThis.localStorage.getItem(COLLAPSED_UI_ALERTS_KEY)).toBe("true");
+    expect(accordionState(container)).toBe("closed");
+    expect(screen.getByRole("button", { name: "+2 more alerts" })).toBeVisible();
+  });
+
+  it("restores the collapsed state from localStorage on reload and surfaces a show-more button", () => {
+    globalThis.localStorage.setItem(COLLAPSED_UI_ALERTS_KEY, "true");
+    setAlerts([
+      { category: "info", text: "Alert one" },
+      { category: "warning", text: "Alert two" },
+      { category: "error", text: "Alert three" },
+    ]);
+
+    const { container } = render(<Dashboard />, { wrapper: Wrapper });
+
+    expect(accordionState(container)).toBe("closed");
+    expect(screen.getByRole("button", { name: "+2 more alerts" })).toBeVisible();
+  });
+
+  it("expands and clears the persisted collapsed state when show-more is clicked", () => {
+    globalThis.localStorage.setItem(COLLAPSED_UI_ALERTS_KEY, "true");
+    setAlerts([
+      { category: "info", text: "Alert one" },
+      { category: "warning", text: "Alert two" },
+    ]);
+
+    const { container } = render(<Dashboard />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "+1 more alert" }));
+
+    expect(globalThis.localStorage.getItem(COLLAPSED_UI_ALERTS_KEY)).toBe("false");
+    expect(accordionState(container)).toBe("open");
+    expect(screen.queryByRole("button", { name: /more alert/u })).not.toBeInTheDocument();
+  });
+
+  it("renders a single alert without an accordion trigger or show-more button", () => {
+    setAlerts([{ category: "info", text: "Only alert" }]);
+
+    const { container } = render(<Dashboard />, { wrapper: Wrapper });
+
+    expect(screen.getByText("Only alert")).toBeInTheDocument();
+    expect(container.querySelector('[data-part="item-trigger"]')).toBeNull();
+    expect(screen.queryByRole("button", { name: /more alert/u })).not.toBeInTheDocument();
+    expect(globalThis.localStorage.getItem(COLLAPSED_UI_ALERTS_KEY)).toBeNull();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Dashboard.tsx
@@ -16,19 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Heading, VStack } from "@chakra-ui/react";
+import { Box, Button, Flex, Heading, VStack } from "@chakra-ui/react";
+import type { AccordionValueChangeDetails } from "@chakra-ui/react";
 import dayjs from "dayjs";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocalStorage } from "usehooks-ts";
 
 import { usePluginServiceGetPlugins } from "openapi/queries";
 import type { ReactAppResponse, UIAlert } from "openapi/requests/types.gen";
-import ReactMarkdown from "src/components/ReactMarkdown";
 import TimeRangeSelector from "src/components/TimeRangeSelector";
-import { Accordion, Alert } from "src/components/ui";
+import { Accordion } from "src/components/ui";
+import { COLLAPSED_UI_ALERTS_KEY } from "src/constants/localStorage";
 import { useConfig } from "src/queries/useConfig";
 
 import { ReactPlugin } from "../ReactPlugin";
+import { AlertContent } from "./AlertContent";
 import { DashboardDeadlines } from "./Deadlines";
 import { FavoriteDags } from "./FavoriteDags";
 import { Health } from "./Health";
@@ -46,6 +49,14 @@ export const Dashboard = () => {
   const now = dayjs();
   const [startDate, setStartDate] = useState(now.subtract(Number(defaultHour), "hour").toISOString());
   const [endDate, setEndDate] = useState(now.toISOString());
+  const [isCollapsed, setIsCollapsed] = useLocalStorage(COLLAPSED_UI_ALERTS_KEY, false);
+
+  const accordionValue = isCollapsed ? [] : ["ui_alerts"];
+  const hasMultipleAlerts = alerts.length > 1;
+
+  const handleAccordionChange = (details: AccordionValueChangeDetails) => {
+    setIsCollapsed(!details.value.includes("ui_alerts"));
+  };
 
   const { data: pluginData } = usePluginServiceGetPlugins();
 
@@ -60,20 +71,43 @@ export const Dashboard = () => {
         {/* All flex items within this VStack should specify an increasing order. This
         will be used by third parties plugins to position themselves within the page via CSS */}
         {alerts.length > 0 ? (
-          <Accordion.Root collapsible defaultValue={["ui_alerts"]} order={1}>
+          <Accordion.Root
+            collapsible
+            data-testid="dashboard-alerts"
+            onValueChange={handleAccordionChange}
+            order={1}
+            value={accordionValue}
+          >
             <Accordion.Item key="ui_alerts" value="ui_alerts">
               {alerts.map((alert: UIAlert, index) =>
                 index === 0 ? (
-                  <Accordion.ItemTrigger key={alert.text} mb={2}>
-                    <Alert status={alert.category}>
-                      <ReactMarkdown>{alert.text}</ReactMarkdown>
-                    </Alert>
-                  </Accordion.ItemTrigger>
+                  <Fragment key={alert.text}>
+                    {hasMultipleAlerts ? (
+                      <Accordion.ItemTrigger mb={2}>
+                        <AlertContent alert={alert} />
+                      </Accordion.ItemTrigger>
+                    ) : (
+                      <Box mb={2}>
+                        <AlertContent alert={alert} />
+                      </Box>
+                    )}
+                    {isCollapsed && hasMultipleAlerts ? (
+                      <Flex justifyContent="center" mb={2}>
+                        <Button
+                          _hover={{ textDecoration: "underline" }}
+                          color="fg.muted"
+                          onClick={() => setIsCollapsed(false)}
+                          size="sm"
+                          variant="plain"
+                        >
+                          {translate("alerts.showMoreAlerts", { count: alerts.length - 1 })}
+                        </Button>
+                      </Flex>
+                    ) : undefined}
+                  </Fragment>
                 ) : (
                   <Accordion.ItemContent key={alert.text} pr={8}>
-                    <Alert status={alert.category}>
-                      <ReactMarkdown>{alert.text}</ReactMarkdown>
-                    </Alert>
+                    <AlertContent alert={alert} />
                   </Accordion.ItemContent>
                 ),
               )}

--- a/airflow-core/src/airflow/ui/tests/e2e/pages/HomePage.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/pages/HomePage.ts
@@ -20,6 +20,8 @@ import { expect, type Locator, type Page } from "@playwright/test";
 import { HITLReviewModal } from "tests/e2e/components/HITLReviewModal";
 import { BasePage } from "tests/e2e/pages/BasePage";
 
+import type { UIAlert } from "openapi/requests/types.gen";
+
 /**
  * Home/Dashboard Page Object
  */
@@ -29,6 +31,9 @@ export class HomePage extends BasePage {
   }
 
   public readonly activeDagsCard: Locator;
+  public readonly alertsAccordionTrigger: Locator;
+  public readonly alertSeeLessButton: Locator;
+  public readonly alertSeeMoreButton: Locator;
   public readonly dagImportErrorsCard: Locator;
   public readonly dagProcessorHealth: Locator;
   public readonly dagRunMetrics: Locator;
@@ -74,6 +79,12 @@ export class HomePage extends BasePage {
     this.historicalMetricsSection = page.getByRole("heading", { name: "History" }).locator("..");
     this.dagRunMetrics = page.getByRole("heading", { name: /dag run/i }).first();
     this.taskInstanceMetrics = page.getByRole("heading", { name: /task instance/i }).first();
+
+    const alertsAccordion = page.getByTestId("dashboard-alerts");
+
+    this.alertsAccordionTrigger = alertsAccordion.locator('[data-part="item-trigger"]');
+    this.alertSeeMoreButton = page.getByRole("button", { exact: true, name: "See more" });
+    this.alertSeeLessButton = page.getByRole("button", { exact: true, name: "See less" });
   }
 
   /**
@@ -106,6 +117,22 @@ export class HomePage extends BasePage {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Stub the /ui/config response so the dashboard renders the given alerts.
+   */
+  public async mockDashboardAlerts(alerts: Array<UIAlert>): Promise<void> {
+    await this.page.route("**/ui/config", async (route) => {
+      const response = await route.fetch();
+      const body = (await response.json()) as Record<string, unknown>;
+
+      await route.fulfill({
+        body: JSON.stringify({ ...body, dashboard_alert: alerts }),
+        contentType: "application/json",
+        status: response.status(),
+      });
+    });
   }
 
   /**

--- a/airflow-core/src/airflow/ui/tests/e2e/specs/home-dashboard.spec.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/specs/home-dashboard.spec.ts
@@ -129,3 +129,39 @@ test.describe("Dashboard Metrics Display", () => {
     await expect(homePage.dagImportErrorsCard).toBeVisible();
   });
 });
+
+test.describe("Dashboard Alert Clamping", () => {
+  const longText = [
+    "Long alert start",
+    ...Array.from({ length: 10 }, (_, index) => `Line ${index + 2}`),
+    "Long alert end",
+  ].join("\n\n");
+  const alerts = [
+    { category: "info" as const, text: longText },
+    { category: "warning" as const, text: "Short alert text" },
+  ];
+
+  test("clamps a tall alert and toggles its height with See more / See less", async ({ homePage }) => {
+    await homePage.mockDashboardAlerts(alerts);
+    await homePage.navigate();
+    await homePage.waitForDashboardLoad();
+
+    await expect(homePage.alertSeeMoreButton).toHaveCount(1);
+    await expect(homePage.alertSeeLessButton).toHaveCount(0);
+
+    // The tall alert is the accordion trigger; its height reflects the clamp.
+    const collapsedHeight = (await homePage.alertsAccordionTrigger.boundingBox())?.height ?? 0;
+
+    await homePage.alertSeeMoreButton.click();
+    await expect(homePage.alertSeeLessButton).toBeVisible();
+    await expect(homePage.alertSeeMoreButton).toHaveCount(0);
+
+    const expandedHeight = (await homePage.alertsAccordionTrigger.boundingBox())?.height ?? 0;
+
+    expect(expandedHeight).toBeGreaterThan(collapsedHeight);
+
+    await homePage.alertSeeLessButton.click();
+    await expect(homePage.alertSeeMoreButton).toBeVisible();
+    expect((await homePage.alertsAccordionTrigger.boundingBox())?.height ?? 0).toBeLessThan(expandedHeight);
+  });
+});


### PR DESCRIPTION
## Changes

This PR is making the following changes.

1. Saves the alert accordion state in the local storage so that it persists across page reloads. 
2. Makes the individual UIAlert objects collapsible and expandable when exceeding 5 lines. The alerts are collapsed by default. 
3. Adds + {N} more at the bottom of alerts section when collapsed. 
4. Fixes Accordion button/trigger being active on single alert. 

When checking the number of lines, the size of the screen is also taken into consideration because it affects greatly how an alert is shown. For example the same alert could take 7 lines in one screen and need to be collapsed, while it would take only 1 line in a large screen.

## Testing

Added e2e playwright tests for

- persist collapsed/expand storage 
- per-alert see-more/see-less behaviour
- single-alert case

Also, tested all the changes manually via breeze by adding multiple UIAlert objects in the airflow-local-settings.py file as follows. 

## Screenshots 
#### Original - Collapsed Alerts 

<img width="1217" height="658" alt="Screenshot_20260610_160959" src="https://github.com/user-attachments/assets/a943a7d0-cd5c-4938-833d-6fe4e15153b3" />

#### Improved - Collapsed Alerts + Per-alert see more, see less feature 

<img width="1216" height="259" alt="Screenshot_20260610_160052" src="https://github.com/user-attachments/assets/64891f3a-bcfc-431c-bf95-362fd15004d2" />

#### Bug - Accordion button/trigger active on single alert 
<img width="1217" height="658" alt="Screenshot_20260610_162149" src="https://github.com/user-attachments/assets/4019d122-8d18-4cea-8a92-530b8df2c031" />

#### Fixed - Accordion button/trigger inactive/not visible on single alert 
<img width="1217" height="215" alt="Screenshot_20260610_163016" src="https://github.com/user-attachments/assets/8483b361-543d-4df1-bdd1-0bc768a77c4a" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Coauthored-by: [Claude Sonnet 4.6, Claude Opus 4.7] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=e4d6e3d action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @Ei-Sandi → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @Ei-Sandi — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->