### PR TITLE
Factor out a shared base for the database error handlers

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -24,13 +24,14 @@ from enum import Enum
 from typing import Generic, TypeVar
 
 from fastapi import HTTPException, Request, status
-from sqlalchemy.exc import DataError, IntegrityError
+from sqlalchemy.exc import DatabaseError, DataError, IntegrityError
 
 from airflow.configuration import conf
 from airflow.exceptions import DeserializationError
 from airflow.utils.strings import get_random_string
 
 T = TypeVar("T", bound=Exception)
+DBError = TypeVar("DBError", bound=DatabaseError)
 
 log = logging.getLogger(__name__)
 
@@ -53,82 +54,27 @@ class _DatabaseDialect(Enum):
     POSTGRES = "postgres"
 
 
-class _UniqueConstraintErrorHandler(BaseErrorHandler[IntegrityError]):
-    """Exception raised when trying to insert a duplicate value in a unique column."""
-
-    unique_constraint_error_prefix_dict: dict[_DatabaseDialect, str] = {
-        _DatabaseDialect.SQLITE: "UNIQUE constraint failed",
-        _DatabaseDialect.MYSQL: "Duplicate entry",
-        _DatabaseDialect.POSTGRES: "violates unique constraint",
-    }
-
-    def __init__(self):
-        super().__init__(IntegrityError)
-        self.dialect: _DatabaseDialect | None = None
-
-    def exception_handler(self, request: Request, exc: IntegrityError):
-        """Handle IntegrityError exception."""
-        if self._is_dialect_matched(exc):
-            exception_id = get_random_string()
-            stacktrace = ""
-            for tb in traceback.format_tb(exc.__traceback__):
-                stacktrace += tb
-
-            log_message = f"Error with id {exception_id}, statement: {exc.statement}\n{stacktrace}"
-            log.error(log_message)
-            if conf.get("api", "expose_stacktrace") == "True":
-                message = log_message
-                statement = str(exc.statement)
-                orig_error = str(exc.orig)
-            else:
-                message = (
-                    "Serious error when handling your request. Check logs for more details - "
-                    f"you will find it in api server when you look for ID {exception_id}"
-                )
-                statement = "hidden"
-                orig_error = "hidden"
-
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "reason": "Unique constraint violation",
-                    "statement": statement,
-                    "orig_error": orig_error,
-                    "message": message,
-                },
-            )
-
-    def _is_dialect_matched(self, exc: IntegrityError) -> bool:
-        """Check if the exception matches the unique constraint error message for any dialect."""
-        exc_orig_str = str(exc.orig)
-        for dialect, error_msg in self.unique_constraint_error_prefix_dict.items():
-            if error_msg in exc_orig_str:
-                self.dialect = dialect
-                return True
-        return False
-
-
-class DataErrorHandler(BaseErrorHandler[DataError]):
+class _DatabaseErrorHandler(BaseErrorHandler[DBError]):
     """
-    Translate ``sqlalchemy.exc.DataError`` into a 422.
+    Base for handlers that turn a SQLAlchemy error into an actionable HTTP response.
 
-    The database rejected a value that passed Pydantic validation (too long, out
-    of range, or the wrong type for its column), so it is a client error, not a
-    500. The statement and underlying DB error are logged under a lookup id and
-    returned to the caller only when ``[api] expose_stacktrace`` is set, mirroring
-    ``_UniqueConstraintErrorHandler``.
+    The failing statement is logged under a random lookup id and echoed back to the
+    caller only when ``[api] expose_stacktrace`` is set; otherwise the response just
+    points at that id in the api server logs. Subclasses set ``status_code`` and
+    ``reason`` and may override ``_should_handle`` to skip exceptions they do not own.
     """
 
-    def __init__(self):
-        super().__init__(DataError)
+    status_code: int
+    reason: str
 
-    def exception_handler(self, request: Request, exc: DataError):
-        """Handle DataError exception."""
+    def _should_handle(self, exc: DBError) -> bool:
+        return True
+
+    def exception_handler(self, request: Request, exc: DBError):
+        if not self._should_handle(exc):
+            return
         exception_id = get_random_string()
-        stacktrace = ""
-        for tb in traceback.format_tb(exc.__traceback__):
-            stacktrace += tb
-
+        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
         log_message = f"Error with id {exception_id}, statement: {exc.statement}\n{stacktrace}"
         log.error(log_message)
         if conf.get("api", "expose_stacktrace") == "True":
@@ -144,14 +90,58 @@ class DataErrorHandler(BaseErrorHandler[DataError]):
             orig_error = "hidden"
 
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=self.status_code,
             detail={
-                "reason": "Value rejected by database",
+                "reason": self.reason,
                 "statement": statement,
                 "orig_error": orig_error,
                 "message": message,
             },
         )
+
+
+class _UniqueConstraintErrorHandler(_DatabaseErrorHandler[IntegrityError]):
+    """Translate a unique-constraint ``IntegrityError`` into a 409, matched per database dialect."""
+
+    status_code = status.HTTP_409_CONFLICT
+    reason = "Unique constraint violation"
+
+    unique_constraint_error_prefix_dict: dict[_DatabaseDialect, str] = {
+        _DatabaseDialect.SQLITE: "UNIQUE constraint failed",
+        _DatabaseDialect.MYSQL: "Duplicate entry",
+        _DatabaseDialect.POSTGRES: "violates unique constraint",
+    }
+
+    def __init__(self):
+        super().__init__(IntegrityError)
+        self.dialect: _DatabaseDialect | None = None
+
+    def _should_handle(self, exc: IntegrityError) -> bool:
+        return self._is_dialect_matched(exc)
+
+    def _is_dialect_matched(self, exc: IntegrityError) -> bool:
+        """Check if the exception matches the unique constraint error message for any dialect."""
+        exc_orig_str = str(exc.orig)
+        for dialect, error_msg in self.unique_constraint_error_prefix_dict.items():
+            if error_msg in exc_orig_str:
+                self.dialect = dialect
+                return True
+        return False
+
+
+class DataErrorHandler(_DatabaseErrorHandler[DataError]):
+    """
+    Translate a ``sqlalchemy.exc.DataError`` into a 422.
+
+    The database rejected a value that passed Pydantic validation (too long, out of
+    range, or the wrong type for its column), so it is a client error, not a 500.
+    """
+
+    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    reason = "Value rejected by database"
+
+    def __init__(self):
+        super().__init__(DataError)
 
 
 class DagErrorHandler(BaseErrorHandler[DeserializationError]):


### PR DESCRIPTION
Cleanup requested in review on #66888: `_UniqueConstraintErrorHandler` and `DataErrorHandler` carried near-identical bodies — the lookup id, statement log, `[api] expose_stacktrace` gating, and `HTTPException` detail shape were copied between them.

This moves that shared body into a `_DatabaseErrorHandler` base, leaving each handler to declare only what differs: its `status_code`, its `reason`, and an optional `_should_handle` guard. The unique-constraint handler keeps its per-dialect match as that guard; `DataErrorHandler` always handles.

No behavior change — same statuses, payloads, and `expose_stacktrace` gating; the existing `TestUniqueConstraintErrorHandler` / `TestDataErrorHandler` suites are untouched and pass.

related: #66888
