### PR TITLE
UI: Complete Spanish UI translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/admin.json
@@ -86,7 +86,7 @@
   },
   "jobs": {
     "columns": {
-      "executorClass": "Clase del Executor",
+      "executorClass": "Clase de Executor",
       "hostname": "Nombre de Host",
       "id": "ID",
       "jobType": "Tipo de Trabajo",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/admin.json
@@ -3,6 +3,7 @@
     "description": "Descripción",
     "key": "Clave",
     "name": "Nombre",
+    "team": "Equipo",
     "value": "Valor"
   },
   "config": {
@@ -52,6 +53,12 @@
     "searchPlaceholder": "Buscar Conexiones",
     "test": "Prueba de Conexión",
     "testDisabled": "La función de prueba de conexión está desactivada. Por favor, contacta a un administrador para activarla.",
+    "testError": {
+      "title": "Prueba de Conexión Fallida"
+    },
+    "testSuccess": {
+      "title": "Prueba de Conexión Exitosa"
+    },
     "typeMeta": {
       "error": "Error al recuperar la Metadata del Tipo de Conexión",
       "standardFields": {
@@ -77,6 +84,23 @@
   "formActions": {
     "save": "Guardar"
   },
+  "jobs": {
+    "columns": {
+      "executorClass": "Clase del Executor",
+      "hostname": "Nombre de Host",
+      "id": "ID",
+      "jobType": "Tipo de Trabajo",
+      "latestHeartbeat": "Último Heartbeat",
+      "unixname": "Nombre de Unix"
+    },
+    "filters": {
+      "allStates": "Todos los Estados",
+      "allTypes": "Todos los Tipos",
+      "dagProcessorJob": "DagProcessorJob",
+      "schedulerJob": "SchedulerJob",
+      "triggererJob": "TriggererJob"
+    }
+  },
   "plugins": {
     "columns": {
       "source": "Origen"
@@ -100,7 +124,8 @@
       "includeDeferred": "Incluir diferidos",
       "nameMaxLength": "El nombre puede contener un máximo de 256 caracteres",
       "nameRequired": "El nombre es requerido",
-      "slots": "Slots"
+      "slots": "Slots",
+      "slotsHelperText": "Use -1 para slots ilimitados."
     },
     "noPoolsFound": "No se encontraron pools",
     "pool_many": "Pools",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
@@ -14,7 +14,7 @@
     "deleteWarning": "El Asset perderá esta entrada de almacén de estado persistente.",
     "edit": "Editar Almacén de Estado de Asset",
     "emptyState": "El almacén de estado de Asset almacena valores con alcance en la identidad de un Asset, compartidos entre todas las ejecuciones del Dag. Los workers pueden escribir en el almacén de estado de Asset mediante el Task SDK.",
-    "lastUpdatedBy": "Última Actualización Por",
+    "lastUpdatedBy": "Última actualización realizada por",
     "lastUpdatedByApi": "API",
     "lastUpdatedByWatcher": "Watcher",
     "title": "Almacén de Estado de Asset"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
@@ -4,20 +4,20 @@
   "asset_one": "Asset",
   "asset_other": "Assets",
   "assetStateStore": {
-    "add": "Agregar Almacén de Estado de Asset",
+    "add": "Agregar Almacenamiento de Estado de Asset",
     "clearAll": {
-      "resource": "todo el almacén de estado de Asset",
-      "title": "Limpiar Todo el Almacén de Estado de Asset",
-      "warning": "Se borrará todo el almacén de estado de Asset. Las tareas que usan este almacén para coordinar trabajo perderán su memoria persistente."
+      "resource": "todo el almacenamiento de estado de Asset",
+      "title": "Limpiar Todo el Almacenamiento de Estado de Asset",
+      "warning": "Se borrará todo el almacenamiento de estado de Asset. Las tareas que usan este almacenamiento para coordinar trabajo perderán su memoria persistente."
     },
-    "delete": "Eliminar Almacén de Estado de Asset",
-    "deleteWarning": "El Asset perderá esta entrada de almacén de estado persistente.",
-    "edit": "Editar Almacén de Estado de Asset",
-    "emptyState": "El almacén de estado de Asset almacena valores con alcance en la identidad de un Asset, compartidos entre todas las ejecuciones del Dag. Los workers pueden escribir en el almacén de estado de Asset mediante el Task SDK.",
+    "delete": "Eliminar Almacenamiento de Estado de Asset",
+    "deleteWarning": "El Asset perderá esta entrada de almacenamiento de estado persistente.",
+    "edit": "Editar Almacenamiento de Estado de Asset",
+    "emptyState": "El almacenamiento de estado de Asset almacena valores con alcance en la identidad de un Asset, compartidos entre todas las ejecuciones del Dag. Los workers pueden escribir en el almacenamiento de estado de Asset mediante el Task SDK.",
     "lastUpdatedBy": "Última Actualización Realizada Por",
     "lastUpdatedByApi": "API",
     "lastUpdatedByWatcher": "Watcher",
-    "title": "Almacén de Estado de Asset"
+    "title": "Almacenamiento de Estado de Asset"
   },
   "consumingDags": "Consumiendo Dags",
   "consumingTasks": "Tareas Consumidoras",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
@@ -14,7 +14,7 @@
     "deleteWarning": "El Asset perderá esta entrada de almacén de estado persistente.",
     "edit": "Editar Almacén de Estado de Asset",
     "emptyState": "El almacén de estado de Asset almacena valores con alcance en la identidad de un Asset, compartidos entre todas las ejecuciones del Dag. Los workers pueden escribir en el almacén de estado de Asset mediante el Task SDK.",
-    "lastUpdatedBy": "Última actualización realizada por",
+    "lastUpdatedBy": "Última Actualización Realizada Por",
     "lastUpdatedByApi": "API",
     "lastUpdatedByWatcher": "Watcher",
     "title": "Almacén de Estado de Asset"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/assets.json
@@ -1,5 +1,26 @@
 {
+  "additional_data": "Datos Adicionales",
+  "asset_many": "Assets",
+  "asset_one": "Asset",
+  "asset_other": "Assets",
+  "assetStateStore": {
+    "add": "Agregar Almacén de Estado de Asset",
+    "clearAll": {
+      "resource": "todo el almacén de estado de Asset",
+      "title": "Limpiar Todo el Almacén de Estado de Asset",
+      "warning": "Se borrará todo el almacén de estado de Asset. Las tareas que usan este almacén para coordinar trabajo perderán su memoria persistente."
+    },
+    "delete": "Eliminar Almacén de Estado de Asset",
+    "deleteWarning": "El Asset perderá esta entrada de almacén de estado persistente.",
+    "edit": "Editar Almacén de Estado de Asset",
+    "emptyState": "El almacén de estado de Asset almacena valores con alcance en la identidad de un Asset, compartidos entre todas las ejecuciones del Dag. Los workers pueden escribir en el almacén de estado de Asset mediante el Task SDK.",
+    "lastUpdatedBy": "Última Actualización Por",
+    "lastUpdatedByApi": "API",
+    "lastUpdatedByWatcher": "Watcher",
+    "title": "Almacén de Estado de Asset"
+  },
   "consumingDags": "Consumiendo Dags",
+  "consumingTasks": "Tareas Consumidoras",
   "createEvent": {
     "button": "Crear Evento",
     "manual": {
@@ -21,10 +42,14 @@
     },
     "title": "Crear Evento de Asset para {{name}}"
   },
+  "events": "Eventos",
+  "extra": "Extra",
   "group": "Grupo",
   "lastAssetEvent": "Último Evento de Asset",
   "name": "Nombre",
   "producingTasks": "Tareas produciendo",
   "scheduledDags": "Dags programados",
-  "searchPlaceholder": "Buscar Assets"
+  "scheduling": "Programación",
+  "searchPlaceholder": "Buscar Assets",
+  "taskDependencies": "Dependencias de Tareas"
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/browse.json
@@ -11,12 +11,55 @@
     },
     "title": "Auditar Log"
   },
+  "deadlines": {
+    "columns": {
+      "alertName": "Nombre de Alerta",
+      "deadlineTime": "Hora del Plazo",
+      "status": "Estado"
+    },
+    "deadline_many": "Plazos",
+    "deadline_one": "Plazo",
+    "deadline_other": "Plazos",
+    "filters": {
+      "status": "Estado",
+      "statusOptions": {
+        "all": "Todos",
+        "missed": "Incumplido",
+        "pending": "Pendiente"
+      }
+    },
+    "title": "Plazos"
+  },
   "xcom": {
+    "add": {
+      "error": "Error al agregar XCom",
+      "errorTitle": "Error",
+      "success": "XCom agregado exitosamente",
+      "successTitle": "XCom Agregado",
+      "title": "Agregar XCom"
+    },
     "columns": {
       "dag": "Dag",
       "key": "Clave",
       "value": "Valor"
     },
-    "title": "XCom"
+    "delete": {
+      "error": "Error al eliminar XCom",
+      "errorTitle": "Error",
+      "success": "XCom eliminado exitosamente",
+      "successTitle": "XCom Eliminado",
+      "title": "Eliminar XCom",
+      "warning": "¿Confirmas que deseas eliminar este XCom? Esta acción no se puede deshacer."
+    },
+    "edit": {
+      "error": "Error al actualizar XCom",
+      "errorTitle": "Error",
+      "success": "XCom actualizado exitosamente",
+      "successTitle": "XCom Actualizado",
+      "title": "Editar XCom"
+    },
+    "key": "Clave",
+    "title": "XCom",
+    "value": "Valor"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -231,8 +231,8 @@
     "roles": "Roles",
     "users": "Usuarios"
   },
-  "selected": "Seleccionado",
   "selectLanguage": "Seleccionar Idioma",
+  "selected": "Seleccionado",
   "showDetailsPanel": "Mostrar Panel de Detalles",
   "signedInAs": "Sesión iniciada como",
   "source": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/common.json
@@ -20,16 +20,22 @@
   "assetEvent_many": "Eventos de Asset",
   "assetEvent_one": "Evento de Asset",
   "assetEvent_other": "Eventos de Asset",
+  "assetInactive": {
+    "tooltip": "El Asset upstream ha sido desactivado; el programador retiene la evaluación de particiones hasta que se reactive."
+  },
   "backfill_many": "Backfills",
   "backfill_one": "Backfill",
   "backfill_other": "Backfills",
   "browse": {
     "auditLog": "Auditar Log",
+    "deadlines": "Plazos",
+    "jobs": "Trabajos",
     "requiredActions": "Acciones Requeridas",
     "xcoms": "XComs"
   },
   "collapseAllExtra": "Colapsar todos los extra json",
   "collapseDetailsPanel": "Colapsar Detalles del Panel",
+  "consumingAsset": "Asset Consumidor",
   "createdAssetEvent_many": "Eventos de Asset Creados",
   "createdAssetEvent_one": "Evento de Asset Creado",
   "createdAssetEvent_other": "Eventos de Asset Creados",
@@ -70,6 +76,8 @@
     },
     "expectedDuration": "Duración Esperada",
     "lastSchedulingDecision": "Última Decisión de Programación",
+    "mappedPartitionKey": "Clave de Partición Mapeada",
+    "partitionKey": "Clave de Partición",
     "queuedAt": "En Cola en",
     "runAfter": "Ejecutar Después",
     "runType": "Tipo de Ejecución",
@@ -84,6 +92,11 @@
   "dagWarnings": "Advertencias/Errores del Dag",
   "defaultToGraphView": "Por defecto a vista gráfica",
   "defaultToGridView": "Por defecto a vista en cuadrícula",
+  "delete": "Eliminar",
+  "diff": "Diff",
+  "diffCompareWith": "Comparar con",
+  "diffExit": "Salir de Diff",
+  "diffSelectVersionToCompare": "Seleccionar versión para comparar",
   "direction": "Dirección",
   "docs": {
     "documentation": "Documentación",
@@ -96,13 +109,21 @@
     "tooltip": "Presiona {{hotkey}} para descargar los registros"
   },
   "duration": "Duración",
+  "edit": "Editar",
   "endDate": "Fecha Final",
   "error": {
     "back": "Atrás",
     "defaultMessage": "Ocurrió un error inesperado",
     "home": "Inicio",
+    "invalidUrl": "Página No Encontrada. Verifica la URL e inténtalo de nuevo.",
     "notFound": "Página no encontrada",
     "title": "Error"
+  },
+  "errors": {
+    "forbidden": {
+      "description": "No tienes permiso para realizar esta acción.",
+      "title": "Acceso Denegado"
+    }
   },
   "expand": {
     "collapse": "Colapsar",
@@ -121,22 +142,33 @@
   "filters": {
     "durationFrom": "Duración Desde",
     "durationTo": "Duración Hasta",
+    "endTime": "Hora Final",
     "logicalDateFrom": "Fecha Lógica Desde",
     "logicalDateTo": "Fecha Lógica Hasta",
     "runAfterFrom": "Ejecutar Después Desde",
-    "runAfterTo": "Ejecutar Después Hasta"
+    "runAfterTo": "Ejecutar Después Hasta",
+    "searchAsset": "Buscar Asset",
+    "selectDateRange": "Seleccionar Rango de Fechas",
+    "startTime": "Hora Inicial"
   },
+  "fullscreen": {
+    "tooltip": "Presiona {{hotkey}} para pantalla completa"
+  },
+  "generateToken": "Generar Token",
+  "key": "Clave",
   "logicalDate": "Fecha Lógica",
   "logout": "Cerrar Sesión",
   "logoutConfirmation": "Estás a punto de cerrar sesión de la aplicación.",
   "mapIndex": "Mapa de Índice",
   "modal": {
+    "add": "Agregar",
     "cancel": "Cancelar",
     "confirm": "Confirmar",
     "delete": {
       "button": "Eliminar",
       "confirmation": "¿Confirmas de querer eliminar {{resourceName}}? Esta acción no se puede deshacer."
-    }
+    },
+    "save": "Guardar"
   },
   "nav": {
     "admin": "Administración",
@@ -153,23 +185,27 @@
   "note": {
     "add": "Agregar una nota",
     "dagRun": "Nota de Ejecución del Dag",
+    "edit": "Editar nota",
     "label": "Nota",
     "placeholder": "Agregar una nota...",
-    "taskInstance": "Nota de Instancia de Tarea"
+    "preview": "Vista Previa",
+    "taskInstance": "Nota de Instancia de Tarea",
+    "write": "Escribir"
   },
-  "pools": {
-    "deferred": "Diferido",
-    "open": "Abierto",
-    "pools_many": "pools",
-    "pools_one": "pool",
-    "pools_other": "pools",
-    "queued": "En Cola",
-    "running": "En Ejecución",
-    "scheduled": "Programado"
+  "overallStatus": "Estado General",
+  "partitionedDagRun_many": "Ejecuciones del Dag Particionadas",
+  "partitionedDagRun_one": "Ejecución del Dag Particionada",
+  "partitionedDagRun_other": "Ejecuciones del Dag Particionadas",
+  "partitionedDagRunDetail": {
+    "receivedAssetEvents": "Eventos de Asset Recibidos"
   },
+  "pendingDagRun_many": "{{count}} Ejecuciones del Dag Pendientes",
+  "pendingDagRun_one": "{{count}} Ejecución del Dag Pendiente",
+  "pendingDagRun_other": "{{count}} Ejecuciones del Dag Pendientes",
   "reset": "Restablecer",
   "runId": "ID de la ejecución",
   "runTypes": {
+    "asset_materialization": "Materialización de Asset",
     "asset_triggered": "Asset Activado",
     "backfill": "Backfill",
     "manual": "Manual",
@@ -182,6 +218,12 @@
     },
     "tooltip": "Presiona {{hotkey}} para desplazarte a {{direction}}"
   },
+  "search": {
+    "advanced": {
+      "description": "Coincide en cualquier parte del valor (búsqueda por subcadena). Más lento en despliegues grandes porque no puede usar el índice B-tree predeterminado. Consulta la sección de documentación sobre índices de metadata personalizados para más detalles.",
+      "title": "Coincidir en Cualquier Parte"
+    }
+  },
   "security": {
     "actions": "Acciones",
     "permissions": "Permisos",
@@ -189,8 +231,10 @@
     "roles": "Roles",
     "users": "Usuarios"
   },
+  "selected": "Seleccionado",
   "selectLanguage": "Seleccionar Idioma",
   "showDetailsPanel": "Mostrar Panel de Detalles",
+  "signedInAs": "Sesión iniciada como",
   "source": {
     "hide": "Ocultar Fuente",
     "hotkey": "s",
@@ -202,10 +246,12 @@
   "startDate": "Fecha Inicial",
   "state": "Estado",
   "states": {
+    "awaiting_input": "Esperando Entrada",
     "deferred": "Diferido",
     "failed": "Fallido",
     "no_status": "Sin Estado",
     "none": "Sin Estado",
+    "open": "Abierto",
     "planned": "Planificado",
     "queued": "En Cola",
     "removed": "Removido",
@@ -234,23 +280,35 @@
       "any": "Cualquiera"
     },
     "tagPlaceholder": "Filtrar por etiqueta",
-    "to": "Hasta"
+    "to": "Hasta",
+    "updatedAt": "Actualizado en"
   },
   "task": {
+    "dependsOnPast": "Depende del Pasado",
     "documentation": "Documentación de la Tarea",
     "lastInstance": "Última Instancia",
     "operator": "Operador",
-    "triggerRule": "Regla de Activación"
+    "retries": "Reintentos",
+    "triggerRule": "Regla de Activación",
+    "waitForDownstream": "Esperar Downstream"
   },
   "task_many": "Tareas",
   "task_one": "Tarea",
   "task_other": "Tareas",
+  "taskGroup": {
+    "documentation": "Documentación del Grupo de Tareas"
+  },
+  "taskGroup_many": "Grupos de Tareas",
+  "taskGroup_one": "Grupo de Tareas",
+  "taskGroup_other": "Grupos de Tareas",
   "taskId": "ID de la Tarea",
   "taskInstance": {
+    "additionalAttributes": "Atributos Adicionales de la Instancia de Tarea",
     "dagVersion": "Versión del Dag",
     "executor": "Executor",
     "executorConfig": "Configuración del Executor",
     "hostname": "Nombre de Host",
+    "id": "ID",
     "maxTries": "Máximo de Intentos",
     "pid": "PID",
     "pool": "Pool",
@@ -258,12 +316,15 @@
     "priorityWeight": "Peso de Prioridad",
     "queue": "Cola",
     "queuedWhen": "En Cola en",
+    "renderedMapIndex": "Map Index Renderizado",
     "scheduledWhen": "Programado en",
+    "trigger": "Trigger",
     "triggerer": {
       "assigned": "Triggerer Asignado",
       "class": "Clase del Trigger",
       "createdAt": "Tiempo de Creación del Trigger",
       "id": "ID del Trigger",
+      "job": "Trabajo del Triggerer",
       "latestHeartbeat": "Último Heartbeat del Triggerer",
       "title": "Información del Triggerer"
     },
@@ -291,11 +352,25 @@
     "utc": "UTC (Tiempo Universal Coordinado)"
   },
   "toaster": {
+    "bulkClear": {
+      "error": "Solicitud de Limpieza Masiva de {{resourceName}} Fallida",
+      "success": {
+        "description": "{{count}} {{resourceName}} han sido limpiados exitosamente. Claves: {{keys}}",
+        "title": "Solicitud de Limpieza Masiva de {{resourceName}} Enviada"
+      }
+    },
     "bulkDelete": {
       "error": "Eliminar {{resourceName}} Request Fallido",
       "success": {
         "description": "{{count}} {{resourceName}} han sido eliminados exitosamente. Claves: {{keys}}",
         "title": "Eliminar {{resourceName}} Request Enviado"
+      }
+    },
+    "bulkUpdate": {
+      "error": "Solicitud de Actualización Masiva de {{resourceName}} Fallida",
+      "success": {
+        "description": "{{count}} {{resourceName}} han sido actualizados exitosamente. Claves: {{keys}}",
+        "title": "Solicitud de Actualización Masiva de {{resourceName}} Enviada"
       }
     },
     "create": {
@@ -327,10 +402,27 @@
       }
     }
   },
+  "tokenGeneration": {
+    "apiToken": "Token de API",
+    "cliToken": "Token de CLI",
+    "errorDescription": "Ocurrió un error al generar el token. Inténtalo de nuevo.",
+    "errorTitle": "Generación de Token Fallida",
+    "generate": "Generar",
+    "selectType": "Selecciona el tipo de token a generar.",
+    "title": "Generar Token",
+    "tokenExpiresIn": "Este token expira en {{duration}}.",
+    "tokenGenerated": "Tu token ha sido generado.",
+    "tokenShownOnce": "Este token solo se mostrará una vez. Cópialo ahora."
+  },
   "total": "Total {{state}}",
   "triggered": "Activado",
   "tryNumber": "Intento Número",
   "user": "Usuario",
+  "validation": {
+    "mustBeAtLeast": "Debe ser al menos {{min}}.",
+    "mustBeValidNumber": "Debe ser un número válido."
+  },
+  "value": "Valor",
   "wrap": {
     "hotkey": "w",
     "tooltip": "Presiona {{hotkey}} para alternar el 'envolver'",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/components.json
@@ -11,8 +11,12 @@
     "maxRuns": "Máximo de Ejecuciones Activas",
     "missingAndErroredRuns": "Ejecutaciones Faltantes y con Errores",
     "missingRuns": "Ejecutaciones Faltantes",
+    "overrideExistingParams": "Sobrescribir parámetros en ejecuciones existentes",
+    "permissionDenied": "Ejecución en Seco Fallida: el usuario no tiene permiso para crear backfills.",
     "reprocessBehavior": "Comportamiento de Reprocesamiento",
     "run": "Ejecutar Backfill",
+    "scheduleNotBackfillable": "La programación de este Dag no admite backfills",
+    "schedulerPriorityHint": "Las ejecuciones del Dag de backfill se ordenan después de las ejecuciones del Dag que no son backfill en cada ciclo del programador. Las ejecuciones de backfill pueden permanecer en cola más tiempo si hay otras ejecuciones que no son backfill presentes.",
     "selectDescription": "Ejecutar este Dag para un rango de fechas",
     "selectLabel": "Backfill",
     "title": "Ejecutar Backfill",
@@ -44,13 +48,18 @@
     "invalidJson": "Formato JSON inválido: {{errorMessage}}"
   },
   "dagWarnings": {
-    "error_many": "Errores",
     "error_one": "1 Error",
-    "error_other": "Errores",
     "errorAndWarning": "1 Error y {{warningText}}",
     "warning_many": "{{count}} Advertencias",
     "warning_one": "1 Advertencia",
     "warning_other": "{{count}} Advertencias"
+  },
+  "dateRangeFilter": {
+    "validation": {
+      "invalidDateFormat": "Formato de fecha inválido.",
+      "invalidTimeFormat": "Formato de hora inválido.",
+      "startBeforeEnd": "La fecha/hora inicial debe ser anterior a la fecha/hora final"
+    }
   },
   "durationChart": {
     "duration": "Duración (segundos)",
@@ -70,6 +79,7 @@
     "files_other": "{{count}} archivos"
   },
   "flexibleForm": {
+    "durationPlaceholder": "Ingresa la duración en formato ISO 8601",
     "placeholder": "Seleccionar Valor",
     "placeholderArray": "Ingrese cada cadena en una nueva línea",
     "placeholderExamples": "Comience a escribir para ver opciones",
@@ -77,6 +87,7 @@
     "validationErrorArrayNotArray": "El valor debe ser un array.",
     "validationErrorArrayNotNumbers": "Todos los elementos en el array deben ser números.",
     "validationErrorArrayNotObject": "Todos los elementos en el array deben ser objetos.",
+    "validationErrorDuration": "Formato de duración ISO 8601 inválido",
     "validationErrorRequired": "Este campo es requerido"
   },
   "graph": {
@@ -91,7 +102,8 @@
     "taskCount_many": "{{count}} Tareas",
     "taskCount_one": "{{count}} Tarea",
     "taskCount_other": "{{count}} Tareas",
-    "taskGroup": "Grupo de Tareas"
+    "taskGroup": "Grupo de Tareas",
+    "zoomToTask": "Zoom a la tarea seleccionada"
   },
   "limitedList": "+{{count}} más",
   "limitedList.allItems": "Todos los {{count}} elementos:",
@@ -113,22 +125,40 @@
   "sortedDescending": "ordenado descendente",
   "sortedUnsorted": "sin ordenar",
   "taskTries": "Intentos de Tarea",
+  "taskTryPlaceholder": "Intento de Tarea",
+  "team": {
+    "selector": {
+      "helperText": "Opcional. Restringe el uso a un equipo específico.",
+      "label": "Equipo",
+      "placeHolder": "Seleccionar un equipo"
+    }
+  },
   "toggleCardView": "Mostrar vista de tarjeta",
   "toggleTableView": "Mostrar vista de tabla",
   "triggerDag": {
     "button": "Trigger",
+    "dataInterval": "Intervalo de Datos",
+    "dataIntervalAuto": "Inferido de la Fecha Lógica y la Programación",
+    "dataIntervalManual": "Especificar Manualmente",
+    "intervalEnd": "Fin",
+    "intervalStart": "Inicio",
     "loading": "Cargando información del Dag...",
     "loadingFailed": "Error al cargar la información del Dag. Por favor, inténtelo de nuevo.",
+    "manualRunDenied": "Las ejecuciones manuales no están permitidas para este Dag",
     "runIdHelp": "Opcional - se generará si no se proporciona",
     "selectDescription": "Activar una ejecución única de este Dag",
     "selectLabel": "Ejecución Única",
     "title": "Activar Dag",
     "toaster": {
+      "error": {
+        "title": "Error al Activar el Dag"
+      },
       "success": {
         "description": "La ejecución del Dag ha sido activada exitosamente.",
         "title": "Ejecución del Dag Activada"
       }
     },
+    "triggerAgainWithConfig": "Activar de nuevo con esta configuración",
     "unpause": "Reanudar {{dagDisplayName}} al activarse"
   },
   "trimText": {
@@ -144,6 +174,7 @@
     "versionId": "ID de la Versión"
   },
   "versionSelect": {
+    "allVersions": "Todas las Versiones",
     "dagVersion": "Versión del Dag",
     "versionCode": "v{{versionCode}}"
   }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/dag.json
@@ -236,7 +236,7 @@
     "runs": "Ejecuciones",
     "storage": "Almacenamiento",
     "taskInstances": "Instancias de Tarea",
-    "taskStateStore": "Almacén de Estado de Tarea",
+    "taskStateStore": "Almacenamiento de Estado de Tarea",
     "tasks": "Tareas",
     "xcom": "XCom"
   },
@@ -245,16 +245,16 @@
     "expandAll": "Expandir todos los grupos de tareas"
   },
   "taskStateStore": {
-    "add": "Agregar Almacén de Estado de Tarea",
+    "add": "Agregar Almacenamiento de Estado de Tarea",
     "clearAll": {
-      "resource": "todo el almacén de estado de tarea",
-      "title": "Limpiar Todo el Almacén de Estado de Tarea",
-      "warning": "Se borrará todo el almacén de estado de tarea. Las tareas que usan este almacén para hacer seguimiento de trabajo externo no podrán reanudarlo sin volver a ejecutarse desde cero."
+      "resource": "todo el almacenamiento de estado de tarea",
+      "title": "Limpiar Todo el Almacenamiento de Estado de Tarea",
+      "warning": "Se borrará todo el almacenamiento de estado de tarea. Las tareas que usan este almacenamiento para hacer seguimiento de trabajo externo no podrán reanudarlo sin volver a ejecutarse desde cero."
     },
-    "delete": "Eliminar Almacén de Estado de Tarea",
+    "delete": "Eliminar Almacenamiento de Estado de Tarea",
     "deleteWarning": "La tarea perderá esta memoria persistente. Si la tarea usa esta clave para hacer seguimiento de trabajo externo (p. ej., un ID de trabajo externo), no podrá reanudarlo.",
-    "edit": "Editar Almacén de Estado de Tarea",
-    "emptyStore": "El almacén de estado de tarea almacena valores que persisten entre reintentos. Los workers pueden escribir en el almacén de estado de tarea mediante el Task SDK.",
+    "edit": "Editar Almacenamiento de Estado de Tarea",
+    "emptyStore": "El almacenamiento de estado de tarea almacena valores que persisten entre reintentos. Los workers pueden escribir en el almacenamiento de estado de tarea mediante el Task SDK.",
     "expiresAt": {
       "column": "Expira en",
       "custom": "Personalizado",
@@ -262,6 +262,6 @@
       "label": "Expiración",
       "never": "Nunca"
     },
-    "title": "Almacén de Estado de Tarea"
+    "title": "Almacenamiento de Estado de Tarea"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/dag.json
@@ -40,17 +40,52 @@
     "parseDuration": "Duración del parseo:",
     "parsedAt": "Parseado en:"
   },
+  "deadlineAlerts": {
+    "completionRule": "Debe completarse dentro de {{interval}} de {{reference}}",
+    "count_many": "{{count}} plazos",
+    "count_one": "{{count}} plazos",
+    "count_other": "{{count}} plazos",
+    "referenceType": {
+      "AverageRuntimeDeadline": "duración promedio de ejecución",
+      "DagRunLogicalDateDeadline": "fecha lógica",
+      "DagRunQueuedAtDeadline": "hora de cola"
+    }
+  },
+  "deadlineStatus": {
+    "actual": "Real",
+    "expected": "Esperado",
+    "finishedEarly": "Finalizado {{duration}} antes del plazo",
+    "finishedLate": "Finalizado {{duration}} después del plazo",
+    "label": "Plazo",
+    "met": "Cumplido",
+    "missed": "Incumplido",
+    "missedCount_many": "{{count}} Plazos Incumplidos",
+    "missedCount_one": "{{count}} Plazos Incumplidos",
+    "missedCount_other": "{{count}} Plazos Incumplidos",
+    "mixedCount": "{{missedCount}} Incumplidos, {{upcomingCount}} Próximos",
+    "stillRunning": "Aún en ejecución",
+    "upcoming": "Próximos",
+    "upcomingCount_many": "{{count}} Plazos Próximos",
+    "upcomingCount_one": "{{count}} Plazos Próximos",
+    "upcomingCount_other": "{{count}} Plazos Próximos"
+  },
   "extraLinks": "Enlaces Extra",
   "grid": {
     "buttons": {
+      "newerRuns": "Ejecuciones más recientes",
+      "olderRuns": "Ejecuciones más antiguas",
       "resetToLatest": "Reiniciar a la última",
       "toggleGroup": "Alternar grupo"
-    }
+    },
+    "runTypeLegend": "Leyenda de Tipo de Ejecución"
   },
   "header": {
     "buttons": {
       "advanced": "Avanzado",
       "dagDocs": "Documentacion del Dag"
+    },
+    "status": {
+      "deactivated": "Desactivado"
     }
   },
   "logs": {
@@ -59,19 +94,27 @@
     "critical": "CRÍTICO",
     "debug": "DEPURACIÓN",
     "error": "ERROR",
-    "fullscreen": {
-      "button": "Pantalla completa",
-      "tooltip": "Presiona {{hotkey}} para pantalla completa"
-    },
     "info": "INFO",
     "noTryNumber": "No hay número de intento",
+    "search": {
+      "matchCount": "{{current}} de {{total}}",
+      "noMatches": "Sin coincidencias",
+      "placeholder": "Buscar en logs..."
+    },
     "settings": "Configuración de logs",
     "viewInExternal": "Ver logs en {{name}} (intento {{attempt}})",
     "warning": "ADVERTENCIA"
   },
   "navigation": {
     "navigation": "Navegación: Shift+{{arrow}}",
+    "openGraphFilters": "Filtros de Tareas: Ctrl+Shift+F",
     "toggleGroup": "Alternar grupo: Espacio"
+  },
+  "notFound": {
+    "back": "Volver",
+    "backToDags": "Volver a Dags",
+    "message": "El Dag \"{{dagId}}\" no existe.",
+    "title": "Dag No Encontrado"
   },
   "overview": {
     "buttons": {
@@ -89,6 +132,10 @@
       "assetEvent_many": "Eventos de Asset Creados",
       "assetEvent_one": "Evento de Asset Creado",
       "assetEvent_other": "Eventos de Asset Creados"
+    },
+    "deadlines": {
+      "showAll": "Mostrar Todo",
+      "title": "Plazos"
     },
     "failedLogs": {
       "hideLogs": "Ocultar Logs",
@@ -118,6 +165,45 @@
     },
     "graphDirection": {
       "label": "Dirección del Gráfico"
+    },
+    "graphFilters": {
+      "clearFilters": "Limpiar Filtros",
+      "durationGte": "Duración mín. (s)",
+      "durationGteHint": "Para tareas mapeadas, mide la duración total en todas las instancias",
+      "mapIndex": "Map Index mín.",
+      "mapIndexHint": "Muestra tareas mapeadas expandidas al menos hasta este índice",
+      "selectStatus": "Seleccionar estado",
+      "selectTaskGroup": "Seleccionar grupo de tareas",
+      "title": "Filtros de Tareas"
+    },
+    "showVersionIndicator": {
+      "label": "Mostrar Indicador de Versión",
+      "options": {
+        "hideAll": "Ocultar Todo",
+        "showAll": "Mostrar Todo",
+        "showBundleVersion": "Mostrar Versión del Bundle",
+        "showDagVersion": "Mostrar Versión del Dag"
+      }
+    },
+    "taskStreamFilter": {
+      "activeFilter": "Filtro activo",
+      "clearFilter": "Limpiar Filtro",
+      "clickTask": "Haz clic en una tarea para seleccionarla como raíz del filtro",
+      "depth": "Profundidad",
+      "direction": "Dirección",
+      "label": "Filtro",
+      "mode": "Modo",
+      "modes": {
+        "static": "Estático",
+        "traverse": "Recorrer"
+      },
+      "modeTooltip": "El modo Estático mantiene la vista actual al navegar a diferentes tareas, mientras que el modo Recorrer actualiza automáticamente el filtro activo a la tarea en la que se hace clic para facilitar el recorrido del Dag.",
+      "options": {
+        "both": "Upstream y Downstream",
+        "downstream": "Downstream",
+        "upstream": "Upstream"
+      },
+      "selectedTask": "Tarea seleccionada"
     }
   },
   "paramsFailed": "Error al cargar los parámetros",
@@ -148,12 +234,34 @@
     "renderedTemplates": "Plantillas Renderizadas",
     "requiredActions": "Acciones Requeridas",
     "runs": "Ejecuciones",
+    "storage": "Almacenamiento",
     "taskInstances": "Instancias de Tarea",
+    "taskStateStore": "Almacén de Estado de Tarea",
     "tasks": "Tareas",
     "xcom": "XCom"
   },
   "taskGroups": {
     "collapseAll": "Colapsar todos los grupos de tareas",
     "expandAll": "Expandir todos los grupos de tareas"
+  },
+  "taskStateStore": {
+    "add": "Agregar Almacén de Estado de Tarea",
+    "clearAll": {
+      "resource": "todo el almacén de estado de tarea",
+      "title": "Limpiar Todo el Almacén de Estado de Tarea",
+      "warning": "Se borrará todo el almacén de estado de tarea. Las tareas que usan este almacén para hacer seguimiento de trabajo externo no podrán reanudarlo sin volver a ejecutarse desde cero."
+    },
+    "delete": "Eliminar Almacén de Estado de Tarea",
+    "deleteWarning": "La tarea perderá esta memoria persistente. Si la tarea usa esta clave para hacer seguimiento de trabajo externo (p. ej., un ID de trabajo externo), no podrá reanudarlo.",
+    "edit": "Editar Almacén de Estado de Tarea",
+    "emptyStore": "El almacén de estado de tarea almacena valores que persisten entre reintentos. Los workers pueden escribir en el almacén de estado de tarea mediante el Task SDK.",
+    "expiresAt": {
+      "column": "Expira en",
+      "custom": "Personalizado",
+      "default": "Predeterminado ({{interval}})",
+      "label": "Expiración",
+      "never": "Nunca"
+    },
+    "title": "Almacén de Estado de Tarea"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/dag.json
@@ -193,11 +193,11 @@
       "direction": "Dirección",
       "label": "Filtro",
       "mode": "Modo",
+      "modeTooltip": "El modo Estático mantiene la vista actual al navegar a diferentes tareas, mientras que el modo Recorrer actualiza automáticamente el filtro activo a la tarea en la que se hace clic para facilitar el recorrido del Dag.",
       "modes": {
         "static": "Estático",
         "traverse": "Recorrer"
       },
-      "modeTooltip": "El modo Estático mantiene la vista actual al navegar a diferentes tareas, mientras que el modo Recorrer actualiza automáticamente el filtro activo a la tarea en la que se hace clic para facilitar el recorrido del Dag.",
       "options": {
         "both": "Upstream y Downstream",
         "downstream": "Downstream",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/dags.json
@@ -34,6 +34,15 @@
       "error": "Error al limpiar {{type}}",
       "title": "Limpiar {{type}}"
     },
+    "clearAllMapped": {
+      "button": "Limpiar Todas las Tareas Mapeadas",
+      "buttonTooltip": "Presiona shift+c para limpiar todas las instancias de tarea mapeadas",
+      "title": "Limpiar Todas las Instancias de Tarea Mapeadas"
+    },
+    "confirmationDialog": {
+      "description": "La tarea está actualmente en estado {{state}}, iniciada por el usuario {{user}} a las {{time}}. \nEl usuario no puede limpiar esta tarea hasta que termine de ejecutarse o hasta que desmarque la opción \"Evitar reejecución si la tarea está en ejecución\" en el diálogo de limpiar tarea.",
+      "title": "No Se Puede Limpiar la Instancia de Tarea"
+    },
     "delete": {
       "button": "Eliminar {{type}}",
       "dialog": {
@@ -61,6 +70,7 @@
       "future": "Futuro",
       "onlyFailed": "Limpiar solo tareas fallidas",
       "past": "Pasado",
+      "preventRunningTasks": "Evitar reejecución si la tarea está en ejecución",
       "queueNew": "Poner en cola nuevas tareas",
       "runOnLatestVersion": "Ejecutar en la última versión del bundle",
       "upstream": "Upstream"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/dashboard.json
@@ -1,4 +1,18 @@
 {
+  "deadlines": {
+    "pending": {
+      "empty": "No hay plazos próximos",
+      "title": "Próximos"
+    },
+    "recentlyMissed": {
+      "empty": "No hay plazos incumplidos",
+      "title": "Plazos Incumplidos"
+    },
+    "showMore": "Mostrar más",
+    "title": "Plazos"
+  },
+  "deferredSlotsNotCounted": "Diferidos no contados en slots: {{count}}",
+  "deferredSlotsNotCountedTooltip": "Las tareas diferidas mostradas en la barra se cuentan contra los slots del pool. Las tareas diferidas mostradas debajo de la barra provienen de pools que no cuentan las tareas diferidas contra los slots.",
   "favorite": {
     "favoriteDags_many": "Primeros {{count}} Dags Favoritos",
     "favoriteDags_one": "Primer {{count}} Dag Favorito",
@@ -31,7 +45,8 @@
   "poolSlots": "Slots del Pool",
   "sortBy": {
     "newestFirst": "Más Recientes",
-    "oldestFirst": "Más Antiguos"
+    "oldestFirst": "Más Antiguos",
+    "placeholder": "Ordenar por"
   },
   "source": "Origen",
   "stats": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/es/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/es/hitl.json
@@ -1,8 +1,7 @@
 {
   "filters": {
     "body": "Cuerpo",
-    "createdAtFrom": "Creado Desde",
-    "createdAtTo": "Creado Hasta",
+    "createdAt": "Creado en",
     "response": {
       "all": "Todas",
       "pending": "Pendientes",
@@ -26,6 +25,20 @@
     "responded_by_user_name": "Respondido por (Nombre de usuario)",
     "success": "Respuesta de {{taskId}} exitosa",
     "title": "Instancia de Tarea Humana - {{taskId}}"
+  },
+  "review": {
+    "detail": {
+      "selectRequiredAction": "Selecciona una acción requerida para ver detalles"
+    },
+    "list": {
+      "completedRequiredActions": "Acciones requeridas completadas ({{count}})",
+      "loadError": "No se pudieron cargar las acciones requeridas",
+      "loadingActions": "Cargando acciones requeridas...",
+      "pendingRequiredActions": "Acciones requeridas pendientes ({{count}})"
+    },
+    "openReviewDrawer": "Abrir Panel de Revisión",
+    "pageLimitHint": "Solo se muestran aquí las primeras acciones. Usa \"$t(review.viewAll)\" para ver todas.",
+    "viewAll": "Ver todas las acciones requeridas"
   },
   "state": {
     "approvalReceived": "Aprobación recibida",


### PR DESCRIPTION
Complete UI translations for Spanish (`es`).

This brings the Spanish locale to full parity with English for recently added UI areas, including deadline alerts, asset and task state stores, HITL review, backfill options, mapped-task clear actions, log search, graph filters, and related admin/browse strings. Stale unused keys were removed where English no longer requires them.

Validation:
- `breeze ui check-translation-completeness --language es` → 100% coverage, 0 missing, 0 unused, 0 TODOs
- `check_i18n_json.py` on `locales/es/*.json` → valid JSON, no TODO markers

Terminology follows the existing `es` locale guidelines: neutral international Spanish, title case for UI labels, and Airflow terms kept in English where established (Dag, Asset, Backfill, XCom, Pool, Trigger/Triggerer as nouns, etc.).

## Test plan

- [x] `breeze ui check-translation-completeness --language es`
- [x] `uv run --project scripts python scripts/ci/prek/check_i18n_json.py airflow-core/src/airflow/ui/public/i18n/locales/es/*.json`
- [ ] CI translation / pre-commit checks

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Composer

Generated-by: Composer following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Made with [Cursor](https://cursor.com)

<!-- pr-triage-fold: triaged=2026-07-02T17:38:30Z head=702a5e1 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @aoelvp94** · by `@potiuk` · 2026-07-02 17:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - These required **static checks** are failing and need a code fix (a rerun won't help): `CI image checks / Static checks`. Run them locally with `pre-commit`/`prek` and push the fixes.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->