### PR TITLE
Fix sensitive data leak in SparkSubmitOperator truncated templates

### DIFF
--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -46,6 +46,7 @@ def test_serialize_template_field_truncation_kicks_in(monkeypatch):
 
     assert "Truncated. You can change this behaviour" in result
 
+
 @pytest.mark.enable_redact
 def test_serialize_template_field_masks_dotted_sensitive_keys_on_truncation(monkeypatch):
     """Dotted config keys like spark.hadoop.*.access.key must be masked even when field is truncated."""
@@ -67,6 +68,7 @@ def test_serialize_template_field_masks_dotted_sensitive_keys_on_truncation(monk
     assert access_key_value not in result, "S3 access key must not appear in truncated output"
     assert token_value not in result, "JWT token must not appear in truncated output"
     assert "***" in result
+
 
 def test_serialize_template_field_with_notset():
     """NOTSET must serialize deterministically via serialize(), not str() fallback."""

--- a/airflow-core/tests/unit/serialization/test_helpers.py
+++ b/airflow-core/tests/unit/serialization/test_helpers.py
@@ -46,6 +46,27 @@ def test_serialize_template_field_truncation_kicks_in(monkeypatch):
 
     assert "Truncated. You can change this behaviour" in result
 
+@pytest.mark.enable_redact
+def test_serialize_template_field_masks_dotted_sensitive_keys_on_truncation(monkeypatch):
+    """Dotted config keys like spark.hadoop.*.access.key must be masked even when field is truncated."""
+    monkeypatch.setenv("AIRFLOW__CORE__MAX_TEMPLATED_FIELD_LENGTH", "1500")
+
+    access_key_value = "AKIA-REGRESSION-FIXTURE-ACCESS-KEY"
+    token_value = "REGRESSION-FIXTURE-JWT-TOKEN-VALUE"
+
+    payload = {
+        "spark.hadoop.fs.s3a.bucket.spark.access.key": access_key_value,
+        "spark.sql.catalog.kometa.token": token_value,
+        "zpadding": "z" * 2000,  # forces truncation
+    }
+
+    result = serialize_template_field(payload, "conf")
+
+    assert isinstance(result, str)
+    assert "Truncated. You can change this behaviour" in result
+    assert access_key_value not in result, "S3 access key must not appear in truncated output"
+    assert token_value not in result, "JWT token must not appear in truncated output"
+    assert "***" in result
 
 def test_serialize_template_field_with_notset():
     """NOTSET must serialize deterministically via serialize(), not str() fallback."""

--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -577,7 +577,8 @@ class SecretsMasker(logging.Filter):
         """
         if isinstance(name, str) and self.hide_sensitive_var_conn_fields:
             name = name.strip().lower()
-            return any(s in name for s in self.sensitive_variables_fields)
+            normalized = re.sub(r"\W+", "_", name)
+            return any(s in normalized for s in self.sensitive_variables_fields)
         return False
 
     def add_mask(self, secret: JsonValue, name: str | None = None):

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -834,6 +834,13 @@ class TestShouldHideValueForKey:
             ("custom_auth_header", True),
             ("service_key", True),
             ("my_service_key", True),
+            ("spark.hadoop.fs.s3a.bucket.spark.access.key", True),
+            ("spark.hadoop.fs.s3a.bucket.spark.secret.key", True),
+            ("spark.sql.catalog.kometa.token", True),
+            ("my-access-key", True),
+            ("auth.example.com/token", True),
+            ("spark.executor.memory", False),
+            ("spark.driver.cores", False),
         ],
     )
     def test_hiding_defaults(self, key, expected_result):


### PR DESCRIPTION
## Fix sensitive data leak in SparkSubmitOperator truncated templates

### Description

This PR fixes a critical bug where sensitive data (like `spark.hadoop.fs.s3a.bucket.spark.access.key` or `spark.sql.catalog.kometa.token`) in Spark and Hadoop configuration dictionaries was leaking in the Airflow UI's Rendered Template view when the field was truncated.

---

### Root Cause

Spark, Hadoop, and Kubernetes configuration keys frequently use dot notation or dashes. The `SecretsMasker`'s `should_hide_value_for_key` method was performing a direct substring check against underscore-style default sensitive fields (e.g., `access_key`, `secret_key`). Because `access.key` or `access-key` does not match `access_key`, the masker completely bypassed these sensitive fields.

---

### Changes Made

* **Core Fix:** Updated `should_hide_value_for_key` in `airflow_shared/secrets_masker/secrets_masker.py` to normalize non-word separators (dots, dashes, slashes) to underscores using `re.sub(r"\W+", "_", name)`. This ensures dotted/dashed config keys correctly map to the underscore-style sensitive fields.

* **Unit Tests:** Added positive and negative test cases in `test_secrets_masker.py` to ensure dotted/dashed keys are masked, while normal configs (like `spark.executor.memory`) remain unmasked.

* **Integration Tests:** Added a specific test in `test_helpers.py` (`test_serialize_template_field_masks_dotted_sensitive_keys_on_truncation`) to reproduce and verify the fix under truncation scenarios (padding payload beyond `MAX_TEMPLATED_FIELD_LENGTH`).

---

### Before / After

#### Before (without fix)

`spark.hadoop...access.key` and `my-access-key` were **NOT** being masked — 2 tests failing:

```
FAILED test_hiding_defaults[spark.hadoop.fs.s3a.bucket.spark.access.key-True]
FAILED test_hiding_defaults[my-access-key-True]

25 passed, 2 failed
```

#### After (with fix)

All dotted/dashed sensitive keys are correctly masked — all 27 tests passing:

```
PASSED test_hiding_defaults[spark.hadoop.fs.s3a.bucket.spark.access.key-True]
PASSED test_hiding_defaults[spark.hadoop.fs.s3a.bucket.spark.secret.key-True]
PASSED test_hiding_defaults[spark.sql.catalog.kometa.token-True]
PASSED test_hiding_defaults[my-access-key-True]
PASSED test_hiding_defaults[auth.example.com/token-True]
PASSED test_hiding_defaults[spark.executor.memory-False]
PASSED test_hiding_defaults[spark.driver.cores-False]

27 passed, 0 failed
```

---

### Closes

Fixes #67459

---

##### Was generative AI tooling used to co-author this PR?
- [x] Yes (please specify the tool below)
Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
---
* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.