### PR TITLE
feat(standard): forward log levels from virtualenv subprocess stdout

### DIFF
--- a/providers/standard/docs/operators/python.rst
+++ b/providers/standard/docs/operators/python.rst
@@ -269,7 +269,7 @@ Log level forwarding
 
 Airflow reads subprocess stdout line by line and re-emits each line at the
 log level encoded in its prefix (``DEBUG: …``, ``INFO: …``, ``WARNING: …``,
-``ERROR: …``, ``CRITICAL: …``). Lines without a recognised prefix fall back to
+``ERROR: …``, ``CRITICAL: …``). Lines without a recognized prefix fall back to
 ``INFO``. Multi-line messages such as tracebacks are split and each line is
 forwarded individually.
 

--- a/providers/standard/docs/operators/python.rst
+++ b/providers/standard/docs/operators/python.rst
@@ -281,6 +281,7 @@ such as tracebacks.
         import sys
         import traceback as _tb
 
+
         # Prefix every output line (including each line of a traceback) with the level name
         # so Airflow can route each line to the correct log level.
         class _PrefixAllLinesFormatter(logging.Formatter):
@@ -289,14 +290,17 @@ such as tracebacks.
                 prefix = record.levelname + ": "
                 return "\n".join(prefix + line for line in msg.splitlines())
 
+
         _handler = logging.StreamHandler()
         _handler.setFormatter(_PrefixAllLinesFormatter())
         logging.root.addHandler(_handler)
+
 
         # Route unhandled top-level exceptions through logging so their tracebacks
         # also get the ERROR: prefix instead of printing to stderr without a level.
         def _logging_excepthook(exc_type, exc_value, exc_tb):
             logging.error("".join(_tb.format_exception(exc_type, exc_value, exc_tb)).rstrip())
+
 
         sys.excepthook = _logging_excepthook
 
@@ -396,6 +400,7 @@ such as tracebacks.
         import sys
         import traceback as _tb
 
+
         # Prefix every output line (including each line of a traceback) with the level name
         # so Airflow can route each line to the correct log level.
         class _PrefixAllLinesFormatter(logging.Formatter):
@@ -404,14 +409,17 @@ such as tracebacks.
                 prefix = record.levelname + ": "
                 return "\n".join(prefix + line for line in msg.splitlines())
 
+
         _handler = logging.StreamHandler()
         _handler.setFormatter(_PrefixAllLinesFormatter())
         logging.root.addHandler(_handler)
+
 
         # Route unhandled top-level exceptions through logging so their tracebacks
         # also get the ERROR: prefix instead of printing to stderr without a level.
         def _logging_excepthook(exc_type, exc_value, exc_tb):
             logging.error("".join(_tb.format_exception(exc_type, exc_value, exc_tb)).rstrip())
+
 
         sys.excepthook = _logging_excepthook
 

--- a/providers/standard/docs/operators/python.rst
+++ b/providers/standard/docs/operators/python.rst
@@ -262,6 +262,52 @@ In case you have problems during runtime with broken cached virtual environments
 Note that any modification of a cached virtual environment (like temp files in binary path, post-installing further requirements) might pollute a cached virtual environment and the
 operator is not maintaining or cleaning the cache path.
 
+Log level forwarding
+^^^^^^^^^^^^^^^^^^^^
+
+When your callable uses Python's standard ``logging`` module, Airflow forwards the correct log level
+to its own logger. Lines written to stdout with a level prefix
+(``DEBUG: …``, ``INFO: …``, ``WARNING: …``, ``ERROR: …``, ``CRITICAL: …``) are re-emitted at the
+matching Airflow log level instead of being collapsed to ``INFO``. This includes multi-line output
+such as tracebacks.
+
+.. dropdown:: Logging setup snippet
+
+    Add this at the top of your callable to enable log-level forwarding, including tracebacks:
+
+    .. code-block:: python
+
+        import logging
+        import sys
+        import traceback as _tb
+
+        # Prefix every output line (including each line of a traceback) with the level name
+        # so Airflow can route each line to the correct log level.
+        class _PrefixAllLinesFormatter(logging.Formatter):
+            def format(self, record):
+                msg = super().format(record)
+                prefix = record.levelname + ": "
+                return "\n".join(prefix + line for line in msg.splitlines())
+
+        _handler = logging.StreamHandler()
+        _handler.setFormatter(_PrefixAllLinesFormatter())
+        logging.root.addHandler(_handler)
+
+        # Route unhandled top-level exceptions through logging so their tracebacks
+        # also get the ERROR: prefix instead of printing to stderr without a level.
+        def _logging_excepthook(exc_type, exc_value, exc_tb):
+            logging.error("".join(_tb.format_exception(exc_type, exc_value, exc_tb)).rstrip())
+
+        sys.excepthook = _logging_excepthook
+
+    With this setup all log levels, including exception tracebacks, appear at the correct level:
+
+    .. code-block:: python
+
+        logging.warning("This will appear as WARNING in Airflow logs")
+        logging.error("This will appear as ERROR in Airflow logs")
+        logging.exception("This traceback will appear as ERROR in Airflow logs")
+
 
 .. _howto/operator:ExternalPythonOperator:
 
@@ -330,6 +376,52 @@ Templating
 ^^^^^^^^^^
 
 Jinja templating can be used in same way as described for the :ref:`howto/operator:PythonOperator`.
+
+Log level forwarding
+^^^^^^^^^^^^^^^^^^^^
+
+When your callable uses Python's standard ``logging`` module, Airflow forwards the correct log level
+to its own logger. Lines written to stdout with a level prefix
+(``DEBUG: …``, ``INFO: …``, ``WARNING: …``, ``ERROR: …``, ``CRITICAL: …``) are re-emitted at the
+matching Airflow log level instead of being collapsed to ``INFO``. This includes multi-line output
+such as tracebacks.
+
+.. dropdown:: Logging setup snippet
+
+    Add this at the top of your callable to enable log-level forwarding, including tracebacks:
+
+    .. code-block:: python
+
+        import logging
+        import sys
+        import traceback as _tb
+
+        # Prefix every output line (including each line of a traceback) with the level name
+        # so Airflow can route each line to the correct log level.
+        class _PrefixAllLinesFormatter(logging.Formatter):
+            def format(self, record):
+                msg = super().format(record)
+                prefix = record.levelname + ": "
+                return "\n".join(prefix + line for line in msg.splitlines())
+
+        _handler = logging.StreamHandler()
+        _handler.setFormatter(_PrefixAllLinesFormatter())
+        logging.root.addHandler(_handler)
+
+        # Route unhandled top-level exceptions through logging so their tracebacks
+        # also get the ERROR: prefix instead of printing to stderr without a level.
+        def _logging_excepthook(exc_type, exc_value, exc_tb):
+            logging.error("".join(_tb.format_exception(exc_type, exc_value, exc_tb)).rstrip())
+
+        sys.excepthook = _logging_excepthook
+
+    With this setup all log levels, including exception tracebacks, appear at the correct level:
+
+    .. code-block:: python
+
+        logging.warning("This will appear as WARNING in Airflow logs")
+        logging.error("This will appear as ERROR in Airflow logs")
+        logging.exception("This traceback will appear as ERROR in Airflow logs")
 
 
 .. _howto/operator:BranchPythonOperator:

--- a/providers/standard/docs/operators/python.rst
+++ b/providers/standard/docs/operators/python.rst
@@ -262,18 +262,25 @@ In case you have problems during runtime with broken cached virtual environments
 Note that any modification of a cached virtual environment (like temp files in binary path, post-installing further requirements) might pollute a cached virtual environment and the
 operator is not maintaining or cleaning the cache path.
 
+.. _howto/operator:PythonVirtualenvOperator:log-level-forwarding:
+
 Log level forwarding
 ^^^^^^^^^^^^^^^^^^^^
 
-When your callable uses Python's standard ``logging`` module, Airflow forwards the correct log level
-to its own logger. Lines written to stdout with a level prefix
-(``DEBUG: …``, ``INFO: …``, ``WARNING: …``, ``ERROR: …``, ``CRITICAL: …``) are re-emitted at the
-matching Airflow log level instead of being collapsed to ``INFO``. This includes multi-line output
-such as tracebacks.
+Airflow reads subprocess stdout line by line and re-emits each line at the
+log level encoded in its prefix (``DEBUG: …``, ``INFO: …``, ``WARNING: …``,
+``ERROR: …``, ``CRITICAL: …``). Lines without a recognised prefix fall back to
+``INFO``. Multi-line messages such as tracebacks are split and each line is
+forwarded individually.
 
-.. dropdown:: Logging setup snippet
+This requires the callable's output lines to carry a level prefix. The
+simplest way is to configure a custom formatter. If ``apache-airflow-sdk`` is
+installed in the virtual environment, its default log formatter already
+produces the required prefix — no extra setup is needed.
 
-    Add this at the top of your callable to enable log-level forwarding, including tracebacks:
+Without ``airflow.sdk``, add this snippet at the top of your callable:
+
+.. dropdown:: Logging setup snippet (without airflow.sdk)
 
     .. code-block:: python
 
@@ -384,52 +391,7 @@ Jinja templating can be used in same way as described for the :ref:`howto/operat
 Log level forwarding
 ^^^^^^^^^^^^^^^^^^^^
 
-When your callable uses Python's standard ``logging`` module, Airflow forwards the correct log level
-to its own logger. Lines written to stdout with a level prefix
-(``DEBUG: …``, ``INFO: …``, ``WARNING: …``, ``ERROR: …``, ``CRITICAL: …``) are re-emitted at the
-matching Airflow log level instead of being collapsed to ``INFO``. This includes multi-line output
-such as tracebacks.
-
-.. dropdown:: Logging setup snippet
-
-    Add this at the top of your callable to enable log-level forwarding, including tracebacks:
-
-    .. code-block:: python
-
-        import logging
-        import sys
-        import traceback as _tb
-
-
-        # Prefix every output line (including each line of a traceback) with the level name
-        # so Airflow can route each line to the correct log level.
-        class _PrefixAllLinesFormatter(logging.Formatter):
-            def format(self, record):
-                msg = super().format(record)
-                prefix = record.levelname + ": "
-                return "\n".join(prefix + line for line in msg.splitlines())
-
-
-        _handler = logging.StreamHandler()
-        _handler.setFormatter(_PrefixAllLinesFormatter())
-        logging.root.addHandler(_handler)
-
-
-        # Route unhandled top-level exceptions through logging so their tracebacks
-        # also get the ERROR: prefix instead of printing to stderr without a level.
-        def _logging_excepthook(exc_type, exc_value, exc_tb):
-            logging.error("".join(_tb.format_exception(exc_type, exc_value, exc_tb)).rstrip())
-
-
-        sys.excepthook = _logging_excepthook
-
-    With this setup all log levels, including exception tracebacks, appear at the correct level:
-
-    .. code-block:: python
-
-        logging.warning("This will appear as WARNING in Airflow logs")
-        logging.error("This will appear as ERROR in Airflow logs")
-        logging.exception("This traceback will appear as ERROR in Airflow logs")
+Log-level forwarding works the same way as for :ref:`howto/operator:PythonVirtualenvOperator:log-level-forwarding`.
 
 
 .. _howto/operator:BranchPythonOperator:

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -134,6 +135,17 @@ def _index_urls_to_uv_env_vars(index_urls: list[str] | None = None) -> dict[str,
     return uv_index_env_vars
 
 
+_LEVEL_PREFIX_RE = re.compile(r"^(DEBUG|INFO|WARNING|ERROR|CRITICAL): (.*)$")
+
+
+def _log_subprocess_line(log: logging.Logger, line: str) -> None:
+    match = _LEVEL_PREFIX_RE.match(line)
+    if match:
+        log.log(getattr(logging, match.group(1)), "%s", match.group(2))
+    else:
+        log.log(logging.INFO, "%s", line)
+
+
 def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str, str] | None = None) -> None:
     """
     Execute a process and stream output to logger.
@@ -158,7 +170,7 @@ def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str
         if proc.stdout:
             with proc.stdout:
                 for line in iter(proc.stdout.readline, b""):
-                    log.info("%s", line.decode().rstrip())
+                    _log_subprocess_line(log, line.decode().rstrip())
 
         exit_code = proc.wait()
     if exit_code != 0:

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -135,15 +135,16 @@ def _index_urls_to_uv_env_vars(index_urls: list[str] | None = None) -> dict[str,
     return uv_index_env_vars
 
 
-_LEVEL_PREFIX_RE = re.compile(r"^(DEBUG|INFO|WARNING|ERROR|CRITICAL): (.*)$")
+_LEVEL_PREFIX_RE = re.compile(r"^(DEBUG|INFO|WARNING|ERROR|CRITICAL): ")
+_MAX_PREFIX_LEN = len("CRITICAL: ")  # longest possible prefix — regex never sees beyond this
 
 
 def _log_subprocess_line(log: logging.Logger, line: str) -> None:
-    match = _LEVEL_PREFIX_RE.match(line)
+    match = _LEVEL_PREFIX_RE.match(line[:_MAX_PREFIX_LEN])
     if match:
-        log.log(getattr(logging, match.group(1)), "%s", match.group(2))
+        log.log(getattr(logging, match.group(1)), "%s", line[match.end() :])
     else:
-        log.log(logging.INFO, "%s", line)
+        log.info("%s", line)
 
 
 def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str, str] | None = None) -> None:

--- a/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
@@ -25,6 +25,7 @@ from unittest import mock
 import pytest
 
 from airflow.providers.standard.utils.python_virtualenv import (
+    _execute_in_subprocess,
     _generate_pip_conf,
     _log_subprocess_line,
     _use_uv,
@@ -301,4 +302,31 @@ class TestLogSubprocessLine:
     def test_log_subprocess_line(self, line, expected_level, expected_message):
         log = mock.MagicMock(spec=logging.Logger)
         _log_subprocess_line(log, line)
-        log.log.assert_called_once_with(expected_level, "%s", expected_message)
+        if expected_level == logging.INFO and not line.startswith(
+            ("DEBUG: ", "INFO: ", "WARNING: ", "ERROR: ", "CRITICAL: ")
+        ):
+            log.info.assert_called_once_with("%s", expected_message)
+        else:
+            log.log.assert_called_once_with(expected_level, "%s", expected_message)
+
+    def test_execute_in_subprocess_forwards_log_levels(self, tmp_path):
+        script = tmp_path / "script.py"
+        script.write_text(
+            "import logging, sys, traceback as _tb\n"
+            "class _F(logging.Formatter):\n"
+            "    def format(self, r):\n"
+            "        msg = super().format(r)\n"
+            "        return '\\n'.join(r.levelname + ': ' + l for l in msg.splitlines())\n"
+            "_h = logging.StreamHandler(); _h.setFormatter(_F()); logging.root.addHandler(_h)\n"
+            "logging.warning('watch out')\n"
+            "logging.error('bad thing\\nstill error')\n"
+        )
+        with mock.patch(
+            "airflow.providers.standard.utils.python_virtualenv._log_subprocess_line"
+        ) as mock_log_line:
+            _execute_in_subprocess(["python", str(script)])
+
+        logged_lines = [c.args[1] for c in mock_log_line.call_args_list]
+        assert "WARNING: watch out" in logged_lines
+        assert "ERROR: bad thing" in logged_lines
+        assert "ERROR: still error" in logged_lines

--- a/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
@@ -17,13 +17,19 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
 import pytest
 
-from airflow.providers.standard.utils.python_virtualenv import _generate_pip_conf, _use_uv, prepare_virtualenv
+from airflow.providers.standard.utils.python_virtualenv import (
+    _generate_pip_conf,
+    _log_subprocess_line,
+    _use_uv,
+    prepare_virtualenv,
+)
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import remove_task_decorator
@@ -275,3 +281,24 @@ class TestPrepareVirtualenv:
 
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
         assert res == expected_source
+
+
+class TestLogSubprocessLine:
+    @pytest.mark.parametrize(
+        ("line", "expected_level", "expected_message"),
+        [
+            ("DEBUG: some debug message", logging.DEBUG, "some debug message"),
+            ("INFO: some info message", logging.INFO, "some info message"),
+            ("WARNING: some warning", logging.WARNING, "some warning"),
+            ("ERROR: an error occurred", logging.ERROR, "an error occurred"),
+            ("CRITICAL: fatal problem", logging.CRITICAL, "fatal problem"),
+            ("plain line without prefix", logging.INFO, "plain line without prefix"),
+            ("WARN: not a valid prefix", logging.INFO, "WARN: not a valid prefix"),
+            ("debug: lowercase not matched", logging.INFO, "debug: lowercase not matched"),
+            ("", logging.INFO, ""),
+        ],
+    )
+    def test_log_subprocess_line(self, line, expected_level, expected_message):
+        log = mock.MagicMock(spec=logging.Logger)
+        _log_subprocess_line(log, line)
+        log.log.assert_called_once_with(expected_level, "%s", expected_message)


### PR DESCRIPTION
feat(standard): forward log levels from virtualenv subprocess stdout

  Parse standard Python logging prefixes (DEBUG/INFO/WARNING/ERROR/CRITICAL)
  from subprocess stdout in `_execute_in_subprocess` and re-emit each line at
  the matching Airflow log level instead of collapsing everything to INFO.

  Adds `_log_subprocess_line` helper with a compiled regex, wires it into the
  stdout loop, and documents the recommended formatter setup (including
  traceback forwarding via `sys.excepthook`) for `PythonVirtualenvOperator`
  and `ExternalPythonOperator`.

  ## Problem

  `PythonVirtualenvOperator` and `ExternalPythonOperator` run user code in a
  subprocess and stream stdout back to the Airflow logger. Previously every
  line was logged at `INFO` regardless of severity, so `WARNING`/`ERROR` log
  lines from user code were invisible at elevated log-level filters and mixed
  into the INFO stream.

  ## Solution

  `_execute_in_subprocess` now calls `_log_subprocess_line` for each output
  line. The helper matches the standard Python logging prefix format
  (`LEVEL: message`) and calls `log.log(level, ...)` accordingly. Lines
  without a recognised prefix fall back to `INFO` — no behaviour change for
  existing code.

  Users opt in by configuring their callable's formatter:

  ```python
  class _PrefixAllLinesFormatter(logging.Formatter):
      def format(self, record):
          msg = super().format(record)
          prefix = record.levelname + ": "
          return "\n".join(prefix + line for line in msg.splitlines())

  handler = logging.StreamHandler()
  handler.setFormatter(_PrefixAllLinesFormatter())
  logging.root.addHandler(handler)
```

  Traceback lines from unhandled top-level exceptions are forwarded via a
  sys.excepthook override documented in the operator how-to page.

  ## Changes

  - python_virtualenv.py: add _LEVEL_PREFIX_RE, _log_subprocess_line,
  wire into subprocess stdout loop
  - test_python_virtualenv.py: TestLogSubprocessLine — 9 parametrised
  cases covering all five levels, fallback, wrong case, wrong prefix name,
  and empty string
  - docs/operators/python.rst: "Log level forwarding" subsection added to
  both PythonVirtualenvOperator and ExternalPythonOperator sections,
  with collapsible snippet showing formatter + excepthook setup

 ### Original behaviour
 <img width="887" height="427" alt="obrázok" src="https://github.com/user-attachments/assets/c80bf12c-b60c-4279-a791-b81681812350" />
 
 ### Updated behaviour
 <img width="883" height="457" alt="obrázok" src="https://github.com/user-attachments/assets/1183ff79-da1a-4bcc-a0fe-31c4e747d3a9" />

 ### Example DAG to test
 ```python
 from datetime import datetime
import logging
from airflow.sdk import DAG, task


with DAG(
    dag_id="venv_dag",
    start_date=datetime(2024, 1, 1),
    schedule=None,
    catchup=False,
):
    @task.virtualenv(task_id="venv_task", requirements=[], system_site_packages=False)
    def venv_task():

        import logging
        import sys
        import traceback as _tb

        class PrefixAllLinesFormatter(logging.Formatter):
            def format(self, record):
                msg = super().format(record)
                prefix = record.levelname + ": "
                return "\n".join(prefix + line for line in msg.splitlines())

        handler = logging.StreamHandler()
        handler.setFormatter(PrefixAllLinesFormatter())
        logging.root.addHandler(handler)

        def _logging_excepthook(exc_type, exc_value, exc_tb):
            logging.error("".join(_tb.format_exception(exc_type, exc_value, exc_tb)).rstrip())

        sys.excepthook = _logging_excepthook
        logging.basicConfig(format="%(levelname)s: %(message)s")
        logging.warning("This will appear as WARNING in Airflow logs")
        logging.error("This will appear as ERROR in Airflow logs")
        logging.exception("This will appear as ERROR with stack trace in Airflow logs")
        try:
            raise Exception("This will appear as ERROR in Airflow logs")
        except Exception as e:
            logging.exception("Caught an exception: %s", e)
            raise e

    @task.virtualenv(task_id="venv_task_old", requirements=[], system_site_packages=False)
    def venv_task_old():
        import logging

        logging.warning("This will appear as WARNING in Airflow logs")
        logging.error("This will appear as ERROR in Airflow logs")
        logging.exception("This will appear as ERROR with stack trace in Airflow logs")
        try:
            raise Exception("This will appear as ERROR in Airflow logs")
        except Exception as e:
            logging.exception("Caught an exception: %s", e)
            raise e

    venv_task()
    venv_task_old()


 ```
  ---
  - [x] Yes (please specify the tool below)

  Co-authored by: Claude (claude.ai/claude-code) following the guidelines
