### PR TITLE
Fix triggerer CrashLoopBackOff when json_logs is enabled

### DIFF
--- a/airflow-core/newsfragments/68584.bugfix.rst
+++ b/airflow-core/newsfragments/68584.bugfix.rst
@@ -1,0 +1,1 @@
+Fix triggerer ``CrashLoopBackOff`` when ``[logging] json_logs`` is enabled. The triggerer reconfigured structlog without honoring ``json_logs`` when setting up subprocess log forwarding, so the JSON (bytes) renderer was paired with a text logger and raised ``TypeError: can't concat str to bytes`` the first time a trigger subprocess wrote to stdout/stderr.

--- a/airflow-core/newsfragments/68584.bugfix.rst
+++ b/airflow-core/newsfragments/68584.bugfix.rst
@@ -1,1 +1,0 @@
-Fix triggerer ``CrashLoopBackOff`` when ``[logging] json_logs`` is enabled. The triggerer reconfigured structlog without honoring ``json_logs`` when setting up subprocess log forwarding, so the JSON (bytes) renderer was paired with a text logger and raised ``TypeError: can't concat str to bytes`` the first time a trigger subprocess wrote to stdout/stderr.

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -941,12 +941,6 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
         from airflow.sdk.log import configure_logging
 
-        # Must match the json_logs setting: calling configure_logging() here reconfigures
-        # structlog globally. Defaulting json_output to False would install the text
-        # WriteLogger factory, while the stdout/stderr forwarders (forward_to_log) emit
-        # bytes from the JSON renderer -- crashing the triggerer with
-        # "TypeError: can't concat str to bytes" the first time a trigger subprocess
-        # writes to stdout/stderr.
         configure_logging(json_output=conf.getboolean("logging", "json_logs", fallback=False))
 
         fallback_log = structlog.get_logger(logger_name=__name__)

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -941,7 +941,13 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
 
         from airflow.sdk.log import configure_logging
 
-        configure_logging()
+        # Must match the json_logs setting: calling configure_logging() here reconfigures
+        # structlog globally. Defaulting json_output to False would install the text
+        # WriteLogger factory, while the stdout/stderr forwarders (forward_to_log) emit
+        # bytes from the JSON renderer -- crashing the triggerer with
+        # "TypeError: can't concat str to bytes" the first time a trigger subprocess
+        # writes to stdout/stderr.
+        configure_logging(json_output=conf.getboolean("logging", "json_logs", fallback=False))
 
         fallback_log = structlog.get_logger(logger_name=__name__)
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -316,16 +316,12 @@ def test_run_invokes_seams_in_order(supervisor_builder, mocker):
 
 @pytest.mark.parametrize("json_logs", [True, False])
 def test_process_log_messages_configures_logging_matching_json_logs(supervisor_builder, mocker, json_logs):
-    """``_process_log_messages_from_subprocess`` must reconfigure structlog with the
-    ``logging.json_logs`` setting, not the ``configure_logging`` default of ``False``.
-
-    Priming this generator calls ``configure_logging()``, which reconfigures structlog
-    globally. With ``json_logs=True`` but ``json_output`` left to default ``False`` the
-    global logger factory becomes the text ``WriteLogger`` while the stdout/stderr
-    forwarders emit bytes from the JSON renderer, crashing the triggerer with
-    ``TypeError: can't concat str to bytes`` the first time a trigger subprocess writes
-    to stdout/stderr. See the regression where enabling json_logs CrashLoopBackOff-ed
-    triggerers running providers that warn at import time.
+    """_process_log_messages_from_subprocess() must reconfigure logging using the
+    configured ``logging.json_logs`` value rather than the default
+    ``json_output=False``.
+    This generator reconfigures structlog globally when first primed. Failing to
+    propagate the configured JSON logging mode can leave the triggerer with an
+    inconsistent logging configuration and break subprocess log forwarding.
     """
     supervisor = supervisor_builder()
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -314,6 +314,31 @@ def test_run_invokes_seams_in_order(supervisor_builder, mocker):
     assert events == ["enter", "tick-1", "tick-2", "tick-3", "exit"]
 
 
+@pytest.mark.parametrize("json_logs", [True, False])
+def test_process_log_messages_configures_logging_matching_json_logs(supervisor_builder, mocker, json_logs):
+    """``_process_log_messages_from_subprocess`` must reconfigure structlog with the
+    ``logging.json_logs`` setting, not the ``configure_logging`` default of ``False``.
+
+    Priming this generator calls ``configure_logging()``, which reconfigures structlog
+    globally. With ``json_logs=True`` but ``json_output`` left to default ``False`` the
+    global logger factory becomes the text ``WriteLogger`` while the stdout/stderr
+    forwarders emit bytes from the JSON renderer, crashing the triggerer with
+    ``TypeError: can't concat str to bytes`` the first time a trigger subprocess writes
+    to stdout/stderr. See the regression where enabling json_logs CrashLoopBackOff-ed
+    triggerers running providers that warn at import time.
+    """
+    supervisor = supervisor_builder()
+
+    configure_logging = mocker.patch("airflow.sdk.log.configure_logging")
+    mocker.patch("airflow.sdk.log.logging_processors")
+
+    with conf_vars({("logging", "json_logs"): str(json_logs)}):
+        gen = supervisor._process_log_messages_from_subprocess()
+        next(gen)  # prime the generator -- this is what calls configure_logging()
+
+    configure_logging.assert_called_once_with(json_output=json_logs)
+
+
 def test_client_delegates_to_make_client_and_caches_result(supervisor_builder, mocker):
     """``supervisor.client`` delegates to ``make_client`` (the subclass-override hook)
     and caches the result across accesses."""


### PR DESCRIPTION
### What

`TriggerRunnerSupervisor._process_log_messages_from_subprocess` primes itself by calling `airflow.sdk.log.configure_logging()` with **no arguments**. `json_output` defaults to `False`, so this call reconfigures structlog **globally** and installs the text `WriteLogger` factory — overwriting the bytes `BytesLogger` factory that startup set up when `[logging] json_logs = True`.

The stdout/stderr forwarders (`_create_log_forwarder` → `forward_to_log`) are already wrapped with the JSON (bytes) processor chain but bind their underlying logger **lazily**. As soon as a trigger subprocess writes to stdout/stderr — e.g. an import-time `DeprecationWarning` from a provider trigger that imports a heavy client such as `KubernetesPodTrigger` (kubernetes) or `S3KeyTrigger` (boto3) — the lazy bind resolves against the now-text factory, and `WriteLogger.msg` does `message + "\n"` on bytes produced by the JSON renderer:

```
TypeError: can't concat str to bytes
  File ".../structlog/_output.py", line 217, in msg
    self._write(message + "\n")
```

This crashes the `TriggerRunnerSupervisor.run` loop and the triggerer enters CrashLoopBackOff. It only manifests when `json_logs` is enabled **and** the triggerer actually runs a trigger whose subprocess emits to stdout/stderr — idle triggerers and those running only quiet triggers (`DateTimeTrigger`, etc.) never reach `forward_to_log`, which is why the crash looks intermittent across deployments.

### Fix

Pass `json_output` from the `[logging] json_logs` config (the same `conf.getboolean("logging", "json_logs", fallback=False)` used elsewhere, e.g. `airflow/logging_config.py`) so the global structlog factory stays consistent with the rest of the process. This matches the already-hardcoded `logging_processors(json_output=True)` a few lines below.

### Tests

Adds a parametrized regression test asserting `_process_log_messages_from_subprocess` calls `configure_logging(json_output=<json_logs>)` for both `True` and `False`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.
-->

---

^ Add meaningful description above. Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines) for more information.