### PR TITLE
Fix Task SDK silently ignoring AirflowRuntimeError when Variable.set() or Variable.delete() fails

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -63,11 +63,7 @@ class Variable:
         from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.context import _set_variable
 
-        try:
-            return _set_variable(key, value, description, serialize_json=serialize_json)
-        except AirflowRuntimeError as e:
-            log.exception(e)
-            raise
+        _set_variable(key, value, description, serialize_json=serialize_json)
 
     @classmethod
     def keys(cls, prefix: str | None = None) -> Sequence[str]:
@@ -98,8 +94,4 @@ class Variable:
         from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.context import _delete_variable
 
-        try:
-            _delete_variable(key=key)
-        except AirflowRuntimeError as e:
-            log.exception(e)
-            raise
+        _delete_variable(key=key)

--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -67,6 +67,7 @@ class Variable:
             return _set_variable(key, value, description, serialize_json=serialize_json)
         except AirflowRuntimeError as e:
             log.exception(e)
+            raise
 
     @classmethod
     def keys(cls, prefix: str | None = None) -> Sequence[str]:
@@ -101,3 +102,4 @@ class Variable:
             _delete_variable(key=key)
         except AirflowRuntimeError as e:
             log.exception(e)
+            raise

--- a/task-sdk/src/airflow/sdk/definitions/variable.py
+++ b/task-sdk/src/airflow/sdk/definitions/variable.py
@@ -60,7 +60,6 @@ class Variable:
 
     @classmethod
     def set(cls, key: str, value: Any, description: str | None = None, serialize_json: bool = False) -> None:
-        from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.context import _set_variable
 
         _set_variable(key, value, description, serialize_json=serialize_json)
@@ -91,7 +90,6 @@ class Variable:
 
     @classmethod
     def delete(cls, key: str) -> None:
-        from airflow.sdk.exceptions import AirflowRuntimeError
         from airflow.sdk.execution_time.context import _delete_variable
 
         _delete_variable(key=key)

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -25,7 +25,15 @@ import pytest
 
 from airflow.sdk import Variable
 from airflow.sdk.configuration import initialize_secrets_backends
-from airflow.sdk.execution_time.comms import GetVariableKeys, PutVariable, VariableKeysResult, VariableResult
+from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
+from airflow.sdk.execution_time.comms import (
+    DeleteVariable,
+    ErrorResponse,
+    GetVariableKeys,
+    PutVariable,
+    VariableKeysResult,
+    VariableResult,
+)
 from airflow.sdk.execution_time.secrets import DEFAULT_SECRETS_SEARCH_PATH_WORKERS
 
 from tests_common.test_utils.config import conf_vars
@@ -88,6 +96,31 @@ class TestVariables:
                 key=key, value=expected_value, description=description, serialize_json=serialize_json
             ),
         )
+
+    def test_var_set_raises_on_runtime_error(self, mock_supervisor_comms):
+        with mock.patch(
+            "airflow.sdk.execution_time.context._set_variable",
+            side_effect=AirflowRuntimeError(
+                ErrorResponse(error=ErrorType.GENERIC_ERROR, detail={"message": "API_SERVER_ERROR"})
+            ),
+        ):
+            with pytest.raises(AirflowRuntimeError):
+                Variable.set(key="my_key", value="my_value")
+
+    def test_var_delete(self, mock_supervisor_comms):
+        Variable.delete(key="my_key")
+
+        mock_supervisor_comms.send.assert_called_once_with(msg=DeleteVariable(key="my_key"))
+
+    def test_var_delete_raises_on_runtime_error(self, mock_supervisor_comms):
+        with mock.patch(
+            "airflow.sdk.execution_time.context._delete_variable",
+            side_effect=AirflowRuntimeError(
+                ErrorResponse(error=ErrorType.GENERIC_ERROR, detail={"message": "API_SERVER_ERROR"})
+            ),
+        ):
+            with pytest.raises(AirflowRuntimeError):
+                Variable.delete(key="my_key")
 
 
 class TestVariableKeys:

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -97,30 +97,10 @@ class TestVariables:
             ),
         )
 
-    def test_var_set_raises_on_runtime_error(self, mock_supervisor_comms):
-        with mock.patch(
-            "airflow.sdk.execution_time.context._set_variable",
-            side_effect=AirflowRuntimeError(
-                ErrorResponse(error=ErrorType.GENERIC_ERROR, detail={"message": "API_SERVER_ERROR"})
-            ),
-        ):
-            with pytest.raises(AirflowRuntimeError):
-                Variable.set(key="my_key", value="my_value")
-
     def test_var_delete(self, mock_supervisor_comms):
         Variable.delete(key="my_key")
 
         mock_supervisor_comms.send.assert_called_once_with(msg=DeleteVariable(key="my_key"))
-
-    def test_var_delete_raises_on_runtime_error(self, mock_supervisor_comms):
-        with mock.patch(
-            "airflow.sdk.execution_time.context._delete_variable",
-            side_effect=AirflowRuntimeError(
-                ErrorResponse(error=ErrorType.GENERIC_ERROR, detail={"message": "API_SERVER_ERROR"})
-            ),
-        ):
-            with pytest.raises(AirflowRuntimeError):
-                Variable.delete(key="my_key")
 
 
 class TestVariableKeys:
@@ -204,8 +184,6 @@ class TestVariableKeys:
         )
 
     def test_keys_raises_on_error_response(self, mock_supervisor_comms):
-        from airflow.sdk.exceptions import AirflowRuntimeError, ErrorType
-        from airflow.sdk.execution_time.comms import ErrorResponse
 
         mock_supervisor_comms.send.return_value = ErrorResponse(
             error=ErrorType.GENERIC_ERROR, detail={"message": "boom"}


### PR DESCRIPTION
Closes #68537  

As per the issue, `Variable.set()` and `Variable.delete()` in the Task SDK were silently ignoring AirflowRuntimeError, logging the exception but not re-raising, causing tasks to report success even when a variable write was rejected by the Execution API. 

~Added `raise` to both except blocks so errors now propagate and fail the task, consistent with the existing behavior of `Variable.get()`.~

Removed `try-except` blocks for `set()` and `delete()` methods as they are logging the error message twice.

Also added the unit test:
- `test_var_delete` - basic success-path coverage for `Variable.delete()`, which was previously untested.


Here's a DAG for testing:
```python
import datetime
from airflow.sdk import dag, task

@dag(
    dag_id="test_variable_error_propagation",
    start_date=datetime.datetime(2026, 1, 1),
    schedule=None,
    catchup=False,
)
def test_variable_error_propagation():
    @task
    def test_variable_set_and_delete_success():
        from airflow.sdk import Variable

        Variable.set("abc", "efg")
        Variable.delete("abc")
        print("Variable.delete succeeded")

    t1 = test_variable_set_and_delete_success()

    t1


test_variable_error_propagation()
```

Use the following middleware plugin with breeze to test 403 API errors
```python
from __future__ import annotations

import json

from airflow.plugins_manager import AirflowPlugin


class RejectVariableWritesMiddleware:
    """Intercept PUT/DELETE /execution/variables/* and return 403."""

    def __init__(self, app) -> None:
        self.app = app

    async def __call__(self, scope, receive, send) -> None:
        if scope["type"] == "http":
            path: str = scope.get("path", "")
            method: str = scope.get("method", "")
            if method in ("PUT", "DELETE") and path.startswith("/execution/variables/"):
                body = json.dumps({"detail": "Variable writes rejected by test middleware"}).encode()
                await send(
                    {
                        "type": "http.response.start",
                        "status": 403,
                        "headers": [
                            [b"content-type", b"application/json"],
                            [b"content-length", str(len(body)).encode()],
                        ],
                    }
                )
                await send({"type": "http.response.body", "body": body})
                return
        await self.app(scope, receive, send)


class RejectVariableWritesPlugin(AirflowPlugin):
    name = "reject_variable_writes"
    fastapi_root_middlewares = [
        {
            "name": "RejectVariableWritesMiddleware",
            "middleware": RejectVariableWritesMiddleware,
        }
    ]
```

Was generative AI tooling used to co-author this PR?

[X] Yes 

Used Claude to generate the middleware plugin to test 403 API errors.