### PR TITLE
Rename misleading last_automated_run param to reference_run

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -644,9 +644,9 @@ class DagModelOperation(NamedTuple):
             dm.bundle_name = self.bundle_name
             dm.bundle_version = self.bundle_version
 
-            last_automated_run: DagRun | None = run_info.latest_run
+            reference_run: DagRun | None = run_info.latest_run
             dm.exceeds_max_non_backfill = run_info.num_active_runs >= dm.max_active_runs
-            dm.calculate_dagrun_date_fields(dag, last_automated_run=last_automated_run)
+            dm.calculate_dagrun_date_fields(dag, reference_run=reference_run)
             if not dag.timetable.asset_condition:
                 dm.schedule_asset_references = []
                 dm.schedule_asset_alias_references = []

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2458,7 +2458,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     dag_id=dag_model.dag_id,
                     logical_date=dag_model.next_dagrun,
                 )
-                dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=dr)
+                dag_model.calculate_dagrun_date_fields(dag=serdag, reference_run=dr)
                 continue
 
             if (
@@ -2498,7 +2498,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     partition_date=next_info.partition_date,
                 )
                 active_runs_of_dags[dag_model.dag_id] += 1
-                dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=created_run)
+                dag_model.calculate_dagrun_date_fields(dag=serdag, reference_run=created_run)
                 self._set_exceeds_max_active_runs(
                     dag_model=dag_model,
                     session=session,

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -813,28 +813,30 @@ class DagModel(Base):
         self,
         dag: SerializedDAG | LazyDeserializedDAG,
         *,
-        last_automated_run: DagRun | None,
+        reference_run: DagRun | None,
     ) -> None:
         """
         Calculate ``next_dagrun`` and `next_dagrun_create_after``.
 
         :param dag: The DAG object
-        :param last_automated_run: DagRun of most recent run of this dag, or none
-            if not yet scheduled.
-            TODO: AIP-76 This is not always latest run! See https://github.com/apache/airflow/issues/59618.
+        :param reference_run: The automated run used as the basis for computing the
+            next run, or None if not yet scheduled. This is the run the scheduler is
+            currently processing, which is not necessarily the latest run of the dag:
+            scheduler processing order and concurrent run creation in a distributed
+            system mean a newer run may already exist.
         """
         # TODO: AIP-76 perhaps we need to add validation for manual runs ensure consistency between
         #   partition_key / partition_date and run_after
 
-        if isinstance(last_automated_run, datetime):
+        if isinstance(reference_run, datetime):
             raise ValueError(
                 "Passing a datetime to `DagModel.calculate_dagrun_date_fields` is not supported. "
                 "Provide a data interval instead."
             )
 
         last_run_info = None
-        if last_automated_run:
-            last_run_info = dag.timetable.run_info_from_dag_run(dag_run=last_automated_run)
+        if reference_run:
+            last_run_info = dag.timetable.run_info_from_dag_run(dag_run=reference_run)
         next_dagrun_info = dag.next_dagrun_info(last_automated_run_info=last_run_info)
         if next_dagrun_info is None:
             # there is no next dag run after the last dag run; set everything to None

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5072,7 +5072,7 @@ class TestSchedulerJob:
                 bash_command="exit 1",
                 retries=1,
             )
-        dag_maker.dag_model.calculate_dagrun_date_fields(dag, last_automated_run=None)
+        dag_maker.dag_model.calculate_dagrun_date_fields(dag, reference_run=None)
 
         @provide_session
         def do_schedule(*, session: Session = NEW_SESSION):

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -4344,7 +4344,7 @@ def test_calculate_dagrun_date_fields(
     run = dag_maker.create_dagrun()
     serdag = dag_maker.serialized_dag
     dag_model = dag_maker.dag_model
-    dag_model.calculate_dagrun_date_fields(dag=serdag, last_automated_run=run)
+    dag_model.calculate_dagrun_date_fields(dag=serdag, reference_run=run)
     assert dag_model.next_dagrun_data_interval == next_interval
     assert dag_model.next_dagrun == next_run
     assert dag_model.next_dagrun_create_after == next_run_after


### PR DESCRIPTION
## Why
`DagModel.calculate_dagrun_date_fields` took a keyword-only param named `last_automated_run`, implying it was always the most recent run.

It isn't: the scheduler passes whichever run it is currently processing, and in a distributed setup a newer run can be created concurrently. The name promised a guarantee the callers never provide.
 
This is a long-standing naming smell — the "last / latest" framing predates the current `DagRun` signature. The partition-driven scheduling work left a `TODO ... See #59618` flagging it; this PR does that cleanup.

Related: #59618

## What

- Rename the keyword-only param `last_automated_run` → `reference_run` on `DagModel.calculate_dagrun_date_fields`, plus its three in-method references.
- Rewrite the docstring: it's the run the scheduler is currently processing, used as the basis for the next-run calculation — not necessarily the latest.
- Update both production callers (`dag_processing/collection.py`, `jobs/scheduler_job_runner.py`) and the two test callers.

No behaviour change — pure rename plus docstring clarification.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
