### PR TITLE
Derive partition_date for composite keys with one temporal dimension

### DIFF
--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -602,6 +602,7 @@ def _handle_clear_run(
             backfill_id=backfill_id,
             dag_run_id=dr.id,
             logical_date=info.logical_date,
+            partition_key=info.partition_key,
             sort_ordinal=sort_ordinal,
         )
     )

--- a/airflow-core/src/airflow/partition_mappers/product.py
+++ b/airflow-core/src/airflow/partition_mappers/product.py
@@ -17,9 +17,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from airflow.partition_mappers.base import PartitionMapper
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ProductMapper(PartitionMapper):
@@ -52,6 +55,32 @@ class ProductMapper(PartitionMapper):
                 )
             results.append(result)
         return self.delimiter.join(results)
+
+    def to_partition_date(self, downstream_key: str) -> datetime | None:
+        """
+        Return the temporal anchor for *downstream_key*, or ``None`` when ambiguous.
+
+        Splits *downstream_key* by :attr:`delimiter` and calls each child mapper's
+        ``to_partition_date`` on the corresponding segment. Exactly one non-``None``
+        result is returned as the anchor. Zero temporal children (all categorical)
+        and two or more temporal children (ambiguous) both return ``None`` —
+        the convention is at most one time-based dimension per product key.
+
+        An unexpected segment count (key does not match the number of child mappers)
+        returns ``None`` rather than raising, matching the scheduler's rule of leaving
+        ``partition_date`` unset when the input is ambiguous.
+        """
+        segments = downstream_key.split(self.delimiter)
+        if len(segments) != len(self.mappers):
+            return None
+        anchors = [
+            anchor
+            for mapper, segment in zip(self.mappers, segments)
+            if (anchor := mapper.to_partition_date(segment)) is not None
+        ]
+        if len(anchors) == 1:
+            return anchors[0]
+        return None
 
     def serialize(self) -> dict[str, Any]:
         from airflow.serialization.encoders import encode_partition_mapper

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -46,7 +46,7 @@ from airflow.models.backfill import (
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import Asset, CronPartitionTimetable, PartitionedAssetTimetable
 from airflow.ti_deps.dep_context import DepContext
-from airflow.timetables.base import DagRunInfo
+from airflow.timetables.base import DagRunInfo, DataInterval
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.strings import get_random_string
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -1324,7 +1324,6 @@ def test_partitioned_backfill_reprocess_failed(dag_maker, session):
 
 def test_handle_clear_run_preserves_partition_key(dag_maker, session):
     """BackfillDagRun created via the clear/reprocess path carries partition_key from info."""
-    from airflow.timetables.base import DataInterval
 
     with dag_maker(schedule="@daily") as dag:
         PythonOperator(task_id="hi", python_callable=print)

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -41,6 +41,7 @@ from airflow.models.backfill import (
     _create_backfill,
     _do_dry_run,
     _get_latest_dag_run_row_query,
+    _handle_clear_run,
 )
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import Asset, CronPartitionTimetable, PartitionedAssetTimetable
@@ -1319,3 +1320,59 @@ def test_partitioned_backfill_reprocess_failed(dag_maker, session):
     assert bdr is not None
     assert bdr.dag_run_id == backfill_run.id
     assert bdr.partition_key == info.partition_key
+
+
+def test_handle_clear_run_preserves_partition_key(dag_maker, session):
+    """BackfillDagRun created via the clear/reprocess path carries partition_key from info."""
+    from airflow.timetables.base import DataInterval
+
+    with dag_maker(schedule="@daily") as dag:
+        PythonOperator(task_id="hi", python_callable=print)
+
+    logical_date = timezone.parse("2026-01-10")
+    dr = dag_maker.create_dagrun(
+        run_id="scheduled_2026-01-10",
+        logical_date=logical_date,
+        session=session,
+        state="failed",
+    )
+    session.commit()
+
+    # Create a Backfill row so the foreign-key constraint is satisfied.
+    backfill = Backfill(
+        dag_id=dag.dag_id,
+        from_date=logical_date,
+        to_date=logical_date,
+        dag_run_conf=None,
+        max_active_runs=1,
+        reprocess_behavior=ReprocessBehavior.FAILED,
+    )
+    session.add(backfill)
+    session.flush()
+
+    partition_key = "2026-01-10T00:00:00"
+    info = DagRunInfo(
+        run_after=logical_date,
+        data_interval=DataInterval(logical_date, logical_date),
+        partition_key=partition_key,
+        partition_date=None,
+    )
+
+    _handle_clear_run(
+        session=session,
+        dag=dag,
+        dr=dr,
+        info=info,
+        backfill_id=backfill.id,
+        sort_ordinal=1,
+    )
+    session.flush()
+
+    bdr = session.scalar(
+        select(BackfillDagRun).where(
+            BackfillDagRun.backfill_id == backfill.id,
+            BackfillDagRun.dag_run_id == dr.id,
+        )
+    )
+    assert bdr is not None
+    assert bdr.partition_key == partition_key

--- a/airflow-core/tests/unit/partition_mappers/test_product.py
+++ b/airflow-core/tests/unit/partition_mappers/test_product.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 
 from airflow.partition_mappers.identity import IdentityMapper
@@ -120,3 +122,41 @@ class TestProductMapper:
         mapper = ProductMapper(StartOfHourMapper(), StartOfDayMapper())
         encoded_var = encode_partition_mapper(mapper)[Encoding.VAR]
         assert "max_downstream_keys" not in encoded_var
+
+    @pytest.mark.parametrize(
+        ("mapper", "downstream_key", "expected"),
+        [
+            pytest.param(
+                ProductMapper(StartOfDayMapper(), IdentityMapper()),
+                "2024-01-15|us-east-1",
+                datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc),
+                id="one-temporal-one-categorical-returns-temporal-anchor",
+            ),
+            pytest.param(
+                ProductMapper(IdentityMapper(), StartOfDayMapper()),
+                "us-east-1|2024-01-15",
+                datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc),
+                id="categorical-first-temporal-second-returns-temporal-anchor",
+            ),
+            pytest.param(
+                ProductMapper(StartOfDayMapper(), StartOfHourMapper()),
+                "2024-01-15|2024-01-15T10",
+                None,
+                id="two-temporal-children-returns-none",
+            ),
+            pytest.param(
+                ProductMapper(IdentityMapper(), IdentityMapper()),
+                "us-east-1|batch-42",
+                None,
+                id="all-categorical-returns-none",
+            ),
+            pytest.param(
+                ProductMapper(StartOfDayMapper(), IdentityMapper()),
+                "2024-01-15",
+                None,
+                id="wrong-segment-count-returns-none",
+            ),
+        ],
+    )
+    def test_to_partition_date(self, mapper, downstream_key, expected):
+        assert mapper.to_partition_date(downstream_key) == expected


### PR DESCRIPTION

## Why
`ProductMapper` lacked a `to_partition_date` implementation, so backfill Dag runs built from composite partition keys (e.g. `date|region`) never had `partition_date` set — even when exactly one dimension was temporal. A separate gap in `_handle_clear_run` dropped `partition_key` when creating the `BackfillDagRun` on the clear/reprocess path, while all other creation sites in that file already forwarded it.

## What
- `ProductMapper.to_partition_date`: splits the downstream key by delimiter, delegates to each child mapper, returns the single non-`None` anchor. Zero temporal children, two-or-more temporal children, and segment-count mismatch all return `None`.
- `_handle_clear_run` in `backfill.py`: adds `partition_key=info.partition_key` so the clear path matches the other six `BackfillDagRun` creation sites.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
