### PR TITLE
Remove dead AIP-44 trigger-over-BaseSerialization path (DAT.BASE_TRIGGER)

### DIFF
--- a/airflow-core/src/airflow/serialization/enums.py
+++ b/airflow-core/src/airflow/serialization/enums.py
@@ -70,7 +70,6 @@ class DagAttributeTypes(str, Enum):
     TIMEDELTA = "timedelta"
     TIMEZONE = "timezone"
     RELATIVEDELTA = "relativedelta"
-    BASE_TRIGGER = "base_trigger"
     AIRFLOW_EXC_SER = "airflow_exc_ser"
     BASE_EXC_SER = "base_exc_ser"
     DICT = "dict"

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -106,7 +106,7 @@ from airflow.task.priority_strategy import (
     validate_and_load_priority_weight_strategy,
 )
 from airflow.timetables.base import DagRunInfo, Timetable
-from airflow.triggers.base import BaseTrigger, StartTriggerArgs
+from airflow.triggers.base import StartTriggerArgs
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.db import LazySelectSequence
 
@@ -470,7 +470,6 @@ class BaseSerialization:
         :meta private:
         """
         from airflow.sdk.definitions._internal.types import is_arg_set
-        from airflow.sdk.exceptions import TaskDeferred
 
         if not is_arg_set(var):
             return cls._encode(None, type_=DAT.ARG_NOT_SET)
@@ -535,7 +534,7 @@ class BaseSerialization:
                 var._asdict(),
                 type_=DAT.TASK_INSTANCE_KEY,
             )
-        elif isinstance(var, (AirflowException, TaskDeferred)) and hasattr(var, "serialize"):
+        elif isinstance(var, AirflowException) and hasattr(var, "serialize"):
             exc_cls_name, args, kwargs = var.serialize()
             return cls._encode(
                 cls.serialize(
@@ -555,14 +554,6 @@ class BaseSerialization:
                     strict=strict,
                 ),
                 type_=DAT.BASE_EXC_SER,
-            )
-        elif isinstance(var, BaseTrigger):
-            return cls._encode(
-                cls.serialize(
-                    var.serialize(),
-                    strict=strict,
-                ),
-                type_=DAT.BASE_TRIGGER,
             )
         elif callable(var):
             return str(get_python_source(var))
@@ -672,10 +663,6 @@ class BaseSerialization:
             else:
                 exc_cls = import_string(f"builtins.{exc_cls_name}")
             return exc_cls(*args, **kwargs)
-        elif type_ == DAT.BASE_TRIGGER:
-            tr_cls_name, kwargs = cls.deserialize(var)
-            tr_cls = import_string(tr_cls_name)
-            return tr_cls(**kwargs)
         elif type_ == DAT.SET:
             return {cls.deserialize(v) for v in var}
         elif type_ == DAT.TUPLE:

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -39,7 +39,6 @@ from airflow.exceptions import (
     AirflowFailException,
     AirflowRescheduleException,
     SerializationError,
-    TaskDeferred,
 )
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG
@@ -104,7 +103,6 @@ from airflow.serialization.serialized_objects import (
     LazyDeserializedDAG,
     _has_kubernetes,
 )
-from airflow.triggers.base import BaseTrigger
 from airflow.utils.db import LazySelectSequence
 
 from unit.models import DEFAULT_DATE
@@ -570,42 +568,14 @@ def test_ser_of_asset_event_accessor():
     assert d[Asset(name="yo", uri="test://yo")].extra == {"this": "that", "the": "other"}
 
 
-class MyTrigger(BaseTrigger):
-    def __init__(self, hi):
-        self.hi = hi
-
-    def serialize(self):
-        return "unit.serialization.test_serialized_objects.MyTrigger", {"hi": self.hi}
-
-    async def run(self):
-        yield
-
-
 def test_roundtrip_exceptions():
-    """
-    This is for AIP-44 when we need to send certain non-error exceptions
-    as part of an RPC call e.g. TaskDeferred or AirflowRescheduleException.
-    """
+    """Non-error AirflowExceptions (e.g. AirflowRescheduleException) round-trip through BaseSerialization."""
     some_date = pendulum.now()
     resched_exc = AirflowRescheduleException(reschedule_date=some_date)
     ser = BaseSerialization.serialize(resched_exc)
     deser = BaseSerialization.deserialize(ser)
     assert isinstance(deser, AirflowRescheduleException)
     assert deser.reschedule_date == some_date
-    del ser
-    del deser
-    exc = TaskDeferred(
-        trigger=MyTrigger(hi="yo"),
-        method_name="meth_name",
-        kwargs={"have": "pie"},
-        timeout=timedelta(seconds=30),
-    )
-    ser = BaseSerialization.serialize(exc)
-    deser = BaseSerialization.deserialize(ser)
-    assert deser.trigger.hi == "yo"
-    assert deser.method_name == "meth_name"
-    assert deser.kwargs == {"have": "pie"}
-    assert deser.timeout == timedelta(seconds=30)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Removes the `DAT.BASE_TRIGGER` serialization path — encoding/decoding a `BaseTrigger` **instance** through `BaseSerialization` — which is dead code left over from AIP-44's Internal API:

- the encode branch (`isinstance(var, BaseTrigger)`), the decode branch (`type_ == DAT.BASE_TRIGGER`), the `DAT.BASE_TRIGGER` enum value, and the now-unused `BaseTrigger` import;
- `TaskDeferred` is also dropped from the exception-encode tuple — `TaskDeferred(BaseException)`'s only role there was carrying a trigger over the AIP-44 RPC.

Generic `AirflowException` / `BASE_EXC_SER` serialization is **kept** — it has live test coverage and an exception can still reach the serializer via XCom / `next_kwargs` / the `ExtendedJSON` column.

## Why it's dead

The live deferral path never serializes a trigger through `BaseSerialization`:

- A task that defers builds a structured `DeferTask` / `TIDeferredStatePayload` from `defer.trigger.serialize()` (the trigger's own classpath + kwargs) — see `task_runner._defer_task`.
- The execution API stores `Trigger(classpath=<str>, encrypted_kwargs=<blob>)` without instantiating anything (`routes/task_instances.py`); the triggerer later imports the classpath from the DB row.
- AIP-44's Internal API — the RPC that serialized runtime objects like triggers/exceptions over the wire — has been removed.

`DAT.BASE_TRIGGER` was referenced only inside `serialized_objects.py` + `enums.py` + tests — no external producer or consumer. (`BaseTrigger.hash` serializes the trigger's *kwargs* dict, not the trigger, so it never hit this branch.)

## Relationship to #67926 / #68511

- **Supersedes #67926** — it gated the now-removed `DAT.BASE_TRIGGER` decode.
- **Complements #68511**, whose `_safe_import_for_deserialize` gate on the *exception* decode (`import_string(exc_cls_name)`) protects a path this PR keeps live.
