### PR TITLE
Tidy DagVersion/DagCode metadata helpers

### DIFF
--- a/airflow-core/src/airflow/models/dag_version.py
+++ b/airflow-core/src/airflow/models/dag_version.py
@@ -91,7 +91,7 @@ class DagVersion(Base):
     @property
     def bundle_url(self) -> str | None:
         """Render the bundle URL using the joined bundle metadata if available."""
-        # When the bundle row is loaded, use it (render_url returns None if it has no URL template).
+        # When a bundle row exists, use it (render_url returns None if it has no URL template).
         # Only when there is no bundle row do we fall back to the deprecated manager lookup -- doing
         # so for an empty template would hit the deprecated path (and its warning) on every call.
         bundle = getattr(self, "bundle", None)

--- a/airflow-core/src/airflow/models/dag_version.py
+++ b/airflow-core/src/airflow/models/dag_version.py
@@ -91,12 +91,13 @@ class DagVersion(Base):
     @property
     def bundle_url(self) -> str | None:
         """Render the bundle URL using the joined bundle metadata if available."""
-        # Prefer using the joined bundle relationship when present to avoid extra queries
-        if getattr(self, "bundle", None) is not None and hasattr(self.bundle, "signed_url_template"):
-            return self.bundle.render_url(self.bundle_version)
+        # When the bundle row is loaded, use it (render_url returns None if it has no URL template).
+        # Only when there is no bundle row do we fall back to the deprecated manager lookup -- doing
+        # so for an empty template would hit the deprecated path (and its warning) on every call.
+        bundle = getattr(self, "bundle", None)
+        if bundle is not None:
+            return bundle.render_url(self.bundle_version)
 
-        # fallback to the deprecated option if the bundle model does not have a signed_url_template
-        # attribute
         if self.bundle_name is None:
             return None
         try:
@@ -233,7 +234,7 @@ class DagVersion(Base):
         :return: The version of the DAG or None if not found.
         """
         version_select_obj = select(cls).where(cls.dag_id == dag_id)
-        if version_number:
+        if version_number is not None:
             version_select_obj = version_select_obj.where(cls.version_number == version_number)
 
         return session.scalar(version_select_obj.order_by(cls.version_number.desc()).limit(1))

--- a/airflow-core/src/airflow/models/dag_version.py
+++ b/airflow-core/src/airflow/models/dag_version.py
@@ -90,7 +90,7 @@ class DagVersion(Base):
 
     @property
     def bundle_url(self) -> str | None:
-        """Render the bundle URL using the joined bundle metadata if available."""
+        """Render the bundle URL from the bundle metadata row, when there is one."""
         # When a bundle row exists, use it (render_url returns None if it has no URL template).
         # Only when there is no bundle row do we fall back to the deprecated manager lookup -- doing
         # so for an empty template would hit the deprecated path (and its warning) on every call.
@@ -229,7 +229,8 @@ class DagVersion(Base):
         Get the version of the DAG.
 
         :param dag_id: The DAG ID.
-        :param version_number: The version number.
+        :param version_number: The version number to look up. When ``None``, the latest
+            version is returned; any other value -- ``0`` included -- is used as a filter.
         :param session: The database session.
         :return: The version of the DAG or None if not found.
         """

--- a/airflow-core/src/airflow/models/dagcode.py
+++ b/airflow-core/src/airflow/models/dagcode.py
@@ -190,5 +190,6 @@ class DagCode(Base):
         if new_source_code_hash != latest_dagcode.source_code_hash:
             latest_dagcode.source_code = new_source_code
             latest_dagcode.source_code_hash = new_source_code_hash
-            # Keep fileloc aligned with the refreshed source.
+        # Keep fileloc aligned even when the contents are unchanged (e.g. the file was moved/renamed).
+        if fileloc != latest_dagcode.fileloc:
             latest_dagcode.fileloc = fileloc

--- a/airflow-core/src/airflow/models/dagcode.py
+++ b/airflow-core/src/airflow/models/dagcode.py
@@ -190,4 +190,5 @@ class DagCode(Base):
         if new_source_code_hash != latest_dagcode.source_code_hash:
             latest_dagcode.source_code = new_source_code
             latest_dagcode.source_code_hash = new_source_code_hash
-            session.merge(latest_dagcode)
+            # Keep fileloc aligned with the refreshed source.
+            latest_dagcode.fileloc = fileloc

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_sources.py
@@ -182,6 +182,18 @@ class TestGetDAGSource:
         response = test_client.get(url, headers={"Accept": "application/json"})
         assert response.status_code == 404
 
+    def test_should_respond_404_for_version_number_zero(self, test_client, test_dag):
+        """version_number=0 is a real filter that matches nothing, not a fallback to the latest version."""
+        response = test_client.get(
+            f"{API_PREFIX}/{TEST_DAG_ID}",
+            params={"version_number": 0},
+            headers={"Accept": "application/json"},
+        )
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": f"The source code of the Dag {TEST_DAG_ID}, version_number 0 was not found"
+        }
+
     @pytest.fixture
     def colocated_unreadable_dag(self, session, test_dag):
         """Insert a second ``DagModel`` sharing the requested Dag's source file."""

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -177,20 +177,14 @@ class TestGetDagVersion(TestDagVersionEndpoint):
         assert response.json() == expected_response
 
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    @mock.patch("airflow.dag_processing.bundles.manager.DagBundlesManager.view_url")
-    @mock.patch("airflow.models.dag_version.hasattr")
-    def test_get_dag_version_with_unconfigured_bundle(
-        self, mock_hasattr, mock_view_url, test_client, dag_maker, session
-    ):
-        """Test that when a bundle is no longer configured, the bundle_url returns an error message."""
-        mock_hasattr.return_value = False
-        mock_view_url.side_effect = ValueError("Bundle not configured")
-
+    @mock.patch("airflow.models.dag_version.DagBundlesManager.view_url")
+    @mock.patch("airflow.models.dagbundle.DagBundleModel.render_url", return_value=None)
+    def test_get_dag_version_with_unconfigured_bundle(self, mock_render_url, mock_view_url, test_client):
+        """A bundle row with no URL template yields an empty bundle_url without the deprecated fallback."""
         response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/1")
         assert response.status_code == 200
-
-        response_data = response.json()
-        assert not response_data["bundle_url"]
+        assert not response.json()["bundle_url"]
+        mock_view_url.assert_not_called()
 
     def test_get_dag_version_404(self, test_client):
         response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/99")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_versions.py
@@ -177,13 +177,16 @@ class TestGetDagVersion(TestDagVersionEndpoint):
         assert response.json() == expected_response
 
     @pytest.mark.usefixtures("make_dag_with_multiple_versions")
-    @mock.patch("airflow.models.dag_version.DagBundlesManager.view_url")
-    @mock.patch("airflow.models.dagbundle.DagBundleModel.render_url", return_value=None)
-    def test_get_dag_version_with_unconfigured_bundle(self, mock_render_url, mock_view_url, test_client):
+    @mock.patch("airflow.models.dag_version.DagBundlesManager.view_url", autospec=True)
+    @mock.patch("airflow.models.dagbundle.DagBundleModel.render_url", autospec=True, return_value=None)
+    def test_get_dag_version_with_bundle_without_url_template(
+        self, mock_render_url, mock_view_url, test_client
+    ):
         """A bundle row with no URL template yields an empty bundle_url without the deprecated fallback."""
         response = test_client.get("/dags/dag_with_multiple_versions/dagVersions/1")
         assert response.status_code == 200
         assert not response.json()["bundle_url"]
+        mock_render_url.assert_called_once()
         mock_view_url.assert_not_called()
 
     def test_get_dag_version_404(self, test_client):

--- a/airflow-core/tests/unit/models/test_dag_version.py
+++ b/airflow-core/tests/unit/models/test_dag_version.py
@@ -52,6 +52,16 @@ class TestDagVersion:
         assert latest_version.version_number == 1
         assert latest_version.dag_id == dag.dag_id
 
+    @pytest.mark.need_serialized_dag
+    def test_get_version_treats_zero_as_a_real_filter(self, dag_maker, session):
+        """version_number=0 must filter (and find nothing), not fall through to 'latest'."""
+        with dag_maker("zero_guard_dag"):
+            EmptyOperator(task_id="task1")
+
+        assert DagVersion.get_version("zero_guard_dag", 0, session=session) is None
+        # version_number=None still returns the latest version.
+        assert DagVersion.get_version("zero_guard_dag", session=session).version_number == 1
+
     def test_writing_dag_version_with_changes(self, dag_maker, session):
         """This also tested the get_latest_version method"""
         with dag_maker("test1") as dag:

--- a/airflow-core/tests/unit/models/test_dag_version.py
+++ b/airflow-core/tests/unit/models/test_dag_version.py
@@ -192,6 +192,36 @@ class TestDagVersion:
         assert retrieved.version_data is None
         assert retrieved.bundle_version == "abc123"
 
+    @pytest.mark.parametrize(
+        ("view_url_kwargs", "expected"),
+        [
+            pytest.param(
+                {"return_value": "https://example.com/tree/abc"},
+                "https://example.com/tree/abc",
+                id="bundle-still-configured",
+            ),
+            pytest.param(
+                {"side_effect": ValueError("Bundle not configured")},
+                None,
+                id="bundle-no-longer-configured",
+            ),
+        ],
+    )
+    @mock.patch("airflow.models.dag_version.DagBundlesManager", autospec=True)
+    def test_bundle_url_falls_back_to_manager_without_a_bundle_row(
+        self, mock_manager, view_url_kwargs, expected
+    ):
+        """Without a dag_bundle row the deprecated manager lookup is the only path left."""
+        mock_manager.return_value.view_url.configure_mock(**view_url_kwargs)
+        # Never persisted, so ``bundle`` resolves to None -- the same state a Dag version
+        # whose bundle row is missing ends up in.
+        dag_version = DagVersion(
+            dag_id="dag_without_bundle_row", bundle_name="removed-bundle", bundle_version="abc"
+        )
+
+        assert dag_version.bundle_url == expected
+        mock_manager.return_value.view_url.assert_called_once_with("removed-bundle", "abc")
+
 
 class TestResolveVersionData:
     """Unit tests for the _resolve_version_data pin-guard helper."""

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -238,3 +238,27 @@ class TestDagCode:
         refreshed = DagCode.get_latest_dagcode(dag.dag_id)
         assert refreshed.fileloc == dag.fileloc
         assert refreshed.source_code_hash != "stalehash"
+
+    def test_update_source_code_refreshes_fileloc_when_source_unchanged(self, dag_maker, session):
+        """A moved/renamed file with identical contents still refreshes a stale fileloc."""
+        with dag_maker("dag_fileloc_moved") as dag:
+
+            @task_decorator
+            def mytask():
+                print("hi")
+
+            mytask()
+        sync_dag_to_db(dag)
+
+        dag_code = DagCode.get_latest_dagcode(dag.dag_id)
+        # Stale fileloc but the stored source hash still matches the file contents.
+        dag_code.fileloc = "/old/stale/path.py"
+        session.add(dag_code)
+        session.commit()
+        original_hash = dag_code.source_code_hash
+
+        DagCode.update_source_code(dag.dag_id, dag.fileloc)
+
+        refreshed = DagCode.get_latest_dagcode(dag.dag_id)
+        assert refreshed.fileloc == dag.fileloc
+        assert refreshed.source_code_hash == original_hash

--- a/airflow-core/tests/unit/models/test_dagcode.py
+++ b/airflow-core/tests/unit/models/test_dagcode.py
@@ -214,3 +214,27 @@ class TestDagCode:
         DagCode.update_source_code(dag.dag_id, dag.fileloc)
         dag_code3 = DagCode.get_latest_dagcode(dag.dag_id)
         assert dag_code3.source_code_hash != 2
+
+    def test_update_source_code_refreshes_fileloc(self, dag_maker, session):
+        """When the source changes, update_source_code also refreshes a stale fileloc."""
+        with dag_maker("dag_fileloc") as dag:
+
+            @task_decorator
+            def mytask():
+                print("hi")
+
+            mytask()
+        sync_dag_to_db(dag)
+
+        dag_code = DagCode.get_latest_dagcode(dag.dag_id)
+        # Simulate a stale fileloc and a changed source so the update path is taken.
+        dag_code.fileloc = "/old/stale/path.py"
+        dag_code.source_code_hash = "stalehash"
+        session.add(dag_code)
+        session.commit()
+
+        DagCode.update_source_code(dag.dag_id, dag.fileloc)
+
+        refreshed = DagCode.get_latest_dagcode(dag.dag_id)
+        assert refreshed.fileloc == dag.fileloc
+        assert refreshed.source_code_hash != "stalehash"


### PR DESCRIPTION
- get_version: use 'if version_number is not None' so version_number=0 filters (and 404s) instead of falling through to the latest version.
- bundle_url: drop the dead hasattr(self.bundle, 'signed_url_template') guard (always true on the ORM model). Behavior is unchanged: a loaded bundle uses render_url(), and the deprecated manager lookup is used only when there is no bundle row -- not on every call for bundles without a URL template.
- DagCode.update_source_code: refresh fileloc alongside the source, and drop the redundant session.merge() on the already-session-attached row.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

claude opus 4.8


