### PR TITLE
Fix MySQL downgrade from 3.3.0 on deadline_alert.interval JSON conversion

### DIFF
--- a/airflow-core/src/airflow/migrations/versions/0117_3_3_0_change_deadline_interval_to_json.py
+++ b/airflow-core/src/airflow/migrations/versions/0117_3_3_0_change_deadline_interval_to_json.py
@@ -38,6 +38,21 @@ depends_on = None
 airflow_version = "3.3.0"
 
 
+def _mysql_downgrade_interval_value_sql(table_name: str = "deadline_alert") -> str:
+    """Unwrap the serialized interval to a bare JSON number; the FLOAT cast happens at the column retype."""
+    return f"""
+        UPDATE {table_name}
+        SET `interval` =
+            CASE
+                WHEN JSON_EXTRACT(`interval`, '$.__data__') IS NOT NULL
+                THEN JSON_EXTRACT(`interval`, '$.__data__')
+                WHEN JSON_EXTRACT(`interval`, '$.__classname__') IS NULL
+                THEN `interval`
+                ELSE NULL
+            END
+    """
+
+
 def upgrade():
     """Apply change deadline interval to JSON."""
     conn = op.get_bind()
@@ -66,8 +81,9 @@ def upgrade():
 
             MySQL:
 
-            Step 1: Convert column type.
-            ALTER TABLE deadline_alert MODIFY COLUMN `interval` JSON;
+            Step 1: Convert column type. Keep NOT NULL — MODIFY COLUMN redefines the whole
+            column, so omitting it would drop the constraint.
+            ALTER TABLE deadline_alert MODIFY COLUMN `interval` JSON NOT NULL;
 
             Step 2: Convert values
             UPDATE deadline_alert
@@ -173,20 +189,24 @@ def downgrade():
 
             MySQL:
 
-            Step 1: Convert values
+            Step 1: Convert values. Leave them as JSON numbers; the column is still JSON
+            here, so casting to a numeric type fails with ER_INVALID_JSON_TEXT (3140). The
+            cast happens in Step 2 instead.
             UPDATE deadline_alert
             SET `interval` =
                 CASE
                     WHEN JSON_EXTRACT(`interval`, '$.__data__') IS NOT NULL
-                        THEN CAST(JSON_EXTRACT(`interval`, '$.__data__') AS DOUBLE)
+                        THEN JSON_EXTRACT(`interval`, '$.__data__')
                     WHEN JSON_EXTRACT(`interval`, '$.__classname__') IS NULL
-                        THEN CAST(`interval` AS DOUBLE)
+                        THEN `interval`
                     ELSE NULL
                 END;
 
-            Step 2: Convert column type
+            Step 2: Convert column type. This casts the JSON numbers to FLOAT (the original
+            pre-upgrade type, matching the online migration). Keep NOT NULL — MODIFY COLUMN
+            redefines the whole column, so omitting it would drop the constraint.
             ALTER TABLE deadline_alert
-            MODIFY COLUMN `interval` DOUBLE;
+            MODIFY COLUMN `interval` FLOAT NOT NULL;
 
             SQLite:
 
@@ -221,17 +241,7 @@ def downgrade():
         """)
 
     elif dialect == "mysql":
-        op.execute("""
-            UPDATE deadline_alert
-            SET `interval` =
-                CASE
-                    WHEN JSON_EXTRACT(`interval`, '$.__data__') IS NOT NULL
-                    THEN CAST(JSON_EXTRACT(`interval`, '$.__data__') AS DOUBLE)
-                    WHEN JSON_EXTRACT(`interval`, '$.__classname__') IS  NULL
-                    THEN CAST(`interval` AS DOUBLE)
-                    ELSE NULL
-                END
-        """)
+        op.execute(_mysql_downgrade_interval_value_sql())
 
     # Serialized VariableInterval objects do not contain a numeric "__data__" field
     # and therefore cannot be converted back to a float representation.

--- a/airflow-core/tests/unit/migrations/test_0117_deadline_interval_json_migration.py
+++ b/airflow-core/tests/unit/migrations/test_0117_deadline_interval_json_migration.py
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Regression test for migration 0117 (8812eb67b63c) on MySQL.
+
+The downgrade must convert ``deadline_alert.interval`` from JSON back to FLOAT without
+raising ``ER_INVALID_JSON_TEXT`` (3140). The failure only reproduces with at least one
+row present, so this seeds rows and runs the migration's own conversion SQL. It is a
+no-op on SQLite/PostgreSQL, which take different code paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from airflow import settings
+
+from tests_common.test_utils.paths import AIRFLOW_CORE_SOURCES_PATH
+
+pytestmark = pytest.mark.db_test
+
+# Migration filenames start with a digit so they cannot be imported via the
+# normal import system; load the module by file path instead.
+_MIGRATION_PATH = (
+    Path(AIRFLOW_CORE_SOURCES_PATH)
+    / "airflow/migrations/versions/0117_3_3_0_change_deadline_interval_to_json.py"
+)
+_spec = importlib.util.spec_from_file_location("migration_0117", _MIGRATION_PATH)
+_migration = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_migration)  # type: ignore[union-attr]
+
+# Isolated table so we run the real conversion SQL without seeding the live deadline_alert
+# table (which has FK/NOT NULL columns).
+_TABLE = "_test_deadline_interval_dg"
+
+# A serialized timedelta as written by the 0117 upgrade.
+_WRAPPED_TIMEDELTA = '{"__classname__": "datetime.timedelta", "__version__": 2, "__data__": 300.0}'
+
+
+class TestMigration0117Downgrade:
+    @pytest.mark.backend("mysql")
+    def test_mysql_downgrade_interval_value_update_does_not_reject_on_json_column(self):
+        """The downgrade value-conversion UPDATE must not raise 3140, and must round-trip to FLOAT."""
+        create = f"CREATE TABLE {_TABLE} (id INT PRIMARY KEY, `interval` JSON NOT NULL)"
+        drop = f"DROP TABLE IF EXISTS {_TABLE}"
+
+        with settings.engine.begin() as conn:
+            conn.execute(sa.text(drop))
+            conn.execute(sa.text(create))
+            conn.execute(
+                sa.text(f"INSERT INTO {_TABLE} (id, `interval`) VALUES (1, :v)"),
+                {"v": _WRAPPED_TIMEDELTA},
+            )
+            conn.execute(
+                sa.text(f"INSERT INTO {_TABLE} (id, `interval`) VALUES (2, CAST(:v AS JSON))"),
+                {"v": "60.0"},
+            )
+
+        try:
+            with settings.engine.begin() as conn:
+                # Column is still JSON here; this UPDATE must not raise 3140. The retype casts.
+                conn.execute(sa.text(_migration._mysql_downgrade_interval_value_sql(_TABLE)))
+                conn.execute(sa.text(f"ALTER TABLE {_TABLE} MODIFY `interval` FLOAT NOT NULL"))
+
+            with settings.engine.connect() as conn:
+                rows = dict(conn.execute(sa.text(f"SELECT id, `interval` FROM {_TABLE}")).all())
+
+            assert rows == {1: 300.0, 2: 60.0}
+        finally:
+            with settings.engine.begin() as conn:
+                conn.execute(sa.text(drop))


### PR DESCRIPTION
Migration `0117` (`8812eb67b63c`) converts `deadline_alert.interval` from `FLOAT` to `JSON` on upgrade and back on downgrade. On MySQL the downgrade unwrapped the value with `CAST(... AS DOUBLE)` inside an `UPDATE` that runs while the column is still typed `JSON`. Writing a non-JSON `DOUBLE` into a `JSON` column makes MySQL reject the whole statement:

```
(MySQLdb.OperationalError) (3140, 'Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'deadline_alert.interval'.')
```

So `airflow db downgrade` fails on MySQL for any deployment with at least one `deadline_alert` row.

The fix keeps the unwrapped value as a JSON number in the `UPDATE` and lets the subsequent column retype to `FLOAT` perform the cast — mirroring how the PostgreSQL branch defers the cast to its `ALTER ... USING` clause. The offline-mode MySQL instructions had the same defect and are corrected too.

Verified on MySQL 8.0: the original SQL reproduces error 3140; the fixed `UPDATE` succeeds and the subsequent `MODIFY ... FLOAT` converts the JSON numbers to `300`/`60`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)