### PR TITLE
Decide pod_template and image based on Coordinator for lang-SDK tasks on KubernetesExecutor

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -73,9 +73,6 @@ if TYPE_CHECKING:
     )
 
 
-log = logging.getLogger(__name__)
-
-
 class KubernetesExecutor(BaseExecutor):
     """Executor for Kubernetes."""
 
@@ -201,8 +198,7 @@ class KubernetesExecutor(BaseExecutor):
             scheduler_job_id=self.scheduler_job_id,
         )
 
-    @staticmethod
-    def _coordinator_extra(queue: str | None) -> dict[str, Any] | None:
+    def _coordinator_extra(self, queue: str | None) -> dict[str, Any] | None:
         """
         Return the ``extra`` mapping a coordinator declares for *queue*, if any.
 
@@ -224,15 +220,14 @@ class KubernetesExecutor(BaseExecutor):
         try:
             return get_coordinator_manager().extra_for_queue(queue)
         except (AirflowConfigException, ValueError):
-            log.warning(
+            self.log.warning(
                 "Ignoring coordinator config for queue %s: invalid [sdk] coordinator config",
                 queue,
                 exc_info=True,
             )
             return None
 
-    @staticmethod
-    def _coordinator_pod_template_file(queue: str | None) -> str | None:
+    def _coordinator_pod_template_file(self, queue: str | None) -> str | None:
         """
         Return the pod template a coordinator declares for *queue*, if any.
 
@@ -240,13 +235,11 @@ class KubernetesExecutor(BaseExecutor):
         queue_to_coordinator``) launch its worker pod from a coordinator-specific
         template — for example an image carrying the JVM for a Java coordinator.
         """
-        extra = KubernetesExecutor._coordinator_extra(queue)
-        if extra is not None:
+        if (extra := self._coordinator_extra(queue)) is not None:
             return extra.get("pod_template_file", None)
         return None
 
-    @staticmethod
-    def _coordinator_kube_image(queue: str | None) -> str | None:
+    def _coordinator_kube_image(self, queue: str | None) -> str | None:
         """
         Return the worker base image a coordinator declares for *queue*, if any.
 
@@ -257,13 +250,10 @@ class KubernetesExecutor(BaseExecutor):
         (e.g. a JRE-bearing image for a Java coordinator); both are required to
         compose an override, otherwise the executor default applies.
         """
-        extra = KubernetesExecutor._coordinator_extra(queue)
-        if not extra:
+        if (extra := self._coordinator_extra(queue)) is None:
             return None
-        repository = extra.get("worker_container_repository")
-        tag = extra.get("worker_container_tag")
-        if repository and tag:
-            return f"{repository}:{tag}"
+        if (repo := extra.get("worker_container_repository")) and (tag := extra.get("worker_container_tag")):
+            return f"{repo}:{tag}"
         return None
 
     def execute_async(
@@ -306,8 +296,7 @@ class KubernetesExecutor(BaseExecutor):
 
         # The base image is not carried by a pod template, so a coordinator routes
         # its worker base image separately (e.g. a JRE image for a Java queue).
-        coordinator_kube_image = self._coordinator_kube_image(queue)
-        if coordinator_kube_image is not None:
+        if (coordinator_kube_image := self._coordinator_kube_image(queue)) is not None:
             self.log.debug(
                 "Using coordinator-declared base image %s for task %s in queue %s",
                 coordinator_kube_image,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -227,21 +227,19 @@ class KubernetesExecutor(BaseExecutor):
             )
             return None
 
-    def _coordinator_pod_template_file(self, queue: str | None) -> str | None:
+    def _coordinator_pod_template_file(self, extra: dict[str, Any]) -> str | None:
         """
-        Return the pod template a coordinator declares for *queue*, if any.
+        Return the pod template declared in a coordinator's *extra* mapping, if any.
 
         Lets a queue routed to a non-Python coordinator (via ``[sdk]
         queue_to_coordinator``) launch its worker pod from a coordinator-specific
         template — for example an image carrying the JVM for a Java coordinator.
         """
-        if (extra := self._coordinator_extra(queue)) is not None:
-            return extra.get("pod_template_file", None)
-        return None
+        return extra.get("pod_template_file", None)
 
-    def _coordinator_kube_image(self, queue: str | None) -> str | None:
+    def _coordinator_kube_image(self, extra: dict[str, Any]) -> str | None:
         """
-        Return the worker base image a coordinator declares for *queue*, if any.
+        Return the worker base image declared in a coordinator's *extra* mapping, if any.
 
         The base container image is never taken from a pod template; it comes
         from ``kube_image`` (``worker_container_repository:worker_container_tag``)
@@ -250,8 +248,6 @@ class KubernetesExecutor(BaseExecutor):
         (e.g. a JRE-bearing image for a Java coordinator); both are required to
         compose an override, otherwise the executor default applies.
         """
-        if (extra := self._coordinator_extra(queue)) is None:
-            return None
         if (repo := extra.get("worker_container_repository")) and (tag := extra.get("worker_container_tag")):
             return f"{repo}:{tag}"
         return None
@@ -284,25 +280,29 @@ class KubernetesExecutor(BaseExecutor):
         else:
             pod_template_file = None
 
-        # A coordinator-level pod_template wins (e.g. a JVM image for JavaCoordinator)
-        if (coordinator_pod_template_file := self._coordinator_pod_template_file(queue)) is not None:
-            self.log.debug(
-                "Using coordinator-declared pod template %s for task %s in queue %s",
-                coordinator_pod_template_file,
-                key,
-                queue,
-            )
-            pod_template_file = coordinator_pod_template_file
+        coordinator_kube_image: str | None = None
+        if (coordinator_extra := self._coordinator_extra(queue)) is not None:
+            # A coordinator-level pod_template wins (e.g. a JVM image for JavaCoordinator)
+            if (
+                coordinator_pod_template_file := self._coordinator_pod_template_file(coordinator_extra)
+            ) is not None:
+                self.log.debug(
+                    "Using coordinator-declared pod template %s for task %s in queue %s",
+                    coordinator_pod_template_file,
+                    key,
+                    queue,
+                )
+                pod_template_file = coordinator_pod_template_file
 
-        # The base image is not carried by a pod template, so a coordinator routes
-        # its worker base image separately (e.g. a JRE image for a Java queue).
-        if (coordinator_kube_image := self._coordinator_kube_image(queue)) is not None:
-            self.log.debug(
-                "Using coordinator-declared base image %s for task %s in queue %s",
-                coordinator_kube_image,
-                key,
-                queue,
-            )
+            # The base image is not carried by a pod template, so a coordinator routes
+            # its worker base image separately (e.g. a JRE image for a Java queue).
+            if (coordinator_kube_image := self._coordinator_kube_image(coordinator_extra)) is not None:
+                self.log.debug(
+                    "Using coordinator-declared base image %s for task %s in queue %s",
+                    coordinator_kube_image,
+                    key,
+                    queue,
+                )
 
         self.event_buffer[key] = (TaskInstanceState.QUEUED, self.scheduler_job_id)
         self.task_queue.put(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -235,7 +235,7 @@ class KubernetesExecutor(BaseExecutor):
         queue_to_coordinator``) launch its worker pod from a coordinator-specific
         template — for example an image carrying the JVM for a Java coordinator.
         """
-        return extra.get("pod_template_file", None)
+        return extra.get("pod_template_file")
 
     def _coordinator_kube_image(self, extra: dict[str, Any]) -> str | None:
         """
@@ -283,9 +283,8 @@ class KubernetesExecutor(BaseExecutor):
         coordinator_kube_image: str | None = None
         if (coordinator_extra := self._coordinator_extra(queue)) is not None:
             # A coordinator-level pod_template wins (e.g. a JVM image for JavaCoordinator)
-            if (
-                coordinator_pod_template_file := self._coordinator_pod_template_file(coordinator_extra)
-            ) is not None:
+            coordinator_pod_template_file = self._coordinator_pod_template_file(coordinator_extra)
+            if coordinator_pod_template_file is not None:
                 self.log.debug(
                     "Using coordinator-declared pod template %s for task %s in queue %s",
                     coordinator_pod_template_file,

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -73,6 +73,9 @@ if TYPE_CHECKING:
     )
 
 
+log = logging.getLogger(__name__)
+
+
 class KubernetesExecutor(BaseExecutor):
     """Executor for Kubernetes."""
 
@@ -198,6 +201,71 @@ class KubernetesExecutor(BaseExecutor):
             scheduler_job_id=self.scheduler_job_id,
         )
 
+    @staticmethod
+    def _coordinator_extra(queue: str | None) -> dict[str, Any] | None:
+        """
+        Return the ``extra`` mapping a coordinator declares for *queue*, if any.
+
+        Read from the coordinator's declarative ``[sdk]`` config without importing
+        or instantiating the coordinator. The coordinator manager only exists on
+        Airflow 3.3+; on older Task SDKs the import fails and we fall back to no
+        extra. A malformed ``[sdk] coordinators`` / ``queue_to_coordinator`` config
+        must not crash the scheduler on this first lookup either, so an invalid
+        config also falls back to no extra. The exception types are imported from
+        ``airflow.sdk`` so they match whatever Task SDK actually raised them.
+        """
+        if not queue:
+            return None
+        try:
+            from airflow.sdk.exceptions import AirflowConfigException
+            from airflow.sdk.execution_time.coordinator import get_coordinator_manager
+        except ImportError:
+            return None
+        try:
+            return get_coordinator_manager().extra_for_queue(queue)
+        except (AirflowConfigException, ValueError):
+            log.warning(
+                "Ignoring coordinator config for queue %s: invalid [sdk] coordinator config",
+                queue,
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _coordinator_pod_template_file(queue: str | None) -> str | None:
+        """
+        Return the pod template a coordinator declares for *queue*, if any.
+
+        Lets a queue routed to a non-Python coordinator (via ``[sdk]
+        queue_to_coordinator``) launch its worker pod from a coordinator-specific
+        template — for example an image carrying the JVM for a Java coordinator.
+        """
+        extra = KubernetesExecutor._coordinator_extra(queue)
+        if extra is not None:
+            return extra.get("pod_template_file", None)
+        return None
+
+    @staticmethod
+    def _coordinator_kube_image(queue: str | None) -> str | None:
+        """
+        Return the worker base image a coordinator declares for *queue*, if any.
+
+        The base container image is never taken from a pod template; it comes
+        from ``kube_image`` (``worker_container_repository:worker_container_tag``)
+        or a per-task ``pod_override``. A coordinator may declare its own
+        ``worker_container_repository`` and ``worker_container_tag`` in ``extra``
+        (e.g. a JRE-bearing image for a Java coordinator); both are required to
+        compose an override, otherwise the executor default applies.
+        """
+        extra = KubernetesExecutor._coordinator_extra(queue)
+        if not extra:
+            return None
+        repository = extra.get("worker_container_repository")
+        tag = extra.get("worker_container_tag")
+        if repository and tag:
+            return f"{repository}:{tag}"
+        return None
+
     def execute_async(
         self,
         key: TaskInstanceKey,
@@ -225,8 +293,32 @@ class KubernetesExecutor(BaseExecutor):
             pod_template_file = executor_config.get("pod_template_file", None)
         else:
             pod_template_file = None
+
+        # A coordinator-level pod_template wins (e.g. a JVM image for JavaCoordinator)
+        if (coordinator_pod_template_file := self._coordinator_pod_template_file(queue)) is not None:
+            self.log.debug(
+                "Using coordinator-declared pod template %s for task %s in queue %s",
+                coordinator_pod_template_file,
+                key,
+                queue,
+            )
+            pod_template_file = coordinator_pod_template_file
+
+        # The base image is not carried by a pod template, so a coordinator routes
+        # its worker base image separately (e.g. a JRE image for a Java queue).
+        coordinator_kube_image = self._coordinator_kube_image(queue)
+        if coordinator_kube_image is not None:
+            self.log.debug(
+                "Using coordinator-declared base image %s for task %s in queue %s",
+                coordinator_kube_image,
+                key,
+                queue,
+            )
+
         self.event_buffer[key] = (TaskInstanceState.QUEUED, self.scheduler_job_id)
-        self.task_queue.put(KubernetesJob(key, command, kube_executor_config, pod_template_file))
+        self.task_queue.put(
+            KubernetesJob(key, command, kube_executor_config, pod_template_file, coordinator_kube_image)
+        )
 
     def queue_workload(self, workload: workloads.All, session: Session | None) -> None:
         from airflow.executors import workloads

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_types.py
@@ -75,6 +75,7 @@ class KubernetesJob(NamedTuple):
     command: Sequence[str]
     kube_executor_config: Any
     pod_template_file: str | None
+    kube_image: str | None = None
 
 
 ALL_NAMESPACES = "ALL_NAMESPACES"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor_utils.py
@@ -558,6 +558,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         command = next_job.command
         kube_executor_config = next_job.kube_executor_config
         pod_template_file = next_job.pod_template_file
+        kube_image = next_job.kube_image or self.kube_config.kube_image
 
         dag_id, task_id, run_id, try_number, map_index = key
         if len(command) == 1:
@@ -586,7 +587,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
             pod_id=create_unique_id(dag_id, task_id),
             dag_id=dag_id,
             task_id=task_id,
-            kube_image=self.kube_config.kube_image,
+            kube_image=kube_image,
             try_number=try_number,
             map_index=map_index,
             date=None,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -972,7 +972,7 @@ class TestKubernetesExecutor:
     def test_coordinator_pod_template_file_skips_lookup_without_queue(self):
         """No queue means no coordinator lookup (and no Task SDK import)."""
         with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
-            assert KubernetesExecutor._coordinator_pod_template_file(None) is None
+            assert self.kubernetes_executor._coordinator_pod_template_file(None) is None
             mock_get_manager.assert_not_called()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
@@ -988,14 +988,14 @@ class TestKubernetesExecutor:
         """The template is read from the queue coordinator's ``extra`` mapping."""
         with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
             mock_get_manager.return_value.extra_for_queue.return_value = extra
-            assert KubernetesExecutor._coordinator_pod_template_file("go") == expected
+            assert self.kubernetes_executor._coordinator_pod_template_file("go") == expected
             mock_get_manager.return_value.extra_for_queue.assert_called_once_with("go")
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     def test_coordinator_pod_template_file_returns_none_on_old_task_sdk(self):
         """Pre-3.3 Task SDKs lack get_coordinator_manager; the import error falls back to None."""
         with mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.coordinator": None}):
-            assert KubernetesExecutor._coordinator_pod_template_file("go") is None
+            assert self.kubernetes_executor._coordinator_pod_template_file("go") is None
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
@@ -1026,7 +1026,7 @@ class TestKubernetesExecutor:
     def test_coordinator_kube_image_skips_lookup_without_queue(self):
         """No queue means no coordinator lookup (and no Task SDK import)."""
         with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
-            assert KubernetesExecutor._coordinator_kube_image(None) is None
+            assert self.kubernetes_executor._coordinator_kube_image(None) is None
             mock_get_manager.assert_not_called()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
@@ -1048,14 +1048,14 @@ class TestKubernetesExecutor:
         """The base image is composed from the queue coordinator's ``extra`` mapping."""
         with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
             mock_get_manager.return_value.extra_for_queue.return_value = extra
-            assert KubernetesExecutor._coordinator_kube_image("java") == expected
+            assert self.kubernetes_executor._coordinator_kube_image("java") == expected
             mock_get_manager.return_value.extra_for_queue.assert_called_once_with("java")
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     def test_coordinator_kube_image_returns_none_on_old_task_sdk(self):
         """Pre-3.3 Task SDKs lack get_coordinator_manager; the import error falls back to None."""
         with mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.coordinator": None}):
-            assert KubernetesExecutor._coordinator_kube_image("java") is None
+            assert self.kubernetes_executor._coordinator_kube_image("java") is None
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @pytest.mark.parametrize("exc_type", ["airflow_config_exception", "value_error"])
@@ -1069,8 +1069,8 @@ class TestKubernetesExecutor:
             exc = ValueError("invalid coordinator key")
         with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
             mock_get_manager.return_value.extra_for_queue.side_effect = exc
-            assert KubernetesExecutor._coordinator_pod_template_file("java") is None
-            assert KubernetesExecutor._coordinator_kube_image("java") is None
+            assert self.kubernetes_executor._coordinator_pod_template_file("java") is None
+            assert self.kubernetes_executor._coordinator_kube_image("java") is None
 
     @pytest.mark.skipif(
         AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -39,6 +39,7 @@ from airflow.providers.cncf.kubernetes.executors.kubernetes_executor import (
 )
 from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_types import (
     ADOPTED,
+    KubernetesJob,
     KubernetesResults,
     KubernetesWatch,
 )
@@ -66,7 +67,11 @@ except ImportError:
 from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_PLUS,
+    AIRFLOW_V_3_3_PLUS,
+)
 
 try:
     # Check whether a module-level function from stats is importable.
@@ -863,11 +868,10 @@ class TestKubernetesExecutor:
 
                 assert not executor.task_queue.empty()
                 task = executor.task_queue.get_nowait()
-                _, _, expected_executor_config, expected_pod_template_file = task
                 executor.task_queue.task_done()
                 # Test that the correct values have been put to queue
-                assert expected_executor_config.metadata.labels == {"release": "stable"}
-                assert expected_pod_template_file == executor_template_file
+                assert task.kube_executor_config.metadata.labels == {"release": "stable"}
+                assert task.pod_template_file == executor_template_file
 
                 self.kubernetes_executor.kube_scheduler.run_next(task)
                 mock_run_pod_async.assert_called_once_with(
@@ -914,6 +918,205 @@ class TestKubernetesExecutor:
                 )
             finally:
                 executor.end()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    @pytest.mark.parametrize(
+        ("coordinator_template", "executor_config", "expected_template"),
+        [
+            pytest.param("/coord/java.yaml", None, "/coord/java.yaml", id="coordinator-template-used"),
+            pytest.param(
+                "/coord/java.yaml",
+                {"pod_template_file": "/from/executor_config.yaml"},
+                "/coord/java.yaml",
+                id="coordinator-template-wins",
+            ),
+            pytest.param(
+                None,
+                {"pod_template_file": "/from/executor_config.yaml"},
+                "/from/executor_config.yaml",
+                id="executor-config-used-without-coordinator",
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    @mock.patch.object(KubernetesExecutor, "_coordinator_pod_template_file")
+    def test_coordinator_pod_template_file_used_for_queue(
+        self,
+        mock_coordinator_template,
+        mock_get_kube_client,
+        mock_kubernetes_job_watcher,
+        coordinator_template,
+        executor_config,
+        expected_template,
+    ):
+        """A queue's coordinator template overrides executor_config; without one, executor_config is used."""
+        mock_coordinator_template.return_value = coordinator_template
+        executor = self.kubernetes_executor
+        executor.start()
+        try:
+            executor.execute_async(
+                key=TaskInstanceKey("dag", "task", "run_id", 1, -1),
+                queue="java",
+                command=["airflow", "tasks", "run", "true", "some_parameter"],
+                executor_config=executor_config,
+            )
+            assert not executor.task_queue.empty()
+            queued_job = executor.task_queue.get_nowait()
+            executor.task_queue.task_done()
+            assert queued_job.pod_template_file == expected_template
+        finally:
+            executor.end()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    def test_coordinator_pod_template_file_skips_lookup_without_queue(self):
+        """No queue means no coordinator lookup (and no Task SDK import)."""
+        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
+            assert KubernetesExecutor._coordinator_pod_template_file(None) is None
+            mock_get_manager.assert_not_called()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    @pytest.mark.parametrize(
+        ("extra", "expected"),
+        [
+            pytest.param({"pod_template_file": "/coord/go.yaml"}, "/coord/go.yaml", id="template-in-extra"),
+            pytest.param({"other": "value"}, None, id="extra-without-template"),
+            pytest.param(None, None, id="no-extra"),
+        ],
+    )
+    def test_coordinator_pod_template_file_reads_extra(self, extra, expected):
+        """The template is read from the queue coordinator's ``extra`` mapping."""
+        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
+            mock_get_manager.return_value.extra_for_queue.return_value = extra
+            assert KubernetesExecutor._coordinator_pod_template_file("go") == expected
+            mock_get_manager.return_value.extra_for_queue.assert_called_once_with("go")
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    def test_coordinator_pod_template_file_returns_none_on_old_task_sdk(self):
+        """Pre-3.3 Task SDKs lack get_coordinator_manager; the import error falls back to None."""
+        with mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.coordinator": None}):
+            assert KubernetesExecutor._coordinator_pod_template_file("go") is None
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    @mock.patch.object(KubernetesExecutor, "_coordinator_kube_image", return_value="repo/java:1")
+    def test_coordinator_kube_image_carried_on_job(
+        self,
+        mock_coordinator_kube_image,
+        mock_get_kube_client,
+        mock_kubernetes_job_watcher,
+    ):
+        """A coordinator base image resolved by queue rides on the queued job."""
+        executor = self.kubernetes_executor
+        executor.start()
+        try:
+            executor.execute_async(
+                key=TaskInstanceKey("dag", "task", "run_id", 1, -1),
+                queue="java",
+                command=["airflow", "tasks", "run", "true", "some_parameter"],
+            )
+            queued_job = executor.task_queue.get_nowait()
+            executor.task_queue.task_done()
+            assert queued_job.kube_image == "repo/java:1"
+        finally:
+            executor.end()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    def test_coordinator_kube_image_skips_lookup_without_queue(self):
+        """No queue means no coordinator lookup (and no Task SDK import)."""
+        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
+            assert KubernetesExecutor._coordinator_kube_image(None) is None
+            mock_get_manager.assert_not_called()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    @pytest.mark.parametrize(
+        ("extra", "expected"),
+        [
+            pytest.param(
+                {"worker_container_repository": "repo/java", "worker_container_tag": "17"},
+                "repo/java:17",
+                id="repository-and-tag",
+            ),
+            pytest.param({"worker_container_repository": "repo/java"}, None, id="repository-only"),
+            pytest.param({"worker_container_tag": "17"}, None, id="tag-only"),
+            pytest.param({"other": "value"}, None, id="extra-without-image"),
+            pytest.param(None, None, id="no-extra"),
+        ],
+    )
+    def test_coordinator_kube_image_reads_extra(self, extra, expected):
+        """The base image is composed from the queue coordinator's ``extra`` mapping."""
+        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
+            mock_get_manager.return_value.extra_for_queue.return_value = extra
+            assert KubernetesExecutor._coordinator_kube_image("java") == expected
+            mock_get_manager.return_value.extra_for_queue.assert_called_once_with("java")
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    def test_coordinator_kube_image_returns_none_on_old_task_sdk(self):
+        """Pre-3.3 Task SDKs lack get_coordinator_manager; the import error falls back to None."""
+        with mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.coordinator": None}):
+            assert KubernetesExecutor._coordinator_kube_image("java") is None
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    @pytest.mark.parametrize("exc_type", ["airflow_config_exception", "value_error"])
+    def test_coordinator_extra_falls_back_on_invalid_config(self, exc_type):
+        """A malformed ``[sdk]`` coordinator config must degrade gracefully, not crash the scheduler."""
+        if exc_type == "airflow_config_exception":
+            from airflow.sdk.exceptions import AirflowConfigException
+
+            exc = AirflowConfigException("invalid json")
+        else:
+            exc = ValueError("invalid coordinator key")
+        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
+            mock_get_manager.return_value.extra_for_queue.side_effect = exc
+            assert KubernetesExecutor._coordinator_pod_template_file("java") is None
+            assert KubernetesExecutor._coordinator_kube_image("java") is None
+
+    @pytest.mark.skipif(
+        AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"
+    )
+    @pytest.mark.parametrize(
+        ("job_image", "use_default"),
+        [
+            pytest.param("repo/java:17", False, id="job-image-wins"),
+            pytest.param(None, True, id="falls-back-to-kube_config"),
+        ],
+    )
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.AirflowKubernetesScheduler.run_pod_async"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.PodGenerator")
+    @mock.patch(
+        "airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.get_base_pod_from_template"
+    )
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    def test_run_next_applies_job_kube_image(
+        self,
+        mock_get_kube_client,
+        mock_get_base_pod,
+        mock_pod_generator,
+        mock_run_pod_async,
+        job_image,
+        use_default,
+    ):
+        """``run_next`` uses the job's coordinator image, falling back to the kube_config default."""
+        executor = self.kubernetes_executor
+        executor.start()
+        try:
+            scheduler = executor.kube_scheduler
+            scheduler.run_next(
+                KubernetesJob(
+                    key=TaskInstanceKey("dag", "task", "run_id", 1, -1),
+                    command=["airflow", "tasks", "run", "true", "some_parameter"],
+                    kube_executor_config=None,
+                    pod_template_file=None,
+                    kube_image=job_image,
+                )
+            )
+            expected = scheduler.kube_config.kube_image if use_default else job_image
+            assert mock_pod_generator.construct_pod.call_args.kwargs["kube_image"] == expected
+        finally:
+            executor.end()
 
     @pytest.mark.db_test
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -921,11 +921,16 @@ class TestKubernetesExecutor:
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @pytest.mark.parametrize(
-        ("coordinator_template", "executor_config", "expected_template"),
+        ("coordinator_extra", "executor_config", "expected_template"),
         [
-            pytest.param("/coord/java.yaml", None, "/coord/java.yaml", id="coordinator-template-used"),
             pytest.param(
+                {"pod_template_file": "/coord/java.yaml"},
+                None,
                 "/coord/java.yaml",
+                id="coordinator-template-used",
+            ),
+            pytest.param(
+                {"pod_template_file": "/coord/java.yaml"},
                 {"pod_template_file": "/from/executor_config.yaml"},
                 "/coord/java.yaml",
                 id="coordinator-template-wins",
@@ -940,18 +945,18 @@ class TestKubernetesExecutor:
     )
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
-    @mock.patch.object(KubernetesExecutor, "_coordinator_pod_template_file")
+    @mock.patch.object(KubernetesExecutor, "_coordinator_extra")
     def test_coordinator_pod_template_file_used_for_queue(
         self,
-        mock_coordinator_template,
+        mock_coordinator_extra,
         mock_get_kube_client,
         mock_kubernetes_job_watcher,
-        coordinator_template,
+        coordinator_extra,
         executor_config,
         expected_template,
     ):
-        """A queue's coordinator template overrides executor_config; without one, executor_config is used."""
-        mock_coordinator_template.return_value = coordinator_template
+        """A queue coordinator's template overrides executor_config; without a coordinator, executor_config is used."""
+        mock_coordinator_extra.return_value = coordinator_extra
         executor = self.kubernetes_executor
         executor.start()
         try:
@@ -969,41 +974,28 @@ class TestKubernetesExecutor:
             executor.end()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
-    def test_coordinator_pod_template_file_skips_lookup_without_queue(self):
-        """No queue means no coordinator lookup (and no Task SDK import)."""
-        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
-            assert self.kubernetes_executor._coordinator_pod_template_file(None) is None
-            mock_get_manager.assert_not_called()
-
-    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @pytest.mark.parametrize(
         ("extra", "expected"),
         [
             pytest.param({"pod_template_file": "/coord/go.yaml"}, "/coord/go.yaml", id="template-in-extra"),
             pytest.param({"other": "value"}, None, id="extra-without-template"),
-            pytest.param(None, None, id="no-extra"),
         ],
     )
     def test_coordinator_pod_template_file_reads_extra(self, extra, expected):
-        """The template is read from the queue coordinator's ``extra`` mapping."""
-        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
-            mock_get_manager.return_value.extra_for_queue.return_value = extra
-            assert self.kubernetes_executor._coordinator_pod_template_file("go") == expected
-            mock_get_manager.return_value.extra_for_queue.assert_called_once_with("go")
-
-    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
-    def test_coordinator_pod_template_file_returns_none_on_old_task_sdk(self):
-        """Pre-3.3 Task SDKs lack get_coordinator_manager; the import error falls back to None."""
-        with mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.coordinator": None}):
-            assert self.kubernetes_executor._coordinator_pod_template_file("go") is None
+        """The template is read straight from the coordinator ``extra`` mapping passed in."""
+        assert self.kubernetes_executor._coordinator_pod_template_file(extra) == expected
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
-    @mock.patch.object(KubernetesExecutor, "_coordinator_kube_image", return_value="repo/java:1")
+    @mock.patch.object(
+        KubernetesExecutor,
+        "_coordinator_extra",
+        return_value={"worker_container_repository": "repo/java", "worker_container_tag": "1"},
+    )
     def test_coordinator_kube_image_carried_on_job(
         self,
-        mock_coordinator_kube_image,
+        mock_coordinator_extra,
         mock_get_kube_client,
         mock_kubernetes_job_watcher,
     ):
@@ -1023,13 +1015,6 @@ class TestKubernetesExecutor:
             executor.end()
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
-    def test_coordinator_kube_image_skips_lookup_without_queue(self):
-        """No queue means no coordinator lookup (and no Task SDK import)."""
-        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
-            assert self.kubernetes_executor._coordinator_kube_image(None) is None
-            mock_get_manager.assert_not_called()
-
-    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @pytest.mark.parametrize(
         ("extra", "expected"),
         [
@@ -1041,21 +1026,24 @@ class TestKubernetesExecutor:
             pytest.param({"worker_container_repository": "repo/java"}, None, id="repository-only"),
             pytest.param({"worker_container_tag": "17"}, None, id="tag-only"),
             pytest.param({"other": "value"}, None, id="extra-without-image"),
-            pytest.param(None, None, id="no-extra"),
         ],
     )
     def test_coordinator_kube_image_reads_extra(self, extra, expected):
-        """The base image is composed from the queue coordinator's ``extra`` mapping."""
-        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
-            mock_get_manager.return_value.extra_for_queue.return_value = extra
-            assert self.kubernetes_executor._coordinator_kube_image("java") == expected
-            mock_get_manager.return_value.extra_for_queue.assert_called_once_with("java")
+        """The base image is composed straight from the coordinator ``extra`` mapping passed in."""
+        assert self.kubernetes_executor._coordinator_kube_image(extra) == expected
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
-    def test_coordinator_kube_image_returns_none_on_old_task_sdk(self):
+    def test_coordinator_extra_skips_lookup_without_queue(self):
+        """No queue means no coordinator lookup (and no Task SDK import)."""
+        with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
+            assert self.kubernetes_executor._coordinator_extra(None) is None
+            mock_get_manager.assert_not_called()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
+    def test_coordinator_extra_returns_none_on_old_task_sdk(self):
         """Pre-3.3 Task SDKs lack get_coordinator_manager; the import error falls back to None."""
         with mock.patch.dict("sys.modules", {"airflow.sdk.execution_time.coordinator": None}):
-            assert self.kubernetes_executor._coordinator_kube_image("java") is None
+            assert self.kubernetes_executor._coordinator_extra("java") is None
 
     @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="The coordinator interface only support since 3.3+")
     @pytest.mark.parametrize("exc_type", ["airflow_config_exception", "value_error"])
@@ -1069,8 +1057,7 @@ class TestKubernetesExecutor:
             exc = ValueError("invalid coordinator key")
         with mock.patch("airflow.sdk.execution_time.coordinator.get_coordinator_manager") as mock_get_manager:
             mock_get_manager.return_value.extra_for_queue.side_effect = exc
-            assert self.kubernetes_executor._coordinator_pod_template_file("java") is None
-            assert self.kubernetes_executor._coordinator_kube_image("java") is None
+            assert self.kubernetes_executor._coordinator_extra("java") is None
 
     @pytest.mark.skipif(
         AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"


### PR DESCRIPTION
## Why

A queue routed to a non-Python coordinator (`[sdk] queue_to_coordinator`) needs a worker pod whose image carries that runtime (e.g. the JVM for a Java coordinator), but the KubernetesExecutor had no way to pick a coordinator-specific pod template or base image short of setting `executor_config` on every task.

## What

- Add `KubernetesExecutor._coordinator_pod_template_file` (reads `pod_template_file` from `extra`, import-guarded for 3.3+) and apply it with **precedence over `executor_config`** in `execute_async`.
  - `pod_template_file` -- applied with precedence over per-task `executor_config` (a queue's coordinator carries the runtime requirement, so it must win). Python queues resolve to `None` and are unaffected.
  - `worker_container_repository` + `worker_container_tag` -- compose a per-queue base image (both required), since the base image is never carried by a pod template. Plumbed through `KubernetesJob.kube_image` to the pod request.
- A malformed `[sdk]` config is logged and ignored rather than crashing the scheduler.

## Example Config to support Lang-SDK feature with KubernetesExecutor

`AIRFLOW__SDK__COORDINATORS`:
```json
{
  "jdk-11": {
    "classpath": "airflow.sdk.coordinators.java.JavaCoordinator",
    "kwargs": {"java_executable": "/usr/lib/jvm/java-11-openjdk/bin/java", "jvm_args": ["-Xmx1024m"]},
    "extra": {
        "pod_template_file": "/opt/airflow/pod_templates/java.yaml",
        "worker_container_repository": "myrepo/airflow-java",
        "worker_container_tag": "2.3.0"
    }
  },
  "jdk-17": {
    "classpath": "airflow.sdk.coordinators.java.JavaCoordinator",
    "kwargs": {"java_executable": "/usr/lib/jvm/java-17-openjdk/bin/java", "jvm_args": ["-Xmx512m"]},
    "extra": {
        "pod_template_file": "/opt/airflow/pod_templates/java.yaml",
        "worker_container_repository": "myrepo/airflow-java",
        "worker_container_tag": "3.3.0"
    }
  }
}
```

## Next

- https://github.com/apache/airflow/pull/68709

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
