### PR TITLE
Fix airflow db clean foreign key violation on dag_version

### DIFF
--- a/airflow-core/src/airflow/utils/db_cleanup.py
+++ b/airflow-core/src/airflow/utils/db_cleanup.py
@@ -77,6 +77,11 @@ class _TableConfig:
         supply additional filters here (e.g. externally triggered dag runs)
     :param keep_last_group_by: if keeping the last record, can keep the last record for each group
     :param dependent_tables: list of tables which have FK relationship with this table
+    :param skip_if_referenced_by: mapping of ``referencing_table_name -> foreign_key_column_name``.
+        A row is excluded from deletion while its primary key is still referenced from any of these
+        columns. This prevents a foreign-key violation when an old parent row (e.g. an old
+        ``dag_version``) is still referenced by a newer child row that is not itself in scope for
+        deletion. The referenced primary key is assumed to be the ``id`` column.
     :param extra_filters: SQLAlchemy expressions ANDed with the recency filter; referenced columns must be in ``extra_columns``.
     """
 
@@ -91,20 +96,25 @@ class _TableConfig:
     # because the relationships are unlikely to change and the number of tables is small.
     # Relying on automation here would increase complexity and reduce maintainability.
     dependent_tables: list[str] | None = None
+    skip_if_referenced_by: dict[str, str] | None = None
     extra_filters: list[Any] | None = None
 
     def __post_init__(self):
         self.recency_column = column(self.recency_column_name)
+        model_columns = [column(x) for x in self.extra_columns or []]
+        # When rows must be excluded while still referenced by other tables, the primary key has to
+        # be part of the lightweight table model so it can be referenced in the generated query.
+        self.pk_column = column("id") if self.skip_if_referenced_by else None
+        if self.pk_column is not None:
+            model_columns.append(self.pk_column)
         if self.dag_id_column_name is None:
             self.dag_id_column = None
-            self.orm_model: Base = table(
-                self.table_name, *[column(x) for x in self.extra_columns or []], self.recency_column
-            )
+            self.orm_model: Base = table(self.table_name, *model_columns, self.recency_column)
         else:
             self.dag_id_column = column(self.dag_id_column_name)
             self.orm_model: Base = table(
                 self.table_name,
-                *[column(x) for x in self.extra_columns or []],
+                *model_columns,
                 self.dag_id_column,
                 self.recency_column,
             )
@@ -178,6 +188,15 @@ config_list: list[_TableConfig] = [
         dag_id_column_name="dag_id",
         keep_last=True,
         keep_last_group_by=["dag_id"],
+        # task_instance.dag_version_id is ON DELETE RESTRICT and dag_run.created_dag_version_id is
+        # ON DELETE SET NULL, so an old dag_version that is still referenced by a newer (out-of-scope)
+        # task instance or dag run must not be deleted -- otherwise the delete raises a foreign-key
+        # violation (task_instance) or silently nulls a surviving row's reference (dag_run).
+        # See https://github.com/apache/airflow/issues/56192
+        skip_if_referenced_by={
+            "task_instance": "dag_version_id",
+            "dag_run": "created_dag_version_id",
+        },
     ),
     _TableConfig(table_name="deadline", recency_column_name="deadline_time", dag_id_column_name="dag_id"),
     _TableConfig(table_name="revoked_token", recency_column_name="exp"),
@@ -344,6 +363,23 @@ def _compile_create_table_as__other(element, compiler, **kw):
     return f"CREATE TABLE {element.name} AS {compiler.process(element.query)}"
 
 
+def _build_skip_if_referenced_filter(*, base_table, skip_if_referenced_by: dict[str, str]) -> list[Any]:
+    """
+    Build filter conditions that exclude rows still referenced by other tables.
+
+    For each ``referencing_table -> foreign_key_column`` mapping, the base table's ``id`` is
+    excluded when it still appears in that foreign-key column, so a parent row is only deleted
+    once nothing references it.
+    """
+    base_pk = base_table.c["id"]
+    conditions: list[Any] = []
+    for ref_table_name, ref_column_name in skip_if_referenced_by.items():
+        ref_table = table(ref_table_name, column(ref_column_name))
+        referenced_ids = select(ref_table.c[ref_column_name]).where(ref_table.c[ref_column_name].is_not(None))
+        conditions.append(base_pk.not_in(referenced_ids))
+    return conditions
+
+
 def _build_query(
     *,
     orm_model,
@@ -357,6 +393,7 @@ def _build_query(
     dag_ids: list[str] | None = None,
     exclude_dag_ids: list[str] | None = None,
     extra_filters: list[Any] | None = None,
+    skip_if_referenced_by: dict[str, str] | None = None,
     **kwargs,
 ) -> Select:
     base_table_alias = "base"
@@ -367,6 +404,13 @@ def _build_query(
 
     if extra_filters:
         conditions.extend(extra_filters)
+
+    if skip_if_referenced_by:
+        conditions.extend(
+            _build_skip_if_referenced_filter(
+                base_table=base_table, skip_if_referenced_by=skip_if_referenced_by
+            )
+        )
 
     if (dag_ids or exclude_dag_ids) and dag_id_column is not None:
         base_table_dag_id_col = base_table.c[dag_id_column.name]
@@ -414,6 +458,7 @@ def _cleanup_table(
     session: Session,
     batch_size: int | None = None,
     extra_filters: list[Any] | None = None,
+    skip_if_referenced_by: dict[str, str] | None = None,
     **kwargs,
 ) -> None:
     print()
@@ -430,6 +475,7 @@ def _cleanup_table(
         keep_last_group_by=keep_last_group_by,
         clean_before_timestamp=clean_before_timestamp,
         extra_filters=extra_filters,
+        skip_if_referenced_by=skip_if_referenced_by,
         session=session,
     )
     logger.debug("old rows query:\n%s", query.selectable.compile())

--- a/airflow-core/tests/unit/utils/test_db_cleanup.py
+++ b/airflow-core/tests/unit/utils/test_db_cleanup.py
@@ -1032,3 +1032,107 @@ class TestConnectionTestRequestCleanup:
             assert seeded[state] in survivors, f"{state} row should NOT be cleaned up"
         for state in ("success", "failed"):
             assert seeded[state] not in survivors, f"{state} row should be cleaned up"
+
+
+@pytest.mark.db_test
+class TestDagVersionReferenceSkip:
+    """Regression tests for the dag_version foreign-key violation in ``airflow db clean``.
+
+    An old ``dag_version`` row can still be referenced by a newer task instance
+    (``task_instance.dag_version_id`` is ``ON DELETE RESTRICT``) or dag run
+    (``dag_run.created_dag_version_id`` is ``ON DELETE SET NULL``) that is not itself in scope
+    for deletion. Deleting it must be skipped rather than raising a ForeignKeyViolation or
+    nulling a surviving row's reference. See https://github.com/apache/airflow/issues/56192.
+    """
+
+    @staticmethod
+    def _setup_two_versions(session, *, base_date):
+        """Create a dag with an old version (in scope) and a newer latest version (kept)."""
+        bundle_name = "testing"
+        session.add(DagBundleModel(name=bundle_name))
+        session.flush()
+        dag_id = "dag_version_cleanup"
+        dag = DAG(dag_id=dag_id)
+        session.add(DagModel(dag_id=dag_id, bundle_name=bundle_name))
+        SerializedDagModel.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=bundle_name)
+        old_version = DagVersion.get_latest_version(dag_id, session=session)
+        new_version = DagVersion.write_dag(dag_id=dag_id, bundle_name=bundle_name, session=session)
+        session.flush()
+        # old_version predates the cutoff and is not the latest -> in scope;
+        # new_version is the latest and recent -> kept by keep_last.
+        old_version.created_at = base_date
+        new_version.created_at = base_date.add(days=20)
+        session.flush()
+        return dag, old_version, new_version
+
+    @staticmethod
+    def _add_run_with_ti(session, *, dag, run_id, start_date, ti_version_id, run_version_id):
+        dag_run = DagRun(dag.dag_id, run_id=run_id, run_type=DagRunType.MANUAL, start_date=start_date)
+        dag_run.created_dag_version_id = run_version_id
+        ti = create_task_instance(
+            PythonOperator(task_id="task", python_callable=print),
+            run_id=run_id,
+            dag_version_id=ti_version_id,
+        )
+        ti.dag_id = dag.dag_id
+        ti.start_date = start_date
+        session.add_all([dag_run, ti])
+
+    def test_old_version_referenced_by_surviving_ti_is_skipped(self):
+        """An old, non-latest version still referenced by a recent task instance is not deleted."""
+        base_date = pendulum.datetime(2022, 1, 1, tz="UTC")
+        with create_session() as session:
+            dag, old_version, new_version = self._setup_two_versions(session, base_date=base_date)
+            old_version_id, new_version_id = old_version.id, new_version.id
+            # A recent (out-of-scope) run whose task instance still references the OLD version.
+            self._add_run_with_ti(
+                session,
+                dag=dag,
+                run_id="recent",
+                start_date=base_date.add(days=20),
+                ti_version_id=old_version_id,
+                run_version_id=new_version_id,
+            )
+            session.commit()
+
+            # Must complete without a ForeignKeyViolation and preserve the still-referenced version.
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=10),
+                table_names=["dag_version"],
+                dry_run=False,
+                confirm=False,
+                session=session,
+            )
+
+            remaining = set(session.scalars(select(DagVersion.id)).all())
+            assert old_version_id in remaining, "referenced old version must not be deleted"
+            assert new_version_id in remaining
+
+    def test_old_version_without_references_is_deleted(self):
+        """An old, non-latest version with no remaining references is still deleted."""
+        base_date = pendulum.datetime(2022, 1, 1, tz="UTC")
+        with create_session() as session:
+            dag, old_version, new_version = self._setup_two_versions(session, base_date=base_date)
+            old_version_id, new_version_id = old_version.id, new_version.id
+            # The surviving run/ti reference the LATEST version, so the old version is unreferenced.
+            self._add_run_with_ti(
+                session,
+                dag=dag,
+                run_id="recent",
+                start_date=base_date.add(days=20),
+                ti_version_id=new_version_id,
+                run_version_id=new_version_id,
+            )
+            session.commit()
+
+            run_cleanup(
+                clean_before_timestamp=base_date.add(days=10),
+                table_names=["dag_version"],
+                dry_run=False,
+                confirm=False,
+                session=session,
+            )
+
+            remaining = set(session.scalars(select(DagVersion.id)).all())
+            assert old_version_id not in remaining, "unreferenced old version should be deleted"
+            assert new_version_id in remaining


### PR DESCRIPTION
`airflow db clean` aborted with a `ForeignKeyViolation` when an old `dag_version` row scoped for deletion was still referenced by a newer task instance (or dag run) that was not itself in scope:

```
psycopg2.errors.ForeignKeyViolation: update or delete on table "dag_version" violates foreign key constraint "task_instance_dag_version_id_fkey" on table "task_instance"
DETAIL:  Key (id)=(0198edf9-f9f1-7d73-92c1-fac5359c10b7) is still referenced from table "task_instance".
```

`db clean` cleans tables in dependency order but filters each table by its own recency column, so an old `dag_version` (old `created_at`, not the latest for its dag) gets scoped for deletion while a newer task instance still referencing it is not. `task_instance.dag_version_id` is `ON DELETE RESTRICT` (so the delete raises) and `dag_run.created_dag_version_id` is `ON DELETE SET NULL` (so the delete would silently null a surviving run's reference).

This adds a `skip_if_referenced_by` option to the cleanup table config. `dag_version` rows whose `id` still appears in `task_instance.dag_version_id` or `dag_run.created_dag_version_id` are excluded from deletion; they are removed on a later run once the referencing rows have themselves aged out of scope. Tests cover both the skip path and that an unreferenced old version is still deleted.

Thanks to @HsiuChuanHsu for the reproduction and the original approach in #56567.

closes: #56192

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
