### PR TITLE
validate exception type when deserializing serialized exceptions

### DIFF
--- a/airflow-core/src/airflow/serialization/enums.py
+++ b/airflow-core/src/airflow/serialization/enums.py
@@ -70,8 +70,6 @@ class DagAttributeTypes(str, Enum):
     TIMEDELTA = "timedelta"
     TIMEZONE = "timezone"
     RELATIVEDELTA = "relativedelta"
-    AIRFLOW_EXC_SER = "airflow_exc_ser"
-    BASE_EXC_SER = "base_exc_ser"
     DICT = "dict"
     SET = "set"
     TUPLE = "tuple"

--- a/airflow-core/src/airflow/serialization/enums.py
+++ b/airflow-core/src/airflow/serialization/enums.py
@@ -70,6 +70,10 @@ class DagAttributeTypes(str, Enum):
     TIMEDELTA = "timedelta"
     TIMEZONE = "timezone"
     RELATIVEDELTA = "relativedelta"
+    # Decode-only: nothing emits these anymore, but rows written before exception serialization
+    # was removed still have to be readable across an upgrade.
+    AIRFLOW_EXC_SER = "airflow_exc_ser"
+    BASE_EXC_SER = "base_exc_ser"
     DICT = "dict"
     SET = "set"
     TUPLE = "tuple"

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -41,7 +41,7 @@ import pydantic
 from dateutil import relativedelta
 from pendulum.tz.timezone import FixedTimezone, Timezone
 
-from airflow._shared.module_loading import import_string, qualname
+from airflow._shared.module_loading import qualname
 from airflow._shared.timezones.timezone import from_timestamp, parse_timezone, utcnow
 from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallbackRequest
 from airflow.exceptions import AirflowException, DeserializationError, SerializationError
@@ -534,27 +534,6 @@ class BaseSerialization:
                 var._asdict(),
                 type_=DAT.TASK_INSTANCE_KEY,
             )
-        elif isinstance(var, AirflowException) and hasattr(var, "serialize"):
-            exc_cls_name, args, kwargs = var.serialize()
-            return cls._encode(
-                cls.serialize(
-                    {"exc_cls_name": exc_cls_name, "args": args, "kwargs": kwargs},
-                    strict=strict,
-                ),
-                type_=DAT.AIRFLOW_EXC_SER,
-            )
-        elif isinstance(var, (KeyError, AttributeError)):
-            return cls._encode(
-                cls.serialize(
-                    {
-                        "exc_cls_name": var.__class__.__name__,
-                        "args": [var.args],
-                        "kwargs": {},
-                    },
-                    strict=strict,
-                ),
-                type_=DAT.BASE_EXC_SER,
-            )
         elif callable(var):
             return str(get_python_source(var))
         elif isinstance(var, set):
@@ -582,7 +561,7 @@ class BaseSerialization:
         elif isinstance(var, XComArg):
             return cls._encode(serialize_xcom_arg(var), type_=DAT.XCOM_REF)
         elif isinstance(var, LazySelectSequence):
-            return cls.serialize(list(var))
+            return cls.serialize(list(var), strict=strict)
         elif isinstance(var, (BaseAsset, SerializedAssetBase)):
             serialized_asset = encode_asset_like(var)
             return cls._encode(serialized_asset, type_=serialized_asset.pop("__type"))
@@ -652,23 +631,6 @@ class BaseSerialization:
             return parse_timezone(var)
         elif type_ == DAT.RELATIVEDELTA:
             return decode_relativedelta(var)
-        elif type_ == DAT.AIRFLOW_EXC_SER or type_ == DAT.BASE_EXC_SER:
-            deser = cls.deserialize(var)
-            exc_cls_name = deser["exc_cls_name"]
-            args = deser["args"]
-            kwargs = deser["kwargs"]
-            del deser
-            if type_ == DAT.AIRFLOW_EXC_SER:
-                exc_cls = import_string(exc_cls_name)
-            else:
-                exc_cls = import_string(f"builtins.{exc_cls_name}")
-            # ``exc_cls_name`` comes from the serialized payload. A tampered blob can name any
-            # importable callable (``os.system``, ``builtins.exec``, ...) which would then be
-            # invoked with attacker-supplied args. Only accept genuine exception types, matching
-            # the import-path guards the timetable/window/wait-policy decoders already apply.
-            if not (isinstance(exc_cls, type) and issubclass(exc_cls, BaseException)):
-                raise DeserializationError(f"{exc_cls_name!r} does not resolve to an exception type")
-            return exc_cls(*args, **kwargs)
         elif type_ == DAT.SET:
             return {cls.deserialize(v) for v in var}
         elif type_ == DAT.TUPLE:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -662,6 +662,12 @@ class BaseSerialization:
                 exc_cls = import_string(exc_cls_name)
             else:
                 exc_cls = import_string(f"builtins.{exc_cls_name}")
+            # ``exc_cls_name`` comes from the serialized payload. A tampered blob can name any
+            # importable callable (``os.system``, ``builtins.exec``, ...) which would then be
+            # invoked with attacker-supplied args. Only accept genuine exception types, matching
+            # the import-path guards the timetable/window/wait-policy decoders already apply.
+            if not (isinstance(exc_cls, type) and issubclass(exc_cls, BaseException)):
+                raise DeserializationError(f"{exc_cls_name!r} does not resolve to an exception type")
             return exc_cls(*args, **kwargs)
         elif type_ == DAT.SET:
             return {cls.deserialize(v) for v in var}

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -631,6 +631,11 @@ class BaseSerialization:
             return parse_timezone(var)
         elif type_ == DAT.RELATIVEDELTA:
             return decode_relativedelta(var)
+        elif type_ in (DAT.AIRFLOW_EXC_SER, DAT.BASE_EXC_SER):
+            # Legacy rows only. ``exc_cls_name`` is payload-supplied, so it is never resolved or
+            # called; the recorded args are rendered with BaseException semantics, giving the same
+            # string form an exception now serializes to.
+            return str(BaseException(*cls.deserialize(var).get("args", ())))
         elif type_ == DAT.SET:
             return {cls.deserialize(v) for v in var}
         elif type_ == DAT.TUPLE:

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -633,9 +633,9 @@ class BaseSerialization:
             return decode_relativedelta(var)
         elif type_ in (DAT.AIRFLOW_EXC_SER, DAT.BASE_EXC_SER):
             # Legacy rows only. ``exc_cls_name`` is payload-supplied, so it is never resolved or
-            # called; the recorded args are rendered with BaseException semantics, giving the same
+            # called; the recorded args are rendered with Exception semantics, giving the same
             # string form an exception now serializes to.
-            return str(BaseException(*cls.deserialize(var).get("args", ())))
+            return str(Exception(*cls.deserialize(var).get("args", ())))
         elif type_ == DAT.SET:
             return {cls.deserialize(v) for v in var}
         elif type_ == DAT.TUPLE:

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -579,6 +579,24 @@ def test_roundtrip_exceptions():
 
 
 @pytest.mark.parametrize(
+    ("exc_type", "exc_cls_name", "args"),
+    [
+        (DAT.AIRFLOW_EXC_SER, "os.system", ["echo gadget"]),
+        (DAT.BASE_EXC_SER, "exec", ["raise SystemExit"]),
+        (DAT.BASE_EXC_SER, "eval", ["1"]),
+    ],
+)
+def test_deserialize_exception_rejects_non_exception_callable(exc_type, exc_cls_name, args):
+    """A tampered exception payload must not import and call an arbitrary callable."""
+    from airflow.exceptions import DeserializationError
+
+    inner = BaseSerialization.serialize({"exc_cls_name": exc_cls_name, "args": args, "kwargs": {}})
+    blob = {Encoding.TYPE: exc_type, Encoding.VAR: inner}
+    with pytest.raises(DeserializationError, match="does not resolve to an exception type"):
+        BaseSerialization.deserialize(blob)
+
+
+@pytest.mark.parametrize(
     "concurrency_parameter",
     [
         "max_active_tis_per_dag",

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -36,7 +36,6 @@ from airflow.api_fastapi.execution_api.datamodels import taskinstance as ti_data
 from airflow.callbacks.callback_requests import DagCallbackRequest, TaskCallbackRequest
 from airflow.exceptions import (
     AirflowException,
-    AirflowFailException,
     AirflowRescheduleException,
     SerializationError,
 )
@@ -135,7 +134,6 @@ def test_recursive_serialize_calls_must_forward_kwargs():
     import airflow.serialization
 
     valid_recursive_call_count = 0
-    skipped_recursive_calls = 0  # when another serialize method called
     file = Path(airflow.serialization.__path__[0]) / "serialized_objects.py"
     content = file.read_text()
     tree = ast.parse(content)
@@ -154,8 +152,7 @@ def test_recursive_serialize_calls_must_forward_kwargs():
     for elem in ast.walk(method_def):
         if isinstance(elem, ast.Call) and getattr(elem.func, "attr", "") == "serialize":
             if not elem.func.value.id == "cls":
-                skipped_recursive_calls += 1
-                break
+                continue
             kwargs = {y.arg: y.value for y in elem.keywords}
             for name in kwonly_args:
                 if name not in kwargs or getattr(kwargs[name], "id", "") != name:
@@ -168,7 +165,6 @@ def test_recursive_serialize_calls_must_forward_kwargs():
                 valid_recursive_call_count += 1
     print(f"validated calls: {valid_recursive_call_count}")
     assert valid_recursive_call_count > 0
-    assert skipped_recursive_calls == 1
 
 
 def test_strict_mode():
@@ -250,10 +246,6 @@ def equals(a, b) -> bool:
 
 def equal_time(a: datetime, b: datetime) -> bool:
     return a.strftime("%s") == b.strftime("%s")
-
-
-def equal_exception(a: AirflowException, b: AirflowException) -> bool:
-    return a.__class__ == b.__class__ and str(a) == str(b)
 
 
 def equal_outlet_event_accessors(a: OutletEventAccessors, b: OutletEventAccessors) -> bool:
@@ -432,16 +424,6 @@ class MockLazySelectSequence(LazySelectSequence):
             equal_outlet_event_accessors,
         ),
         (
-            AirflowException("test123 wohoo!"),
-            DAT.AIRFLOW_EXC_SER,
-            equal_exception,
-        ),
-        (
-            AirflowFailException("uuups, failed :-("),
-            DAT.AIRFLOW_EXC_SER,
-            equal_exception,
-        ),
-        (
             DAG_WITH_TASKS,
             DAT.DAG,
             lambda _, b: list(b.task_group.children.keys()) == sorted(b.task_group.children.keys()),
@@ -568,31 +550,18 @@ def test_ser_of_asset_event_accessor():
     assert d[Asset(name="yo", uri="test://yo")].extra == {"this": "that", "the": "other"}
 
 
-def test_roundtrip_exceptions():
-    """Non-error AirflowExceptions (e.g. AirflowRescheduleException) round-trip through BaseSerialization."""
-    some_date = pendulum.now()
-    resched_exc = AirflowRescheduleException(reschedule_date=some_date)
-    ser = BaseSerialization.serialize(resched_exc)
-    deser = BaseSerialization.deserialize(ser)
-    assert isinstance(deser, AirflowRescheduleException)
-    assert deser.reschedule_date == some_date
+def test_exceptions_not_serialized_by_general_framework():
+    """Exceptions no longer round-trip through BaseSerialization; they fall back to their string form."""
+    resched_exc = AirflowRescheduleException(reschedule_date=pendulum.now())
+    assert BaseSerialization.serialize(resched_exc) == str(resched_exc)
 
 
-@pytest.mark.parametrize(
-    ("exc_type", "exc_cls_name", "args"),
-    [
-        (DAT.AIRFLOW_EXC_SER, "os.system", ["echo gadget"]),
-        (DAT.BASE_EXC_SER, "exec", ["raise SystemExit"]),
-        (DAT.BASE_EXC_SER, "eval", ["1"]),
-    ],
-)
-def test_deserialize_exception_rejects_non_exception_callable(exc_type, exc_cls_name, args):
-    """A tampered exception payload must not import and call an arbitrary callable."""
-    from airflow.exceptions import DeserializationError
-
-    inner = BaseSerialization.serialize({"exc_cls_name": exc_cls_name, "args": args, "kwargs": {}})
+@pytest.mark.parametrize("exc_type", ["airflow_exc_ser", "base_exc_ser"])
+def test_deserialize_rejects_legacy_exception_blob(exc_type):
+    """A crafted exception blob is no longer imported and called; the type is simply unknown now."""
+    inner = BaseSerialization.serialize({"exc_cls_name": "os.system", "args": ["echo gadget"], "kwargs": {}})
     blob = {Encoding.TYPE: exc_type, Encoding.VAR: inner}
-    with pytest.raises(DeserializationError, match="does not resolve to an exception type"):
+    with pytest.raises(TypeError, match="Invalid type"):
         BaseSerialization.deserialize(blob)
 
 

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -556,13 +556,40 @@ def test_exceptions_not_serialized_by_general_framework():
     assert BaseSerialization.serialize(resched_exc) == str(resched_exc)
 
 
-@pytest.mark.parametrize("exc_type", ["airflow_exc_ser", "base_exc_ser"])
-def test_deserialize_rejects_legacy_exception_blob(exc_type):
-    """A crafted exception blob is no longer imported and called; the type is simply unknown now."""
-    inner = BaseSerialization.serialize({"exc_cls_name": "os.system", "args": ["echo gadget"], "kwargs": {}})
-    blob = {Encoding.TYPE: exc_type, Encoding.VAR: inner}
-    with pytest.raises(TypeError, match="Invalid type"):
-        BaseSerialization.deserialize(blob)
+def build_legacy_exception_blob(type_, exc_cls_name, args):
+    """Build the payload a pre-removal Airflow wrote for a serialized exception."""
+    inner = BaseSerialization.serialize({"exc_cls_name": exc_cls_name, "args": args, "kwargs": {}})
+    return {Encoding.TYPE: type_, Encoding.VAR: inner}
+
+
+@pytest.mark.parametrize(
+    ("type_", "exc_cls_name", "args", "expected"),
+    [
+        ("airflow_exc_ser", "airflow.exceptions.AirflowException", ["boom"], "boom"),
+        ("airflow_exc_ser", "airflow.exceptions.AirflowRescheduleException", [], ""),
+        ("base_exc_ser", "KeyError", [("some_key",)], "('some_key',)"),
+    ],
+)
+def test_deserialize_legacy_exception_blob_yields_message(type_, exc_cls_name, args, expected):
+    """Rows written before the removal still deserialize, to the exception's message."""
+    assert BaseSerialization.deserialize(build_legacy_exception_blob(type_, exc_cls_name, args)) == expected
+
+
+@pytest.mark.parametrize(
+    ("type_", "exc_cls_name", "build_arg"),
+    [
+        ("base_exc_ser", "exec", lambda marker: f"open({str(marker)!r}, 'w').close()"),
+        ("airflow_exc_ser", "os.system", lambda marker: f"touch {marker}"),
+    ],
+)
+def test_deserialize_legacy_exception_blob_does_not_invoke_payload_name(
+    type_, exc_cls_name, build_arg, tmp_path
+):
+    """The payload's class name is never resolved and called, whatever it names."""
+    marker = tmp_path / "gadget"
+    arg = build_arg(marker)
+    assert BaseSerialization.deserialize(build_legacy_exception_blob(type_, exc_cls_name, [arg])) == arg
+    assert not marker.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`BaseSerialization.deserialize` rebuilds `AIRFLOW_EXC_SER`/`BASE_EXC_SER` payloads by feeding `exc_cls_name` straight into `import_string` and then calling the result as `exc_cls(*args, **kwargs)`, with the class name and arguments all taken from the serialized blob. A tampered payload can name any importable callable (`os.system`, `builtins.exec`, `builtins.eval`, ...) and have it invoked with attacker-chosen arguments, so anything that deserializes a crafted object runs arbitrary code, including the scheduler reading a serialized Dag where user code is never meant to run.

The decoders for timetables, windows and wait policies already refuse non-core import paths before handing them to `import_string`; the exception branch was the gap. This checks that the resolved object is a real exception type before instantiating it and raises `DeserializationError` otherwise. Putting the check next to the import keeps both exception branches covered in one place, and legitimate `AirflowException`/`KeyError`/`AttributeError` round-trips are unaffected.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=b55216e action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @naruto-lgtm** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Some review feedback from `@ashb` is waiting on you:
> - 2 unresolved review thread(s) from `@ashb` need a reply or a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->