### PR TITLE
Correctly quote remaining identifiers in single path segments in TaskSDK client

### DIFF
--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -241,6 +241,17 @@ def _log_and_trace_retry(retry_state) -> None:
         )
 
 
+def _path(prefix: str, *identifiers: str) -> str:
+    """
+    Build a request path, quoting each identifier so it stays a single segment.
+
+    ``prefix`` is the fixed, trusted portion of the path. Each identifier is quoted
+    with ``safe=""`` because a value containing ``/`` or ``..`` would otherwise be
+    collapsed by httpx dot-segment normalization and escape onto another endpoint.
+    """
+    return "/".join([prefix, *(quote(identifier, safe="") for identifier in identifiers)])
+
+
 class TaskInstanceOperations:
     __slots__ = ("client",)
 
@@ -410,9 +421,7 @@ class TaskInstanceOperations:
         if state:
             params["state"] = state.value if isinstance(state, TaskInstanceState) else state
 
-        resp = self.client.get(
-            f"task-instances/previous/{quote(dag_id, safe='')}/{quote(task_id, safe='')}", params=params
-        )
+        resp = self.client.get(_path("task-instances/previous", dag_id, task_id), params=params)
         return PreviousTIResult(task_instance=resp.json())
 
     def get_task_states(
@@ -463,7 +472,7 @@ class ConnectionOperations:
     def get(self, conn_id: str) -> ConnectionResponse | ErrorResponse:
         """Get a connection from the API server."""
         try:
-            resp = self.client.get(f"connections/{quote(conn_id, safe='')}")
+            resp = self.client.get(_path("connections", conn_id))
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug(
@@ -923,7 +932,7 @@ class DagRunOperations:
 
         try:
             self.client.post(
-                f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}",
+                _path("dag-runs", dag_id, run_id),
                 content=body.model_dump_json(exclude_defaults=True),
             )
         except ServerResponseError as e:
@@ -940,18 +949,18 @@ class DagRunOperations:
 
     def clear(self, dag_id: str, run_id: str) -> OKResponse:
         """Clear a Dag run via the API server."""
-        self.client.post(f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}/clear")
+        self.client.post(f"{_path('dag-runs', dag_id, run_id)}/clear")
         # TODO: Error handling
         return OKResponse(ok=True)
 
     def get_detail(self, dag_id: str, run_id: str) -> DagRun:
         """Get detail of a dag run."""
-        resp = self.client.get(f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}")
+        resp = self.client.get(_path("dag-runs", dag_id, run_id))
         return DagRun.model_validate_json(resp.read())
 
     def get_state(self, dag_id: str, run_id: str) -> DagRunStateResponse:
         """Get the state of a Dag run via the API server."""
-        resp = self.client.get(f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}/state")
+        resp = self.client.get(f"{_path('dag-runs', dag_id, run_id)}/state")
         return DagRunStateResponse.model_validate_json(resp.read())
 
     def get_count(
@@ -1000,7 +1009,7 @@ class DagsOperations:
 
     def get(self, dag_id: str) -> DagResponse:
         """Get a DAG via the API server."""
-        resp = self.client.get(f"dags/{quote(dag_id, safe='')}")
+        resp = self.client.get(_path("dags", dag_id))
         return DagResponse.model_validate_json(resp.read())
 
 

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -410,7 +410,9 @@ class TaskInstanceOperations:
         if state:
             params["state"] = state.value if isinstance(state, TaskInstanceState) else state
 
-        resp = self.client.get(f"task-instances/previous/{dag_id}/{task_id}", params=params)
+        resp = self.client.get(
+            f"task-instances/previous/{quote(dag_id, safe='')}/{quote(task_id, safe='')}", params=params
+        )
         return PreviousTIResult(task_instance=resp.json())
 
     def get_task_states(
@@ -461,7 +463,7 @@ class ConnectionOperations:
     def get(self, conn_id: str) -> ConnectionResponse | ErrorResponse:
         """Get a connection from the API server."""
         try:
-            resp = self.client.get(f"connections/{conn_id}")
+            resp = self.client.get(f"connections/{quote(conn_id, safe='')}")
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug(
@@ -921,7 +923,8 @@ class DagRunOperations:
 
         try:
             self.client.post(
-                f"dag-runs/{dag_id}/{run_id}", content=body.model_dump_json(exclude_defaults=True)
+                f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}",
+                content=body.model_dump_json(exclude_defaults=True),
             )
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.CONFLICT:
@@ -937,18 +940,18 @@ class DagRunOperations:
 
     def clear(self, dag_id: str, run_id: str) -> OKResponse:
         """Clear a Dag run via the API server."""
-        self.client.post(f"dag-runs/{dag_id}/{run_id}/clear")
+        self.client.post(f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}/clear")
         # TODO: Error handling
         return OKResponse(ok=True)
 
     def get_detail(self, dag_id: str, run_id: str) -> DagRun:
         """Get detail of a dag run."""
-        resp = self.client.get(f"dag-runs/{dag_id}/{run_id}")
+        resp = self.client.get(f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}")
         return DagRun.model_validate_json(resp.read())
 
     def get_state(self, dag_id: str, run_id: str) -> DagRunStateResponse:
         """Get the state of a Dag run via the API server."""
-        resp = self.client.get(f"dag-runs/{dag_id}/{run_id}/state")
+        resp = self.client.get(f"dag-runs/{quote(dag_id, safe='')}/{quote(run_id, safe='')}/state")
         return DagRunStateResponse.model_validate_json(resp.read())
 
     def get_count(

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -241,15 +241,17 @@ def _log_and_trace_retry(retry_state) -> None:
         )
 
 
-def _path(prefix: str, *identifiers: str) -> str:
+def _path(prefix: str, *identifiers: str | uuid.UUID) -> str:
     """
     Build a request path, quoting each identifier so it stays a single segment.
 
     ``prefix`` is the fixed, trusted portion of the path. Each identifier is quoted
     with ``safe=""`` because a value containing ``/`` or ``..`` would otherwise be
     collapsed by httpx dot-segment normalization and escape onto another endpoint.
+    Keys that the server matches with a ``:path`` converter still resolve, since the
+    encoded ``%2F`` is decoded back to ``/`` before routing.
     """
-    return "/".join([prefix, *(quote(identifier, safe="") for identifier in identifiers)])
+    return "/".join([prefix, *(quote(str(identifier), safe="") for identifier in identifiers)])
 
 
 class TaskInstanceOperations:
@@ -510,7 +512,7 @@ class VariableOperations:
     def get(self, key: str) -> VariableResponse | ErrorResponse:
         """Get a variable from the API server."""
         try:
-            resp = self.client.get(f"variables/{key}")
+            resp = self.client.get(_path("variables", key))
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug(
@@ -539,7 +541,7 @@ class VariableOperations:
     def set(self, key: str, value: str | None, description: str | None = None) -> OKResponse:
         """Set an Airflow Variable via the API server."""
         body = VariablePostBody(val=value, description=description)
-        self.client.put(f"variables/{key}", content=body.model_dump_json())
+        self.client.put(_path("variables", key), content=body.model_dump_json())
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
         # decouple from the server response string
@@ -550,7 +552,7 @@ class VariableOperations:
         key: str,
     ) -> OKResponse:
         """Delete a variable with given key via the API server."""
-        self.client.delete(f"variables/{key}")
+        self.client.delete(_path("variables", key))
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
         # decouple from the server response string
@@ -573,7 +575,7 @@ class XComOperations:
 
     def head(self, dag_id: str, run_id: str, task_id: str, key: str) -> XComCountResponse:
         """Get the number of mapped XCom values."""
-        resp = self.client.head(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}")
+        resp = self.client.head(_path("xcoms", dag_id, run_id, task_id, key))
 
         # content_range: str | None
         if not (content_range := resp.headers["Content-Range"]) or not content_range.startswith(
@@ -598,7 +600,7 @@ class XComOperations:
         if include_prior_dates:
             params.update({"include_prior_dates": include_prior_dates})
         try:
-            resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
+            resp = self.client.get(_path("xcoms", dag_id, run_id, task_id, key), params=params)
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.error(
@@ -638,7 +640,7 @@ class XComOperations:
             params["map_index"] = map_index
         if mapped_length is not None and mapped_length >= 0:
             params["mapped_length"] = mapped_length
-        self.client.post(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params, json=value)
+        self.client.post(_path("xcoms", dag_id, run_id, task_id, key), params=params, json=value)
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
         # decouple from the server response string
@@ -657,7 +659,7 @@ class XComOperations:
             params = {"map_index": map_index}
         else:
             params = {}
-        self.client.delete(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params)
+        self.client.delete(_path("xcoms", dag_id, run_id, task_id, key), params=params)
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
         # decouple from the server response string
@@ -672,7 +674,7 @@ class XComOperations:
         offset: int,
     ) -> XComSequenceIndexResponse | ErrorResponse:
         try:
-            resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}/item/{offset}")
+            resp = self.client.get(f"{_path('xcoms', dag_id, run_id, task_id, key)}/item/{offset}")
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.error(
@@ -718,7 +720,7 @@ class XComOperations:
             params["step"] = step
         if include_prior_dates:
             params["include_prior_dates"] = include_prior_dates
-        resp = self.client.get(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}/slice", params=params)
+        resp = self.client.get(f"{_path('xcoms', dag_id, run_id, task_id, key)}/slice", params=params)
         return XComSequenceSliceResponse.model_validate_json(resp.read())
 
 
@@ -731,7 +733,7 @@ class TaskStateStoreOperations:
     def get(self, ti_id: uuid.UUID, key: str) -> TaskStateStoreResponse | ErrorResponse:
         """Get a task store value from the API server."""
         try:
-            resp = self.client.get(f"store/ti/{ti_id}/{key}")
+            resp = self.client.get(_path("store/ti", ti_id, key))
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug("Task store key not found", ti_id=ti_id, key=key)
@@ -742,17 +744,17 @@ class TaskStateStoreOperations:
     def set(self, ti_id: uuid.UUID, key: str, value: JsonValue, expires_at: datetime | None) -> OKResponse:
         """Set a task store value via the API server."""
         body = TaskStateStorePutBody(value=value, expires_at=expires_at)
-        self.client.put(f"store/ti/{ti_id}/{key}", content=body.model_dump_json())
+        self.client.put(_path("store/ti", ti_id, key), content=body.model_dump_json())
         return OKResponse(ok=True)
 
     def delete(self, ti_id: uuid.UUID, key: str) -> OKResponse:
         """Delete a single task store key via the API server."""
-        self.client.delete(f"store/ti/{ti_id}/{key}")
+        self.client.delete(_path("store/ti", ti_id, key))
         return OKResponse(ok=True)
 
     def clear(self, ti_id: uuid.UUID) -> OKResponse:
         """Clear all task store keys for a task instance via the API server."""
-        self.client.delete(f"store/ti/{ti_id}")
+        self.client.delete(_path("store/ti", ti_id))
         return OKResponse(ok=True)
 
 
@@ -1049,7 +1051,7 @@ class HITLOperations:
             assigned_users=assigned_users,
         )
         resp = self.client.post(
-            f"/hitlDetails/{ti_id}",
+            _path("/hitlDetails", ti_id),
             content=payload.model_dump_json(),
         )
         return HITLDetailRequest.model_validate_json(resp.read())
@@ -1068,14 +1070,14 @@ class HITLOperations:
             params_input=params_input,
         )
         resp = self.client.patch(
-            f"/hitlDetails/{ti_id}",
+            _path("/hitlDetails", ti_id),
             content=payload.model_dump_json(),
         )
         return HITLDetailResponse.model_validate_json(resp.read())
 
     def get_detail_response(self, ti_id: uuid.UUID) -> HITLDetailResponse:
         """Get content part of a Human-in-the-loop response for a specific Task Instance."""
-        resp = self.client.get(f"/hitlDetails/{ti_id}")
+        resp = self.client.get(_path("/hitlDetails", ti_id))
         return HITLDetailResponse.model_validate_json(resp.read())
 
 
@@ -1087,7 +1089,7 @@ class ConnectionTestOperations:
 
     def get_connection(self, connection_test_id: uuid.UUID) -> ConnectionTestConnectionResponse:
         """Fetch connection data for a test request from the API server."""
-        resp = self.client.get(f"connection-tests/{connection_test_id}/connection")
+        resp = self.client.get(f"{_path('connection-tests', connection_test_id)}/connection")
         return ConnectionTestConnectionResponse.model_validate_json(resp.read())
 
     def update_state(
@@ -1100,7 +1102,7 @@ class ConnectionTestOperations:
             state=state,
             result_message=ResultMessage(result_message) if result_message is not None else None,
         )
-        self.client.patch(f"connection-tests/{id}", content=body.model_dump_json())
+        self.client.patch(_path("connection-tests", id), content=body.model_dump_json())
 
 
 class BearerAuth(httpx.Auth):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -925,6 +925,30 @@ class TestVariableOperations:
         result = client.variables.delete(key="test_key")
         assert result == OKResponse(ok=True)
 
+    def test_get_quotes_key_as_single_path_segment(self):
+        """A variable key cannot escape the variables API path onto another endpoint."""
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            if request.url.path == "/connections/aws_default":
+                return httpx.Response(
+                    status_code=200,
+                    json={"conn_id": "aws_default", "conn_type": "aws", "password": "super-secret"},
+                )
+            return httpx.Response(
+                status_code=404,
+                json={"detail": {"reason": "not_found", "message": "Variable not found"}},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.variables.get(key="../connections/aws_default")
+
+        assert requests_seen[0].url.raw_path == b"/variables/..%2Fconnections%2Faws_default"
+        assert requests_seen[0].url.path != "/connections/aws_default"
+        assert isinstance(result, ErrorResponse)
+        assert result.error == ErrorType.VARIABLE_NOT_FOUND
+
 
 class TestXCOMOperations:
     """
@@ -1127,6 +1151,33 @@ class TestXCOMOperations:
             mapped_length=3,
         )
         assert result == OKResponse(ok=True)
+
+    def test_get_quotes_identifiers_as_single_path_segments(self):
+        """A dag_id / run_id / task_id cannot escape the xcoms API path."""
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                status_code=404,
+                json={"detail": {"reason": "not_found", "message": "XCom not found"}},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.xcoms.get(
+            dag_id="x/../../variables/secret_key",
+            run_id="run_id",
+            task_id="task_id",
+            key="key",
+        )
+
+        assert (
+            requests_seen[0].url.raw_path.split(b"?")[0]
+            == b"/xcoms/x%2F..%2F..%2Fvariables%2Fsecret_key/run_id/task_id/key"
+        )
+        assert requests_seen[0].url.path != "/variables/secret_key"
+        assert isinstance(result, XComResponse)
+        assert result.value is None
 
 
 class TestConnectionOperations:
@@ -2118,6 +2169,28 @@ class TestTaskStateOperations:
         client = make_client(transport=httpx.MockTransport(handle_request))
         result = client.task_state_store.clear(ti_id=self.TI_ID)
         assert result == OKResponse(ok=True)
+
+    def test_get_quotes_key_as_single_path_segment(self):
+        """A task store key cannot escape the store/ti API path."""
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                status_code=404,
+                json={"detail": {"reason": "not_found", "message": "not found"}},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.task_state_store.get(ti_id=self.TI_ID, key="../../variables/secret_key")
+
+        assert (
+            requests_seen[0].url.raw_path
+            == f"/store/ti/{self.TI_ID}/..%2F..%2Fvariables%2Fsecret_key".encode()
+        )
+        assert requests_seen[0].url.path != "/store/variables/secret_key"
+        assert isinstance(result, ErrorResponse)
+        assert result.error == ErrorType.TASK_STORE_NOT_FOUND
 
 
 class TestAssetStateOperations:

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -779,6 +779,24 @@ class TestTaskInstanceOperations:
         assert isinstance(result, PreviousTIResult)
         assert result.task_instance is None
 
+    def test_get_previous_quotes_dag_id_and_task_id_as_single_path_segments(self):
+        """A dag_id / task_id cannot escape the task-instances/previous API path."""
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(status_code=200, content="null")
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.task_instances.get_previous(dag_id="x/../../variables/secret_key", task_id="t")
+
+        assert (
+            requests_seen[0].url.raw_path.split(b"?")[0]
+            == b"/task-instances/previous/x%2F..%2F..%2Fvariables%2Fsecret_key/t"
+        )
+        assert requests_seen[0].url.path != "/variables/secret_key"
+        assert isinstance(result, PreviousTIResult)
+
 
 class TestVariableOperations:
     """
@@ -1170,6 +1188,31 @@ class TestConnectionOperations:
         assert result.error == ErrorType.PERMISSION_DENIED
         assert result.detail == {"conn_id": "denied_conn", "status_code": status_code}
 
+    def test_get_quotes_conn_id_as_single_path_segment(self):
+        """A connection id cannot escape the connections API path."""
+        requests_seen = []
+        crafted_conn_id = "x/../../variables/secret_key"
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            if request.url.path == "/variables/secret_key":
+                return httpx.Response(
+                    status_code=200,
+                    json={"key": "secret_key", "value": "super-secret-value"},
+                )
+            return httpx.Response(
+                status_code=404,
+                json={"reason": "not_found", "message": "Connection not found"},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.connections.get(conn_id=crafted_conn_id)
+
+        assert requests_seen[0].url.raw_path == b"/connections/x%2F..%2F..%2Fvariables%2Fsecret_key"
+        assert requests_seen[0].url.path != "/variables/secret_key"
+        assert isinstance(result, ErrorResponse)
+        assert "super-secret-value" not in str(result.detail)
+
 
 class TestAssetEventOperations:
     @pytest.mark.parametrize(
@@ -1479,6 +1522,20 @@ class TestDagRunOperations:
         )
 
         assert result == OKResponse(ok=True)
+
+    def test_trigger_quotes_dag_id_and_run_id_as_single_path_segments(self):
+        """A dag_id / run_id cannot escape the dag-runs API path."""
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(status_code=204)
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        client.dag_runs.trigger(dag_id="x/../../variables", run_id="secret_key")
+
+        assert requests_seen[0].url.raw_path == b"/dag-runs/x%2F..%2F..%2Fvariables/secret_key"
+        assert requests_seen[0].url.path != "/variables/secret_key"
 
     def test_trigger_conflict(self):
         """Test that if the dag run already exists, the client returns an error when default reset_dag_run=False"""


### PR DESCRIPTION
Repro: pass an identifier containing `/` or `..` to one of the remaining lookups in the task SDK client, e.g. `connections.get("x/../../variables/secret_key")`. httpx collapses the dot-segments and the request lands on an unrelated API path.
Cause: #68129 quoted `dag_id` in `DagsOperations.get`, but the sibling single-segment lookups still interpolate the identifier into the URL unescaped: `ConnectionOperations.get`, `TaskInstanceOperations.get_previous`, and the four `DagRunOperations` methods.
Fix: wrap each identifier in `quote(..., safe='')` so it stays one path segment, same as the dags lookup.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

<!-- pr-triage-fold: triaged=2026-07-15T16:20:06Z head=e6fce7f action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @naruto-lgtm** · by `@potiuk` · 2026-07-15 16:20 UTC
>
> The `ready for maintainer review` label was removed — the next move is yours (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Merge conflicts** — rebase on `main`. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Rebase on `main`, resolve conflicts, then mark it **Ready for review** again.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
