### PR TITLE
Gate raw Dag deserialization error detail behind api.expose_stacktrace and log it server-side

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -116,9 +116,21 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
 
     def exception_handler(self, request: Request, exc: DeserializationError):
         """Handle Dag deserialization exceptions."""
+        if conf.get("api", "expose_stacktrace") == "True":
+            log.error("Error while trying to deserialize Dag: %s", exc, exc_info=exc)
+            detail = f"An error occurred while trying to deserialize Dag: {exc}"
+        else:
+            # Only mint a correlation id when the detail is redacted, so the
+            # generic client message can be tied back to the server-side log.
+            exception_id = get_random_string()
+            log.error("Error with id %s while trying to deserialize Dag: %s", exception_id, exc, exc_info=exc)
+            detail = (
+                "An error occurred while trying to deserialize the Dag. Check the api server "
+                f"logs for more details - look for ID {exception_id}."
+            )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"An error occurred while trying to deserialize Dag: {exc}",
+            detail=detail,
         )
 
 

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -406,6 +406,7 @@ class TestDagErrorHandler:
             "ValueError",
         ],
     )
+    @conf_vars({("api", "expose_stacktrace"): "True"})
     def test_handle_deserialization_error(self, cause: Exception) -> None:
         deserialization_error = DeserializationError("test_dag_id")
         deserialization_error.__cause__ = cause
@@ -418,6 +419,26 @@ class TestDagErrorHandler:
         with pytest.raises(HTTPException, match=re.escape(expected_exception.detail)):
             DagErrorHandler().exception_handler(Mock(), deserialization_error)
 
+    @conf_vars({("api", "expose_stacktrace"): "False"})
+    def test_handle_deserialization_error_without_stacktrace(self) -> None:
+        deserialization_error = DeserializationError("secret_dag_id")
+        deserialization_error.__cause__ = RuntimeError("internal credential leak xyz")
+
+        with patch("airflow.api_fastapi.common.exceptions.log") as mock_log:
+            with pytest.raises(HTTPException) as exc_info:
+                DagErrorHandler().exception_handler(Mock(), deserialization_error)
+
+        detail = exc_info.value.detail
+        assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        # Raw exception text is withheld when expose_stacktrace is off ...
+        assert str(deserialization_error) not in detail
+        assert "internal credential leak xyz" not in detail
+        # ... and the caller gets an id to correlate with the server-side log.
+        assert "look for ID" in detail
+        # The error is still logged server-side, so detail is not silently lost.
+        mock_log.error.assert_called_once()
+
+    @conf_vars({("api", "expose_stacktrace"): "True"})
     @pytest.mark.usefixtures("testing_dag_bundle")
     @pytest.mark.need_serialized_dag
     def test_handle_real_dag_deserialization_error(self, session: Session, dag_maker: DagMaker) -> None:


### PR DESCRIPTION
`DagErrorHandler` interpolated the raw `str(exc)` of a `DeserializationError` directly into the HTTP 500 `detail`, ignoring the `api.expose_stacktrace` setting that its sibling `_UniqueConstraintErrorHandler` already honors. This makes the two handlers consistent: the raw exception text is returned only when `expose_stacktrace` is enabled; otherwise the response carries a generic message plus a correlation id, and the full error is logged server-side (previously it was not logged at all).

- Gate the raw deserialization-error text behind `api.expose_stacktrace`, mirroring `_UniqueConstraintErrorHandler`.
- Log the error server-side with a correlation id so detail is not lost when not exposed.
- Tests: existing raw-detail cases now run under `expose_stacktrace=True`; a new case asserts the detail is withheld + an id is returned + the error is logged when off.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 4.8 (1M context)

Generated-by: Claude Opus 4.8 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
