### PR TITLE
Add batch_asset_events parameter to asset-triggered timetables

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/asset-scheduling.rst
+++ b/airflow-core/docs/authoring-and-scheduling/asset-scheduling.rst
@@ -419,3 +419,27 @@ AssetTimetable Integration
 You can schedule Dags based on both asset events and time-based schedules using ``AssetOrTimeSchedule``. This allows you to create workflows when a Dag needs both to be triggered by data updates and run periodically according to a fixed timetable.
 
 For more detailed information on ``AssetOrTimeSchedule``, refer to the corresponding section in :ref:`AssetOrTimeSchedule <asset-timetable-section>`.
+
+
+Controlling DagRun creation per asset event
+---------------------------------------------
+
+By default, when multiple asset events arrive for the same Dag between
+scheduler ticks, they are batched into a single DagRun. Set
+``batch_asset_events=False`` on the timetable to create one DagRun per
+individual event instead.
+
+.. code-block:: python
+
+    from airflow.sdk import DAG, Asset
+    from airflow.timetables.simple import AssetTriggeredTimetable
+
+    # Each update to "data-file" produces its own DagRun
+    with DAG(
+        dag_id="per-event-consumer",
+        schedule=AssetTriggeredTimetable(
+            assets=Asset("s3://bucket/data-file"),
+            batch_asset_events=False,
+        ),
+    ):
+        ...

--- a/airflow-core/docs/authoring-and-scheduling/asset-scheduling.rst
+++ b/airflow-core/docs/authoring-and-scheduling/asset-scheduling.rst
@@ -424,6 +424,8 @@ For more detailed information on ``AssetOrTimeSchedule``, refer to the correspon
 Controlling DagRun creation per asset event
 ---------------------------------------------
 
+.. versionadded:: 3.3.0
+
 By default, when multiple asset events arrive for the same Dag between
 scheduler ticks, they are batched into a single DagRun. Set
 ``batch_asset_events=False`` on the timetable to create one DagRun per

--- a/airflow-core/docs/authoring-and-scheduling/asset-scheduling.rst
+++ b/airflow-core/docs/authoring-and-scheduling/asset-scheduling.rst
@@ -424,7 +424,7 @@ For more detailed information on ``AssetOrTimeSchedule``, refer to the correspon
 Controlling DagRun creation per asset event
 ---------------------------------------------
 
-.. versionadded:: 3.3.0
+.. versionadded:: 3.3.1
 
 By default, when multiple asset events arrive for the same Dag between
 scheduler ticks, they are batched into a single DagRun. Set

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -706,8 +706,8 @@ class AssetManager(LoggingMixin):
         target_dag: DagModel,
         rollup_fingerprint: dict,
         asset_id: int,
+        allow_reuse: bool,
         session: Session,
-        allow_reuse: bool = True,
     ) -> AssetPartitionDagRun:
         """
         Get or create an APDR.

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -685,6 +685,7 @@ class AssetManager(LoggingMixin):
                     rollup_fingerprint=fingerprint,
                     asset_id=asset_id,
                     session=session,
+                    allow_reuse=timetable.batch_asset_events,
                 )
                 log_record = PartitionedAssetKeyLog(
                     asset_id=asset_id,
@@ -706,6 +707,7 @@ class AssetManager(LoggingMixin):
         rollup_fingerprint: dict,
         asset_id: int,
         session: Session,
+        allow_reuse: bool = True,
     ) -> AssetPartitionDagRun:
         """
         Get or create an APDR.
@@ -733,6 +735,12 @@ class AssetManager(LoggingMixin):
           one, the producing assets disagree; picking one would be order-dependent, so the
           carried date is suppressed to ``None`` (and re-adoptable by a later event).
         - Otherwise (the dates agree, or this event carries none) the existing value is kept.
+
+        When ``allow_reuse=True`` (default), an existing pending APDR for the same
+        ``(target_dag, partition_key)`` is reused — multiple events accumulate on one
+        APDR. When ``allow_reuse=False`` (set when the timetable's ``batch_asset_events``
+        is ``False``), a new APDR is always created so each event gets its own APDR
+        and the scheduler produces one DagRun per event.
         """
         with _lock_asset_model(session=session, asset_id=asset_id):
             latest_apdr: AssetPartitionDagRun | None = session.scalar(
@@ -744,7 +752,7 @@ class AssetManager(LoggingMixin):
                 .order_by(AssetPartitionDagRun.id.desc())
                 .limit(1)
             )
-            if latest_apdr and latest_apdr.created_dag_run_id is None:
+            if latest_apdr and latest_apdr.created_dag_run_id is None and allow_reuse:
                 existing_partition_date = latest_apdr.partition_date
                 if existing_partition_date is None:
                     # No carried date yet; adopt the incoming one if present (no conflict

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2688,32 +2688,40 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
             )
 
-            dag_run = dag.create_dagrun(
-                run_id=DagRun.generate_run_id(
-                    run_type=DagRunType.ASSET_TRIGGERED, logical_date=None, run_after=triggered_date
-                ),
-                logical_date=None,
-                data_interval=None,
-                run_after=triggered_date,
-                run_type=DagRunType.ASSET_TRIGGERED,
-                triggered_by=DagRunTriggeredByType.ASSET,
-                state=DagRunState.QUEUED,
-                creating_job_id=self.job.id,
-                session=session,
-            )
+            # Build the list of (run_after, events) to process: one entry per DagRun to create.
+            if dag.timetable.batch_asset_events:
+                event_runs = [(triggered_date, asset_events)]
+            else:
+                event_runs = [(timezone.coerce_datetime(ev.timestamp), [ev]) for ev in asset_events]
+
             team_name = (
                 self._get_team_names_for_dag_ids([dag.dag_id], session).get(dag.dag_id)
                 if self._multi_team
                 else None
             )
-            stats.incr("asset.triggered_dagruns", tags=prune_dict({"team_name": team_name}))
-            dag_run.consumed_asset_events.extend(asset_events)
-            self.log.info(
-                "Created asset-triggered DagRun for '%s': run_id=%s, consumed %d asset events",
-                dag.dag_id,
-                dag_run.run_id,
-                len(asset_events),
-            )
+
+            for run_after, events in event_runs:
+                dag_run = dag.create_dagrun(
+                    run_id=DagRun.generate_run_id(
+                        run_type=DagRunType.ASSET_TRIGGERED, logical_date=None, run_after=run_after
+                    ),
+                    logical_date=None,
+                    data_interval=None,
+                    run_after=run_after,
+                    run_type=DagRunType.ASSET_TRIGGERED,
+                    triggered_by=DagRunTriggeredByType.ASSET,
+                    state=DagRunState.QUEUED,
+                    creating_job_id=self.job.id,
+                    session=session,
+                )
+                stats.incr("asset.triggered_dagruns", tags=prune_dict({"team_name": team_name}))
+                dag_run.consumed_asset_events.extend(events)
+                self.log.info(
+                    "Created asset-triggered DagRun for '%s': run_id=%s, consumed %d asset events",
+                    dag.dag_id,
+                    dag_run.run_id,
+                    len(events),
+                )
 
             # Delete only consumed ADRQ rows to avoid dropping newly queued events
             # (e.g. DagRun triggered by asset A while a new event for asset B arrives).

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -363,7 +363,10 @@ class _Serializer:
 
     @serialize_timetable.register
     def _(self, timetable: AssetTriggeredTimetable) -> dict[str, Any]:
-        return {"asset_condition": encode_asset_like(timetable.asset_condition)}
+        return {
+            "asset_condition": encode_asset_like(timetable.asset_condition),
+            "batch_asset_events": timetable.batch_asset_events,
+        }
 
     @serialize_timetable.register
     def _(self, timetable: EventsTimetable) -> dict[str, Any]:

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -437,6 +437,7 @@ class _Serializer:
     def _(self, timetable: PartitionedAssetTimetable) -> dict[str, Any]:
         return {
             "asset_condition": encode_asset_like(timetable.asset_condition),
+            "batch_asset_events": timetable.batch_asset_events,
             "default_partition_mapper": encode_partition_mapper(timetable.default_partition_mapper),
             "partition_mapper_config": [
                 (encode_asset_like(asset), encode_partition_mapper(partition_mapper))

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -218,8 +218,11 @@ class AssetTriggeredTimetable(_TrivialTimetable):
 
     description: str = "Triggered by assets"
 
-    def __init__(self, assets: Collection[SerializedAsset] | SerializedAssetBase) -> None:
+    def __init__(
+        self, assets: Collection[SerializedAsset] | SerializedAssetBase, *, batch_asset_events: bool = True
+    ) -> None:
         super().__init__()
+        self.batch_asset_events = batch_asset_events
         # Compatibility: Handle SDK assets if needed so this class works in dag files.
         if isinstance(assets, SerializedAssetBase | BaseAsset):
             self.asset_condition = ensure_serialized_asset(assets)
@@ -230,14 +233,20 @@ class AssetTriggeredTimetable(_TrivialTimetable):
     def deserialize(cls, data: dict[str, Any]) -> Timetable:
         from airflow.serialization.decoders import decode_asset_like
 
-        return cls(decode_asset_like(data["asset_condition"]))
+        return cls(
+            decode_asset_like(data["asset_condition"]),
+            batch_asset_events=data.get("batch_asset_events", True),
+        )
 
     @property
     def summary(self) -> str:
         return "Asset"
 
     def serialize(self) -> dict[str, Any]:
-        return {"asset_condition": encode_asset_like(self.asset_condition)}
+        return {
+            "asset_condition": encode_asset_like(self.asset_condition),
+            "batch_asset_events": self.batch_asset_events,
+        }
 
     def generate_run_id(
         self,
@@ -285,10 +294,11 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
         self,
         *,
         assets: SerializedAssetBase,
+        batch_asset_events: bool = True,
         partition_mapper_config: dict[SerializedAssetBase, PartitionMapper] | None = None,
         default_partition_mapper: PartitionMapper = DEFAULT_PARTITION_MAPPER,
     ) -> None:
-        super().__init__(assets=assets)
+        super().__init__(assets=assets, batch_asset_events=batch_asset_events)
         self.partition_mapper_config = partition_mapper_config or {}
         self.default_partition_mapper = default_partition_mapper
 
@@ -402,6 +412,7 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
 
         return {
             "asset_condition": encode_asset_like(self.asset_condition),
+            "batch_asset_events": self.batch_asset_events,
             "partition_mapper_config": [
                 (encode_asset_like(asset), encode_partition_mapper(partition_mapper))
                 for asset, partition_mapper in self.partition_mapper_config.items()
@@ -419,6 +430,7 @@ class PartitionedAssetTimetable(AssetTriggeredTimetable):
 
         timetable = cls(
             assets=decode_asset_like(data["asset_condition"]),
+            batch_asset_events=data.get("batch_asset_events", True),
             default_partition_mapper=decode_partition_mapper(default_partition_mapper_data),
             partition_mapper_config={
                 decode_asset_like(ser_asest): decode_partition_mapper(ser_partition_mapper)

--- a/airflow-core/src/airflow/timetables/simple.py
+++ b/airflow-core/src/airflow/timetables/simple.py
@@ -246,7 +246,7 @@ class AssetTriggeredTimetable(_TrivialTimetable):
         return {
             "asset_condition": encode_asset_like(self.asset_condition),
             "batch_asset_events": self.batch_asset_events,
-        }
+        }  # serialize batch_asset_events flag for the scheduler
 
     def generate_run_id(
         self,

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -493,6 +493,88 @@ class TestAssetManager:
         assert apdr.partition_date is None
         mock_log.exception.assert_called_once()
 
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_get_or_create_apdr_allow_reuse_true_reuses_pending(self, session):
+        """``allow_reuse=True`` (default) reuses a pending APDR for the same ``(target_dag, partition_key)``.
+
+        When two events arrive for the same key and ``allow_reuse=True``, the
+        second call returns the same APDR — they accumulate on one row.
+        """
+        asm = AssetModel(uri="test://reuse-true/", name="reuse_asset_true", group="asset")
+        testing_dag = DagModel(
+            dag_id="reuse_test_dag_true", is_stale=False, bundle_name="testing"
+        )
+        session.add_all([asm, testing_dag])
+        session.commit()
+        session.flush()
+        assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 0
+
+        rollup_fingerprint = {}
+
+        apdr_1 = AssetManager._get_or_create_apdr(
+            target_key="key-1",
+            target_dag=testing_dag,
+            rollup_fingerprint=rollup_fingerprint,
+            asset_id=asm.id,
+            session=session,
+            allow_reuse=True,
+        )
+        apdr_2 = AssetManager._get_or_create_apdr(
+            target_key="key-1",
+            target_dag=testing_dag,
+            rollup_fingerprint=rollup_fingerprint,
+            asset_id=asm.id,
+            session=session,
+            allow_reuse=True,
+        )
+
+        assert apdr_1.id == apdr_2.id
+        assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
+        assert apdr_1.created_dag_run_id is None  # still pending
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_get_or_create_apdr_allow_reuse_false_creates_new(self, session):
+        """``allow_reuse=False`` creates a new APDR each call even if a pending one exists for the same key.
+
+        When two events arrive for the same key and ``allow_reuse=False``, each
+        event gets its own APDR — the scheduler later produces one DagRun per
+        event.
+        """
+        asm = AssetModel(
+            uri="test://reuse-false/", name="reuse_asset_false", group="asset"
+        )
+        testing_dag = DagModel(
+            dag_id="reuse_test_dag_false", is_stale=False, bundle_name="testing"
+        )
+        session.add_all([asm, testing_dag])
+        session.commit()
+        session.flush()
+        assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 0
+
+        rollup_fingerprint = {}
+
+        apdr_1 = AssetManager._get_or_create_apdr(
+            target_key="key-1",
+            target_dag=testing_dag,
+            rollup_fingerprint=rollup_fingerprint,
+            asset_id=asm.id,
+            session=session,
+            allow_reuse=False,
+        )
+        apdr_2 = AssetManager._get_or_create_apdr(
+            target_key="key-1",
+            target_dag=testing_dag,
+            rollup_fingerprint=rollup_fingerprint,
+            asset_id=asm.id,
+            session=session,
+            allow_reuse=False,
+        )
+
+        assert apdr_1.id != apdr_2.id
+        assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 2
+        assert apdr_1.created_dag_run_id is None
+        assert apdr_2.created_dag_run_id is None
+
     @pytest.mark.need_serialized_dag
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_queue_partitioned_dags_stamps_rollup_fingerprint(self, session, dag_maker):

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -500,6 +500,8 @@ class TestAssetManager:
         When two events arrive for the same key and ``allow_reuse=True``, the
         second call returns the same APDR — they accumulate on one row.
         """
+        clear_db_apdr()
+        clear_db_pakl()
         asm = AssetModel(uri="test://reuse-true/", name="reuse_asset_true", group="asset")
         testing_dag = DagModel(dag_id="reuse_test_dag_true", is_stale=False, bundle_name="testing")
         session.add_all([asm, testing_dag])
@@ -538,6 +540,8 @@ class TestAssetManager:
         event gets its own APDR — the scheduler later produces one DagRun per
         event.
         """
+        clear_db_apdr()
+        clear_db_pakl()
         asm = AssetModel(uri="test://reuse-false/", name="reuse_asset_false", group="asset")
         testing_dag = DagModel(dag_id="reuse_test_dag_false", is_stale=False, bundle_name="testing")
         session.add_all([asm, testing_dag])

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -519,19 +519,21 @@ class TestAssetManager:
 
         apdr_1 = AssetManager._get_or_create_apdr(
             target_key="key-1",
+            target_partition_date=None,
             target_dag=testing_dag,
             rollup_fingerprint=rollup_fingerprint,
             asset_id=asm.id,
-            session=session,
             allow_reuse=True,
+            session=session,
         )
         apdr_2 = AssetManager._get_or_create_apdr(
             target_key="key-1",
+            target_partition_date=None,
             target_dag=testing_dag,
             rollup_fingerprint=rollup_fingerprint,
             asset_id=asm.id,
-            session=session,
             allow_reuse=True,
+            session=session,
         )
 
         assert apdr_1.id == apdr_2.id
@@ -559,19 +561,21 @@ class TestAssetManager:
 
         apdr_1 = AssetManager._get_or_create_apdr(
             target_key="key-1",
+            target_partition_date=None,
             target_dag=testing_dag,
             rollup_fingerprint=rollup_fingerprint,
             asset_id=asm.id,
-            session=session,
             allow_reuse=False,
+            session=session,
         )
         apdr_2 = AssetManager._get_or_create_apdr(
             target_key="key-1",
+            target_partition_date=None,
             target_dag=testing_dag,
             rollup_fingerprint=rollup_fingerprint,
             asset_id=asm.id,
-            session=session,
             allow_reuse=False,
+            session=session,
         )
 
         assert apdr_1.id != apdr_2.id

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -316,6 +316,7 @@ class TestAssetManager:
                     target_dag=testing_dag,
                     rollup_fingerprint=rollup_fingerprint,
                     asset_id=asm.id,
+                    allow_reuse=True,
                     session=_session,
                 ).id
             finally:
@@ -354,6 +355,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            allow_reuse=True,
             session=session,
         )
         assert first.partition_date == timezone.parse("2026-05-20T00:00:00")
@@ -365,6 +367,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            allow_reuse=True,
             session=session,
         )
         assert second.id == first.id  # same pending APDR
@@ -385,6 +388,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            allow_reuse=True,
             session=session,
         )
         first = AssetManager._get_or_create_apdr(target_partition_date=source_date, **kwargs)
@@ -413,6 +417,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            allow_reuse=True,
             session=session,
         )
         # First event carries no date (e.g. producer had no partition_date).
@@ -439,6 +444,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            allow_reuse=True,
             session=session,
         )
         first = AssetManager._get_or_create_apdr(target_partition_date=date_1, **kwargs)

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -501,9 +501,7 @@ class TestAssetManager:
         second call returns the same APDR — they accumulate on one row.
         """
         asm = AssetModel(uri="test://reuse-true/", name="reuse_asset_true", group="asset")
-        testing_dag = DagModel(
-            dag_id="reuse_test_dag_true", is_stale=False, bundle_name="testing"
-        )
+        testing_dag = DagModel(dag_id="reuse_test_dag_true", is_stale=False, bundle_name="testing")
         session.add_all([asm, testing_dag])
         session.commit()
         session.flush()
@@ -540,12 +538,8 @@ class TestAssetManager:
         event gets its own APDR — the scheduler later produces one DagRun per
         event.
         """
-        asm = AssetModel(
-            uri="test://reuse-false/", name="reuse_asset_false", group="asset"
-        )
-        testing_dag = DagModel(
-            dag_id="reuse_test_dag_false", is_stale=False, bundle_name="testing"
-        )
+        asm = AssetModel(uri="test://reuse-false/", name="reuse_asset_false", group="asset")
+        testing_dag = DagModel(dag_id="reuse_test_dag_false", is_stale=False, bundle_name="testing")
         session.add_all([asm, testing_dag])
         session.commit()
         session.flush()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -11021,9 +11021,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         EmptyOperator(task_id="task")
     session.commit()
 
-    dag_model = session.scalar(
-        select(DagModel).where(DagModel.dag_id == "non-part-batch-true-consumer")
-    )
+    dag_model = session.scalar(select(DagModel).where(DagModel.dag_id == "non-part-batch-true-consumer"))
     assert dag_model is not None
     asset_model = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
@@ -11103,9 +11101,7 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
         EmptyOperator(task_id="task")
     session.commit()
 
-    dag_model = session.scalar(
-        select(DagModel).where(DagModel.dag_id == "non-part-batch-false-consumer")
-    )
+    dag_model = session.scalar(select(DagModel).where(DagModel.dag_id == "non-part-batch-false-consumer"))
     assert dag_model is not None
     asset_model = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -11026,15 +11026,20 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
     asset_model = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
 
-    # Create two asset events with timestamps clearly before the ADRQ's created_at.
-    now = timezone.utcnow()
+    # Events must fall within the event window: after the
+    # DagScheduleAssetReference.created_at floor and before the ADRQ's created_at.
+    base = session.scalar(
+        select(DagScheduleAssetReference.created_at).where(
+            DagScheduleAssetReference.dag_id == "non-part-batch-true-consumer"
+        )
+    )
     event_1 = AssetEvent(
         asset_id=asset_model.id,
         source_task_id="task",
         source_dag_id="non-part-batch-true-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now - timedelta(minutes=5),
+        timestamp=base + timedelta(seconds=1),
     )
     event_2 = AssetEvent(
         asset_id=asset_model.id,
@@ -11042,13 +11047,19 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         source_dag_id="non-part-batch-true-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now - timedelta(minutes=4),
+        timestamp=base + timedelta(seconds=2),
     )
     session.add_all([event_1, event_2])
     session.flush()
 
     # Queue an ADRQ for this Dag so the scheduler picks it up.
-    session.add(AssetDagRunQueue(asset_id=asset_model.id, target_dag_id="non-part-batch-true-consumer"))
+    session.add(
+        AssetDagRunQueue(
+            asset_id=asset_model.id,
+            target_dag_id="non-part-batch-true-consumer",
+            created_at=base + timedelta(hours=1),
+        )
+    )
     session.flush()
 
     runner = SchedulerJobRunner(
@@ -11106,14 +11117,18 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
     asset_model = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
 
-    now = timezone.utcnow()
+    base = session.scalar(
+        select(DagScheduleAssetReference.created_at).where(
+            DagScheduleAssetReference.dag_id == "non-part-batch-false-consumer"
+        )
+    )
     event_1 = AssetEvent(
         asset_id=asset_model.id,
         source_task_id="task",
         source_dag_id="non-part-batch-false-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now - timedelta(minutes=5),
+        timestamp=base + timedelta(seconds=1),
     )
     event_2 = AssetEvent(
         asset_id=asset_model.id,
@@ -11121,12 +11136,18 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
         source_dag_id="non-part-batch-false-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now - timedelta(minutes=4),
+        timestamp=base + timedelta(seconds=2),
     )
     session.add_all([event_1, event_2])
     session.flush()
 
-    session.add(AssetDagRunQueue(asset_id=asset_model.id, target_dag_id="non-part-batch-false-consumer"))
+    session.add(
+        AssetDagRunQueue(
+            asset_id=asset_model.id,
+            target_dag_id="non-part-batch-false-consumer",
+            created_at=base + timedelta(hours=1),
+        )
+    )
     session.flush()
 
     runner = SchedulerJobRunner(

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10936,9 +10936,7 @@ def test_partitioned_batch_asset_events_true_single_dagrun(dag_maker: DagMaker, 
 
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
-def test_partitioned_batch_asset_events_false_one_dagrun_per_event(
-    dag_maker: DagMaker, session: Session
-):
+def test_partitioned_batch_asset_events_false_one_dagrun_per_event(dag_maker: DagMaker, session: Session):
     """batch_asset_events=False: each event gets its own APDR → one DagRun per event.
 
     Two events for the same partition key produce two APDRs (no reuse).
@@ -11027,9 +11025,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         select(DagModel).where(DagModel.dag_id == "non-part-batch-true-consumer")
     )
     assert dag_model is not None
-    asset_model: AssetModel = session.scalar(
-        select(AssetModel).where(AssetModel.uri == asset_1.uri)
-    )
+    asset_model: AssetModel = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
 
     # Create two asset events with timestamps clearly before the ADRQ's created_at.
@@ -11065,9 +11061,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         session=session,
     )
 
-    dag_runs = session.scalars(
-        select(DagRun).where(DagRun.dag_id == "non-part-batch-true-consumer")
-    ).all()
+    dag_runs = session.scalars(select(DagRun).where(DagRun.dag_id == "non-part-batch-true-consumer")).all()
     assert len(dag_runs) == 1
     dag_run = dag_runs[0]
     assert dag_run.run_type == DagRunType.ASSET_TRIGGERED
@@ -11077,9 +11071,9 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
     # The ADRQ should have been cleaned up.
     assert (
         session.scalar(
-            select(func.count()).select_from(AssetDagRunQueue).where(
-                AssetDagRunQueue.target_dag_id == "non-part-batch-true-consumer"
-            )
+            select(func.count())
+            .select_from(AssetDagRunQueue)
+            .where(AssetDagRunQueue.target_dag_id == "non-part-batch-true-consumer")
         )
         == 0
     )
@@ -11113,9 +11107,7 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
         select(DagModel).where(DagModel.dag_id == "non-part-batch-false-consumer")
     )
     assert dag_model is not None
-    asset_model: AssetModel = session.scalar(
-        select(AssetModel).where(AssetModel.uri == asset_1.uri)
-    )
+    asset_model: AssetModel = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
 
     now = timezone.utcnow()
@@ -11163,9 +11155,9 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
     # ADRQ cleaned up.
     assert (
         session.scalar(
-            select(func.count()).select_from(AssetDagRunQueue).where(
-                AssetDagRunQueue.target_dag_id == "non-part-batch-false-consumer"
-            )
+            select(func.count())
+            .select_from(AssetDagRunQueue)
+            .where(AssetDagRunQueue.target_dag_id == "non-part-batch-false-consumer")
         )
         == 0
     )

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -11021,11 +11021,11 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         EmptyOperator(task_id="task")
     session.commit()
 
-    dag_model: DagModel = session.scalar(
+    dag_model = session.scalar(
         select(DagModel).where(DagModel.dag_id == "non-part-batch-true-consumer")
     )
     assert dag_model is not None
-    asset_model: AssetModel = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
+    asset_model = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
 
     # Create two asset events with timestamps clearly before the ADRQ's created_at.
@@ -11095,7 +11095,7 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
     with dag_maker(
         dag_id="non-part-batch-false-consumer",
         schedule=AssetTriggeredTimetable(
-            assets=asset_1,
+            assets=asset_1,  # type: ignore[arg-type]
             batch_asset_events=False,
         ),
         session=session,
@@ -11103,11 +11103,11 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
         EmptyOperator(task_id="task")
     session.commit()
 
-    dag_model: DagModel = session.scalar(
+    dag_model = session.scalar(
         select(DagModel).where(DagModel.dag_id == "non-part-batch-false-consumer")
     )
     assert dag_model is not None
-    asset_model: AssetModel = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
+    asset_model = session.scalar(select(AssetModel).where(AssetModel.uri == asset_1.uri))
     assert asset_model is not None
 
     now = timezone.utcnow()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -138,6 +138,7 @@ from airflow.serialization.encoders import ensure_serialized_asset
 from airflow.serialization.serialized_objects import LazyDeserializedDAG
 from airflow.timetables.base import DagRunInfo, DataInterval, compute_rollup_fingerprint
 from airflow.timetables.simple import (
+    AssetTriggeredTimetable,
     PartitionedAssetTimetable as CorePartitionedAssetTimetable,
     PartitionedAtRuntime,
 )
@@ -10876,6 +10877,298 @@ def _produce_and_register_asset_event(
     assert apdr.partition_key == expected_partition_key
 
     return apdr
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows")
+def test_partitioned_batch_asset_events_true_single_dagrun(dag_maker: DagMaker, session: Session):
+    """batch_asset_events=True (default): APDR reuse produces one DagRun for all events.
+
+    Two events for the same partition key share one APDR. The scheduler
+    creates a single DagRun consuming both events.
+    """
+    asset_1 = Asset(name="asset-batch-true")
+
+    # Consumer Dag with batch_asset_events=True (default).
+    with dag_maker(
+        dag_id="batch-true-consumer",
+        schedule=PartitionedAssetTimetable(
+            assets=asset_1,
+            default_partition_mapper=IdentityMapper(),
+        ),
+        session=session,
+    ):
+        EmptyOperator(task_id="hi")
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+
+    # Two events, same partition key → same APDR (reuse).
+    apdr = _produce_and_register_asset_event(
+        dag_id="batch-true-producer-1",
+        asset=asset_1,
+        partition_key="key-1",
+        session=session,
+        dag_maker=dag_maker,
+    )
+    _produce_and_register_asset_event(
+        dag_id="batch-true-producer-2",
+        asset=asset_1,
+        partition_key="key-1",
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
+
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    assert len(partition_dags) == 1
+    assert partition_dags == {"batch-true-consumer"}
+
+    session.refresh(apdr)
+    assert apdr.created_dag_run_id is not None
+    dag_run = session.scalar(select(DagRun).where(DagRun.id == apdr.created_dag_run_id))
+    assert dag_run is not None
+    assert len(dag_run.consumed_asset_events) == 2
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows")
+def test_partitioned_batch_asset_events_false_one_dagrun_per_event(
+    dag_maker: DagMaker, session: Session
+):
+    """batch_asset_events=False: each event gets its own APDR → one DagRun per event.
+
+    Two events for the same partition key produce two APDRs (no reuse).
+    The scheduler creates two DagRuns, one per event.
+    """
+    asset_1 = Asset(name="asset-batch-false")
+
+    # Consumer Dag with batch_asset_events=False.
+    with dag_maker(
+        dag_id="batch-false-consumer",
+        schedule=PartitionedAssetTimetable(
+            assets=asset_1,
+            default_partition_mapper=IdentityMapper(),
+            batch_asset_events=False,
+        ),
+        session=session,
+    ):
+        EmptyOperator(task_id="hi")
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+
+    # Two events, same partition key → two APDRs (no reuse because batch_asset_events=False).
+    apdr_1 = _produce_and_register_asset_event(
+        dag_id="batch-false-producer-1",
+        asset=asset_1,
+        partition_key="key-1",
+        session=session,
+        dag_maker=dag_maker,
+    )
+    apdr_2 = _produce_and_register_asset_event(
+        dag_id="batch-false-producer-2",
+        asset=asset_1,
+        partition_key="key-1",
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    assert apdr_1.id != apdr_2.id
+    assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 2
+
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    assert len(partition_dags) == 1
+    assert partition_dags == {"batch-false-consumer"}
+
+    # Both APDRs should now have a DagRun.
+    session.refresh(apdr_1)
+    session.refresh(apdr_2)
+    assert apdr_1.created_dag_run_id is not None
+    assert apdr_2.created_dag_run_id is not None
+    assert apdr_1.created_dag_run_id != apdr_2.created_dag_run_id
+
+    dag_run_1 = session.scalar(select(DagRun).where(DagRun.id == apdr_1.created_dag_run_id))
+    dag_run_2 = session.scalar(select(DagRun).where(DagRun.id == apdr_2.created_dag_run_id))
+    assert dag_run_1 is not None
+    assert dag_run_2 is not None
+    assert dag_run_1.run_id != dag_run_2.run_id
+    assert len(dag_run_1.consumed_asset_events) == 1
+    assert len(dag_run_2.consumed_asset_events) == 1
+
+
+@pytest.mark.need_serialized_dag
+def test_non_partitioned_batch_asset_events_true_single_dagrun(
+    dag_maker: DagMaker,
+    session: Session,
+):
+    """``batch_asset_events=True`` in non-partitioned path: one DagRun for all events.
+
+    Multiple asset events for the same asset and Dag produce a single DagRun
+    that consumes all events.
+    """
+    asset_1 = Asset(name="non-part-batch-true")
+
+    # Consumer Dag with default AssetTriggeredTimetable (batch_asset_events=True).
+    with dag_maker(
+        dag_id="non-part-batch-true-consumer",
+        schedule=[asset_1],
+        session=session,
+    ):
+        EmptyOperator(task_id="task")
+    session.commit()
+
+    dag_model: DagModel = session.scalar(
+        select(DagModel).where(DagModel.dag_id == "non-part-batch-true-consumer")
+    )
+    assert dag_model is not None
+    asset_model: AssetModel = session.scalar(
+        select(AssetModel).where(AssetModel.uri == asset_1.uri)
+    )
+    assert asset_model is not None
+
+    # Create two asset events within the triggered window.
+    now = timezone.utcnow()
+    event_1 = AssetEvent(
+        asset_id=asset_model.id,
+        source_task_id="task",
+        source_dag_id="non-part-batch-true-consumer",
+        source_run_id="test-run",
+        source_map_index=-1,
+        timestamp=now,
+    )
+    event_2 = AssetEvent(
+        asset_id=asset_model.id,
+        source_task_id="task",
+        source_dag_id="non-part-batch-true-consumer",
+        source_run_id="test-run",
+        source_map_index=-1,
+        timestamp=now + timedelta(seconds=1),
+    )
+    session.add_all([event_1, event_2])
+    session.flush()
+
+    # Queue an ADRQ for this Dag so the scheduler picks it up.
+    session.add(AssetDagRunQueue(asset_id=asset_model.id, target_dag_id="non-part-batch-true-consumer"))
+    session.flush()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._create_dag_runs_asset_triggered(
+        dag_models=[dag_model],
+        session=session,
+    )
+
+    dag_runs = session.scalars(
+        select(DagRun).where(DagRun.dag_id == "non-part-batch-true-consumer")
+    ).all()
+    assert len(dag_runs) == 1
+    dag_run = dag_runs[0]
+    assert dag_run.run_type == DagRunType.ASSET_TRIGGERED
+    assert dag_run.state == DagRunState.QUEUED
+    assert len(dag_run.consumed_asset_events) == 2
+
+    # The ADRQ should have been cleaned up.
+    assert (
+        session.scalar(
+            select(func.count()).select_from(AssetDagRunQueue).where(
+                AssetDagRunQueue.target_dag_id == "non-part-batch-true-consumer"
+            )
+        )
+        == 0
+    )
+
+
+@pytest.mark.need_serialized_dag
+def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
+    dag_maker: DagMaker,
+    session: Session,
+):
+    """``batch_asset_events=False`` in non-partitioned path: one DagRun per event.
+
+    Multiple asset events for the same asset and Dag each produce their own
+    DagRun, each consuming exactly one event.
+    """
+    asset_1 = Asset(name="non-part-batch-false")
+
+    # Consumer Dag with batch_asset_events=False on the timetable.
+    with dag_maker(
+        dag_id="non-part-batch-false-consumer",
+        schedule=AssetTriggeredTimetable(
+            assets=asset_1,
+            batch_asset_events=False,
+        ),
+        session=session,
+    ):
+        EmptyOperator(task_id="task")
+    session.commit()
+
+    dag_model: DagModel = session.scalar(
+        select(DagModel).where(DagModel.dag_id == "non-part-batch-false-consumer")
+    )
+    assert dag_model is not None
+    asset_model: AssetModel = session.scalar(
+        select(AssetModel).where(AssetModel.uri == asset_1.uri)
+    )
+    assert asset_model is not None
+
+    now = timezone.utcnow()
+    event_1 = AssetEvent(
+        asset_id=asset_model.id,
+        source_task_id="task",
+        source_dag_id="non-part-batch-false-consumer",
+        source_run_id="test-run",
+        source_map_index=-1,
+        timestamp=now,
+    )
+    event_2 = AssetEvent(
+        asset_id=asset_model.id,
+        source_task_id="task",
+        source_dag_id="non-part-batch-false-consumer",
+        source_run_id="test-run",
+        source_map_index=-1,
+        timestamp=now + timedelta(seconds=1),
+    )
+    session.add_all([event_1, event_2])
+    session.flush()
+
+    session.add(AssetDagRunQueue(asset_id=asset_model.id, target_dag_id="non-part-batch-false-consumer"))
+    session.flush()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._create_dag_runs_asset_triggered(
+        dag_models=[dag_model],
+        session=session,
+    )
+
+    dag_runs = session.scalars(
+        select(DagRun).where(DagRun.dag_id == "non-part-batch-false-consumer").order_by(DagRun.id)
+    ).all()
+    assert len(dag_runs) == 2
+    for dag_run in dag_runs:
+        assert dag_run.run_type == DagRunType.ASSET_TRIGGERED
+        assert dag_run.state == DagRunState.QUEUED
+    assert len(dag_runs[0].consumed_asset_events) == 1
+    assert len(dag_runs[1].consumed_asset_events) == 1
+    assert dag_runs[0].run_id != dag_runs[1].run_id
+
+    # ADRQ cleaned up.
+    assert (
+        session.scalar(
+            select(func.count()).select_from(AssetDagRunQueue).where(
+                AssetDagRunQueue.target_dag_id == "non-part-batch-false-consumer"
+            )
+        )
+        == 0
+    )
 
 
 @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -11032,7 +11032,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
     )
     assert asset_model is not None
 
-    # Create two asset events within the triggered window.
+    # Create two asset events with timestamps clearly before the ADRQ's created_at.
     now = timezone.utcnow()
     event_1 = AssetEvent(
         asset_id=asset_model.id,
@@ -11040,7 +11040,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         source_dag_id="non-part-batch-true-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now,
+        timestamp=now - timedelta(minutes=5),
     )
     event_2 = AssetEvent(
         asset_id=asset_model.id,
@@ -11048,7 +11048,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
         source_dag_id="non-part-batch-true-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now + timedelta(seconds=1),
+        timestamp=now - timedelta(minutes=4),
     )
     session.add_all([event_1, event_2])
     session.flush()
@@ -11125,7 +11125,7 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
         source_dag_id="non-part-batch-false-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now,
+        timestamp=now - timedelta(minutes=5),
     )
     event_2 = AssetEvent(
         asset_id=asset_model.id,
@@ -11133,7 +11133,7 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
         source_dag_id="non-part-batch-false-consumer",
         source_run_id="test-run",
         source_map_index=-1,
-        timestamp=now + timedelta(seconds=1),
+        timestamp=now - timedelta(minutes=4),
     )
     session.add_all([event_1, event_2])
     session.flush()

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -11033,6 +11033,7 @@ def test_non_partitioned_batch_asset_events_true_single_dagrun(
             DagScheduleAssetReference.dag_id == "non-part-batch-true-consumer"
         )
     )
+    assert base is not None
     event_1 = AssetEvent(
         asset_id=asset_model.id,
         source_task_id="task",
@@ -11122,6 +11123,7 @@ def test_non_partitioned_batch_asset_events_false_one_dagrun_per_event(
             DagScheduleAssetReference.dag_id == "non-part-batch-false-consumer"
         )
     )
+    assert base is not None
     event_1 = AssetEvent(
         asset_id=asset_model.id,
         source_task_id="task",

--- a/airflow-core/tests/unit/timetables/test_assets_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_assets_timetable.py
@@ -268,6 +268,44 @@ def test_run_ordering_inheritance(core_asset_timetable) -> None:
     assert core_asset_timetable.run_ordering == AssetTriggeredTimetable.run_ordering
 
 
+def test_asset_triggered_timetable_serialize():
+    """AssetTriggeredTimetable.serialize includes batch_asset_events."""
+    asset = SerializedAsset(name="test", uri="test://uri", group="asset", extra={}, watchers=[])
+    timetable = AssetTriggeredTimetable(assets=asset)
+    serialized = timetable.serialize()
+    assert serialized["batch_asset_events"] is True
+    assert "asset_condition" in serialized
+
+
+def test_asset_triggered_timetable_deserialize():
+    """AssetTriggeredTimetable.deserialize recovers batch_asset_events."""
+    asset = SerializedAsset(name="test", uri="test://uri", group="asset", extra={}, watchers=[])
+    data = {
+        "asset_condition": {
+            "__type": "asset",
+            "name": "test",
+            "uri": "test://uri",
+            "group": "asset",
+            "extra": {},
+        },
+        "batch_asset_events": True,
+    }
+    timetable = AssetTriggeredTimetable.deserialize(data)
+    assert timetable.batch_asset_events is True
+    assert timetable.asset_condition == asset
+
+
+def test_asset_triggered_timetable_batch_asset_events_false_roundtrip():
+    """AssetTriggeredTimetable batch_asset_events=False survives serialize → deserialize."""
+    asset = SerializedAsset(name="test", uri="test://uri", group="asset", extra={}, watchers=[])
+    timetable = AssetTriggeredTimetable(assets=asset, batch_asset_events=False)
+    serialized = timetable.serialize()
+    assert serialized["batch_asset_events"] is False
+
+    deserialized = AssetTriggeredTimetable.deserialize(serialized)
+    assert deserialized.batch_asset_events is False
+
+
 @pytest.mark.db_test
 class TestAssetConditionWithTimetable:
     @pytest.fixture(autouse=True)

--- a/airflow-core/tests/unit/timetables/test_assets_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_assets_timetable.py
@@ -379,6 +379,7 @@ class TestAssetConditionWithTimetable:
 
         serialized_timetable_dict = DagSerialization.to_dict(dag)["dag"]["timetable"]["__var"]
         assert serialized_timetable_dict == {
+            "batch_asset_events": True,
             "asset_condition": {
                 "__type": "asset_any",
                 "objects": [

--- a/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_partitioned_timetable.py
@@ -194,6 +194,7 @@ class TestPartitionedAssetTimetable:
             assets=ser_asset, partition_mapper_config={ser_asset: IdentityMapper()}
         )
         assert timetable.serialize() == {
+            "batch_asset_events": True,
             "asset_condition": {
                 "__type": DagAttributeTypes.ASSET,
                 "name": "test",
@@ -225,6 +226,7 @@ class TestPartitionedAssetTimetable:
     def test_deserialize(self):
         timetable = PartitionedAssetTimetable.deserialize(
             {
+                "batch_asset_events": True,
                 "asset_condition": {
                     "__type": DagAttributeTypes.ASSET,
                     "name": "test",
@@ -257,6 +259,21 @@ class TestPartitionedAssetTimetable:
         assert timetable.asset_condition == ser_asset
         assert isinstance(timetable.default_partition_mapper, IdentityMapper)
         assert isinstance(timetable.partition_mapper_config[ser_asset], IdentityMapper)
+        assert timetable.batch_asset_events is True
+
+    def test_serialize_deserialize_batch_asset_events_false(self):
+        """Serialize/deserialize round-trip preserves batch_asset_events=False."""
+        ser_asset = ensure_serialized_asset(Asset("test"))
+        timetable = PartitionedAssetTimetable(
+            assets=ser_asset,
+            partition_mapper_config={ser_asset: IdentityMapper()},
+            batch_asset_events=False,
+        )
+        serialized = timetable.serialize()
+        assert serialized["batch_asset_events"] is False
+
+        deserialized = PartitionedAssetTimetable.deserialize(serialized)
+        assert deserialized.batch_asset_events is False
 
     @pytest.mark.parametrize(
         "asset_like",

--- a/devel-common/src/tests_common/test_utils/version_compat.py
+++ b/devel-common/src/tests_common/test_utils/version_compat.py
@@ -42,6 +42,7 @@ AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
 AIRFLOW_V_3_2_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 2)
 AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
+AIRFLOW_V_3_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 3, 1)
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import PokeReturnValue, timezone

--- a/providers/openlineage/src/airflow/providers/openlineage/version_compat.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/version_compat.py
@@ -35,6 +35,7 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
 AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
+AIRFLOW_V_3_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 3, 1)
 
 
-__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_2_PLUS", "AIRFLOW_V_3_3_PLUS"]
+__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_2_PLUS", "AIRFLOW_V_3_3_PLUS", "AIRFLOW_V_3_3_1_PLUS"]

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -54,7 +54,6 @@ from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_1_PLUS,
     AIRFLOW_V_3_3_1_PLUS,
-    AIRFLOW_V_3_3_PLUS,
 )
 
 if AIRFLOW_V_3_1_PLUS:

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -50,7 +50,7 @@ from airflow.utils.types import DagRunType
 from tests_common.test_utils.compat import (
     BashOperator,
 )
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.models.dag import get_next_data_interval
@@ -437,7 +437,7 @@ def test_serialize_timetable_complex_with_alias():
     dag.timetable = AssetTriggeredTimetable(asset)
     dag_info = DagInfo(dag)
 
-    assert dag_info.timetable == {
+    expected: dict = {
         "asset_condition": {
             "__type": DagAttributeTypes.ASSET_ANY,
             "objects": [
@@ -479,15 +479,17 @@ def test_serialize_timetable_complex_with_alias():
                 },
             ],
         },
-        "batch_asset_events": True,
     }
+    if AIRFLOW_V_3_3_PLUS:
+        expected["batch_asset_events"] = True
+    assert dag_info.timetable == expected
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
 def test_serialize_timetable_single_asset():
     dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=Asset("a"))
     dag_info = DagInfo(dag)
-    assert dag_info.timetable == {
+    expected: dict = {
         "asset_condition": {
             "__type": DagAttributeTypes.ASSET,
             "uri": "a",
@@ -495,15 +497,17 @@ def test_serialize_timetable_single_asset():
             "group": "asset",
             "extra": {},
         },
-        "batch_asset_events": True,
     }
+    if AIRFLOW_V_3_3_PLUS:
+        expected["batch_asset_events"] = True
+    assert dag_info.timetable == expected
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
 def test_serialize_timetable_list_of_assets():
     dag = DAG(dag_id="test", start_date=datetime.datetime(2025, 1, 1), schedule=[Asset("a"), Asset("b")])
     dag_info = DagInfo(dag)
-    assert dag_info.timetable == {
+    expected: dict = {
         "asset_condition": {
             "__type": DagAttributeTypes.ASSET_ALL,
             "objects": [
@@ -511,8 +515,10 @@ def test_serialize_timetable_list_of_assets():
                 {"__type": DagAttributeTypes.ASSET, "uri": "b", "name": "b", "group": "asset", "extra": {}},
             ],
         },
-        "batch_asset_events": True,
     }
+    if AIRFLOW_V_3_3_PLUS:
+        expected["batch_asset_events"] = True
+    assert dag_info.timetable == expected
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")
@@ -524,7 +530,7 @@ def test_serialize_timetable_with_complex_logical_condition():
         & (Asset("ds3") | Asset("ds4", extra={"another_extra": 345})),
     )
     dag_info = DagInfo(dag)
-    assert dag_info.timetable == {
+    expected: dict = {
         "asset_condition": {
             "__type": DagAttributeTypes.ASSET_ALL,
             "objects": [
@@ -568,8 +574,10 @@ def test_serialize_timetable_with_complex_logical_condition():
                 },
             ],
         },
-        "batch_asset_events": True,
     }
+    if AIRFLOW_V_3_3_PLUS:
+        expected["batch_asset_events"] = True
+    assert dag_info.timetable == expected
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This test checks serialization only in 3.0 conditions")

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -50,7 +50,12 @@ from airflow.utils.types import DagRunType
 from tests_common.test_utils.compat import (
     BashOperator,
 )
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS, AIRFLOW_V_3_3_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
+    AIRFLOW_V_3_3_1_PLUS,
+    AIRFLOW_V_3_3_PLUS,
+)
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.models.dag import get_next_data_interval
@@ -480,7 +485,7 @@ def test_serialize_timetable_complex_with_alias():
             ],
         },
     }
-    if AIRFLOW_V_3_3_PLUS:
+    if AIRFLOW_V_3_3_1_PLUS:
         expected["batch_asset_events"] = True
     assert dag_info.timetable == expected
 
@@ -498,7 +503,7 @@ def test_serialize_timetable_single_asset():
             "extra": {},
         },
     }
-    if AIRFLOW_V_3_3_PLUS:
+    if AIRFLOW_V_3_3_1_PLUS:
         expected["batch_asset_events"] = True
     assert dag_info.timetable == expected
 
@@ -516,7 +521,7 @@ def test_serialize_timetable_list_of_assets():
             ],
         },
     }
-    if AIRFLOW_V_3_3_PLUS:
+    if AIRFLOW_V_3_3_1_PLUS:
         expected["batch_asset_events"] = True
     assert dag_info.timetable == expected
 
@@ -575,7 +580,7 @@ def test_serialize_timetable_with_complex_logical_condition():
             ],
         },
     }
-    if AIRFLOW_V_3_3_PLUS:
+    if AIRFLOW_V_3_3_1_PLUS:
         expected["batch_asset_events"] = True
     assert dag_info.timetable == expected
 

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_utils.py
@@ -478,7 +478,8 @@ def test_serialize_timetable_complex_with_alias():
                     ],
                 },
             ],
-        }
+        },
+        "batch_asset_events": True,
     }
 
 
@@ -493,7 +494,8 @@ def test_serialize_timetable_single_asset():
             "name": "a",
             "group": "asset",
             "extra": {},
-        }
+        },
+        "batch_asset_events": True,
     }
 
 
@@ -508,7 +510,8 @@ def test_serialize_timetable_list_of_assets():
                 {"__type": DagAttributeTypes.ASSET, "uri": "a", "name": "a", "group": "asset", "extra": {}},
                 {"__type": DagAttributeTypes.ASSET, "uri": "b", "name": "b", "group": "asset", "extra": {}},
             ],
-        }
+        },
+        "batch_asset_events": True,
     }
 
 
@@ -564,7 +567,8 @@ def test_serialize_timetable_with_complex_logical_condition():
                     ],
                 },
             ],
-        }
+        },
+        "batch_asset_events": True,
     }
 
 

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -93,6 +93,7 @@ from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_2_PLUS,
     AIRFLOW_V_3_3_PLUS,
+    AIRFLOW_V_3_3_1_PLUS,
 )
 
 BASH_OPERATOR_PATH = "airflow.providers.standard.operators.bash"
@@ -2542,7 +2543,7 @@ class TestDagInfoAirflow3:
             },
             "timetable_summary": "Asset",
         }
-        if AIRFLOW_V_3_3_PLUS:
+        if AIRFLOW_V_3_3_1_PLUS:
             expected["timetable"]["batch_asset_events"] = True
         assert dict(result) == expected
 
@@ -2578,7 +2579,7 @@ class TestDagInfoAirflow3:
             },
             "timetable_summary": "Asset",
         }
-        if AIRFLOW_V_3_3_PLUS:
+        if AIRFLOW_V_3_3_1_PLUS:
             expected["timetable"]["batch_asset_events"] = True
         assert dict(result) == expected
 
@@ -2682,7 +2683,7 @@ class TestDagInfoAirflow3:
             },
             "timetable_summary": "Asset",
         }
-        if AIRFLOW_V_3_3_PLUS:
+        if AIRFLOW_V_3_3_1_PLUS:
             expected["timetable"]["batch_asset_events"] = True
         assert dict(result) == expected
 

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -2523,7 +2523,7 @@ class TestDagInfoAirflow3:
         )
 
         result = DagInfo(dag)
-        assert dict(result) == {
+        expected: dict = {
             "dag_id": "dag_id",
             "description": None,
             "fileloc": pathlib.Path(__file__).resolve().as_posix(),
@@ -2539,10 +2539,12 @@ class TestDagInfoAirflow3:
                     "group": "asset",
                     "extra": {"a": 1},
                 },
-                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
+        if AIRFLOW_V_3_3_PLUS:
+            expected["timetable"]["batch_asset_events"] = True
+        assert dict(result) == expected
 
     def test_dag_info_schedule_list_single_assets(self):
         dag = DAG(
@@ -2552,7 +2554,7 @@ class TestDagInfoAirflow3:
         )
 
         result = DagInfo(dag)
-        assert dict(result) == {
+        expected: dict = {
             "dag_id": "dag_id",
             "description": None,
             "fileloc": pathlib.Path(__file__).resolve().as_posix(),
@@ -2573,10 +2575,12 @@ class TestDagInfoAirflow3:
                         }
                     ],
                 },
-                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
+        if AIRFLOW_V_3_3_PLUS:
+            expected["timetable"]["batch_asset_events"] = True
+        assert dict(result) == expected
 
     def test_dag_info_schedule_list_two_assets(self):
         dag = DAG(
@@ -2586,7 +2590,7 @@ class TestDagInfoAirflow3:
         )
 
         result = DagInfo(dag)
-        assert dict(result) == {
+        expected: dict = {
             "dag_id": "dag_id",
             "description": None,
             "fileloc": pathlib.Path(__file__).resolve().as_posix(),
@@ -2608,10 +2612,12 @@ class TestDagInfoAirflow3:
                         {"__type": "asset", "uri": "uri2", "name": "uri2", "group": "asset", "extra": {}},
                     ],
                 },
-                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
+        if AIRFLOW_V_3_3_PLUS:
+            expected["timetable"]["batch_asset_events"] = True
+        assert dict(result) == expected
 
     def test_dag_info_schedule_assets_logical_condition(self):
         dag = DAG(
@@ -2621,7 +2627,7 @@ class TestDagInfoAirflow3:
         )
 
         result = DagInfo(dag)
-        assert dict(result) == {
+        expected: dict = {
             "dag_id": "dag_id",
             "description": None,
             "fileloc": pathlib.Path(__file__).resolve().as_posix(),
@@ -2673,10 +2679,12 @@ class TestDagInfoAirflow3:
                         },
                     ],
                 },
-                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
+        if AIRFLOW_V_3_3_PLUS:
+            expected["timetable"]["batch_asset_events"] = True
+        assert dict(result) == expected
 
     def test_dag_info_schedule_asset_or_time_schedule(self):
         from airflow.timetables.assets import AssetOrTimeSchedule

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -2616,7 +2616,7 @@ class TestDagInfoAirflow3:
             },
             "timetable_summary": "Asset",
         }
-        if AIRFLOW_V_3_3_PLUS:
+        if AIRFLOW_V_3_3_1_PLUS:
             expected["timetable"]["batch_asset_events"] = True
         assert dict(result) == expected
 

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -2538,7 +2538,8 @@ class TestDagInfoAirflow3:
                     "name": "uri1",
                     "group": "asset",
                     "extra": {"a": 1},
-                }
+                },
+                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
@@ -2571,7 +2572,8 @@ class TestDagInfoAirflow3:
                             "extra": {"a": 1},
                         }
                     ],
-                }
+                },
+                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
@@ -2605,7 +2607,8 @@ class TestDagInfoAirflow3:
                         },
                         {"__type": "asset", "uri": "uri2", "name": "uri2", "group": "asset", "extra": {}},
                     ],
-                }
+                },
+                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }
@@ -2669,7 +2672,8 @@ class TestDagInfoAirflow3:
                             ],
                         },
                     ],
-                }
+                },
+                "batch_asset_events": True,
             },
             "timetable_summary": "Asset",
         }

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -92,8 +92,8 @@ from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_3_PLUS,
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_2_PLUS,
-    AIRFLOW_V_3_3_PLUS,
     AIRFLOW_V_3_3_1_PLUS,
+    AIRFLOW_V_3_3_PLUS,
 )
 
 BASH_OPERATOR_PATH = "airflow.providers.standard.operators.bash"

--- a/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
@@ -43,6 +43,7 @@ class AssetTriggeredTimetable(BaseTimetable):
     """
 
     asset_condition: BaseAsset = attrs.field(alias="assets")
+    batch_asset_events: bool = True
 
 
 @attrs.define

--- a/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/assets.py
@@ -50,7 +50,6 @@ class AssetTriggeredTimetable(BaseTimetable):
 class PartitionedAssetTimetable(AssetTriggeredTimetable):
     """Asset-driven timetable that listens for partitioned assets."""
 
-    asset_condition: BaseAsset = attrs.field(alias="assets")
     partition_mapper_config: dict[BaseAsset, PartitionMapper] = attrs.field(factory=dict)
     default_partition_mapper: PartitionMapper = IdentityMapper()
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

## Add `batch_asset_events` parameter to asset-triggered timetables

Introduces `batch_asset_events: bool = True` on `AssetTriggeredTimetable` and
`PartitionedAssetTimetable` (both SDK and core versions). When set to `False`,
asset-triggered Dags create one DagRun per individual asset event instead of
batching all events into a single DagRun.

### Behavior

| `batch_asset_events` | Partitioned (APDR) | Non-partitioned (ADRQ) |
|---|---|---|
| `True` (default) | Events for same partition key share one APDR → one DagRun consuming all events | One DagRun per tick consuming all queued events |
| `False` | Each event creates its own APDR → one DagRun per event | One DagRun per event (run_after = event timestamp) |

### Usage

`batch_asset_events` defaults to `True`. Set to `False` for one DagRun per event.

**Non-partitioned:**
`Dag(dag_id="per-event", schedule=AssetTriggeredTimetable(assets=asset_1, batch_asset_ events=False))`

**Partitioned:**
`Dag(dag_id="per-event", schedule=PartitionedAssetTimetable(assets=asset_1, batch_asset _events=False))`

Related #53896

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [codewhale](https://github.com/Hmbown/CodeWhale) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=7b5072d action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @renat-sagut** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@uranusjr` is waiting on you:
> - 3 unresolved review thread(s) from `@uranusjr` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->