### PR TITLE
Fix race in shared-stream overflow test that could hang the suite

### DIFF
--- a/airflow-core/tests/unit/triggers/test_shared_stream.py
+++ b/airflow-core/tests/unit/triggers/test_shared_stream.py
@@ -1421,8 +1421,23 @@ async def test_ack_mode_queue_full_during_fanout_does_not_break_iteration():
         group = manager._groups[key]
         group._subscribers[1].put_nowait(("filler", -1))
 
-        # t_full: its queue will be drained + replaced by _PollFailure(_SubscriberOverflow).
-        # _drain() raises the inner exception, so we expect _SubscriberOverflow here.
+        # Wait for the background poll task to fan the burst out before we start draining
+        # s_full. The fan-out hits QueueFull on trigger 1's pre-filled queue, overflow-fails
+        # it (recorded in ``_failed_subscribers``) and drains+replaces its queue with the
+        # _PollFailure, while trigger 2's enqueue succeeds. Synchronising on the overflow is
+        # required, not just convenient: if collect_full() drained the filler first, trigger
+        # 1's queue would no longer be full when the burst is fanned out, the put_nowait would
+        # succeed, and the overflow under test would never happen (the iteration would then
+        # block forever waiting for an event that was delivered as a normal item).
+        for _ in range(10000):
+            if 1 in group._failed_subscribers:
+                break
+            await asyncio.sleep(0)
+        else:
+            raise AssertionError("poll task did not overflow the pre-filled subscriber queue")
+
+        # t_full: its queue was drained + replaced by _PollFailure(_SubscriberOverflow).
+        # _ack_drain() raises the inner exception, so we expect _SubscriberOverflow here.
         full_exc: list[BaseException] = []
 
         async def collect_full():
@@ -1434,8 +1449,8 @@ async def test_ack_mode_queue_full_during_fanout_does_not_break_iteration():
 
         # t_ok: drive its ack stream and collect the real event.
         async with _consume_in_background(t_ok.filter_shared_stream(s_ok)) as ok_collector:
-            await asyncio.wait_for(collect_full(), timeout=2.0)
-            ok_result = await ok_collector.wait_for(1)
+            await asyncio.wait_for(collect_full(), timeout=5.0)
+            ok_result = await ok_collector.wait_for(1, timeout=5.0)
 
             # Give the advance pump a tick to run.
             await asyncio.sleep(0)


### PR DESCRIPTION
The scheduled canary flaked on
`test_ack_mode_queue_full_during_fanout_does_not_break_iteration` with a
`TimeoutError` (e.g. the LowestDeps ARM run).

Root cause is a race in the **test**, not the production code. The test
pre-fills trigger 1's subscriber queue with a sentinel so the background poll
task hits `QueueFull` and overflow-fails it at fan-out. But it then started
draining `s_full` immediately, so depending on event-loop scheduling the drain
could consume the sentinel *first* — leaving the queue no longer full when the
burst was fanned out. The `put_nowait` then succeeded, the overflow under test
never happened, and the iteration blocked forever (surfacing as the
`TimeoutError`). It passed most of the time only because the poll task usually
won the race.

Fix: synchronise on the overflow — wait until trigger 1 is recorded in
`_failed_subscribers` before draining `s_full`. The test is now deterministic
(passes 6/6 locally in ~1s instead of hanging), and the production overflow
path is unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)