### PR TITLE
Add missing Polish (pl) UI translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/assets.json
@@ -4,6 +4,19 @@
   "asset_many": "Zasobów",
   "asset_one": "Zasób",
   "asset_other": "Zasoby",
+  "assetStore": {
+    "add": "Dodaj magazyn zasobów",
+    "clearAll": {
+      "resource": "cały magazyn zasobów",
+      "title": "Wyczyść cały magazyn zasobów",
+      "warning": "Cały magazyn zasobów zostanie wyczyszczony. Zadania, które używają tego magazynu do koordynowania pracy, utracą swoje zapisane dane."
+    },
+    "delete": "Usuń magazyn zasobów",
+    "deleteWarning": "Zasób utraci ten zapisany wpis magazynu.",
+    "edit": "Edytuj magazyn zasobów",
+    "emptyState": "Magazyn zasobów przechowuje wartości powiązane z identyfikatorem zasobu, współdzielone między wszystkimi uruchomieniami Dagów. Procesy robocze mogą zapisywać do magazynu zasobów za pomocą Task SDK.",
+    "title": "Magazyn zasobów"
+  },
   "consumingDags": "Przetwarzanie Dagów",
   "consumingTasks": "Przetwarzanie zadań",
   "createEvent": {
@@ -27,6 +40,7 @@
     },
     "title": "Utwórz zdarzenie zasobu dla {{name}}"
   },
+  "events": "Zdarzenia",
   "extra": "Dodatkowe",
   "group": "Grupa",
   "lastAssetEvent": "Ostatnie zdarzenie zasobu",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/browse.json
@@ -11,6 +11,26 @@
     },
     "title": "Dziennik audytu"
   },
+  "deadlines": {
+    "columns": {
+      "alertName": "Nazwa alertu",
+      "deadlineTime": "Czas terminu",
+      "status": "Stan"
+    },
+    "deadline_few": "Terminy",
+    "deadline_many": "Terminów",
+    "deadline_one": "Termin",
+    "deadline_other": "Terminów",
+    "filters": {
+      "status": "Stan",
+      "statusOptions": {
+        "all": "Wszystkie",
+        "missed": "Niedotrzymane",
+        "pending": "Oczekujące"
+      }
+    },
+    "title": "Terminy"
+  },
   "xcom": {
     "add": {
       "error": "Nie udało się dodać XCom",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -22,12 +22,16 @@
   "assetEvent_many": "Zdarzeń zasobów",
   "assetEvent_one": "Zdarzenie Zasobu",
   "assetEvent_other": "Zdarzenia Zasobów",
+  "assetInactive": {
+    "tooltip": "Zasób nadrzędny został deaktywowany; harmonogram wstrzymuje ocenę partycji do czasu jego ponownej aktywacji."
+  },
   "backfill_few": "Wypełnienia wsteczne",
   "backfill_many": "Wypełnień wstecznych",
   "backfill_one": "Wypełnienie wsteczne",
   "backfill_other": "Wypełnienia wsteczne",
   "browse": {
     "auditLog": "Log audytu",
+    "deadlines": "Terminy",
     "jobs": "Zadania",
     "requiredActions": "Wymagane akcje",
     "xcoms": "XComy"
@@ -154,6 +158,7 @@
     "startTime": "Czas rozpoczęcia"
   },
   "generateToken": "Wygeneruj token",
+  "key": "Klucz",
   "logicalDate": "Data logiczna",
   "logout": "Wyloguj",
   "logoutConfirmation": "Zamierzasz wylogować się z aplikacji.",
@@ -187,6 +192,7 @@
     "placeholder": "Dodaj notatkę...",
     "taskInstance": "Notatka instancji zadania"
   },
+  "overallStatus": "Stan ogólny",
   "partitionedDagRun_few": "Partycjonowane wykonania Dagów",
   "partitionedDagRun_many": "Partycjonowanych wykonań Dagów",
   "partitionedDagRun_one": "Partycjonowane wykonanie Daga",
@@ -243,6 +249,7 @@
   "startDate": "Data rozpoczęcia",
   "state": "Stan",
   "states": {
+    "awaiting_input": "Oczekuje na dane wejściowe",
     "deferred": "Odłożone",
     "failed": "Niepowodzenie",
     "no_status": "Brak stanu",
@@ -277,18 +284,25 @@
       "any": "Dowolne"
     },
     "tagPlaceholder": "Filtruj według etykiety",
-    "to": "Do"
+    "to": "Do",
+    "updatedAt": "Zaktualizowano"
   },
   "task": {
+    "dependsOnPast": "Zależy od przeszłych uruchomień",
     "documentation": "Dokumentacja zadania",
     "lastInstance": "Ostatnia instancja zadania",
     "operator": "Operator",
-    "triggerRule": "Reguła zależności"
+    "retries": "Ponowne próby",
+    "triggerRule": "Reguła zależności",
+    "waitForDownstream": "Czekaj na zadania podrzędne"
   },
   "task_few": "Zadania",
   "task_many": "Zadań",
   "task_one": "Zadanie",
   "task_other": "Zadania",
+  "taskGroup": {
+    "documentation": "Dokumentacja grupy zadań"
+  },
   "taskGroup_few": "Grupy zadań",
   "taskGroup_many": "Grup zadań",
   "taskGroup_one": "Grupa zadań",
@@ -306,6 +320,7 @@
     "priorityWeight": "Waga priorytetu",
     "queue": "Kolejka",
     "queuedWhen": "Zakolejkowano o",
+    "renderedMapIndex": "Wyrenderowany indeks mapowania",
     "scheduledWhen": "Zaplanowano o",
     "triggerer": {
       "assigned": "Przypisany wyzwalacz",
@@ -410,6 +425,7 @@
     "mustBeAtLeast": "Musi wynosić co najmniej {{min}}.",
     "mustBeValidNumber": "Musi być prawidłową liczbą."
   },
+  "value": "Wartość",
   "wrap": {
     "hotkey": "w",
     "tooltip": "Wybierz {{hotkey}} aby przełączyć zawijanie",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -17,6 +17,7 @@
     "reprocessBehavior": "Zachowanie ponownego przetwarzania",
     "run": "Uruchom ponowne przetwarzanie",
     "scheduleNotBackfillable": "Harmonogram tego Daga nie obsługuje wypełnień wstecznych",
+    "schedulerPriorityHint": "Uruchomienia wypełnienia wstecznego są szeregowane po uruchomieniach niebędących wypełnieniem wstecznym w każdym cyklu harmonogramu. Uruchomienia wypełnienia wstecznego mogą dłużej pozostawać w kolejce, jeśli obecne są inne uruchomienia niebędące wypełnieniem wstecznym.",
     "selectDescription": "Uruchom ten Dag dla zakresu dat",
     "selectLabel": "Wypełnienie wsteczne",
     "title": "Uruchom uzupełnienie wsteczne",
@@ -83,6 +84,7 @@
     "files_other": "{{count}} plików"
   },
   "flexibleForm": {
+    "durationPlaceholder": "Wprowadź czas trwania w formacie ISO 8601",
     "placeholder": "Wybierz wartość",
     "placeholderArray": "Wprowadź każdy ciąg w nowej linii",
     "placeholderExamples": "Zacznij pisać, aby zobaczyć opcje",
@@ -90,6 +92,7 @@
     "validationErrorArrayNotArray": "Wartość musi być tablicą.",
     "validationErrorArrayNotNumbers": "Wszystkie elementy w tablicy muszą być liczbami.",
     "validationErrorArrayNotObject": "Wszystkie elementy w tablicy muszą być obiektami.",
+    "validationErrorDuration": "Nieprawidłowy format czasu trwania ISO 8601",
     "validationErrorRequired": "To pole jest wymagane"
   },
   "graph": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -261,7 +261,7 @@
     "clearAll": {
       "resource": "cały magazyn zadań",
       "title": "Wyczyść cały magazyn zadań",
-      "warning": "Cały magazyn zadań zostanie wyczyszczony. Zadania, które używają tego magazynu do śledzenia zewnętrznej pracy, nie będą mogły jej wznowić bez ponownego uruchomienia od początku."
+      "warning": "Cały magazyn zadań zostanie wyczyszczony. Zadania, które używają tego magazynu do śledzenia zewnętrznej pracy, nie będą mogły jej wznowić bez ponownego uruchomienia."
     },
     "delete": "Usuń magazyn zadań",
     "deleteWarning": "Zadanie utraci te zapisane dane. Jeśli zadanie używa tego klucza do śledzenia zewnętrznej pracy (np. identyfikatora zewnętrznego zadania), nie będzie mogło jej wznowić.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -246,12 +246,34 @@
     "renderedTemplates": "Wyrenderowane szablony",
     "requiredActions": "Wymagane akcje",
     "runs": "Wykonania",
+    "storage": "Magazyn",
     "taskInstances": "Instancje zadań",
+    "taskStore": "Magazyn zadań",
     "tasks": "Zadania",
     "xcom": "XCom"
   },
   "taskGroups": {
     "collapseAll": "Zwiń wszystkie grupy zadań",
     "expandAll": "Rozwiń wszystkie grupy zadań"
+  },
+  "taskStore": {
+    "add": "Dodaj magazyn zadań",
+    "clearAll": {
+      "resource": "cały magazyn zadań",
+      "title": "Wyczyść cały magazyn zadań",
+      "warning": "Cały magazyn zadań zostanie wyczyszczony. Zadania, które używają tego magazynu do śledzenia zewnętrznej pracy, nie będą mogły jej wznowić bez ponownego uruchomienia od początku."
+    },
+    "delete": "Usuń magazyn zadań",
+    "deleteWarning": "Zadanie utraci te zapisane dane. Jeśli zadanie używa tego klucza do śledzenia zewnętrznej pracy (np. identyfikatora zewnętrznego zadania), nie będzie mogło jej wznowić.",
+    "edit": "Edytuj magazyn zadań",
+    "emptyStore": "Magazyn zadań przechowuje wartości, które są zachowywane między ponownymi próbami. Procesy robocze mogą zapisywać do magazynu zadań za pomocą Task SDK.",
+    "expiresAt": {
+      "column": "Wygasa o",
+      "custom": "Niestandardowy",
+      "default": "Domyślny ({{interval}})",
+      "label": "Wygaśnięcie",
+      "never": "Nigdy"
+    },
+    "title": "Magazyn zadań"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
@@ -1,4 +1,6 @@
 {
+  "deferredSlotsNotCounted": "Odłożone pominięte do slotów: {{count}}",
+  "deferredSlotsNotCountedTooltip": "Odłożone zadania pokazane na pasku są liczone do slotów puli. Odłożone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, pomijając odłożone zadania.",
   "favorite": {
     "favoriteDags_few": "Pierwsze {{count}} ulubione Dagi",
     "favoriteDags_many": "Pierwsze {{count}} ulubionych Dagów",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
@@ -1,6 +1,6 @@
 {
-  "deferredSlotsNotCounted": "Odłożone pominięte do slotów: {{count}}",
-  "deferredSlotsNotCountedTooltip": "Odłożone zadania pokazane na pasku są liczone do slotów puli. Odłożone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, pomijając odłożone zadania.",
+  "deferredSlotsNotCounted": "Odłożone, ale nieliczone do slotów: {{count}}",
+  "deferredSlotsNotCountedTooltip": "Odłożone zadania pokazane na pasku są liczone do slotów puli. Odłożone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, nie licząc odłożonych zadań.",
   "favorite": {
     "favoriteDags_few": "Pierwsze {{count}} ulubione Dagi",
     "favoriteDags_many": "Pierwsze {{count}} ulubionych Dagów",


### PR DESCRIPTION
Fills the 55 untranslated strings in the Polish (`pl`) UI locale, bringing
Polish coverage from 94.5% to 100%.

Covers the new **Asset Store** and **Task Store** features (labels, empty
states, clear/delete warnings, expiry options), the **Deadlines** browse
table, several task fields (depends-on-past, retries, wait-for-downstream,
rendered map index), and the dashboard deferred-slots tooltip.

Terminology follows the existing `pl` locale and the project's Polish
translation guideline — established terms reused, `{{placeholders}}`
preserved, Polish plural forms applied, and `Dag` / `XCom` / `Task SDK` /
`ISO 8601` kept in English. Validated with
`breeze ui check-translation-completeness --language pl` (100%, 0 TODOs)
and the UI ESLint/Prettier hook.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
