### PR TITLE
Fix misleading comment and pin reprocess behaviour for partitioned backfill

### DIFF
--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -503,10 +503,11 @@ def _create_backfill_dag_run_partitioned(
                 "Skipping dag run creation.", non_create_reason=non_create_reason, backfill_id=backfill_id
             )
             return
-        # reprocess_behavior allows a retry: create a new run alongside the existing
-        # one rather than clearing it. The prior run is kept as a historical record;
-        # _get_latest_dag_run_row_query picks the newest run by start_date, so the
-        # new backfill run becomes the active one going forward.
+
+    # reprocess_behavior allows a retry: create a new run alongside the existing
+    # one rather than clearing it. The prior run is kept as a historical record;
+    # _get_latest_dag_run_row_query picks the newest run by start_date, so the
+    # new backfill run becomes the active one going forward.
     dr = dag.create_dagrun(
         run_id=dag.timetable.generate_run_id(
             run_type=DagRunType.BACKFILL_JOB,

--- a/airflow-core/src/airflow/models/backfill.py
+++ b/airflow-core/src/airflow/models/backfill.py
@@ -484,10 +484,6 @@ def _create_backfill_dag_run_partitioned(
     triggering_user_name: str | None,
     session: Session,
 ) -> None:
-    # Partitioned backfills don't currently reprocess existing runs — if a run exists
-    # for this partition, it's recorded as skipped via exception_reason rather than
-    # cleared and re-queued. As a result, this function never calls ``_handle_clear_run``
-    # and therefore doesn't need to forward ``dag_run_conf`` for the reprocess path.
     stmt = _get_latest_dag_run_row_query(dag_id=dag.dag_id, info=info)
     dr = session.scalar(stmt)
     if dr:
@@ -507,6 +503,10 @@ def _create_backfill_dag_run_partitioned(
                 "Skipping dag run creation.", non_create_reason=non_create_reason, backfill_id=backfill_id
             )
             return
+        # reprocess_behavior allows a retry: create a new run alongside the existing
+        # one rather than clearing it. The prior run is kept as a historical record;
+        # _get_latest_dag_run_row_query picks the newest run by start_date, so the
+        # new backfill run becomes the active one going forward.
     dr = dag.create_dagrun(
         run_id=dag.timetable.generate_run_id(
             run_type=DagRunType.BACKFILL_JOB,

--- a/airflow-core/tests/unit/models/test_backfill.py
+++ b/airflow-core/tests/unit/models/test_backfill.py
@@ -1259,3 +1259,63 @@ def test_backfill_partitioned_offset_zero_behavior_unchanged(dag_maker, session)
         str(pendulum.instance(x.partition_date).in_timezone("Asia/Taipei").date()) for x in dag_runs
     ]
     assert partition_date_labels == ["2026-02-18", "2026-02-19", "2026-02-20"]
+
+
+def test_partitioned_backfill_reprocess_failed(dag_maker, session):
+    """Partitioned backfill with reprocess_behavior=FAILED creates a new run, keeping the failed one.
+
+    Unlike non-partitioned Dags (which clear and re-queue), partitioned backfills create a
+    fresh run alongside the existing failed one. The prior run is kept as a historical record;
+    the new backfill run becomes the active one (latest start_date wins in deduplication).
+    """
+    with dag_maker(schedule=CronPartitionTimetable("0 0 * * *", timezone="Asia/Taipei")) as dag:
+        PythonOperator(task_id="hi", python_callable=print)
+
+    # Determine the UTC partition_date for the 2026-02-18 Asia/Taipei partition.
+    info = next(
+        i for i in dag.iter_dagrun_infos_between(pendulum.parse("2026-02-18"), pendulum.parse("2026-02-18"))
+    )
+    expected_partition_date = info.partition_date
+
+    # Simulate a previously-scheduled run that failed.
+    dag_maker.create_dagrun(
+        run_id="scheduled__2026-02-18",
+        logical_date=None,
+        run_type="scheduled",
+        state=DagRunState.FAILED,
+        partition_key=info.partition_key,
+        partition_date=expected_partition_date,
+        session=session,
+    )
+    session.commit()
+
+    b = _create_backfill(
+        dag_id=dag.dag_id,
+        from_date=pendulum.parse("2026-02-18"),
+        to_date=pendulum.parse("2026-02-18"),
+        max_active_runs=1,
+        reverse=False,
+        triggering_user_name="pytest",
+        dag_run_conf={},
+        reprocess_behavior=ReprocessBehavior.FAILED,
+    )
+
+    session.expunge_all()
+
+    all_runs = session.scalars(select(DagRun).where(DagRun.dag_id == dag.dag_id)).all()
+    # Two runs: original failed run kept as historical record + new backfill run.
+    assert len(all_runs) == 2
+
+    failed_run = next(r for r in all_runs if r.run_id == "scheduled__2026-02-18")
+    assert failed_run.state == DagRunState.FAILED
+
+    backfill_run = next(r for r in all_runs if r.run_id != "scheduled__2026-02-18")
+    assert backfill_run.state == DagRunState.QUEUED
+    assert backfill_run.run_type == DagRunType.BACKFILL_JOB
+    assert backfill_run.partition_date == expected_partition_date
+
+    # BackfillDagRun links to the new run, not the historical failed one.
+    bdr = session.scalar(select(BackfillDagRun).where(BackfillDagRun.backfill_id == b.id))
+    assert bdr is not None
+    assert bdr.dag_run_id == backfill_run.id
+    assert bdr.partition_key == info.partition_key


### PR DESCRIPTION
`_create_backfill_dag_run_partitioned` already created a new run when `reprocess_behavior=FAILED/COMPLETED`; the old comment incorrectly stated that partitioned backfills never reprocess existing runs. Adds a test to document and guard the intended behaviour (new run alongside the failed one, prior run kept as historical record).

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
