### PR TITLE
Adding example dag for task state store with mapped tasks

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_task_state_store_mapped.py
+++ b/airflow-core/src/airflow/example_dags/example_task_state_store_mapped.py
@@ -49,10 +49,7 @@ with DAG(
             "row_count": row_count,
             "processed_at": datetime.now(tz=timezone.utc).isoformat(timespec="seconds"),
         }
-
-        task_state_store.set("table", table)
         task_state_store.set("status", "complete")
-        task_state_store.set("row_count", row_count)
         task_state_store.set("result", result)
 
         print(f"[map_index={ti.map_index}] Processed {table}: {row_count} rows")

--- a/airflow-core/src/airflow/example_dags/example_task_state_store_mapped.py
+++ b/airflow-core/src/airflow/example_dags/example_task_state_store_mapped.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example DAG with mapped tasks to demonstrate task state store isolation per map_index."""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime, timezone
+
+from airflow.sdk import DAG, task
+
+TABLES = ["orders", "customers", "products"]
+
+with DAG(
+    dag_id="example_task_state_store_mapped",
+    schedule=None,
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    tags=["example", "task-state-store"],
+    doc_md=__doc__,
+) as dag:
+
+    @task
+    def get_tables() -> list[str]:
+        """Return the list of tables to process."""
+        return TABLES
+
+    @task
+    def process_table(table: str, task_state_store=None, ti=None) -> dict:
+        """Process one table — each mapped instance gets its own task state."""
+        row_count = random.randint(100, 10000)
+        result = {
+            "table": table,
+            "map_index": ti.map_index,
+            "row_count": row_count,
+            "processed_at": datetime.now(tz=timezone.utc).isoformat(timespec="seconds"),
+        }
+
+        task_state_store.set("table", table)
+        task_state_store.set("status", "complete")
+        task_state_store.set("row_count", row_count)
+        task_state_store.set("result", result)
+
+        print(f"[map_index={ti.map_index}] Processed {table}: {row_count} rows")
+        return result
+
+    tables = get_tables()
+    process_table.expand(table=tables)


### PR DESCRIPTION

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What

`example_task_state_store.py` shows the crash-recovery pattern for a single task instance. There was no example showing how `task_state_store` behaves with mapped tasks, specifically that each `map_index` gets its own isolated store, so sibling instances cannot collide on keys.

### Change

Adding a new dag: `example_task_state_store_mapped.py`. 

- A `get_tables` task produces a list of table names, `process_table` is expanded over that list. 
- Each mapped instance writes its own `table`, `status`, `row_count`, and `result` keys to `task_state_store`, demonstrating that the store is scoped per `(dag_id, run_id, task_id, map_index)` and not shared across sibling instances.

Observe the differences of map_index in the screenshots below:

<img width="2495" height="1047" alt="image" src="https://github.com/user-attachments/assets/3dad9a3b-a627-4e19-84dd-7a6f49c30e7c" />


<img width="2495" height="1047" alt="image" src="https://github.com/user-attachments/assets/153ead4d-c029-4a59-b993-e5fdf3e82bcc" />


<img width="2495" height="1047" alt="image" src="https://github.com/user-attachments/assets/5a4dda82-3ade-4e15-8d55-9ffdff429281" />



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
