### PR TITLE
Add team_name tag to remaining multi-team metrics

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -110,7 +110,7 @@ from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
 from airflow.serialization.serialized_objects import DagSerialization
 from airflow.triggers.base import BaseEventTrigger, BaseTrigger, DiscrimatedTriggerEvent, TriggerEvent
 from airflow.triggers.shared_stream import SharedStreamManager
-from airflow.utils.helpers import log_filename_template_renderer
+from airflow.utils.helpers import log_filename_template_renderer, prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import create_session, provide_session
 
@@ -710,7 +710,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             if entry.persist_seq is not None:
                 self.persisted_event_seqs.append(entry.persist_seq)
             # Emit stat event
-            stats.incr("triggers.succeeded")
+            stats.incr("triggers.succeeded", tags=prune_dict({"team_name": self.team_name}))
 
     def on_trigger_event(self, trigger_id: int, event: TriggerEvent) -> None:
         """Record that a trigger fired an event."""
@@ -731,7 +731,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
             trigger_id, exc = self.failed_triggers.popleft()
             self.on_trigger_failure(trigger_id=trigger_id, exc=exc)
             # Emit stat event
-            stats.incr("triggers.failed")
+            stats.incr("triggers.failed", tags=prune_dict({"team_name": self.team_name}))
 
     def on_trigger_failure(self, trigger_id: int, exc: list[str] | None) -> None:
         """Record that a trigger failed."""

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -679,7 +679,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         perform_heartbeat(self.job, heartbeat_callback=self.heartbeat_callback, only_if_necessary=True)
 
     def heartbeat_callback(self, session: Session | None = None) -> None:
-        stats.incr("triggerer_heartbeat", 1, 1)
+        stats.incr("triggerer_heartbeat", 1, 1, tags=prune_dict({"team_name": self.team_name}))
 
     def load_triggers(self) -> None:
         """Assign triggers to this triggerer and update the runner with the IDs it should run."""
@@ -753,7 +753,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 "TriggerRunnerSupervisor.metric_tags() requires a Job with a hostname; "
                 "subclasses without a metadata-DB Job must override this method."
             )
-        return {"hostname": hostname}
+        return prune_dict({"hostname": hostname, "team_name": self.team_name})
 
     def emit_metrics(self):
         tags = self.metric_tags()

--- a/airflow-core/src/airflow/models/callback.py
+++ b/airflow-core/src/airflow/models/callback.py
@@ -39,6 +39,7 @@ from airflow.executors.workloads.callback import CallbackFetchMethod
 from airflow.models import Base
 from airflow.models.base import StringID
 from airflow.models.dagbundle import DagBundleModel
+from airflow.utils.helpers import prune_dict
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 from airflow.utils.state import CallbackState
 
@@ -156,7 +157,7 @@ class Callback(Base, BaseWorkload):
     def queue(self, *, session: Session) -> None:
         self.state = CallbackState.QUEUED
 
-    def get_metric_info(self, status: CallbackState, result: Any) -> dict:
+    def get_metric_info(self, status: CallbackState, result: Any, team_name: str | None = None) -> dict:
         tags = {"result": result, **self.data}
         tags.pop("prefix", None)
 
@@ -176,6 +177,10 @@ class Callback(Base, BaseWorkload):
             else json.dumps(v, default=str, sort_keys=True)
             for k, v in tags.items()
         }
+
+        # team_name is omitted entirely when not in a multi-team deployment or when the
+        # callback's bundle is not mapped to a team.
+        tags = prune_dict({**tags, "team_name": team_name})
 
         prefix = self.data.get("prefix", "")
         name = f"{prefix}.callback_{status}" if prefix else f"callback_{status}"
@@ -250,9 +255,12 @@ class TriggererCallback(Callback):
         if (status := event.payload.get(PAYLOAD_STATUS_KEY)) and status in (ACTIVE_STATES | TERMINAL_STATES):
             self.state = status
             if status in TERMINAL_STATES:
+                team_name: str | None = None
+                if self.bundle_name and conf.getboolean("core", "multi_team"):
+                    team_name = DagBundleModel.get_team_name(self.bundle_name, session=session)
                 self.trigger = None
                 self.output = event.payload.get(PAYLOAD_BODY_KEY)
-                stats.incr(**self.get_metric_info(status, self.output))
+                stats.incr(**self.get_metric_info(status, self.output, team_name=team_name))
 
             session.add(self)
         else:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1505,7 +1505,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         stats.timing(
             f"task.{metric_name}",
             timing,
-            tags={"task_id": self.task_id, "dag_id": self.dag_id, "queue": self.queue},
+            tags={**self.stats_tags, "queue": self.queue},
         )
 
     def clear_next_method_args(self) -> None:

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -2460,6 +2460,48 @@ def test_handle_events_does_not_confirm_seq_when_persist_fails(jobless_superviso
     assert list(jobless_supervisor.persisted_event_seqs) == []
 
 
+@pytest.mark.parametrize(
+    ("team_name", "expected_tags"),
+    [
+        pytest.param("team_alpha", {"team_name": "team_alpha"}, id="with_team"),
+        pytest.param(None, {}, id="without_team"),
+    ],
+)
+def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_tags):
+    """triggers.succeeded carries the triggerer's team_name (omitted when the triggerer has none)."""
+    jobless_supervisor.team_name = team_name
+    jobless_supervisor.events.append(TriggerEventEntry(1, TriggerEvent(True), 7))
+
+    with (
+        mock.patch.object(TriggerRunnerSupervisor, "on_trigger_event", autospec=True),
+        mock.patch("airflow.jobs.triggerer_job_runner.stats.incr") as mock_incr,
+    ):
+        jobless_supervisor.handle_events()
+
+    mock_incr.assert_called_once_with("triggers.succeeded", tags=expected_tags)
+
+
+@pytest.mark.parametrize(
+    ("team_name", "expected_tags"),
+    [
+        pytest.param("team_alpha", {"team_name": "team_alpha"}, id="with_team"),
+        pytest.param(None, {}, id="without_team"),
+    ],
+)
+def test_handle_failed_triggers_emits_team_name(jobless_supervisor, team_name, expected_tags):
+    """triggers.failed carries the triggerer's team_name (omitted when the triggerer has none)."""
+    jobless_supervisor.team_name = team_name
+    jobless_supervisor.failed_triggers.append((1, None))
+
+    with (
+        mock.patch.object(TriggerRunnerSupervisor, "on_trigger_failure", autospec=True),
+        mock.patch("airflow.jobs.triggerer_job_runner.stats.incr") as mock_incr,
+    ):
+        jobless_supervisor.handle_failed_triggers()
+
+    mock_incr.assert_called_once_with("triggers.failed", tags=expected_tags)
+
+
 def test_state_sync_carries_and_drains_persist_confirmations(jobless_supervisor):
     """The state-sync response carries pending confirmations once, then None when there are none."""
     jobless_supervisor.persisted_event_seqs.extend([3, 9])

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -2502,6 +2502,41 @@ def test_handle_failed_triggers_emits_team_name(jobless_supervisor, team_name, e
     mock_incr.assert_called_once_with("triggers.failed", tags=expected_tags)
 
 
+@pytest.mark.parametrize(
+    ("team_name", "expected_tags"),
+    [
+        pytest.param("team_alpha", {"team_name": "team_alpha"}, id="with_team"),
+        pytest.param(None, {}, id="without_team"),
+    ],
+)
+def test_heartbeat_callback_emits_team_name(jobless_supervisor, team_name, expected_tags):
+    jobless_supervisor.team_name = team_name
+
+    with mock.patch("airflow.jobs.triggerer_job_runner.stats.incr") as mock_incr:
+        jobless_supervisor.heartbeat_callback()
+
+    mock_incr.assert_called_once_with("triggerer_heartbeat", 1, 1, tags=expected_tags)
+
+
+@pytest.mark.parametrize(
+    ("team_name", "expected_extra"),
+    [
+        pytest.param("team_alpha", {"team_name": "team_alpha"}, id="with_team"),
+        pytest.param(None, {}, id="without_team"),
+    ],
+)
+def test_emit_metrics_includes_team_name(supervisor_builder, mocker, team_name, expected_extra):
+    supervisor = supervisor_builder()
+    supervisor.team_name = team_name
+    gauge = mocker.patch("airflow.jobs.triggerer_job_runner.stats.gauge")
+
+    supervisor.emit_metrics()
+
+    expected_tags = {"hostname": supervisor.job.hostname, **expected_extra}
+    gauge.assert_any_call("triggers.running", mock.ANY, tags=expected_tags)
+    gauge.assert_any_call("triggerer.capacity_left", mock.ANY, tags=expected_tags)
+
+
 def test_state_sync_carries_and_drains_persist_confirmations(jobless_supervisor):
     """The state-sync response carries pending confirmations once, then None when there are none."""
     jobless_supervisor.persisted_event_seqs.extend([3, 9])

--- a/airflow-core/tests/unit/models/test_callback.py
+++ b/airflow-core/tests/unit/models/test_callback.py
@@ -143,6 +143,21 @@ class TestCallback:
         # insertion order collapse to one metric series (no needless cardinality split).
         assert metric_info["tags"]["result"] == '{"code": 0, "output": [1, 2]}'
 
+    @pytest.mark.parametrize(
+        ("team_name", "expect_tag"),
+        [
+            pytest.param("team_alpha", True, id="with_team"),
+            pytest.param(None, False, id="without_team"),
+        ],
+    )
+    def test_get_metric_info_includes_team_name(self, team_name, expect_tag):
+        callback = TriggererCallback(TEST_ASYNC_CALLBACK, prefix="deadline_alerts", dag_id=TEST_DAG_ID)
+        metric_info = callback.get_metric_info(CallbackState.SUCCESS, "0", team_name=team_name)
+        if expect_tag:
+            assert metric_info["tags"]["team_name"] == team_name
+        else:
+            assert "team_name" not in metric_info["tags"]
+
 
 class TestTriggererCallback:
     def test_polymorphic_serde(self, session):
@@ -248,6 +263,36 @@ class TestTriggererCallback:
         if terminal_state:
             assert callback.trigger is None
             assert callback.output == event.payload[PAYLOAD_BODY_KEY]
+
+    @pytest.mark.parametrize(
+        ("multi_team", "team_name", "expect_tag"),
+        [
+            pytest.param("true", "team_alpha", True, id="with_team"),
+            pytest.param("false", None, False, id="without_team"),
+        ],
+    )
+    @patch("airflow.models.callback.stats.incr")
+    def test_handle_event_emits_team_name(self, mock_incr, multi_team, team_name, expect_tag, session):
+        """On a terminal event, callback_{status} carries team_name resolved from the bundle."""
+        callback = TriggererCallback(TEST_ASYNC_CALLBACK, dag_id=TEST_DAG_ID)
+        callback.bundle_name = "test_bundle"
+        event = TriggerEvent({PAYLOAD_STATUS_KEY: CallbackState.SUCCESS, PAYLOAD_BODY_KEY: "0"})
+
+        with (
+            conf_vars({("core", "multi_team"): multi_team}),
+            patch(
+                "airflow.models.callback.DagBundleModel.get_team_name", return_value=team_name
+            ) as mock_get_team_name,
+        ):
+            callback.handle_event(event, session)
+
+        mock_incr.assert_called_once()
+        _, kwargs = mock_incr.call_args
+        if expect_tag:
+            assert kwargs["tags"]["team_name"] == team_name
+        else:
+            mock_get_team_name.assert_not_called()
+            assert "team_name" not in kwargs["tags"]
 
 
 class TestExecutorCallback:

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -4126,3 +4126,41 @@ class TestTaskInstanceStatsTagsTeamName:
         ti._team_name = None
         tags = ti.stats_tags
         assert "team_name" not in tags
+
+    @pytest.mark.parametrize(
+        ("team_name", "expected_tags"),
+        [
+            pytest.param(
+                "my_team",
+                {"dag_id": "test_dag", "task_id": "my_task", "team_name": "my_team", "queue": "default"},
+                id="with_team",
+            ),
+            pytest.param(
+                None,
+                {"dag_id": "test_dag", "task_id": "my_task", "queue": "default"},
+                id="without_team",
+            ),
+        ],
+    )
+    @mock.patch("airflow._shared.observability.metrics.stats.timing")
+    def test_emit_state_change_metric_includes_team_name(
+        self, mock_timing, team_name, expected_tags, dag_maker, session
+    ):
+        with dag_maker("test_dag"):
+            EmptyOperator(task_id="my_task")
+        dr = dag_maker.create_dagrun()
+        ti = dr.get_task_instance("my_task", session=session)
+        ti.state = TaskInstanceState.SCHEDULED
+        ti.scheduled_dttm = timezone.utcnow()
+        if team_name:
+            ti._team_name = team_name
+        session.merge(ti)
+        session.flush()
+
+        ti.emit_state_change_metric(TaskInstanceState.QUEUED)
+
+        mock_timing.assert_called_once_with(
+            "task.scheduled_duration",
+            mock.ANY,
+            tags=expected_tags,
+        )

--- a/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
@@ -107,13 +107,13 @@ class ResumableJobMixin:
         Closing this window would require atomic "submit + persist", which is not possible across
         an external system boundary.
         """
-        operator_tag = {"operator": type(self).__name__}
+        stats_tags = {"operator": type(self).__name__}
         # The task is team-scoped in multi-team deployments; surface team_name on the
         # resumable_job metrics via the running task instance's stats tags (omitted when
         # not multi-team or the task has no team).
         ti = context.get("ti")
         if ti is not None and (team_name := ti.stats_tags.get("team_name")):
-            operator_tag["team_name"] = team_name
+            stats_tags["team_name"] = team_name
         reconnect_to: Any = None
         already_succeeded_id: Any = None
 
@@ -131,7 +131,7 @@ class ResumableJobMixin:
             else:
                 external_id = task_state_store.get(self.external_id_key)
                 if external_id:
-                    stats.incr("resumable_job.reconnect_attempt", tags=operator_tag)
+                    stats.incr("resumable_job.reconnect_attempt", tags=stats_tags)
 
                     status = self.get_job_status(external_id, context)
 
@@ -141,7 +141,7 @@ class ResumableJobMixin:
                     if self.is_job_active(status):
                         # Job is still running, skip submission and reconnect to it.
                         span.set_attribute("resumable.decision", "reconnect")
-                        stats.incr("resumable_job.reconnect_success", tags=operator_tag)
+                        stats.incr("resumable_job.reconnect_success", tags=stats_tags)
                         self.log.info(
                             "Reconnecting to existing job",
                             external_id_key=self.external_id_key,
@@ -152,7 +152,7 @@ class ResumableJobMixin:
                     elif self.is_job_succeeded(status):
                         # Job already finished successfully, skip polling and return result directly.
                         span.set_attribute("resumable.decision", "already_succeeded")
-                        stats.incr("resumable_job.already_succeeded", tags=operator_tag)
+                        stats.incr("resumable_job.already_succeeded", tags=stats_tags)
                         self.log.info(
                             "Job already completed successfully, skipping resubmission",
                             external_id_key=self.external_id_key,
@@ -162,7 +162,7 @@ class ResumableJobMixin:
                     else:
                         # Job is in a terminal failed state, fall through and submit a new job.
                         span.set_attribute("resumable.decision", "terminal_resubmit")
-                        stats.incr("resumable_job.terminal_resubmit", tags=operator_tag)
+                        stats.incr("resumable_job.terminal_resubmit", tags=stats_tags)
                         self.log.warning(
                             "Prior job in terminal state, resubmitting fresh",
                             external_id_key=self.external_id_key,
@@ -171,7 +171,7 @@ class ResumableJobMixin:
                         )
                 else:
                     span.set_attribute("resumable.decision", "fresh_submit")
-                    stats.incr("resumable_job.fresh_submit", tags=operator_tag)
+                    stats.incr("resumable_job.fresh_submit", tags=stats_tags)
                     self.log.debug(
                         "No stored external ID found; submitting fresh job",
                         external_id_key=self.external_id_key,

--- a/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
@@ -108,6 +108,12 @@ class ResumableJobMixin:
         an external system boundary.
         """
         operator_tag = {"operator": type(self).__name__}
+        # The task is team-scoped in multi-team deployments; surface team_name on the
+        # resumable_job metrics via the running task instance's stats tags (omitted when
+        # not multi-team or the task has no team).
+        ti = context.get("ti")
+        if ti is not None and (team_name := ti.stats_tags.get("team_name")):
+            operator_tag["team_name"] = team_name
         reconnect_to: Any = None
         already_succeeded_id: Any = None
 

--- a/task-sdk/src/airflow/sdk/types.py
+++ b/task-sdk/src/airflow/sdk/types.py
@@ -151,6 +151,9 @@ class RuntimeTaskInstanceProtocol(Protocol):
     @property
     def mark_success_url(self) -> str: ...
 
+    @property
+    def stats_tags(self) -> dict[str, str]: ...
+
     def xcom_pull(
         self,
         task_ids: str | Iterable[str] | None = None,

--- a/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
@@ -85,6 +85,20 @@ def make_context(task_store: FakeTaskState | None = None) -> dict:
     return ctx
 
 
+class FakeTI:
+    """Minimal stand-in for RuntimeTaskInstance exposing stats_tags with an optional team_name."""
+
+    def __init__(self, team_name: str | None = None):
+        self._team_name = team_name
+
+    @property
+    def stats_tags(self) -> dict[str, str]:
+        tags = {"dag_id": "d", "task_id": "t"}
+        if self._team_name:
+            tags["team_name"] = self._team_name
+        return tags
+
+
 class TestFirstSubmission:
     def test_submits_and_polls_when_no_prior_state(self):
         op = ConcreteResumableOperator(task_id="test_task")
@@ -252,6 +266,26 @@ class TestMetrics:
         assert "resumable_job.terminal_resubmit" in called_names
         assert "resumable_job.reconnect_success" not in called_names
         assert "resumable_job.fresh_submit" not in called_names
+
+    @pytest.mark.parametrize(
+        ("team_name", "expected_tag"),
+        [
+            pytest.param(
+                "team_alpha",
+                {"operator": "ConcreteResumableOperator", "team_name": "team_alpha"},
+                id="with_team",
+            ),
+            pytest.param(None, {"operator": "ConcreteResumableOperator"}, id="without_team"),
+        ],
+    )
+    def test_team_name_added_to_metric_tags(self, team_name, expected_tag):
+        op = ConcreteResumableOperator(task_id="test_task")
+        ctx = make_context(FakeTaskState())
+        ctx["ti"] = FakeTI(team_name)
+        mock_incr = MagicMock()
+        with patch(self._PATCH, mock_incr):
+            op.execute_resumable(ctx)
+        mock_incr.assert_called_once_with("resumable_job.fresh_submit", tags=expected_tag)
 
 
 class TestTracing:


### PR DESCRIPTION
Part 7 of 6 :sweat_smile: , adding a few that I missed or don't fit neatly into one of the existing categories. 

Follow-up to https://github.com/apache/airflow/pull/68108
Can be reviewed/merged in parallel with https://github.com/apache/airflow/pull/68367, https://github.com/apache/airflow/pull/68589, https://github.com/apache/airflow/pull/68593, https://github.com/apache/airflow/pull/68594, and https://github.com/apache/airflow/pull/68599


--- 

This should be the last one.  


For posterity: In order to check if I got them all, I pointed Claude Opus 4.8 at the codebase with the following prompt:

---

A metric can be tied to a team if:
- one of the following is available at the emit site: dag_id, bundle_name, pool, team-scoped executor, team-scoped triggerer, connection-test row, TaskInstance / RuntimeTaskInstance, or  DagRun context 
- AND it is NOT a shared-infrastructure or cross-team-aggregate metric because those cannot be attributed to any single team even when a team identity is technically nearby.

Metrics which do not have emit sites, metrics which only exist in providers, and metrics which can not be tied to a team are considered out of scope for this discussion. 

Metrics which are included in the PR list below are considered done and should not be included in the list of remaining work. 

1. Read the list of metrics from the metrics registry at `shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml`
2. For each metric in the registry, locate and read its emit site and determine if it is in scope
3. Generate a report which contains three lists: 
  - 1) Done: Metrics which are included in the PR list below, or whose emitted tags include team_name either directly or via an indirect source such as stats_tags/metric_tags
  - 2) Remaining work: Metrics which can be linked to a Team and do not include the team_name tag.
  - 3) Out of Scope: Metrics which are out of scope, sorted by the reason (legacy, provider, or non-team)
4. Finally, cross-check those lists to ensure that every metric you found exists on one and only one of those lists.

Related PRs:
- 68108
- 68367
- 68589
- 68593
- 68594
- 68599
- 68601

---

and this was the generated report:


# Multi-Team Metrics: Final Count

Categorization of all 125 metrics in the registry (`metrics_template.yaml`), based on the 7 related PRs and a trace of every emit site.

## How the 7 PRs map

The PRs explicitly tag 47 metrics.  A further 9 are already covered indirectly
because they emit through `DagRun.stats_tags` / `TaskInstance.stats_tags` /
`RuntimeTaskInstance.stats_tags`, all of which were given `team_name` in 68108.
So 56 are Done.

## 1) Done (56)

Directly tagged by a listed PR:

- 68108 (DagRun/TI stats_tags + pools + SDK): `pool.open_slots`, `pool.queued_slots`, `pool.running_slots`, `pool.deferred_slots`, `pool.scheduled_slots`, `pool.starving_tasks`, `ti.start`, `operator_successes`, `operator_failures`, `ti_successes`, `ti_failures`, `task.duration`
- 68367 (assets): `asset.updates`, `asset.triggered_dagruns`
- 68589 (deadlines): `deadline_alerts.deadline_created`, `deadline_alerts.deadline_missed`, `deadline_alerts.deadline_not_missed`
- 68593 (executors): `executor.open_slots`, `executor.queued_tasks`, `executor.running_tasks`
- 68594 (scheduler): `scheduler.tasks.killed_externally`, `dagrun.schedule_delay`, `dagrun.duration.failed`, `ti.scheduled`, `ti.queued`, `ti.running`, `ti.deferred`, `task_instances_without_heartbeats_killed`
- 68599 (dag processor): `dag_processing.other_callback_count`, `dag_processing.last_run.seconds_ago`, `dag_processing.processes`, `dag_processing.processor_timeouts`, `dag_processing.callback_only_count`, `dag_processing.last_duration`, `dag.callback_exceptions`
- 68601 (stragglers): `triggerer_heartbeat`, `triggers.succeeded`, `triggers.failed`, `triggers.running`, `triggerer.capacity_left`, `task.scheduled_duration`, `task.queued_duration`, `resumable_job.fresh_submit`, `resumable_job.already_succeeded`, `resumable_job.terminal_resubmit`, `resumable_job.reconnect_attempt`, `resumable_job.reconnect_success`

Done indirectly (emit through a stats_tags source that now carries `team_name`):

- `ti.finish` (task-sdk `run()`, shares the `ti.stats_tags` variable)
- `previously_succeeded` (`taskinstance.py`, `ti.stats_tags`)
- `task_removed_from_dag`, `task_restored_to_dag`, `task_instance_created` (`dagrun.py`, `self.stats_tags`)
- `dagrun.dependency-check`, `dagrun.first_task_scheduling_delay`, `dagrun.first_task_start_delay`, `dagrun.duration.success` (`dagrun.py`, `self.stats_tags`)

## 2) Remaining work (6)

Team-attributable, emit site has a team identity, but no `team_name` tag yet:

- `connection_test.reaped` (scheduler reaper; `ct.team_name` is literally in scope and logged one line above the `stats.incr`, only `prior_state` is tagged)
- `connection_test.success` (worker connection-test supervisor; per connection-test row)
- `connection_test.failed` (same)
- `connection_test.hook_duration` (same)
- `scheduler.executor_heartbeat_duration` (loops over `self.executors`; each `executor.team_name` is available, tagged only by executor class)
- `triggers.blocked_main_thread` (emitted in a team-scoped triggerer's `TriggerRunner`; `team_name` lives on the runner/supervisor but is not plumbed to this emit)

Two of these are more borderline than the others: `scheduler.executor_heartbeat_duration`
and `triggers.blocked_main_thread` are component-level (team-scoped executor /
team-scoped triggerer).  They satisfy the signal list, but if those components are
considered "shared," they'd drop to non-team.  The four `connection_test.*` rows are
clean Remaining items per the explicit "connection-test row" signal.

## 3) Out of Scope

Sorted by reason.

### Legacy / no emit site (6)

- `local_task_job.task_exit` (only in the validator regex; no emit)
- `dag_file_processor_timeouts` (marked DEPRECATED; no emit)
- `dag_processing.manager_stalls` (no emit)
- `dag_file_refresh_error` (no emit)
- `dag_processing.last_num_of_db_queries.{dag_file}` (stored on `DagFileStat`, never emitted)
- `collect_db_dags` (no emit anywhere)

### Provider-only (28)

- celery: `celery.task_timeout_error`, `celery.execute_command.failure`
- openlineage: `ol.emit.failed`, `ol.event.size`, `ol.emit.attempts`, `ol.extract`
- edge3 worker: `edge_worker.status`, `edge_worker.connected`, `edge_worker.maintenance`, `edge_worker.jobs_active`, `edge_worker.concurrency`, `edge_worker.free_concurrency`, `edge_worker.num_queues`, `edge_worker.heartbeat_count`, `edge_worker.ti.start`, `edge_worker.ti.finish`
- edge3 executor: `edge_executor.sync.duration`
- cncf.kubernetes: `kubernetes_executor.pod_creation_status`, `kubernetes_executor.pod_deletion_status`, `kubernetes_executor.pod_patching_status`, `kubernetes_executor.clear_not_launched_queued_tasks.duration`, `kubernetes_executor.adopt_task_instances.duration`, `kubernetes_executor.pod_creation`, `kubernetes_executor.pod_deletion`, `kubernetes_executor.pod_patching`
- amazon: `batch_executor.adopt_task_instances.duration`, `ecs_executor.adopt_task_instances.duration`, `lambda_executor.adopt_task_instances.duration`

### Non-team (shared infrastructure or cross-team aggregate) (29)

- Job/component lifecycle: `{job_name}_start`, `{job_name}_end`, `{job_name}_heartbeat_failure`, `scheduler_heartbeat`, `dag_processor_heartbeat`
- Scheduler aggregates/infra: `scheduler.orphaned_tasks.cleared`, `scheduler.orphaned_tasks.adopted`, `scheduler.critical_section_busy`, `scheduler.tasks.starving`, `scheduler.tasks.executable`, `scheduler.dagruns.running`, `scheduler.critical_section_duration`, `scheduler.critical_section_query_duration`, `scheduler.scheduler_loop_duration`
- Dag-processing aggregates: `dag_processing.file_path_queue_update_count`, `dag_processing.import_errors`, `dag_processing.total_parse_time`, `dag_processing.file_path_queue_size`, `dagbag_size`
- Assets aggregate: `asset.orphaned`
- API-server shared cache: `api_server.dag_bag.cache_hit`, `api_server.dag_bag.cache_miss`, `api_server.dag_bag.cache_clear`, `api_server.dag_bag.cache_size`
- Connection-test aggregates: `connection_test.active`, `connection_test.pending`, `connection_test.dispatch_duration`
- SDK startup infra: `airflow.io.load_filesystems`, `serde.load_serializers`

## 4) Cross-check

- Done 56 + Remaining 6 + Legacy 6 + Provider 28 + Non-team 29 = 125, which equals the registry count.
- Each metric appears on exactly one list; no metric is on two lists, and none is unaccounted for.




 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

Interesting question..... see description; Claude was used to verify the scope, not sure if that counts.

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
