### PR TITLE
Docs: Remove stale reload_on_plugin_change from API config reference

### DIFF
--- a/airflow-core/docs/administration-and-deployment/web-stack.rst
+++ b/airflow-core/docs/administration-and-deployment/web-stack.rst
@@ -144,7 +144,6 @@ The following configuration options are available in the ``[api]`` section:
 - ``worker_refresh_batch_size``: Number of workers to refresh per cycle (default: 1)
 - ``dag_cache_size``: Max cached SerializedDAG versions in the API server (default: 64, 0 = unbounded)
 - ``dag_cache_ttl``: TTL in seconds for cached DAGs (default: 3600, 0 = LRU only)
-- ``reload_on_plugin_change``: Reload when plugin files change (default: False)
 
 When to Use Gunicorn
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The reload_on_plugin_change option was dropped when the legacy webserver was replaced by the uvicorn/gunicorn API server; it no longer exists in config.yml and setting it has no effect. Remove the leftover prose entry in the web-stack docs so the documented [api] options match the actual config reference.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
ClaudeCode Opus 4.8