### PR TITLE
Fix triggerer crash when trigger subclass does not call `super().__init__()`

### DIFF
--- a/airflow-core/src/airflow/triggers/base.py
+++ b/airflow-core/src/airflow/triggers/base.py
@@ -101,8 +101,8 @@ class BaseTrigger(abc.ABC, Templater, LoggingMixin):
         return None
 
     @property
-    def task_instance(self) -> TaskInstance:
-        return self._task_instance
+    def task_instance(self) -> TaskInstance | None:
+        return getattr(self, "_task_instance", None)
 
     @task_instance.setter
     def task_instance(self, value: TaskInstance | None) -> None:

--- a/airflow-core/tests/unit/triggers/test_base_trigger.py
+++ b/airflow-core/tests/unit/triggers/test_base_trigger.py
@@ -140,6 +140,25 @@ def test_render_template_fields_empty_when_no_trigger_kwargs(create_task_instanc
     assert trigger.name == "Hello {{ name }}"
 
 
+class _TriggerWithoutSuperInit(BaseTrigger):
+    """A trigger that does not call super().__init__() — simulates third-party triggers."""
+
+    def __init__(self, queue_url: str):
+        self.queue_url = queue_url
+
+    def serialize(self):
+        return (f"{type(self).__module__}.{type(self).__qualname__}", {"queue_url": self.queue_url})
+
+    async def run(self):
+        yield TriggerEvent({"queue_url": self.queue_url})
+
+
+def test_task_instance_property_works_without_super_init():
+    """task_instance property must return None when subclass skips super().__init__()."""
+    trigger = _TriggerWithoutSuperInit(queue_url="https://sqs.example.com/queue")
+    assert trigger.task_instance is None
+
+
 class _PlainEventTrigger(BaseEventTrigger):
     """A BaseEventTrigger that does not opt into shared streams."""
 


### PR DESCRIPTION
When a trigger subclass (e.g. `SqsSensorTrigger`) does not call `super().__init__()`, the `_task_instance` attribute is never set on the instance. In the asset watcher code path, where no task instance is assigned by the triggerer, accessing the `task_instance` property raises `AttributeError` and crashes the triggerer.

This was introduced in #55068 which refactored `task_instance` from a plain attribute to a property backed by `self._task_instance`.

The fix uses `getattr(self, "_task_instance", None)` in the property getter so it gracefully returns `None` regardless of whether `super().__init__()` was called.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
