### PR TITLE
Explicitly initialize Stats in API server lifespan

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -71,8 +71,32 @@ class _AuthManagerState:
     _lock = threading.Lock()
 
 
+def _initialize_api_server_stats() -> None:
+    """
+    Initialize the ``Stats`` singleton in the API server process.
+
+    Initialization is guarded so a metrics misconfiguration can never prevent the API server
+    from starting.
+    """
+    try:
+        from airflow._shared.observability.metrics import stats
+        from airflow.observability.metrics import stats_utils
+
+        stats.initialize(
+            factory=stats_utils.get_stats_factory(),
+            export_legacy_names=conf.getboolean("metrics", "legacy_names_on"),
+        )
+    except Exception:
+        log.warning(
+            "Failed to initialize API server Stats in the API server; metrics emitted through the "
+            "API server Stats singleton will not be recorded.",
+            exc_info=True,
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _initialize_api_server_stats()
     async with AsyncExitStack() as stack:
         for route in app.routes:
             if isinstance(route, Mount) and isinstance(route.app, FastAPI):

--- a/airflow-core/tests/unit/api_fastapi/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/test_app.py
@@ -168,3 +168,47 @@ def test_create_auth_manager_thread_safety():
     assert call_count == 1
 
     app_module.purge_cached_app()
+
+
+class TestInitializeApiServerStats:
+    """
+    Ensure that stats subsystem is properly initialized in API server.
+    """
+
+    def test_initializes_api_server_stats_with_factory(self):
+        """It initializes the Stats singleton in the API server using the configured factory."""
+        sentinel_factory = object()
+        with (
+            mock.patch("airflow._shared.observability.metrics.stats") as mock_stats,
+            mock.patch(
+                "airflow.observability.metrics.stats_utils.get_stats_factory",
+                return_value=sentinel_factory,
+            ) as mock_get_factory,
+        ):
+            app_module._initialize_api_server_stats()
+
+            mock_get_factory.assert_called_once_with()
+            mock_stats.initialize.assert_called_once()
+            _, kwargs = mock_stats.initialize.call_args
+            assert kwargs["factory"] is sentinel_factory
+            assert isinstance(kwargs["export_legacy_names"], bool)
+
+    def test_stats_failure_does_not_block_startup(self):
+        """A metrics misconfiguration must not prevent the API server from starting."""
+        with (
+            mock.patch("airflow._shared.observability.metrics.stats") as mock_stats,
+            mock.patch("airflow.observability.metrics.stats_utils.get_stats_factory"),
+            mock.patch("airflow.api_fastapi.app.log") as mock_logger,
+        ):
+            mock_stats.initialize.side_effect = RuntimeError("boom")
+
+            # Must not raise.
+            app_module._initialize_api_server_stats()
+
+        mock_logger.warning.assert_called_once()
+
+    def test_stats_initialized_during_lifespan(self, client):
+        """_initialize_api_server_stats must be called as part of the app lifespan, not just defined."""
+        with mock.patch.object(app_module, "_initialize_api_server_stats") as mock_init:
+            with client():
+                mock_init.assert_called_once()


### PR DESCRIPTION
Re-apply #68078 by @diogosilva30 with fixes after a bad review, merge and reversion in #68481:

Fixes from the original PR:

* Not mentioning "Task SDK" anymore as this is _only_ about initializing stats correctly in API server
* Remove caplog as we actually wanted to ban this
* Double checked: no newsfragment. really.

Why I am re-applying this PR: Because in all Airflow components the "Stats" is correctly initialized, but missing in API server.

closes: #68077

Original PR quote:

> ## Why
> 
> The API server serves the Edge Worker REST API (/edge_worker/v1/...). A worker heartbeat (PATCH /edge_worker/v1/worker/) runs set_state → set_metrics, which records edge_worker.* metrics through the Task SDK Stats singleton (resolved by the Edge provider via airflow.providers.common.compat).
>
> ### On main: hardening against a fragile import side effect
>
> The bug does not reproduce on current main. On main, task_runner.py imports serde at module level, which triggers serde._register() → Stats.initialize(...) as a side effect. That fires on any import airflow — including in the API server — so Stats gets initialized accidentally.
>
> However, this is fragile: it would silently regress if the module-level serde import in task_runner were ever made lazy, or if the mask-secrets import chain changed. The API server doesn't actually depend on serde, so relying on this side effect is not intentional.
>
> Adding an explicit Stats.initialize(...) in the FastAPI lifespan makes the dependency intentional and self-contained. It's a no-op on main (already initialized) and removes the accidental coupling.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
