### PR TITLE
Fix variable PATCH for encoded leading slash keys

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from typing import Annotated
+from urllib.parse import unquote
 
 from fastapi import Depends, HTTPException, Query, status
 from sqlalchemy import delete, select
@@ -50,6 +51,13 @@ from airflow.api_fastapi.logging.decorators import action_logging
 from airflow.models.variable import Variable
 
 variables_router = AirflowRouter(tags=["Variable"], prefix="/variables")
+
+
+def _resolve_patch_variable_key(variable_key: str, patch_body: VariableBody) -> str:
+    decoded_variable_key = unquote(variable_key)
+    if decoded_variable_key == patch_body.key:
+        return decoded_variable_key
+    return variable_key
 
 
 @variables_router.delete(
@@ -149,6 +157,7 @@ def patch_variable(
     update_mask: list[str] | None = Query(None),
 ) -> VariableResponse:
     """Update a variable by key."""
+    variable_key = _resolve_patch_variable_key(variable_key, patch_body)
     variable = update_orm_from_pydantic(variable_key, patch_body, update_mask, session)
     return variable
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -547,6 +547,43 @@ class TestPatchVariable(TestVariableEndpoint):
         }
         check_last_log(session, dag_id=None, event="patch_variable", logical_date=None)
 
+    @pytest.mark.enable_redact
+    @pytest.mark.parametrize(
+        "path_key",
+        [
+            pytest.param(f"%2F{TEST_VARIABLE_KEY}", id="encoded-slash"),
+            # TestClient decodes the URL once before Starlette builds the ASGI scope, so this
+            # represents the ASGI path produced by an external request with ``%252F``.
+            pytest.param(f"%25252F{TEST_VARIABLE_KEY}", id="encoded-slash-in-asgi-path"),
+        ],
+    )
+    def test_patch_leading_slash_key_should_respond_200(self, test_client, session, path_key):
+        key = f"/{TEST_VARIABLE_KEY}"
+        Variable.set(
+            key=key,
+            value=TEST_VARIABLE_VALUE,
+            description=TEST_VARIABLE_DESCRIPTION,
+        )
+
+        response = test_client.patch(
+            f"/variables/{path_key}",
+            json={
+                "key": key,
+                "value": "The new value",
+                "description": "The new description",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "key": key,
+            "value": "The new value",
+            "description": "The new description",
+            "is_encrypted": True,
+            "team_name": None,
+        }
+        check_last_log(session, dag_id=None, event="patch_variable", logical_date=None)
+
     def test_patch_should_respond_400(self, test_client):
         response = test_client.patch(
             f"/variables/{TEST_VARIABLE_KEY}",


### PR DESCRIPTION

Fixes https://github.com/apache/airflow/issues/68065.

When `PATCH /api/v2/variables/{variable_key}` receives an encoded leading slash as the path parameter, the route can see `%2Ffoo` while the immutable body key is correctly `/foo`. The existing mismatch guard then rejects the request before the variable lookup.

This changes the PATCH route to decode the path key once only when the decoded value exactly matches the request body's `key`. Literal keys containing `%2F` are still preserved when the body key matches the literal path value.

## Tests

```bash
/opt/anaconda3/bin/uv run ruff format airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
/opt/anaconda3/bin/uv run ruff check --fix airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
/opt/anaconda3/bin/uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py::TestPatchVariable -xvs
/opt/anaconda3/bin/uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py -q