### PR TITLE
Document that Dag bundle kwargs should reference a Connection, not inline credentials

### DIFF
--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -69,7 +69,7 @@ Dag bundles are configured in :ref:`config:dag_processor__dag_bundle_config_list
     configuration can read these values verbatim, so they must not contain secrets.
 
     Do **not** embed credentials directly in bundle ``kwargs`` — for example a
-    token inlined into a ``repo_url`` like
+    token placed directly in a ``repo_url`` like
     ``https://x-access-token:<token>@github.com/org/repo.git``. Instead reference
     an Airflow :doc:`Connection <../authoring-and-scheduling/connections>`
     (``git_conn_id`` for Git, ``aws_conn_id`` for S3, ``gcp_conn_id`` for GCS) and

--- a/airflow-core/docs/administration-and-deployment/dag-bundles.rst
+++ b/airflow-core/docs/administration-and-deployment/dag-bundles.rst
@@ -61,6 +61,24 @@ Configuring Dag bundles
 
 Dag bundles are configured in :ref:`config:dag_processor__dag_bundle_config_list`. You can add one or more Dag bundles here.
 
+.. warning:: Reference credentials through a Connection — do not inline them
+
+    Bundle ``kwargs`` are stored in the ``[dag_processor] dag_bundle_config_list``
+    configuration, which Airflow exposes through the Config API when
+    :ref:`config:api__expose_config` is enabled. Any user authorized to read the
+    configuration can read these values verbatim, so they must not contain secrets.
+
+    Do **not** embed credentials directly in bundle ``kwargs`` — for example a
+    token inlined into a ``repo_url`` like
+    ``https://x-access-token:<token>@github.com/org/repo.git``. Instead reference
+    an Airflow :doc:`Connection <../authoring-and-scheduling/connections>`
+    (``git_conn_id`` for Git, ``aws_conn_id`` for S3, ``gcp_conn_id`` for GCS) and
+    keep the credential in your
+    :doc:`secrets backend <../security/secrets/secrets-backend/index>`. Connection
+    fields are resolved at runtime and are not written into
+    ``dag_bundle_config_list``.
+
+
 By default, Airflow adds a ``LocalDagBundle`` pointing at the configured Dags folder, maintaining the same behaviour as Airflow 2's Dags folder. The only kwarg is ``path``, which defaults to the value of :ref:`config:core__dags_folder` when omitted:
 
 .. code-block:: ini


### PR DESCRIPTION
Adds guidance to the Dag bundles documentation that credentials for a Dag bundle should be supplied through an Airflow Connection (`git_conn_id` / `aws_conn_id` / `gcp_conn_id`) rather than inlined into the bundle `kwargs`.

`dag_bundle_config_list` is surfaced by the Config API when `[api] expose_config` is enabled, so a credential placed directly in a bundle's `kwargs` (for example a token embedded in `repo_url`) is readable by anyone authorized to read the configuration. Referencing a Connection keeps the credential in the secrets backend and out of the exposed configuration.

Docs-only change.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.8 (1M context)

Generated-by: Claude Opus 4.8 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
