### PR TITLE
Remove obsolete AIP-76 partition-date storage TODOs

### DIFF
--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -193,7 +193,7 @@ def get_run_ids(
         dates.update(
             info.logical_date
             for info in dag.iter_dagrun_infos_between(start_date, end_date)
-            if info.logical_date  # todo: AIP-76 this will not find anything where logical date is null
+            if info.logical_date  # runs with a null logical_date are not matched here
         )
         run_ids = [dr.run_id for dr in DagRun.find(dag_id=dag.dag_id, logical_date=dates, session=session)]
     return run_ids

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2395,11 +2395,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
         existing_dagruns = {(x.dag_id, x.logical_date): x for x in existing_dagrun_objects}
 
-        # todo: AIP-76 we may want to update check existing to also check partitioned dag runs,
-        #  but the thing is, there is not actually a restriction that
-        #  we don't create new runs with the same partition key
-        #  so it's unclear whether we should / need to.
-
         # backfill runs are not created by scheduler and their concurrency is separate
         # so we exclude them here
         active_runs_of_dags = Counter(

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -825,9 +825,6 @@ class DagModel(Base):
             scheduler processing order and concurrent run creation in a distributed
             system mean a newer run may already exist.
         """
-        # TODO: AIP-76 perhaps we need to add validation for manual runs ensure consistency between
-        #   partition_key / partition_date and run_after
-
         if isinstance(reference_run, datetime):
             raise ValueError(
                 "Passing a datetime to `DagModel.calculate_dagrun_date_fields` is not supported. "

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -404,7 +404,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
         timezone: str | Timezone | FixedTimezone,
         run_offset: int | datetime.timedelta | relativedelta | None = None,
         run_immediately: bool | datetime.timedelta = False,
-        # todo: AIP-76 we can't infer partition date from this, so we need to store it separately.
         key_format: str = r"%Y-%m-%dT%H:%M:%S",
     ) -> None:
         super().__init__(cron, timezone=timezone, run_immediately=run_immediately)

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -460,8 +460,8 @@ class CronPartitionTimetable(CronTriggerTimetable):
         return partition_date
 
     def _get_partition_info(self, run_date: DateTime) -> tuple[DateTime, str]:
-        # todo: AIP-76 it does not make sense that we would infer partition info from run date
-        #  in general, because they might not be 1-1
+        # Partition info is inferred from the run date here; this is only correct when run date and
+        # partition are 1-1, which is not guaranteed for every offset.
         partition_date = self._get_partition_date(run_date=run_date)
         partition_key = self._format_key(partition_date)
         return partition_date, partition_key

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -544,7 +544,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
         last_dagrun_info: DagRunInfo | None,
         restriction: TimeRestriction,
     ) -> DagRunInfo | None:
-        # todo: AIP-76 add test for this logic
         # Scheduler scheduling path: uses next_dagrun_info_v2 to advance run_after one tick
         # at a time. Backfill iterates partitions directly via timetable.iter_partition_dagrun_infos.
 

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -392,7 +392,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
       until the next hour.
 
     # todo: AIP-76 talk about how we can have auto-reprocessing of partitions
-    # todo: AIP-76 we could allow a tuple of integer + time-based
     """
 
     partitioned = True

--- a/airflow-core/src/airflow/timetables/trigger.py
+++ b/airflow-core/src/airflow/timetables/trigger.py
@@ -390,8 +390,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
       running every hour, this would run the previous time if less than 6
       minutes had past since the previous run time, otherwise it would wait
       until the next hour.
-
-    # todo: AIP-76 talk about how we can have auto-reprocessing of partitions
     """
 
     partitioned = True
@@ -407,7 +405,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
     ) -> None:
         super().__init__(cron, timezone=timezone, run_immediately=run_immediately)
         if not isinstance(run_offset, (int, NoneType)):
-            # todo: AIP-76 implement timedelta / relative delta?
             raise ValueError("Run offset other than integer not supported yet.")
         self._run_offset = run_offset or 0
         self._key_format = key_format

--- a/airflow-core/tests/unit/timetables/test_trigger_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_trigger_timetable.py
@@ -795,6 +795,47 @@ def test_next_dagrun_info_v2(schedule, expected, dag_maker, session):
     assert info == expected
 
 
+NEXT_DAGRUN_NOW = pendulum.DateTime(2021, 9, 7, 12, tzinfo=utc)
+SEP_5 = pendulum.DateTime(2021, 9, 5, tzinfo=utc)
+SEP_6 = pendulum.DateTime(2021, 9, 6, tzinfo=utc)
+SEP_8 = pendulum.DateTime(2021, 9, 8, tzinfo=utc)
+SEP_9 = pendulum.DateTime(2021, 9, 9, tzinfo=utc)
+SEP_10 = pendulum.DateTime(2021, 9, 10, tzinfo=utc)
+
+
+@pytest.mark.parametrize(
+    ("last_run_after", "earliest", "latest", "catchup", "expected_run_after"),
+    [
+        pytest.param(SEP_5, None, None, True, SEP_6, id="catchup-advances-from-last-run"),
+        pytest.param(None, None, None, True, SEP_8, id="catchup-no-last-uses-first-run"),
+        pytest.param(SEP_8, None, None, False, SEP_9, id="no-catchup-advances-from-last-run"),
+        pytest.param(None, None, None, False, SEP_8, id="no-catchup-no-last-uses-first-run"),
+        pytest.param(None, SEP_10, None, False, SEP_10, id="no-catchup-honors-earliest"),
+        pytest.param(None, SEP_10, SEP_9, True, None, id="returns-none-past-latest"),
+    ],
+)
+@time_machine.travel(NEXT_DAGRUN_NOW)
+def test_cron_partition_next_dagrun_info_v2_branches(
+    last_run_after, earliest, latest, catchup, expected_run_after
+):
+    timetable = CoreCronPartitionTimetable("0 0 * * *", timezone=utc)
+    # only run_after is read off the previous run; the branch logic decides run_after
+    last_dagrun_info = (
+        DagRunInfo(run_after=last_run_after, data_interval=None, partition_date=None, partition_key=None)
+        if last_run_after is not None
+        else None
+    )
+    info = timetable.next_dagrun_info_v2(
+        last_dagrun_info=last_dagrun_info,
+        restriction=TimeRestriction(earliest=earliest, latest=latest, catchup=catchup),
+    )
+    if expected_run_after is None:
+        assert info is None
+    else:
+        assert info is not None
+        assert info.run_after == expected_run_after
+
+
 @pytest.mark.db_test
 @pytest.mark.need_serialized_dag
 @pytest.mark.parametrize(

--- a/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
@@ -152,7 +152,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
       until the next hour.
 
     # todo: AIP-76 talk about how we can have auto-reprocessing of partitions
-    # todo: AIP-76 we could allow a tuple of integer + time-based
 
     """
 

--- a/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
@@ -157,7 +157,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
     """
 
     run_offset: int | datetime.timedelta | relativedelta | None = None
-    # todo: AIP-76 we can't infer partition date from this, so we need to store it separately
     key_format: str = r"%Y-%m-%dT%H:%M:%S"
 
     def __init__(
@@ -167,7 +166,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
         timezone: str | Timezone | FixedTimezone,
         run_offset: int | datetime.timedelta | relativedelta | None = None,
         run_immediately: bool | datetime.timedelta = False,
-        # todo: AIP-76 we can't infer partition date from this, so we need to store it separately
         key_format: str = r"%Y-%m-%dT%H:%M:%S",
     ) -> None:
         if not isinstance(run_offset, (int, NoneType)):

--- a/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
+++ b/task-sdk/src/airflow/sdk/definitions/timetables/trigger.py
@@ -150,9 +150,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
       running every hour, this would run the previous time if less than 6
       minutes had past since the previous run time, otherwise it would wait
       until the next hour.
-
-    # todo: AIP-76 talk about how we can have auto-reprocessing of partitions
-
     """
 
     run_offset: int | datetime.timedelta | relativedelta | None = None
@@ -168,7 +165,6 @@ class CronPartitionTimetable(CronTriggerTimetable):
         key_format: str = r"%Y-%m-%dT%H:%M:%S",
     ) -> None:
         if not isinstance(run_offset, (int, NoneType)):
-            # todo: AIP-76 implement timedelta / relative delta?
             raise ValueError("Run offset other than integer not supported yet.")
         self.__attrs_init__(  # type: ignore[attr-defined]
             cron,


### PR DESCRIPTION
## Why
AIP-76 (Asset Partitions) left a scattering of `# todo: AIP-76` notes, but most are no longer actionable: some describe behavior that has since changed, some are open-ended design musings, and some restate an accepted limitation. Comments that read like a TODO but cannot be acted on rot — they mislead readers into thinking there is pending work.

## What

No behavior change — this is comment cleanup plus one added test.

- **Remove obsolete partition-date storage TODOs.** The "we can't infer the partition date from this, so we need to store it separately" note predates the `next_dagrun_partition_date` / `next_dagrun_partition_key` columns and `DagRunInfo.partition_date` / `partition_key`. The partition date is now stored independently and no longer back-derived from the key format, so the note no longer matches the code (core + SDK, 3 sites).
- **Remove speculative design-question comments.** Open-ended musings ("we could…", "perhaps we need…", "unclear whether we should…") in `trigger.py`, `dag.py`, and the scheduler are not actionable items; they read as a parked idea list rather than work.
- **Demote limitation caveats from TODO to plain comments.** Two notes describe already-accepted behaviour (run-date→partition is lossy for some offsets; runs with a null `logical_date` are not matched). They are rewritten as neutral comments that keep the caveat without implying pending work.
- **Remove untracked forward-looking TODOs.** The auto-reprocessing note was only a discussion starter with no tracking issue; the `run_offset` timedelta / relativedelta note duplicated the adjacent guard that already raises "not supported yet".
- **Cover `CronPartitionTimetable.next_dagrun_info_v2` branches with tests.** The existing db-backed test only exercised the catch-up + no-previous-run branch. A direct unit test now covers the rest (catching up advancing from a previous run, first run with no earliest, non-catchup candidate selection, the earliest lower bound, and the latest upper bound returning `None`), letting the "add test for this logic" TODO go.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
