### PR TITLE
[AIP-94] Add deprecation marker to assets list/details cli commands

### DIFF
--- a/airflow-core/src/airflow/cli/commands/asset_command.py
+++ b/airflow-core/src/airflow/cli/commands/asset_command.py
@@ -54,6 +54,7 @@ def _list_assets(args, *, session: Session) -> tuple[Any, type[BaseModel]]:
     return assets, AssetResponse
 
 
+@deprecated_for_airflowctl("airflowctl assets list / airflowctl assets list-aliases")
 @cli_utils.action_cli
 @provide_session
 def asset_list(args, *, session: Session = NEW_SESSION) -> None:
@@ -106,6 +107,7 @@ def _detail_asset(args, *, session: Session) -> BaseModel:
     return AssetResponse.model_validate(asset)
 
 
+@deprecated_for_airflowctl("airflowctl assets get / airflowctl assets get-by-alias")
 @cli_utils.action_cli
 @provide_session
 def asset_details(args, *, session: Session = NEW_SESSION) -> None:

--- a/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
+++ b/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
@@ -43,6 +43,8 @@ MIGRATED_CLI_COMMANDS = [
     (pool_command.pool_import, "airflowctl pools import"),
     (pool_command.pool_export, "airflowctl pools export"),
     (asset_command.asset_materialize, "airflowctl assets materialize"),
+    (asset_command.asset_list, "airflowctl assets list / airflowctl assets list-aliases"),
+    (asset_command.asset_details, "airflowctl assets get / airflowctl assets get-by-alias"),
 ]
 
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
This PR adds deprecation markers to `assets list` and `assets details` to point to the corresponding airflowctl commands. As described in the issue this is only a maintainer/developer-facing signal that freezes them from further development. It does not warn users.

Note - depending on the parameters passed, a single cli command can correspond to multiple airflowctl commands (e.g., listing assets and listing asset aliases). That is why you will see two commands included in the deprecation warnings here. Also, you will notice the `airflowctl assets list-aliases` command in one of the deprecation warnings. That is dependent on #68522 being merged (I proposed a rename to list-aliases).

related: #68402
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
