### PR TITLE
Improve HITL form UX

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -28,6 +28,28 @@ import { Accordion } from "../ui";
 import { Row } from "./Row";
 import { isRequired } from "./isParamRequired";
 
+const FlatSection = ({
+  children,
+  hasError,
+  title,
+}: {
+  readonly children: React.ReactNode;
+  readonly hasError: boolean;
+  readonly title: string;
+}) => (
+  <Stack gap={2}>
+    <Text color={hasError ? "fg.error" : undefined} fontWeight="medium">
+      {title}
+      {hasError ? (
+        <Icon color="fg.error" margin="-1" ml={1}>
+          <MdError />
+        </Icon>
+      ) : undefined}
+    </Text>
+    {children}
+  </Stack>
+);
+
 const computeSectionErrors = (
   params: Record<string, ParamSpec>,
   defaultSection: string,
@@ -54,6 +76,7 @@ export type FlexibleFormProps = {
   readonly isHITL?: boolean;
   readonly key?: string;
   readonly namespace?: string;
+  readonly noAccordion?: boolean;
   readonly setError: (error: boolean) => void;
   readonly subHeader?: string;
 };
@@ -65,6 +88,7 @@ export const FlexibleForm = ({
   initialParamsDict,
   isHITL,
   namespace = "default",
+  noAccordion,
   setError,
   subHeader,
 }: FlexibleFormProps) => {
@@ -110,6 +134,51 @@ export const FlexibleForm = ({
     setSectionError(newSectionError);
     setError(Boolean(error) || newSectionError.size > 0);
   };
+
+  if (noAccordion) {
+    return Object.keys(params).length > 0 ? (
+      <>
+        {Object.entries(params).map(([, secParam]) => {
+          const currentSection = secParam.schema.section ?? flexibleFormDefaultSection;
+
+          if (processedSections.has(currentSection)) {
+            return undefined;
+          }
+          processedSections.set(currentSection, true);
+
+          return (
+            <FlatSection
+              hasError={Boolean(sectionError.get(currentSection))}
+              key={currentSection}
+              title={currentSection}
+            >
+              {Boolean(subHeader) ? (
+                <Text color="fg.muted" fontSize="xs">
+                  {subHeader}
+                </Text>
+              ) : undefined}
+              <Stack separator={<StackSeparator py={2} />}>
+                {Boolean(flexFormDescription) ? (
+                  <ReactMarkdown>{flexFormDescription}</ReactMarkdown>
+                ) : undefined}
+                {Object.entries(params)
+                  .filter(
+                    ([, param]) =>
+                      param.schema.section === currentSection ||
+                      (currentSection === flexibleFormDefaultSection && !Boolean(param.schema.section)),
+                  )
+                  .map(([name]) => (
+                    <Row key={name} name={name} namespace={namespace} onUpdate={onUpdate} />
+                  ))}
+              </Stack>
+            </FlatSection>
+          );
+        })}
+      </>
+    ) : isHITL && Boolean(flexFormDescription) ? (
+      <ReactMarkdown>{flexFormDescription}</ReactMarkdown>
+    ) : undefined;
+  }
 
   return Object.keys(params).length > 0 ? (
     Object.entries(params).map(([, secParam]) => {

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -175,8 +175,13 @@ export const FlexibleForm = ({
           );
         })}
       </>
-    ) : isHITL && Boolean(flexFormDescription) ? (
-      <ReactMarkdown>{flexFormDescription}</ReactMarkdown>
+    ) : isHITL ? (
+      <FlatSection
+        hasError={Boolean(sectionError.get(flexibleFormDefaultSection))}
+        title={flexibleFormDefaultSection}
+      >
+        {Boolean(flexFormDescription) ? <ReactMarkdown>{flexFormDescription}</ReactMarkdown> : undefined}
+      </FlatSection>
     ) : undefined;
   }
 

--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewBadge.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewBadge.tsx
@@ -43,7 +43,7 @@ export const NeedsReviewBadge = ({ dagId, pendingActions }: Props) => {
         data-testid="needs-review-badge"
         to={`/dags/${dagId}/required_actions?${SearchParamsKeys.RESPONSE_RECEIVED}=false`}
       >
-        <StateBadge colorPalette="deferred" fontSize="md" variant="solid">
+        <StateBadge colorPalette="awaiting_input" fontSize="md" variant="solid">
           <LuUserRoundPen />
           {pendingActions.length}
         </StateBadge>

--- a/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/NeedsReviewButton.tsx
@@ -58,7 +58,7 @@ export const NeedsReviewButton = ({
   return hitlTIsCount > 0 ? (
     <Box maxW="250px">
       <StatsCard
-        colorScheme="deferred"
+        colorScheme="awaiting_input"
         count={hitlTIsCount}
         icon={<LuUserRoundPen />}
         isLoading={isLoading}

--- a/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
+++ b/airflow-core/src/airflow/ui/src/constants/filterConfigs.tsx
@@ -280,7 +280,7 @@ export const useFilterConfigs = () => {
       options: [
         { label: translate("hitl:filters.response.all"), value: "all" },
         {
-          label: <StateBadge state="deferred">{translate("hitl:filters.response.pending")}</StateBadge>,
+          label: <StateBadge state="awaiting_input">{translate("hitl:filters.response.pending")}</StateBadge>,
           value: "false",
         },
         {

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
@@ -36,7 +36,7 @@ export const RequiredActionFilter = ({ needsReview, onToggle }: Props) => {
       onClick={onToggle}
       variant={needsReview ? "solid" : "outline"}
     >
-      <StateBadge colorPalette="deferred">
+      <StateBadge state="awaiting_input">
         <LuUserRoundPen />
       </StateBadge>
       {translate("requiredAction_other")}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsFilters/RequiredActionFilter.tsx
@@ -18,7 +18,6 @@
  */
 import { Button } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
-import { LuUserRoundPen } from "react-icons/lu";
 
 import { StateBadge } from "src/components/StateBadge";
 
@@ -36,9 +35,7 @@ export const RequiredActionFilter = ({ needsReview, onToggle }: Props) => {
       onClick={onToggle}
       variant={needsReview ? "solid" : "outline"}
     >
-      <StateBadge state="awaiting_input">
-        <LuUserRoundPen />
-      </StateBadge>
+      <StateBadge state="awaiting_input" />
       {translate("requiredAction_other")}
     </Button>
   );

--- a/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/HITLTaskInstances/HITLResponseForm.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, Box, Spacer, HStack, Accordion, Text } from "@chakra-ui/react";
+import { Button, Box, Spacer, HStack, Text } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FiSend } from "react-icons/fi";
@@ -108,14 +108,7 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
             : undefined}
         </Text>
       ) : undefined}
-      <Accordion.Root
-        defaultValue={[hitlDetail.subject]}
-        mb={4}
-        mt={4}
-        overflow="visible"
-        size="lg"
-        variant="enclosed"
-      >
+      <Box mb={4} mt={4} overflow="visible">
         <FlexibleForm
           disabled={!isPending || hitlDetail.response_received}
           flexFormDescription={hitlDetail.body ?? undefined}
@@ -126,9 +119,10 @@ export const HITLResponseForm = ({ hitlDetail }: HITLResponseFormProps) => {
           isHITL
           key={hitlDetail.subject}
           namespace="hitl"
+          noAccordion
           setError={setErrors}
         />
-      </Accordion.Root>
+      </Box>
 
       <Box as="footer" display="flex" justifyContent="flex-end" mt={4}>
         <HStack w="full">

--- a/airflow-core/src/airflow/ui/src/queries/useUpdateHITLDetail.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useUpdateHITLDetail.ts
@@ -26,6 +26,7 @@ import {
   UseGanttServiceGetGanttDataKeyFn,
   useTaskInstanceServiceGetHitlDetailsKey,
   useTaskInstanceServiceGetHitlDetailKey,
+  useTaskInstanceServiceGetHitlDetailTryDetailKey,
   useTaskInstanceServiceUpdateHitlDetail,
   useTaskInstanceServiceGetTaskInstanceKey,
   useTaskInstanceServiceGetTaskInstancesKey,
@@ -58,6 +59,7 @@ export const useUpdateHITLDetail = ({
       [useTaskInstanceServiceGetTaskInstanceKey, { dagId, dagRunId, mapIndex, taskId }],
       [useTaskInstanceServiceGetHitlDetailsKey, { dagIdPrefixPattern: dagId, dagRunId }],
       [useTaskInstanceServiceGetHitlDetailKey, { dagId, dagRunId }],
+      [useTaskInstanceServiceGetHitlDetailTryDetailKey, { dagId, dagRunId }],
       UseGanttServiceGetGanttDataKeyFn({ dagId, runId: dagRunId }),
       ...tiPerAttemptQueryKeys,
     ];

--- a/airflow-core/src/airflow/ui/src/utils/hitl.ts
+++ b/airflow-core/src/airflow/ui/src/utils/hitl.ts
@@ -120,7 +120,7 @@ export const getHITLParamsDict = (
       const paramData = hitlDetail.params[key] as ParamsSpec | undefined;
 
       // Check if there's a preloaded value from URL params
-      let finalValue = hitlDetail.params_input?.[key] ?? value;
+      let finalValue = hitlDetail.params_input?.[key] ?? paramData?.value ?? value;
 
       // If preloaded value is a string that might be JSON, try to parse it
       if (typeof finalValue === "string" && finalValue.trim().startsWith("{")) {

--- a/airflow-core/src/airflow/ui/src/utils/hitl.ts
+++ b/airflow-core/src/airflow/ui/src/utils/hitl.ts
@@ -76,7 +76,7 @@ export const getHITLParamsDict = (
   searchParams: URLSearchParams,
 ): ParamsSpec => {
   const paramsDict: ParamsSpec = {};
-  const { preloadedHITLOptions, preloadedHITLParams } = getPreloadHITLFormData(searchParams, hitlDetail);
+  const { preloadedHITLOptions } = getPreloadHITLFormData(searchParams, hitlDetail);
   const isApprovalTask =
     hitlDetail.options.includes("Approve") &&
     hitlDetail.options.includes("Reject") &&
@@ -120,7 +120,7 @@ export const getHITLParamsDict = (
       const paramData = hitlDetail.params[key] as ParamsSpec | undefined;
 
       // Check if there's a preloaded value from URL params
-      let finalValue = preloadedHITLParams[key] ?? value;
+      let finalValue = hitlDetail.params_input?.[key] ?? value;
 
       // If preloaded value is a string that might be JSON, try to parse it
       if (typeof finalValue === "string" && finalValue.trim().startsWith("{")) {
@@ -170,7 +170,7 @@ export const getHITLParamsDict = (
       paramsDict[key] = {
         description,
         schema,
-        value: paramData?.value ?? finalValue,
+        value: finalValue ?? paramData?.value,
       };
     });
   }


### PR DESCRIPTION
Our HITL was never great, while https://github.com/apache/airflow/pull/68346 is doing a full modal overhaul. This PR removed the accordion from the hitl forms since it was not needed. Also, make sure that responses are actually rendered in a disabled form when looking at older actions.

Also, fixed a mismatched colors for the Dags List filter button


<img width="634" height="493" alt="Screenshot 2026-06-11 at 11 26 27 AM" src="https://github.com/user-attachments/assets/cb7a8dec-9297-47cb-a6fe-52061d545995" />
<img width="647" height="496" alt="Screenshot 2026-06-11 at 11 26 22 AM" src="https://github.com/user-attachments/assets/8538807f-d979-49ea-86f9-3ebcec5c4fdf" />




---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Clause Sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
