### PR TITLE
Fix flaky shared-stream overflow test that times out in CI

### DIFF
--- a/airflow-core/tests/unit/triggers/test_shared_stream.py
+++ b/airflow-core/tests/unit/triggers/test_shared_stream.py
@@ -1434,6 +1434,15 @@ async def test_ack_mode_queue_full_during_fanout_does_not_break_iteration():
 
         # t_ok: drive its ack stream and collect the real event.
         async with _consume_in_background(t_ok.filter_shared_stream(s_ok)) as ok_collector:
+            # Let the poll loop fan the event out and force QueueFull on trigger 1's
+            # pre-filled queue *before* draining s_full. Otherwise collect_full can pull
+            # the filler off the queue first, the fan-out put then succeeds, and the
+            # overflow path is never taken.
+            deadline = asyncio.get_event_loop().time() + 1.0
+            while 1 not in group._failed_subscribers:
+                assert asyncio.get_event_loop().time() < deadline, "fan-out did not overflow trigger 1"
+                await asyncio.sleep(0)
+
             await asyncio.wait_for(collect_full(), timeout=2.0)
             ok_result = await ok_collector.wait_for(1)
 


### PR DESCRIPTION
The failure is a race in `test_ack_mode_queue_full_during_fanout_does_not_break_iteration`, not in the shared-stream code.

The test pre-fills the overflowing subscriber's queue (maxsize 1) with a filler so the poll loop's fan-out `put_nowait` raises `QueueFull` and the subscriber is force-failed with `_SubscriberOverflow`. But it begins draining that subscriber's stream (`collect_full`) concurrently with the poll loop's fan-out. When the consumer wins the race it pulls the filler off the queue first; the fan-out `put_nowait` then succeeds, the overflow path is never taken.

The fix makes the overflow deterministic: before draining the subscriber's stream, wait until the poll loop has actually force-failed it (`1 in group._failed_subscribers`).

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
closes: #68628
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (Claude Code with Opus 4.8)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
