### PR TITLE
Fix: per-index trigger rule evaluation broken for mapped task groups after upstream expansion

### DIFF
--- a/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow-core/src/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -183,12 +183,23 @@ class TriggerRuleDep(BaseTIDep):
             # each instance must depend on the upstream instance(s) that share its
             # map index, otherwise a single upstream failure would wrongly trigger
             # every expanded instance (see #50210).
+            #
+            # For non-fast-triggered rules (e.g. ALL_SUCCESS), the summary ti must
+            # also avoid the placeholder-to-index-0 rewrite introduced for XCom
+            # resolution. If the rewrite applied here, the trigger rule would see
+            # only the first expanded upstream instance (index 0), so a failure at
+            # index 0 would prematurely mark the summary ti as upstream_failed and
+            # block expansion. Instead we return the summary ti's own map_index (-1),
+            # which refers to the upstream placeholder that no longer exists after
+            # expansion. The trigger rule therefore sees no relevant instances and
+            # passes, allowing the summary ti to expand normally so that each
+            # resulting instance can be evaluated per-index (see #68417).
             if is_mapped(task.task_group) and ti.map_index < 0:
                 is_fast_triggered = task.trigger_rule in (TR.ONE_SUCCESS, TR.ONE_FAILED, TR.ONE_DONE)
-                if is_fast_triggered and upstream_id not in set(
-                    _iter_expansion_dependencies(task_group=task.task_group)
-                ):
-                    return None
+                if upstream_id not in set(_iter_expansion_dependencies(task_group=task.task_group)):
+                    if is_fast_triggered:
+                        return None
+                    return ti.map_index
 
             try:
                 expanded_ti_count = _get_expanded_ti_count()

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llamaindex_embedding.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llamaindex_embedding.py
@@ -125,9 +125,15 @@ class LlamaIndexEmbeddingOperator(BaseOperator):
         nodes = splitter.get_nodes_from_documents(llama_docs)
         self.log.info("Split %d documents into %d chunks", len(llama_docs), len(nodes))
 
-        # ``VectorStoreIndex(...)`` populates each node's ``.embedding`` as a
-        # side effect of building the index; capture the index so the
-        # variable isn't discarded.
+        # Pre-embed nodes before building the index so the original node
+        # objects carry their vectors. VectorStoreIndex._get_node_with_embedding()
+        # internally calls node.copy() before attaching embeddings, leaving the
+        # original node objects with embedding=None.
+        texts = [node.get_content() for node in nodes]
+        embeddings = embed_model.get_text_embedding_batch(texts, show_progress=False)
+        for node, embedding in zip(nodes, embeddings):
+            node.embedding = embedding
+
         index = VectorStoreIndex(nodes, embed_model=embed_model, show_progress=False)
 
         if self.persist_dir:
@@ -136,8 +142,8 @@ class LlamaIndexEmbeddingOperator(BaseOperator):
         # ``SentenceSplitter`` always returns ``TextNode`` instances, but the
         # base ``get_nodes_from_documents`` signature is typed as
         # ``list[BaseNode]`` (which has no ``.text``). Cast so mypy doesn't
-        # flag the ``.text`` access; ``node.embedding`` is populated by
-        # ``VectorStoreIndex`` for every node above.
+        # flag the ``.text`` access; ``node.embedding`` was populated by the
+        # pre-embedding step above.
         text_nodes = cast("list[TextNode]", nodes)
         chunks = [
             {

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llamaindex_embedding.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llamaindex_embedding.py
@@ -48,7 +48,10 @@ def _node(text: str = "chunk text", metadata: dict | None = None, vector=None):
 
 def _byo_embedding():
     """Return a duck-typed ``BaseEmbedding`` stand-in (has the two methods the operator checks)."""
-    return MagicMock(name="MyBaseEmbedding", spec=["get_text_embedding", "_get_query_embedding"])
+    return MagicMock(
+        name="MyBaseEmbedding",
+        spec=["get_text_embedding", "_get_query_embedding", "get_text_embedding_batch"],
+    )
 
 
 class TestEmbeddingOperatorInit:
@@ -71,8 +74,9 @@ class TestEmbeddingOperatorExecute:
     @patch("airflow.providers.common.ai.hooks.llamaindex.LlamaIndexHook.get_embedding_model")
     def test_string_embed_model_goes_through_hook(self, mock_get_embed, _li):
         # `embed_model` as a string -> hook builds OpenAIEmbedding.
+        mock_get_embed.return_value.get_text_embedding_batch.return_value = [[0.1, 0.2]]
         _li["SentenceSplitter"].return_value.get_nodes_from_documents.return_value = [
-            _node(text="chunk a", vector=[0.1, 0.2]),
+            _node(text="chunk a"),
         ]
 
         op = LlamaIndexEmbeddingOperator(
@@ -142,9 +146,13 @@ class TestEmbeddingOperatorExecute:
 
     @patch("airflow.providers.common.ai.hooks.llamaindex.LlamaIndexHook.get_embedding_model")
     def test_chunks_carry_text_metadata_vector(self, mock_get_embed, _li):
+        mock_get_embed.return_value.get_text_embedding_batch.return_value = [
+            [1.0, 2.0],
+            [3.0, 4.0],
+        ]
         _li["SentenceSplitter"].return_value.get_nodes_from_documents.return_value = [
-            _node(text="x", metadata={"k": "v"}, vector=[1.0, 2.0]),
-            _node(text="y", metadata={"k": "v2"}, vector=[3.0, 4.0]),
+            _node(text="x", metadata={"k": "v"}),
+            _node(text="y", metadata={"k": "v2"}),
         ]
 
         op = LlamaIndexEmbeddingOperator(
@@ -158,6 +166,27 @@ class TestEmbeddingOperatorExecute:
             {"text": "x", "metadata": {"k": "v"}, "vector": [1.0, 2.0]},
             {"text": "y", "metadata": {"k": "v2"}, "vector": [3.0, 4.0]},
         ]
+
+
+    def test_vectors_populated_when_vectorstoreindex_copies_nodes(self, _li):
+        """Regression: VectorStoreIndex copies nodes internally, so original node.embedding
+        would be None without pre-embedding. Vectors must be non-None in the output."""
+        byo = _byo_embedding()
+        byo.get_text_embedding_batch.return_value = [[0.1, 0.2, 0.3]]
+
+        node = _node(text="hello world", metadata={})
+        # Simulate real-world initial state: node has no embedding yet.
+        node.embedding = None
+        _li["SentenceSplitter"].return_value.get_nodes_from_documents.return_value = [node]
+
+        op = LlamaIndexEmbeddingOperator(
+            task_id="test",
+            documents=[{"text": "hello world"}],
+            embed_model=byo,
+        )
+        result = op.execute(context=MagicMock())
+
+        assert result["chunks"][0]["vector"] == [0.1, 0.2, 0.3]
 
 
 class TestEmbeddingOperatorPersist:


### PR DESCRIPTION
 Closes #68417

## Problem

When you use a mapped task group (e.g. `divide_and_report.expand(i=gen_examples())`), 
tasks inside the group should evaluate their trigger rules **per index**. so if 
`divide(0)` fails, only `report_success(0)` should become `upstream_failed`, while 
`report_success(1)`, `(2)`, `(3)` still run successfully.

This was working correctly until PR #59691 landed. That PR fixed a real bug in XCom 
resolution (downstream tasks incorrectly referencing a placeholder that no longer 
existed after upstream expansion), but it accidentally broke trigger-rule evaluation 
as a side effect.

### What went wrong ?

When an upstream task expands (its summary placeholder at `map_index=-1` gets replaced 
by real instances at `0, 1, 2, ...`), PR #59691 introduced a rewrite that maps the 
downstream placeholder's dependency from `-1` to `0`. This rewrite is correct for 
XCom resolution, but it was also kicking in during **trigger-rule evaluation** of the 
downstream summary task instance (the unexpanded placeholder, also at `map_index=-1`).

The result: the summary instance of `report_success` would evaluate its `ALL_SUCCESS` 
trigger rule against **only** `divide(0)` instead of all divide instances. Since 
`divide(0)` failed, `report_success(-1)` got marked `upstream_failed` before it ever 
had a chance to expand. Once the summary is `upstream_failed`, all its expanded 
instances (`0`, `1`, `2`, `3`) inherit that state so everything ends up 
`upstream_failed` instead of just index `0`.

Before the fix:
report_success: {0: upstream_failed, 1: upstream_failed, 2: upstream_failed, 3: upstream_failed}  ❌



After the fix:
report_success: {0: upstream_failed, 1: success, 2: success, 3: success}  ✅



## The Fix

The fix is a small, targeted change in `trigger_rule_dep.py`.

When evaluating the trigger rule for a **summary task instance** (`map_index < 0`) 
inside a mapped task group, and the upstream task is **not** an expansion dependency 
(i.e. it lives inside the same group), we now skip the placeholder-to-index-0 rewrite 
entirely.

- For **fast-triggered rules** (`ONE_SUCCESS`, `ONE_FAILED`, `ONE_DONE`): behavior is 
  unchanged we return `None` so all upstream instances are considered, letting the 
  rule fire as soon as one instance meets the condition.

- For **all other rules** (`ALL_SUCCESS`, `NONE_FAILED`, etc.): we return the summary 
  map index (`-1`) directly. After the upstream has expanded, its `-1` placeholder no 
  longer exists in the database, so the trigger rule sees zero relevant instances and 
  passes. The summary task instance is then free to expand, and each resulting 
  per-index instance evaluates its trigger rule independently against the correct 
  upstream instance.

The XCom resolution path is completely unaffected because it calls 
`get_relevant_upstream_map_indexes` directly, not through the trigger-rule evaluation 
code path.

## Tests

The following existing tests cover this fix and were broken before this change:

- `test_one_failed_trigger_rule_in_mapped_task_group_is_per_index`   verifies that a 
  single upstream failure only affects the downstream instance at the same index
- `test_one_failed_trigger_rule_runs_on_indirect_failure_in_mapped_task_group`  
  verifies that `ONE_FAILED` still fires correctly before expansion
- `test_downstream_placeholder_handles_upstream_post_expansion`  verifies that the 
  XCom resolution rewrite still works correctly and is unaffected by this change