### PR TITLE
Configure logging for API server

### DIFF
--- a/airflow-core/newsfragments/68660.bugfix.rst
+++ b/airflow-core/newsfragments/68660.bugfix.rst
@@ -1,0 +1,1 @@
+The API server now respects the ``logging.colored_console_log`` setting, so colored console output can be disabled there as for other components.

--- a/airflow-core/src/airflow/api_fastapi/main.py
+++ b/airflow-core/src/airflow/api_fastapi/main.py
@@ -39,6 +39,12 @@ if sys.version_info >= (3, 12) and (
     )
 
 from airflow.api_fastapi.app import cached_app
+from airflow.sdk.log import configure_logging
+
+# Configure logging in every worker so logging settings such as
+# logging.colored_console_log are respected. Both uvicorn and gunicorn import
+# this module in each worker process.
+configure_logging()
 
 # There is no way to pass the apps to this file from Airflow CLI
 # because fastapi dev command does not accept any additional arguments

--- a/airflow-core/src/airflow/api_fastapi/main.py
+++ b/airflow-core/src/airflow/api_fastapi/main.py
@@ -39,7 +39,7 @@ if sys.version_info >= (3, 12) and (
     )
 
 from airflow.api_fastapi.app import cached_app
-from airflow.sdk.log import configure_logging
+from airflow.sdk.log import configure_logging  # noqa: SDK001
 
 # Configure logging in every worker so logging settings such as
 # logging.colored_console_log are respected. Both uvicorn and gunicorn import

--- a/airflow-core/tests/unit/api_fastapi/test_main.py
+++ b/airflow-core/tests/unit/api_fastapi/test_main.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import importlib
+from unittest import mock
+
+
+def test_main_configures_logging():
+    """Each API server worker imports ``airflow.api_fastapi.main`` and must
+    configure logging so settings like ``logging.colored_console_log`` are
+    respected (regression test for the API server ignoring that setting)."""
+    main_module = importlib.import_module("airflow.api_fastapi.main")
+    with mock.patch("airflow.sdk.log.configure_logging") as mock_configure_logging:
+        importlib.reload(main_module)
+
+    mock_configure_logging.assert_called_once()


### PR DESCRIPTION
The API server did not respect `logging.colored_console_log`. Setting `AIRFLOW__LOGGING__COLORED_CONSOLE_LOG=False` left the API server emitting ANSI color escape sequences, which are hard to read in log aggregators that don't render colors.

The root cause is the same one #54992 fixed for the Triggerer: the process never called `configure_logging()`, so structlog fell back to its default (`colors=True`) and ignored the `colored_console_log` config. #54992 fixed the Triggerer but left the API server (the second process named in #54962) unaddressed.

## Fix

Call `configure_logging()` in `airflow.api_fastapi.main`, the module that **both** uvicorn and gunicorn import in every worker process (uvicorn runs `main:app`; gunicorn's worker `load()` does `from airflow.api_fastapi.main import app`). `configure_logging()` reads `logging.colored_console_log` from config, so the API server now honors it.

## Design notes

- The call is placed in the per-worker entrypoint rather than the CLI master process (`_run_api_server`) on purpose: uvicorn/gunicorn load the app independently in each worker, so configuring logging only in the master would not reach the worker processes that actually emit the request/app logs.
- This mirrors the approach merged in #54992 for the Triggerer.

## Tests

Added `test_main.py` asserting `configure_logging()` is invoked when the worker entrypoint is loaded.

closes: #54962

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=ca6cb93 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Abdulrehman-PIAIC80387** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@pierrejeambrun` is waiting on you:
> - 1 unresolved review thread(s) from `@pierrejeambrun` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->