### PR TITLE
Add Dag source code location metadata

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -707,6 +707,32 @@ This is especially useful if your tasks are built dynamically from configuration
             EmptyOperator(task_id="extract_orders")
 
 
+Dag Source Code Location
+------------------------
+
+You can annotate a Dag with information about the source repository and revision that define it.
+This metadata is stored with the serialized Dag and can be used by integrations that need to link a Dag run back to source code.
+
+.. code-block:: python
+
+    from airflow.sdk import DAG, SourceCodeLocation
+
+    with DAG(
+        "my_dag",
+        schedule="@daily",
+        source_code_location=SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/my_dag.py",
+            version="abc123",
+            branch="main",
+        ),
+    ):
+        ...
+
+``SourceCodeLocation`` accepts ``type`` (``"git"`` or ``"svn"``), ``url``, ``repo_url``, ``path``, ``version``, ``tag``, and ``branch``.
+At least one of ``url`` or ``repo_url`` must be provided.
+
+
 Packaging Dags
 --------------
 

--- a/airflow-core/newsfragments/68588.feature.rst
+++ b/airflow-core/newsfragments/68588.feature.rst
@@ -1,0 +1,1 @@
+Add Dag source code location metadata and emit it as an OpenLineage ``sourceCodeLocation`` job facet.

--- a/airflow-core/src/airflow/serialization/definitions/dag.py
+++ b/airflow-core/src/airflow/serialization/definitions/dag.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 
     from airflow.models.taskinstance import TaskInstance
     from airflow.sdk import DAG
+    from airflow.sdk.definitions.dag import SourceCodeLocation
     from airflow.serialization.definitions.taskgroup import SerializedTaskGroup
     from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedOperator
     from airflow.timetables.base import Timetable
@@ -130,6 +131,7 @@ class SerializedDAG:
     params: SerializedParamsDict = attrs.field(factory=SerializedParamsDict)
     partial: bool = False
     render_template_as_native_obj: bool = False
+    source_code_location: SourceCodeLocation | None = None
     start_date: datetime.datetime | None = None
     tags: set[str] = attrs.field(factory=set)
     template_searchpath: tuple[str, ...] | None = None
@@ -178,6 +180,7 @@ class SerializedDAG:
                 "owner_links",
                 "relative_fileloc",
                 "render_template_as_native_obj",
+                "source_code_location",
                 "start_date",
                 "tags",
                 "task_group",

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -230,6 +230,10 @@
             "branch": { "type": "string" }
           },
           "required": ["type"],
+          "anyOf": [
+            { "required": ["url"] },
+            { "required": ["repo_url"] }
+          ],
           "additionalProperties": false
         },
         "tags": { "type": "array" },

--- a/airflow-core/src/airflow/serialization/schema.json
+++ b/airflow-core/src/airflow/serialization/schema.json
@@ -218,6 +218,20 @@
         "has_on_success_callback":  { "type": "boolean", "default": false },
         "has_on_failure_callback":  { "type": "boolean", "default": false },
         "render_template_as_native_obj":  { "type": "boolean", "default": false },
+        "source_code_location": {
+          "type": "object",
+          "properties": {
+            "type": { "enum": ["git", "svn"] },
+            "url": { "type": "string" },
+            "repo_url": { "type": "string" },
+            "path": { "type": "string" },
+            "version": { "type": "string" },
+            "tag": { "type": "string" },
+            "branch": { "type": "string" }
+          },
+          "required": ["type"],
+          "additionalProperties": false
+        },
         "tags": { "type": "array" },
         "task_group": {"anyOf": [
           { "type": "null" },

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -57,6 +57,7 @@ from airflow.sdk.definitions.asset import (
     AssetUniqueKey,
     BaseAsset,
 )
+from airflow.sdk.definitions.dag import SourceCodeLocation
 from airflow.sdk.definitions.deadline import DeadlineAlert
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.operator_resources import Resources
@@ -1720,6 +1721,12 @@ class DagSerialization(BaseSerialization):
             else:
                 serialized_dag["allowed_run_types"] = None
 
+            if dag.source_code_location:
+                serialized_dag["source_code_location"] = attrs.asdict(
+                    dag.source_code_location,
+                    filter=lambda _attribute, value: value is not None,
+                )
+
             # Edge info in the JSON exactly matches our internal structure
             serialized_dag["edge_info"] = dag.edge_info
             serialized_dag["params"] = cls._serialize_params_dict(dag.params)
@@ -1822,6 +1829,8 @@ class DagSerialization(BaseSerialization):
                     v = frozenset(DagRunType(x) for x in v)
                 else:
                     v = None
+            elif k == "source_code_location" and v is not None:
+                v = SourceCodeLocation(**v)
             # else use v as it is
 
             object.__setattr__(dag, k, v)

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -65,6 +65,7 @@ from airflow.sdk import DAG, Asset, AssetAlias, BaseHook, TaskGroup, WeightRule,
 from airflow.sdk.bases.decorator import DecoratedOperator
 from airflow.sdk.bases.operator import OPERATOR_DEFAULTS, BaseOperator
 from airflow.sdk.definitions._internal.expandinput import EXPAND_INPUT_EMPTY
+from airflow.sdk.definitions.dag import SourceCodeLocation
 from airflow.sdk.definitions.operator_resources import Resources
 from airflow.sdk.definitions.param import Param, ParamsDict
 from airflow.security import permissions
@@ -780,6 +781,31 @@ class TestStringifiedDAGs:
         dag = get_timetable_based_simple_dag(timetable)
         roundtripped = DagSerialization.from_json(DagSerialization.to_json(dag))
         self.validate_deserialized_dag(roundtripped, dag)
+
+    def test_dag_roundtrip_with_source_code_location(self):
+        """Verify Dag source code location metadata survives serialization."""
+        dag = DAG(
+            "source-code-location-dag",
+            schedule=None,
+            source_code_location=SourceCodeLocation(
+                repo_url="https://github.com/apache/airflow.git",
+                path="dags/example.py",
+                version="abc123",
+                branch="main",
+            ),
+        )
+
+        serialized = DagSerialization.to_dict(dag)
+        roundtripped = DagSerialization.from_dict(serialized)
+
+        assert serialized["dag"]["source_code_location"] == {
+            "type": "git",
+            "repo_url": "https://github.com/apache/airflow.git",
+            "path": "dags/example.py",
+            "version": "abc123",
+            "branch": "main",
+        }
+        assert roundtripped.source_code_location == dag.source_code_location
 
     def validate_deserialized_dag(self, serialized_dag: SerializedDAG, dag: DAG):
         """

--- a/providers/openlineage/docs/guides/developer.rst
+++ b/providers/openlineage/docs/guides/developer.rst
@@ -242,6 +242,28 @@ you might want to attach ``SqlJobFacet`` if your Operator is executing SQL.
 
 To learn more about facets in OpenLineage see :ref:`configuration_custom_facets:openlineage`.
 
+Dag source code location
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The OpenLineage provider emits the OpenLineage ``sourceCodeLocation`` job facet when a Dag defines ``source_code_location``.
+The facet is included on Dag-run events and on task events emitted for tasks in that Dag.
+
+.. code-block:: python
+
+    from airflow.sdk import DAG, SourceCodeLocation
+
+    with DAG(
+        dag_id="example_operator",
+        schedule="@once",
+        source_code_location=SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/example_operator.py",
+            version="abc123",
+            branch="main",
+        ),
+    ):
+        ...
+
 Registering Custom Extractor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/providers/openlineage/docs/guides/developer.rst
+++ b/providers/openlineage/docs/guides/developer.rst
@@ -242,28 +242,6 @@ you might want to attach ``SqlJobFacet`` if your Operator is executing SQL.
 
 To learn more about facets in OpenLineage see :ref:`configuration_custom_facets:openlineage`.
 
-Dag source code location
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-The OpenLineage provider emits the OpenLineage ``sourceCodeLocation`` job facet when a Dag defines ``source_code_location``.
-The facet is included on Dag-run events and on task events emitted for tasks in that Dag.
-
-.. code-block:: python
-
-    from airflow.sdk import DAG, SourceCodeLocation
-
-    with DAG(
-        dag_id="example_operator",
-        schedule="@once",
-        source_code_location=SourceCodeLocation(
-            repo_url="https://github.com/apache/airflow.git",
-            path="dags/example_operator.py",
-            version="abc123",
-            branch="main",
-        ),
-    ):
-        ...
-
 Registering Custom Extractor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -237,6 +237,7 @@ class OpenLineageAdapter(LoggingMixin):
         task: OperatorLineage | None,
         job_description_type: str | None = None,
         run_facets: dict[str, RunFacet] | None = None,
+        job_facets: dict[str, JobFacet] | None = None,
     ) -> RunEvent:
         """
         Emit openlineage event of type START.
@@ -252,10 +253,12 @@ class OpenLineageAdapter(LoggingMixin):
         :param tags: list of tags
         :param task: metadata container with information extracted from operator
         :param run_facets: custom run facets
+        :param job_facets: custom job facets
         """
         run_facets = run_facets or {}
         if task:
             run_facets = {**task.run_facets, **run_facets}
+        task_job_facets = task.job_facets if task else {}
         event = RunEvent(
             eventType=RunState.START,
             eventTime=event_time,
@@ -272,7 +275,7 @@ class OpenLineageAdapter(LoggingMixin):
                 job_description_type=job_description_type,
                 job_owners=owners,
                 job_tags=tags,
-                job_facets=task.job_facets if task else None,
+                job_facets={**task_job_facets, **(job_facets or {})},
             ),
             inputs=task.inputs if task else [],
             outputs=task.outputs if task else [],
@@ -293,6 +296,7 @@ class OpenLineageAdapter(LoggingMixin):
         job_description: str | None,
         job_description_type: str | None = None,
         run_facets: dict[str, RunFacet] | None = None,
+        job_facets: dict[str, JobFacet] | None = None,
     ) -> RunEvent:
         """
         Emit openlineage event of type COMPLETE.
@@ -308,6 +312,7 @@ class OpenLineageAdapter(LoggingMixin):
         :param task: metadata container with information extracted from operator
         :param owners: list of owners
         :param run_facets: additional run facets
+        :param job_facets: custom job facets
         """
         run_facets = run_facets or {}
         if task:
@@ -324,7 +329,7 @@ class OpenLineageAdapter(LoggingMixin):
             job=self._build_job(
                 job_name,
                 job_type=_JOB_TYPE_TASK,
-                job_facets=task.job_facets,
+                job_facets={**task.job_facets, **(job_facets or {})},
                 job_owners=owners,
                 job_tags=tags,
                 job_description=job_description,
@@ -350,6 +355,7 @@ class OpenLineageAdapter(LoggingMixin):
         job_description_type: str | None = None,
         error: str | BaseException | None = None,
         run_facets: dict[str, RunFacet] | None = None,
+        job_facets: dict[str, JobFacet] | None = None,
     ) -> RunEvent:
         """
         Emit openlineage event of type FAIL.
@@ -367,6 +373,7 @@ class OpenLineageAdapter(LoggingMixin):
         :param owners: list of owners
         :param error: error
         :param run_facets: additional run facets
+        :param job_facets: custom job facets
         """
         run_facets = run_facets or {}
         if task:
@@ -394,7 +401,7 @@ class OpenLineageAdapter(LoggingMixin):
             job=self._build_job(
                 job_name,
                 job_type=_JOB_TYPE_TASK,
-                job_facets=task.job_facets,
+                job_facets={**task.job_facets, **(job_facets or {})},
                 job_owners=owners,
                 job_tags=tags,
                 job_description=job_description,

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -475,6 +475,7 @@ class OpenLineageAdapter(LoggingMixin):
         job_description: str | None,
         is_asset_triggered: bool,
         job_description_type: str | None = None,
+        job_facets: dict[str, JobFacet] | None = None,  # Custom job facets
     ):
         try:
             job_dependency_facet = {}
@@ -488,6 +489,7 @@ class OpenLineageAdapter(LoggingMixin):
                     job_type=_JOB_TYPE_DAG,
                     job_owners=owners,
                     job_tags=tags,
+                    job_facets=job_facets,
                     job_description=job_description,
                     job_description_type=job_description_type,
                 ),
@@ -533,6 +535,7 @@ class OpenLineageAdapter(LoggingMixin):
         job_description: str | None,
         is_asset_triggered: bool,
         job_description_type: str | None = None,
+        job_facets: dict[str, JobFacet] | None = None,  # Custom job facets
     ):
         try:
             job_dependency_facet = {}
@@ -546,6 +549,7 @@ class OpenLineageAdapter(LoggingMixin):
                     job_type=_JOB_TYPE_DAG,
                     job_owners=owners,
                     job_tags=tags,
+                    job_facets=job_facets,
                     job_description=job_description,
                     job_description_type=job_description_type,
                 ),

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -51,6 +51,7 @@ from airflow.providers.openlineage.utils.utils import (
     get_dag_parent_run_facet,
     get_dag_run_dag_and_task_from_ti,
     get_job_name,
+    get_source_code_location_job_facet,
     get_task_documentation,
     get_task_parent_run_facet,
     get_user_provided_run_facets,
@@ -1089,7 +1090,10 @@ class OpenLineageListener:
                 tags=dag_run.dag.tags if dag_run.dag else [],
                 # AirflowJobFacet should be created outside ProcessPoolExecutor that pickles objects,
                 # as it causes lack of some TaskGroup attributes and crashes event emission.
-                job_facets=get_airflow_job_facet(dag_run=dag_run),
+                job_facets={
+                    **get_airflow_job_facet(dag_run=dag_run),
+                    **get_source_code_location_job_facet(dag_run.dag),
+                },
                 run_facets={
                     **get_airflow_dag_run_facet(dag_run),
                     **get_dag_parent_run_facet(getattr(dag_run, "conf", {})),
@@ -1146,6 +1150,7 @@ class OpenLineageListener:
                     **get_airflow_dag_run_facet(dag_run),
                     **get_dag_parent_run_facet(getattr(dag_run, "conf", {})),
                 },
+                job_facets=get_source_code_location_job_facet(dag_run.dag),
                 is_asset_triggered=is_dag_run_asset_triggered(dag_run),
             )
         except BaseException as e:
@@ -1195,6 +1200,7 @@ class OpenLineageListener:
                 dag_run_state=dag_run.get_state(),
                 task_ids=task_ids,
                 msg=msg,
+                job_facets=get_source_code_location_job_facet(dag_run.dag),
                 run_facets={
                     **get_airflow_dag_run_facet(dag_run),
                     **get_dag_parent_run_facet(getattr(dag_run, "conf", {})),

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -42,6 +42,7 @@ from airflow.providers.openlineage.utils.utils import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_2_PLUS,
     DagRunInfo,
+    build_task_event_job_facets,
     get_airflow_dag_run_facet,
     get_airflow_debug_facet,
     get_airflow_job_facet,
@@ -154,6 +155,18 @@ def _emit_manual_state_change_event(adapter_method_name: str, stats_key: str, **
     event = getattr(_get_process_adapter(), adapter_method_name)(**kwargs)
     Stats.gauge(stats_key, len(Serde.to_json(event).encode("utf-8")))
     return event
+
+
+def _build_task_event_job_facet_kwargs(*, task, dag, task_metadata: OperatorLineage) -> dict:
+    if not get_source_code_location_job_facet(dag):
+        return {}
+    return {
+        "job_facets": build_task_event_job_facets(
+            task=task,
+            dag=dag,
+            additional_job_facets=task_metadata.job_facets,
+        )
+    }
 
 
 class OpenLineageListener:
@@ -329,6 +342,7 @@ class OpenLineageListener:
                     ),
                     **debug_facet,
                 },
+                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -490,6 +504,7 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
+                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -666,6 +681,7 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
+                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -817,6 +833,7 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
+                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -919,6 +936,8 @@ class OpenLineageListener:
             doc: str | None = None
             doc_type: str | None = None
             airflow_run_facet: dict = {}
+            job_facet_kwargs: dict = {}
+            task_metadata = OperatorLineage()
             if task:  # on scheduler, we should have access to task
                 doc, doc_type = get_task_documentation(task)
                 dag = getattr(task, "dag")
@@ -935,12 +954,15 @@ class OpenLineageListener:
                         task_uuid,
                         include_full_task_info=include_full_task_info,
                     )
+                    job_facet_kwargs = _build_task_event_job_facet_kwargs(
+                        task=task, dag=dag, task_metadata=task_metadata
+                    )
 
             adapter_kwargs: dict = {
                 "run_id": task_uuid,
                 "job_name": get_job_name(ti),
                 "end_time": end_date.isoformat(),
-                "task": OperatorLineage(),
+                "task": task_metadata,
                 "nominal_start_time": data_interval_start,
                 "nominal_end_time": data_interval_end,
                 "tags": dag_tags,
@@ -956,6 +978,7 @@ class OpenLineageListener:
                     **airflow_run_facet,
                     **get_airflow_debug_facet(),
                 },
+                **job_facet_kwargs,
             }
             if ti_state == TaskInstanceState.FAILED:
                 adapter_kwargs["error"] = error

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -42,7 +42,7 @@ from airflow.providers.openlineage.utils.utils import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_2_PLUS,
     DagRunInfo,
-    build_task_event_job_facets,
+    build_task_event_job_facet_kwargs,
     get_airflow_dag_run_facet,
     get_airflow_debug_facet,
     get_airflow_job_facet,
@@ -155,18 +155,6 @@ def _emit_manual_state_change_event(adapter_method_name: str, stats_key: str, **
     event = getattr(_get_process_adapter(), adapter_method_name)(**kwargs)
     Stats.gauge(stats_key, len(Serde.to_json(event).encode("utf-8")))
     return event
-
-
-def _build_task_event_job_facet_kwargs(*, task, dag, task_metadata: OperatorLineage) -> dict:
-    if not get_source_code_location_job_facet(dag):
-        return {}
-    return {
-        "job_facets": build_task_event_job_facets(
-            task=task,
-            dag=dag,
-            additional_job_facets=task_metadata.job_facets,
-        )
-    }
 
 
 class OpenLineageListener:
@@ -342,7 +330,9 @@ class OpenLineageListener:
                     ),
                     **debug_facet,
                 },
-                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
+                **build_task_event_job_facet_kwargs(
+                    task=task, dag=dag, additional_job_facets=task_metadata.job_facets
+                ),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -504,7 +494,9 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
-                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
+                **build_task_event_job_facet_kwargs(
+                    task=task, dag=dag, additional_job_facets=task_metadata.job_facets
+                ),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -681,7 +673,9 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
-                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
+                **build_task_event_job_facet_kwargs(
+                    task=task, dag=dag, additional_job_facets=task_metadata.job_facets
+                ),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -833,7 +827,9 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
-                **_build_task_event_job_facet_kwargs(task=task, dag=dag, task_metadata=task_metadata),
+                **build_task_event_job_facet_kwargs(
+                    task=task, dag=dag, additional_job_facets=task_metadata.job_facets
+                ),
             )
             event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
 
@@ -954,8 +950,8 @@ class OpenLineageListener:
                         task_uuid,
                         include_full_task_info=include_full_task_info,
                     )
-                    job_facet_kwargs = _build_task_event_job_facet_kwargs(
-                        task=task, dag=dag, task_metadata=task_metadata
+                    job_facet_kwargs = build_task_event_job_facet_kwargs(
+                        task=task, dag=dag, additional_job_facets=task_metadata.job_facets
                     )
 
             adapter_kwargs: dict = {

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -933,7 +933,7 @@ class OpenLineageListener:
             doc_type: str | None = None
             airflow_run_facet: dict = {}
             job_facet_kwargs: dict = {}
-            task_metadata = OperatorLineage()
+            task_metadata: OperatorLineage = OperatorLineage()
             if task:  # on scheduler, we should have access to task
                 doc, doc_type = get_task_documentation(task)
                 dag = getattr(task, "dag")

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -1391,19 +1391,23 @@ def get_source_code_location_job_facet(dag: DAG | SerializedDAG | None) -> dict[
     if not source_code_location:
         return {}
 
-    url = source_code_location.url or source_code_location.repo_url
+    def get_optional_str(name: str) -> str | None:
+        value = getattr(source_code_location, name, None)
+        return value if isinstance(value, str) else None
+
+    url = get_optional_str("url") or get_optional_str("repo_url")
     if not url:
         return {}
 
     return {
         "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
-            type=source_code_location.type,
+            type=get_optional_str("type") or "git",
             url=url,
-            repoUrl=source_code_location.repo_url,
-            path=source_code_location.path,
-            version=source_code_location.version,
-            tag=source_code_location.tag,
-            branch=source_code_location.branch,
+            repoUrl=get_optional_str("repo_url"),
+            path=get_optional_str("path"),
+            version=get_optional_str("version"),
+            tag=get_optional_str("tag"),
+            branch=get_optional_str("branch"),
             producer=_PRODUCER,
         )
     }

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -362,6 +362,23 @@ def build_task_event_job_facets(
     }
 
 
+def build_task_event_job_facet_kwargs(
+    *,
+    task,
+    dag,
+    additional_job_facets: dict[str, JobFacet] | None = None,
+) -> dict[str, dict[str, JobFacet]]:
+    if not get_source_code_location_job_facet(dag):
+        return {}
+    return {
+        "job_facets": build_task_event_job_facets(
+            task=task,
+            dag=dag,
+            additional_job_facets=additional_job_facets,
+        )
+    }
+
+
 def _get_parent_run_facet(
     parent_run_id: str,
     parent_job_name: str,

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -34,6 +34,7 @@ from openlineage.client.facet_v2 import (
     nominal_time_run,
     ownership_job,
     parent_run,
+    source_code_location_job,
     tags_job,
 )
 from openlineage.client.utils import RedactMixin
@@ -357,6 +358,7 @@ def build_task_event_job_facets(
         **documentation_facet,
         **ownership_facet,
         **tags_facet,
+        **get_source_code_location_job_facet(dag),
     }
 
 
@@ -1382,6 +1384,29 @@ def get_airflow_job_facet(dag_run: DagRun) -> dict[str, AirflowJobFacet]:
         log.warning("Failed to build AirflowJobFacet for DagRun %s/%s: %s.", dag_run.dag, dag_run.run_id, e)
         log.debug("Exception details:", exc_info=True)
         return {}
+
+
+def get_source_code_location_job_facet(dag: DAG | SerializedDAG | None) -> dict[str, JobFacet]:
+    source_code_location = getattr(dag, "source_code_location", None)
+    if not source_code_location:
+        return {}
+
+    url = source_code_location.url or source_code_location.repo_url
+    if not url:
+        return {}
+
+    return {
+        "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
+            type=source_code_location.type,
+            url=url,
+            repoUrl=source_code_location.repo_url,
+            path=source_code_location.path,
+            version=source_code_location.version,
+            tag=source_code_location.tag,
+            branch=source_code_location.branch,
+            producer=_PRODUCER,
+        )
+    }
 
 
 def get_airflow_state_run_facet(

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -36,6 +36,7 @@ from openlineage.client.facet_v2 import (
     ownership_job,
     parent_run,
     processing_engine_run,
+    source_code_location_job,
     sql_job,
     tags_job,
 )
@@ -1258,6 +1259,11 @@ def test_emit_dag_complete_event(
 
     mocked_fetch_tis.return_value = [ti0, ti1, ti2]
     build_ol_id.return_value = random_uuid
+    job_facets = {
+        "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
+            type="git", url="https://github.com/apache/airflow.git"
+        )
+    }
 
     adapter.dag_success(
         dag_id=dag_id,
@@ -1274,6 +1280,7 @@ def test_emit_dag_complete_event(
         nominal_start_time=datetime.datetime(2022, 1, 1).isoformat(),
         nominal_end_time=datetime.datetime(2022, 1, 1).isoformat(),
         is_asset_triggered=False,
+        job_facets=job_facets,
         run_facets={
             "parent": parent_run.ParentRunFacet(
                 run=parent_run.Run(runId=random_uuid),
@@ -1348,6 +1355,7 @@ def test_emit_dag_complete_event(
                     "jobType": job_type_job.JobTypeJobFacet(
                         processingType="BATCH", integration="AIRFLOW", jobType="DAG"
                     ),
+                    **job_facets,
                 },
             ),
             producer=_PRODUCER,
@@ -1425,6 +1433,11 @@ def test_emit_dag_failed_event(
     mocked_fetch_tis.return_value = [ti0, ti1, ti2]
 
     build_ol_id.return_value = random_uuid
+    job_facets = {
+        "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
+            type="git", url="https://github.com/apache/airflow.git"
+        )
+    }
 
     adapter.dag_failed(
         dag_id=dag_id,
@@ -1441,6 +1454,7 @@ def test_emit_dag_failed_event(
         job_description_type="text/plain",
         nominal_start_time=datetime.datetime(2022, 1, 1).isoformat(),
         nominal_end_time=datetime.datetime(2022, 1, 1).isoformat(),
+        job_facets=job_facets,
         run_facets={
             "parent": parent_run.ParentRunFacet(
                 run=parent_run.Run(runId=random_uuid),
@@ -1519,6 +1533,7 @@ def test_emit_dag_failed_event(
                     "jobType": job_type_job.JobTypeJobFacet(
                         processingType="BATCH", integration="AIRFLOW", jobType="DAG"
                     ),
+                    **job_facets,
                 },
             ),
             producer=_PRODUCER,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -119,13 +119,6 @@ def direct_submit_call(self, callable, *args, **kwargs):
     return callable(*args, **kwargs)
 
 
-def assert_source_code_location_job_facet(event):
-    source_code_location_facet = event.job.facets["sourceCodeLocation"]
-    assert source_code_location_facet.url == "https://github.com/apache/airflow.git"
-    assert source_code_location_facet.path == "dags/example.py"
-    assert source_code_location_facet.version == "abc123"
-
-
 class MockExecutor:
     def __init__(self, *args, **kwargs):
         self.submitted = False
@@ -474,7 +467,7 @@ class TestOpenLineageListenerAirflow2:
 
     @pytest.mark.parametrize("event_name", ["running", "success", "failed"])
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet", return_value={})
-    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled", return_value=False)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.resolve_task_emission_policy")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet", return_value={})
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet", return_value={})
     @mock.patch(
@@ -497,6 +490,7 @@ class TestOpenLineageListenerAirflow2:
         event_name,
     ):
         listener, task_instance = self._create_listener_and_task_instance()
+        mock_disabled.return_value = EmissionPolicy.defaults()
         task_instance.task.dag.source_code_location = SourceCodeLocation(
             repo_url="https://github.com/apache/airflow.git",
             path="dags/example.py",
@@ -514,7 +508,10 @@ class TestOpenLineageListenerAirflow2:
             listener.on_task_instance_failed(None, task_instance, ValueError("test"), None)
 
         emitted_event = listener.adapter.emit.call_args.args[0]
-        assert_source_code_location_job_facet(emitted_event)
+        source_code_location_facet = emitted_event.job.facets["sourceCodeLocation"]
+        assert source_code_location_facet.url == "https://github.com/apache/airflow.git"
+        assert source_code_location_facet.path == "dags/example.py"
+        assert source_code_location_facet.version == "abc123"
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
@@ -1483,7 +1480,7 @@ class TestOpenLineageListenerAirflow3:
 
     @pytest.mark.parametrize("event_name", ["running", "success", "failed", "skipped"])
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet", return_value={})
-    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled", return_value=False)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.resolve_task_emission_policy")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet", return_value={})
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet", return_value={})
     @mock.patch(
@@ -1506,6 +1503,7 @@ class TestOpenLineageListenerAirflow3:
         event_name,
     ):
         listener, task_instance = self._create_listener_and_task_instance()
+        mock_disabled.return_value = EmissionPolicy.defaults()
         task_instance.task.dag.source_code_location = SourceCodeLocation(
             repo_url="https://github.com/apache/airflow.git",
             path="dags/example.py",
@@ -1525,7 +1523,10 @@ class TestOpenLineageListenerAirflow3:
             listener.on_task_instance_skipped(None, task_instance)
 
         emitted_event = listener.adapter.emit.call_args.args[0]
-        assert_source_code_location_job_facet(emitted_event)
+        source_code_location_facet = emitted_event.job.facets["sourceCodeLocation"]
+        assert source_code_location_facet.url == "https://github.com/apache/airflow.git"
+        assert source_code_location_facet.path == "dags/example.py"
+        assert source_code_location_facet.version == "abc123"
 
     @pytest.mark.parametrize(
         ("team_name", "expected_tags"),

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -119,6 +119,13 @@ def direct_submit_call(self, callable, *args, **kwargs):
     return callable(*args, **kwargs)
 
 
+def assert_source_code_location_job_facet(event):
+    source_code_location_facet = event.job.facets["sourceCodeLocation"]
+    assert source_code_location_facet.url == "https://github.com/apache/airflow.git"
+    assert source_code_location_facet.path == "dags/example.py"
+    assert source_code_location_facet.version == "abc123"
+
+
 class MockExecutor:
     def __init__(self, *args, **kwargs):
         self.submitted = False
@@ -464,6 +471,50 @@ class TestOpenLineageListenerAirflow2:
         task_instance.get_template_context()["task_reschedule_count"] = 0
 
         return listener, task_instance
+
+    @pytest.mark.parametrize("event_name", ["running", "success", "failed"])
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet", return_value={})
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled", return_value=False)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet", return_value={})
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet", return_value={})
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet", return_value={}
+    )
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets", return_value={}
+    )
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_task_events_emit_source_code_location_job_facet(
+        self,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        event_name,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        task_instance.task.dag.source_code_location = SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/example.py",
+            version="abc123",
+        )
+        listener.extractor_manager.extract_metadata.return_value = OperatorLineage()
+        listener.adapter = OpenLineageAdapter()
+        listener.adapter.emit = mock.Mock(side_effect=lambda event: event)
+
+        if event_name == "running":
+            listener.on_task_instance_running(None, task_instance, None)
+        elif event_name == "success":
+            listener.on_task_instance_success(None, task_instance, None)
+        else:
+            listener.on_task_instance_failed(None, task_instance, ValueError("test"), None)
+
+        emitted_event = listener.adapter.emit.call_args.args[0]
+        assert_source_code_location_job_facet(emitted_event)
 
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
@@ -1429,6 +1480,52 @@ class TestOpenLineageListenerAirflow3:
         listener.adapter = adapter
 
         return listener, task_instance
+
+    @pytest.mark.parametrize("event_name", ["running", "success", "failed", "skipped"])
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet", return_value={})
+    @mock.patch("airflow.providers.openlineage.plugins.listener.is_operator_disabled", return_value=False)
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_task_parent_run_facet", return_value={})
+    @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet", return_value={})
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet", return_value={}
+    )
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets", return_value={}
+    )
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+    )
+    def test_task_events_emit_source_code_location_job_facet(
+        self,
+        mock_get_user_provided_run_facets,
+        mock_get_airflow_mapped_task_facet,
+        mock_get_airflow_run_facet,
+        mock_get_task_parent_run_facet,
+        mock_disabled,
+        mock_debug_facet,
+        event_name,
+    ):
+        listener, task_instance = self._create_listener_and_task_instance()
+        task_instance.task.dag.source_code_location = SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/example.py",
+            version="abc123",
+        )
+        listener.extractor_manager.extract_metadata.return_value = OperatorLineage()
+        listener.adapter = OpenLineageAdapter()
+        listener.adapter.emit = mock.Mock(side_effect=lambda event: event)
+
+        if event_name == "running":
+            listener.on_task_instance_running(None, task_instance)
+        elif event_name == "success":
+            listener.on_task_instance_success(None, task_instance)
+        elif event_name == "failed":
+            listener.on_task_instance_failed(None, task_instance, ValueError("test"))
+        else:
+            listener.on_task_instance_skipped(None, task_instance)
+
+        emitted_event = listener.adapter.emit.call_args.args[0]
+        assert_source_code_location_job_facet(emitted_event)
 
     @pytest.mark.parametrize(
         ("team_name", "expected_tags"),

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -42,6 +42,7 @@ from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
 from airflow.providers.openlineage.plugins.listener import OpenLineageListener
 from airflow.providers.openlineage.utils.emission_policy import EmissionPolicy
 from airflow.providers.openlineage.utils.selective_enable import disable_lineage, enable_lineage
+from airflow.sdk.definitions.dag import SourceCodeLocation
 from airflow.utils import types
 from airflow.utils.state import DagRunState, State
 
@@ -1118,6 +1119,49 @@ class TestOpenLineageListenerAirflow2:
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Airflow 3 tests")
 class TestOpenLineageListenerAirflow3:
+    @pytest.mark.parametrize(
+        "method",
+        ["on_dag_run_running", "on_dag_run_success", "on_dag_run_failed"],
+    )
+    @mock.patch.object(DagRun, "_get_partial_task_ids", return_value=[])
+    def test_dag_run_events_include_source_code_location_job_facet(self, mock_get_task_ids, method):
+        date = timezone.datetime(2022, 1, 1)
+        dag = DAG(
+            "dag",
+            schedule=None,
+            start_date=date,
+            source_code_location=SourceCodeLocation(
+                repo_url="https://github.com/apache/airflow.git",
+                path="dags/example.py",
+                version="abc123",
+            ),
+        )
+        dag_run = DagRun(
+            dag_id=dag.dag_id,
+            run_id="run",
+            logical_date=date,
+            run_after=date,
+            start_date=date,
+        )
+        dag_run.end_date = date
+        dag_run.dag = dag
+
+        listener = OpenLineageListener()
+        listener._executor = mock.Mock(spec=["submit"])
+
+        getattr(listener, method)(dag_run, msg="test")
+
+        submitted_kwargs = listener._executor.submit.call_args.kwargs
+        source_code_location_facet = submitted_kwargs["job_facets"]["sourceCodeLocation"]
+        assert source_code_location_facet.url == "https://github.com/apache/airflow.git"
+        assert source_code_location_facet.path == "dags/example.py"
+        assert source_code_location_facet.version == "abc123"
+        if method == "on_dag_run_running":
+            assert "airflow" in submitted_kwargs["job_facets"]
+            mock_get_task_ids.assert_not_called()
+        else:
+            mock_get_task_ids.assert_called()
+
     @pytest.mark.skip("Rendering fields is not migrated yet in Airflow 3")
     @patch("airflow.models.BaseOperator.render_template")
     def test_listener_does_not_change_task_instance(self, render_mock, mock_supervisor_comms, spy_agency):

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -4440,6 +4440,12 @@ def test_get_source_code_location_job_facet_returns_empty_for_missing_location()
     assert get_source_code_location_job_facet(dag) == {}
 
 
+def test_get_source_code_location_job_facet_returns_empty_for_mock_location():
+    dag = MagicMock()
+
+    assert get_source_code_location_job_facet(dag) == {}
+
+
 def test_build_task_event_job_facets_prefers_task_doc_over_dag_doc():
     facets = build_task_event_job_facets(
         task=_job_task(doc_md="task-doc"),

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pendulum
 import pytest
-from openlineage.client.facet_v2 import parent_run
+from openlineage.client.facet_v2 import parent_run, source_code_location_job
 from uuid6 import uuid7
 
 from airflow import DAG
@@ -36,6 +36,7 @@ from airflow.providers.openlineage.conf import namespace
 from airflow.providers.openlineage.plugins.facets import AirflowDagRunFacet, AirflowJobFacet
 from airflow.providers.openlineage.utils.utils import (
     _MAX_DOC_BYTES,
+    _PRODUCER,
     AssetInfo,
     DagInfo,
     DagRunInfo,
@@ -70,6 +71,7 @@ from airflow.providers.openlineage.utils.utils import (
     get_parent_information_from_dagrun_conf,
     get_root_information_from_dagrun_conf,
     get_runtime_outlet_assets,
+    get_source_code_location_job_facet,
     get_task_documentation,
     get_task_parent_run_facet,
     get_user_provided_run_facets,
@@ -78,6 +80,7 @@ from airflow.providers.openlineage.utils.utils import (
     translate_airflow_asset,
 )
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk.definitions.dag import SourceCodeLocation
 from airflow.timetables.events import EventsTimetable
 from airflow.timetables.trigger import CronTriggerTimetable
 from airflow.utils.edgemodifier import Label
@@ -4399,9 +4402,42 @@ def _job_task(**kw):
 
 
 def _job_dag(**kw):
-    defaults = dict(owner="dag_owner", tags=[], doc_md=None, description=None)
+    defaults = dict(owner="dag_owner", tags=[], doc_md=None, description=None, source_code_location=None)
     defaults.update(kw)
     return MagicMock(**defaults)
+
+
+def test_get_source_code_location_job_facet():
+    dag = DAG(
+        "dag",
+        schedule=None,
+        source_code_location=SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/example.py",
+            version="abc123",
+            branch="main",
+        ),
+    )
+
+    facets = get_source_code_location_job_facet(dag)
+
+    assert facets == {
+        "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
+            type="git",
+            url="https://github.com/apache/airflow.git",
+            repoUrl="https://github.com/apache/airflow.git",
+            path="dags/example.py",
+            version="abc123",
+            branch="main",
+            producer=_PRODUCER,
+        )
+    }
+
+
+def test_get_source_code_location_job_facet_returns_empty_for_missing_location():
+    dag = DAG("dag", schedule=None)
+
+    assert get_source_code_location_job_facet(dag) == {}
 
 
 def test_build_task_event_job_facets_prefers_task_doc_over_dag_doc():
@@ -4427,6 +4463,24 @@ def test_build_task_event_job_facets_tags_sorted_from_dag():
         dag=_job_dag(owner="", tags=["b", "a"]),
     )
     assert [t.key for t in facets["tags"].tags] == ["a", "b"]
+
+
+def test_build_task_event_job_facets_includes_source_code_location_from_dag():
+    facets = build_task_event_job_facets(
+        task=_job_task(owner="airflow"),
+        dag=_job_dag(
+            owner="",
+            source_code_location=SourceCodeLocation(
+                repo_url="https://github.com/apache/airflow.git",
+                path="dags/example.py",
+                version="abc123",
+            ),
+        ),
+    )
+
+    assert facets["sourceCodeLocation"].url == "https://github.com/apache/airflow.git"
+    assert facets["sourceCodeLocation"].path == "dags/example.py"
+    assert facets["sourceCodeLocation"].version == "abc123"
 
 
 def test_build_task_event_job_facets_minimal_when_nothing_set():

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pendulum
 import pytest
-from openlineage.client.facet_v2 import parent_run, source_code_location_job
+from openlineage.client.facet_v2 import parent_run
 from uuid6 import uuid7
 
 from airflow import DAG
@@ -36,7 +36,6 @@ from airflow.providers.openlineage.conf import namespace
 from airflow.providers.openlineage.plugins.facets import AirflowDagRunFacet, AirflowJobFacet
 from airflow.providers.openlineage.utils.utils import (
     _MAX_DOC_BYTES,
-    _PRODUCER,
     AssetInfo,
     DagInfo,
     DagRunInfo,
@@ -53,6 +52,7 @@ from airflow.providers.openlineage.utils.utils import (
     _get_tasks_details,
     _truncate_string_to_byte_size,
     build_dag_run_ol_run_id,
+    build_task_event_job_facet_kwargs,
     build_task_event_job_facets,
     build_task_event_run_facets,
     build_task_instance_ol_run_id,
@@ -4421,17 +4421,12 @@ def test_get_source_code_location_job_facet():
 
     facets = get_source_code_location_job_facet(dag)
 
-    assert facets == {
-        "sourceCodeLocation": source_code_location_job.SourceCodeLocationJobFacet(
-            type="git",
-            url="https://github.com/apache/airflow.git",
-            repoUrl="https://github.com/apache/airflow.git",
-            path="dags/example.py",
-            version="abc123",
-            branch="main",
-            producer=_PRODUCER,
-        )
-    }
+    assert facets["sourceCodeLocation"].type == "git"
+    assert facets["sourceCodeLocation"].url == "https://github.com/apache/airflow.git"
+    assert facets["sourceCodeLocation"].repoUrl == "https://github.com/apache/airflow.git"
+    assert facets["sourceCodeLocation"].path == "dags/example.py"
+    assert facets["sourceCodeLocation"].version == "abc123"
+    assert facets["sourceCodeLocation"].branch == "main"
 
 
 def test_get_source_code_location_job_facet_returns_empty_for_missing_location():
@@ -4487,6 +4482,25 @@ def test_build_task_event_job_facets_includes_source_code_location_from_dag():
     assert facets["sourceCodeLocation"].url == "https://github.com/apache/airflow.git"
     assert facets["sourceCodeLocation"].path == "dags/example.py"
     assert facets["sourceCodeLocation"].version == "abc123"
+
+
+def test_build_task_event_job_facet_kwargs_includes_facets_when_source_location_is_set():
+    kwargs = build_task_event_job_facet_kwargs(
+        task=_job_task(owner="airflow"),
+        dag=_job_dag(
+            owner="",
+            source_code_location=SourceCodeLocation(
+                repo_url="https://github.com/apache/airflow.git",
+                path="dags/example.py",
+                version="abc123",
+            ),
+        ),
+    )
+
+    source_code_location_facet = kwargs["job_facets"]["sourceCodeLocation"]
+    assert source_code_location_facet.url == "https://github.com/apache/airflow.git"
+    assert source_code_location_facet.path == "dags/example.py"
+    assert source_code_location_facet.version == "abc123"
 
 
 def test_build_task_event_job_facets_minimal_when_nothing_set():

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -81,6 +81,7 @@ __all__ = [
     "RollupMapper",
     "SegmentWindow",
     "SkipMixin",
+    "SourceCodeLocation",
     "SyncCallback",
     "StartOfDayMapper",
     "StartOfHourMapper",
@@ -150,7 +151,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.callback import AsyncCallback, SyncCallback
     from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.definitions.context import Context, get_current_context, get_parsing_context
-    from airflow.sdk.definitions.dag import DAG, dag
+    from airflow.sdk.definitions.dag import DAG, SourceCodeLocation, dag
     from airflow.sdk.definitions.deadline import DeadlineAlert, DeadlineReference
     from airflow.sdk.definitions.decorators import result, setup, task, teardown
     from airflow.sdk.definitions.decorators.task_group import task_group
@@ -284,6 +285,7 @@ __lazy_imports: dict[str, str] = {
     "SecretCache": ".execution_time.cache",
     "SegmentWindow": ".definitions.partition_mappers.window",
     "SkipMixin": ".bases.skipmixin",
+    "SourceCodeLocation": ".definitions.dag",
     "SyncCallback": ".definitions.callback",
     "StartOfDayMapper": ".definitions.partition_mappers.temporal",
     "StartOfHourMapper": ".definitions.partition_mappers.temporal",

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -88,6 +88,7 @@ TAG_MAX_LEN = 100
 
 __all__ = [
     "DAG",
+    "SourceCodeLocation",
     "dag",
 ]
 
@@ -105,6 +106,35 @@ DagStateChangeCallback = Callable[[Context], None]
 ScheduleInterval = None | str | timedelta | relativedelta
 
 ScheduleArg = Union[ScheduleInterval, BaseTimetable, "CoreTimetable", BaseAsset, Collection[BaseAsset]]
+
+
+@attrs.define(frozen=True)
+class SourceCodeLocation:
+    """Location of the source code that defines a Dag."""
+
+    type: str = attrs.field(default="git", validator=attrs.validators.in_(("git", "svn")))
+    url: str | None = attrs.field(
+        default=None, validator=attrs.validators.optional(attrs.validators.instance_of(str))
+    )
+    repo_url: str | None = attrs.field(
+        default=None, validator=attrs.validators.optional(attrs.validators.instance_of(str))
+    )
+    path: str | None = attrs.field(
+        default=None, validator=attrs.validators.optional(attrs.validators.instance_of(str))
+    )
+    version: str | None = attrs.field(
+        default=None, validator=attrs.validators.optional(attrs.validators.instance_of(str))
+    )
+    tag: str | None = attrs.field(
+        default=None, validator=attrs.validators.optional(attrs.validators.instance_of(str))
+    )
+    branch: str | None = attrs.field(
+        default=None, validator=attrs.validators.optional(attrs.validators.instance_of(str))
+    )
+
+    def __attrs_post_init__(self) -> None:
+        if not self.url and not self.repo_url:
+            raise ValueError("At least one of url or repo_url must be provided")
 
 
 _DAG_HASH_ATTRS = frozenset(
@@ -232,6 +262,17 @@ def _convert_deadline(deadline: list[DeadlineAlert] | DeadlineAlert | None) -> l
     if isinstance(deadline, DeadlineAlert):
         return [deadline]
     return list(deadline)
+
+
+def _convert_source_code_location(
+    source_code_location: SourceCodeLocation | dict[str, str | None] | None,
+) -> SourceCodeLocation | None:
+    """Convert source code location metadata to a ``SourceCodeLocation`` instance."""
+    if source_code_location is None or isinstance(source_code_location, SourceCodeLocation):
+        return source_code_location
+    return SourceCodeLocation(
+        **{key: value for key, value in source_code_location.items() if value is not None}
+    )
 
 
 def _convert_doc_md(doc_md: str | None) -> str | None:
@@ -428,6 +469,7 @@ class DAG:
     :param rerun_with_latest_version: If True, cleared or rerun tasks will use the latest
         available bundle version. If False, they use the original bundle version. If None
         (default), inherits from the global config ``[core] rerun_with_latest_version``.
+    :param source_code_location: Optional information about where the Dag source code is located.
     """
 
     __serialized_fields: ClassVar[frozenset[str]]
@@ -540,6 +582,11 @@ class DAG:
     dag_display_name: str = attrs.field(
         default=attrs.Factory(_default_dag_display_name, takes_self=True),
         validator=attrs.validators.instance_of(str),
+    )
+    source_code_location: SourceCodeLocation | None = attrs.field(
+        default=None,
+        converter=_convert_source_code_location,
+        validator=attrs.validators.optional(attrs.validators.instance_of(SourceCodeLocation)),
     )
 
     task_dict: dict[str, Operator] = attrs.field(factory=dict, init=False)
@@ -1637,6 +1684,7 @@ if TYPE_CHECKING:
         dag_display_name: str | None = None,
         disable_bundle_versioning: bool = False,
         rerun_with_latest_version: bool | None = None,
+        source_code_location: SourceCodeLocation | None = None,
     ) -> Callable[[Callable], Callable[..., DAG]]:
         """
         Python dag decorator which wraps a function into an Airflow Dag.

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -31,6 +31,7 @@ from airflow.sdk import (
     Label,
     Param,
     PartitionedAtRuntime,
+    SourceCodeLocation,
     TaskGroup,
     dag as dag_decorator,
     task,
@@ -199,6 +200,54 @@ class TestDag:
 
         assert isinstance(dag.params, ParamsDict)
         assert len(dag.params) == 0
+
+    def test_source_code_location(self):
+        source_code_location = SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/example.py",
+            version="abc123",
+            branch="main",
+        )
+
+        dag = DAG("test-dag", schedule=None, source_code_location=source_code_location)
+
+        assert dag.source_code_location == source_code_location
+
+    def test_source_code_location_from_dict(self):
+        dag = DAG(
+            "test-dag",
+            schedule=None,
+            source_code_location={
+                "repo_url": "https://github.com/apache/airflow.git",
+                "path": "dags/example.py",
+                "version": "abc123",
+            },
+        )
+
+        assert dag.source_code_location == SourceCodeLocation(
+            repo_url="https://github.com/apache/airflow.git",
+            path="dags/example.py",
+            version="abc123",
+        )
+
+    def test_source_code_location_requires_url_or_repo_url(self):
+        with pytest.raises(ValueError, match="At least one of url or repo_url must be provided"):
+            SourceCodeLocation(path="dags/example.py")
+
+    def test_source_code_location_rejects_unknown_type(self):
+        with pytest.raises(ValueError, match="'hg'"):
+            SourceCodeLocation(type="hg", repo_url="https://example.invalid/repo")
+
+    def test_dag_decorator_accepts_source_code_location(self):
+        source_code_location = SourceCodeLocation(repo_url="https://github.com/apache/airflow.git")
+
+        @dag_decorator(schedule=None, source_code_location=source_code_location)
+        def test_dag():
+            pass
+
+        dag = test_dag()
+
+        assert dag.source_code_location == source_code_location
 
     def test_params_passed_and_params_in_default_args_no_override(self):
         """


### PR DESCRIPTION
Adds Dag-level source code location metadata that can record repository, path, revision, branch, or tag information and preserves it through Dag serialization.

The OpenLineage provider emits this metadata as the OpenLineage `sourceCodeLocation` job facet for Dag-run events and task events, so lineage consumers can link emitted jobs back to the source that defined the Dag.

closes: #51321

Tests:
- `uv run --project providers/openlineage pytest providers/openlineage/tests/unit/openlineage/plugins/test_listener.py -xvs`
- `uv run --project providers/openlineage pytest providers/openlineage/tests/unit/openlineage/plugins/test_listener.py::TestOpenLineageListenerAirflow3::test_task_events_emit_source_code_location_job_facet -q`
- `uv run --project providers/openlineage pytest providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py::test_emit_start_event providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py::test_emit_start_event_with_additional_information providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py::test_emit_complete_event providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py::test_emit_complete_event_with_additional_information providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py::test_emit_failed_event providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py::test_emit_failed_event_with_additional_information -xvs`
- `uv run --project providers/openlineage pytest providers/openlineage/tests/unit/openlineage/utils/test_utils.py::test_get_source_code_location_job_facet_returns_empty_for_mock_location providers/openlineage/tests/unit/openlineage/utils/test_utils.py::test_get_source_code_location_job_facet_returns_empty_for_missing_location providers/openlineage/tests/unit/openlineage/utils/test_utils.py::test_build_task_event_job_facets_includes_source_code_location_from_dag -xvs`
- `uv run ruff format providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py providers/openlineage/src/airflow/providers/openlineage/utils/utils.py providers/openlineage/tests/unit/openlineage/plugins/test_listener.py providers/openlineage/tests/unit/openlineage/utils/test_utils.py`
- `uv run ruff check --fix providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py providers/openlineage/src/airflow/providers/openlineage/utils/utils.py providers/openlineage/tests/unit/openlineage/plugins/test_listener.py providers/openlineage/tests/unit/openlineage/utils/test_utils.py`
- `git diff --check FETCH_HEAD...HEAD`
- commit hook pre-commit checks during `git commit`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex (GPT-5.5)

Generated-by: OpenAI Codex (GPT-5.5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-28T17:13:27Z head=c24c62f action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @ametel01** · by `@potiuk` · 2026-07-28 17:13 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
