### PR TITLE
Fix truncated details tabs and page overflow in the grid view

### DIFF
--- a/airflow/www/jest-globals-setup.js
+++ b/airflow/www/jest-globals-setup.js
@@ -47,12 +47,11 @@ if (typeof globalThis.window !== "undefined" && !globalThis.window.matchMedia) {
 
 // Mock ResizeObserver (not implemented in jsdom) — used by useContentHeight
 if (typeof globalThis.ResizeObserver === "undefined") {
-  globalThis.ResizeObserver = function ResizeObserver() {
-    return {
-      observe() {},
-      unobserve() {},
-      disconnect() {},
-    };
+  globalThis.ResizeObserver = function ResizeObserver(callback) {
+    this.callback = callback;
+    this.observe = () => {};
+    this.unobserve = () => {};
+    this.disconnect = () => {};
   };
 }
 

--- a/airflow/www/jest-globals-setup.js
+++ b/airflow/www/jest-globals-setup.js
@@ -45,6 +45,17 @@ if (typeof globalThis.window !== "undefined" && !globalThis.window.matchMedia) {
   };
 }
 
+// Mock ResizeObserver (not implemented in jsdom) — used by useContentHeight
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = function ResizeObserver() {
+    return {
+      observe() {},
+      unobserve() {},
+      disconnect() {},
+    };
+  };
+}
+
 // Unwrap React 19 AggregateError for readable test failure messages
 const OrigAggregateError = globalThis.AggregateError;
 if (OrigAggregateError) {

--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -35,7 +35,7 @@ import { isEmpty, debounce } from "lodash";
 import { FaExpandArrowsAlt, FaCompressArrowsAlt } from "react-icons/fa";
 
 import { useGridData } from "src/api";
-import { hoverDelay } from "src/utils";
+import { hoverDelay, useContentHeight } from "src/utils";
 
 import ShortcutCheatSheet from "src/components/ShortcutCheatSheet";
 import { useKeysPress } from "src/utils/useKeysPress";
@@ -56,21 +56,6 @@ const saveWidth = debounce(
   hoverDelay,
 );
 
-const footerHeight =
-  parseInt(
-    getComputedStyle(
-      document.getElementsByTagName("body")[0],
-    ).paddingBottom.replace("px", ""),
-    10,
-  ) || 0;
-const headerHeight =
-  parseInt(
-    getComputedStyle(
-      document.getElementsByTagName("body")[0],
-    ).paddingTop.replace("px", ""),
-    10,
-  ) || 0;
-
 const Main = () => {
   const {
     data: { groups },
@@ -85,6 +70,8 @@ const Main = () => {
   const gridRef = useRef<HTMLDivElement>(null);
   const gridScrollRef = useRef<HTMLDivElement>(null);
   const ganttScrollRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLDivElement>(null);
+  const mainHeight = useContentHeight(mainRef);
 
   const [hoveredTaskState, setHoveredTaskState] = useState<
     string | null | undefined
@@ -199,9 +186,8 @@ const Main = () => {
   return (
     <Box
       flex={1}
-      height={`calc(100vh - ${footerHeight + headerHeight}px)`}
-      maxHeight={`calc(100vh - ${footerHeight + headerHeight}px)`}
-      minHeight="750px"
+      ref={mainRef}
+      height={`${mainHeight}px`}
       overflow="hidden"
       position="relative"
     >

--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -190,6 +190,7 @@ const Main = () => {
       height={`${mainHeight}px`}
       overflow="hidden"
       position="relative"
+      minHeight="750px"
     >
       <Accordion allowToggle index={accordionIndexes} borderTopWidth={0}>
         <AccordionItem

--- a/airflow/www/static/js/dag/details/EventLog.tsx
+++ b/airflow/www/static/js/dag/details/EventLog.tsx
@@ -43,7 +43,7 @@ import {
 } from "chakra-react-select";
 
 import { useEventLogs } from "src/api";
-import { getMetaValue, useOffsetTop } from "src/utils";
+import { getMetaValue, useContentHeight } from "src/utils";
 import type { DagRun } from "src/types";
 import LinkButton from "src/components/LinkButton";
 import type { EventLog as EventLogType } from "src/types/api-generated";
@@ -75,7 +75,7 @@ const columnHelper = createColumnHelper<EventLogType>();
 
 const EventLog = ({ taskId, run, showMapped }: Props) => {
   const logRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(logRef);
+  const contentHeight = useContentHeight(logRef);
   const { tableURLState, setTableURLState } = useTableURLState({
     sorting: [{ id: "when", desc: true }],
   });
@@ -216,7 +216,7 @@ const EventLog = ({ taskId, run, showMapped }: Props) => {
   return (
     <Box
       height="100%"
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      maxHeight={`${contentHeight}px`}
       ref={logRef}
       overflowY="auto"
     >

--- a/airflow/www/static/js/dag/details/dag/Dag.tsx
+++ b/airflow/www/static/js/dag/details/dag/Dag.tsx
@@ -41,7 +41,7 @@ import {
   getMetaValue,
   getTaskSummary,
   toSentenceCase,
-  useOffsetTop,
+  useContentHeight,
 } from "src/utils";
 import { useGridData, useDagDetails } from "src/api";
 import Time from "src/components/Time";
@@ -61,7 +61,7 @@ const Dag = () => {
     data: { dagRuns, groups },
   } = useGridData();
   const detailsRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(detailsRef);
+  const contentHeight = useContentHeight(detailsRef);
 
   const { data: dagDetailsData, isLoading: isLoadingDagDetails } =
     useDagDetails();
@@ -160,7 +160,7 @@ const Dag = () => {
   return (
     <Box
       height="100%"
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      maxHeight={`${contentHeight}px`}
       ref={detailsRef}
       overflowY="auto"
     >

--- a/airflow/www/static/js/dag/details/dagCode/index.tsx
+++ b/airflow/www/static/js/dag/details/dagCode/index.tsx
@@ -20,7 +20,7 @@
 import React, { useRef } from "react";
 import { Box, Heading, Spinner } from "@chakra-ui/react";
 
-import { useOffsetTop } from "src/utils";
+import { useContentHeight } from "src/utils";
 import Time from "src/components/Time";
 import { useDag, useDagCode } from "src/api";
 import ErrorAlert from "src/components/ErrorAlert";
@@ -29,7 +29,7 @@ import CodeBlock from "./CodeBlock";
 
 const DagCode = () => {
   const dagCodeRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(dagCodeRef);
+  const contentHeight = useContentHeight(dagCodeRef);
   const { data: dagData, isLoading: isLoadingDag, error: dagError } = useDag();
   const {
     data: codeSource = "",
@@ -41,7 +41,7 @@ const DagCode = () => {
   const error = codeError || dagError;
 
   return (
-    <Box ref={dagCodeRef} height={`calc(100% - ${offsetTop}px)`}>
+    <Box ref={dagCodeRef} height={`${contentHeight}px`}>
       {dagData?.lastParsedTime && (
         <Heading as="h4" size="md" paddingBottom="10px" fontSize="14px">
           Parsed at: <Time dateTime={dagData.lastParsedTime} />

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -20,7 +20,7 @@ import React, { useRef } from "react";
 import { Box } from "@chakra-ui/react";
 
 import { useGridData } from "src/api";
-import { getMetaValue, useOffsetTop } from "src/utils";
+import { getMetaValue, useContentHeight } from "src/utils";
 import type { DagRun as DagRunType } from "src/types";
 import NotesAccordion from "src/dag/details/NotesAccordion";
 
@@ -38,7 +38,7 @@ const DagRun = ({ runId }: Props) => {
     data: { dagRuns },
   } = useGridData();
   const detailsRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(detailsRef);
+  const contentHeight = useContentHeight(detailsRef);
 
   const run = dagRuns.find((dr) => dr.runId === runId);
 
@@ -47,7 +47,7 @@ const DagRun = ({ runId }: Props) => {
 
   return (
     <Box
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      maxHeight={`${contentHeight}px`}
       ref={detailsRef}
       overflowY="auto"
       pb={4}

--- a/airflow/www/static/js/dag/details/graph/index.tsx
+++ b/airflow/www/static/js/dag/details/graph/index.tsx
@@ -39,7 +39,7 @@ import {
   useUpstreamDatasetEvents,
 } from "src/api";
 import useSelection from "src/dag/useSelection";
-import { getMetaValue, getTask, useOffsetTop } from "src/utils";
+import { getMetaValue, getTask, useContentHeight } from "src/utils";
 import { useGraphLayout } from "src/utils/graph";
 import Edge from "src/components/Graph/Edge";
 import type { DepNode, WebserverEdge } from "src/types";
@@ -244,7 +244,7 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   const { colors } = useTheme();
   const { getZoom, fitView } = useReactFlow();
   const latestDagRunId = dagRuns[dagRuns.length - 1]?.runId;
-  const offsetTop = useOffsetTop(graphRef);
+  const contentHeight = useContentHeight(graphRef);
 
   useOnViewportChange({
     onEnd: (viewport: Viewport) => {
@@ -312,11 +312,11 @@ const Graph = ({ openGroupIds, onToggleGroups, hoveredTaskState }: Props) => {
   return (
     <Box
       ref={graphRef}
-      height={`calc(100% - ${offsetTop}px)`}
+      height={`${contentHeight}px`}
       borderWidth={1}
       borderColor="gray.200"
     >
-      {!!offsetTop && (
+      {!!contentHeight && (
         <ReactFlow
           nodes={nodes}
           edges={edges}

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogBlock.tsx
@@ -19,7 +19,7 @@
 
 import React, { useRef, useEffect, useState } from "react";
 import { Code } from "@chakra-ui/react";
-import { useOffsetTop } from "src/utils";
+import { useContentHeight } from "src/utils";
 
 interface Props {
   parsedLogs: string;
@@ -37,7 +37,7 @@ const LogBlock = ({
   const [autoScroll, setAutoScroll] = useState(true);
 
   const logBoxRef = useRef<HTMLPreElement>(null);
-  const offsetTop = useOffsetTop(logBoxRef);
+  const contentHeight = useContentHeight(logBoxRef);
 
   const scrollToBottom = () => {
     if (logBoxRef.current) {
@@ -47,13 +47,13 @@ const LogBlock = ({
 
   useEffect(() => {
     // Always scroll to bottom when wrap or tryNumber change
-    if (offsetTop) scrollToBottom();
-  }, [wrap, tryNumber, offsetTop]);
+    if (contentHeight) scrollToBottom();
+  }, [wrap, tryNumber, contentHeight]);
 
   useEffect(() => {
     // When logs change, only scroll if autoScroll is enabled
-    if (autoScroll && offsetTop) scrollToBottom();
-  }, [parsedLogs, autoScroll, offsetTop]);
+    if (autoScroll && contentHeight) scrollToBottom();
+  }, [parsedLogs, autoScroll, contentHeight]);
 
   const onScroll = (e: React.UIEvent<HTMLDivElement>) => {
     if (e.currentTarget) {
@@ -103,7 +103,7 @@ const LogBlock = ({
       ref={logBoxRef}
       onScroll={onScroll}
       onClick={onClick}
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      maxHeight={`${contentHeight}px`}
       overflowY="auto"
       p={3}
       display="block"

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -27,7 +27,7 @@ import { useMappedInstances } from "src/api";
 import { StatusWithNotes } from "src/dag/StatusBox";
 import { Table, CellProps } from "src/components/Table";
 import Time from "src/components/Time";
-import { useOffsetTop } from "src/utils";
+import { useContentHeight } from "src/utils";
 
 interface Props {
   dagId: string;
@@ -38,7 +38,7 @@ interface Props {
 
 const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   const mappedTasksRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(mappedTasksRef);
+  const contentHeight = useContentHeight(mappedTasksRef);
   const limit = 25;
   const [offset, setOffset] = useState(0);
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([]);
@@ -125,11 +125,7 @@ const MappedInstances = ({ dagId, runId, taskId, onRowClicked }: Props) => {
   );
 
   return (
-    <Box
-      ref={mappedTasksRef}
-      maxHeight={`calc(100% - ${offsetTop}px)`}
-      overflowY="auto"
-    >
+    <Box ref={mappedTasksRef} maxHeight={`${contentHeight}px`} overflowY="auto">
       <Table
         data={data}
         columns={columns}

--- a/airflow/www/static/js/dag/details/taskInstance/RenderedK8s.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/RenderedK8s.tsx
@@ -21,7 +21,7 @@ import React, { useRef } from "react";
 import { Code } from "@chakra-ui/react";
 import YAML from "json-to-pretty-yaml";
 
-import { getMetaValue, useOffsetTop } from "src/utils";
+import { getMetaValue, useContentHeight } from "src/utils";
 
 import useSelection from "src/dag/useSelection";
 import { useRenderedK8s } from "src/api";
@@ -36,17 +36,12 @@ const RenderedK8s = () => {
   const { data: renderedK8s } = useRenderedK8s(runId, taskId, mapIndex);
 
   const k8sRef = useRef<HTMLPreElement>(null);
-  const offsetTop = useOffsetTop(k8sRef);
+  const contentHeight = useContentHeight(k8sRef);
 
   if (!isK8sExecutor || !runId || !taskId) return null;
 
   return (
-    <Code
-      mt={3}
-      ref={k8sRef}
-      maxHeight={`calc(100% - ${offsetTop}px)`}
-      overflowY="auto"
-    >
+    <Code mt={3} ref={k8sRef} maxHeight={`${contentHeight}px`} overflowY="auto">
       <pre>{YAML.stringify(renderedK8s)}</pre>
     </Code>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/Xcom/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Xcom/index.tsx
@@ -31,7 +31,7 @@ import {
 
 import type { Dag, DagRun, TaskInstance } from "src/types";
 import { useTaskXcomCollection } from "src/api";
-import { useOffsetTop } from "src/utils";
+import { useContentHeight } from "src/utils";
 import ErrorAlert from "src/components/ErrorAlert";
 
 import XcomEntry from "./XcomEntry";
@@ -52,7 +52,7 @@ const XcomCollection = ({
   tryNumber,
 }: Props) => {
   const taskXcomRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(taskXcomRef);
+  const contentHeight = useContentHeight(taskXcomRef);
 
   const {
     data: xcomCollection,
@@ -70,7 +70,7 @@ const XcomCollection = ({
     <Box
       ref={taskXcomRef}
       height="100%"
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      maxHeight={`${contentHeight}px`}
       overflowY="auto"
     >
       {isLoading && <Spinner size="xl" thickness="4px" speed="0.65s" />}

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -21,7 +21,7 @@ import React, { useRef } from "react";
 import { Box } from "@chakra-ui/react";
 
 import { useGridData, useTaskInstance } from "src/api";
-import { getMetaValue, getTask, useOffsetTop } from "src/utils";
+import { getMetaValue, getTask, useContentHeight } from "src/utils";
 import type { DagRun, TaskInstance as GridTaskInstance } from "src/types";
 import NotesAccordion from "src/dag/details/NotesAccordion";
 
@@ -43,7 +43,7 @@ interface Props {
 
 const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
   const taskInstanceRef = useRef<HTMLDivElement>(null);
-  const offsetTop = useOffsetTop(taskInstanceRef);
+  const contentHeight = useContentHeight(taskInstanceRef);
   const isMapIndexDefined = !(mapIndex === undefined);
   const {
     data: { dagRuns, groups },
@@ -79,8 +79,7 @@ const TaskInstance = ({ taskId, runId, mapIndex }: Props) => {
   return (
     <Box
       py="4px"
-      height="100%"
-      maxHeight={`calc(100% - ${offsetTop}px)`}
+      height={`${contentHeight}px`}
       ref={taskInstanceRef}
       overflowY="auto"
     >

--- a/airflow/www/static/js/utils/index.ts
+++ b/airflow/www/static/js/utils/index.ts
@@ -21,6 +21,7 @@ import Color from "color";
 import type { DagRun, RunOrdering, Task, TaskInstance } from "src/types";
 
 import { LogLevel } from "src/dag/details/taskInstance/Logs/utils";
+import useContentHeight from "./useContentHeight";
 import useOffsetTop from "./useOffsetTop";
 
 // Delay in ms for various hover actions
@@ -232,6 +233,7 @@ export {
   getTaskSummary,
   getDagRunLabel,
   getStatusBackgroundColor,
+  useContentHeight,
   useOffsetTop,
   toSentenceCase,
   highlightByKeywords,

--- a/airflow/www/static/js/utils/useContentHeight.ts
+++ b/airflow/www/static/js/utils/useContentHeight.ts
@@ -1,0 +1,61 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useLayoutEffect, useState } from "react";
+
+// Vertical space available to a scroll container: from where the element actually sits in the page
+// down to the body's bottom padding (the Flask footer reserve). Anchoring to the viewport this way
+// avoids the `height: 100%` cascade, which over-claims because <Tabs>/<TabPanel> have sibling chrome
+// (tab headers) on top — that cascade is what truncated the details tabs.
+const useContentHeight = (contentRef: React.RefObject<HTMLElement>) => {
+  const [height, setHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const update = () => {
+      const element = contentRef.current;
+      if (!element) return;
+      const footerReserve =
+        parseInt(
+          getComputedStyle(document.body).paddingBottom.replace("px", ""),
+          10,
+        ) || 0;
+      const available = Math.max(
+        window.innerHeight -
+          element.getBoundingClientRect().top -
+          footerReserve,
+        0,
+      );
+      // Guard against re-setting the same value (avoids ResizeObserver feedback loops).
+      setHeight((previous) => (previous === available ? previous : available));
+    };
+
+    update();
+    window.addEventListener("resize", update);
+    const observer = new ResizeObserver(update);
+    observer.observe(document.body);
+    return () => {
+      window.removeEventListener("resize", update);
+      observer.disconnect();
+    };
+  }, [contentRef]);
+
+  return height;
+};
+
+export default useContentHeight;

--- a/airflow/www/static/js/utils/useContentHeight.ts
+++ b/airflow/www/static/js/utils/useContentHeight.ts
@@ -19,10 +19,14 @@
 
 import React, { useLayoutEffect, useState } from "react";
 
-// Vertical space available to a scroll container: from where the element actually sits in the page
-// down to the body's bottom padding (the Flask footer reserve). Anchoring to the viewport this way
-// avoids the `height: 100%` cascade, which over-claims because <Tabs>/<TabPanel> have sibling chrome
-// (tab headers) on top — that cascade is what truncated the details tabs.
+// Vertical space available to a scroll container, measured down to the bottom of the nearest
+// min-height-constrained ancestor — the grid's Main box, which has a min-height floor. Anchoring to
+// that box (rather than the viewport) lets the content grow to fill the floored area even when the
+// box is taller than the viewport and the page scrolls, instead of shrinking to the fold and
+// leaving a blank strip below. When there is no such ancestor (the Main box measuring itself), it
+// falls back to the viewport minus the body's bottom padding (the Flask footer reserve). Either way
+// this avoids the `height: 100%` cascade, which over-claims because <Tabs>/<TabPanel> have sibling
+// chrome (tab headers) stacked above the panel — that cascade is what truncated the details tabs.
 const useContentHeight = (contentRef: React.RefObject<HTMLElement>) => {
   const [height, setHeight] = useState(0);
 
@@ -30,12 +34,19 @@ const useContentHeight = (contentRef: React.RefObject<HTMLElement>) => {
     const update = () => {
       const element = contentRef.current;
       if (!element) return;
-      const footerReserve =
-        parseFloat(getComputedStyle(document.body).paddingBottom) || 0;
+      let container = element.parentElement;
+      while (
+        container &&
+        !(parseFloat(getComputedStyle(container).minHeight) > 0)
+      ) {
+        container = container.parentElement;
+      }
+      const bottom = container
+        ? container.getBoundingClientRect().bottom
+        : window.innerHeight -
+          (parseFloat(getComputedStyle(document.body).paddingBottom) || 0);
       const available = Math.max(
-        window.innerHeight -
-          element.getBoundingClientRect().top -
-          footerReserve,
+        bottom - element.getBoundingClientRect().top,
         0,
       );
       // Guard against re-setting the same value (avoids ResizeObserver feedback loops).

--- a/airflow/www/static/js/utils/useContentHeight.ts
+++ b/airflow/www/static/js/utils/useContentHeight.ts
@@ -31,10 +31,7 @@ const useContentHeight = (contentRef: React.RefObject<HTMLElement>) => {
       const element = contentRef.current;
       if (!element) return;
       const footerReserve =
-        parseInt(
-          getComputedStyle(document.body).paddingBottom.replace("px", ""),
-          10,
-        ) || 0;
+        parseFloat(getComputedStyle(document.body).paddingBottom) || 0;
       const available = Math.max(
         window.innerHeight -
           element.getBoundingClientRect().top -


### PR DESCRIPTION
Since the Chakra UI 2.10 / React 19 upgrade, the grid view's `height: 100%` cascade no longer resolves through the `<Tabs>`/`<TabPanel>` chrome. The details tabs render taller than their visible area — content is cut off with no way to scroll to it — and the main column pushes the page footer below the viewport, so the whole page scrolls instead.

This anchors the affected heights to the viewport so each details tab scrolls within its own area and the footer stays visible without a page-level scroll.

**After**
<img width="1502" height="900" alt="Screenshot 2026-07-03 at 13 09 13" src="https://github.com/user-attachments/assets/582cdca2-f9d5-47a1-9d53-632d4963cc20" />
<img width="1509" height="858" alt="Screenshot 2026-07-03 at 13 10 09" src="https://github.com/user-attachments/assets/a61bd0e2-a3ef-43a2-ab2c-d40c29cb2538" />
<img width="1506" height="896" alt="Screenshot 2026-07-03 at 13 10 17" src="https://github.com/user-attachments/assets/88ecc3c1-c338-4f21-b19d-df672d535deb" />
<img width="1501" height="758" alt="Screenshot 2026-07-03 at 13 11 45" src="https://github.com/user-attachments/assets/9ee4a0c5-24a3-4401-8bb7-522ca075cc14" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
