### PR TITLE
Add agent guidance to comment sparingly

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -65,7 +65,7 @@ Flag these patterns that indicate low-quality AI-generated contributions:
 - **Description doesn't match code**: PR description describes something different from what the code actually does.
 - **No evidence of testing**: Claims of fixes without test evidence, or author admitting they cannot run the test suite.
 - **Over-engineered solutions**: Adding caching layers, complex locking, or benchmark scripts for problems that don't exist or are misunderstood.
-- **Narrating comments**: Comments that restate what the next line does (e.g., `# Add the item to the list` before `list.append(item)`).
+- **Narrating or redundant comments**: Comments that restate what the next line does (e.g., `# Add the item to the list` before `list.append(item)`); multi-line prose explaining a one-line change; the same rationale repeated at several sites; or explanatory comments on tests whose names already convey intent. Comments should explain *why* when it is non-obvious, not narrate *what*. Flag over-commenting as noise to be trimmed.
 - **Empty PR descriptions**: PRs with just the template filled in and no actual description of the changes.
 
 ## Quality Signals to Check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ reported as such are described in "What is NOT considered a security vulnerabili
 
 - **Always format and check Python files with ruff immediately after writing or editing them:** `uv run ruff format <file_path>` and `uv run ruff check --fix <file_path>`. Do this for every Python file you create or modify, before moving on to the next step.
 - No `assert` in production code.
+- **Comment sparingly — code says *what*, comments say *why*.** Add a comment only when the reasoning is non-obvious and cannot be carried by a clear name or the code itself. Do not write narrating comments that restate the next line, do not pad logic with multi-line prose, and do not repeat the same rationale at several sites — put one concise note at the source of truth and let the others stand on their own. Tests whose names already describe intent need no explanatory comment. Reserve longer explanation for genuinely complex or non-obvious logic (e.g. a security check whose threat model isn't apparent), and keep even that as tight as it can be. Over-commenting is noise that ages badly and obscures the code it wraps.
 - `time.monotonic()` for durations, not `time.time()`.
 - In `airflow-core`, functions with a `session` parameter must not call `session.commit()`. Use keyword-only `session` parameters.
 - Imports at top of file. Valid exceptions: circular imports, lazy loading for worker isolation, `TYPE_CHECKING` blocks.


### PR DESCRIPTION
Agent-assisted contributions frequently over-comment: multi-line prose narrating a one-line change, the same rationale duplicated across call sites, and explanatory comments on tests whose names already convey intent (see e.g. #[67667](https://github.com/apache/airflow/pull/67667/changes/00df35e6909724490cd25ca4c54e5c6fc09f43fa)). The existing review checklist only caught the narrowest case — a comment restating the very next line — and the write-time coding standards in `AGENTS.md` said nothing at all, so agents had no rule steering them away from the pattern in the first place.

This adds a coding standard in `AGENTS.md` directing contributors to comment sparingly (code says *what*, comments say *why* when non-obvious), and broadens the "narrating comments" signal in the code-review instructions to cover the wider family of over-commenting.

Docs-only change to agent/contributor guidance — no newsfragment (not user-facing). `CLAUDE.md` is a symlink to `AGENTS.md`, so it picks up the change automatically.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)