### PR TITLE
Docs: Clarify rollback process and limitations of db downgrade command

### DIFF
--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -320,6 +320,8 @@ Downgrading Airflow
 .. note::
 
     It's recommended that you backup your database before running ``db downgrade`` or any other database operation.
+    ``airflow db downgrade`` only downgrades the database schema managed by Alembic migrations.
+    It does not rewrite metadata database rows that were serialized by a newer Airflow version.
 
 You can downgrade to a particular Airflow version with the ``db downgrade`` command.  Alternatively you may provide an Alembic revision id to downgrade to.
 
@@ -333,6 +335,17 @@ For a mapping between Airflow version and Alembic revision see :doc:`/migrations
 
     It's highly recommended that you reserialize your Dags with ``dags reserialize`` after you finish downgrading your Airflow environment (meaning, after you've downgraded the Airflow version installed in your Python environment, not immediately after you've downgraded the database).
     This is to ensure that the serialized Dags are compatible with the downgraded version of Airflow.
+
+.. warning::
+
+    Downgrading the database schema is not a complete rollback after a newer Airflow version has run
+    against the metadata database. For example, Airflow 3.2.x can write SDK-serialized metadata
+    rows that Airflow 3.1.x cannot deserialize, such as trigger kwargs, Dag run configuration,
+    deferred task payloads, or other serialized values. In that case, components such as the
+    scheduler or triggerer may fail even though ``airflow db downgrade`` completed successfully.
+    Restore a metadata database backup from before the upgrade when you need a reliable rollback.
+    Manual cleanup of incompatible rows can unblock some environments, but it is deployment-specific
+    and can cause data loss.
 
 .. _cli-export-connections:
 

--- a/airflow-core/docs/installation/upgrading.rst
+++ b/airflow-core/docs/installation/upgrading.rst
@@ -41,6 +41,13 @@ a half-migrated state and restoring DB from backup and repeating the
 migration might be the only easy way out. This can for example be caused by a broken
 network connection between your CLI and the database while the migration happens, so taking
 a backup is an important precaution to avoid problems like this.
+The backup is also important if you need to roll back to an older Airflow version
+after the new version has already run against the metadata database. The
+``airflow db downgrade`` command only downgrades the database schema; it does not
+rewrite serialized row contents that were written by the newer Airflow version.
+For example, after Airflow 3.2.x writes SDK-serialized metadata rows, Airflow
+3.1.x might not be able to deserialize those rows. Restoring a metadata database
+backup taken before the upgrade is the safest rollback path.
 
 When you need to upgrade
 ========================

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1727,6 +1727,7 @@ DB_COMMANDS = (
         help="Downgrade the schema of the metadata database.",
         description=(
             "Downgrade the schema of the metadata database. "
+            "This does not rewrite serialized metadata rows that were written by a newer Airflow version. "
             "You must provide either `--to-revision` or `--to-version`. "
             "To print but not execute commands, use option `--show-sql-only`. "
             "If using options `--from-revision` or `--from-version`, you must also use `--show-sql-only`, "
@@ -2087,6 +2088,7 @@ DB_MANAGERS_COMMANDS = (
         help="Downgrade the schema of the external metadata database.",
         description=(
             "Downgrade the schema of the metadata database. "
+            "This does not rewrite serialized metadata rows that were written by a newer Airflow version. "
             "You must provide either `--to-revision` or `--to-version`. "
             "To print but not execute commands, use option `--show-sql-only`. "
             "If using options `--from-revision` or `--from-version`, you must also use `--show-sql-only`, "


### PR DESCRIPTION
Updated the documentation to emphasize that the `airflow db downgrade` command only downgrades the database schema and does not rewrite serialized metadata rows from newer Airflow versions. Added warnings about potential issues when downgrading and the importance of restoring a metadata database backup for a reliable rollback.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Document that `airflow db downgrade` only downgrades the metadata database schema and does not rewrite serialized metadata row contents written by newer Airflow versions.

This adds guidance for rollback scenarios such as Airflow 3.2.x to 3.1.x, where SDK-serialized metadata rows can remain in the database after a successful schema downgrade and older Airflow code may fail to deserialize them. The docs now recommend restoring a metadata database backup taken before the upgrade as the reliable rollback path, and note that manual cleanup of incompatible rows is deployment-specific and can cause data loss.

closes: #68317


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=2987bd6 action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @imrichardwu → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @imrichardwu — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->