### PR TITLE
Fix ADLS ObjectStoragePath connection parsing

### DIFF
--- a/providers/microsoft/azure/docs/connections/adls_v2.rst
+++ b/providers/microsoft/azure/docs/connections/adls_v2.rst
@@ -58,7 +58,8 @@ Password (optional)
     It can be left out to fall back on DefaultAzureCredential_.
 
 Host (optional)
-    Specify the account url for anonymous public read, Active Directory, shared access key authentication.
+    Specify the storage account name or account URL for anonymous public read, Active Directory,
+    shared access key authentication.
     It can be left out to fall back on DefaultAzureCredential_.
 
 Extra (optional)

--- a/providers/microsoft/azure/docs/filesystems/adls.rst
+++ b/providers/microsoft/azure/docs/filesystems/adls.rst
@@ -23,9 +23,9 @@ through Airflow's ObjectStoragePath interface.
 
 Supported URL formats:
 
-* ``abfs://connection_id/container/path/to/file``
-* ``abfss://connection_id/container/path/to/file``
-* ``adl://connection_id/container/path/to/file``
+* ``abfs://connection_id@container/path/to/file``
+* ``abfss://connection_id@container/path/to/file``
+* ``adl://connection_id@container/path/to/file``
 
 Connection Configuration
 ------------------------
@@ -51,18 +51,18 @@ Read from ADLS Gen2 with ObjectStoragePath:
 
 .. code-block:: python
 
-    from airflow.sdk.io.path import ObjectStoragePath
+    from airflow.sdk import ObjectStoragePath
 
-    path = ObjectStoragePath("abfs://adls_default/raw/events.json")
+    path = ObjectStoragePath("abfs://adls_default@raw/events.json")
     content = path.read_text()
 
 Write to ADLS Gen2:
 
 .. code-block:: python
 
-    from airflow.sdk.io.path import ObjectStoragePath
+    from airflow.sdk import ObjectStoragePath
 
-    output_path = ObjectStoragePath("abfss://adls_default/processed/events.json")
+    output_path = ObjectStoragePath("abfss://adls_default@processed/events.json")
     output_path.write_text('{"status": "ok"}')
 
 Requirements

--- a/providers/microsoft/azure/docs/filesystems/adls.rst
+++ b/providers/microsoft/azure/docs/filesystems/adls.rst
@@ -1,0 +1,76 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Azure Data Lake Storage Gen2 Filesystem
+=======================================
+
+The Azure Data Lake Storage Gen2 filesystem provides access to ADLS Gen2
+through Airflow's ObjectStoragePath interface.
+
+Supported URL formats:
+
+* ``abfs://connection_id/container/path/to/file``
+* ``abfss://connection_id/container/path/to/file``
+* ``adl://connection_id/container/path/to/file``
+
+Connection Configuration
+------------------------
+
+Create an ADLS Gen2 connection in Airflow with the following parameters:
+
+* **Connection Type**: adls
+* **Host**: Storage account name, for example ``mystorageaccount``
+* **Login**: Client ID for Active Directory authentication
+* **Password**: Client secret for Active Directory authentication, or account key for shared key authentication
+
+The connection form provides additional configuration fields:
+
+* ``tenant_id``: Tenant ID for Active Directory authentication
+* ``connection_string``: ADLS Gen2 connection string; this takes precedence over other authentication fields
+* ``account_name``: Optional explicit storage account name override
+* ``account_host``: Optional custom storage account host, for private endpoints or custom domains
+
+Examples
+--------
+
+Read from ADLS Gen2 with ObjectStoragePath:
+
+.. code-block:: python
+
+    from airflow.sdk.io.path import ObjectStoragePath
+
+    path = ObjectStoragePath("abfs://adls_default/raw/events.json")
+    content = path.read_text()
+
+Write to ADLS Gen2:
+
+.. code-block:: python
+
+    from airflow.sdk.io.path import ObjectStoragePath
+
+    output_path = ObjectStoragePath("abfss://adls_default/processed/events.json")
+    output_path.write_text('{"status": "ok"}')
+
+Requirements
+------------
+
+The Azure Data Lake Storage Gen2 filesystem requires the ``adlfs`` Python package.
+
+Cross-References
+----------------
+
+* :doc:`ADLS Gen2 connection </connections/adls_v2>`

--- a/providers/microsoft/azure/docs/filesystems/adls.rst
+++ b/providers/microsoft/azure/docs/filesystems/adls.rst
@@ -33,7 +33,7 @@ Connection Configuration
 Create an ADLS Gen2 connection in Airflow with the following parameters:
 
 * **Connection Type**: adls
-* **Host**: Storage account name, for example ``mystorageaccount``
+* **Host**: Storage account name, for example ``mystorageaccount``, or a full account URL/custom endpoint
 * **Login**: Client ID for Active Directory authentication
 * **Password**: Client secret for Active Directory authentication, or account key for shared key authentication
 

--- a/providers/microsoft/azure/docs/filesystems/adls.rst
+++ b/providers/microsoft/azure/docs/filesystems/adls.rst
@@ -33,7 +33,8 @@ Connection Configuration
 Create an ADLS Gen2 connection in Airflow with the following parameters:
 
 * **Connection Type**: adls
-* **Host**: Storage account name, for example ``mystorageaccount``, or a full account URL/custom endpoint
+* **Host**: Storage account name, for example ``mystorageaccount``. For a private endpoint or
+  custom domain, set the ``account_host`` field below rather than a full URL here.
 * **Login**: Client ID for Active Directory authentication
 * **Password**: Client secret for Active Directory authentication, or account key for shared key authentication
 

--- a/providers/microsoft/azure/newsfragments/68344.bugfix.rst
+++ b/providers/microsoft/azure/newsfragments/68344.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ADLS ``ObjectStoragePath`` connection parsing to pass ``account_name`` for Active Directory ``adls`` connections while preserving the existing ``account_url`` behavior for WASB, full-URL, and custom-endpoint connections

--- a/providers/microsoft/azure/newsfragments/68344.bugfix.rst
+++ b/providers/microsoft/azure/newsfragments/68344.bugfix.rst
@@ -1,1 +1,0 @@
-Fix ADLS ``ObjectStoragePath`` connection parsing to pass ``account_name`` for Active Directory ``adls`` connections while preserving the existing ``account_url`` behavior for WASB, full-URL, and custom-endpoint connections

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 from azure.identity import ClientSecretCredential
 
 from airflow.providers.common.compat.sdk import BaseHook
-from airflow.providers.microsoft.azure.utils import get_field
+from airflow.providers.microsoft.azure.utils import get_field, parse_blob_account_url
 
 if TYPE_CHECKING:
     from fsspec import AbstractFileSystem
@@ -42,15 +42,11 @@ def _account_name_from_host(host: str | None) -> str | None:
     return hostname.split(".", 1)[0]
 
 
-def _get_default_account_name(conn_type: str, host: str | None, login: str | None) -> str | None:
+def _storage_account_name_from_host(host: str | None) -> str | None:
     account_name = _account_name_from_host(host)
-    if conn_type == "adls":
+    if account_name and account_name == host:
         return account_name
-
-    if account_name and "." in (host or ""):
-        return account_name
-
-    return login or account_name
+    return None
 
 
 def get_fs(conn_id: str | None, storage_options: dict[str, Any] | None = None) -> AbstractFileSystem:
@@ -71,13 +67,17 @@ def get_fs(conn_id: str | None, storage_options: dict[str, Any] | None = None) -
     if connection_string:
         return AzureBlobFileSystem(connection_string=connection_string)
 
-    options: dict[str, Any] = {}
-    account_name = _get_default_account_name(conn_type, conn.host, conn.login)
-    if account_name:
-        options["account_name"] = account_name
-
     # mirror handling of custom field "client_secret_auth_config" from extras. Ignore if missing as AzureBlobFileSystem can handle.
     tenant_id = get_field(conn_id=conn_id, conn_type=conn_type, extras=extras, field_name="tenant_id")
+    options: dict[str, Any] = {}
+    account_name = _storage_account_name_from_host(conn.host)
+    # Preserve account_url for existing WASB, full URL, and custom endpoint connections.
+    # ADLS Active Directory connections use login as client_id, so bare hosts are account names.
+    if conn_type == "adls" and account_name:
+        options["account_name"] = account_name
+    elif conn_type != "adls" or conn.host or not tenant_id:
+        options["account_url"] = parse_blob_account_url(conn.host, conn.login)
+
     login = conn.login or ""
     password = conn.password or ""
     # assumption (from WasbHook) that if tenant_id is set, we want service principal connection

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
@@ -45,7 +45,7 @@ def _account_name_from_host(host: str | None) -> str | None:
 def _get_default_account_name(conn_type: str, host: str | None, login: str | None) -> str | None:
     account_name = _account_name_from_host(host)
     if conn_type == "adls":
-        return account_name or login
+        return account_name
 
     if account_name and "." in (host or ""):
         return account_name

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
@@ -17,16 +17,40 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from azure.identity import ClientSecretCredential
 
 from airflow.providers.common.compat.sdk import BaseHook
-from airflow.providers.microsoft.azure.utils import get_field, parse_blob_account_url
+from airflow.providers.microsoft.azure.utils import get_field
 
 if TYPE_CHECKING:
     from fsspec import AbstractFileSystem
 
 schemes = ["abfs", "abfss", "adl"]
+
+
+def _account_name_from_host(host: str | None) -> str | None:
+    if not host:
+        return None
+
+    parsed_url = urlparse(host if "://" in host else f"//{host}")
+    hostname = parsed_url.hostname
+    if not hostname:
+        return None
+
+    return hostname.split(".", 1)[0]
+
+
+def _get_default_account_name(conn_type: str, host: str | None, login: str | None) -> str | None:
+    account_name = _account_name_from_host(host)
+    if conn_type == "adls":
+        return account_name or login
+
+    if account_name and "." in (host or ""):
+        return account_name
+
+    return login or account_name
 
 
 def get_fs(conn_id: str | None, storage_options: dict[str, Any] | None = None) -> AbstractFileSystem:
@@ -47,9 +71,10 @@ def get_fs(conn_id: str | None, storage_options: dict[str, Any] | None = None) -
     if connection_string:
         return AzureBlobFileSystem(connection_string=connection_string)
 
-    options: dict[str, Any] = {
-        "account_url": parse_blob_account_url(conn.host, conn.login),
-    }
+    options: dict[str, Any] = {}
+    account_name = _get_default_account_name(conn_type, conn.host, conn.login)
+    if account_name:
+        options["account_name"] = account_name
 
     # mirror handling of custom field "client_secret_auth_config" from extras. Ignore if missing as AzureBlobFileSystem can handle.
     tenant_id = get_field(conn_id=conn_id, conn_type=conn_type, extras=extras, field_name="tenant_id")

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/adls.py
@@ -30,22 +30,23 @@ if TYPE_CHECKING:
 schemes = ["abfs", "abfss", "adl"]
 
 
-def _account_name_from_host(host: str | None) -> str | None:
+def _bare_account_name_from_host(host: str | None) -> str | None:
+    """
+    Return the storage account name when the host is a bare account name, else ``None``.
+
+    A bare host such as ``mystorageaccount`` is the ADLS account name itself. A full host
+    like ``mystorageaccount.dfs.core.windows.net`` (or anything with a scheme, port or path)
+    is an endpoint and should keep the ``account_url`` handling instead.
+    """
     if not host:
         return None
 
-    parsed_url = urlparse(host if "://" in host else f"//{host}")
-    hostname = parsed_url.hostname
-    if not hostname:
-        return None
-
-    return hostname.split(".", 1)[0]
-
-
-def _storage_account_name_from_host(host: str | None) -> str | None:
-    account_name = _account_name_from_host(host)
-    if account_name and account_name == host:
-        return account_name
+    # urlparse().hostname is already lowercased, so compare against a lowercased host to keep
+    # the check case-insensitive (Azure account names are lowercase anyway). The dot guard
+    # keeps full endpoints like "acct.dfs.core.windows.net" out of the account_name path.
+    hostname = urlparse(host if "://" in host else f"//{host}").hostname
+    if hostname and "." not in hostname and hostname == host.lower():
+        return hostname
     return None
 
 
@@ -70,13 +71,16 @@ def get_fs(conn_id: str | None, storage_options: dict[str, Any] | None = None) -
     # mirror handling of custom field "client_secret_auth_config" from extras. Ignore if missing as AzureBlobFileSystem can handle.
     tenant_id = get_field(conn_id=conn_id, conn_type=conn_type, extras=extras, field_name="tenant_id")
     options: dict[str, Any] = {}
-    account_name = _storage_account_name_from_host(conn.host)
-    # Preserve account_url for existing WASB, full URL, and custom endpoint connections.
-    # ADLS Active Directory connections use login as client_id, so bare hosts are account names.
+    account_name = _bare_account_name_from_host(conn.host)
     if conn_type == "adls" and account_name:
+        # An ADLS Active Directory connection uses ``login`` as the client_id, so a bare host
+        # is the storage account name rather than part of an account URL.
         options["account_name"] = account_name
     elif conn_type != "adls" or conn.host or not tenant_id:
+        # WASB, full-URL, and custom-endpoint connections keep the historical account_url path.
         options["account_url"] = parse_blob_account_url(conn.host, conn.login)
+    # Otherwise (adls + no host + a tenant_id) neither account_name nor account_url is set, so
+    # adlfs falls back to DefaultAzureCredential using the client_id/secret assembled below.
 
     login = conn.login or ""
     password = conn.password or ""

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
@@ -49,7 +49,7 @@ def mocked_blob_file_system():
                 host="testaccountname.blob.core.windows.net",
             ),
             {
-                "account_name": "testaccountname",
+                "account_url": "https://testaccountname.blob.core.windows.net",
             },
         ),
         (
@@ -59,7 +59,7 @@ def mocked_blob_file_system():
                 login="testaccountname",
             ),
             {
-                "account_name": "testaccountname",
+                "account_url": "https://testaccountname.blob.core.windows.net/",
             },
         ),
         (
@@ -96,6 +96,7 @@ def mocked_blob_file_system():
                 },
             ),
             {
+                "account_url": "https://testaccountname.blob.core.windows.net/",
                 "account_name": "account_name",
                 "client_id": "testaccountname",
                 "client_secret": "password",
@@ -117,7 +118,7 @@ def mocked_blob_file_system():
                 extra={},
             ),
             {
-                "account_name": "testaccountname",
+                "account_url": "https://testaccountname.blob.core.windows.net/",
                 "account_key": "password",
             },
         ),
@@ -133,7 +134,7 @@ def mocked_blob_file_system():
                 },
             ),
             {
-                "account_name": "testaccountname",
+                "account_url": "https://testaccountname.blob.core.windows.net/",
                 "account_host": "mystorageaccount.blob.core.mydomain.io",
                 "account_key": "password",
             },
@@ -160,6 +161,19 @@ def mocked_blob_file_system():
             Connection(
                 conn_id="testconn",
                 conn_type="adls",
+                host="testaccountname",
+                password="account_key",
+                extra={},
+            ),
+            {
+                "account_name": "testaccountname",
+                "account_key": "account_key",
+            },
+        ),
+        (
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
                 host="testaccountname.dfs.core.windows.net",
                 login="client_id",
                 password="client_secret",
@@ -168,7 +182,25 @@ def mocked_blob_file_system():
                 },
             ),
             {
-                "account_name": "testaccountname",
+                "account_url": "https://testaccountname.dfs.core.windows.net",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "tenant_id": "tenant_id",
+            },
+        ),
+        (
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
+                host="https://custom.blob.core.mydomain.io",
+                login="client_id",
+                password="client_secret",
+                extra={
+                    "tenant_id": "tenant_id",
+                },
+            ),
+            {
+                "account_url": "https://custom.blob.core.mydomain.io",
                 "client_id": "client_id",
                 "client_secret": "client_secret",
                 "tenant_id": "tenant_id",

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
@@ -174,6 +174,40 @@ def mocked_blob_file_system():
                 "tenant_id": "tenant_id",
             },
         ),
+        (
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
+                login="client_id",
+                password="client_secret",
+                extra={
+                    "tenant_id": "tenant_id",
+                },
+            ),
+            {
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "tenant_id": "tenant_id",
+            },
+        ),
+        (
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
+                login="client_id",
+                password="client_secret",
+                extra={
+                    "account_name": "testaccountname",
+                    "tenant_id": "tenant_id",
+                },
+            ),
+            {
+                "account_name": "testaccountname",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "tenant_id": "tenant_id",
+            },
+        ),
     ],
     indirect=["mocked_connection"],
 )

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
@@ -49,7 +49,7 @@ def mocked_blob_file_system():
                 host="testaccountname.blob.core.windows.net",
             ),
             {
-                "account_url": "https://testaccountname.blob.core.windows.net",
+                "account_name": "testaccountname",
             },
         ),
         (
@@ -59,7 +59,7 @@ def mocked_blob_file_system():
                 login="testaccountname",
             ),
             {
-                "account_url": "https://testaccountname.blob.core.windows.net/",
+                "account_name": "testaccountname",
             },
         ),
         (
@@ -96,11 +96,9 @@ def mocked_blob_file_system():
                 },
             ),
             {
-                "account_url": "https://testaccountname.blob.core.windows.net/",
-                # "account_url": "https://testaccountid.blob.core.windows.net/",
+                "account_name": "account_name",
                 "client_id": "testaccountname",
                 "client_secret": "password",
-                "account_name": "account_name",
                 "account_key": "account_key",
                 "sas_token": "sas_token",
                 "tenant_id": "tenant_id",
@@ -119,8 +117,7 @@ def mocked_blob_file_system():
                 extra={},
             ),
             {
-                "account_url": "https://testaccountname.blob.core.windows.net/",
-                # "account_url": "https://testaccountid.blob.core.windows.net/",
+                "account_name": "testaccountname",
                 "account_key": "password",
             },
         ),
@@ -136,9 +133,45 @@ def mocked_blob_file_system():
                 },
             ),
             {
-                "account_url": "https://testaccountname.blob.core.windows.net/",
+                "account_name": "testaccountname",
                 "account_host": "mystorageaccount.blob.core.mydomain.io",
                 "account_key": "password",
+            },
+        ),
+        (
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
+                host="testaccountname",
+                login="client_id",
+                password="client_secret",
+                extra={
+                    "tenant_id": "tenant_id",
+                },
+            ),
+            {
+                "account_name": "testaccountname",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "tenant_id": "tenant_id",
+            },
+        ),
+        (
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
+                host="testaccountname.dfs.core.windows.net",
+                login="client_id",
+                password="client_secret",
+                extra={
+                    "tenant_id": "tenant_id",
+                },
+            ),
+            {
+                "account_name": "testaccountname",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "tenant_id": "tenant_id",
             },
         ),
     ],

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_adls.py
@@ -158,6 +158,25 @@ def mocked_blob_file_system():
             },
         ),
         (
+            # A mixed-case bare host is still an account name; urlparse lowercases it.
+            Connection(
+                conn_id="testconn",
+                conn_type="adls",
+                host="MyAccount",
+                login="client_id",
+                password="client_secret",
+                extra={
+                    "tenant_id": "tenant_id",
+                },
+            ),
+            {
+                "account_name": "myaccount",
+                "client_id": "client_id",
+                "client_secret": "client_secret",
+                "tenant_id": "tenant_id",
+            },
+        ),
+        (
             Connection(
                 conn_id="testconn",
                 conn_type="adls",


### PR DESCRIPTION
Fixes #40410.

This updates the ADLS ObjectStoragePath filesystem adapter to pass `account_name` to `adlfs.AzureBlobFileSystem` instead of an `account_url` keyword. `adlfs` requires `account_name`, and the previous logic could derive the account from `login`, which breaks ADLS V2 service principal connections where `login` is the client ID and `host` is the storage account name.

Changes:
- infer account name from `host` for `adls` connections while preserving the existing login fallback for legacy `wasb`-style connections
- add unit coverage for ADLS V2 service principal connections with plain account-name and DNS host values
- document ADLS ObjectStoragePath URL formats and connection fields

Tests:
- `python -m ruff check providers\microsoft\azure\src\airflow\providers\microsoft\azure\fs\adls.py providers\microsoft\azure\tests\unit\microsoft\azure\fs\test_adls.py`
- `python -m ruff format --check providers\microsoft\azure\src\airflow\providers\microsoft\azure\fs\adls.py providers\microsoft\azure\tests\unit\microsoft\azure\fs\test_adls.py`
- `python -m py_compile providers\microsoft\azure\src\airflow\providers\microsoft\azure\fs\adls.py providers\microsoft\azure\tests\unit\microsoft\azure\fs\test_adls.py`

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Chinmay1220** · by `@potiuk` · 2026-06-22 06:31 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks** — failing: CI image checks / Static checks.
> - :x: **Tests** — failing: provider distributions tests / Compat 2.11.1:P3.10:, provider distributions tests / Compat 3.0.6:P3.10:, provider distributions tests / Compat 3.1.8:P3.10:, provider distributions tests / Compat 3.2.2:P3.10:.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->