### PR TITLE
Drop stale type:ignore[override] on ExecutionAPISecretsBackend

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
+++ b/task-sdk/src/airflow/sdk/execution_time/secrets/execution_api.py
@@ -65,7 +65,7 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
                 "to a less-restrictive secrets backend."
             )
 
-    def get_connection(self, conn_id: str, team_name: str | None = None) -> Connection | None:  # type: ignore[override]
+    def get_connection(self, conn_id: str, team_name: str | None = None) -> Connection | None:
         """
         Return connection object by routing through SUPERVISOR_COMMS.
 
@@ -135,7 +135,7 @@ class ExecutionAPISecretsBackend(BaseSecretsBackend):
             # to allow fallback to other backends.
             return None
 
-    async def aget_connection(self, conn_id: str) -> Connection | None:  # type: ignore[override]
+    async def aget_connection(self, conn_id: str) -> Connection | None:
         """
         Return connection object asynchronously via SUPERVISOR_COMMS.
 


### PR DESCRIPTION
Two `# type: ignore[override]` annotations on `ExecutionAPISecretsBackend`
are no longer needed; removing them lets mypy verify the override contract
for real instead of silencing it.

- **`aget_connection`**: `BaseSecretsBackend` has no `aget_connection` (it
  is sync-only), so `[override]` cannot fire — there is nothing to
  override.
- **`get_connection`**: signature now matches the base exactly after
  multi-team added `team_name` to `BaseSecretsBackend.get_connection`;
  the override only narrows the return type to `Connection | None`, which
  is a covariant return and accepted. The same pattern is used without
  the ignore in `providers/hashicorp/.../vault.py`,
  `providers/akeyless/.../akeyless.py`, and
  `airflow-core/.../local_filesystem.py`.

Internal type-only cleanup; no runtime behaviour change, no newsfragment.

Follow-up to #65347 / #67216, same pattern.
---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude