### PR TITLE
Fix scope of values.schema.json file schema validation

### DIFF
--- a/chart/values_schema.schema.json
+++ b/chart/values_schema.schema.json
@@ -1,86 +1,82 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "description": "This schema is used to validate `values.schema.json` to ensure each parameter has `default` and `description` set, and that top level properties have a `x-docsSection` set.",
-    "definitions": {
-        "leafs": {
-            "additionalProperties": {
-                "if": {
-                    "not": {
-                        "properties": {
-                            "description": {
-                                "pattern": "^Labels for the configmap$|^Labels for the secret$|^Annotations for the configmap$|^Annotations for the secret$"
-                            }
-                        }
-                    }
-                },
-                "then": {
+    "description": "This schema is used to validate `values.schema.json` file.",
+    "$defs": {
+        "commonRequired": {
+            "required": []
+        },
+        "leaf": {
+            "properties": {
+                "properties": {
                     "additionalProperties": {
-                        "$ref": "#/definitions/leafs"
+                        "if": {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "integer"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "number"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "string"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "object"
+                                        },
+                                        "properties": false
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "array"
+                                        },
+                                        "items": false
+                                    }
+                                }
+                            ]
+                        },
+                        "then": {
+                            "$ref": "#/$defs/commonRequired"
+                        },
+                        "else": {
+                            "$ref": "#/$defs/leaf"
+                        }
                     }
                 }
-            },
-            "if": {
-                "oneOf": [
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "integer"
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "number"
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "string"
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "boolean"
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "object"
-                            },
-                            "properties": false
-                        }
-                    },
-                    {
-                        "properties": {
-                            "type": {
-                                "const": "array"
-                            },
-                            "items": false
-                        }
-                    }
-                ]
-            },
-            "then": {
-                "required": [
-                    "description",
-                    "default"
-                ]
             }
         }
     },
     "required": [
-        "x-docsSectionOrder"
+        "description",
+        "type",
+        "x-docsSectionOrder",
+        "properties"
     ],
     "properties": {
-        "section_order": {
+        "x-docsSectionOrder": {
             "type": "array",
             "items": {
                 "type": "string"
@@ -90,7 +86,10 @@
             "additionalProperties": {
                 "allOf": [
                     {
-                        "$ref": "#/definitions/leafs"
+                        "$ref": "#/$defs/leaf"
+                    },
+                    {
+                        "$ref": "#/$defs/commonRequired"
                     },
                     {
                         "required": [

--- a/chart/values_schema.schema.json
+++ b/chart/values_schema.schema.json
@@ -15,6 +15,56 @@
                                 {
                                     "properties": {
                                         "type": {
+                                            "const": "array"
+                                        },
+                                        "items": false
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": [
+                                                "array",
+                                                "null"
+                                            ]
+                                        },
+                                        "items": false
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": [
+                                                "boolean",
+                                                "integer",
+                                                "number",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": [
+                                                "boolean",
+                                                "null",
+                                                "number",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
                                             "const": "integer"
                                         }
                                     }
@@ -22,21 +72,48 @@
                                 {
                                     "properties": {
                                         "type": {
+                                            "const": [
+                                                "integer",
+                                                "null"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": [
+                                                "integer",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": [
+                                                "null",
+                                                "object"
+                                            ]
+                                        },
+                                        "properties": false
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
                                             "const": "number"
-                                        }
-                                    }
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "const": "string"
-                                        }
-                                    }
-                                },
-                                {
-                                    "properties": {
-                                        "type": {
-                                            "const": "boolean"
                                         }
                                     }
                                 },
@@ -51,9 +128,8 @@
                                 {
                                     "properties": {
                                         "type": {
-                                            "const": "array"
-                                        },
-                                        "items": false
+                                            "const": "string"
+                                        }
                                     }
                                 }
                             ]

--- a/chart/values_schema.schema.json
+++ b/chart/values_schema.schema.json
@@ -1,22 +1,69 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "description": "This schema is used to validate `values.schema.json` to ensure each parameter has `default` and `description` set, and that top level properties have a `x-docsSection` set.",
-    "definitions": {
-        "leafs": {
-            "additionalProperties": {
-                "if": {
-                    "not": {
-                        "properties": {
-                            "description": {
-                                "pattern": "^Labels for the configmap$|^Labels for the secret$|^Annotations for the configmap$|^Annotations for the secret$"
-                            }
-                        }
-                    }
-                },
-                "then": {
+    "description": "This schema is used to validate `values.schema.json` file.",
+    "$defs": {
+        "commonRequired": {
+            "required": []
+        },
+        "leaf": {
+            "properties": {
+                "properties": {
                     "additionalProperties": {
-                        "$ref": "#/definitions/leafs"
+                        "if": {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "integer"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "number"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "string"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "object"
+                                        },
+                                        "properties": false
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "type": {
+                                            "const": "array"
+                                        },
+                                        "items": false
+                                    }
+                                }
+                            ]
+                        },
+                        "then": {
+                            "$ref": "#/$defs/commonRequired"
+                        },
+                        "else": {
+                            "$ref": "#/$defs/leaf"
+                        }
                     }
                 }
             },
@@ -153,10 +200,13 @@
         }
     },
     "required": [
-        "x-docsSectionOrder"
+        "description",
+        "type",
+        "x-docsSectionOrder",
+        "properties"
     ],
     "properties": {
-        "section_order": {
+        "x-docsSectionOrder": {
             "type": "array",
             "items": {
                 "type": "string"
@@ -166,7 +216,10 @@
             "additionalProperties": {
                 "allOf": [
                     {
-                        "$ref": "#/definitions/leafs"
+                        "$ref": "#/$defs/leaf"
+                    },
+                    {
+                        "$ref": "#/$defs/commonRequired"
                     },
                     {
                         "required": [

--- a/scripts/ci/prek/update_helm_schema_schema_type_fields_match.py
+++ b/scripts/ci/prek/update_helm_schema_schema_type_fields_match.py
@@ -85,7 +85,9 @@ def main() -> int:
     with open(_VALUES_SCHEMA_SCHEMA_FILE, encoding="utf-8") as schema_file:
         schema = json.loads(schema_file.read())
 
-    schema["definitions"]["leafs"]["if"]["oneOf"] = _get_one_of_for_schema(field_types)
+    schema["$defs"]["leaf"]["properties"]["properties"]["additionalProperties"]["if"]["oneOf"] = (
+        _get_one_of_for_schema(field_types)
+    )
 
     with open(_VALUES_SCHEMA_SCHEMA_FILE, "w", encoding="utf-8") as schema_file:
         json.dump(schema, schema_file, indent=4)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Follow-up to #68509.

Currently, the `values_schema.schema.json` file is used for verification of the `values.schema.json` file, which is not detecting cases like missing descriptions or defaults on particular levels of hierarchy, e.g. it didn't catch a missing `description` field in `images.otelCollector` https://github.com/apache/airflow/blob/helm-chart/1.22.0/chart/values.schema.json#L1103.

This PR introduces changes which will make verification of defined fields correct on all levels. However, there are some cases which are, at least for now, out of the schema. Parsing will not include:
1. `additionalProperties` field defined on the `object` type field - we have a couple of cases like `additionalProperties: {type: string}` which are omitted now
2. `items` field for `arrays` type field - same case as with point 1
3. All definitions content

This PR also removes the previous, partially working, verification for `description` and `default` fields, as it will require a lot of fixes within the file, which I think will be good for follow-up PRs.

Before this PR:
1. Prek hook for sorting the `type` object field in the `values.schema.json` file if it is an array - it is needed as matching in `values_schema.schema.json` file with e.g. `const: string` will work for `type: string`, but not for `type: [string, null]` (we have quite several cases like that) - #70796
2. Prek hook for detecting unmapped type fields between `values.schema.json` and `values_schema.schema.json` file to make sure full validation of rules with modification of `values_schema.schema.json` file - #71680

After this PR:
1. PR with `description` field enabled
2. PR with `default` field enabled

Also for 1.2x line. This one and prek hooks probably will be possible to do with automated cherry pick, but PRs which will enable enforcement of fields we will need to do manually (as we have already removed a couple of deprecation fields on main, which may not contain the required fields).

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
