### PR TITLE
Fix GlueJobHook failing to update a Glue job that has tags

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/glue.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/glue.py
@@ -36,6 +36,7 @@ from tenacity import (
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
+from airflow.providers.amazon.aws.hooks.sts import StsHook
 from airflow.providers.common.compat.sdk import AirflowException
 
 DEFAULT_LOG_SUFFIX = "output"
@@ -485,6 +486,8 @@ class GlueJobHook(AwsBaseHook):
         :return: True if job was updated and false otherwise
         """
         job_name = job_kwargs.pop("Name")
+        # Glue ``update_job`` does not accept ``Tags`` in ``JobUpdate``; reconcile them separately.
+        tags_updated = self.update_tags(job_name, job_kwargs.pop("Tags")) if "Tags" in job_kwargs else False
         current_job = self.conn.get_job(JobName=job_name)["Job"]
 
         update_config = {
@@ -495,7 +498,34 @@ class GlueJobHook(AwsBaseHook):
             self.conn.update_job(JobName=job_name, JobUpdate=job_kwargs)
             self.log.info("Updated configurations: %s", update_config)
             return True
-        return False
+        return tags_updated
+
+    def update_tags(self, job_name: str, job_tags: dict) -> bool:
+        """
+        Reconcile a job's tags with the desired set.
+
+        Glue manages tags outside of ``update_job``, so adds/updates go through
+        ``tag_resource`` and removals through ``untag_resource``.
+
+        .. seealso::
+            - :external+boto3:py:meth:`Glue.Client.tag_resource`
+            - :external+boto3:py:meth:`Glue.Client.untag_resource`
+
+        :param job_name: Name of the job for which to update tags
+        :param job_tags: Desired tags. Keys absent from this mapping are removed from the job.
+        :return: True if any tag was added, changed, or removed, False otherwise
+        """
+        account_number = StsHook(aws_conn_id=self.aws_conn_id).get_account_number()
+        job_arn = f"arn:{self.conn_partition}:glue:{self.conn_region_name}:{account_number}:job/{job_name}"
+        current_tags: dict = self.conn.get_tags(ResourceArn=job_arn)["Tags"]
+
+        if tags_to_add := {key: value for key, value in job_tags.items() if current_tags.get(key) != value}:
+            self.log.info("Updating job tags: %s", job_name)
+            self.conn.tag_resource(ResourceArn=job_arn, TagsToAdd=tags_to_add)
+        if tags_to_remove := [key for key in current_tags if key not in job_tags]:
+            self.log.info("Removing job tags: %s", job_name)
+            self.conn.untag_resource(ResourceArn=job_arn, TagsToRemove=tags_to_remove)
+        return bool(tags_to_add or tags_to_remove)
 
     def get_or_create_glue_job(self) -> str | None:
         """

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_glue.py
@@ -26,6 +26,7 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.glue import GlueDataQualityHook, GlueJobHook
@@ -309,6 +310,74 @@ class TestGlueJobHook:
             },
         )
         assert result == job_name
+
+    @mock_aws
+    @pytest.mark.parametrize(
+        ("current_tags", "desired_tags", "expected_tags", "expected_changed"),
+        [
+            pytest.param(
+                {"env": "dev"},
+                {"env": "dev", "team": "data"},
+                {"env": "dev", "team": "data"},
+                True,
+                id="add-new-tag",
+            ),
+            pytest.param({"env": "dev"}, {"env": "prod"}, {"env": "prod"}, True, id="replace-value"),
+            pytest.param(
+                {"env": "dev", "team": "data"}, {"env": "dev"}, {"env": "dev"}, True, id="remove-tag"
+            ),
+            pytest.param({"env": "dev"}, {}, {}, True, id="remove-all-tags"),
+            pytest.param({"env": "dev"}, {"env": "dev"}, {"env": "dev"}, False, id="no-change"),
+        ],
+    )
+    def test_update_tags(self, current_tags, desired_tags, expected_tags, expected_changed):
+        """Tags are reconciled through the tag API because Glue ``update_job`` cannot modify them."""
+        job_name = "aws_test_glue_job_with_tags"
+        boto3.client("glue", region_name=self.some_aws_region).create_job(
+            Name=job_name,
+            Role="test-role",
+            Command={"Name": "glueetl", "ScriptLocation": "s3://glue-examples/script.py"},
+            Tags=current_tags,
+        )
+        hook = GlueJobHook(job_name=job_name, region_name=self.some_aws_region)
+
+        assert hook.update_tags(job_name, desired_tags) is expected_changed
+
+        job_arn = f"arn:aws:glue:{self.some_aws_region}:{DEFAULT_ACCOUNT_ID}:job/{job_name}"
+        assert hook.conn.get_tags(ResourceArn=job_arn)["Tags"] == expected_tags
+
+    @mock.patch.object(GlueJobHook, "update_tags")
+    @mock.patch.object(AwsBaseHook, "conn")
+    def test_update_job_keeps_tags_out_of_job_update(self, mock_conn, mock_update_tags):
+        """``Tags`` must be stripped from ``JobUpdate`` and reconciled separately."""
+        job_name = "aws_test_glue_job"
+        mock_conn.get_job.return_value = {"Job": {"Name": job_name, "Description": "old"}}
+        mock_update_tags.return_value = False
+        hook = GlueJobHook(job_name=job_name, region_name=self.some_aws_region)
+
+        updated = hook.update_job(Name=job_name, Description="new", Tags={"env": "prod"})
+
+        mock_update_tags.assert_called_once_with(job_name, {"env": "prod"})
+        mock_conn.update_job.assert_called_once_with(JobName=job_name, JobUpdate={"Description": "new"})
+        assert updated is True
+
+    @pytest.mark.parametrize("tags_changed", [True, False])
+    @mock.patch.object(GlueJobHook, "update_tags")
+    @mock.patch.object(AwsBaseHook, "conn")
+    def test_update_job_returns_tag_result_when_config_unchanged(
+        self, mock_conn, mock_update_tags, tags_changed
+    ):
+        """With no config diff, the result reflects whether only the tags changed."""
+        job_name = "aws_test_glue_job"
+        mock_conn.get_job.return_value = {"Job": {"Name": job_name, "Description": "same"}}
+        mock_update_tags.return_value = tags_changed
+        hook = GlueJobHook(job_name=job_name, region_name=self.some_aws_region)
+
+        updated = hook.update_job(Name=job_name, Description="same", Tags={"env": "prod"})
+
+        mock_update_tags.assert_called_once_with(job_name, {"env": "prod"})
+        mock_conn.update_job.assert_not_called()
+        assert updated is tags_changed
 
     @mock_aws
     @mock.patch.object(GlueJobHook, "get_iam_execution_role")


### PR DESCRIPTION
When `GlueJobOperator` / `GlueJobHook` runs with `update_config=True` against a job that already exists and whose `create_job_kwargs` include `Tags`, the update fails.

AWS Glue's [`CreateJob`](https://docs.aws.amazon.com/glue/latest/webapi/API_CreateJob.html)
accepts a top-level `Tags` parameter, but [`UpdateJob`](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateJob.html) only accepts `JobName` and a `JobUpdate` structure. The hook passed the whole config (including `Tags`) straight into `JobUpdate`, so botocore rejected the call with a `ParamValidationError`. The result was an inconsistency: tagging a job worked on first creation but broke on every subsequent update.

This strips `Tags` out of the `JobUpdate` payload and reconciles them through the dedicated tag APIs ([`TagResource`](https://docs.aws.amazon.com/glue/latest/webapi/API_TagResource.html) / [`UntagResource`](https://docs.aws.amazon.com/glue/latest/webapi/API_UntagResource.html)), mirroring how `GlueCrawlerHook` already handles the same Glue limitation for crawlers. Tag additions, value changes, and removals are all applied. The `update_job` now reports that an update happened, when only the tags change.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
closes: #68676
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude Code with Opus 4.8] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
