### PR TITLE
Fix flaky SimpleAuthManager login tests under parallel runs

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/auth/managers/simple/conftest.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/simple/conftest.py
@@ -31,6 +31,22 @@ from airflow.api_fastapi.auth.managers.simple.user import SimpleAuthManagerUser
 from tests_common.test_utils.config import conf_vars
 
 
+@pytest.fixture(autouse=True)
+def isolated_password_file(tmp_path):
+    """
+    Point the SimpleAuthManager generated-password file at a per-test path.
+
+    By default the file lives under ``AIRFLOW_HOME``, a single path shared by every
+    test process. Fixtures and tests here create, overwrite, and delete it, so under
+    parallel (xdist) runs one process can delete the file another is mid-read on,
+    raising ``FileNotFoundError``. Giving each test its own ``tmp_path`` file removes
+    that cross-process race.
+    """
+    password_file = tmp_path / "simple_auth_manager_passwords.json.generated"
+    with conf_vars({("core", "simple_auth_manager_passwords_file"): str(password_file)}):
+        yield
+
+
 @pytest.fixture
 def auth_manager():
     auth_manager = SimpleAuthManager()


### PR DESCRIPTION
# Human Summary
This PR fixes a race between tests of `SimpleAuthManager` that utilize the same generated JSON file.

# AI Summary
<details>
<summary>Click Here</summary>
The SimpleAuthManager tests under `airflow-core/tests/unit/api_fastapi/auth/managers/simple/` all share a single generated-password file path under `AIRFLOW_HOME` (`simple_auth_manager_passwords.json.generated`). Several fixtures and tests create, overwrite, and delete that file — notably the `auth_manager` conftest fixture (`os.remove`), `test_init_with_all_admins`, and `test_get_passwords`.

Because the path is global, under parallel (xdist) runs one worker process can delete the file while another is mid-read on it. `SimpleAuthManager.get_passwords()` opens the file with `"r+"` and fails hard if it is missing, so e.g. `test_create_token_invalid_user_password` intermittently raises:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../simple_auth_manager_passwords.json.generated'
```

This is a long-standing latent test-isolation bug (the shared-path fixture dates back to the sources-move in #47798), surfaced when these test types run together in the same parallel pool.

**Fix:** isolate the password file per test via an autouse fixture that points the existing `[core] simple_auth_manager_passwords_file` config option at a per-test `tmp_path`. Each test (and each xdist worker) gets its own file, removing the cross-process race. No source change needed — the source already honors that config option.

Verified by reproducing the failure (~1-in-5 parallel runs before) and confirming 10/10 clean parallel runs of the whole directory after the fix.
</details>


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)