### PR TITLE
Render saved note indicator in Airflow 3 Grid View UI

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -19,11 +19,16 @@
 import { Badge, Box, Flex } from "@chakra-ui/react";
 import { Link, useLocation, useParams, useSearchParams } from "react-router-dom";
 
+import { useTaskInstanceServiceGetTaskInstance } from "openapi/queries";
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { StateIcon } from "src/components/StateIcon";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import { useHover } from "src/context/hover";
 import { buildTaskInstanceUrl } from "src/utils/links";
+
+// Render the lighter shade when there's a note
+const NOTE_GRADIENT =
+  "linear-gradient(45deg, var(--chakra-colors-color-palette-solid) 65%, var(--chakra-colors-color-palette-emphasized) 65%)";
 
 type Props = {
   readonly dagId: string;
@@ -40,6 +45,15 @@ export const GridTI = ({ dagId, instance, isGroup, isMapped, onClick, runId, tas
   const { hoveredTaskId, setHoveredTaskId } = useHover();
   const { groupId: selectedGroupId, taskId: selectedTaskId } = useParams();
   const location = useLocation();
+
+  // use this to pull the saved note
+  const { data: fullTaskInstance } = useTaskInstanceServiceGetTaskInstance({
+    dagId,
+    dagRunId: runId,
+    taskId,
+  });
+
+  const hasNote = Boolean(fullTaskInstance?.note);
 
   const [searchParams] = useSearchParams();
 
@@ -107,6 +121,7 @@ export const GridTI = ({ dagId, instance, isGroup, isMapped, onClick, runId, tas
               justifyContent="center"
               minH={0}
               p={0}
+              style={hasNote ? { background: NOTE_GRADIENT } : undefined}
               variant="solid"
               width="14px"
             >


### PR DESCRIPTION
Closes #68615 

Modified the `GridTI.tsx` file to render the task instance badge with a lighter shade to indicate a saved note similar to Airflow 2 UI.

Here's how it looks like in the Airflow 3 UI:

<img width="561" height="237" alt="image" src="https://github.com/user-attachments/assets/71b104f2-d07d-455f-9f2c-c90546d1bc56" />
<img width="604" height="223" alt="image" src="https://github.com/user-attachments/assets/051ea194-ce96-4b27-a215-51bdb3e2d4d1" />


Was generative AI tooling used to co-author this PR?

[X] Yes 

Used Claude to understand the task instance service code.