### PR TITLE
Validate connection port values

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -191,7 +191,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(default=None, ge=1, le=65535)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13075,6 +13075,8 @@ components:
         port:
           anyOf:
           - type: integer
+            maximum: 65535.0
+            minimum: 1.0
           - type: 'null'
           title: Port
         password:
@@ -13230,6 +13232,8 @@ components:
         port:
           anyOf:
           - type: integer
+            maximum: 65535.0
+            minimum: 1.0
           - type: 'null'
           title: Port
         password:

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -858,7 +858,9 @@ ARG_CONN_PASSWORD = Arg(
 ARG_CONN_SCHEMA = Arg(
     ("--conn-schema",), help="Connection schema, optional when adding a connection", type=str
 )
-ARG_CONN_PORT = Arg(("--conn-port",), help="Connection port, optional when adding a connection", type=str)
+ARG_CONN_PORT = Arg(
+    ("--conn-port",), help="Connection port between 1 and 65535, optional when adding a connection", type=int
+)
 ARG_CONN_EXTRA = Arg(
     ("--conn-extra",), help="Connection `Extra` field, optional when adding a connection", type=str
 )

--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -340,27 +340,30 @@ def connections_add(args):
                 f"the --conn-{'uri' if has_uri else 'json'} flag: {invalid_args!r}"
             )
 
-    if args.conn_uri:
-        new_conn = Connection(conn_id=args.conn_id, description=args.conn_description, uri=args.conn_uri)
-        if args.conn_extra is not None:
-            new_conn.set_extra(args.conn_extra)
-    elif args.conn_json:
-        new_conn = Connection.from_json(conn_id=args.conn_id, value=args.conn_json)
-        if not new_conn.conn_type:
-            raise SystemExit("conn-json is invalid; must supply conn-type")
-    else:
-        new_conn = Connection(
-            conn_id=args.conn_id,
-            conn_type=args.conn_type,
-            description=args.conn_description,
-            host=args.conn_host,
-            login=args.conn_login,
-            password=args.conn_password,
-            schema=args.conn_schema,
-            port=args.conn_port,
-        )
-        if args.conn_extra is not None:
-            new_conn.set_extra(args.conn_extra)
+    try:
+        if args.conn_uri:
+            new_conn = Connection(conn_id=args.conn_id, description=args.conn_description, uri=args.conn_uri)
+            if args.conn_extra is not None:
+                new_conn.set_extra(args.conn_extra)
+        elif args.conn_json:
+            new_conn = Connection.from_json(conn_id=args.conn_id, value=args.conn_json)
+            if not new_conn.conn_type:
+                raise SystemExit("conn-json is invalid; must supply conn-type")
+        else:
+            new_conn = Connection(
+                conn_id=args.conn_id,
+                conn_type=args.conn_type,
+                description=args.conn_description,
+                host=args.conn_host,
+                login=args.conn_login,
+                password=args.conn_password,
+                schema=args.conn_schema,
+                port=args.conn_port,
+            )
+            if args.conn_extra is not None:
+                new_conn.set_extra(args.conn_extra)
+    except ValueError as e:
+        raise SystemExit(f"Could not create connection. {e}") from e
 
     with create_session() as session:
         if not session.scalar(select(Connection).where(Connection.conn_id == new_conn.conn_id).limit(1)):
@@ -420,7 +423,10 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
 
     :param overwrite: Whether to skip or overwrite on collision.
     """
-    connections_dict = load_connections_dict(file_path)
+    try:
+        connections_dict = load_connections_dict(file_path)
+    except ValueError as e:
+        raise SystemExit(f"Could not import connections. {e}") from e
     with create_session() as session:
         for conn_id, conn in connections_dict.items():
             try:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -224,18 +224,22 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
 
     @staticmethod
     def _coerce_port(port: int | str | None) -> int | None:
-        if port is None:
-            return None
-        if isinstance(port, bool):
-            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
-        if isinstance(port, int):
-            return port
-        if isinstance(port, str):
-            try:
-                return int(port)
-            except ValueError:
-                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
-        raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+        match port:
+            case None:
+                return None
+            case bool():
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+            case int():
+                return port
+            case str():
+                try:
+                    return int(port)
+                except ValueError:
+                    raise ValueError(
+                        f"Expected integer value for `port`, but got {port!r} instead."
+                    ) from None
+            case _:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
 
     @classmethod
     def _normalize_port(cls, port: int | str | None) -> int | None:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -62,6 +62,8 @@ log = logging.getLogger(__name__)
 RE_SANITIZE_CONN_ID = re.compile(r"^[\w#!()\-.:/\\]{1,}$")
 # the conn ID max len should be 250
 CONN_ID_MAX_LEN: int = 250
+_MIN_PORT = 1
+_MAX_PORT = 65535
 
 
 def sanitize_conn_id(conn_id: str | None, max_length=CONN_ID_MAX_LEN) -> str | None:
@@ -166,6 +168,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         extra: str | dict | None = None,
         uri: str | None = None,
         team_name: str | None = None,
+        _validate_port: bool = True,
     ):
         super().__init__()
         self.description = description
@@ -178,7 +181,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
                 "You can't mix these two ways to create this object."
             )
         if uri:
-            self._parse_from_uri(uri)
+            self._parse_from_uri(uri, validate_port=_validate_port)
         else:
             if conn_type is not None:
                 self.conn_type = conn_type
@@ -187,7 +190,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             self.login = login
             self.password = password
             self.schema = schema
-            self.port = port
+            self.port = self._normalize_port(port) if _validate_port else self._coerce_port(port)
             self.extra = extra
 
         if conn_id is not None:
@@ -219,6 +222,32 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             raise ValueError(f"Encountered non-JSON in `extra` field for connection {conn_id!r}.")
         return None
 
+    @staticmethod
+    def _coerce_port(port: int | str | None) -> int | None:
+        if port is None:
+            return None
+        if isinstance(port, bool):
+            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+        if isinstance(port, int):
+            return port
+        if isinstance(port, str):
+            try:
+                return int(port)
+            except ValueError:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
+        raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+
+    @classmethod
+    def _normalize_port(cls, port: int | str | None) -> int | None:
+        normalized_port = cls._coerce_port(port)
+        if normalized_port is None:
+            return None
+        if not _MIN_PORT <= normalized_port <= _MAX_PORT:
+            raise ValueError(
+                f"Connection port must be between {_MIN_PORT} and {_MAX_PORT}, got {normalized_port}."
+            )
+        return normalized_port
+
     @reconstructor
     def on_db_load(self):
         if self.password:
@@ -233,7 +262,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             conn_type = conn_type.replace("-", "_")
         return conn_type
 
-    def _parse_from_uri(self, uri: str):
+    def _parse_from_uri(self, uri: str, validate_port: bool = True):
         schemes_count_in_uri = uri.count("://")
         if schemes_count_in_uri > 2:
             raise AirflowException("Invalid connection string.")
@@ -256,7 +285,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         self.schema = unquote(quoted_schema) if quoted_schema else quoted_schema
         self.login = unquote(uri_parts.username) if uri_parts.username else uri_parts.username
         self.password = unquote(uri_parts.password) if uri_parts.password else uri_parts.password
-        self.port = uri_parts.port
+        self.port = self._normalize_port(uri_parts.port) if validate_port else uri_parts.port
         if uri_parts.query:
             query = dict(parse_qsl(uri_parts.query, keep_blank_values=True))
             if self.EXTRA_KEY in query:
@@ -511,7 +540,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         # enabled only if SecretCache.init() has been called first
         try:
             uri = SecretCache.get_connection_uri(conn_id, team_name=team_name)
-            return Connection(conn_id=conn_id, uri=uri)
+            return Connection(conn_id=conn_id, uri=uri, _validate_port=False)
         except SecretCache.NotPresentException:
             pass  # continue business
 
@@ -565,7 +594,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         return conn
 
     @classmethod
-    def from_json(cls, value, conn_id=None) -> Connection:
+    def from_json(cls, value, conn_id=None, validate_port: bool = True) -> Connection:
         if hasattr(sys.modules.get("airflow.sdk.execution_time.task_runner"), "SUPERVISOR_COMMS"):
             from airflow.sdk import Connection as TaskSDKConnection
 
@@ -576,7 +605,9 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
                 stacklevel=1,
             )
 
-            return TaskSDKConnection.from_json(value, conn_id=conn_id)  # type: ignore[return-value]
+            return TaskSDKConnection.from_json(  # type: ignore[return-value]
+                value, conn_id=conn_id, validate_port=validate_port
+            )
 
         kwargs = json.loads(value)
         extra = kwargs.pop("extra", None)
@@ -585,13 +616,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         conn_type = kwargs.pop("conn_type", None)
         if conn_type:
             kwargs["conn_type"] = cls._normalize_conn_type(conn_type)
-        port = kwargs.pop("port", None)
-        if port:
-            try:
-                kwargs["port"] = int(port)
-            except ValueError:
-                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
-        return Connection(conn_id=conn_id, **kwargs)
+        return Connection(conn_id=conn_id, **kwargs, _validate_port=validate_port)
 
     def as_json(self) -> str:
         """Convert Connection to JSON-string object."""

--- a/airflow-core/src/airflow/secrets/local_filesystem.py
+++ b/airflow-core/src/airflow/secrets/local_filesystem.py
@@ -193,12 +193,12 @@ def _parse_secret_file(file_path: str) -> dict[str, Any]:
     return secrets
 
 
-def _create_connection(conn_id: str, value: Any):
+def _create_connection(conn_id: str, value: Any, validate_port: bool = True):
     """Create a connection based on a URL or JSON object."""
     from airflow.models.connection import Connection
 
     if isinstance(value, str):
-        return Connection(conn_id=conn_id, uri=value)
+        return Connection(conn_id=conn_id, uri=value, _validate_port=validate_port)
     if isinstance(value, dict):
         connection_parameter_names = get_connection_parameter_names() | {"extra_dejson"}
         current_keys = set(value.keys())
@@ -225,7 +225,7 @@ def _create_connection(conn_id: str, value: Any):
                 f"The item has the value: {conn_id}."
             )
         value["conn_id"] = conn_id
-        return Connection(**value)
+        return Connection(**value, _validate_port=validate_port)
     raise AirflowException(
         f"Unexpected value type: {type(value)}. The connection can only be defined using a string or object."
     )
@@ -260,12 +260,15 @@ def load_variables(file_path: str) -> dict[str, Any]:
     return variables
 
 
-def load_connections_dict(file_path: str) -> dict[str, Any]:
+def load_connections_dict(file_path: str, validate_port: bool = True) -> dict[str, Any]:
     """
     Load connection from text file.
 
     ``JSON``, `YAML` and ``.env`` files are supported.
 
+    :param validate_port: When ``False``, skip port range validation so that connection
+        files written before validation existed can still be read by the secrets backend.
+        Creation paths (e.g. ``airflow connections import``) keep the default ``True``.
     :return: A dictionary where the key contains a connection ID and the value contains the connection.
     """
     log.debug("Loading connection")
@@ -278,9 +281,9 @@ def load_connections_dict(file_path: str) -> dict[str, Any]:
                 raise ConnectionNotUnique(f"Found multiple values for {key} in {file_path}.")
 
             for secret_value in secret_values:
-                connection_by_conn_id[key] = _create_connection(key, secret_value)
+                connection_by_conn_id[key] = _create_connection(key, secret_value, validate_port)
         else:
-            connection_by_conn_id[key] = _create_connection(key, secret_values)
+            connection_by_conn_id[key] = _create_connection(key, secret_values, validate_port)
 
     num_conn = len(connection_by_conn_id)
     log.debug("Loaded %d connections", num_conn)
@@ -344,7 +347,7 @@ class LocalFilesystemBackend(BaseSecretsBackend, LoggingMixin):
             self.log.debug("The file for connection is not specified. Skipping")
             # The user may not specify any file.
             return {}
-        return load_connections_dict(self.connections_file)
+        return load_connections_dict(self.connections_file, validate_port=False)
 
     @property
     def _local_configs(self) -> dict[str, str]:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2297,7 +2297,9 @@ export const $ConnectionBody = {
         port: {
             anyOf: [
                 {
-                    type: 'integer'
+                    type: 'integer',
+                    maximum: 65535,
+                    minimum: 1
                 },
                 {
                     type: 'null'
@@ -2552,7 +2554,9 @@ export const $ConnectionTestRequestBody = {
         port: {
             anyOf: [
                 {
-                    type: 'integer'
+                    type: 'integer',
+                    maximum: 65535,
+                    minimum: 1
                 },
                 {
                     type: 'null'

--- a/airflow-core/tests/unit/always/test_secrets_backends.py
+++ b/airflow-core/tests/unit/always/test_secrets_backends.py
@@ -74,6 +74,22 @@ class TestBaseSecretsBackend:
         # we could make this more precise by defining __eq__ method for Connection
         assert sample_conn_1.host.lower() == conn.host
 
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "AIRFLOW_CONN_LEGACY_URI_PORT": "mysql://host:0/",
+            "AIRFLOW_CONN_LEGACY_JSON_PORT": '{"conn_type": "mysql", "host": "host", "port": 0}',
+        },
+    )
+    @pytest.mark.parametrize("conn_id", ["legacy_uri_port", "legacy_json_port"])
+    def test_connection_env_secrets_backend_allows_legacy_invalid_port(self, conn_id):
+        env_secrets_backend = EnvironmentVariablesBackend()
+        env_secrets_backend._set_connection_class(Connection)
+
+        conn = env_secrets_backend.get_connection(conn_id)
+
+        assert conn.port == 0
+
     def test_connection_metastore_secrets_backend(self):
         sample_conn_2 = SampleConn("sample_2", "A")
         with create_session() as session:

--- a/airflow-core/tests/unit/always/test_secrets_backends.py
+++ b/airflow-core/tests/unit/always/test_secrets_backends.py
@@ -74,22 +74,6 @@ class TestBaseSecretsBackend:
         # we could make this more precise by defining __eq__ method for Connection
         assert sample_conn_1.host.lower() == conn.host
 
-    @mock.patch.dict(
-        "os.environ",
-        {
-            "AIRFLOW_CONN_LEGACY_URI_PORT": "mysql://host:0/",
-            "AIRFLOW_CONN_LEGACY_JSON_PORT": '{"conn_type": "mysql", "host": "host", "port": 0}',
-        },
-    )
-    @pytest.mark.parametrize("conn_id", ["legacy_uri_port", "legacy_json_port"])
-    def test_connection_env_secrets_backend_allows_legacy_invalid_port(self, conn_id):
-        env_secrets_backend = EnvironmentVariablesBackend()
-        env_secrets_backend._set_connection_class(Connection)
-
-        conn = env_secrets_backend.get_connection(conn_id)
-
-        assert conn.port == 0
-
     def test_connection_metastore_secrets_backend(self):
         sample_conn_2 = SampleConn("sample_2", "A")
         with create_session() as session:

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -247,35 +247,6 @@ class TestLoadConnection:
             assert expected_connection_uris == connection_uris_by_conn_id
 
     @pytest.mark.parametrize(
-        "file_content",
-        [
-            "CONN_ID=mysql://host_1:0/",
-            {"CONN_ID": {"conn_type": "mysql", "host": "host_1", "port": 0}},
-        ],
-    )
-    def test_should_load_connection_with_legacy_invalid_port(self, file_content):
-        suffix = "env" if isinstance(file_content, str) else "json"
-        with mock_local_file(file_content if isinstance(file_content, str) else json.dumps(file_content)):
-            connections_by_conn_id = local_filesystem.load_connections_dict(
-                f"a.{suffix}", validate_port=False
-            )
-
-            assert connections_by_conn_id["CONN_ID"].port == 0
-
-    @pytest.mark.parametrize(
-        "file_content",
-        [
-            "CONN_ID=mysql://host_1:0/",
-            {"CONN_ID": {"conn_type": "mysql", "host": "host_1", "port": 0}},
-        ],
-    )
-    def test_load_connections_dict_validates_port_by_default(self, file_content):
-        suffix = "env" if isinstance(file_content, str) else "json"
-        with mock_local_file(file_content if isinstance(file_content, str) else json.dumps(file_content)):
-            with pytest.raises(ValueError, match="between 1 and 65535"):
-                local_filesystem.load_connections_dict(f"a.{suffix}")
-
-    @pytest.mark.parametrize(
         ("file_content", "expected_connection_uris"),
         [
             ({"CONN_ID": None}, "Unexpected value type: <class 'NoneType'>."),
@@ -584,12 +555,6 @@ class TestLocalFileBackend:
         backend = LocalFilesystemBackend(connections_file_path=os.fspath(path))
         assert backend.get_connection("CONN_A").get_uri() == "mysql://host_a"
         assert backend.get_variable("CONN_B") is None
-
-    def test_should_read_connection_with_legacy_invalid_port(self, tmp_path):
-        path = tmp_path / "testfile.env"
-        path.write_text("CONN_A=mysql://host_a:0/")
-        backend = LocalFilesystemBackend(connections_file_path=os.fspath(path))
-        assert backend.get_connection("CONN_A").port == 0
 
     def test_files_are_optional(self):
         backend = LocalFilesystemBackend()

--- a/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
+++ b/airflow-core/tests/unit/always/test_secrets_local_filesystem.py
@@ -247,6 +247,35 @@ class TestLoadConnection:
             assert expected_connection_uris == connection_uris_by_conn_id
 
     @pytest.mark.parametrize(
+        "file_content",
+        [
+            "CONN_ID=mysql://host_1:0/",
+            {"CONN_ID": {"conn_type": "mysql", "host": "host_1", "port": 0}},
+        ],
+    )
+    def test_should_load_connection_with_legacy_invalid_port(self, file_content):
+        suffix = "env" if isinstance(file_content, str) else "json"
+        with mock_local_file(file_content if isinstance(file_content, str) else json.dumps(file_content)):
+            connections_by_conn_id = local_filesystem.load_connections_dict(
+                f"a.{suffix}", validate_port=False
+            )
+
+            assert connections_by_conn_id["CONN_ID"].port == 0
+
+    @pytest.mark.parametrize(
+        "file_content",
+        [
+            "CONN_ID=mysql://host_1:0/",
+            {"CONN_ID": {"conn_type": "mysql", "host": "host_1", "port": 0}},
+        ],
+    )
+    def test_load_connections_dict_validates_port_by_default(self, file_content):
+        suffix = "env" if isinstance(file_content, str) else "json"
+        with mock_local_file(file_content if isinstance(file_content, str) else json.dumps(file_content)):
+            with pytest.raises(ValueError, match="between 1 and 65535"):
+                local_filesystem.load_connections_dict(f"a.{suffix}")
+
+    @pytest.mark.parametrize(
         ("file_content", "expected_connection_uris"),
         [
             ({"CONN_ID": None}, "Unexpected value type: <class 'NoneType'>."),
@@ -555,6 +584,12 @@ class TestLocalFileBackend:
         backend = LocalFilesystemBackend(connections_file_path=os.fspath(path))
         assert backend.get_connection("CONN_A").get_uri() == "mysql://host_a"
         assert backend.get_variable("CONN_B") is None
+
+    def test_should_read_connection_with_legacy_invalid_port(self, tmp_path):
+        path = tmp_path / "testfile.env"
+        path.write_text("CONN_A=mysql://host_a:0/")
+        backend = LocalFilesystemBackend(connections_file_path=os.fspath(path))
+        assert backend.get_connection("CONN_A").port == 0
 
     def test_files_are_optional(self):
         backend = LocalFilesystemBackend()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -153,6 +153,17 @@ class TestGetConnection(TestConnectionEndpoint):
         assert body["conn_type"] == TEST_CONN_TYPE
         assert body["team_name"] == testing_team.name
 
+    def test_get_should_return_existing_connection_with_invalid_port(self, test_client, session):
+        session.execute(
+            Connection.__table__.insert().values(conn_id=TEST_CONN_ID, conn_type=TEST_CONN_TYPE, port=0)
+        )
+        session.commit()
+
+        response = test_client.get(f"/connections/{TEST_CONN_ID}")
+
+        assert response.status_code == 200
+        assert response.json()["port"] == 0
+
     def test_should_respond_401(self, unauthenticated_test_client):
         response = unauthenticated_test_client.get(f"/connections/{TEST_CONN_ID}")
         assert response.status_code == 401
@@ -367,6 +378,15 @@ class TestPostConnection(TestConnectionEndpoint):
                 }
             ]
         }
+
+    @pytest.mark.parametrize("port", [-1, 0, 65536])
+    def test_post_should_respond_422_for_invalid_port(self, test_client, port):
+        response = test_client.post(
+            "/connections",
+            json={"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "port": port},
+        )
+
+        assert response.status_code == 422
 
     @conf_vars({("core", "multi_team"): "False"})
     def test_post_rejects_team_name_when_multi_team_disabled(self, test_client):
@@ -647,6 +667,17 @@ class TestPatchConnection(TestConnectionEndpoint):
         _check_last_log(session, dag_id=None, event="patch_connection", logical_date=None)
 
         assert response.json() == expected_result
+
+    @pytest.mark.parametrize("port", [-1, 0, 65536])
+    def test_patch_should_respond_422_for_invalid_port(self, test_client, port):
+        self.create_connection()
+
+        response = test_client.patch(
+            f"/connections/{TEST_CONN_ID}",
+            json={"connection_id": TEST_CONN_ID, "conn_type": TEST_CONN_TYPE, "port": port},
+        )
+
+        assert response.status_code == 422
 
     @conf_vars({("core", "multi_team"): "True"})
     def test_patch_with_team_should_respond_200(self, test_client, testing_team, session):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -154,9 +154,7 @@ class TestGetConnection(TestConnectionEndpoint):
         assert body["team_name"] == testing_team.name
 
     def test_get_should_return_existing_connection_with_invalid_port(self, test_client, session):
-        session.execute(
-            Connection.__table__.insert().values(conn_id=TEST_CONN_ID, conn_type=TEST_CONN_TYPE, port=0)
-        )
+        session.add(Connection(conn_id=TEST_CONN_ID, conn_type=TEST_CONN_TYPE, port=0, _validate_port=False))
         session.commit()
 
         response = test_client.get(f"/connections/{TEST_CONN_ID}")

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -721,6 +721,21 @@ class TestCliAddConnections:
                 self.parser.parse_args(["connections", "add", conn_id, f"--conn-uri={TEST_URL}"])
             )
 
+    def test_cli_connections_add_rejects_non_integer_port(self):
+        with pytest.raises(SystemExit):
+            self.parser.parse_args(
+                ["connections", "add", "new1", "--conn-type=postgres", "--conn-port=not-a-port"]
+            )
+
+    @pytest.mark.parametrize("port", ["-1", "0", "65536"])
+    def test_cli_connections_add_rejects_invalid_port(self, port):
+        with pytest.raises(SystemExit, match="Connection port must be between 1 and 65535"):
+            connection_command.connections_add(
+                self.parser.parse_args(
+                    ["connections", "add", "new1", "--conn-type=postgres", f"--conn-port={port}"]
+                )
+            )
+
     def test_cli_connections_add_delete_with_missing_parameters(self):
         # Attempt to add without providing conn_uri
         with pytest.raises(
@@ -848,6 +863,17 @@ class TestCliImportConnections:
             ),
         ):
             connection_command.connections_import(self.parser.parse_args(["connections", "import", filepath]))
+
+    def test_cli_connections_import_rejects_invalid_port(self, mocker):
+        mocker.patch(
+            "airflow.secrets.local_filesystem._parse_secret_file",
+            return_value={"new0": {"conn_type": "postgres", "host": "host", "port": 0}},
+        )
+        mocker.patch("os.path.exists", return_value=True)
+        with pytest.raises(SystemExit, match="Connection port must be between 1 and 65535"):
+            connection_command.connections_import(
+                self.parser.parse_args(["connections", "import", "sample.json"])
+            )
 
     def test_cli_connections_import_should_load_connections(self, mocker):
         # Sample connections to import

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -243,10 +243,6 @@ class TestConnection:
         with pytest.raises(ValueError, match="port"):
             Connection(conn_id="test_conn", conn_type="test", port=port)
 
-    def test_parse_from_uri_rejects_port_zero(self):
-        with pytest.raises(ValueError, match="between 1 and 65535"):
-            Connection(conn_id="test_conn", uri="type://host:0/schema")
-
     def test_validate_port_false_allows_legacy_port(self):
         from_uri = Connection(conn_id="test_conn", uri="type://host:0/schema", _validate_port=False)
         from_values = Connection(conn_id="test_conn", conn_type="test", port=0, _validate_port=False)
@@ -597,9 +593,7 @@ class TestConnection:
     @pytest.mark.db_test
     def test_existing_connection_with_invalid_port_can_be_loaded(self, session: Session):
         clear_db_connections()
-        session.execute(
-            Connection.__table__.insert().values(conn_id="legacy_invalid_port", conn_type="test", port=0)
-        )
+        session.add(Connection(conn_id="legacy_invalid_port", conn_type="test", port=0, _validate_port=False))
         session.flush()
 
         connection = session.scalar(select(Connection).where(Connection.conn_id == "legacy_invalid_port"))

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -17,12 +17,14 @@
 # under the License.
 from __future__ import annotations
 
+import json
 import re
 import sys
 from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
+from sqlalchemy import select
 from structlog.testing import capture_logs
 
 from airflow.exceptions import AirflowException, AirflowNotFoundException
@@ -220,6 +222,57 @@ class TestConnection:
             assert conn.port == expected_port
             assert conn.schema == expected_schema
             assert conn.extra_dejson == expected_extra_dict
+
+    @pytest.mark.parametrize(
+        ("port", "expected_port"),
+        [
+            (None, None),
+            (1, 1),
+            ("1", 1),
+            (65535, 65535),
+            ("65535", 65535),
+        ],
+    )
+    def test_connection_accepts_valid_ports(self, port, expected_port):
+        connection = Connection(conn_id="test_conn", conn_type="test", port=port)
+
+        assert connection.port == expected_port
+
+    @pytest.mark.parametrize("port", [-1, 0, 65536, "0", "65536", "not-a-port", True])
+    def test_connection_rejects_invalid_ports(self, port):
+        with pytest.raises(ValueError, match="port"):
+            Connection(conn_id="test_conn", conn_type="test", port=port)
+
+    def test_parse_from_uri_rejects_port_zero(self):
+        with pytest.raises(ValueError, match="between 1 and 65535"):
+            Connection(conn_id="test_conn", uri="type://host:0/schema")
+
+    def test_validate_port_false_allows_legacy_port(self):
+        from_uri = Connection(conn_id="test_conn", uri="type://host:0/schema", _validate_port=False)
+        from_values = Connection(conn_id="test_conn", conn_type="test", port=0, _validate_port=False)
+
+        assert from_uri.port == 0
+        assert from_values.port == 0
+
+    @pytest.mark.parametrize("port", [0, "0", 65536, "65536"])
+    def test_from_json_rejects_invalid_ports(self, port):
+        json_data = {
+            "conn_type": "postgresql",
+            "host": "localhost",
+            "port": port,
+        }
+
+        with pytest.raises(ValueError, match="port"):
+            Connection.from_json(json.dumps(json_data), conn_id="test_conn")
+
+    def test_from_json_validate_port_false_allows_legacy_port(self):
+        connection = Connection.from_json(
+            json.dumps({"conn_type": "postgresql", "host": "localhost", "port": 0}),
+            conn_id="test_conn",
+            validate_port=False,
+        )
+
+        assert connection.port == 0
 
     @pytest.mark.parametrize(
         ("connection", "expected_uri"),
@@ -539,4 +592,19 @@ class TestConnection:
             "test_conn1": "testing",
             "test_conn2": None,
         }
+        clear_db_connections()
+
+    @pytest.mark.db_test
+    def test_existing_connection_with_invalid_port_can_be_loaded(self, session: Session):
+        clear_db_connections()
+        session.execute(
+            Connection.__table__.insert().values(conn_id="legacy_invalid_port", conn_type="test", port=0)
+        )
+        session.flush()
+
+        connection = session.scalar(select(Connection).where(Connection.conn_id == "legacy_invalid_port"))
+
+        assert connection is not None
+        assert connection.port == 0
+        assert connection.to_dict()["port"] == 0
         clear_db_connections()

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -331,6 +331,10 @@ class ConfigSection(BaseModel):
     options: Annotated[list[ConfigOption], Field(title="Options")]
 
 
+class Port(RootModel[int]):
+    root: Annotated[int, Field(ge=1, le=65535, title="Port")]
+
+
 class TeamName(RootModel[str]):
     root: Annotated[str, Field(max_length=50, title="Team Name")]
 
@@ -349,7 +353,7 @@ class ConnectionBody(BaseModel):
     host: Annotated[str | None, Field(title="Host")] = None
     login: Annotated[str | None, Field(title="Login")] = None
     schema_: Annotated[str | None, Field(alias="schema", title="Schema")] = None
-    port: Annotated[int | None, Field(title="Port")] = None
+    port: Annotated[Port | None, Field(title="Port")] = None
     password: Annotated[str | None, Field(title="Password")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
     team_name: Annotated[TeamName | None, Field(title="Team Name")] = None
@@ -400,7 +404,7 @@ class ConnectionTestRequestBody(BaseModel):
     host: Annotated[str | None, Field(title="Host")] = None
     login: Annotated[str | None, Field(title="Login")] = None
     schema_: Annotated[str | None, Field(alias="schema", title="Schema")] = None
-    port: Annotated[int | None, Field(title="Port")] = None
+    port: Annotated[Port | None, Field(title="Port")] = None
     password: Annotated[str | None, Field(title="Password")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
     team_name: Annotated[TeamName | None, Field(title="Team Name")] = None

--- a/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
+++ b/providers/apache/hive/tests/unit/apache/hive/hooks/test_hive.py
@@ -854,19 +854,23 @@ class TestHiveServer2Hook:
         ],
     )
     def test_get_conn_with_wrong_connection_parameters(self, host, port, schema, message):
-        connection = Connection(
-            conn_id="test",
-            conn_type="hive",
-            host=host,
-            port=port,
-            schema=schema,
-        )
-        hook = HiveCliHook()
-        if message:
-            with pytest.raises(Exception, match=message):
-                hook._validate_beeline_parameters(connection)
-        else:
+        def validate_connection():
+            connection = Connection(
+                conn_id="test",
+                conn_type="hive",
+                host=host,
+                port=10000,
+                schema=schema,
+            )
+            connection.port = port
+            hook = HiveCliHook()
             hook._validate_beeline_parameters(connection)
+
+        if message:
+            with pytest.raises(ValueError, match=message):
+                validate_connection()
+        else:
+            validate_connection()
 
     def test_get_records(self):
         hook = MockHiveServer2Hook()

--- a/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_cloud_sql.py
@@ -826,7 +826,7 @@ def _parse_from_uri(uri: str):
 def _connection_from_uri(uri: str):
     if AIRFLOW_V_3_1_PLUS:
         return Connection(conn_id="test_conn_id", **_parse_from_uri(uri))
-    return Connection(uri=uri)  # type: ignore[call-arg]
+    return Connection(conn_id="test_cloud_sql_conn", uri=uri)
 
 
 class TestCloudSqlDatabaseHook:

--- a/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
+++ b/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import inspect
 from abc import ABC
 from collections.abc import Callable
+from typing import Any
 
 
 def _accepts_team_name(method: Callable) -> bool:
@@ -119,15 +120,45 @@ class BaseSecretsBackend(ABC):
         return conn_class
 
     @staticmethod
-    def _deserialize_connection_value(conn_class: type, conn_id: str, value: str):
+    def _call_with_parameter_if_supported(
+        func: Callable, *, parameter_name: str, parameter_value: Any, **kwargs
+    ):
+        try:
+            has_parameter = parameter_name in inspect.signature(func).parameters
+        except (TypeError, ValueError):
+            has_parameter = False
+        if has_parameter:
+            kwargs[parameter_name] = parameter_value
+        return func(**kwargs)
+
+    @classmethod
+    def _deserialize_connection_value(cls, conn_class: type, conn_id: str, value: str):
         value = value.strip()
         if value[0] == "{":
-            return conn_class.from_json(value=value, conn_id=conn_id)  # type: ignore[attr-defined]
+            return cls._call_with_parameter_if_supported(
+                conn_class.from_json,  # type: ignore[attr-defined]
+                parameter_name="validate_port",
+                parameter_value=False,
+                value=value,
+                conn_id=conn_id,
+            )
 
         # TODO: Only sdk has from_uri defined on it. Is it worthwhile developing the core path or not?
         if hasattr(conn_class, "from_uri"):
-            return conn_class.from_uri(conn_id=conn_id, uri=value)
-        return conn_class(conn_id=conn_id, uri=value)
+            return cls._call_with_parameter_if_supported(
+                conn_class.from_uri,
+                parameter_name="validate_port",
+                parameter_value=False,
+                conn_id=conn_id,
+                uri=value,
+            )
+        return cls._call_with_parameter_if_supported(
+            conn_class,
+            parameter_name="_validate_port",
+            parameter_value=False,
+            conn_id=conn_id,
+            uri=value,
+        )
 
     def deserialize_connection(self, conn_id: str, value: str):
         """

--- a/shared/secrets_backend/tests/secrets_backend/test_base.py
+++ b/shared/secrets_backend/tests/secrets_backend/test_base.py
@@ -31,6 +31,26 @@ class MockConnection:
         self._kwargs = kwargs
 
     @classmethod
+    def from_json(cls, value: str, conn_id: str, validate_port: bool = True):
+        import json
+
+        data = json.loads(value)
+        return cls(conn_id=conn_id, validate_port=validate_port, **data)
+
+    @classmethod
+    def from_uri(cls, conn_id: str, uri: str, validate_port: bool = True):
+        return cls(conn_id=conn_id, uri=uri, validate_port=validate_port)
+
+
+class MockConnectionWithoutValidationParameter:
+    """Mock Connection class that simulates older deserialization signatures."""
+
+    def __init__(self, conn_id: str, uri: str | None = None, **kwargs):
+        self.conn_id = conn_id
+        self.uri = uri
+        self._kwargs = kwargs
+
+    @classmethod
     def from_json(cls, value: str, conn_id: str):
         import json
 
@@ -123,6 +143,7 @@ class TestBaseSecretsBackend:
         assert isinstance(conn, MockConnection)
         assert conn.conn_id == "test_conn"
         assert conn._kwargs["conn_type"] == "mysql"
+        assert conn._kwargs["validate_port"] is False
 
     def test_deserialize_connection_uri(self, sample_conn_uri):
         """Test deserialize_connection with URI format through _TestBackend."""
@@ -133,6 +154,27 @@ class TestBaseSecretsBackend:
         assert isinstance(conn, MockConnection)
         assert conn.conn_id == "test_conn"
         assert conn.uri == sample_conn_uri
+        assert conn._kwargs["validate_port"] is False
+
+    def test_deserialize_connection_json_without_validate_port_parameter(self, sample_conn_json):
+        backend = _TestBackend()
+        backend._set_connection_class(MockConnectionWithoutValidationParameter)
+
+        conn = backend.deserialize_connection("test_conn", sample_conn_json)
+
+        assert isinstance(conn, MockConnectionWithoutValidationParameter)
+        assert conn._kwargs["conn_type"] == "mysql"
+        assert "validate_port" not in conn._kwargs
+
+    def test_deserialize_connection_uri_without_validate_port_parameter(self, sample_conn_uri):
+        backend = _TestBackend()
+        backend._set_connection_class(MockConnectionWithoutValidationParameter)
+
+        conn = backend.deserialize_connection("test_conn", sample_conn_uri)
+
+        assert isinstance(conn, MockConnectionWithoutValidationParameter)
+        assert conn.uri == sample_conn_uri
+        assert "validate_port" not in conn._kwargs
 
 
 class _LegacyConnValueBackend(BaseSecretsBackend):

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -29,6 +29,8 @@ from airflow.sdk.exceptions import AirflowException, AirflowNotFoundException, A
 from airflow.sdk.providers_manager_runtime import ProvidersManagerTaskRuntime
 
 log = logging.getLogger(__name__)
+_MIN_PORT = 1
+_MAX_PORT = 65535
 
 
 def _parse_netloc_to_hostname(uri_parts):
@@ -49,6 +51,32 @@ def _parse_netloc_to_hostname(uri_parts):
             hostname = hostname.split(":", 1)[0]
         hostname = unquote(hostname)
     return hostname
+
+
+def _coerce_port(port: int | str | None) -> int | None:
+    if port is None:
+        return None
+    if isinstance(port, bool):
+        raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+    if isinstance(port, int):
+        return port
+    if isinstance(port, str):
+        try:
+            return int(port)
+        except ValueError:
+            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
+    raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+
+
+def _normalize_port(port: int | str | None) -> int | None:
+    normalized_port = _coerce_port(port)
+    if normalized_port is None:
+        return None
+    if not _MIN_PORT <= normalized_port <= _MAX_PORT:
+        raise ValueError(
+            f"Connection port must be between {_MIN_PORT} and {_MAX_PORT}, got {normalized_port}."
+        )
+    return normalized_port
 
 
 def _prune_dict(val: Any, mode="strict"):
@@ -93,7 +121,7 @@ def _prune_dict(val: Any, mode="strict"):
     return val
 
 
-@attrs.define(slots=False)
+@attrs.define(slots=False, init=False)
 class Connection:
     """
     A connection to an external data source.
@@ -124,7 +152,7 @@ class Connection:
     EXTRA_KEY = "__extra__"
 
     @overload
-    def __init__(self, *, conn_id: str, uri: str) -> None: ...
+    def __init__(self, *, conn_id: str, uri: str, _validate_port: bool = True) -> None: ...
 
     @overload
     def __init__(
@@ -139,9 +167,12 @@ class Connection:
         password: str | None = None,
         port: int | None = None,
         extra: str | None = None,
+        _validate_port: bool = True,
     ) -> None: ...
 
-    def __init__(self, *, conn_id: str, uri: str | None = None, **kwargs) -> None:
+    def __init__(
+        self, *, conn_id: str, uri: str | None = None, _validate_port: bool = True, **kwargs
+    ) -> None:
         if uri is not None and kwargs:
             raise AirflowException(
                 "You must create an object using the URI or individual values "
@@ -149,9 +180,15 @@ class Connection:
                 "You can't mix these two ways to create this object."
             )
         if uri is None:
+            if "port" in kwargs:
+                kwargs["port"] = (
+                    _normalize_port(kwargs["port"]) if _validate_port else _coerce_port(kwargs["port"])
+                )
             self.__attrs_init__(conn_id=conn_id, **kwargs)  # type: ignore[attr-defined]
         else:
-            self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
+            self.__dict__.update(
+                attrs.asdict(self.from_uri(uri, conn_id=conn_id, validate_port=_validate_port), recurse=False)
+            )
 
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""
@@ -346,7 +383,7 @@ class Connection:
         return conn
 
     @classmethod
-    def from_json(cls, value, conn_id=None) -> Connection:
+    def from_json(cls, value, conn_id=None, validate_port: bool = True) -> Connection:
         kwargs = json.loads(value)
         extra = kwargs.pop("extra", None)
         if extra:
@@ -354,13 +391,7 @@ class Connection:
         conn_type = kwargs.pop("conn_type", None)
         if conn_type:
             kwargs["conn_type"] = cls._normalize_conn_type(conn_type)
-        port = kwargs.pop("port", None)
-        if port:
-            try:
-                kwargs["port"] = int(port)
-            except ValueError:
-                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
-        return cls(conn_id=conn_id, **kwargs)
+        return cls(conn_id=conn_id, **kwargs, _validate_port=validate_port)
 
     def as_json(self) -> str:
         """Convert Connection to JSON-string object."""
@@ -369,12 +400,15 @@ class Connection:
         return json.dumps(conn_repr)
 
     @classmethod
-    def from_uri(cls, uri: str, conn_id: str) -> Connection:
+    def from_uri(cls, uri: str, conn_id: str, validate_port: bool = True) -> Connection:
         """
         Create a Connection from a URI string.
 
         :param uri: URI string to parse
         :param conn_id: Connection ID to assign to the connection
+        :param validate_port: When ``False``, skip port range validation so that
+            connections already stored with a now-invalid port (e.g. in a secrets
+            backend) can still be read. Defaults to ``True`` for creation paths.
         :return: Connection object
         """
         schemes_count_in_uri = uri.count("://")
@@ -415,6 +449,7 @@ class Connection:
             password=password,
             port=port,
             extra=extra,
+            _validate_port=validate_port,
         )
 
     @staticmethod

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -54,18 +54,20 @@ def _parse_netloc_to_hostname(uri_parts):
 
 
 def _coerce_port(port: int | str | None) -> int | None:
-    if port is None:
-        return None
-    if isinstance(port, bool):
-        raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
-    if isinstance(port, int):
-        return port
-    if isinstance(port, str):
-        try:
-            return int(port)
-        except ValueError:
-            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
-    raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+    match port:
+        case None:
+            return None
+        case bool():
+            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+        case int():
+            return port
+        case str():
+            try:
+                return int(port)
+            except ValueError:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.") from None
+        case _:
+            raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
 
 
 def _normalize_port(port: int | str | None) -> int | None:

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -178,7 +178,7 @@ def _process_connection_result_conn(conn_result: ReceiveMsgType | None) -> Conne
         assert isinstance(conn_result, ConnectionResult)
 
     # `by_alias=True` is used to convert the `schema` field to `schema_` in the Connection model
-    return Connection(**conn_result.model_dump(exclude={"type"}, by_alias=True))
+    return Connection(**conn_result.model_dump(exclude={"type"}, by_alias=True), _validate_port=False)
 
 
 def _mask_connection_secrets(conn: Connection) -> None:
@@ -227,7 +227,7 @@ def _get_connection(conn_id: str) -> Connection:
         uri = SecretCache.get_connection_uri(conn_id)
         from airflow.sdk.definitions.connection import Connection
 
-        conn = Connection.from_uri(uri, conn_id=conn_id)
+        conn = Connection.from_uri(uri, conn_id=conn_id, validate_port=False)
         _mask_connection_secrets(conn)
         return conn
     except SecretCache.NotPresentException:
@@ -275,7 +275,7 @@ async def _async_get_connection(conn_id: str) -> Connection:
         uri = SecretCache.get_connection_uri(conn_id)
         from airflow.sdk.definitions.connection import Connection
 
-        conn = Connection.from_uri(uri, conn_id=conn_id)
+        conn = Connection.from_uri(uri, conn_id=conn_id, validate_port=False)
         await _amask_connection_secrets(conn)
         return conn
     except SecretCache.NotPresentException:

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1208,7 +1208,9 @@ def _fetch_remote_logging_conn(conn_id: str, client: Client) -> Connection | Non
         conn_result = ConnectionResult.from_conn_response(conn)
         from airflow.sdk.definitions.connection import Connection
 
-        result: Connection | None = Connection(**conn_result.model_dump(exclude={"type"}, by_alias=True))
+        result: Connection | None = Connection(
+            **conn_result.model_dump(exclude={"type"}, by_alias=True), _validate_port=False
+        )
         _REMOTE_LOGGING_CONN_CACHE[conn_id] = result
     else:
         result = None

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -122,6 +122,14 @@ class TestConnections:
             extra=None,
         )
 
+    def test_conn_get_allows_legacy_invalid_port(self, mock_supervisor_comms):
+        conn_result = ConnectionResult(conn_id="legacy_conn", conn_type="mysql", host="mysql", port=0)
+        mock_supervisor_comms.send.return_value = conn_result
+
+        conn = Connection.get(conn_id="legacy_conn")
+
+        assert conn.port == 0
+
     def test_conn_get_not_found(self, mock_supervisor_comms):
         error_response = ErrorResponse(error=ErrorType.CONNECTION_NOT_FOUND)
         mock_supervisor_comms.send.return_value = error_response
@@ -174,6 +182,26 @@ class TestConnections:
         assert result["host"] == "localhost"
         assert result["port"] == 5432
 
+    @pytest.mark.parametrize(
+        ("port", "expected_port"),
+        [
+            (None, None),
+            (1, 1),
+            ("1", 1),
+            (65535, 65535),
+            ("65535", 65535),
+        ],
+    )
+    def test_connection_accepts_valid_ports(self, port, expected_port):
+        connection = Connection(conn_id="test_conn", conn_type="test", port=port)
+
+        assert connection.port == expected_port
+
+    @pytest.mark.parametrize("port", [-1, 0, 65536, "0", "65536", "not-a-port", True])
+    def test_connection_rejects_invalid_ports(self, port):
+        with pytest.raises(ValueError, match="port"):
+            Connection(conn_id="test_conn", conn_type="test", port=port)
+
     def test_from_json(self):
         """Test that from_json creates Connection with type normalization."""
         json_data = {
@@ -188,6 +216,26 @@ class TestConnections:
         assert connection.conn_type == expected_id
         assert connection.host == "localhost"
         assert connection.port == 5432
+
+    @pytest.mark.parametrize("port", [0, "0", 65536, "65536"])
+    def test_from_json_rejects_invalid_ports(self, port):
+        json_data = {
+            "conn_type": "postgresql",
+            "host": "localhost",
+            "port": port,
+        }
+
+        with pytest.raises(ValueError, match="port"):
+            Connection.from_json(json.dumps(json_data), conn_id="test_conn")
+
+    def test_from_json_validate_port_false_allows_legacy_port(self):
+        connection = Connection.from_json(
+            json.dumps({"conn_type": "postgresql", "host": "localhost", "port": 0}),
+            conn_id="test_conn",
+            validate_port=False,
+        )
+
+        assert connection.port == 0
 
     def test_from_json_without_conn_type(self):
         """Test that from_json works without conn_type (backward compatibility with AF 2)."""
@@ -376,6 +424,20 @@ class TestConnectionFromUri:
         uri = "http://user@host://example.com"
         with pytest.raises(AirflowException, match="Invalid connection string"):
             Connection.from_uri(uri, conn_id="test_conn")
+
+    def test_from_uri_rejects_port_zero(self):
+        with pytest.raises(ValueError, match="between 1 and 65535"):
+            Connection.from_uri("type://host:0/schema", conn_id="test_conn")
+
+    def test_from_uri_validate_port_false_allows_legacy_port(self):
+        conn = Connection.from_uri("type://host:0/schema", conn_id="test_conn", validate_port=False)
+
+        assert conn.port == 0
+
+    def test_constructor_uri_validate_port_false_allows_legacy_port(self):
+        conn = Connection(conn_id="test_conn", uri="type://host:0/schema", _validate_port=False)
+
+        assert conn.port == 0
 
     def test_connection_constructor_with_uri(self):
         """Test Connection(uri=..., conn_id=...) constructor form."""

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -1160,7 +1160,29 @@ class TestSecretsBackend:
             assert conn is not None
             assert conn.conn_id == "test_conn"
             assert conn.host == "example.com"
+            assert conn.port == 443
             mock_supervisor_comms.send.assert_called_once()
+
+    def test_get_connection_allows_legacy_invalid_port(self, mock_supervisor_comms):
+        from airflow.sdk.api.datamodels._generated import ConnectionResponse
+        from airflow.sdk.execution_time.comms import ConnectionResult
+
+        conn_response = ConnectionResponse(
+            conn_id="test_conn",
+            conn_type="http",
+            host="example.com",
+            port=0,
+        )
+        mock_supervisor_comms.send.return_value = ConnectionResult.from_conn_response(conn_response)
+
+        supervisor_backend = ExecutionAPISecretsBackend()
+
+        with patch("airflow.sdk.execution_time.supervisor.ensure_secrets_backend_loaded") as mock_load:
+            mock_load.return_value = [supervisor_backend]
+
+            conn = _get_connection("test_conn")
+
+            assert conn.port == 0
 
     def test_get_connection_backend_fallback(self, mock_supervisor_comms):
         """Test that _get_connection falls through backends correctly."""

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3906,7 +3906,7 @@ def test_fetch_remote_logging_conn_does_not_cache_none_result(mocker):
             schema_=None,
             login=None,
             password=None,
-            port=None,
+            port=0,
             extra=None,
         ),
     ]
@@ -3917,6 +3917,7 @@ def test_fetch_remote_logging_conn_does_not_cache_none_result(mocker):
     second_call_result = supervisor._fetch_remote_logging_conn(conn_id, client)
     assert second_call_result is not None
     assert second_call_result.conn_id == conn_id
+    assert second_call_result.port == 0
     assert supervisor._REMOTE_LOGGING_CONN_CACHE[conn_id] is not None
     # The first call resulted in None and was not cached, so the second fetch calls the API again.
     assert client.connections.get.call_count == 2


### PR DESCRIPTION
closes: #68382

## What

Connection `port` accepted any integer, so values outside the valid TCP/UDP range: `0`, `-1`, `99999999` were silently persisted and only surfaced later as confusing failures deep inside provider hooks. This validates that `port` is within **1–65535** at every boundary where a connection is *created*, catching the problem at the source.



## Where Validation Is Enforced

- **REST API** — `ConnectionBody` now constrains `port` with `ge=1, le=65535`, so `POST`/`PATCH`/bulk and the connection-test endpoint return `422` for an out-of-range port. The generated OpenAPI spec is regenerated to match.
- **CLI** — `airflow connections add` (`--conn-port` is now typed, and range errors surface as a clean `SystemExit`) and `airflow connections import`.
- **Models** — `Connection(...)` / `Connection(uri=...)` and `Connection.from_json(...)` in core, plus `Connection(...)`, `Connection.from_uri(...)`, and `Connection.from_json(...)` in the Task SDK.

Port handling is split into `_coerce_port` (type coercion: `str` → `int`, reject `bool`/non-integer) and `_normalize_port` (coerce + range check), so the two concerns are explicit and reused consistently.

## Handling Existing Data

The change deliberately validates only on **create/write** and stays tolerant on **read**, so deployments with connections already storing a now-invalid port keep working:

- **No DB change** — no migration and no `CHECK` constraint, so existing rows are never re-validated.
- **Response schema unconstrained** — only the request model carries the range, so `GET` still serializes a legacy `port=0` connection.
- **Secrets backends read tolerantly** — the shared secrets-backend deserialization, `LocalFilesystemBackend`, the env-var backend, and the in-worker secret cache all pass `validate_port=False`, so a connection stored in Vault / AWS Secrets Manager / a local file / `AIRFLOW_CONN_*` with a legacy port still loads. A small signature-introspection shim keeps this compatible with older published Task SDK `Connection` classes that do not yet accept the flag.

Per review guidance, port `0` is rejected on creation, but tolerated when reading pre-existing data.

## Tests

Added coverage for valid/invalid ports across the model, Task SDK, REST API, and both CLI commands; for read-tolerance of legacy ports through the metadata DB, local-filesystem and env-var secrets backends, and the shared deserialization path; and for the cross-version shim.

Validation run locally:

- `uv run --project shared/secrets_backend pytest shared/secrets_backend/tests/secrets_backend/test_base.py -xvs`
- `uv run --project airflow-core pytest airflow-core/tests/unit/models/test_connection.py airflow-core/tests/unit/always/test_secrets_backends.py airflow-core/tests/unit/always/test_secrets_local_filesystem.py -xvs`
- `uv run --project airflow-core pytest airflow-core/tests/unit/cli/commands/test_connection_command.py -xvs`
- `uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py -xvs`
- `uv run --project task-sdk pytest task-sdk/tests/task_sdk/definitions/test_connection.py task-sdk/tests/task_sdk/execution_time/test_context.py::TestSecretsBackend::test_get_connection_allows_legacy_invalid_port task-sdk/tests/task_sdk/execution_time/test_context.py::TestSecretsBackend::test_get_connection_uses_backend_chain task-sdk/tests/task_sdk/execution_time/test_supervisor.py::test_fetch_remote_logging_conn_does_not_cache_none_result -xvs`
- `prek run ruff --from-ref upstream/main`
- `prek run ruff-format --from-ref upstream/main`
- `prek run mypy-shared-secrets_backend --all-files`
- `prek run ts-compile-lint-ui --from-ref upstream/main`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5.5)

<!-- pr-triage-fold: triaged=2026-07-02T17:46:42Z head=bb352fd action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Revanth14** · by `@potiuk` · 2026-07-02 17:46 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - This PR has **merge conflicts with `main`**. Please rebase onto the latest `main` and resolve them.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->