### PR TITLE
use pod_template_file config setting as default pod template

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -1461,13 +1461,14 @@ class KubernetesPodOperator(BaseOperator):
         template file.
         """
         self.log.debug("Creating pod for KubernetesPodOperator task %s", self.task_id)
+        default_pod_template_file = conf.get("kubernetes_executor", "pod_template_file", fallback=None)
 
         self.env_vars = convert_env_vars_or_raise_error(self.env_vars) if self.env_vars else []
         if self.pod_runtime_info_envs:
             self.env_vars.extend(self.pod_runtime_info_envs)
 
         if self.pod_template_file:
-            self.log.debug("Pod template file found, will parse for base pod")
+            self.log.debug("Using pod template file %s", self.pod_template_file)
             pod_template = pod_generator.PodGenerator.deserialize_model_file(self.pod_template_file)
             if self.full_pod_spec:
                 pod_template = PodGenerator.reconcile_pods(pod_template, self.full_pod_spec)
@@ -1478,6 +1479,9 @@ class KubernetesPodOperator(BaseOperator):
                 pod_template = PodGenerator.reconcile_pods(pod_template, self.full_pod_spec)
         elif self.full_pod_spec:
             pod_template = self.full_pod_spec
+        elif default_pod_template_file:
+            self.log.debug("Using pod template_file %s for base pod", default_pod_template_file)
+            pod_template = pod_generator.PodGenerator.deserialize_model_file(default_pod_template_file)
         else:
             pod_template = k8s.V1Pod(metadata=k8s.V1ObjectMeta())
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -60,6 +60,7 @@ from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 
 from tests_common.test_utils import db
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.taskinstance import create_task_instance, get_template_context
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
@@ -1423,6 +1424,60 @@ class TestKubernetesPodOperator:
         }
 
         assert pod.spec.affinity.to_dict() == affinity
+
+    def test_pod_template_file_default(self, pod_template_file):
+        with conf_vars({("kubernetes_executor", "pod_template_file"): pod_template_file}):
+            k = KubernetesPodOperator(
+                task_id="task",
+            )
+            pod = k.build_pod_request_obj(create_context(k))
+        assert pod.metadata.namespace == "templatenamespace"
+        assert pod.spec.containers[0].image == "ubuntu:16.04"
+        assert pod.spec.containers[0].image_pull_policy == "Always"
+        assert pod.spec.containers[0].command == ["something"]
+        assert pod.spec.service_account_name == "foo"
+        assert not pod.spec.automount_service_account_token
+
+    def test_pod_template_file_default_with_override(self, pod_template_file):
+        templated_pod = k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(
+                namespace="templatenamespace2",
+                name="hello2",
+                labels={"release": "stable"},
+            ),
+            spec=k8s.V1PodSpec(
+                containers=[],
+                init_containers=[
+                    k8s.V1Container(
+                        name="git-clone",
+                        image="registry.k8s.io/git-sync:v3.1.1",
+                        args=[
+                            "--repo=git@github.com:airflow/some_repo.git",
+                            "--branch={{ params.get('repo_branch', 'master') }}",
+                        ],
+                    ),
+                ],
+            ),
+        )
+
+        with conf_vars({("kubernetes_executor", "pod_template_file"): pod_template_file}):
+            k = KubernetesPodOperator(
+                task_id="task",
+                pod_template_dict=pod_generator.PodGenerator.serialize_pod(templated_pod),
+            )
+            pod = k.build_pod_request_obj(create_context(k))
+        assert pod.metadata.namespace == "templatenamespace2"
+        assert pod.metadata.labels["release"] == "stable"
+        assert pod.metadata.name == "hello2"
+        assert len(pod.spec.containers) == 0
+
+
+        assert pod.spec.init_containers[0].name == "git-clone"
+        assert pod.spec.init_containers[0].image == "registry.k8s.io/git-sync:v3.1.1"
+        assert pod.spec.init_containers[0].args == [
+            "--repo=git@github.com:airflow/some_repo.git",
+            "--branch=test_branch",
+        ]
 
     @pytest.mark.parametrize("randomize_name", (True, False))
     def test_pod_template_file_kwargs_override(self, randomize_name, pod_template_file):


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Use pod_template_file config setting as default pod template
---

if `[kubernetes_executor] pod_template_file` / `AIRFLOW__KUBERNETES_EXECUTOR__POD_TEMPLATE_FILE` is set, use it as a default for `KubernetesPodOperator.build_pod_request_obj`

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

<!-- pr-triage-fold: triaged=2026-07-28T17:13:01Z head=ef8d393 action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @stephen-bracken** · by `@potiuk` · 2026-07-28 17:13 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
