### PR TITLE
Fix FAB widget mock leakage in hook metadata

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -141,6 +141,7 @@ class HookMetaService:
         from importlib.util import find_spec
         from unittest.mock import MagicMock
 
+        use_mocked_form_dependencies = False
         for mod_name in [
             "wtforms",
             "wtforms.csrf",
@@ -156,13 +157,14 @@ class HookMetaService:
                     raise ModuleNotFoundError
             except ModuleNotFoundError:
                 sys.modules[mod_name] = MagicMock()
+                use_mocked_form_dependencies = True
 
         # We conditionally inject mock classes for missing dependencies
         # to ensure `ProvidersManager` can initialize hook connection widgets
         # without crashing when FAB/WTForms are not installed.
-        if "wtforms.StringField" not in sys.modules:
-            # Only apply mocks if the actual module wasn't loaded beforehand.
-            # This avoids thread-safety issues caused by `unittest.mock.patch` mutating global states.
+        if use_mocked_form_dependencies:
+            # Only patch symbols in synthetic modules. Real FAB/WTForms globals
+            # are used by the web UI and must not be mutated during requests.
             with (
                 mock.patch("wtforms.StringField", HookMetaService.MockStringField),
                 mock.patch("wtforms.fields.StringField", HookMetaService.MockStringField),

--- a/airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py
@@ -16,6 +16,9 @@
 # under the License.
 from __future__ import annotations
 
+import importlib.util
+from unittest import mock
+
 from airflow.api_fastapi.core_api.services.ui.connections import HookMetaService
 
 
@@ -30,3 +33,30 @@ class TestMockOptional:
         validator = HookMetaService.MockOptional()
         result = validator(None, None)
         assert result is None
+
+
+class TestGetHooksWithMockedFab:
+    def test_uses_real_form_dependencies_without_patching(self, monkeypatch):
+        """Installed FAB/WTForms classes must not be globally patched during UI requests."""
+
+        class FakeProvidersManager:
+            hooks = {}
+            connection_form_widgets = {}
+            field_behaviours = {}
+
+        monkeypatch.setattr(
+            "airflow.api_fastapi.core_api.services.ui.connections.ProvidersManager",
+            FakeProvidersManager,
+        )
+        monkeypatch.setattr(importlib.util, "find_spec", lambda mod_name: object())
+
+        patch_calls = []
+
+        def fail_patch(*args, **kwargs):
+            patch_calls.append((args, kwargs))
+            raise AssertionError("unexpected patch")
+
+        monkeypatch.setattr(mock, "patch", fail_patch)
+
+        assert HookMetaService._get_hooks_with_mocked_fab() == ({}, {}, {})
+        assert patch_calls == []


### PR DESCRIPTION
## Summary

Fixes #68354.

This changes hook metadata collection so FAB/WTForms globals are only patched when those form dependencies are missing and synthetic modules are installed. When the real dependencies are available, the UI now leaves `flask_appbuilder.fieldwidgets` untouched, avoiding request-time leakage into unrelated FAB views.

A regression test covers the installed-dependency path and fails if `_get_hooks_with_mocked_fab()` tries to call `unittest.mock.patch`.

## Testing

- `uv tool run ruff format airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py`
- `uv tool run ruff check --fix airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py`
- `git diff --check`

Not run locally:

- `uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/services/ui/test_connections.py -xvs`

The standard Airflow `uv run` path attempted to sync the full environment but stopped while building `python-ldap==3.4.7` because this WSL image is missing the system LDAP header `lber.h`. Installing the needed system package requires sudo password entry in this environment.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - OpenAI Codex (GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
