### PR TITLE
Change log level from info to debug for Edge job fetch

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -118,7 +118,7 @@ Execution API") for the security boundary.
 .. code-block:: bash
 
     airflow edge worker
-    2025-09-27T12:28:32.954316Z [info     ] Starting worker with API endpoint http://localhost:8080/edge_worker/v1/rpcapi
+    2026-07-09T12:28:32.954316Z [info     ] Starting worker with API endpoint http://localhost:8080/edge_worker/v1/rpcapi
       ____________       _____________
      ____    |__( )_________  __/__  /________      __
     ____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
@@ -130,7 +130,7 @@ Execution API") for the security boundary.
     /___/\_,_/\_, /\__/   |__/|__/\___/_/ /_/\_\\__/_/
             /___/
 
-    2025-09-27T12:28:33.171525Z [info     ] No new job to process
+    2026-07-09T12:28:33.171525Z [debug    ] No new job to process
 
 
 To start a worker assigned to a specific team:

--- a/providers/edge3/src/airflow/providers/edge3/cli/worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/worker.py
@@ -674,7 +674,7 @@ class EdgeWorker:
         logger.debug("Attempting to fetch a new job...")
         edge_job = await jobs_fetch(self.hostname, self.queues, self.free_concurrency, self.team_name)
         if not edge_job:
-            logger.info(
+            logger.debug(
                 "No new job to process%s",
                 f", {len(self.jobs)} still running" if self.jobs else "",
             )


### PR DESCRIPTION
This changes the log level of the "No new job to process" message in `fetch_and_run_job()` from `logger.info` to `logger.debug`.

**Why**: An idle edge worker emits this message every job_poll_interval seconds for as long as no work is queued. In many deployments, workers spend the majority of their time idle — that's by design, since edge workers are often provisioned for bursty or on-demand workloads. The result is that this single message dominates the worker logs, drowning out genuinely useful INFO-level entries like job starts, completions, state changes, and heartbeat events.

Per Python's logging conventions, INFO should communicate "confirmation that things are working as expected" — meaningful milestones and state transitions. An idle worker having nothing to do is the expected steady state, not a notable event. By contrast, DEBUG is the correct level for routine operational chatter useful only when actively troubleshooting.

For comparison, the line immediately above it already uses the right level: logger.debug("Attempting to fetch a new job..."). The "no job found" outcome is the other half of the same operation and should match.

Impact: No behaviour change. Operators who want to see these messages can still set the edge worker log level to DEBUG. Everyone else gets cleaner logs at the default INFO level.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
