### PR TITLE
Skip asset-change registration for tasks with no outlets

### DIFF
--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -1524,6 +1524,14 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         *,
         session: Session = NEW_SESSION,
     ) -> None:
+        # Fast path: a task with no outlets and no outlet events has nothing to
+        # register. Returning early avoids the AssetModel lookup below (which
+        # would run with empty IN () clauses) and all downstream work. This is
+        # the common case -- most tasks declare no outlets -- and it sits on the
+        # task-success path that gates scheduling the next task.
+        if not task_outlets and not outlet_events:
+            return
+
         from airflow.serialization.definitions.assets import (
             SerializedAsset,
             SerializedAssetNameRef,

--- a/airflow-core/tests/unit/models/test_taskinstance.py
+++ b/airflow-core/tests/unit/models/test_taskinstance.py
@@ -113,6 +113,7 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils import db
+from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_runs
 from tests_common.test_utils.mock_operators import MockOperator
@@ -3546,6 +3547,23 @@ def test_find_relevant_relatives_with_non_mapped_task_as_tuple(dag_maker, sessio
     )
     # Should return t1 as the upstream of t2
     assert result == {"t1"}
+
+
+def test_register_asset_changes_in_db_no_outlets_is_a_noop(dag_maker, session):
+    """A task with no outlets and no outlet events must not issue any queries."""
+    with dag_maker(dag_id="no_outlets", schedule=None, session=session):
+        EmptyOperator(task_id="hi")
+    dr = dag_maker.create_dagrun(session=session)
+    [ti] = dr.get_task_instances(session=session)
+    session.commit()
+
+    with assert_queries_count(0):
+        TaskInstance.register_asset_changes_in_db(
+            ti=ti,
+            task_outlets=[],
+            outlet_events=[],
+            session=session,
+        )
 
 
 def test_when_dag_run_has_partition_then_asset_does(dag_maker, session):


### PR DESCRIPTION
## Summary

`TaskInstance.register_asset_changes_in_db` runs on every task-success state transition (from the execution API `PATCH .../state` handler). For a task that declares **no** outlet assets and emits **no** outlet events — the common case — the method still executed its full body, including an `AssetModel` SELECT whose `IN (...)` clauses are all empty, before ultimately doing nothing.

This adds an early return when both `task_outlets` and `outlet_events` are empty, eliminating that database round-trip. It sits on the task-completion path, which gates how quickly the next task can be scheduled.

## Detail

- `airflow-core/src/airflow/models/taskinstance.py`: early-return guard at the top of `register_asset_changes_in_db`.
- All downstream work (`payloads_by_asset`, the `AssetModel` lookup, the per-key `_register` calls, and the alias path) derives from `task_outlets` / `outlet_events`, so when both are empty the method is already a no-op — this just makes that explicit and cheap.

## Tests

Added `test_register_asset_changes_in_db_no_outlets_is_a_noop`, which asserts (via `assert_queries_count(0)`) that no queries are issued for a task with no outlets. Existing asset-registration / partition tests continue to pass.
