### PR TITLE
List related commits in release testing issue for new providers

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -255,6 +255,16 @@ MY_DIR_PATH = os.path.dirname(__file__)
 SOURCE_DIR_PATH = str(AIRFLOW_ROOT_PATH)
 PR_PATTERN = re.compile(r".*\(#([0-9]+)\)")
 ISSUE_MATCH_IN_BODY = re.compile(r" #([0-9]+)[^0-9]")
+# Release-management commits (provider documentation / release preparation) are pure
+# release-process noise: they are not user-facing changes and existing providers already
+# exclude them (the release tooling parks them in the changelog's excluded section). Match
+# only the release-manager titles, not every commit starting with "Prepare" (real provider
+# PRs such as "Prepare bteq command ..." must not be filtered out).
+RELEASE_MANAGEMENT_COMMIT_PATTERN = re.compile(
+    r"^Prepare\s+(?:provider|providers|provider's|ad-hoc)\b.*\b(?:release|documentation)\b"
+    r"|^Prepare\s+documentation\s+for\s+next\s+release\b",
+    re.IGNORECASE,
+)
 
 
 def remove_code_blocks(text: str) -> str:
@@ -2630,6 +2640,53 @@ def get_prs_for_package(provider_id: str, current_release_version: str | None = 
     return prs
 
 
+def get_prs_from_git_log_for_new_provider(provider_id: str) -> list[int]:
+    """
+    Return PR numbers referenced by every commit that touched a new provider's sources.
+
+    A new provider's changelog only lists changes made *after* its initial release, so for
+    the first release there are no PR references to extract from it. Instead, we collect the
+    related PRs directly from the git history of the provider's directory. The result is
+    ordered from newest to oldest commit. Release-management commits (provider documentation
+    / release preparation) are skipped to match how existing providers behave, but the list
+    may still include other bootstrap and development commits that are not user-facing.
+    """
+    provider_details = get_provider_details(provider_id)
+    git_command = [
+        "git",
+        "log",
+        "--pretty=format:%s",
+        "--",
+        provider_details.root_provider_path.as_posix(),
+    ]
+    result = run_command(
+        git_command,
+        cwd=AIRFLOW_ROOT_PATH,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        console_print(
+            f"[warning]Could not retrieve git history for provider {provider_id}: {result.stderr}[/]"
+        )
+        return []
+    prs: list[int] = []
+    seen: set[int] = set()
+    for line in result.stdout.splitlines():
+        subject = line.strip()
+        if RELEASE_MANAGEMENT_COMMIT_PATTERN.match(subject):
+            # Skip release-preparation / documentation commits (release-process noise).
+            continue
+        match_result = PR_PATTERN.match(subject)
+        if match_result:
+            pr_number = int(match_result.group(1))
+            if pr_number not in seen:
+                seen.add(pr_number)
+                prs.append(pr_number)
+    return prs
+
+
 def _is_initial_provider_release(provider_yaml_dict: dict[str, Any] | None) -> bool:
     """Return True when metadata indicates this is the provider's first release."""
     if not provider_yaml_dict:
@@ -2795,6 +2852,19 @@ def generate_issue_content_providers(
             if not provider_yaml_dict:
                 raise RuntimeError(f"The provider id {provider_id} does not have provider.yaml file")
             prs = get_prs_for_package(provider_id, current_release_version=provider_yaml_dict["versions"][0])
+            if not prs and _is_initial_provider_release(provider_yaml_dict):
+                # New providers have no PR references in their changelog yet, so collect the
+                # related PRs directly from the git history of the provider's sources.
+                prs = get_prs_from_git_log_for_new_provider(provider_id)
+                if prs:
+                    console_print(
+                        f"[info]Including new provider {provider_id}: collected {len(prs)} related "
+                        "PR(s) from the git history of its sources."
+                    )
+                else:
+                    console_print(
+                        f"[info]Including new provider {provider_id}: no related PRs found in git history."
+                    )
             filtered_prs = [pr for pr in prs if pr not in excluded_prs]
             if not _should_include_provider_in_issue(provider_yaml_dict, prs, filtered_prs):
                 console_print(
@@ -2802,10 +2872,6 @@ def generate_issue_content_providers(
                     "The changelog file does not contain PR references for the release.\n"
                 )
                 continue
-            if not prs and _is_initial_provider_release(provider_yaml_dict):
-                console_print(
-                    f"[info]Including provider {provider_id}: initial release without PR references in changelog."
-                )
             all_prs.update(prs)
             provider_prs[provider_id] = filtered_prs
             all_retrieved_prs.update(provider_prs[provider_id])

--- a/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
+++ b/dev/breeze/src/airflow_breeze/provider_issue_TEMPLATE.md.jinja2
@@ -13,6 +13,9 @@ These are providers that require testing as there were some substantial changes 
 ## Provider [{{ provider_id }}: {{ provider_info.version }}{{ provider_info.suffix }}](https://pypi.org/project/{{ provider_info.pypi_package_name }}/{{ provider_info.version }}{{ provider_info.suffix }})
 {%- if provider_info.is_new %} **:tada: New provider**{%- endif %}
 {%- if provider_info.pr_list %}
+{%- if provider_info.is_new %}
+   > **Note:** This is a new provider, so the PRs below are collected from the git history of the provider's sources rather than from a changelog diff. The list may therefore include bootstrap and development commits (e.g. release-preparation commits) that are not user-facing changes.
+{%- endif %}
 {%- for pr in provider_info.pr_list %}
    - [ ] [{{ pr.title }} (#{{ pr.number }})]({{ pr.html_url }}): @{{ pr.user.login }}
    {%- if pr.number in linked_issues %}

--- a/dev/breeze/tests/test_provider_issue_template.py
+++ b/dev/breeze/tests/test_provider_issue_template.py
@@ -43,3 +43,59 @@ def test_provider_issue_template_marks_new_provider(is_new: bool, has_marker: bo
     )
 
     assert (":tada: New provider" in rendered) is has_marker
+
+
+def test_new_provider_lists_commits_with_bootstrap_note():
+    pr = SimpleNamespace(
+        title="Add ClickHouse Provider",
+        number=67080,
+        html_url="https://github.com/apache/airflow/pull/67080",
+        user=SimpleNamespace(login="someone"),
+    )
+    provider_info = SimpleNamespace(
+        version="1.0.0",
+        suffix="rc2",
+        pypi_package_name="apache-airflow-providers-clickhousedb",
+        pr_list=[pr],
+        is_new=True,
+    )
+    template = Template(TEMPLATE_PATH.read_text())
+
+    rendered = template.render(
+        providers={"clickhousedb": provider_info},
+        linked_issues={},
+        date="2026-04-24",
+    )
+
+    # Retains the new-provider marker.
+    assert ":tada: New provider" in rendered
+    # Lists the related commit in the same checkbox format as existing providers.
+    assert (
+        "- [ ] [Add ClickHouse Provider (#67080)]"
+        "(https://github.com/apache/airflow/pull/67080): @someone" in rendered
+    )
+    # Adds the note that the list may include bootstrap/development commits.
+    assert "may therefore include bootstrap and development commits" in rendered
+    # No longer falls back to the smoke-test placeholder.
+    assert "Please run smoke tests" not in rendered
+
+
+def test_new_provider_without_commits_falls_back_to_smoke_tests():
+    provider_info = SimpleNamespace(
+        version="1.0.0",
+        suffix="rc1",
+        pypi_package_name="apache-airflow-providers-vespa",
+        pr_list=[],
+        is_new=True,
+    )
+    template = Template(TEMPLATE_PATH.read_text())
+
+    rendered = template.render(
+        providers={"vespa": provider_info},
+        linked_issues={},
+        date="2026-04-24",
+    )
+
+    assert ":tada: New provider" in rendered
+    assert "Please run smoke tests" in rendered
+    assert "bootstrap and development commits" not in rendered

--- a/dev/breeze/tests/test_release_management_commands.py
+++ b/dev/breeze/tests/test_release_management_commands.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -24,6 +25,7 @@ from airflow_breeze.commands.release_management_commands import (
     _ensure_default_python_for_reproducible_client,
     _is_initial_provider_release,
     _should_include_provider_in_issue,
+    get_prs_from_git_log_for_new_provider,
     get_suffix_from_package_in_dist,
     is_package_in_dist,
 )
@@ -66,6 +68,69 @@ def test_should_include_provider_in_issue(
         )
         is expected
     )
+
+
+def test_get_prs_from_git_log_for_new_provider(monkeypatch):
+    git_output = (
+        # Release-management commits must be skipped (release-process noise).
+        "Prepare provider documentation 2026-06-16 (#68642)\n"
+        "Bump `clickhouse-connect>=1.3.0` (#68400)\n"
+        "docs: clarify when to use custom `handler` (#68345)\n"
+        "Prepare providers release 2026-06-08 (#68203)\n"
+        # A real provider PR whose title merely starts with "Prepare" must NOT be filtered.
+        "Prepare bteq command with subprocess arg list (#67999)\n"
+        "Add ClickHouse Provider (#67080)\n"
+        # A duplicate PR reference must be collected only once.
+        "Add ClickHouse Provider (#67080)\n"
+        # A commit without a PR reference must be ignored.
+        "Initial scaffolding commit"
+    )
+    monkeypatch.setattr(
+        "airflow_breeze.commands.release_management_commands.get_provider_details",
+        lambda provider_id: SimpleNamespace(root_provider_path=Path("/repo/providers/clickhousedb")),
+    )
+    monkeypatch.setattr(
+        "airflow_breeze.commands.release_management_commands.run_command",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=git_output, stderr=""),
+    )
+
+    prs = get_prs_from_git_log_for_new_provider("clickhousedb")
+
+    assert prs == [68400, 68345, 67999, 67080]
+
+
+@pytest.mark.parametrize(
+    ("subject", "is_release_commit"),
+    [
+        ("Prepare provider documentation 2026-06-16 (#68642)", True),
+        ("Prepare providers release 2026-06-08 (#68203)", True),
+        ("Prepare Providers Release 2026-06-08 (#1)", True),
+        ("Prepare provider's documentation (#2)", True),
+        ("Prepare ad-hoc RC2 providers release (#3)", True),
+        ("Prepare documentation for next release of providers (#4)", True),
+        # Real provider PRs that must not be mistaken for release-management commits.
+        ("Prepare bteq command with subprocess arg list (#67999)", False),
+        ("Add ClickHouse Provider (#67080)", False),
+        ("Bump `clickhouse-connect>=1.3.0` (#68400)", False),
+    ],
+)
+def test_release_management_commit_pattern(subject: str, is_release_commit: bool):
+    from airflow_breeze.commands.release_management_commands import RELEASE_MANAGEMENT_COMMIT_PATTERN
+
+    assert bool(RELEASE_MANAGEMENT_COMMIT_PATTERN.match(subject)) is is_release_commit
+
+
+def test_get_prs_from_git_log_for_new_provider_returns_empty_on_git_failure(monkeypatch):
+    monkeypatch.setattr(
+        "airflow_breeze.commands.release_management_commands.get_provider_details",
+        lambda provider_id: SimpleNamespace(root_provider_path=Path("/repo/providers/clickhousedb")),
+    )
+    monkeypatch.setattr(
+        "airflow_breeze.commands.release_management_commands.run_command",
+        lambda *args, **kwargs: SimpleNamespace(returncode=128, stdout="", stderr="fatal: bad revision"),
+    )
+
+    assert get_prs_from_git_log_for_new_provider("clickhousedb") == []
 
 
 def _fake_version_info(version: str) -> SimpleNamespace:


### PR DESCRIPTION
## Human summary
Currently when creating a GitHub issue for testing a new provider, the message is shown with a general instruction for "performing smoke tests".
This PR changes this behavior it shows the related commits since the provider has been introduced to the `main` branch (based on the git history), with a clear warning that some commits are for bootstrap and development (i.e., might be irrelevant for actual testing).

## AI summary
<details><summary>Click here</summary>When the release manager generates the provider testing issue
(`breeze release-management generate-issue-content-providers`), new
providers had no PR references in their changelog — the changelog only
records changes made *after* the initial release — so their entry showed
only a generic placeholder:

> Initial release does not list PR references in changelog. Please run smoke tests.

This made it hard for testers to know what actually went into a brand new
provider.

This PR makes new-provider entries list their related commits. For a new
provider, the related PRs are collected directly from the git history of
the provider's sources and rendered with the **same checkbox format**
(PR title, number and author) used for existing providers. The
`:tada: New provider` marker is retained, and a note is added warning that
the list may include bootstrap and development commits (e.g.
release-preparation commits) that are not user-facing changes. When git
history yields no PRs, the entry still falls back to the smoke-test
placeholder.

Example output for `clickhousedb` (new provider):

> ## Provider [clickhousedb: 1.0.0rc2](...) **:tada: New provider**
>    > **Note:** This is a new provider, so the PRs below are collected from the git history of the provider's sources rather than from a changelog diff. The list may therefore include bootstrap and development commits (e.g. release-preparation commits) that are not user-facing changes.
>    - [ ] [Add ClickHouse Provider (#67080)](...): @BentsiLeviav
>    - ...<details>


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)