### PR TITLE
Fix Connection port boundary validation (#68382)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -40,7 +40,7 @@ class ConnectionResponse(BaseModel):
     host: str | None
     login: str | None
     schema_: str | None = Field(alias="schema")
-    port: int | None
+    port: int | None = Field(default=None, ge=0, le=65535)
     password: str | None
     extra: str | None
     team_name: str | None
@@ -191,7 +191,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(default=None, ge=0, le=65535)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/connection.py
@@ -31,5 +31,5 @@ class ConnectionResponse(BaseModel):
     schema_: str | None = Field(alias="schema")
     login: str | None
     password: str | None
-    port: int | None
+    port: int | None = Field(default=None, ge=0, le=65535)
     extra: str | None

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import ForeignKey, Integer, String, Text, select
-from sqlalchemy.orm import Mapped, mapped_column, reconstructor
+from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
@@ -152,6 +152,17 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         ForeignKey("team.name", ondelete="SET NULL"),
         nullable=True,
     )
+
+    @validates("port")
+    def validate_port(self, key, port):
+        if port is not None:
+            try:
+                port = int(port)
+            except ValueError:
+                raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+            if not (0 <= port <= 65535):
+                raise ValueError(f"The `port` must be between 0 and 65535, but got {port!r}.")
+        return port
 
     def __init__(
         self,

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -540,3 +540,20 @@ class TestConnection:
             "test_conn2": None,
         }
         clear_db_connections()
+
+    @pytest.mark.parametrize(
+        "port, expected_error",
+        [
+            (-1, "The `port` must be between 0 and 65535, but got -1."),
+            (65536, "The `port` must be between 0 and 65535, but got 65536."),
+            ("invalid", "Expected integer value for `port`, but got 'invalid' instead."),
+        ]
+    )
+    def test_port_validation_raises_error(self, port, expected_error):
+        with pytest.raises(ValueError, match=re.escape(expected_error)):
+            Connection(conn_id="test_port", conn_type="http", port=port)
+
+    @pytest.mark.parametrize("port", [0, 80, 65535, None])
+    def test_port_validation_success(self, port):
+        conn = Connection(conn_id="test_port", conn_type="http", port=port)
+        assert conn.port == port

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -93,6 +93,16 @@ def _prune_dict(val: Any, mode="strict"):
     return val
 
 
+def validate_port(instance, attribute, value):
+    if value is not None:
+        try:
+            val = int(value)
+        except ValueError:
+            raise ValueError(f"Expected integer value for `port`, but got {value!r} instead.")
+        if not (0 <= val <= 65535):
+            raise ValueError(f"The `port` must be between 0 and 65535, but got {value!r}.")
+
+
 @attrs.define(slots=False)
 class Connection:
     """
@@ -118,7 +128,7 @@ class Connection:
     schema: str | None = None
     login: str | None = None
     password: str | None = None
-    port: int | None = None
+    port: int | None = attrs.field(default=None, validator=validate_port)
     extra: str | None = None
 
     EXTRA_KEY = "__extra__"

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -225,6 +225,23 @@ class TestConnections:
         connection.extra = '{"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}'
         assert connection.extra_dejson == {"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}
 
+    @pytest.mark.parametrize(
+        "port, expected_error",
+        [
+            (-1, "The `port` must be between 0 and 65535, but got -1."),
+            (65536, "The `port` must be between 0 and 65535, but got 65536."),
+            ("invalid", "Expected integer value for `port`, but got 'invalid' instead."),
+        ]
+    )
+    def test_port_validation_raises_error(self, port, expected_error):
+        with pytest.raises(ValueError, match=expected_error):
+            Connection(conn_id="test_port", port=port)
+
+    @pytest.mark.parametrize("port", [0, 80, 65535, None])
+    def test_port_validation_success(self, port):
+        conn = Connection(conn_id="test_port", port=port)
+        assert conn.port == port
+
 
 class TestConnectionsFromSecrets:
     def test_get_connection_secrets_backend(self, mock_supervisor_comms, tmp_path):


### PR DESCRIPTION
### Description
Fixes #68382.

Airflow previously persisted connections with invalid port numbers (e.g., `-1`, `99999999`). 
This PR introduces boundary validation at the creation/update boundary across all entry points so that `port` must satisfy `0 <= port <= 65535`.

Specifically, this PR:
1. Adds a `@validates("port")` method to `airflow.models.connection.Connection` (Core Model) to raise `ValueError` on out-of-bounds ports.
2. Adds a custom validator to the `attrs`-based `Connection` model in `airflow.sdk.definitions.connection` (Task SDK).
3. Adds Pydantic `Field(ge=0, le=65535)` validation to both the Execution API and Public REST API `datamodels` to fail early with 422 if an invalid port is passed.
4. Includes tests covering bounds validation for both the Core Model and the Task SDK.

### Testing
- Added unit tests to `tests/unit/models/test_connection.py`.
- Added unit tests to `task-sdk/tests/task_sdk/definitions/test_connection.py`.
