### PR TITLE
Task SDK: Fix Variable.set/delete swallowing API errors — propagate AirflowRuntimeError to fail the task

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Sequence
 from typing import Any
 
@@ -25,8 +24,6 @@ import attrs
 
 from airflow.sdk.definitions._internal.types import NOTSET
 from airflow.sdk.log import mask_secret
-
-log = logging.getLogger(__name__)
 
 
 @attrs.define
@@ -60,13 +57,9 @@ class Variable:
 
     @classmethod
     def set(cls, key: str, value: Any, description: str | None = None, serialize_json: bool = False) -> None:
-        from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.context import _set_variable
 
-        try:
-            return _set_variable(key, value, description, serialize_json=serialize_json)
-        except AirflowRuntimeError as e:
-            log.exception(e)
+        _set_variable(key, value, description, serialize_json=serialize_json)
 
     @classmethod
     def keys(cls, prefix: str | None = None) -> Sequence[str]:
@@ -94,10 +87,6 @@ class Variable:
 
     @classmethod
     def delete(cls, key: str) -> None:
-        from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.context import _delete_variable
 
-        try:
-            _delete_variable(key=key)
-        except AirflowRuntimeError as e:
-            log.exception(e)
+        _delete_variable(key=key)

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -89,6 +89,30 @@ class TestVariables:
             ),
         )
 
+    def test_var_set_raises_on_error(self, mock_supervisor_comms):
+        """Variable.set() must propagate AirflowRuntimeError so the task fails on a rejected write."""
+        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+        from airflow.sdk.execution_time.comms import ErrorResponse
+
+        mock_supervisor_comms.send.side_effect = AirflowRuntimeError(
+            error=ErrorResponse(error=ErrorType.API_SERVER_ERROR, detail={"message": "forbidden"})
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            Variable.set(key="forbidden_key", value="v")
+
+    def test_var_delete_raises_on_error(self, mock_supervisor_comms):
+        """Variable.delete() must propagate AirflowRuntimeError so the task fails on a rejected delete."""
+        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+        from airflow.sdk.execution_time.comms import ErrorResponse
+
+        mock_supervisor_comms.send.side_effect = AirflowRuntimeError(
+            error=ErrorResponse(error=ErrorType.API_SERVER_ERROR, detail={"message": "forbidden"})
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            Variable.delete(key="forbidden_key")
+
 
 class TestVariableKeys:
     @pytest.mark.parametrize(


### PR DESCRIPTION
When the Execution API rejects a variable write (any non-2xx response —
e.g. a 403 authorization denial or a server error), `Variable.set()` and
`Variable.delete()` were catching `AirflowRuntimeError` and only logging
it. The task still finished as **success** and the variable was left
unchanged.

This is inconsistent with `Variable.get()`, which already raises on error
(and since #66575 even refuses secrets-backend fallback on a 401/403).
Reads fail loudly on denial; writes silently succeeded.

### Changes

- **`Variable.set()`**: Remove the `try/except AirflowRuntimeError` block
  that swallowed the error. Any API rejection now propagates and fails the
  task.
- **`Variable.delete()`**: Same fix.
- Remove the now-unused `logging` import and `log` variable from
  `variable.py`.
- Add `test_var_set_raises_on_error` and `test_var_delete_raises_on_error`
  to cover the error propagation path.

### Root cause

```python
# Before (broken)
try:
    _set_variable(...)
except AirflowRuntimeError as e:
    log.exception(e)   # swallowed — task reports success

# After (fixed)
_set_variable(...)     # AirflowRuntimeError propagates — task fails
```
closes: #68537
Related: #66575 (fixed the analogous read / secrets-backend path)
