### PR TITLE
Fix LlamaIndexEmbeddingOperator returning None vectors for all chunks

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llamaindex_embedding.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llamaindex_embedding.py
@@ -125,9 +125,15 @@ class LlamaIndexEmbeddingOperator(BaseOperator):
         nodes = splitter.get_nodes_from_documents(llama_docs)
         self.log.info("Split %d documents into %d chunks", len(llama_docs), len(nodes))
 
-        # ``VectorStoreIndex(...)`` populates each node's ``.embedding`` as a
-        # side effect of building the index; capture the index so the
-        # variable isn't discarded.
+        # Pre-embed nodes before building the index so the original node
+        # objects carry their vectors. VectorStoreIndex._get_node_with_embedding()
+        # internally calls node.copy() before attaching embeddings, leaving the
+        # original node objects with embedding=None.
+        texts = [node.get_content() for node in nodes]
+        embeddings = embed_model.get_text_embedding_batch(texts, show_progress=False)
+        for node, embedding in zip(nodes, embeddings):
+            node.embedding = embedding
+
         index = VectorStoreIndex(nodes, embed_model=embed_model, show_progress=False)
 
         if self.persist_dir:
@@ -136,8 +142,8 @@ class LlamaIndexEmbeddingOperator(BaseOperator):
         # ``SentenceSplitter`` always returns ``TextNode`` instances, but the
         # base ``get_nodes_from_documents`` signature is typed as
         # ``list[BaseNode]`` (which has no ``.text``). Cast so mypy doesn't
-        # flag the ``.text`` access; ``node.embedding`` is populated by
-        # ``VectorStoreIndex`` for every node above.
+        # flag the ``.text`` access; ``node.embedding`` was populated by the
+        # pre-embedding step above.
         text_nodes = cast("list[TextNode]", nodes)
         chunks = [
             {

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llamaindex_embedding.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llamaindex_embedding.py
@@ -48,7 +48,10 @@ def _node(text: str = "chunk text", metadata: dict | None = None, vector=None):
 
 def _byo_embedding():
     """Return a duck-typed ``BaseEmbedding`` stand-in (has the two methods the operator checks)."""
-    return MagicMock(name="MyBaseEmbedding", spec=["get_text_embedding", "_get_query_embedding"])
+    return MagicMock(
+        name="MyBaseEmbedding",
+        spec=["get_text_embedding", "_get_query_embedding", "get_text_embedding_batch"],
+    )
 
 
 class TestEmbeddingOperatorInit:
@@ -71,8 +74,9 @@ class TestEmbeddingOperatorExecute:
     @patch("airflow.providers.common.ai.hooks.llamaindex.LlamaIndexHook.get_embedding_model")
     def test_string_embed_model_goes_through_hook(self, mock_get_embed, _li):
         # `embed_model` as a string -> hook builds OpenAIEmbedding.
+        mock_get_embed.return_value.get_text_embedding_batch.return_value = [[0.1, 0.2]]
         _li["SentenceSplitter"].return_value.get_nodes_from_documents.return_value = [
-            _node(text="chunk a", vector=[0.1, 0.2]),
+            _node(text="chunk a"),
         ]
 
         op = LlamaIndexEmbeddingOperator(
@@ -142,9 +146,13 @@ class TestEmbeddingOperatorExecute:
 
     @patch("airflow.providers.common.ai.hooks.llamaindex.LlamaIndexHook.get_embedding_model")
     def test_chunks_carry_text_metadata_vector(self, mock_get_embed, _li):
+        mock_get_embed.return_value.get_text_embedding_batch.return_value = [
+            [1.0, 2.0],
+            [3.0, 4.0],
+        ]
         _li["SentenceSplitter"].return_value.get_nodes_from_documents.return_value = [
-            _node(text="x", metadata={"k": "v"}, vector=[1.0, 2.0]),
-            _node(text="y", metadata={"k": "v2"}, vector=[3.0, 4.0]),
+            _node(text="x", metadata={"k": "v"}),
+            _node(text="y", metadata={"k": "v2"}),
         ]
 
         op = LlamaIndexEmbeddingOperator(
@@ -158,6 +166,27 @@ class TestEmbeddingOperatorExecute:
             {"text": "x", "metadata": {"k": "v"}, "vector": [1.0, 2.0]},
             {"text": "y", "metadata": {"k": "v2"}, "vector": [3.0, 4.0]},
         ]
+
+
+    def test_vectors_populated_when_vectorstoreindex_copies_nodes(self, _li):
+        """Regression: VectorStoreIndex copies nodes internally, so original node.embedding
+        would be None without pre-embedding. Vectors must be non-None in the output."""
+        byo = _byo_embedding()
+        byo.get_text_embedding_batch.return_value = [[0.1, 0.2, 0.3]]
+
+        node = _node(text="hello world", metadata={})
+        # Simulate real-world initial state: node has no embedding yet.
+        node.embedding = None
+        _li["SentenceSplitter"].return_value.get_nodes_from_documents.return_value = [node]
+
+        op = LlamaIndexEmbeddingOperator(
+            task_id="test",
+            documents=[{"text": "hello world"}],
+            embed_model=byo,
+        )
+        result = op.execute(context=MagicMock())
+
+        assert result["chunks"][0]["vector"] == [0.1, 0.2, 0.3]
 
 
 class TestEmbeddingOperatorPersist:


### PR DESCRIPTION
## Problem

`LlamaIndexEmbeddingOperator` was returning `vector: None` for every chunk in its output, making the results unusable for downstream vector storage tasks.

**Root cause:** `VectorStoreIndex._get_node_with_embedding()` in `llama-index-core` calls `node.copy()` internally before attaching embedding vectors. This means embeddings are only stored on the internal copies, The original node objects in the `nodes` list retain `embedding=None`.

Minimal reproduction:
```python
from llama_index.core import Document, VectorStoreIndex
from llama_index.core.node_parser import SentenceSplitter
from llama_index.core.embeddings.mock_embed_model import MockEmbedding

docs = [Document(text="hello world")]
nodes = SentenceSplitter(chunk_size=512).get_nodes_from_documents(docs)
index = VectorStoreIndex(nodes, embed_model=MockEmbedding(embed_dim=8))

print(nodes[0].embedding)  # None  ← bug
print(index.vector_store.data.embedding_dict)  # {node_id: [...]}  ← vector is here, not on the node
```


## Fix
Pre-embed the nodes using embed_model.get_text_embedding_batch() before building the index and assign the results directly to the original node objects. Since VectorStoreIndex skips re-embedding nodes that already carry a vector, this avoids redundant API calls while ensuring node.embedding is correctly set on the objects we read from later.

## Changes
providers/common/ai/.../operators/llamaindex_embedding.py - added pre-embedding step before VectorStoreIndex construction
providers/common/ai/tests/.../test_llamaindex_embedding.py - updated existing tests to mock get_text_embedding_batch, added regression test