### PR TITLE
Fix Java-SDK connection port casting

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
@@ -327,13 +327,27 @@ def _setup_java_sdk_integration(dot_env_file, tmp_dir):
     )
     queue_to_coordinator = json.dumps({"java": "java-jdk"})
 
+    # Connection expected by the Java example bundle tasks. The JSON form
+    # covers all connection fields, in particular the port: wire integers
+    # arrive in the JVM as Long and the SDK must map them to Int.
+    test_http_conn = json.dumps(
+        {
+            "conn_type": "http",
+            "login": "user",
+            "password": "pass",
+            "host": "example.com",
+            "port": 1234,
+            "extra": {"param1": "val1", "param2": "val2"},
+        }
+    )
+
     dot_env_file.write_text(
         f"AIRFLOW_UID={os.getuid()}\n"
         # Single-quote the JSON values so Docker Compose reads them literally.
         f"AIRFLOW__SDK__COORDINATORS='{coordinator_config}'\n"
         f"AIRFLOW__SDK__QUEUE_TO_COORDINATOR='{queue_to_coordinator}'\n"
-        # Connection and variable expected by the Java example bundle tasks.
-        "AIRFLOW_CONN_TEST_HTTP=http://test:test@example.com/\n"
+        f"AIRFLOW_CONN_TEST_HTTP='{test_http_conn}'\n"
+        # Variable expected by the Java example bundle tasks.
         "AIRFLOW_VAR_MY_VARIABLE=test_value\n"
     )
     os.environ["ENV_FILE_PATH"] = str(dot_env_file)

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
@@ -79,7 +79,9 @@ class Client internal constructor(
         schema = schema as String?,
         login = login as String?,
         password = password as String?,
-        port = port as Int?,
+        // The msgpack decoder yields Long for wire integers, so convert
+        // numerically instead of casting.
+        port = (port as Number?)?.toInt(),
         extra = extra,
       )
     }

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/ClientTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/ClientTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk
+
+import org.apache.airflow.sdk.execution.comm.ConnectionResult
+import org.apache.airflow.sdk.execution.comm.StartupDetails
+import org.apache.airflow.sdk.execution.comm.VariableResult
+import org.apache.airflow.sdk.execution.comm.XComResult
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+private class FakeTransport(
+  val connection: ConnectionResult,
+) : org.apache.airflow.sdk.execution.Client {
+  override fun getConnection(id: String): ConnectionResult = connection
+
+  override fun getVariable(key: String): VariableResult = throw NotImplementedError()
+
+  override fun getXCom(
+    key: String,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int?,
+    includePriorDates: Boolean,
+  ): XComResult = throw NotImplementedError()
+
+  override fun setXCom(
+    key: String,
+    value: Any,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int,
+  ) = throw NotImplementedError()
+}
+
+class ClientTest {
+  private fun clientWith(connection: ConnectionResult) = Client(StartupDetails(), FakeTransport(connection))
+
+  @Test
+  @DisplayName("Should convert a Long port from the wire to Int")
+  fun shouldConvertLongPort() {
+    val result =
+      ConnectionResult().apply {
+        connId = "test_http"
+        connType = "http"
+        host = "example.com"
+        // The msgpack decoder yields Long for wire integers.
+        port = 8080L
+      }
+
+    val connection = clientWith(result).getConnection("test_http")
+
+    Assertions.assertEquals("test_http", connection.id)
+    Assertions.assertEquals("http", connection.type)
+    Assertions.assertEquals("example.com", connection.host)
+    Assertions.assertEquals(8080, connection.port)
+  }
+
+  @Test
+  @DisplayName("Should keep an unset port null")
+  fun shouldKeepUnsetPortNull() {
+    val result =
+      ConnectionResult().apply {
+        connId = "test_http"
+        connType = "http"
+      }
+
+    val connection = clientWith(result).getConnection("test_http")
+
+    Assertions.assertNull(connection.port)
+  }
+}


### PR DESCRIPTION
## Why

@vatsrahul1001 ran into this error when setting up connection with port in Java-SDK. For example setting `AIRFLOW_CONN_TEST_HTTP='{"conn_type": "http", "login": "user", "password": "pass", "host": "example.com", "port": 1234, "extra": {"param1": "val1", "param2": "val2"}}'` in breeze we will get:

```
[2026-06-11 14:44:12] DEBUG - Connected logs addr=/127.0.0.1:56941
[2026-06-11 14:44:12] DEBUG - Connected comm addr=/127.0.0.1:40867
[2026-06-11 14:44:13] DEBUG - Handling id=0
[2026-06-11 14:44:13] ERROR - [main] INFO org.apache.airflow.example.AnnotationExample - Hello from task
[2026-06-11 14:44:13] DEBUG - Sending id=0 body=org.apache.airflow.sdk.execution.comm.GetXCom@72ea6193[key=return_value,dagId=java_annotation_example,runId=manual__2026-06-11T09:14:11.101516+00:00,taskId=python_task_1,mapIndex=<null>,includePriorDates=false,type=GetXCom]
[2026-06-11 14:44:13] DEBUG - Handling id=0
[2026-06-11 14:44:13] ERROR - [main] INFO org.apache.airflow.example.AnnotationExample - Got XCom from Python Task 'python_task_1' value_from_python_task_1
[2026-06-11 14:44:13] DEBUG - Sending id=1 body=org.apache.airflow.sdk.execution.comm.GetConnection@698122b2[connId=test_http,type=GetConnection]
[2026-06-11 14:44:13] DEBUG - Handling id=1
[2026-06-11 14:44:13] ERROR - Error executing task ti=org.apache.airflow.sdk.execution.comm.TaskInstanceDTO@13cf7d52[id=019eb5f5-e328-7e25-8784-591f08ba329a,dagVersionId=019eb5d5-63b2-7d13-b8d9-b088827410a0,taskId=extract,dagId=java_annotation_example,runId=manual__2026-06-11T09:14:11.101516+00:00,tryNumber=1,mapIndex=-1,poolSlots=1,queue=java,priorityWeight=3,parentContextCarrier=<null>,contextCarrier={traceparent=00-236f21095f7ed4196bdb938d71f41dac-812162b32d6c7f78-01}] error=java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap') trace=java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')
	at org.apache.airflow.sdk.Client.getConnection(Client.kt:82)
	at org.apache.airflow.example.AnnotationExample.extractValue(AnnotationExample.java:39)
	at org.apache.airflow.example.AnnotationExampleBuilder$ExtractValue.execute(AnnotationExampleBuilder.java:23)
	at org.apache.airflow.sdk.execution.TaskRunner.runTask$sdk(Task.kt:66)
	at org.apache.airflow.sdk.execution.TaskKt.runTask(Task.kt:80)
	at org.apache.airflow.sdk.execution.CoordinatorComm.handleIncoming(Comm.kt:105)
	at org.apache.airflow.sdk.execution.CoordinatorComm$startProcessing$2.invoke(Comm.kt:62)
	at org.apache.airflow.sdk.execution.CoordinatorComm$startProcessing$2.invoke(Comm.kt:62)
	at org.apache.airflow.sdk.execution.CoordinatorComm.processOnce(Comm.kt:87)
	at org.apache.airflow.sdk.execution.CoordinatorComm.startProcessing(Comm.kt:62)
	at org.apache.airflow.sdk.Server$serveAsync$2$1.invokeSuspend(Server.kt:149)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:94)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:70)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at org.apache.airflow.sdk.execution.LogSender.sendTo(Logger.kt:112)
	at org.apache.airflow.sdk.execution.LogSender.configure(Logger.kt:88)
	at org.apache.airflow.sdk.Server$serveAsync$2$2.invokeSuspend(Server.kt:155)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:94)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:70)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
	at org.apache.airflow.sdk.Server.serve(Server.kt:121)
	at org.apache.airflow.example.ExampleBundleBuilder.main(ExampleBundleBuilder.java:35)
[2026-06-11 14:44:13] ERROR - java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.Client.getConnection(Client.kt:82)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.example.AnnotationExample.extractValue(AnnotationExample.java:39)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.example.AnnotationExampleBuilder$ExtractValue.execute(AnnotationExampleBuilder.java:23)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.execution.TaskRunner.runTask$sdk(Task.kt:66)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.execution.TaskKt.runTask(Task.kt:80)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.execution.CoordinatorComm.handleIncoming(Comm.kt:105)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.execution.CoordinatorComm$startProcessing$2.invoke(Comm.kt:62)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.execution.CoordinatorComm$startProcessing$2.invoke(Comm.kt:62)
[2026-06-11 14:44:13] ERROR - 	at org.apache.airflow.sdk.execution.CoordinatorComm.processOnce(Comm.kt:87)
```

## What

- Fix the `Long` to `Int` casting error at Java-SDK connection client side
- Fill the Java-SDK e2e test gap by using connection with all the available fields (`port`, `extra`, `conn_type`) etc.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
