### PR TITLE
Block retry_policy argument for StubOperator

### DIFF
--- a/providers/standard/src/airflow/providers/standard/decorators/stub.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/stub.py
@@ -46,6 +46,16 @@ class _StubOperator(DecoratedOperator):
             task_id=task_id,
             **kwargs,
         )
+        # A retry_policy is user Python evaluated in-process by the task runner. Stub tasks
+        # execute on a remote/native worker via the Task Execution Interface and never run the
+        # Python task runner, so the policy would silently never fire. Reject it up front.
+        # (retries is fine -- the server computes retry eligibility regardless of runtime.)
+        if self.retry_policy is not None:
+            raise ValueError(
+                "@task.stub does not support `retry_policy`: it runs Python in-process, but stub "
+                "tasks execute on a lang-sdk runtime and never evaluate the policy. Use `retries` "
+                "instead."
+            )
         # Validate python callable
         module = ast.parse(self.get_python_source())
 

--- a/providers/standard/src/airflow/providers/standard/decorators/stub.py
+++ b/providers/standard/src/airflow/providers/standard/decorators/stub.py
@@ -50,7 +50,7 @@ class _StubOperator(DecoratedOperator):
         # execute on a remote/native worker via the Task Execution Interface and never run the
         # Python task runner, so the policy would silently never fire. Reject it up front.
         # (retries is fine -- the server computes retry eligibility regardless of runtime.)
-        if self.retry_policy is not None:
+        if getattr(self, "retry_policy", None) is not None:
             raise ValueError(
                 "@task.stub does not support `retry_policy`: it runs Python in-process, but stub "
                 "tasks execute on a lang-sdk runtime and never evaluate the policy. Use `retries` "

--- a/providers/standard/tests/unit/standard/decorators/test_stub.py
+++ b/providers/standard/tests/unit/standard/decorators/test_stub.py
@@ -55,3 +55,14 @@ def fn_code():
 def test_stub_signature(fn, error):
     with error:
         stub(fn)()
+
+
+def test_stub_rejects_retry_policy():
+    from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy
+
+    with pytest.raises(ValueError, match="does not support retry_policy"):
+        stub(fn_pass, retry_policy=ExceptionRetryPolicy(rules=[]))()
+
+
+def test_stub_allows_retries():
+    stub(fn_pass, retries=5)()

--- a/providers/standard/tests/unit/standard/decorators/test_stub.py
+++ b/providers/standard/tests/unit/standard/decorators/test_stub.py
@@ -22,6 +22,8 @@ import pytest
 
 from airflow.providers.standard.decorators.stub import stub
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
 
 def fn_ellipsis(): ...
 
@@ -57,10 +59,11 @@ def test_stub_signature(fn, error):
         stub(fn)()
 
 
+@pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="retry_policy added in Airflow 3.3")
 def test_stub_rejects_retry_policy():
     from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy
 
-    with pytest.raises(ValueError, match="does not support retry_policy"):
+    with pytest.raises(ValueError, match="does not support `retry_policy`"):
         stub(fn_pass, retry_policy=ExceptionRetryPolicy(rules=[]))()
 
 


### PR DESCRIPTION
- related: https://github.com/apache/airflow/issues/67797

## Why

While reading through how the `retries` setup for Task Execution. I found that we should block the new `retry_policy` argument in the first place for StubOperator.

Unless all the lang-sdk runtime implement the handling `RetryPolicy` (but that will not happen in the near future) so fail fast at authoring level.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)