### PR TITLE
Add v3-3-test to CI, dependabot, backport, and fork-sync configuration

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -356,6 +356,24 @@ labelPRBasedOnFilePath:
     - .rat-excludes
     - .readthedocs.yml
 
+  # This should be copy of the "area:dev-tools" above minus contributing docs and some files that should
+  # only make sense in main - it should be updated when we switch maintenance branch.
+  # Scoped to PRs targeting `main` only — a PR opened directly against v3-3-test
+  # does not need a backport-to-v3-3-test label.
+  backport-to-v3-3-test:
+    paths:
+      - scripts/**/*
+      - dev/**/*
+      - .github/**/*
+      - Dockerfile.ci
+      - yamllint-config.yml
+      - .dockerignore
+      - .hadolint.yaml
+      - .pre-commit-config.yaml
+      - .rat-excludes
+    targetBranchFilter:
+      - ^main$
+
   # Apply to PRs touching airflow-ctl code so the release manager notices when a
   # fix should land on the airflow-ctl/v0-1-test maintenance branch.
   # Scoped to PRs targeting `main` only.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
-    target-branch: v3-2-test
+    target-branch: v3-3-test
     groups:
       github-actions-updates:
         patterns:
@@ -200,7 +200,7 @@ updates:
         update-types:
           - "major"
 
-  # Repeat dependency updates on v3-2-test branch as well
+  # Repeat dependency updates on v3-3-test branch as well
   - package-ecosystem: pip
     cooldown:
       default-days: 4
@@ -216,7 +216,7 @@ updates:
       - /
     schedule:
       interval: daily
-    target-branch: v3-2-test
+    target-branch: v3-3-test
     groups:
       pip-dependency-updates:
         patterns:
@@ -229,9 +229,9 @@ updates:
       - /airflow-core/src/airflow/ui
     schedule:
       interval: "weekly"
-    target-branch: v3-2-test
+    target-branch: v3-3-test
     groups:
-      3-2-core-ui-package-updates:
+      3-3-core-ui-package-updates:
         patterns:
           - "*"
         update-types:
@@ -248,9 +248,9 @@ updates:
       - /airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui
     schedule:
       interval: "weekly"
-    target-branch: v3-2-test
+    target-branch: v3-3-test
     groups:
-      3-2-auth-ui-package-updates:
+      3-3-auth-ui-package-updates:
         patterns:
           - "*"
         update-types:

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -36,7 +36,7 @@ jobs:
   workflow-status:
     strategy:
       matrix:
-        branch: ["v3-2-test"]
+        branch: ["v3-3-test"]
         # Track AMD; ARM is the canary slot and is reported separately by
         # `ci-arm.yml`'s notify-slack job on schedule events.
         workflow-id: ["ci-amd.yml"]

--- a/.github/workflows/milestone-tag-assistant.yml
+++ b/.github/workflows/milestone-tag-assistant.yml
@@ -21,6 +21,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+      - v3-3-test
       - v3-2-test
       - v3-1-test
 

--- a/dev/sync_fork.sh
+++ b/dev/sync_fork.sh
@@ -43,7 +43,7 @@ set -euo pipefail
 
 UPSTREAM="${UPSTREAM_REMOTE:-upstream}"
 ORIGIN="${ORIGIN_REMOTE:-origin}"
-DEFAULT_BRANCHES=(main v3-2-test airflow-ctl/v0-1-test)
+DEFAULT_BRANCHES=(main v3-3-test airflow-ctl/v0-1-test)
 
 if [[ $# -gt 0 ]]; then
     BRANCHES=("$@")


### PR DESCRIPTION
The `v3-3-test` release branch was cut for the 3.3.0 release cycle, so the automation on `main` needs to track it.

- **dependabot.yml** — switch the release-branch dependency updates from `v3-2-test` to `v3-3-test` (github-actions, pip, npm).
- **milestone-tag-assistant.yml** — add `v3-3-test` to the push-branches list.
- **ci-notification.yml** — switch the `workflow-status` matrix branch to `v3-3-test`.
- **boring-cyborg.yml** — re-add the dev-tools backport auto-label rule targeting `v3-3-test` (mirroring the `v3-2-test` rule that #68220 removed), so PRs on `main` touching dev-tooling paths are labelled for backport to the current maintenance branch.
- **dev/sync_fork.sh** — point `DEFAULT_BRANCHES` at `v3-3-test`.

`basic-tests.yml`'s release-management dry-run is intentionally left untouched and will be updated once `3.3.0rc1` is cut.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)