### PR TITLE
Add additional task instance attributes to task instance's details section

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -302,11 +302,10 @@
       "class": "Trigger class",
       "createdAt": "Trigger creation time",
       "id": "Trigger ID",
+      "job": "Triggerer Job",
       "latestHeartbeat": "Latest triggerer heartbeat",
       "title": "Triggerer Info"
     },
-    "triggererJob": "Triggerer Job",
-    "tryNumber": "Try Number",
     "unixname": "Unix Name"
   },
   "taskInstance_one": "Task Instance",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -286,7 +286,7 @@
     "executor": "Executor",
     "executorConfig": "Executor Config",
     "hostname": "Hostname",
-    "id": "Task Instance ID",
+    "id": "ID",
     "maxTries": "Max Tries",
     "pid": "PID",
     "pool": "Pool",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -281,6 +281,7 @@
   "taskGroup_other": "Task Groups",
   "taskId": "Task ID",
   "taskInstance": {
+    "additionalAttributes": "Additional Task Instance Attributes",
     "dagVersion": "Dag Version",
     "executor": "Executor",
     "executorConfig": "Executor Config",
@@ -294,6 +295,7 @@
     "queuedWhen": "Queued At",
     "renderedMapIndex": "Rendered Map Index",
     "scheduledWhen": "Scheduled At",
+    "trigger": "Trigger",
     "triggerer": {
       "assigned": "Assigned triggerer",
       "class": "Trigger class",
@@ -302,6 +304,8 @@
       "latestHeartbeat": "Latest triggerer heartbeat",
       "title": "Triggerer Info"
     },
+    "triggererJob": "Triggerer Job",
+    "tryNumber": "Try Number",
     "unixname": "Unix Name"
   },
   "taskInstance_one": "Task Instance",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -286,6 +286,7 @@
     "executor": "Executor",
     "executorConfig": "Executor Config",
     "hostname": "Hostname",
+    "id": "Task Instance ID",
     "maxTries": "Max Tries",
     "pid": "PID",
     "pool": "Pool",

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, HStack, Table } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Table } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
 
@@ -84,6 +84,26 @@ export const Details = () => {
     },
   );
 
+  const renderValue = (value: unknown) => {
+    if (value === null || value === undefined || value === "") {
+      return translate("common:none", { defaultValue: "None" });
+    }
+
+    if (typeof value === "object") {
+      return JSON.stringify(value, undefined, 2);
+    }
+
+    return String(value);
+  };
+
+  const rawTaskInstanceDetails: Array<{ label: string; value: unknown }> = [
+    { label: "Try Number", value: tryInstance?.try_number },
+    { label: "Max Tries", value: tryInstance?.max_tries },
+    { label: "DAG ID", value: tryInstance?.dag_id },
+    { label: "Trigger", value: taskInstance?.trigger },
+    { label: "Triggerer Job", value: taskInstance?.triggerer_job },
+  ];
+
   return (
     <Box p={2}>
       {taskInstance === undefined || tryNumber === undefined || taskInstance.try_number <= 1 ? (
@@ -97,7 +117,7 @@ export const Details = () => {
       )}
       <ExtraLinks refetchInterval={isStatePending(tryInstance?.state) ? refetchInterval : false} />
       {taskInstance === undefined ||
-      ![null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
+        ![null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
         <BlockingDeps
           refetchInterval={isStatePending(tryInstance?.state) ? refetchInterval : false}
           taskInstance={taskInstance}
@@ -225,6 +245,27 @@ export const Details = () => {
           </Table.Row>
         </Table.Body>
       </Table.Root>
+      <Box mt={6}>
+        <Heading as="h3" size="sm" mb={3}>
+          Additional Task Instance Attributes
+        </Heading>
+
+        <Table.Root striped>
+          <Table.Body>
+            {rawTaskInstanceDetails.map(({ label, value }) => (
+              <Table.Row key={label}>
+                <Table.Cell>{label}</Table.Cell>
+                <Table.Cell
+                  whiteSpace="pre-wrap"
+                  fontFamily={typeof value === "object" ? "mono" : undefined}
+                >
+                  {renderValue(value)}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Root>
+      </Box>
     </Box>
   );
 };

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -104,11 +104,17 @@ export const Details = () => {
     return "";
   };
 
+  // omit kwargs from trigger
+  const triggerWithoutKwargs = taskInstance?.trigger
+    ? (({ kwargs, ...rest }) => rest)(taskInstance.trigger)
+    : undefined;
+
   const rawTaskInstanceDetails: Array<{ label: string; value: unknown }> = [
+    { label: translate("taskInstance.id"), value: taskInstance?.id },
     { label: translate("taskInstance.tryNumber"), value: tryInstance?.try_number },
     { label: translate("taskInstance.maxTries"), value: tryInstance?.max_tries },
     { label: translate("dagId"), value: tryInstance?.dag_id },
-    { label: translate("taskInstance.trigger"), value: taskInstance?.trigger },
+    { label: translate("taskInstance.trigger"), value: triggerWithoutKwargs },
     { label: translate("taskInstance.triggererJob"), value: taskInstance?.triggerer_job },
   ];
 

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { Box, Flex, Heading, HStack, Table } from "@chakra-ui/react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
 
@@ -25,6 +26,7 @@ import {
   useTaskInstanceServiceGetTaskInstanceTryDetails,
 } from "openapi/queries";
 import { DagVersionDetails } from "src/components/DagVersionDetails";
+import RenderedJsonField from "src/components/RenderedJsonField";
 import { StateBadge } from "src/components/StateBadge";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
 import Time from "src/components/Time";
@@ -84,9 +86,13 @@ export const Details = () => {
     },
   );
 
-  const renderValue = (value: unknown): string => {
+  const renderValue = (value: unknown): ReactNode => {
     if (value === null || value === undefined || value === "") {
       return translate("common:none", { defaultValue: "None" });
+    }
+
+    if (typeof value === "object") {
+      return <RenderedJsonField content={value} />;
     }
 
     if (typeof value === "string") {
@@ -97,11 +103,7 @@ export const Details = () => {
       return value.toString();
     }
 
-    if (typeof value === "object") {
-      return JSON.stringify(value, undefined, 2);
-    }
-
-    return "";
+    return translate("common:none", { defaultValue: "None" });
   };
 
   // omit kwargs from trigger
@@ -111,11 +113,11 @@ export const Details = () => {
 
   const rawTaskInstanceDetails: Array<{ label: string; value: unknown }> = [
     { label: translate("taskInstance.id"), value: taskInstance?.id },
-    { label: translate("taskInstance.tryNumber"), value: tryInstance?.try_number },
+    { label: translate("tryNumber"), value: tryInstance?.try_number },
     { label: translate("taskInstance.maxTries"), value: tryInstance?.max_tries },
     { label: translate("dagId"), value: tryInstance?.dag_id },
     { label: translate("taskInstance.trigger"), value: triggerWithoutKwargs },
-    { label: translate("taskInstance.triggererJob"), value: taskInstance?.triggerer_job },
+    { label: translate("taskInstance.triggerer.job"), value: taskInstance?.triggerer_job },
   ];
 
   return (
@@ -266,14 +268,21 @@ export const Details = () => {
 
         <Table.Root striped>
           <Table.Body>
-            {rawTaskInstanceDetails.map(({ label, value }) => (
-              <Table.Row key={label}>
-                <Table.Cell>{label}</Table.Cell>
-                <Table.Cell fontFamily={typeof value === "object" ? "mono" : undefined} whiteSpace="pre-wrap">
-                  {renderValue(value)}
-                </Table.Cell>
-              </Table.Row>
-            ))}
+            {rawTaskInstanceDetails.map(({ label, value }) => {
+              const isObject = typeof value === "object" && value !== null;
+
+              return (
+                <Table.Row key={label}>
+                  <Table.Cell>{label}</Table.Cell>
+                  <Table.Cell
+                    fontFamily={isObject ? undefined : "mono"}
+                    whiteSpace={isObject ? undefined : "pre-wrap"}
+                  >
+                    {renderValue(value)}
+                  </Table.Cell>
+                </Table.Row>
+              );
+            })}
           </Table.Body>
         </Table.Root>
       </Box>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -84,24 +84,32 @@ export const Details = () => {
     },
   );
 
-  const renderValue = (value: unknown) => {
+  const renderValue = (value: unknown): string => {
     if (value === null || value === undefined || value === "") {
       return translate("common:none", { defaultValue: "None" });
+    }
+
+    if (typeof value === "string") {
+      return value;
+    }
+
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return value.toString();
     }
 
     if (typeof value === "object") {
       return JSON.stringify(value, undefined, 2);
     }
 
-    return String(value);
+    return "";
   };
 
   const rawTaskInstanceDetails: Array<{ label: string; value: unknown }> = [
-    { label: "Try Number", value: tryInstance?.try_number },
-    { label: "Max Tries", value: tryInstance?.max_tries },
-    { label: "DAG ID", value: tryInstance?.dag_id },
-    { label: "Trigger", value: taskInstance?.trigger },
-    { label: "Triggerer Job", value: taskInstance?.triggerer_job },
+    { label: translate("taskInstance.tryNumber"), value: tryInstance?.try_number },
+    { label: translate("taskInstance.maxTries"), value: tryInstance?.max_tries },
+    { label: translate("dagId"), value: tryInstance?.dag_id },
+    { label: translate("taskInstance.trigger"), value: taskInstance?.trigger },
+    { label: translate("taskInstance.triggererJob"), value: taskInstance?.triggerer_job },
   ];
 
   return (
@@ -117,7 +125,7 @@ export const Details = () => {
       )}
       <ExtraLinks refetchInterval={isStatePending(tryInstance?.state) ? refetchInterval : false} />
       {taskInstance === undefined ||
-        ![null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
+      ![null, "queued", "scheduled"].includes(taskInstance.state) ? undefined : (
         <BlockingDeps
           refetchInterval={isStatePending(tryInstance?.state) ? refetchInterval : false}
           taskInstance={taskInstance}
@@ -246,8 +254,8 @@ export const Details = () => {
         </Table.Body>
       </Table.Root>
       <Box mt={6}>
-        <Heading as="h3" size="sm" mb={3}>
-          Additional Task Instance Attributes
+        <Heading as="h3" mb={3} size="sm">
+          {translate("taskInstance.additionalAttributes")}
         </Heading>
 
         <Table.Root striped>
@@ -255,10 +263,7 @@ export const Details = () => {
             {rawTaskInstanceDetails.map(({ label, value }) => (
               <Table.Row key={label}>
                 <Table.Cell>{label}</Table.Cell>
-                <Table.Cell
-                  whiteSpace="pre-wrap"
-                  fontFamily={typeof value === "object" ? "mono" : undefined}
-                >
+                <Table.Cell fontFamily={typeof value === "object" ? "mono" : undefined} whiteSpace="pre-wrap">
                   {renderValue(value)}
                 </Table.Cell>
               </Table.Row>


### PR DESCRIPTION
Closes: #67971

## What

This PR enhances the Airflow 3 Task Instance Details page by surfacing additional task instance metadata that was previously available in Airflow 2.

A new **Additional Task Instance Attributes** section has been added to the Details view, displaying:

* Try Number
* Max Tries
* DAG ID
* Trigger
* Triggerer Job

The PR also adds the corresponding translation strings for the new UI labels.

## Why

Airflow 3 exposes task retry history through the try selector, but some task instance metadata is not easily discoverable from the Details view.

This change surfaces additional task instance attributes such as Max Tries, DAG ID, Trigger, and Triggerer Job, making task debugging and troubleshooting easier while restoring information that was previously available in Airflow 2.

## Testing

Tested locally using Breeze and the Airflow UI.

Verified:

* Successful task instances display the new attributes section.
* Retrying tasks display updated Try Number and Max Tries values.
* Deferrable sensor tasks correctly surface Trigger and Triggerer Job information when applicable.
* Existing task details functionality remains unchanged.
* UI linting, formatting, and TypeScript compilation checks pass.

## Screenshots
<img width="1450" height="754" alt="additional task attributes - triggerer" src="https://github.com/user-attachments/assets/20c11e5c-54e5-4e37-8f2c-584cfd93eca6" />

Also, the screenshot in issue #67971 shows the "Dependencies Blocking Task From Getting Scheduled" section. This functionality is already present in Airflow 3. The section is displayed when a task is waiting for its upstream dependencies to complete and is hidden once the task is no longer blocked (for example, after the upstream tasks have completed).

Here's the screenshot of the same:
<img width="1506" height="757" alt="dependencies" src="https://github.com/user-attachments/assets/6a6469ef-6111-4a9c-a92b-87c43edc48e8" />


Was generative AI tooling used to co-author this PR?

[X] Yes 

Used ChatGPT to understand the codebase and assist with implementing the changes in Details.tsx.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=6c71049 action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @jayachandrakasarla → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @jayachandrakasarla — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->