### PR TITLE
Switch the default async Postgres driver from asyncpg to psycopg3 (core)

### DIFF
--- a/airflow-core/docs/howto/set-up-database.rst
+++ b/airflow-core/docs/howto/set-up-database.rst
@@ -184,9 +184,9 @@ in the Postgres documentation to learn more.
 
 .. warning::
 
-   When you use SQLAlchemy 1.4.0+, you need to use ``postgresql+psycopg2://`` as the database in the ``sql_alchemy_conn``.
-   In the previous versions of SQLAlchemy it was possible to use ``postgres://``, but using it in
-   SQLAlchemy 1.4.0+ results in:
+   On SQLAlchemy 1.4+, use ``postgresql://`` as the connection string schema in ``sql_alchemy_conn``.
+   In earlier versions of SQLAlchemy it was possible to use ``postgres://``, but doing so in
+   SQLAlchemy 1.4+ results in:
 
    .. code-block::
 
@@ -195,16 +195,50 @@ in the Postgres documentation to learn more.
               )
       E       sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres
 
-   If you cannot change the prefix of your URL immediately, Airflow continues to work with SQLAlchemy
-   1.3 and you can downgrade SQLAlchemy, but we recommend to update the prefix.
-
    Details in the `SQLAlchemy Changelog <https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-3687655465c25a39b968b4f5f6e9170b>`_.
 
-We recommend using the ``psycopg2`` driver and specifying it in your SqlAlchemy connection string.
+We recommend specifying a driver, such as ``psycopg2``, explicitly in your SQLAlchemy connection string:
 
 .. code-block:: text
 
-   postgresql+psycopg2://<user>:<password>@<host>/<db>
+   postgresql+<driver>://<user>:<password>@<host>/<db>
+
+Async SQLAlchemy engine and the async driver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the synchronous engine, Airflow maintains an async SQLAlchemy engine for the metadata database (used e.g. by async API endpoints).
+When ``[database] sql_alchemy_conn_async`` is not set, its URL is derived from ``sql_alchemy_conn`` using ``psycopg`` (psycopg3) as the async driver:
+
+.. code-block:: text
+
+   postgresql+psycopg_async://<user>:<password>@<host>/<db>
+
+psycopg3 is the default because it is safe behind transaction-mode PgBouncer (recommended for all production Postgres installations, see the note below) with no extra configuration.
+psycopg3 `defers statement preparation <https://www.psycopg.org/psycopg3/docs/advanced/prepare.html>`_ behind a threshold (default 5 executions) and lets you disable it entirely with ``prepare_threshold=None``.
+If psycopg3 is not installed — for example with an older ``apache-airflow-providers-postgres`` release that ships ``asyncpg`` but not ``psycopg`` — Airflow falls back to deriving an ``asyncpg`` URL instead.
+
+If you need the extra throughput of ``asyncpg``, opt in by installing the ``apache-airflow-providers-postgres[asyncpg]`` extra and setting the async URL explicitly:
+
+.. code-block:: ini
+
+   [database]
+   sql_alchemy_conn_async = postgresql+asyncpg://<user>:<password>@<host>/<db>
+
+asyncpg uses `named server-side prepared statements <https://magicstack.github.io/asyncpg/current/faq.html#why-am-i-getting-prepared-statement-errors>`_, which break under transaction-mode PgBouncer.
+If you run asyncpg behind transaction-mode PgBouncer, you must disable its prepared-statement caching by pointing ``sql_alchemy_connect_args_async`` at a dictionary defined in your ``airflow_local_settings.py``:
+
+.. code-block:: python
+
+   # airflow_local_settings.py
+   connect_args_async = {
+       "statement_cache_size": 0,
+       "prepared_statement_cache_size": 0,
+   }
+
+.. code-block:: ini
+
+   [database]
+   sql_alchemy_connect_args_async = airflow_local_settings.connect_args_async
 
 Also note that since SqlAlchemy does not expose a way to target a specific schema in the database URI, you need to ensure schema ``public`` is in your Postgres user's search_path.
 

--- a/airflow-core/newsfragments/68496.significant.rst
+++ b/airflow-core/newsfragments/68496.significant.rst
@@ -1,0 +1,32 @@
+Default async Postgres driver changed from asyncpg to psycopg3
+
+When ``[database] sql_alchemy_conn_async`` is not set, Airflow derives the async metadata database URL from ``sql_alchemy_conn``. For PostgreSQL, the derived URL now uses psycopg3 (``postgresql+psycopg_async://``) instead of asyncpg (``postgresql+asyncpg://``) when psycopg3 is installed. If psycopg3 is not installed — for example with an older ``apache-airflow-providers-postgres`` release that ships ``asyncpg`` but not ``psycopg`` — the derived URL keeps using asyncpg, so upgrading core without upgrading the provider does not break the async engine.
+
+**Why:** Airflow recommends running PgBouncer in front of PostgreSQL in production. asyncpg uses named server-side prepared statements, which break under transaction-mode PgBouncer unless prepared-statement caching is explicitly disabled. psycopg3 is safe behind transaction-mode PgBouncer with no extra configuration, so the default async engine now works out of the box in recommended production deployments.
+
+The SQLite (``aiosqlite``) and MySQL (``aiomysql``) async URL derivations are unchanged, and an explicitly configured ``sql_alchemy_conn_async`` is never rewritten.
+
+**Packaging:** the ``apache-airflow-providers-postgres`` distribution now installs ``psycopg`` (psycopg3) by default, and ``asyncpg`` is no longer installed by default. Instead, it moved to the ``asyncpg`` optional extra. Note that Airflow versions older than 3.4.0 always derive an asyncpg URL (they have no psycopg3 fallback), so running the new provider release on an older core requires either the ``asyncpg`` extra or an explicitly configured ``sql_alchemy_conn_async``.
+
+**To keep using asyncpg**, install the extra and configure the async URL explicitly:
+
+.. code-block:: bash
+
+    pip install 'apache-airflow-providers-postgres[asyncpg]'
+
+.. code-block:: ini
+
+    [database]
+    sql_alchemy_conn_async = postgresql+asyncpg://<user>:<password>@<host>/<db>
+
+When running behind transaction-mode PgBouncer, also disable asyncpg's prepared-statement caching by pointing ``sql_alchemy_connect_args_async`` at a dict defined in ``airflow_local_settings.py``:
+
+.. code-block:: python
+
+    # airflow_local_settings.py
+    connect_args_async = {"statement_cache_size": 0, "prepared_statement_cache_size": 0}
+
+.. code-block:: ini
+
+    [database]
+    sql_alchemy_connect_args_async = airflow_local_settings.connect_args_async

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -241,8 +241,12 @@ def load_policy_plugins(pm: pluggy.PluginManager):
 
 
 def _get_async_conn_uri_from_sync(sync_uri):
-    AIO_LIBS_MAPPING = {"sqlite": "aiosqlite", "postgresql": "asyncpg", "mysql": "aiomysql"}
-    """Mapping of sync scheme to async scheme."""
+    # Mapping of backend to async driver:
+    AIO_LIBS_MAPPING = {
+        "sqlite": "aiosqlite",
+        "postgresql": "psycopg_async" if _USE_PSYCOPG3 else "asyncpg",
+        "mysql": "aiomysql",
+    }
 
     scheme, rest = sync_uri.split(":", maxsplit=1)
     scheme = scheme.split("+", maxsplit=1)[0]

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -434,6 +434,39 @@ def test_sqlite_relative_path(value, expectation):
             settings.configure_orm()
 
 
+@pytest.mark.parametrize(
+    ("sync_uri", "use_psycopg3", "expected_async_uri"),
+    [
+        ("postgresql://user:pass@host/db", True, "postgresql+psycopg_async://user:pass@host/db"),
+        ("postgresql://user:pass@host/db", False, "postgresql+asyncpg://user:pass@host/db"),
+        ("postgresql+psycopg2://user:pass@host/db", True, "postgresql+psycopg_async://user:pass@host/db"),
+        ("postgresql+psycopg2://user:pass@host/db", False, "postgresql+asyncpg://user:pass@host/db"),
+        ("sqlite:////root/airflow.db", True, "sqlite+aiosqlite:////root/airflow.db"),
+        ("mysql://user:pass@host/db", True, "mysql+aiomysql://user:pass@host/db"),
+        ("mssql://user:pass@host/db", True, "mssql://user:pass@host/db"),
+    ],
+)
+def test_get_async_conn_uri_from_sync(sync_uri, use_psycopg3, expected_async_uri):
+    from airflow import settings
+
+    with patch.object(settings, "_USE_PSYCOPG3", use_psycopg3):
+        assert settings._get_async_conn_uri_from_sync(sync_uri) == expected_async_uri
+
+
+def test_explicit_sql_alchemy_conn_async_is_not_rewritten():
+    from airflow import settings
+
+    from tests_common.test_utils.config import conf_vars
+
+    explicit_async_uri = "postgresql+asyncpg://user:pass@host/db"
+    try:
+        with conf_vars({("database", "sql_alchemy_conn_async"): explicit_async_uri}):
+            settings.configure_vars()
+            assert explicit_async_uri == settings.SQL_ALCHEMY_CONN_ASYNC
+    finally:
+        settings.configure_vars()
+
+
 class TestDisposeOrm:
     """Tests for dispose_orm() async engine disposal."""
 


### PR DESCRIPTION
depends on: 
- #68314

related:
- #69089

closes:
- #67801

---

## What

When `[database] sql_alchemy_conn_async` is not set, Airflow derives the async metadata-database URL from `sql_alchemy_conn`. For PostgreSQL, the derived URL now uses **psycopg3** (`postgresql+psycopg_async://`) instead of asyncpg (`postgresql+asyncpg://`).

Packaging follows: `apache-airflow-providers-postgres` now installs `psycopg[binary]` by default, and `asyncpg` moves to a new opt-in `asyncpg` extra. `psycopg2-binary` is unchanged — the sync engine still uses psycopg2.

## Why

Airflow recommends running PgBouncer in front of PostgreSQL in production. asyncpg uses named server-side prepared statements, which break under transaction-mode PgBouncer unless prepared-statement caching is explicitly disabled. psycopg3 is safe behind transaction-mode PgBouncer with **zero configuration**, so the default async engine now works out of the box in recommended production deployments. A safe default beats a documentation note operators miss.

asyncpg was originally chosen only because Airflow was pinned to SQLAlchemy 1.4; that constraint is gone (`airflow-core` requires `sqlalchemy[asyncio]>=2.0.48`), and psycopg3 serves both sync and async from a single driver.

## Keeping asyncpg

asyncpg remains fully supported as a throughput opt-in:

```bash
pip install 'apache-airflow-providers-postgres[asyncpg]'
```

```ini
[database]
sql_alchemy_conn_async = postgresql+asyncpg://<user>:<password>@<host>/<db>
```

Behind transaction-mode PgBouncer, also disable asyncpg's prepared-statement caching via `sql_alchemy_connect_args_async` (a dict defined in `airflow_local_settings.py`):

```python
# airflow_local_settings.py
connect_args_async = {"statement_cache_size": 0, "prepared_statement_cache_size": 0}
```

## Notes for reviewers

- The derived async dialect is `postgresql+psycopg_async://` (explicit form), not the `postgresql+psycopg` shorthand mentioned in the issue body — chosen deliberately for explicitness, matching the explicit-sync-driver direction of #68314.
- **Scope:** SQLite (`aiosqlite`) and MySQL (`aiomysql`) async derivations are unchanged, and an explicitly configured `sql_alchemy_conn_async` is never rewritten.
- **psycopg2 is intentionally kept** as the sync hard dependency in this PR to keep it reviewable. Removing psycopg2 and migrating the sync engine to psycopg3 (aligned with the SQLAlchemy 2.1 upgrade, where the `postgresql://` default flips to psycopg3) is tracked in https://github.com/apache/airflow/issues/68453.
- **Merge ordering:** depends on #68314 (explicit sync `postgresql+psycopg2://`). #67800 (async heartbeat) will rebase its docs onto this change.
- **Bulk-write caveat:** psycopg3-async is markedly slower on batch `INSERT`/`COPY` in localhost benchmarks. Today's async routes are single-row OLTP, so this does not affect the switch, but bulk paths must be validated before they migrate to async (#67799).

## Validation

Validated end to end against a real transaction-mode PgBouncer in front of Postgres (`dev/pgbouncer_e2e/`): the default-derived `psycopg_async` engine runs repeated single-row and row-returning queries with **no named prepared statements left on the backend**, and the documented asyncpg opt-in recipe behaves the same.

## Appendix: E2E tests

<details><summary>docker-compose.yaml</summary>
<p>

~~~yaml
# Throwaway stack for validating the default async metadata engine behind
# transaction-mode PgBouncer (issue #67801 acceptance check). Not for production.
services:
  postgres:
    image: postgres:16
    environment:
      POSTGRES_USER: airflow
      POSTGRES_PASSWORD: airflow
      POSTGRES_DB: airflow
    ports:
      - "55432:5432"
    healthcheck:
      test: ["CMD-SHELL", "pg_isready -U airflow"]
      interval: 2s
      timeout: 2s
      retries: 30

  pgbouncer:
    image: edoburu/pgbouncer:latest
    environment:
      DB_HOST: postgres
      DB_USER: airflow
      DB_PASSWORD: airflow
      DB_NAME: airflow
      POOL_MODE: transaction
      AUTH_TYPE: scram-sha-256
      LISTEN_PORT: "6432"
    ports:
      - "56432:6432"
    depends_on:
      postgres:
        condition: service_healthy
~~~

</p>
</details> 


<details><summary>pgbouncer_e2e.py</summary>
<p>

~~~python
"""
E2E validation for issue #67801: the default-derived async Postgres engine must work
behind transaction-mode PgBouncer with no extra configuration, and the documented
asyncpg opt-in recipe must also work.

Run after `docker compose -f dev/pgbouncer_e2e/docker-compose.yaml up -d`:

    uv run --project airflow-core python dev/pgbouncer_e2e/run_e2e.py
"""

from __future__ import annotations

import asyncio
import os
import sys

PGBOUNCER_SYNC_URL = os.environ.get(
    "E2E_SYNC_URL", "postgresql+psycopg2://airflow:airflow@localhost:56432/airflow"
)
BACKEND_DIRECT_URL = os.environ.get(
    "E2E_BACKEND_URL", "postgresql+psycopg2://airflow:airflow@localhost:55432/airflow"
)
NUM_QUERIES = 50


def count_backend_prepared_statements(samples: int = 20) -> int:
    """
    Count named prepared statements visible on PgBouncer's pooled backend connections.

    ``pg_prepared_statements`` is connection-local, so the leftovers from a previous client
    are only visible when PgBouncer hands us the same backend connection. Sample many
    short transactions through PgBouncer (transaction mode rotates backends) and report
    the maximum seen on any backend.
    """
    from sqlalchemy import create_engine, text
    from sqlalchemy.pool import NullPool

    pgbouncer_url = PGBOUNCER_SYNC_URL
    worst = 0
    engine = create_engine(pgbouncer_url, poolclass=NullPool)
    for _ in range(samples):
        with engine.connect() as conn:
            count = conn.execute(text("SELECT count(*) FROM pg_prepared_statements")).scalar()
            worst = max(worst, int(count or 0))
    engine.dispose()
    return worst


async def exercise_async_engine(async_url: str, connect_args: dict) -> None:
    from sqlalchemy import text
    from sqlalchemy.ext.asyncio import create_async_engine

    engine = create_async_engine(async_url, connect_args=connect_args, pool_pre_ping=True)
    for i in range(NUM_QUERIES):
        async with engine.connect() as conn:
            value = (await conn.execute(text("SELECT 1"))).scalar()
            if value != 1:
                raise RuntimeError(f"query {i} returned {value!r}")
            ti = (
                await conn.execute(text("SELECT typname FROM pg_type WHERE typname = 'int4' LIMIT 1"))
            ).scalar()
            if ti != "int4":
                raise RuntimeError(f"row-returning query {i} returned {ti!r}")
    await engine.dispose()


def derive_default_async_url() -> str:
    os.environ["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = PGBOUNCER_SYNC_URL
    os.environ.pop("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_ASYNC", None)
    from airflow import settings

    settings.configure_vars()
    derived = settings.SQL_ALCHEMY_CONN_ASYNC
    print(f"derived async URL: {derived}")
    if not derived.startswith("postgresql+psycopg_async://"):
        raise RuntimeError(f"unexpected derived async URL: {derived}")
    return derived


def main() -> int:
    # Step 1+2: default derivation, then 50 queries through PgBouncer with the derived engine
    derived = derive_default_async_url()
    asyncio.run(exercise_async_engine(derived, connect_args={}))
    print(f"step 2 OK: {NUM_QUERIES} queries via default psycopg_async engine through PgBouncer")

    # Step 3: no named prepared statements may remain on the backend
    leftover = count_backend_prepared_statements()
    print(f"step 3: backend prepared statements after psycopg run: {leftover}")
    if leftover != 0:
        print("FAIL: psycopg run left prepared statements on the backend")
        return 1

    # Step 4: explicit asyncpg opt-in with the documented PgBouncer-safe recipe
    asyncpg_url = PGBOUNCER_SYNC_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
    asyncio.run(
        exercise_async_engine(
            asyncpg_url,
            connect_args={"statement_cache_size": 0, "prepared_statement_cache_size": 0},
        )
    )
    leftover = count_backend_prepared_statements()
    print(f"step 4: backend prepared statements after asyncpg recipe run: {leftover}")
    if leftover != 0:
        print("FAIL: asyncpg recipe run left prepared statements on the backend")
        return 1

    print("E2E PASS")
    return 0


if __name__ == "__main__":
    sys.exit(main())
~~~

</p>
</details> 

---


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
