### PR TITLE
Fix flaky AwsTaskLogFetcher tests caused by global Event.is_set mock

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/utils/test_task_log_fetcher.py
+++ b/providers/amazon/tests/unit/amazon/aws/utils/test_task_log_fetcher.py
@@ -45,10 +45,6 @@ class TestAwsTaskLogFetcher:
         self.set_up_log_fetcher()
 
     @mock.patch(
-        "threading.Event.is_set",
-        side_effect=(False, False, False, True),
-    )
-    @mock.patch(
         "airflow.providers.amazon.aws.hooks.logs.AwsLogsHook.get_log_events",
         side_effect=(
             iter(
@@ -65,8 +61,9 @@ class TestAwsTaskLogFetcher:
             iter([]),
         ),
     )
-    def test_run(self, get_log_events_mock, event_is_set_mock):
-        self.log_fetcher.run()
+    def test_run(self, get_log_events_mock):
+        with mock.patch.object(self.log_fetcher._event, "is_set", side_effect=(False, False, False, True)):
+            self.log_fetcher.run()
 
         self.logger_mock.log.assert_has_calls(
             [
@@ -147,10 +144,6 @@ class TestAwsTaskLogFetcher:
         assert self.log_fetcher.get_last_log_messages(2) == []
 
     @mock.patch(
-        "threading.Event.is_set",
-        side_effect=(False, True),
-    )
-    @mock.patch(
         "airflow.providers.amazon.aws.hooks.logs.AwsLogsHook.get_log_events",
         side_effect=(
             iter(
@@ -171,8 +164,9 @@ class TestAwsTaskLogFetcher:
             ),
         ),
     )
-    def test_run_with_log_level_detection(self, get_log_events_mock, event_is_set_mock):
-        self.log_fetcher.run()
+    def test_run_with_log_level_detection(self, get_log_events_mock):
+        with mock.patch.object(self.log_fetcher._event, "is_set", side_effect=(False, True)):
+            self.log_fetcher.run()
 
         self.logger_mock.log.assert_has_calls(
             [


### PR DESCRIPTION
The `test_run_with_log_level_detection` is flaky. It intermittently fails with `StopIteration`.

It patches `threading.Event.is_set` at the class level. Any other `threading.Event` in the same process steals values from the shared `side_effect` iterator. If unrelated calls hit the mock and exhaust the iterator before the fetcher's own loop finishes, the test case fails with `StopIteration`. The `TestAwsTaskLogFetcher.test_run` also has similar issue.

Failed CI example: https://github.com/apache/airflow/actions/runs/27810209629/job/82300565084?pr=68625

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code (Opus 4.8)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
