### PR TITLE
Fix UnicodeDecodeError in DefaultResponseHandler when response content is binary

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -91,7 +91,7 @@ class DefaultResponseHandler(ResponseHandler):
 
     @staticmethod
     def get_value(response: Response) -> Any:
-        with suppress(JSONDecodeError):
+        with suppress(JSONDecodeError, UnicodeDecodeError):
             return response.json()
         content = response.content
         if not content:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -675,7 +675,7 @@ class TestResponseHandler:
 
         assert isinstance(actual, bytes)
         assert actual == users
-        
+
     def test_default_response_handler_when_unicode_content(self):
         dummy = load_file_from_resources(
             dirname(__file__), "..", "resources", "dummy.pdf", mode="rb", encoding=None

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -675,6 +675,18 @@ class TestResponseHandler:
 
         assert isinstance(actual, bytes)
         assert actual == users
+        
+    def test_default_response_handler_when_unicode_content(self):
+        dummy = load_file_from_resources(
+            dirname(__file__), "..", "resources", "dummy.pdf", mode="rb", encoding=None
+        )
+        response = mock_response(200, dummy)
+        response.json.side_effect = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+        actual = asyncio.run(DefaultResponseHandler().handle_response_async(response, None))
+
+        assert isinstance(actual, bytes)
+        assert actual == dummy
 
     def test_default_response_handler_when_no_content_but_headers(self):
         response = mock_response(200, headers={"RequestId": "ffb6096e-d409-4826-aaeb-b5d4b165dc4d"})


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

### What

`DefaultResponseHandler.get_value` suppresses `JSONDecodeError` when `response.json()` fails and falls back to `response.content` or headers. This PR extends the suppression to also include `UnicodeDecodeError` when the response body contains invalid bytes.

**Note:** This seems to be specific to the `httpx` transport used by this response handler, which calls CPython's `json.loads()` without any additional exception handling. The `json.loads()` function [can raise both `JSONDecodeError` and `UnicodeDecodeError'](https://docs.python.org/3/library/json.html#basic-usage).

### Why

Hooks that extend the `KiotaRequestAdapterHook` may call API endpoints that return binary responses. One such use case is to allow users to extend the `PowerBIHook` to support exporting reports to PDF. In these cases, `response.json()` raises a UnicodeDecodeError rather than a JSONDecodeError, causing the request to fail before reaching the `response.content` fall through path. Suppressing `UnicodeDecodeError` alongside `JSONDecodeError` allows these binary responses to be handled correctly and returned as bytes.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
