### PR TITLE
Unify Dag Code tab toolbar with Logs toolbar style

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -145,6 +145,9 @@
     "selectDateRange": "Select Date Range",
     "startTime": "Start Time"
   },
+  "fullscreen": {
+    "tooltip": "Press {{hotkey}} for fullscreen"
+  },
   "generateToken": "Generate Token",
   "key": "Key",
   "logicalDate": "Logical Date",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dag.json
@@ -91,10 +91,6 @@
     "critical": "CRITICAL",
     "debug": "DEBUG",
     "error": "ERROR",
-    "fullscreen": {
-      "button": "Full screen",
-      "tooltip": "Press {{hotkey}} for fullscreen"
-    },
     "info": "INFO",
     "noTryNumber": "No try number",
     "search": {

--- a/airflow-core/src/airflow/ui/src/components/ui/LazyClipboard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/ui/LazyClipboard.tsx
@@ -24,11 +24,12 @@ import { IconButton } from ".";
 
 type LazyClipboardProps = {
   readonly getValue: () => string;
+  readonly label?: string;
 } & ButtonProps;
 
 /** Clipboard button that lazily computes the value only when clicked */
 export const LazyClipboard = React.forwardRef<HTMLButtonElement, LazyClipboardProps>(
-  ({ getValue, ...props }, ref) => {
+  ({ getValue, label, ...props }, ref) => {
     const [copied, setCopied] = React.useState(false);
 
     const handleClick = () => {
@@ -40,7 +41,7 @@ export const LazyClipboard = React.forwardRef<HTMLButtonElement, LazyClipboardPr
     };
 
     return (
-      <IconButton onClick={handleClick} ref={ref} size="xs" variant="subtle" {...props}>
+      <IconButton label={label} onClick={handleClick} ref={ref} size="xs" variant="subtle" {...props}>
         {copied ? <LuCheck /> : <LuClipboard />}
       </IconButton>
     );

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Code/Code.tsx
@@ -20,7 +20,7 @@ import { Box, Button, Heading, HStack, Link, VStack } from "@chakra-ui/react";
 import { useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useTranslation } from "react-i18next";
-import { MdOutlineOpenInFull } from "react-icons/md";
+import { MdOutlineDifference, MdOutlineOpenInFull, MdWrapText } from "react-icons/md";
 import { useParams } from "react-router-dom";
 
 import {
@@ -35,7 +35,8 @@ import { DagVersionSelect } from "src/components/DagVersionSelect";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import Editor, { type EditorProps } from "src/components/MonacoEditor";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardButton, Dialog, IconButton, Tooltip, ProgressBar } from "src/components/ui";
+import { Dialog, IconButton, ProgressBar } from "src/components/ui";
+import { LazyClipboard } from "src/components/ui/LazyClipboard";
 import { useMonacoTheme } from "src/context/colorMode";
 import useSelectedVersion from "src/hooks/useSelectedVersion";
 import { useConfig } from "src/queries/useConfig";
@@ -46,7 +47,7 @@ import { FileLocation } from "./FileLocation";
 import { VersionCompareSelect } from "./VersionCompareSelect";
 
 export const Code = () => {
-  const { t: translate } = useTranslation(["dag", "common"]);
+  const { t: translate } = useTranslation(["dag", "common", "components"]);
   const { dagId } = useParams();
 
   const selectedVersion = useSelectedVersion();
@@ -202,6 +203,43 @@ export const Code = () => {
     </Box>
   );
 
+  const actionButtons = (
+    <HStack gap={1}>
+      <IconButton
+        aria-label={translate(`common:wrap.${wrap ? "un" : ""}wrap`)}
+        label={translate("common:wrap.tooltip", { hotkey: "w" })}
+        onClick={toggleWrap}
+        variant={wrap ? "solid" : "ghost"}
+      >
+        <MdWrapText />
+      </IconButton>
+      {hasMultipleVersions ? (
+        <IconButton
+          aria-label={translate("common:diff")}
+          label={translate("common:diff")}
+          onClick={toggleCompareDropdown}
+          variant={isCompareDropdownOpen || isDiffMode ? "solid" : "ghost"}
+        >
+          <MdOutlineDifference />
+        </IconButton>
+      ) : undefined}
+      {isFullscreen ? undefined : (
+        <IconButton
+          label={translate("common:fullscreen.tooltip", { hotkey: "f" })}
+          onClick={toggleFullscreen}
+        >
+          <MdOutlineOpenInFull />
+        </IconButton>
+      )}
+      <LazyClipboard
+        getValue={() => code?.content ?? ""}
+        label={translate("components:clipboard.copy")}
+        size="md"
+        variant="ghost"
+      />
+    </HStack>
+  );
+
   const codeHeader = (
     <HStack justifyContent="space-between" mt={2}>
       <HStack gap={5}>
@@ -239,40 +277,7 @@ export const Code = () => {
       <VStack gap={2} position="relative">
         <HStack flexWrap="wrap" gap={2}>
           <DagVersionSelect showLabel={false} />
-          <ClipboardRoot value={code?.content ?? ""}>
-            <ClipboardButton />
-          </ClipboardRoot>
-          <Tooltip
-            closeDelay={100}
-            content={translate("common:wrap.tooltip", { hotkey: "w" })}
-            openDelay={100}
-          >
-            <Button
-              aria-label={translate(`common:wrap.${wrap ? "un" : ""}wrap`)}
-              onClick={toggleWrap}
-              variant="outline"
-            >
-              {translate(`common:wrap.${wrap ? "un" : ""}wrap`)}
-            </Button>
-          </Tooltip>
-          {isFullscreen ? undefined : (
-            <IconButton
-              label={translate("logs.fullscreen.tooltip", { hotkey: "f" })}
-              onClick={toggleFullscreen}
-              variant="outline"
-            >
-              <MdOutlineOpenInFull />
-            </IconButton>
-          )}
-          {hasMultipleVersions ? (
-            <Button
-              aria-label={translate("common:diff")}
-              onClick={toggleCompareDropdown}
-              variant={isCompareDropdownOpen ? "solid" : "outline"}
-            >
-              {translate("common:diff")}
-            </Button>
-          ) : undefined}
+          {actionButtons}
           {isDiffMode ? (
             <Button aria-label={translate("common:diffExit")} onClick={exitDiffMode} variant="solid">
               {translate("common:diffExit")}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Logs/TaskLogHeader.tsx
@@ -234,19 +234,15 @@ export const TaskLogHeader = ({
             </Menu.Content>
           </Menu.Root>
           {!isFullscreen && (
-            <IconButton
-              label={translate("dag:logs.fullscreen.tooltip", { hotkey: "f" })}
-              onClick={toggleFullscreen}
-            >
+            <IconButton label={translate("fullscreen.tooltip", { hotkey: "f" })} onClick={toggleFullscreen}>
               <MdOutlineOpenInFull />
             </IconButton>
           )}
 
           <LazyClipboard
-            aria-label={translate("components:clipboard.copy")}
             getValue={getLogString}
+            label={translate("components:clipboard.copy")}
             size="md"
-            title={translate("components:clipboard.copy")}
             variant="ghost"
           />
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

The Dag Code tab toolbar used an older button style (outline text buttons) that
was inconsistent with the task Logs toolbar on the same Dag page. This PR
aligns both toolbars to the same icon-button pattern and interaction model:

- Replace the outline copy and wrap-text buttons with ghost icon buttons
  (`LazyClipboard`, `MdWrapText`), matching the Logs toolbar
- Convert the Diff button to an icon button (`MdOutlineDifference`); it uses
  the `solid` variant while the compare dropdown is open or diff mode is
  active, consistent with the wrap-text toggle ("Exit diff" remains a text
  button for clarity)
- Reorder actions to match the Logs toolbar: view toggles → fullscreen → copy
- Add Chakra tooltip support to `LazyClipboard` via a `label` prop, replacing
  the native `title` tooltip used by the copy button in both the Code and Logs
  tabs
- Move the shared `fullscreen.tooltip` translation key from `dag:logs` to
  `common` across all locales and remove the unused `fullscreen.button` key


## Before

| log | code|
|----|----|
| <img width="496" height="416" alt="image" src="https://github.com/user-attachments/assets/054ad0b6-4f42-4318-83a6-6d63d5503406" /> |  <img width="512" height="412" alt="image" src="https://github.com/user-attachments/assets/61644ef7-0a3b-40f5-b14c-dc61b3e124e7" /> |


## After

<img width="2168" height="1402" alt="image" src="https://github.com/user-attachments/assets/b046198d-4bd8-4054-9d92-bbd12a289054" />

<img width="2168" height="1402" alt="image" src="https://github.com/user-attachments/assets/0b16eec1-d808-4c68-9bbd-bd13cfbe05b0" />

<img width="2168" height="1402" alt="image" src="https://github.com/user-attachments/assets/f8463664-e1d9-4c73-85a9-92c39fd485e3" />



<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
claude opus 4.8
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
