### PR TITLE
Fix backward compatibility for DagRunInfo partition fields

### DIFF
--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -143,8 +143,8 @@ class DagRunInfo(NamedTuple):
     data_interval: DataInterval | None
     """The data interval this DagRun to operate over."""
 
-    partition_date: DateTime | None
-    partition_key: str | None
+    partition_date: DateTime | None = None
+    partition_key: str | None = None
 
     @classmethod
     def exact(cls, at: DateTime) -> DagRunInfo:

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -834,6 +834,8 @@ def test_generate_run_id_without_partition_key() -> None:
         data_interval=None,
     )
     assert run_id.startswith("manual__2025-06-07T08:09:00+00:00__")
+
+
 def test_dagruninfo_backward_compatibility() -> None:
     start = pendulum.datetime(2025, 1, 1, tz="UTC")
     end = pendulum.datetime(2025, 1, 2, tz="UTC")
@@ -848,3 +850,4 @@ def test_dagruninfo_backward_compatibility() -> None:
 
     assert info.partition_date is None
     assert info.partition_key is None
+     

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -834,7 +834,7 @@ def test_generate_run_id_without_partition_key() -> None:
         data_interval=None,
     )
     assert run_id.startswith("manual__2025-06-07T08:09:00+00:00__")
-def test_dagruninfo_backward_compatibility():
+def test_dagruninfo_backward_compatibility() -> None:
     start = pendulum.datetime(2025, 1, 1, tz="UTC")
     end = pendulum.datetime(2025, 1, 2, tz="UTC")
 
@@ -847,5 +847,4 @@ def test_dagruninfo_backward_compatibility():
     )
 
     assert info.partition_date is None
-    assert info.partition_key is None   
- 
+    assert info.partition_key is None

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -834,3 +834,18 @@ def test_generate_run_id_without_partition_key() -> None:
         data_interval=None,
     )
     assert run_id.startswith("manual__2025-06-07T08:09:00+00:00__")
+def test_dagruninfo_backward_compatibility():
+    start = pendulum.datetime(2025, 1, 1, tz="UTC")
+    end = pendulum.datetime(2025, 1, 2, tz="UTC")
+
+    info = DagRunInfo(
+        run_after=end,
+        data_interval=DataInterval(
+            start=start,
+            end=end,
+        ),
+    )
+
+    assert info.partition_date is None
+    assert info.partition_key is None   
+ 

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -850,4 +850,4 @@ def test_dagruninfo_backward_compatibility() -> None:
 
     assert info.partition_date is None
     assert info.partition_key is None
-     
+         

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -850,4 +850,3 @@ def test_dagruninfo_backward_compatibility() -> None:
 
     assert info.partition_date is None
     assert info.partition_key is None
-         


### PR DESCRIPTION
## What

This PR restores backward compatibility for custom timetables that were written against Airflow 3.1.x.

Airflow 3.2 introduced `partition_date` and `partition_key` fields in `DagRunInfo`. Since these fields were required, existing custom timetables constructing `DagRunInfo` with only `run_after` and `data_interval` raise a `TypeError`, causing scheduling to stop.

## Why

Custom timetable DAGs fail to schedule after upgrading to Airflow 3.2.x:

```python
DagRunInfo(
    run_after=run_after,
    data_interval=data_interval,
)
```

raises:

```text
TypeError: DagRunInfo.__new__() missing 2 required positional arguments:
'partition_date' and 'partition_key'
```

This can result in DAGs showing an empty Next Run field and no scheduled DAG runs being created.

## Changes

* Added default `None` values for:

  * `partition_date`
  * `partition_key`
* Added a regression test to verify backward compatibility with the legacy `DagRunInfo` constructor.

## Testing

Added unit test covering construction of `DagRunInfo` using the pre-3.2 API and verified default values are correctly assigned to the new partition fields.

Fixes #68315


**Gen-AI disclosure:** I used a generative AI tool to help identify the root
cause, write tests, and draft the PR description. I reviewed, tested, and
verified all changes locally before submitting.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)