### PR TITLE
UI E2E: Clarify HITL e2e helper parameter name and error message

### DIFF
--- a/airflow-core/src/airflow/ui/tests/e2e/components/HITLReviewDrawer.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/components/HITLReviewDrawer.ts
@@ -25,8 +25,8 @@ export class HITLReviewDrawer {
     this.root = page.getByRole("dialog", { name: "Required Actions" });
   }
 
-  public async expectOpenWith(dagId: string): Promise<void> {
+  public async expectOpenWith(expectedText: string): Promise<void> {
     await expect(this.root).toBeVisible();
-    await expect(this.root).toContainText(dagId);
+    await expect(this.root).toContainText(expectedText);
   }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/components/HITLReviewModal.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/components/HITLReviewModal.ts
@@ -25,8 +25,8 @@ export class HITLReviewModal {
     this.root = page.getByRole("dialog", { name: "Required Actions" });
   }
 
-  public async expectOpenWith(dagId: string): Promise<void> {
+  public async expectOpenWith(expectedText: string): Promise<void> {
     await expect(this.root).toBeVisible();
-    await expect(this.root).toContainText(dagId, { timeout: 60_000 });
+    await expect(this.root).toContainText(expectedText);
   }
 }

--- a/airflow-core/src/airflow/ui/tests/e2e/utils/api/hitl.ts
+++ b/airflow-core/src/airflow/ui/tests/e2e/utils/api/hitl.ts
@@ -200,7 +200,7 @@ export async function setupPendingHITLFlowViaAPI(source: RequestLike, dagId: str
   const response = await request.patch(`${baseUrl}/api/v2/dags/${dagId}`, { data: { is_paused: false } });
 
   if (!response.ok()) {
-    throw new Error(`HITL response failed (${response.status()})`);
+    throw new Error(`Failed to unpause Dag ${dagId} (${response.status()})`);
   }
 
   const { dagRunId } = await apiTriggerDagRun(request, dagId);


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->


## Why
The HITL review page objects named their assertion parameter `dagId`, but some callers pass a run id instead, so the name misrepresented what the helper actually checks and could mislead anyone reading the specs.

The setup helper's generic "HITL response failed" message also hid which step actually failed, making a failing run harder to diagnose.

and drop the redundant 60s timeout override so the modal assertion uses the default timeout.


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
