### PR TITLE
UI: Align Dag Runs and Task Instances filter spacing

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstancesFilter.tsx
@@ -88,14 +88,12 @@ export const TaskInstancesFilter = () => {
   });
 
   return (
-    <VStack align="start" justifyContent="space-between">
-      <VStack alignItems="flex-start" gap={1}>
-        <FilterBar
-          configs={filterConfigs}
-          initialValues={initialValues}
-          onFiltersChange={handleFiltersChange}
-        />
-      </VStack>
+    <VStack align="start" gap={4} paddingY="4px">
+      <FilterBar
+        configs={filterConfigs}
+        initialValues={initialValues}
+        onFiltersChange={handleFiltersChange}
+      />
     </VStack>
   );
 };


### PR DESCRIPTION
Fixes inconsistent spacing between the Dag Runs and Task Instances global list views.

Task Instances now uses the same filter wrapper spacing as Dag Runs. The visible fix is adding the missing `paddingY="4px"`; the previous nested wrapper had only one child, so `gap` / `justifyContent` did not affect layout.

closes: #68639

### Before
<img width="1507" height="548" alt="before_img1" src="https://github.com/user-attachments/assets/237cd600-da46-4fd0-aaad-fe442425ef31" />
<img width="1501" height="591" alt="before_img2" src="https://github.com/user-attachments/assets/260619bc-5c2b-4633-9fcf-a5401c8d8959" />

https://github.com/user-attachments/assets/dc17d525-7dd0-4ff2-a207-334d1ae77964

### After
<img width="1491" height="444" alt="aft_img1" src="https://github.com/user-attachments/assets/5c8c5529-062c-478f-9519-86c5605c3138" />
<img width="1491" height="465" alt="aft_img2" src="https://github.com/user-attachments/assets/100568aa-fbc8-45ce-ac81-0a1b498eee5e" />

https://github.com/user-attachments/assets/b33b624f-4821-46a4-8966-f8ec83892266


