### PR TITLE
KubernetesPodOperator: make pod retention patching explicit

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1228,12 +1228,13 @@ class KubernetesPodOperator(BaseOperator):
         istio_enabled = self.is_istio_enabled(remote_pod)
         pod_phase = remote_pod.status.phase if hasattr(remote_pod, "status") else None
 
+        should_keep = self.on_finish_action in {
+            OnFinishAction.KEEP_POD,
+            OnFinishAction.DELETE_ACTIVE_POD,
+        }
+
         # if the pod fails or success, but we don't want to delete it
-        if (
-            pod_phase != PodPhase.SUCCEEDED
-            or self.on_finish_action == OnFinishAction.KEEP_POD
-            or self.on_finish_action == OnFinishAction.DELETE_ACTIVE_POD
-        ):
+        if pod_phase != PodPhase.SUCCEEDED or should_keep:
             self.patch_already_checked(remote_pod, reraise=False)
 
         if istio_enabled or self.do_xcom_push:


### PR DESCRIPTION
**Description**

This change is a small cleanup that was originally intended for PR #61637 but was omitted when that PR was closed.

**Rationale**

The pod retention logic has been made more explicit to clearly distinguish between pods that are deleted and pods that are intentionally retained due to phase-based deletion rules. No functional behavior is changed.

**Backwards Compatibility**

No existing defaults are modified, and no public APIs have beem removed or altered.