### PR TITLE
Document `apply_function` dot notation requirement for Kafka message queues

### DIFF
--- a/airflow-core/docs/core-concepts/message-queues.rst
+++ b/airflow-core/docs/core-concepts/message-queues.rst
@@ -38,4 +38,9 @@ Airflow constantly monitors the state of an external resource and updates the as
 resource reaches a given state (if it does reach it). To achieve this, we leverage Airflow Triggers.
 Triggers are small, asynchronous pieces of Python code whose job is to poll an external resource state.
 
+Each queue provider accepts provider-specific keyword arguments that are forwarded to the underlying
+trigger. Refer to the provider's message queue documentation for the supported arguments. Because
+triggers run in the Triggerer, any user code referenced by these arguments (for example a function
+passed as a string in Python dot notation) must be importable there.
+
 The list of supported message queues is available in :doc:`apache-airflow-providers:core-extensions/message-queues`.

--- a/providers/apache/kafka/docs/message-queues/index.rst
+++ b/providers/apache/kafka/docs/message-queues/index.rst
@@ -74,3 +74,47 @@ asset.
 
 For how to use the trigger, refer to the documentation of the
 :ref:`Messaging Trigger <howto/trigger:MessageQueueTrigger>`
+
+.. _howto/triggers:KafkaApplyFunction:
+
+The ``apply_function``
+----------------------
+
+The ``apply_function`` is applied to every message polled from the Kafka topic(s). If it returns any data,
+the returned value is used as the payload of the ``TriggerEvent``. Otherwise the trigger continues polling.
+It is required when using the Kafka queue provider, while the Kafka sensors also accept ``None``, in which
+case the raw message value (decoded as UTF-8) is used as the event payload.
+
+The function must be passed as a string in Python dot notation, for example
+``"my_package.my_module.my_function"``, not as the function object, because trigger arguments are
+serialized to the metadata database. The function is imported in the triggerer at runtime, so the module
+must be importable there, and changes to the function require a triggerer restart.
+
+Additional arguments can be passed using ``apply_function_args`` and ``apply_function_kwargs``. The message
+is always passed as the last positional argument:
+
+.. code-block:: python
+
+    # my_package/my_module.py
+    import json
+
+    from confluent_kafka import Message
+
+
+    def my_function(prefix: str, message: Message, threshold: int = 0) -> str | None:
+        val = json.loads(message.value())
+        if val["amount"] > threshold:
+            return f"{prefix}{val}"
+
+.. code-block:: python
+
+    # In your Dag file
+    from airflow.providers.common.messaging.triggers.msg_queue import MessageQueueTrigger
+
+    trigger = MessageQueueTrigger(
+        scheme="kafka",
+        topics=["my_topic"],
+        apply_function="my_package.my_module.my_function",
+        apply_function_args=["received:"],
+        apply_function_kwargs={"threshold": 100},
+    )

--- a/providers/apache/kafka/docs/message-queues/index.rst
+++ b/providers/apache/kafka/docs/message-queues/index.rst
@@ -80,8 +80,8 @@ For how to use the trigger, refer to the documentation of the
 The ``apply_function``
 ----------------------
 
-The ``apply_function`` is applied to every message polled from the Kafka topic(s). If it returns any data,
-the returned value is used as the payload of the ``TriggerEvent``. Otherwise the trigger continues polling.
+The ``apply_function`` is applied to every message polled from the Kafka topic(s). If it returns a truthy
+value, that value is used as the payload of the ``TriggerEvent``. Otherwise, the trigger keeps polling.
 It is required when using the Kafka queue provider, while the Kafka sensors also accept ``None``, in which
 case the raw message value (decoded as UTF-8) is used as the event payload.
 

--- a/providers/apache/kafka/docs/sensors.rst
+++ b/providers/apache/kafka/docs/sensors.rst
@@ -29,6 +29,12 @@ A sensor that defers until a specific message is published to a Kafka topic.
 The sensor will create a consumer reading messages from a Kafka topic until a message fulfilling criteria defined in the
 ``apply_function`` parameter is found. If the ``apply_function`` returns any data, a ``TriggerEvent`` is raised and the ``AwaitMessageSensor`` completes successfully.
 
+.. note::
+
+    The ``apply_function`` must be provided as a string in Python dot notation, not as a function
+    object. The function is imported in the triggerer, so the module must be importable there. See
+    :ref:`the apply_function documentation <howto/triggers:KafkaApplyFunction>` for details.
+
 For parameter definitions take a look at :class:`~airflow.providers.apache.kafka.sensors.kafka.AwaitMessageSensor`.
 
 Using the sensor
@@ -56,6 +62,9 @@ AwaitMessageTriggerFunctionSensor
 Similar to the ``AwaitMessageSensor`` above, this sensor will defer until it consumes a message from a Kafka topic fulfilling the criteria
 of its ``apply_function``. Once a positive event is encountered, the ``AwaitMessageTriggerFunctionSensor`` will trigger a callable provided
 to ``event_triggered_function``. Afterwards the sensor will be deferred again, continuing to consume messages.
+
+The same :ref:`apply_function requirements <howto/triggers:KafkaApplyFunction>` as for the ``AwaitMessageSensor``
+apply.
 
 For parameter definitions take a look at :class:`~airflow.providers.apache.kafka.sensors.kafka.AwaitMessageTriggerFunctionSensor`.
 


### PR DESCRIPTION
Add some docs about `apply_function` dot notation requirement for Kafka message queues.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude Opus 4.8 for inspecting existing docs.

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-06-12T13:30:58Z head=b6aa3cc action=ready -->

---

> [!NOTE]
> **✅ Ready for review** · @aeroyorch → `@potiuk` · 2026-06-12 13:30 UTC
>
> Thanks @aeroyorch — all checks are green and this PR is marked **ready for maintainer review**. The ball is with the maintainers now; a maintainer will take the next look.
>
> <sub>_Automated triage — may be imperfect._</sub>

<!-- /pr-triage-fold -->