### PR TITLE
Validate connection port range in ConnectionBody

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -191,7 +191,11 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(
+        default=None,
+        ge=1,
+        le=65535,
+    )
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -22,6 +22,7 @@ from importlib.metadata import PackageNotFoundError, metadata
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -2006,3 +2007,44 @@ class TestPostConnectionExtraBackwardCompatibility(TestConnectionEndpoint):
                 "method": "POST",
             },
         )
+
+
+def test_connection_body_port_validation():
+    with pytest.raises(ValidationError):
+        ConnectionBody(
+            connection_id="test_conn",
+            conn_type="http",
+            port=-1,
+        )
+
+    with pytest.raises(ValidationError):
+        ConnectionBody(
+            connection_id="test_conn",
+            conn_type="http",
+            port=0,
+        )
+
+    with pytest.raises(ValidationError):
+        ConnectionBody(
+            connection_id="test_conn",
+            conn_type="http",
+            port=65536,
+        )
+
+    ConnectionBody(
+        connection_id="test_conn",
+        conn_type="http",
+        port=1,
+    )
+
+    ConnectionBody(
+        connection_id="test_conn",
+        conn_type="http",
+        port=65535,
+    )
+
+    ConnectionBody(
+    connection_id="test_conn",
+    conn_type="http",
+    port=None,
+)


### PR DESCRIPTION
## What

Add validation for the `port` field in `ConnectionBody` to ensure only valid port numbers are accepted.

The valid range is now enforced as:

* Minimum: `1`
* Maximum: `65535`

## Why

Previously, invalid values such as negative numbers, `0`, or values greater than `65535` could be passed to the API model.

This change prevents invalid connection configurations from being accepted.

## Tests

Added unit tests covering:

* Invalid ports: `-1`, `0`, `65536`
* Valid ports: `1`, `65535`
* Optional value: `None`