### PR TITLE
Remove redundant tests from airflow-core

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_kerberos_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_kerberos_command.py
@@ -121,16 +121,6 @@ class TestKerberosCommand:
 
     @mock.patch("airflow.cli.commands.kerberos_command.krb")
     @conf_vars({("core", "executor"): "CeleryExecutor"})
-    def test_run_command_with_mode_standard(self, mock_krb):
-        args = self.parser.parse_args(["kerberos", "PRINCIPAL", "--keytab", "/tmp/airflow.keytab"])
-
-        kerberos_command.kerberos(args)
-        mock_krb.run.assert_called_once_with(
-            keytab="/tmp/airflow.keytab", principal="PRINCIPAL", mode=KerberosMode.STANDARD
-        )
-
-    @mock.patch("airflow.cli.commands.kerberos_command.krb")
-    @conf_vars({("core", "executor"): "CeleryExecutor"})
     def test_run_command_with_mode_one_time(self, mock_krb):
         args = self.parser.parse_args(
             ["kerberos", "PRINCIPAL", "--keytab", "/tmp/airflow.keytab", "--one-time"]

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -445,16 +445,6 @@ def test_state_queued():
     assert executor.event_buffer[key] == (TaskInstanceState.QUEUED, info)
 
 
-def test_state_generic():
-    executor = BaseExecutor()
-    key = TaskInstanceKey("my_dag1", "my_task1", timezone.utcnow(), 1)
-    executor.running.add(key)
-    info = "info"
-    executor.queued(key, info=info)
-    assert not executor.running
-    assert executor.event_buffer[key] == (TaskInstanceState.QUEUED, info)
-
-
 def test_state_running():
     executor = BaseExecutor()
     key = TaskInstanceKey("my_dag1", "my_task1", timezone.utcnow(), 1)
@@ -648,11 +638,6 @@ class TestCallbackSupport:
     def test_supports_callbacks_flag_default_false(self):
         executor = BaseExecutor()
         assert executor.supports_callbacks is False
-
-    def test_local_executor_supports_callbacks_true(self):
-        """Test that LocalExecutor sets supports_callbacks to True."""
-        executor = LocalExecutor()
-        assert executor.supports_callbacks is True
 
     @pytest.mark.db_test
     def test_queue_callback_without_support_raises_error(self, dag_maker, session):

--- a/airflow-core/tests/unit/jobs/test_base_job.py
+++ b/airflow-core/tests/unit/jobs/test_base_job.py
@@ -56,16 +56,6 @@ class TestJob:
         assert job.state == State.SUCCESS
         assert job.end_date is not None
 
-    def test_base_job_respects_plugin_hooks(self):
-        import sys
-
-        job = Job()
-        job_runner = MockJobRunner(job=job, func=lambda: sys.exit(0))
-        run_job(job=job, execute_callable=job_runner._execute)
-
-        assert job.state == State.SUCCESS
-        assert job.end_date is not None
-
     def test_base_job_respects_plugin_lifecycle(self, dag_maker, listener_manager):
         """
         Test if DagRun is successful, and if Success callbacks is defined, it is sent to DagFileProcessor.

--- a/airflow-core/tests/unit/logging/test_logging_config.py
+++ b/airflow-core/tests/unit/logging/test_logging_config.py
@@ -57,14 +57,6 @@ class TestGetLoggingConfig:
             config = _get_logging_config()
         assert config is custom
 
-    def test_empty_string_falls_back_to_default(self):
-        from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-
-        with mock.patch("airflow.logging_config.conf") as mocked_conf:
-            mocked_conf.get.return_value = ""
-            config = _get_logging_config()
-        assert config == DEFAULT_LOGGING_CONFIG
-
     @pytest.mark.parametrize(
         "logging_class_path",
         [pytest.param("", id="empty-string"), pytest.param(None, id="none")],

--- a/airflow-core/tests/unit/partition_mappers/test_rollup_wait_policy.py
+++ b/airflow-core/tests/unit/partition_mappers/test_rollup_wait_policy.py
@@ -50,14 +50,6 @@ class TestPolicyConstruction:
     def test_minimum_count_stores_n(self, n):
         assert MinimumCount(n).n == n
 
-    def test_wait_for_all_is_stateless(self):
-        a = WaitForAll()
-        b = WaitForAll()
-        assert type(a) is WaitForAll
-        assert type(b) is WaitForAll
-        assert a == b
-        assert hash(a) == hash(b)
-
     def test_default_wait_policy_is_wait_for_all_instance(self, make_mapper):
         mapper = make_mapper()
         assert isinstance(mapper.wait_policy, WaitForAll)
@@ -111,15 +103,6 @@ class TestPolicySemantics:
     )
     def test_is_unreachable(self, policy, expected, unreachable):
         assert policy.is_unreachable(expected) is unreachable
-
-
-class TestRepr:
-    def test_wait_for_all_repr(self):
-        assert repr(WaitForAll()) == "WaitForAll()"
-
-    def test_minimum_count_repr(self):
-        assert repr(MinimumCount(5)) == "MinimumCount(n=5)"
-        assert repr(MinimumCount(-3)) == "MinimumCount(n=-3)"
 
 
 class TestSerializeRoundTrip:


### PR DESCRIPTION
## Human Summary

related: #68502, #68507

This PR removes tests that are either stdlib/3rd-party's concern, trivial attribute round-trip, or duplicated tests.

Summarizing table is in the "AI Summary".

## AI Summary

<details><summary>Click Here</summary>

Candidates were surfaced by two detectors — per-test **coverage signatures** and an **AST scan of the whole test tree** (cross-file duplicates + dunder/stdlib + round-trip patterns) — and every one was confirmed by reading the test body, its decorators, and the production code before deletion.

**Legend — patterns:**

- **P1** Stdlib / third-party behavior tested directly
- **P2** Trivial attribute round-trip
- **P5** Exact or near-exact duplicate function

| Test | File : line | Pattern | Why redundant |
|---|---|---|---|
| `test_state_generic` | `airflow-core/tests/unit/executors/test_base_executor.py:448` | P5 | Byte-identical body to `test_state_queued` (same `BaseExecutor.queued()` call and the two assertions on `running`/`event_buffer`); only the name differs. Kept `test_state_queued`. |
| `test_empty_string_falls_back_to_default` | `airflow-core/tests/unit/logging/test_logging_config.py:60` | P5 | Fully subsumed by `test_falsy_logging_class_path_falls_back_to_default`, which is `@parametrize`d over `["", None]` and already exercises the empty-string case with the identical assertion. |
| `TestCallbackSupport::test_local_executor_supports_callbacks_true` | `airflow-core/tests/unit/executors/test_base_executor.py:642` | P5 | Byte-identical, cross-file duplicate of `test_local_executor.py::TestLocalExecutorCallbackSupport::test_supports_callbacks_flag_is_true` (`LocalExecutor(); assert supports_callbacks is True`). LocalExecutor's flag belongs in `test_local_executor.py`; kept that copy. |
| `test_base_job_respects_plugin_hooks` | `airflow-core/tests/unit/jobs/test_base_job.py:59` | P5 | Byte-identical to `test_state_sysexit` (runs `sys.exit(0)`, asserts `SUCCESS`) — tests nothing about plugin hooks despite its name. Real plugin coverage is the separate `test_base_job_respects_plugin_lifecycle`. |
| `test_run_command_with_mode_standard` | `airflow-core/tests/unit/cli/commands/test_kerberos_command.py:124` | P5 | Byte-identical to `test_run_command` — neither passes `--mode`, both assert the `STANDARD` default. Adds no coverage beyond `test_run_command`. |
| `TestRepr::test_wait_for_all_repr` | `airflow-core/tests/unit/partition_mappers/test_rollup_wait_policy.py:109` | P1 | Asserts `repr(WaitForAll()) == "WaitForAll()"` — `WaitForAll` is `@attrs.define(frozen=True)` with no custom `__repr__`; this tests attrs' generated repr. |
| `TestRepr::test_minimum_count_repr` | `airflow-core/tests/unit/partition_mappers/test_rollup_wait_policy.py:112` | P1 | Asserts `repr(MinimumCount(5)) == "MinimumCount(n=5)"` — attrs-generated repr, no custom `__repr__` on the class. |
| `TestPolicyConstruction::test_wait_for_all_is_stateless` | `airflow-core/tests/unit/partition_mappers/test_rollup_wait_policy.py:53` | P1 | Asserts `WaitForAll() == WaitForAll()` and equal hashes — `@attrs.define(frozen=True)` auto-generates `__eq__`/`__hash__` for the field-less class; tests attrs, not airflow logic. |

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)