### PR TITLE
UI: Add custom expiration datetime picker for task store modal

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskStore/TaskStoreModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskStore/TaskStoreModal.tsx
@@ -19,7 +19,7 @@
 import { Box, Button, Heading, Input, RadioCard, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import tz from "dayjs/plugin/timezone";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -79,6 +79,10 @@ export const TaskStoreModal = ({
   const [customExpiresAt, setCustomExpiresAt] = useState("");
   const isEditMode = mode === "edit";
   const isValueValid = isJsonValid(value);
+  const minDateTime = useMemo(
+    () => dayjs().tz(selectedTimezone).format("YYYY-MM-DDTHH:mm"),
+    [selectedTimezone],
+  );
 
   const { data: existingState, isLoading: isFetchingExisting } = useTaskStoreServiceGetTaskStore(
     { dagId, dagRunId: runId, key: storeKey ?? "", mapIndex, taskId },
@@ -92,11 +96,14 @@ export const TaskStoreModal = ({
       if (existingState.expires_at === null) {
         setExpiresAt("never");
       } else {
+        // The API always returns an absolute datetime — there is no way to distinguish
+        // the default value from value saved as custom datetime. Show it as
+        // Custom pre-filled with the resolved date so the user can adjust it.
         setExpiresAt("custom");
-        setCustomExpiresAt(existingState.expires_at);
+        setCustomExpiresAt(dayjs(existingState.expires_at).tz(selectedTimezone).format("YYYY-MM-DDTHH:mm"));
       }
     }
-  }, [existingState, isEditMode]);
+  }, [existingState, isEditMode, selectedTimezone]);
 
   const { isPending, mutate: setTaskStore } = useTaskStoreServiceSetTaskStore(
     useStoreMutation({
@@ -191,7 +198,7 @@ export const TaskStoreModal = ({
                 </RadioCard.Root>
                 {expiresAt === "custom" && (
                   <DateTimeInput
-                    min={dayjs().tz(selectedTimezone).format("YYYY-MM-DDTHH:mm")}
+                    min={minDateTime}
                     mt={2}
                     onChange={(ev) => setCustomExpiresAt(ev.target.value)}
                     value={customExpiresAt}

--- a/airflow-core/src/airflow/ui/src/pages/TaskStore/TaskStoreModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskStore/TaskStoreModal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Button, Heading, Input, RadioCard, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Flex, Heading, Input, RadioCard, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import tz from "dayjs/plugin/timezone";
 import { useEffect, useMemo, useState } from "react";
@@ -166,35 +166,41 @@ export const TaskStoreModal = ({
                   onValueChange={(ev) => setExpiresAt(ev.value as "custom" | "default" | "never")}
                   value={expiresAt}
                 >
-                  <RadioCard.Item value="default">
-                    <RadioCard.ItemHiddenInput />
-                    <RadioCard.ItemControl>
-                      <RadioCard.ItemContent>
-                        <RadioCard.ItemText>
-                          {translate("dag:taskStore.expiresAt.default", { interval: "30 days" })}
-                        </RadioCard.ItemText>
-                      </RadioCard.ItemContent>
-                      <RadioCard.ItemIndicator />
-                    </RadioCard.ItemControl>
-                  </RadioCard.Item>
-                  <RadioCard.Item value="never">
-                    <RadioCard.ItemHiddenInput />
-                    <RadioCard.ItemControl>
-                      <RadioCard.ItemContent>
-                        <RadioCard.ItemText>{translate("dag:taskStore.expiresAt.never")}</RadioCard.ItemText>
-                      </RadioCard.ItemContent>
-                      <RadioCard.ItemIndicator />
-                    </RadioCard.ItemControl>
-                  </RadioCard.Item>
-                  <RadioCard.Item value="custom">
-                    <RadioCard.ItemHiddenInput />
-                    <RadioCard.ItemControl>
-                      <RadioCard.ItemContent>
-                        <RadioCard.ItemText>{translate("dag:taskStore.expiresAt.custom")}</RadioCard.ItemText>
-                      </RadioCard.ItemContent>
-                      <RadioCard.ItemIndicator />
-                    </RadioCard.ItemControl>
-                  </RadioCard.Item>
+                  <Flex gap={2}>
+                    <RadioCard.Item flex={1} value="default">
+                      <RadioCard.ItemHiddenInput />
+                      <RadioCard.ItemControl>
+                        <RadioCard.ItemContent>
+                          <RadioCard.ItemText>
+                            {translate("dag:taskStore.expiresAt.default", { interval: "30 days" })}
+                          </RadioCard.ItemText>
+                        </RadioCard.ItemContent>
+                        <RadioCard.ItemIndicator />
+                      </RadioCard.ItemControl>
+                    </RadioCard.Item>
+                    <RadioCard.Item flex={1} value="never">
+                      <RadioCard.ItemHiddenInput />
+                      <RadioCard.ItemControl>
+                        <RadioCard.ItemContent>
+                          <RadioCard.ItemText>
+                            {translate("dag:taskStore.expiresAt.never")}
+                          </RadioCard.ItemText>
+                        </RadioCard.ItemContent>
+                        <RadioCard.ItemIndicator />
+                      </RadioCard.ItemControl>
+                    </RadioCard.Item>
+                    <RadioCard.Item flex={1} value="custom">
+                      <RadioCard.ItemHiddenInput />
+                      <RadioCard.ItemControl>
+                        <RadioCard.ItemContent>
+                          <RadioCard.ItemText>
+                            {translate("dag:taskStore.expiresAt.custom")}
+                          </RadioCard.ItemText>
+                        </RadioCard.ItemContent>
+                        <RadioCard.ItemIndicator />
+                      </RadioCard.ItemControl>
+                    </RadioCard.Item>
+                  </Flex>
                 </RadioCard.Root>
                 {expiresAt === "custom" && (
                   <DateTimeInput

--- a/airflow-core/src/airflow/ui/src/pages/TaskStore/TaskStoreModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskStore/TaskStoreModal.tsx
@@ -17,6 +17,8 @@
  * under the License.
  */
 import { Box, Button, Heading, Input, RadioCard, Text, VStack } from "@chakra-ui/react";
+import dayjs from "dayjs";
+import tz from "dayjs/plugin/timezone";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -26,9 +28,13 @@ import {
   useTaskStoreServiceListTaskStoreKey,
   useTaskStoreServiceSetTaskStore,
 } from "openapi/queries";
+import { DateTimeInput } from "src/components/DateTimeInput";
 import { JsonEditor } from "src/components/JsonEditor";
 import { Dialog, ProgressBar } from "src/components/ui";
+import { useTimezone } from "src/context/timezone";
 import { useStoreMutation } from "src/queries/useStoreMutation";
+
+dayjs.extend(tz);
 
 type Props = {
   readonly dagId: string;
@@ -66,9 +72,11 @@ export const TaskStoreModal = ({
   taskId,
 }: Props) => {
   const { t: translate } = useTranslation(["dag", "common"]);
+  const { selectedTimezone } = useTimezone();
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
-  const [expiresAt, setExpiresAt] = useState<"default" | "never">("default");
+  const [expiresAt, setExpiresAt] = useState<"custom" | "default" | "never">("default");
+  const [customExpiresAt, setCustomExpiresAt] = useState("");
   const isEditMode = mode === "edit";
   const isValueValid = isJsonValid(value);
 
@@ -81,7 +89,12 @@ export const TaskStoreModal = ({
   useEffect(() => {
     if (isEditMode && existingState !== undefined) {
       setValue(JSON.stringify(existingState.value, null, 2));
-      setExpiresAt(existingState.expires_at === null ? "never" : "default");
+      if (existingState.expires_at === null) {
+        setExpiresAt("never");
+      } else {
+        setExpiresAt("custom");
+        setCustomExpiresAt(existingState.expires_at);
+      }
     }
   }, [existingState, isEditMode]);
 
@@ -100,7 +113,10 @@ export const TaskStoreModal = ({
       dagRunId: runId,
       key: isEditMode ? (storeKey ?? "") : key,
       mapIndex,
-      requestBody: { expires_at: expiresAt === "never" ? null : "default", value: JSON.parse(value) },
+      requestBody: {
+        expires_at: expiresAt === "never" ? null : expiresAt === "custom" ? customExpiresAt : "default",
+        value: JSON.parse(value),
+      },
       taskId,
     });
   };
@@ -140,7 +156,7 @@ export const TaskStoreModal = ({
                   {translate("dag:taskStore.expiresAt.label")}
                 </Text>
                 <RadioCard.Root
-                  onValueChange={(ev) => setExpiresAt(ev.value as "default" | "never")}
+                  onValueChange={(ev) => setExpiresAt(ev.value as "custom" | "default" | "never")}
                   value={expiresAt}
                 >
                   <RadioCard.Item value="default">
@@ -163,8 +179,7 @@ export const TaskStoreModal = ({
                       <RadioCard.ItemIndicator />
                     </RadioCard.ItemControl>
                   </RadioCard.Item>
-                  {/* TODO: Add a datetime picker for custom expiry once a picker component is available */}
-                  <RadioCard.Item disabled value="custom">
+                  <RadioCard.Item value="custom">
                     <RadioCard.ItemHiddenInput />
                     <RadioCard.ItemControl>
                       <RadioCard.ItemContent>
@@ -174,6 +189,14 @@ export const TaskStoreModal = ({
                     </RadioCard.ItemControl>
                   </RadioCard.Item>
                 </RadioCard.Root>
+                {expiresAt === "custom" && (
+                  <DateTimeInput
+                    min={dayjs().tz(selectedTimezone).format("YYYY-MM-DDTHH:mm")}
+                    mt={2}
+                    onChange={(ev) => setCustomExpiresAt(ev.target.value)}
+                    value={customExpiresAt}
+                  />
+                )}
               </Box>
             </VStack>
           )}
@@ -183,7 +206,12 @@ export const TaskStoreModal = ({
             {translate("common:modal.cancel")}
           </Button>
           <Button
-            disabled={isFetchingExisting || !isValueValid || (!isEditMode && key === "")}
+            disabled={
+              isFetchingExisting ||
+              !isValueValid ||
+              (!isEditMode && key === "") ||
+              (expiresAt === "custom" && !customExpiresAt)
+            }
             loading={isPending}
             onClick={onSave}
           >


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes claude sonnet

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---

### What

The "Custom" expiration option in the Add/Edit Task Store modal was stubbed out and disabled, with a TODO comment waiting for a datetime picker component. `DateTimeInput` already existed but wasn't wired up.

<img width="1978" height="1512" alt="image (89)" src="https://github.com/user-attachments/assets/ab92af8d-fee4-4e71-98df-4b8eb0ead489" />


### Current behaviour

The "Custom" radio card in the Expiration section is disabled. Users can only choose "Default (30 days)" or "Never" — there is no way to set an arbitrary expiration datetime via the UI.

### Proposed change

Enables the "Custom" option and renders a `DateTimeInput` below the radio group when it is selected. The picker respects the user's selected Airflow timezone and enforces a `min` of the current time so past datetimes cannot be chosen. The selected datetime is sent to the core API as an ISO 8601 string. Edit mode hydrates the picker correctly when an existing entry has a specific `expires_at`.

The Save button remains disabled until a date is entered when "Custom" is selected.

### Testing

Adding a new task store

<img width="2554" height="1049" alt="image" src="https://github.com/user-attachments/assets/e3275534-ee16-4f4f-a4c6-dae29ea39bc3" />


After its added

<img width="2554" height="1049" alt="image" src="https://github.com/user-attachments/assets/5934fb86-e8e1-41cc-85a3-6fe09ba68be4" />


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
