### PR TITLE
Fix 500 error for event logs with NULL dttm

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -64,6 +64,12 @@ def get_event_log(
     session: SessionDep,
 ) -> EventLogResponse:
     event_log = session.scalar(
+        # Log.dttm is nullable at the DB level, but EventLogResponse.when is a non-optional
+        # datetime. Rows with dttm=NULL would cause a Pydantic validation error (500), so
+        # exclude them here. Such rows can exist in legacy installs or via direct DB inserts
+        # that bypass Log.__init__ (which always sets dttm = timezone.utcnow()).
+        # Making EventLogResponse.when nullable would be a breaking API contract change for
+        # clients that currently rely on `when` always being present.
         select(Log)
         .where(Log.id == event_log_id, Log.dttm.is_not(None))
         .options(joinedload(Log.task_instance))
@@ -158,6 +164,12 @@ def get_event_logs(
 ) -> EventLogCollectionResponse:
     """Get all Event Logs."""
     query = (
+        # Log.dttm is nullable at the DB level, but EventLogResponse.when is a non-optional
+        # datetime. Rows with dttm=NULL would cause a Pydantic validation error (500), so
+        # exclude them here. Such rows can exist in legacy installs or via direct DB inserts
+        # that bypass Log.__init__ (which always sets dttm = timezone.utcnow()).
+        # Making EventLogResponse.when nullable would be a breaking API contract change for
+        # clients that currently rely on `when` always being present.
         select(Log)
         .where(Log.dttm.is_not(None))
         .options(joinedload(Log.task_instance), joinedload(Log.dag_model))

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -64,7 +64,9 @@ def get_event_log(
     session: SessionDep,
 ) -> EventLogResponse:
     event_log = session.scalar(
-        select(Log).where(Log.id == event_log_id).options(joinedload(Log.task_instance))
+        select(Log)
+        .where(Log.id == event_log_id, Log.dttm.is_not(None))
+        .options(joinedload(Log.task_instance))
     )
     if event_log is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"The Event Log with id: `{event_log_id}` not found")
@@ -155,7 +157,11 @@ def get_event_logs(
     readable_event_logs_filter: ReadableEventLogsFilterDep,
 ) -> EventLogCollectionResponse:
     """Get all Event Logs."""
-    query = select(Log).options(joinedload(Log.task_instance), joinedload(Log.dag_model))
+    query = (
+        select(Log)
+        .where(Log.dttm.is_not(None))
+        .options(joinedload(Log.task_instance), joinedload(Log.dag_model))
+    )
     event_logs_select, total_entries = paginated_select(
         statement=query,
         order_by=order_by,

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -50,6 +50,7 @@ EVENT_NORMAL = "NORMAL_EVENT"
 EVENT_WITH_OWNER = "EVENT_WITH_OWNER"
 EVENT_WITH_TASK_INSTANCE = "EVENT_WITH_TASK_INSTANCE"
 EVENT_WITH_OWNER_AND_TASK_INSTANCE = "EVENT_WITH_OWNER_AND_TASK_INSTANCE"
+EVENT_WITHOUT_DTTM = "EVENT_WITHOUT_DTTM"
 EVENT_NON_EXISTED_ID = 9999
 
 
@@ -233,6 +234,19 @@ class TestGetEventLog(TestEventLogsEndpoint):
             user=mock.ANY,
         )
 
+    @provide_session
+    def test_should_return_404_for_log_without_dttm(self, test_client, *, session: Session = NEW_SESSION):
+        event_log = Log(event=EVENT_WITHOUT_DTTM)
+        session.add(event_log)
+        session.flush()
+        event_log_id = event_log.id
+        event_log.dttm = None
+        session.commit()
+
+        response = test_client.get(f"/eventLogs/{event_log_id}")
+
+        assert response.status_code == 404
+
 
 class TestGetEventLogs(TestEventLogsEndpoint):
     @pytest.mark.parametrize(
@@ -349,6 +363,24 @@ class TestGetEventLogs(TestEventLogsEndpoint):
         assert resp_json["total_entries"] == expected_total_entries
         for event_log, expected_event in zip(resp_json["event_logs"], expected_events):
             assert event_log["event"] == expected_event
+
+    @provide_session
+    def test_get_event_logs_excludes_logs_without_dttm(
+        self, test_client, *, session: Session = NEW_SESSION
+    ):
+        event_log = Log(event=EVENT_WITHOUT_DTTM)
+        session.add(event_log)
+        session.flush()
+        event_log.dttm = None
+        session.commit()
+
+        with assert_queries_count(3):
+            response = test_client.get("/eventLogs", params={"order_by": "-when"})
+
+        assert response.status_code == 200
+        resp_json = response.json()
+        assert resp_json["total_entries"] == 4
+        assert EVENT_WITHOUT_DTTM not in {event_log["event"] for event_log in resp_json["event_logs"]}
 
     # Ordering of nulls values is DB specific.
     @pytest.mark.backend("sqlite")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -366,7 +366,10 @@ class TestGetEventLogs(TestEventLogsEndpoint):
 
     @provide_session
     def test_get_event_logs_excludes_logs_without_dttm(
-        self, test_client, *, session: Session = NEW_SESSION  # noqa: PT028
+        self,
+        test_client,
+        *,
+        session: Session = NEW_SESSION,  # noqa: PT028
     ):
         event_log = Log(event=EVENT_WITHOUT_DTTM)
         session.add(event_log)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -235,7 +235,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
         )
 
     @provide_session
-    def test_should_return_404_for_log_without_dttm(self, test_client, *, session: Session = NEW_SESSION):
+    def test_should_return_404_for_log_without_dttm(self, test_client, *, session: Session = NEW_SESSION):  # noqa: PT028
         event_log = Log(event=EVENT_WITHOUT_DTTM)
         session.add(event_log)
         session.flush()
@@ -366,7 +366,7 @@ class TestGetEventLogs(TestEventLogsEndpoint):
 
     @provide_session
     def test_get_event_logs_excludes_logs_without_dttm(
-        self, test_client, *, session: Session = NEW_SESSION
+        self, test_client, *, session: Session = NEW_SESSION  # noqa: PT028
     ):
         event_log = Log(event=EVENT_WITHOUT_DTTM)
         session.add(event_log)


### PR DESCRIPTION
## Summary

`Log.dttm` is nullable at the database level, but `EventLogResponse.dttm` (`when` in the API) is declared as a non-optional `datetime`. When a log row has `dttm=NULL`, FastAPI/Pydantic raises a validation error producing a **500 Internal Server Error** instead of a sensible response.

This happens for legacy records or rows inserted directly into the database bypassing the model (which always sets `dttm = timezone.utcnow()` in `__init__`).

## Why this approach

Rather than making `when` nullable in the API schema (a breaking contract change that would affect all API consumers expecting a non-null timestamp), we filter out null-dttm rows at the query level:

- **`GET /eventLogs/{id}`** — returns **404** for a log whose `dttm` is `NULL`. The resource is not serveable through this API.
- **`GET /eventLogs`** — silently excludes null-dttm rows from both the results and `total_entries`, keeping the response consistent and well-typed.

This is the minimal, safe fix: it stops the 500 crash without changing the API contract or requiring a schema migration.

closes: #68333

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)