### PR TITLE
Revise auth in WASBHook to use explicit credentials

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -30,6 +30,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, cast
 
+from azure.core.credentials import AzureSasCredential
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
 from azure.identity import ClientSecretCredential
 from azure.identity.aio import (
@@ -203,7 +204,9 @@ class WasbHook(BaseHook):
         if sas_token:
             if sas_token.startswith("https"):
                 return BlobServiceClient(account_url=sas_token, **extra)
-            return BlobServiceClient(account_url=f"{account_url.rstrip('/')}/{sas_token}", **extra)
+            return BlobServiceClient(
+                account_url=account_url, credential=AzureSasCredential(sas_token), **extra
+            )
 
         # Fall back to old auth (password) or use managed identity if not provided.
         credential: str | TokenCredential | None = conn.password
@@ -671,7 +674,7 @@ class WasbAsyncHook(WasbHook):
                 self.blob_service_client = AsyncBlobServiceClient(account_url=sas_token, **extra)
             else:
                 self.blob_service_client = AsyncBlobServiceClient(
-                    account_url=f"{account_url.rstrip('/')}/{sas_token}", **extra
+                    account_url=account_url, credential=AzureSasCredential(sas_token), **extra
                 )
             return self.blob_service_client
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_wasb.py
@@ -23,6 +23,7 @@ from unittest import mock
 from unittest.mock import create_autospec
 
 import pytest
+from azure.core.credentials import AzureSasCredential
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient, ContainerClient
 from azure.storage.blob._models import BlobProperties
@@ -304,10 +305,16 @@ class TestWasbHook:
         self, mocked_connection, mocked_blob_service_client
     ):
         WasbHook(wasb_conn_id="testconn").get_conn()
-        mocked_blob_service_client.assert_called_once_with(
-            account_url="https://testaccountname.blob.core.windows.net/SAStoken",
-            sas_token="SAStoken",
+        assert mocked_blob_service_client.call_args == (
+            (),
+            {
+                "account_url": "https://testaccountname.blob.core.windows.net/",
+                "credential": mock.ANY,
+            },
         )
+        called_credential = mocked_blob_service_client.call_args[1]["credential"]
+        assert isinstance(called_credential, AzureSasCredential)
+        assert called_credential.signature == "SAStoken"
 
     @pytest.mark.parametrize(
         "mocked_connection",
@@ -362,9 +369,9 @@ class TestWasbHook:
         sas_token = hook_conn.extra_dejson[extra_key]
         assert isinstance(conn, BlobServiceClient)
         assert conn.url.startswith("https://")
-        if hook_conn.login:
-            assert hook_conn.login in conn.url
-        assert conn.url.endswith(sas_token + "/")
+        assert isinstance(conn.credential, AzureSasCredential)
+        assert conn.credential.signature == sas_token
+        assert hook_conn.login in conn.url
 
     @pytest.mark.parametrize(
         argnames="conn_id_str",


### PR DESCRIPTION
The previous approach of using a token suffix in the URL seems to have been broken in the latest azure-storage-blob (12.30.0, released on 8 Jun 2026). This switched the hook to use the more canonical approach to provide the credential with an argument to the service client instead, which should work both before and after the version.

This should fix recent CI failures in provider compat jobs.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: [Claude Code] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
