### PR TITLE
Fix remote logging connection caching in Task SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1181,10 +1181,10 @@ def _fetch_remote_logging_conn(conn_id: str, client: Client) -> Connection | Non
         from airflow.sdk.definitions.connection import Connection
 
         result: Connection | None = Connection(**conn_result.model_dump(exclude={"type"}, by_alias=True))
+        _REMOTE_LOGGING_CONN_CACHE[conn_id] = result
     else:
         result = None
 
-    _REMOTE_LOGGING_CONN_CACHE[conn_id] = result
     return result
 
 


### PR DESCRIPTION
## Summary

- Fix remote logging connection caching in Task SDK to resolve regression in Airflow 3.2.2.
- Prevent caching of `None` results for connection lookups in the supervisor.

## Details

In the new two-token execution mechanism, a worker starts with a **workload-scoped token** which lacks permission to access connections. The connection preloading logic attempts to fetch connections, receives **None**, and was previously caching this empty result. Later, when the task runs and the worker's token is upgraded to an **execution-scoped token** (which has connection access), the system continued to use the cached **None** value, preventing hooks from finding the necessary credentials.

The fix modifies `_fetch_remote_logging_conn` in `task-sdk/src/airflow/sdk/execution_time/supervisor.py` to only cache truthy connection results. By not caching **None**, the worker is forced to re-attempt the connection lookup later (e.g., during log upload) when it has the correct token scope, allowing it to successfully retrieve the connection details.

## Testing

- Verified that `_fetch_remote_logging_conn` no longer caches **None** values when lookups fail.
- Verified that subsequent lookups successfully re-attempt connection retrieval.

Fixes: #68366
