### PR TITLE
Propagate resolved task log level to language SDK runtimes

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/index.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/index.rst
@@ -77,6 +77,11 @@ The execution model has three moving parts.
    worker to identify the workload, executes the task, and communicates through the coordinator as a proxy
    back to the worker process.
 
+   A runtime cannot read Airflow's configuration, so the coordinator passes the resolved logging
+   configuration through the environment at launch: ``AIRFLOW__LOGGING__LOGGING_LEVEL`` (the root level)
+   and, when set, ``AIRFLOW__LOGGING__NAMESPACE_LEVELS`` (per-logger ``<logger>=<level>`` pairs, separated
+   by whitespace or commas). Each SDK is responsible for reading these and filtering its own logs.
+
 .. _language-sdks/stub-tasks:
 
 Stub tasks

--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/index.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/index.rst
@@ -77,11 +77,6 @@ The execution model has three moving parts.
    worker to identify the workload, executes the task, and communicates through the coordinator as a proxy
    back to the worker process.
 
-   A runtime cannot read Airflow's configuration, so the coordinator passes the resolved logging
-   configuration through the environment at launch: ``AIRFLOW__LOGGING__LOGGING_LEVEL`` (the root level)
-   and, when set, ``AIRFLOW__LOGGING__NAMESPACE_LEVELS`` (per-logger ``<logger>=<level>`` pairs, separated
-   by whitespace or commas). Each SDK is responsible for reading these and filtering its own logs.
-
 .. _language-sdks/stub-tasks:
 
 Stub tasks

--- a/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
+++ b/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
@@ -41,6 +41,7 @@ import attrs
 import psutil
 import structlog
 
+from airflow.sdk.configuration import conf
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
 from airflow.sdk.execution_time.supervisor import ActivitySubprocess, NeverRaised, ProcessTracker
 
@@ -301,6 +302,13 @@ class _PopenActivitySubprocess(ActivitySubprocess):
                 ],
                 stdout=stdout_w.fileno(),
                 stderr=stderr_w.fileno(),
+                # A language SDK runtime cannot read Airflow's config, so propagate the
+                # resolved task log level via the environment at launch. StartupDetails
+                # arrives too late, the logs might already be produced by then.
+                env={
+                    **os.environ,
+                    "AIRFLOW__LOGGING__LOGGING_LEVEL": conf.get("logging", "logging_level", fallback="INFO"),
+                },
             )
             tracker.track(proc)
             for soc in tracker.untrack(stdout_w, stderr_w):

--- a/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
+++ b/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
@@ -300,9 +300,8 @@ class _PopenActivitySubprocess(ActivitySubprocess):
             env = {
                 **os.environ,
                 "AIRFLOW__LOGGING__LOGGING_LEVEL": conf.get("logging", "logging_level", fallback="INFO"),
+                "AIRFLOW__LOGGING__NAMESPACE_LEVELS": conf.get("logging", "namespace_levels", fallback=""),
             }
-            if namespace_levels := conf.get("logging", "namespace_levels", fallback=None):
-                env["AIRFLOW__LOGGING__NAMESPACE_LEVELS"] = namespace_levels
 
             proc = subprocess.Popen(
                 [

--- a/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
+++ b/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
@@ -294,6 +294,16 @@ class _PopenActivitySubprocess(ActivitySubprocess):
             stdout_r, stdout_w = tracker.track(*socket.socketpair())
             stderr_r, stderr_w = tracker.track(*socket.socketpair())
 
+            # A language SDK runtime cannot read Airflow's config, so propagate the
+            # resolved log levels via the environment at launch. StartupDetails
+            # arrives too late, the logs might already be produced by then.
+            env = {
+                **os.environ,
+                "AIRFLOW__LOGGING__LOGGING_LEVEL": conf.get("logging", "logging_level", fallback="INFO"),
+            }
+            if namespace_levels := conf.get("logging", "namespace_levels", fallback=None):
+                env["AIRFLOW__LOGGING__NAMESPACE_LEVELS"] = namespace_levels
+
             proc = subprocess.Popen(
                 [
                     *command,
@@ -302,13 +312,7 @@ class _PopenActivitySubprocess(ActivitySubprocess):
                 ],
                 stdout=stdout_w.fileno(),
                 stderr=stderr_w.fileno(),
-                # A language SDK runtime cannot read Airflow's config, so propagate the
-                # resolved task log level via the environment at launch. StartupDetails
-                # arrives too late, the logs might already be produced by then.
-                env={
-                    **os.environ,
-                    "AIRFLOW__LOGGING__LOGGING_LEVEL": conf.get("logging", "logging_level", fallback="INFO"),
-                },
+                env=env,
             )
             tracker.track(proc)
             for soc in tracker.untrack(stdout_w, stderr_w):

--- a/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
+++ b/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
@@ -45,6 +45,7 @@ from airflow.sdk.coordinators._subprocess import (
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
 from airflow.sdk.execution_time.supervisor import ActivitySubprocess
 
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
 
 if not AIRFLOW_V_3_3_PLUS:
@@ -762,6 +763,13 @@ class TestPopenActivitySubprocessStart:
         kwargs = mock_on_started.call_args.kwargs
         assert kwargs["ti"] is ti
         assert kwargs["dag_rel_path"] == "bundle"
+
+    @conf_vars({("logging", "logging_level"): "DEBUG"})
+    def test_resolved_log_level_passed_to_subprocess_env(self, mock_client):
+        """A language SDK runtime gets the resolved task log level via the environment at launch."""
+        _, popen_mock, _ = self._start_with_mocks(mock_client, command=["/bin/true"])
+        env = popen_mock.call_args.kwargs["env"]
+        assert env["AIRFLOW__LOGGING__LOGGING_LEVEL"] == "DEBUG"
 
     def test_register_pipe_readers_called_with_four_sockets(self, mock_client):
         """Both socketpair read-ends and both TCP sockets must be registered, with a data kwarg."""

--- a/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
+++ b/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
@@ -771,6 +771,20 @@ class TestPopenActivitySubprocessStart:
         env = popen_mock.call_args.kwargs["env"]
         assert env["AIRFLOW__LOGGING__LOGGING_LEVEL"] == "DEBUG"
 
+    @conf_vars({("logging", "namespace_levels"): "sqlalchemy=INFO, botocore=WARNING"})
+    def test_namespace_levels_passed_to_subprocess_env(self, mock_client):
+        """Per-logger levels are propagated verbatim for the runtime to parse."""
+        _, popen_mock, _ = self._start_with_mocks(mock_client, command=["/bin/true"])
+        env = popen_mock.call_args.kwargs["env"]
+        assert env["AIRFLOW__LOGGING__NAMESPACE_LEVELS"] == "sqlalchemy=INFO, botocore=WARNING"
+
+    @conf_vars({("logging", "namespace_levels"): ""})
+    def test_namespace_levels_omitted_when_unset(self, mock_client):
+        """An empty value has no pairs to parse, so the variable is left out."""
+        _, popen_mock, _ = self._start_with_mocks(mock_client, command=["/bin/true"])
+        env = popen_mock.call_args.kwargs["env"]
+        assert "AIRFLOW__LOGGING__NAMESPACE_LEVELS" not in env
+
     def test_register_pipe_readers_called_with_four_sockets(self, mock_client):
         """Both socketpair read-ends and both TCP sockets must be registered, with a data kwarg."""
         with (

--- a/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
+++ b/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
@@ -783,7 +783,7 @@ class TestPopenActivitySubprocessStart:
         """An empty value has no pairs to parse, so the variable is left out."""
         _, popen_mock, _ = self._start_with_mocks(mock_client, command=["/bin/true"])
         env = popen_mock.call_args.kwargs["env"]
-        assert "AIRFLOW__LOGGING__NAMESPACE_LEVELS" not in env
+        assert env["AIRFLOW__LOGGING__NAMESPACE_LEVELS"] == ""
 
     def test_register_pipe_readers_called_with_four_sockets(self, mock_client):
         """Both socketpair read-ends and both TCP sockets must be registered, with a data kwarg."""


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/68696#discussion_r3433102278

## Why

Pointed out in above related link, we should propagate the `logging_level` info from Supervisor (Task-SDK world) to Lang-SDK runtime to respect the Airflow side `conf`. So that no matter user configure the `[logging/logging_level]` using `airflow.cfg` or secret backend, the Lang-SDK runtime should retrieve the same conf.

## How

Here're the approach we came up with:

1. **(Current approach)** Passing as `AIRFLOW__LOGGING__LOGGING_LEVEL` env, each Lang-SDK will consume by `os.environ` themself.
2. Passing by CLI flag like `java -classpath ... --comms=... --logs=... --logging-level=...` CLI. **Cons**: We will introduce a new CLI flag for all the further `conf` propagation. (There isn't `--comms` or `--logs` equivalent Airflow env, so having the existing  `--comms, --logs` as-is is a valid direction)
3. Passing by `StartUpDetails.logging_level`. **Cons**: Caught by @uranusjr that the Task subprocess had already started producing logs (e.g. logging for connecting to the coordinator) before the Task subprocess got the `StartUpDetails` msgpack, which causes the wrong logging level at the Task subprocess startup time.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
