### PR TITLE
UI: Add a column in asset store display table linking to the TI that wrote it

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/assets.json
@@ -14,6 +14,8 @@
     "edit": "Edit Asset Store",
     "emptyState": "Asset store stores values scoped to an asset identity, shared across all Dag runs. Workers can write asset store via the Task SDK.",
     "lastUpdatedBy": "Last Updated By",
+    "lastUpdatedByApi": "API",
+    "lastUpdatedByWatcher": "Watcher",
     "title": "Asset Store"
   },
   "consumingDags": "Consuming Dags",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/assets.json
@@ -13,6 +13,7 @@
     "deleteWarning": "The asset will lose this persisted store entry.",
     "edit": "Edit Asset Store",
     "emptyState": "Asset store stores values scoped to an asset identity, shared across all Dag runs. Workers can write asset store via the Task SDK.",
+    "lastUpdatedBy": "Last Updated By",
     "title": "Asset Store"
   },
   "consumingDags": "Consuming Dags",

--- a/airflow-core/src/airflow/ui/src/pages/Asset/AssetStore/AssetStore.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/AssetStore/AssetStore.tsx
@@ -22,17 +22,29 @@ import { useTranslation } from "react-i18next";
 import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { useAssetStoreServiceListAssetStore } from "openapi/queries";
-import type { AssetStoreResponse } from "openapi/requests";
+import type { AssetStoreLastUpdatedBy, AssetStoreResponse } from "openapi/requests";
 import { DataTable } from "src/components/DataTable";
 import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { StoreValueCell } from "src/components/StoreValueCell";
 import Time from "src/components/Time";
+import { getTaskInstanceLink } from "src/utils/links";
 
 import { AddAssetStoreButton } from "./AddAssetStoreButton";
 import { ClearAllAssetStoreButton } from "./ClearAllAssetStoreButton";
 import { DeleteAssetStoreButton } from "./DeleteAssetStoreButton";
 import { EditAssetStoreButton } from "./EditAssetStoreButton";
+
+type TaskWriter = { dag_id: string; run_id: string; task_id: string } & AssetStoreLastUpdatedBy;
+
+const isTaskWriter = (writer: AssetStoreLastUpdatedBy): writer is TaskWriter =>
+  writer.kind === "task" &&
+  writer.dag_id !== null &&
+  writer.dag_id !== undefined &&
+  writer.run_id !== null &&
+  writer.run_id !== undefined &&
+  writer.task_id !== null &&
+  writer.task_id !== undefined;
 
 type ColumnsProps = {
   readonly assetId: number;
@@ -64,17 +76,13 @@ const getColumns = ({ assetId, translate }: ColumnsProps): Array<ColumnDef<Asset
       if (!writer) {
         return <Text color="fg.muted">—</Text>;
       }
-      if (
-        writer.kind === "task" &&
-        writer.dag_id !== null &&
-        writer.run_id !== null &&
-        writer.task_id !== null
-      ) {
-        const mapSuffix =
-          writer.map_index !== null && writer.map_index !== undefined && writer.map_index >= 0
-            ? `/mapped/${writer.map_index}`
-            : "";
-        const path = `/dags/${writer.dag_id}/runs/${writer.run_id}/tasks/${writer.task_id}${mapSuffix}`;
+      if (isTaskWriter(writer)) {
+        const path = getTaskInstanceLink({
+          dagId: writer.dag_id,
+          dagRunId: writer.run_id,
+          mapIndex: writer.map_index ?? undefined,
+          taskId: writer.task_id,
+        });
 
         return (
           <Flex direction="column">
@@ -88,7 +96,13 @@ const getColumns = ({ assetId, translate }: ColumnsProps): Array<ColumnDef<Asset
         );
       }
 
-      return <Text>{writer.kind === "api" ? "API" : "Watcher"}</Text>;
+      return (
+        <Text>
+          {writer.kind === "api"
+            ? translate("assets:assetStore.lastUpdatedByApi")
+            : translate("assets:assetStore.lastUpdatedByWatcher")}
+        </Text>
+      );
     },
     enableSorting: false,
     header: translate("assets:assetStore.lastUpdatedBy"),

--- a/airflow-core/src/airflow/ui/src/pages/Asset/AssetStore/AssetStore.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/AssetStore/AssetStore.tsx
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Flex, Text } from "@chakra-ui/react";
+import { Flex, Link, Text } from "@chakra-ui/react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
+import { Link as RouterLink, useParams } from "react-router-dom";
 
 import { useAssetStoreServiceListAssetStore } from "openapi/queries";
 import type { AssetStoreResponse } from "openapi/requests";
@@ -55,6 +55,43 @@ const getColumns = ({ assetId, translate }: ColumnsProps): Array<ColumnDef<Asset
     accessorKey: "updated_at",
     cell: ({ row: { original } }) => <Time datetime={original.updated_at} />,
     header: translate("common:table.updatedAt"),
+  },
+  {
+    accessorKey: "last_updated_by",
+    cell: ({ row: { original } }) => {
+      const writer = original.last_updated_by;
+
+      if (!writer) {
+        return <Text color="fg.muted">—</Text>;
+      }
+      if (
+        writer.kind === "task" &&
+        writer.dag_id !== null &&
+        writer.run_id !== null &&
+        writer.task_id !== null
+      ) {
+        const mapSuffix =
+          writer.map_index !== null && writer.map_index !== undefined && writer.map_index >= 0
+            ? `/mapped/${writer.map_index}`
+            : "";
+        const path = `/dags/${writer.dag_id}/runs/${writer.run_id}/tasks/${writer.task_id}${mapSuffix}`;
+
+        return (
+          <Flex direction="column">
+            <Link asChild color="fg.info">
+              <RouterLink to={path}>{writer.task_id}</RouterLink>
+            </Link>
+            <Text color="fg.muted" fontSize="xs">
+              {writer.dag_id}
+            </Text>
+          </Flex>
+        );
+      }
+
+      return <Text>{writer.kind === "api" ? "API" : "Watcher"}</Text>;
+    },
+    enableSorting: false,
+    header: translate("assets:assetStore.lastUpdatedBy"),
   },
   {
     accessorKey: "actions",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes: claude sonnet

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---

### What

The Asset Store table had no visibility into what wrote each entry. When a task updates an asset store value via the execution API, there was no way to trace which task instance was responsible from the UI.

### Current behaviour

The Asset Store table shows key, value, and updated-at timestamp but no information about what wrote the entry.

### Proposed change

Adds a "Last Updated By" column to the Asset Store table. When an entry was written by a task, it renders the task ID as a clickable link to the task instance page (`/dags/{dag_id}/runs/{run_id}/tasks/{task_id}`) with the Dag ID shown as a muted subtitle. Mapped task instances link to the mapped variant path. API and watcher writes show plain "API" or "Watcher" text.

### Changes of Note

The `AssetStoreWriterKind` enum values in the OpenAPI-generated types are lowercase (`'task' | 'watcher' | 'api'`), matching what the API returns. Comparisons must use lowercase string literals accordingly.

### Some screenshots

<img width="1783" height="1049" alt="image" src="https://github.com/user-attachments/assets/c17abc0b-e485-40bf-94e0-2fd42686a0ae" />

Clicking on the link leads to TI logs page

<img width="1783" height="1049" alt="image" src="https://github.com/user-attachments/assets/0403d7be-014a-465d-9a58-e24aff14d623" />



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
