### PR TITLE
Tighten test-scope guidance: test only what the PR changes

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -36,8 +36,7 @@ Use these rules when reviewing pull requests to the Apache Airflow repository.
 
 ## Testing Requirements
 
-- **Flag any new public method or behavior without corresponding tests.** Tests must cover success, failure, and edge cases.
-- **Flag tests that cover pre-existing logic or standard-library behavior.** Tests should be scoped to what the PR introduces or changes — not to logic that was already there before the PR, and not to stdlib/third-party functions. A test that passes without the PR's change is padding, not coverage.
+- **Flag any changed or added behaviour without a corresponding test, and flag tests that a reviewer cannot fail by reverting the PR's change.** The target is exactly 100% coverage of what the PR changes — no more, no less. Tests for pre-existing logic or standard-library/third-party functions are padding; missing tests for changed behaviour are gaps. Exception: deliberate behaviour or integration tests may cross those boundaries by design.
 - **Flag any `unittest.TestCase` subclass.** Use pytest patterns instead.
 - **Flag any `mock.Mock()` or `mock.MagicMock()` without `spec` or `autospec`.** Unspec'd mocks silently accept any attribute access, hiding real bugs.
 - **Flag any `time.sleep` or `datetime.now()` in tests.** Use `time_machine` for time-dependent tests.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -37,6 +37,7 @@ Use these rules when reviewing pull requests to the Apache Airflow repository.
 ## Testing Requirements
 
 - **Flag any new public method or behavior without corresponding tests.** Tests must cover success, failure, and edge cases.
+- **Flag tests that cover pre-existing logic or standard-library behavior.** Tests should be scoped to what the PR introduces or changes — not to logic that was already there before the PR, and not to stdlib/third-party functions. A test that passes without the PR's change is padding, not coverage.
 - **Flag any `unittest.TestCase` subclass.** Use pytest patterns instead.
 - **Flag any `mock.Mock()` or `mock.MagicMock()` without `spec` or `autospec`.** Unspec'd mocks silently accept any attribute access, hiding real bugs.
 - **Flag any `time.sleep` or `datetime.now()` in tests.** Use `time_machine` for time-dependent tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ reported as such are described in "What is NOT considered a security vulnerabili
 
 ## Testing Standards
 
-- Add tests for new behavior — cover success, failure, and edge cases. Test exactly what the PR changes: do not add tests for pre-existing logic that existed before the PR, and do not test standard-library or third-party functions. A test that would pass without the PR's change is not a test of that change.
+- Target exactly 100% coverage of what the PR changes — no more, no less. Every changed or added behaviour must have a test; every test must fail without the PR's change. Do not add tests for pre-existing logic that was already present before the PR, and do not test standard-library or third-party functions. The exception is deliberate behaviour or integration tests, which may cross those boundaries by design.
 - Use pytest patterns, not `unittest.TestCase`.
 - Use `spec`/`autospec` when mocking.
 - Prefer `@mock.patch` decorators over `with mock.patch(...)` context managers for patching. Use `conf_vars` (from `tests_common.test_utils.config`) for Airflow config overrides — as a decorator when the value is fixed, as a context manager when it varies via `@pytest.mark.parametrize`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,7 @@ reported as such are described in "What is NOT considered a security vulnerabili
 
 ## Testing Standards
 
-- Add tests for new behavior — cover success, failure, and edge cases.
+- Add tests for new behavior — cover success, failure, and edge cases. Test exactly what the PR changes: do not add tests for pre-existing logic that existed before the PR, and do not test standard-library or third-party functions. A test that would pass without the PR's change is not a test of that change.
 - Use pytest patterns, not `unittest.TestCase`.
 - Use `spec`/`autospec` when mocking.
 - Prefer `@mock.patch` decorators over `with mock.patch(...)` context managers for patching. Use `conf_vars` (from `tests_common.test_utils.config`) for Airflow config overrides — as a decorator when the value is fixed, as a context manager when it varies via `@pytest.mark.parametrize`.


### PR DESCRIPTION
## Human Summary

I've noticed that AI generated PRs often introduce a lot of unit tests.
In the past (pre-AI), I used to think that having a lot of unit tests is better than having less.
However, it now becomes a burden both for human-reviewing + it overloads the CI.
The idea is that unit tests will reach exactly 100% coverage (no more, no less) - exception is given when we test an integration/behavior, which requires exceeding this limit by nature.

## AI Summary

<details><summary>Click here</summary>

Tests should be scoped to new behavior introduced by the PR — not to
pre-existing logic that was already there before the PR, and not to
standard-library or third-party functions. A test that passes without
the PR's change is padding, not coverage.

This adds that rule to two places:

- `AGENTS.md` (Testing Standards) — so agents and contributors know
  the expectation when writing tests
- `.github/instructions/code-review.instructions.md` (Testing
  Requirements) — so reviewers flag over-coverage during code review

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 4.6)

Generated-by: Claude Code (Sonnet 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)