### PR TITLE
Instruct AI agents not to tag individuals in PR/issue comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,22 @@ block under the AI-disclosure checkbox; commit messages still follow
 the no-self-as-co-author rule above). Do not skip the footer to
 shorten a message — attribution applies regardless of message length.
 
+#### Do not tag individuals
+
+AI agents MUST NOT mention or tag individual contributors, committers,
+PMC members, or maintainers using GitHub usernames (e.g. `@user`) unless
+explicitly instructed by a human reviewer. When suggesting who might be
+relevant to a discussion, refer to roles, teams, code ownership
+information, labels, or components instead of individuals. This keeps
+notification noise down and avoids pulling people into threads they have
+not chosen to join.
+
+The only exceptions are mentions a human has explicitly authorized —
+including the `@<github-handle>` in the `Drafted-by: … reviewed by
+@<handle>` footer above, which names the reviewer who approved the
+message — and replying within a thread to people already actively
+participating in that same PR/issue discussion.
+
 ## apache-steward framework
 
 This repo adopts the [`apache/airflow-steward`](https://github.com/apache/airflow-steward)


### PR DESCRIPTION
# Human Summary
Following recent incidents I was involved in, both as the person causing the issue and as the subject of it, I find it annoying when an AI agent tags me or others without a good reason, especially if they are not a part of an ongoing discussion in a PR/issue.
This PR tries to address this.

# AI Summary
Adds a default instruction in `AGENTS.md` (the file `CLAUDE.md` symlinks to) telling AI agents not to `@`-mention individual contributors, committers, PMC members, or maintainers when commenting on PRs/issues, unless a human reviewer has explicitly authorized it.

Agent-authored comments that tag people by username generate notification noise and pull people into threads they have not chosen to join. The new guidance directs agents to refer to roles, teams, code ownership information, labels, or components instead, with narrow exceptions for the reviewer named in the `Drafted-by: … reviewed by @<handle>` attribution footer and for replies to people already participating in the same thread.

The note is placed inside the existing "GitHub messages drafted by agents" section, where the other agent-posting rules already live.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)