### PR TITLE
Percent-encode API client path params

### DIFF
--- a/airflow-core/src/airflow/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.ts
@@ -29,6 +29,12 @@ if (OpenAPI.BASE.endsWith("/")) {
   OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
 }
 
+// Encode path params as full URI components so values containing "/" (e.g. a variable key like
+// "/foo") become "%2Ffoo" rather than a literal "//", which proxies may collapse. The generated
+// client otherwise defaults to encodeURI, which leaves "/" untouched.
+// The backend automatically decodes path params.
+OpenAPI.ENCODE_PATH = encodeURIComponent;
+
 const RETRY_COUNT = 3;
 
 const retryFunction = (failureCount: number, error: unknown) => {


### PR DESCRIPTION
Variable keys may start with or contain `/` (e.g. `/foo`). The generated UI API client interpolated path params with `encodeURI`, which intentionally leaves `/` unescaped — so a key `/foo` produced a literal `//` in the URL (`/api/v2/variables//foo`). Some proxies collapse `//` → `/`, silently dropping the slash and corrupting the key, so GET/PATCH/DELETE of such variables fail behind those proxies (create is unaffected, since the key travels in the request body).

Switching `OpenAPI.ENCODE_PATH` to `encodeURIComponent` escapes `/` as `%2F`, so no literal `//` ever appears; the backend decodes it back to `/`. It's a no-op for plain keys, and also correctly escapes other characters (`?`, `#`, `&`, …) that `encodeURI` wrongly left untouched in path-param values.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)