### PR TITLE
KubernetesExecutor: self.completed adoption set is never drained

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -300,8 +300,18 @@ class KubernetesExecutor(BaseExecutor):
                 finally:
                     self.result_queue.task_done()
 
-                for result in self.completed:
+        if self.completed:
+            still_pending: set[KubernetesResults] = set()
+            for result in self.completed:
+                try:
                     self._change_state(result)
+                except Exception:
+                    self.log.exception(
+                        "Exception when attempting to change state of adopted completed pod %s, will retry.",
+                        result,
+                    )
+                    still_pending.add(result)
+            self.completed = still_pending
 
         from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import ResourceVersion
 
@@ -813,11 +823,13 @@ class KubernetesExecutor(BaseExecutor):
                 continue
 
             ti_id = annotations_to_key(pod.metadata.annotations)
+            pod_name = pod.metadata.name
+            self.completed = {result for result in self.completed if result.pod_name != pod_name}
             self.completed.add(
                 KubernetesResults(
                     key=ti_id,
                     state="completed",
-                    pod_name=pod.metadata.name,
+                    pod_name=pod_name,
                     namespace=pod.metadata.namespace,
                     resource_version=pod.metadata.resource_version,
                     failure_details=None,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -114,7 +114,7 @@ class KubernetesExecutor(BaseExecutor):
         self.task_publish_max_retries = self.conf.getint(
             "kubernetes_executor", "task_publish_max_retries", fallback=0
         )
-        self.completed: set[KubernetesResults] = set()
+        self.completed: dict[tuple[str, str], KubernetesResults] = {}
         self.create_pods_after: datetime | None = None
 
     def _list_pods(self, query_kwargs):
@@ -301,8 +301,8 @@ class KubernetesExecutor(BaseExecutor):
                     self.result_queue.task_done()
 
         if self.completed:
-            still_pending: set[KubernetesResults] = set()
-            for result in self.completed:
+            still_pending: dict[tuple[str, str], KubernetesResults] = {}
+            for pod_key, result in self.completed.items():
                 try:
                     self._change_state(result)
                 except Exception:
@@ -310,7 +310,7 @@ class KubernetesExecutor(BaseExecutor):
                         "Exception when attempting to change state of adopted completed pod %s, will retry.",
                         result,
                     )
-                    still_pending.add(result)
+                    still_pending[pod_key] = result
             self.completed = still_pending
 
         from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import ResourceVersion
@@ -824,16 +824,14 @@ class KubernetesExecutor(BaseExecutor):
 
             ti_id = annotations_to_key(pod.metadata.annotations)
             pod_name = pod.metadata.name
-            self.completed = {result for result in self.completed if result.pod_name != pod_name}
-            self.completed.add(
-                KubernetesResults(
-                    key=ti_id,
-                    state="completed",
-                    pod_name=pod_name,
-                    namespace=pod.metadata.namespace,
-                    resource_version=pod.metadata.resource_version,
-                    failure_details=None,
-                )
+            namespace = pod.metadata.namespace
+            self.completed[(namespace, pod_name)] = KubernetesResults(
+                key=ti_id,
+                state="completed",
+                pod_name=pod_name,
+                namespace=namespace,
+                resource_version=pod.metadata.resource_version,
+                failure_details=None,
             )
 
     def _flush_task_queue(self) -> None:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1561,12 +1561,8 @@ class TestKubernetesExecutor:
                     None,
                 )
             }
-            executor.result_queue.put(
-                KubernetesResults(queue_key, None, "queue-pod", "default", "2", None)
-            )
-            executor.result_queue.put(
-                KubernetesResults(queue_key, None, "queue-pod-2", "default", "3", None)
-            )
+            executor.result_queue.put(KubernetesResults(queue_key, None, "queue-pod", "default", "2", None))
+            executor.result_queue.put(KubernetesResults(queue_key, None, "queue-pod-2", "default", "3", None))
 
             executor.sync()
 
@@ -1603,12 +1599,8 @@ class TestKubernetesExecutor:
                     None,
                 )
             }
-            executor.result_queue.put(
-                KubernetesResults(queue_key, None, "queue-pod", "default", "2", None)
-            )
-            executor.result_queue.put(
-                KubernetesResults(queue_key, None, "queue-pod-2", "default", "3", None)
-            )
+            executor.result_queue.put(KubernetesResults(queue_key, None, "queue-pod", "default", "2", None))
+            executor.result_queue.put(KubernetesResults(queue_key, None, "queue-pod-2", "default", "3", None))
 
             executor.sync()
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1397,7 +1397,7 @@ class TestKubernetesExecutor:
             ],
             any_order=True,
         )
-        assert {k8s_res.key for k8s_res in executor.completed} == expected_running_ti_keys
+        assert {k8s_res.key for k8s_res in executor.completed.values()} == expected_running_ti_keys
 
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor.DynamicClient")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
@@ -1536,6 +1536,7 @@ class TestKubernetesExecutor:
             "_alive_other_scheduler_job_ids closed/detached the caller's scoped session"
         )
 
+    @pytest.mark.db_test
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
     @mock.patch(
@@ -1551,7 +1552,7 @@ class TestKubernetesExecutor:
             completed_key = TaskInstanceKey(dag_id="dag", task_id="completed", run_id="run_id", try_number=1)
             queue_key = TaskInstanceKey(dag_id="dag", task_id="queued", run_id="run_id", try_number=1)
             executor.completed = {
-                KubernetesResults(
+                ("default", "completed-pod"): KubernetesResults(
                     completed_key,
                     "completed",
                     "completed-pod",
@@ -1570,7 +1571,58 @@ class TestKubernetesExecutor:
             executor.sync()
 
             assert mock_delete_pod.call_count == 3
-            assert executor.completed == set()
+            assert executor.completed == {}
+        finally:
+            executor.end()
+
+    @pytest.mark.db_test
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler"
+    )
+    def test_sync_processes_completed_pods_once_without_deletion(
+        self, mock_kubescheduler, mock_get_kube_client, mock_kubernetes_job_watcher
+    ):
+        """Adopted completed pods must not be re-patched for every result-queue item."""
+        mock_delete_pod = mock_kubescheduler.return_value.delete_pod
+        mock_patch_pod = mock_kubescheduler.return_value.patch_pod_executor_done
+        executor = self.kubernetes_executor
+        executor.kube_config.delete_worker_pods = False
+        executor.start()
+        try:
+            completed_key = TaskInstanceKey(dag_id="dag", task_id="completed", run_id="run_id", try_number=1)
+            queue_key = TaskInstanceKey(dag_id="dag", task_id="queued", run_id="run_id", try_number=1)
+            executor.completed = {
+                ("default", "completed-pod"): KubernetesResults(
+                    completed_key,
+                    "completed",
+                    "completed-pod",
+                    "default",
+                    "1",
+                    None,
+                )
+            }
+            executor.result_queue.put(
+                KubernetesResults(queue_key, None, "queue-pod", "default", "2", None)
+            )
+            executor.result_queue.put(
+                KubernetesResults(queue_key, None, "queue-pod-2", "default", "3", None)
+            )
+
+            executor.sync()
+
+            mock_delete_pod.assert_not_called()
+            assert mock_patch_pod.call_count == 3
+            mock_patch_pod.assert_has_calls(
+                [
+                    mock.call(pod_name="completed-pod", namespace="default"),
+                    mock.call(pod_name="queue-pod", namespace="default"),
+                    mock.call(pod_name="queue-pod-2", namespace="default"),
+                ],
+                any_order=True,
+            )
+            assert executor.completed == {}
         finally:
             executor.end()
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1536,6 +1536,44 @@ class TestKubernetesExecutor:
             "_alive_other_scheduler_job_ids closed/detached the caller's scoped session"
         )
 
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.delete_pod"
+    )
+    def test_sync_processes_completed_pods_once(
+        self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher
+    ):
+        """Adopted completed pods must not be re-deleted for every result-queue item."""
+        executor = self.kubernetes_executor
+        executor.start()
+        try:
+            completed_key = TaskInstanceKey(dag_id="dag", task_id="completed", run_id="run_id", try_number=1)
+            queue_key = TaskInstanceKey(dag_id="dag", task_id="queued", run_id="run_id", try_number=1)
+            executor.completed = {
+                KubernetesResults(
+                    completed_key,
+                    "completed",
+                    "completed-pod",
+                    "default",
+                    "1",
+                    None,
+                )
+            }
+            executor.result_queue.put(
+                KubernetesResults(queue_key, None, "queue-pod", "default", "2", None)
+            )
+            executor.result_queue.put(
+                KubernetesResults(queue_key, None, "queue-pod-2", "default", "3", None)
+            )
+
+            executor.sync()
+
+            assert mock_delete_pod.call_count == 3
+            assert executor.completed == set()
+        finally:
+            executor.end()
+
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
     def test_not_adopt_unassigned_task(self, mock_kube_client):
         """


### PR DESCRIPTION
**Solves https://github.com/apache/airflow/issues/68683**

Airflow version observed 3.2.1

**`KubernetesExecutor.sync()` re-runs `_change_state()` over the entire `self.completed` set, and nothing ever removes entries from that set. 
Iteration over the `self.completed` is nested inside the result-queue `while True`**

With `delete_worker_pods=False`, the data structure only grows, with no removals. So every adopted completed pod is re-PATCHed forever, and the set grows monotonically over the scheduler's lifetime.
With `delete_worker_pods=True`, the same happens with pod deletion.

The same pod name is deleted many times within seconds:
```
2026-06-11T18:49:36.108968Z  Deleting pod trigger-test-dags-trigger-zwyr4icn ...
2026-06-11T18:49:36.228925Z  Deleting pod trigger-test-dags-trigger-zwyr4icn ...
2026-06-11T18:49:36.397320Z  Deleting pod trigger-test-dags-trigger-zwyr4icn ...
... (166 total for this one pod)
```
This starves the scheduler loop: with (in my case ~1,855) scheduled TIs waiting, most of each loop is spent re-deleting finished pods instead of launching new ones.

### Expected behaviour
Each finished worker pod should be patched or deleted **once**. Subsequent scheduler loops should not re-issue calls for pods already processed.

### Reproduce
1. Deploy Airflow 3.2.x with `KubernetesExecutor`.
2. Trigger DAGs with many mapped tasks (e.g. 100+ mapped `trigger` tasks) so pods complete in quick succession.
3. Inspect scheduler logs:

   ```bash
   kubectl logs <scheduler-pod> -c scheduler | grep "Deleting pod" \
     | sed 's/.*Deleting pod \([^ ]*\) in.*/\1/' | sort | uniq -c | sort -rn | head
   ```
4. Observe the same pod names with delete counts >> 1.

### RCA
Introduced/regressed around **#55797** (Oct 2025), which added a `self.completed` set for orphaned completed pod adoption.
In `KubernetesExecutor.sync()` (`providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py`):

1. **`self.completed` is processed inside the `while True` loop** that drains `result_queue` — for every completion event, **all** entries in `self.completed` call `_change_state()` again, each triggering `delete_pod()`:

   ```python
   while True:
       results = self.result_queue.get_nowait()
       ...
       self._change_state(results)

       for result in self.completed:   # <-- nested inside while True
           self._change_state(result)
   ```

2. **`self.completed` is never cleared** after processing, so entries accumulate and are re-processed on every subsequent completion event.

Expected delete volume ≈ `num_result_queue_events × (1 + len(self.completed))`

### Proposed fix
1. Move `for result in self.completed` **outside** the result-queue drain loop (once per `sync()`).
2. **Clear** or discard from `self.completed` after successful processing.
3. Deduplicate by `pod_name` when adopting completed pods.


### Expected impact
Before: `delete_calls ≈ num_result_events × (1 + len(completed))` per `sync()`.
After: `delete_calls ≈ num_result_events + len(completed)` per `sync()`, with `completed` cleared after processing.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes 
Generated-by: [Cursor Composer ] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
