### PR TITLE
Defer `InProcessExecutionAPI` import

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -48,7 +48,6 @@ from uuid6 import uuid7
 from airflow._shared.observability.metrics import stats
 from airflow._shared.observability.metrics.stats import normalize_name_for_stats
 from airflow._shared.timezones import timezone
-from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
 from airflow.configuration import conf
 from airflow.dag_processing.bundles.base import (
     BundleUsageTrackingManager,
@@ -91,9 +90,20 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from sqlalchemy.sql import Select
 
+    from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
     from airflow.callbacks.callback_requests import CallbackRequest
     from airflow.dag_processing.bundles.base import BaseDagBundle
     from airflow.sdk.api.client import Client
+
+
+def _make_execution_api() -> InProcessExecutionAPI:
+    # This is a seriously weighty import, pulling in svcs, cadwyn, fastapi, aiohttp, etc.
+    #
+    # Defer it so that an import of this module for types (e.g. DagFileStat, DagFileInto) doesn't need to pay
+    # that cost.
+    from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
+
+    return InProcessExecutionAPI()
 
 
 class DagParsingStat(NamedTuple):
@@ -286,7 +296,7 @@ class DagFileProcessorManager(LoggingMixin):
         factory=_config_get_factory("dag_processor", "file_parsing_sort_mode")
     )
 
-    _api_server: InProcessExecutionAPI = attrs.field(init=False, factory=InProcessExecutionAPI)
+    _api_server: InProcessExecutionAPI = attrs.field(init=False, factory=_make_execution_api)
     """API server to interact with Metadata DB"""
 
     def register_exit_signals(self):


### PR DESCRIPTION
We don't need this until someone actually constructs a `DagFileProcessorManager`, so defer it to reduce the impact of importing this module.

A test that does `from airflow.dag_processing.manager import DagFileInfo` pulls in ~20k tracked objects and ~1.2k objects worth of garbage that the caller never needs.

A minimal harness to show this:

```python
import gc
import time

gc.disable()

t0 = time.monotonic()
from airflow.dag_processing.manager import DagFileInfo
import_ = time.monotonic() - t0

t0 = time.monotonic()
freed = gc.collect()
collect = time.monotonic() - t0

import_ms = import_ * 1000
collect_ms = collect * 1000

print(import_ms, collect_ms, len(gc.get_objects()), freed)
```

Running this 10 times with and without this patch shows the extent of the difference:

    # Before
    import ms      median= 897.5  min= 842.8  max= 925.0
    gc.collect ms  median=  67.2  min=  57.3  max=  81.2
    tracked obj    median=261611
    freed          median= 22152

    # After
    import ms      median= 797.9  min= 774.8  max= 853.0
    gc.collect ms  median=  54.6  min=  49.1  max=  65.6
    tracked obj    median=241052
    freed          median= 21064

    # Change
    import ms        897.5  ->   797.9   (-11.1%, 1.12x  )
    gc.collect ms     67.2  ->    54.6   (-18.8%, 1.23x  )
    tracked obj     261611  ->  241052   ( -7.9%, 1.09x  )
    freed            22152  ->   21064   ( -4.9%, 1.05x  )

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->