### PR TITLE
[v3-3-test] Percent-encode API client path params

### DIFF
--- a/airflow-core/src/airflow/ui/src/queryClient.ts
+++ b/airflow-core/src/airflow/ui/src/queryClient.ts
@@ -29,6 +29,12 @@ if (OpenAPI.BASE.endsWith("/")) {
   OpenAPI.BASE = OpenAPI.BASE.slice(0, -1);
 }
 
+// Encode path params as full URI components so values containing "/" (e.g. a variable key like
+// "/foo") become "%2Ffoo" rather than a literal "//", which proxies may collapse. The generated
+// client otherwise defaults to encodeURI, which leaves "/" untouched.
+// The backend automatically decodes path params.
+OpenAPI.ENCODE_PATH = encodeURIComponent;
+
 const RETRY_COUNT = 3;
 
 const retryFunction = (failureCount: number, error: unknown) => {


### PR DESCRIPTION
Backport of #68667 to `v3-3-test`.

Cherry-picked from 9140ce5aee1960094beb6e58f8d21cb13a6167ab.

Clean cherry-pick, no conflicts.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)