### PR TITLE
Triggerer: Strengthen Triggerer Metric Test Coverage

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -2851,7 +2851,12 @@ def test_handle_events_does_not_confirm_seq_when_persist_fails(jobless_superviso
 def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_tags):
     """triggers.succeeded carries the triggerer's team_name (omitted when the triggerer has none)."""
     jobless_supervisor.team_name = team_name
-    jobless_supervisor.events.append(TriggerEventEntry(1, TriggerEvent(True), 7))
+    jobless_supervisor.events.extend(
+        [
+            TriggerEventEntry(1, TriggerEvent(True), 7),
+            TriggerEventEntry(2, TriggerEvent(True), 8),
+        ]
+    )
 
     with (
         mock.patch.object(TriggerRunnerSupervisor, "on_trigger_event", autospec=True),
@@ -2859,7 +2864,13 @@ def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_t
     ):
         jobless_supervisor.handle_events()
 
-    mock_incr.assert_called_once_with("triggers.succeeded", tags=expected_tags)
+    mock_incr.assert_has_calls(
+        [
+            mock.call("triggers.succeeded", tags=expected_tags),
+            mock.call("triggers.succeeded", tags=expected_tags),
+        ]
+    )
+    assert mock_incr.call_count == 2
 
 
 @pytest.mark.parametrize(
@@ -2872,7 +2883,12 @@ def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_t
 def test_handle_failed_triggers_emits_team_name(jobless_supervisor, team_name, expected_tags):
     """triggers.failed carries the triggerer's team_name (omitted when the triggerer has none)."""
     jobless_supervisor.team_name = team_name
-    jobless_supervisor.failed_triggers.append((1, None))
+    jobless_supervisor.failed_triggers.extend(
+        [
+            (1, Exception("failure one")),
+            (2, Exception("failure two")),
+        ]
+    )
 
     with (
         mock.patch.object(TriggerRunnerSupervisor, "on_trigger_failure", autospec=True),
@@ -2880,7 +2896,13 @@ def test_handle_failed_triggers_emits_team_name(jobless_supervisor, team_name, e
     ):
         jobless_supervisor.handle_failed_triggers()
 
-    mock_incr.assert_called_once_with("triggers.failed", tags=expected_tags)
+    mock_incr.assert_has_calls(
+        [
+            mock.call("triggers.failed", tags=expected_tags),
+            mock.call("triggers.failed", tags=expected_tags),
+        ]
+    )
+    assert mock_incr.call_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Description**

This change strengthens unit test coverage for metrics emitted by the triggerer.

The tests for `triggers.succeeded` and `triggers.failed` are expanded to verify that metrics are emitted for each processed trigger event and failed trigger.

**Rationale**

The triggerer's metrics form part of its observability surface and may be consumed by external monitoring and alerting systems. Additional coverage helps guard against regressions that could result in metrics being emitted only once per invocation rather than once per processed event.

**Tests**

Coverage has been extended for `triggers.succeeded` and `triggers.failed` to verify that a metric is emitted for each processed trigger event and failed trigger.

**Backwards Compatibility**

This change adds test coverage only and does not modify trigger execution behavior, lifecycle semantics, metrics, or public APIs.