### PR TITLE
Conditional deprecated table generation in doc

### DIFF
--- a/chart/docs/conf.py
+++ b/chart/docs/conf.py
@@ -296,8 +296,14 @@ for name in chart_schema["x-docsSectionOrder"]:
 if sections:
     raise ValueError(f"Found section(s) which were not in `section_order`: {list(sections.keys())}")
 
+deprecations_exist = False
+for param in (param for sec in ordered_sections for param in sec["params"]):
+    if "deprecated" in param["description"]:
+        deprecations_exist = True
+        break
+
 jinja_contexts = {
-    "params_ctx": {"sections": ordered_sections},
+    "params_ctx": {"sections": ordered_sections, "deprecations_exist": deprecations_exist},
     "official_download_page": {
         "base_url": "https://downloads.apache.org/airflow/helm-chart",
         "closer_lua_url": "https://www.apache.org/dyn/closer.lua/airflow/helm-chart",

--- a/chart/docs/parameters-ref.rst
+++ b/chart/docs/parameters-ref.rst
@@ -86,6 +86,7 @@ in the next Helm Chart major release.
 
 .. jinja:: params_ctx
 
+   {% if deprecations_exist %}
    .. list-table::
       :widths: 15 10 30
       :header-rows: 1
@@ -111,3 +112,6 @@ in the next Helm Chart major release.
          {% endif %}
       {% endfor %}
    {% endfor %}
+   {% else %}
+   There are no deprecations within current release of Helm Chart.
+   {% endif %}


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

In Sphinx `list-table` object cannot be empty. During the removal of deprecated parameters, sooner or later, we will encounter a build doc issue which will be unrelated to the ongoing work. This PR introduced conditional generated of the deprecated paramters table with the proper information in the doc when there is no deprecated parameters within the release.

Deprecated parameters exist:
<img width="1197" height="405" alt="image" src="https://github.com/user-attachments/assets/47fc105e-47ec-45ca-8794-9f77fff91f6a" />

No deprecated parameters:
<img width="1193" height="206" alt="image" src="https://github.com/user-attachments/assets/d49a6e2e-1f8f-44b9-9a2c-a4a6d1ab59e5" />

Not needed for 1.2x line, but for some consistency we can add it as the automatic backport should work without any issue here.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
