### PR TITLE
Add rerun policy for rollups when an upstream partition is re-run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -336,6 +336,16 @@ repos:
           ^task-sdk/src/airflow/sdk/definitions/partition_mappers/window\.py$
         pass_filenames: false
         require_serial: true
+      - id: check-rerun-policy-in-sync
+        name: Check RerunPolicy definitions stay in sync (core/SDK)
+        entry: ./scripts/ci/prek/check_rerun_policy_in_sync.py
+        language: python
+        files: >
+          (?x)
+          ^airflow-core/src/airflow/partition_mappers/rerun_policy\.py$|
+          ^task-sdk/src/airflow/sdk/definitions/partition_mappers/rerun_policy\.py$
+        pass_filenames: false
+        require_serial: true
       - id: sync-uv-min-version-markers
         name: Sync `# sync-uv-min-version` markers with [tool.uv] required-version
         entry: ./scripts/ci/prek/sync_uv_min_version_markers.py

--- a/airflow-core/docs/authoring-and-scheduling/assets.rst
+++ b/airflow-core/docs/authoring-and-scheduling/assets.rst
@@ -874,6 +874,55 @@ missing" — and is equivalent to ``MinimumCount(2)`` for a three-member window.
 Pass :class:`~airflow.sdk.WaitForAll` explicitly when you want to document intent
 rather than relying on the default.
 
+Rerun policies
+~~~~~~~~~~~~~~
+
+.. versionadded:: 3.4.0
+
+Once a window is satisfied the downstream Dag run fires and the window is materialized.
+If an upstream partition that run already consumed is later cleared and re-run, a fresh
+asset event arrives for a window that has already fired.
+:class:`~airflow.sdk.RollupMapper` accepts an optional ``rerun_policy`` argument that
+decides what happens to that event.
+
+* :class:`~airflow.sdk.RerunPolicy` ``.HOLD`` (the default) queues a provisional run and
+  re-evaluates the window through the wait policy, just as the first materialization did
+  — under ``WaitForAll`` the whole window has to re-materialize before the Dag run fires
+  again, while ``MinimumCount`` can fire once its threshold is met again.
+* ``RerunPolicy.REFRESH`` re-fires the downstream Dag run right away so it reprocesses
+  with the corrected data. Neither the wait policy nor the Dag's schedule condition is
+  re-evaluated.
+* ``RerunPolicy.IGNORE`` drops the late event — nothing is queued and the downstream Dag
+  run does not re-fire.
+
+.. code-block:: python
+
+    from airflow.sdk import (
+        DAG,
+        DayWindow,
+        PartitionedAssetTimetable,
+        RerunPolicy,
+        RollupMapper,
+        StartOfHourMapper,
+    )
+
+    with DAG(
+        dag_id="daily_sales_summary",
+        schedule=PartitionedAssetTimetable(
+            assets=hourly_sales,
+            default_partition_mapper=RollupMapper(
+                upstream_mapper=StartOfHourMapper(),
+                window=DayWindow(),
+                rerun_policy=RerunPolicy.REFRESH,
+            ),
+        ),
+        catchup=False,
+    ):
+        ...
+
+``HOLD`` is how a rollup behaved before ``rerun_policy`` existed, so leaving it unset
+keeps existing Dags unchanged.
+
 .. _segment-categorical-rollup:
 
 Segment (categorical) rollup

--- a/airflow-core/docs/migrations-ref.rst
+++ b/airflow-core/docs/migrations-ref.rst
@@ -39,7 +39,9 @@ Here's the list of all the Database Migrations that are executed via when you ru
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | Revision ID             | Revises ID       | Airflow Version   | Description                                                  |
 +=========================+==================+===================+==============================================================+
-| ``b2f1a9c7d4e0`` (head) | ``7a98f1b7dbd3`` | ``3.4.0``         | Reference the asset event from asset_dag_run_queue (consume- |
+| ``623bce373cdf`` (head) | ``b2f1a9c7d4e0`` | ``3.4.0``         | Add rerun_policy to AssetPartitionDagRun.                    |
++-------------------------+------------------+-------------------+--------------------------------------------------------------+
+| ``b2f1a9c7d4e0``        | ``7a98f1b7dbd3`` | ``3.4.0``         | Reference the asset event from asset_dag_run_queue (consume- |
 |                         |                  |                   | by-reference).                                               |
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | ``7a98f1b7dbd3``        | ``c4e7a1f9b2d0`` | ``3.4.0``         | Add index on asset_event (asset_id, partition_key).          |

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -45,6 +45,7 @@ from airflow.models.asset import (
     asset_alias_asset_event_association_table,
 )
 from airflow.models.log import Log
+from airflow.partition_mappers.rerun_policy import RerunPolicy
 from airflow.timetables.base import compute_rollup_fingerprint
 from airflow.utils.helpers import is_container, prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -679,6 +680,8 @@ class AssetManager(LoggingMixin):
                 )
                 target_partition_date = None
 
+            # Every mapper reports a rerun_policy. Non-rollup mappers report the HOLD as default.
+            rerun_policy = mapper.rerun_policy
             for target_key in target_keys:
                 apdr = cls._get_or_create_apdr(
                     target_key=target_key,
@@ -686,8 +689,15 @@ class AssetManager(LoggingMixin):
                     target_dag=target_dag,
                     rollup_fingerprint=fingerprint,
                     asset_id=asset_id,
+                    rerun_policy=rerun_policy,
                     session=session,
                 )
+                # _get_or_create_apdr returns None only under RerunPolicy.IGNORE,
+                # when this event re-arrives for a window that already fired.
+                # The user chose to drop such late events, so skip writing the
+                # PartitionedAssetKeyLog below.
+                if apdr is None:
+                    continue
                 log_record = PartitionedAssetKeyLog(
                     asset_id=asset_id,
                     asset_event_id=event.id,
@@ -707,8 +717,9 @@ class AssetManager(LoggingMixin):
         target_dag: DagModel,
         rollup_fingerprint: dict,
         asset_id: int,
+        rerun_policy: RerunPolicy,
         session: Session,
-    ) -> AssetPartitionDagRun:
+    ) -> AssetPartitionDagRun | None:
         """
         Get or create an APDR.
 
@@ -735,6 +746,17 @@ class AssetManager(LoggingMixin):
           one, the producing assets disagree; picking one would be order-dependent, so the
           carried date is suppressed to ``None`` (and re-adoptable by a later event).
         - Otherwise (the dates agree, or this event carries none) the existing value is kept.
+
+        ``rerun_policy`` is a mapper's policy. Default is ``RerunPolicy.HOLD`` for non-rollup
+        mappers. It only takes effect when the latest APDR for this (key, dag) has already fired.
+
+        - A new APDR is stamped the neutral ``RerunPolicy.HOLD`` for a window's first materialization.
+        - A still-pending latest APDR is always reused so events accumulating toward a window's
+          first firing are untouched, regardless of policy.
+        - On a re-arrival, :attr:`RerunPolicy.IGNORE` returns ``None`` so the caller drops the
+          event (no APDR, no key log); otherwise a fresh APDR is created and stamped with the
+          policy, which the scheduler resolves to decide how to fire it
+          (:attr:`RerunPolicy.fires_immediately`).
         """
         with _lock_asset_model(session=session, asset_id=asset_id):
             latest_apdr: AssetPartitionDagRun | None = session.scalar(
@@ -778,12 +800,27 @@ class AssetManager(LoggingMixin):
                 )
                 return latest_apdr
 
+            # First materialization is not a re-run: stamp the neutral HOLD default.
+            stamped_policy = RerunPolicy.HOLD
+            if latest_apdr is not None:
+                # The latest APDR already fired, so this event re-arrives for an
+                # already-materialized window. Apply the rollup's rerun policy.
+                if rerun_policy.drops_event:
+                    cls.logger().debug(
+                        "Dropping re-arrived event for fired window key %s dag_id %s (IGNORE)",
+                        target_key,
+                        target_dag.dag_id,
+                    )
+                    return None
+                stamped_policy = rerun_policy
+
             apdr = AssetPartitionDagRun(
                 target_dag_id=target_dag.dag_id,
                 created_dag_run_id=None,
                 partition_key=target_key,
                 partition_date=target_partition_date,
                 rollup_fingerprint=rollup_fingerprint,
+                rerun_policy=stamped_policy.value,
             )
             session.add(apdr)
             session.flush()

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -111,6 +111,7 @@ from airflow.models.team import Team
 from airflow.models.trigger import TRIGGER_FAIL_REPR, Trigger, TriggerFailureReason, handle_event_submit
 from airflow.observability.metrics import stats_utils
 from airflow.partition_mappers.base import is_rollup
+from airflow.partition_mappers.rerun_policy import RerunPolicy
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.definitions.notset import NOTSET
 from airflow.ti_deps.dependencies_states import ACTIVE_STATES, EXECUTION_STATES
@@ -2369,23 +2370,31 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             source_key_by_asset = source_key_by_asset_per_apdr[apdr.id]
             timetable = dag.timetable
-            statuses: dict[SerializedAssetUniqueKey, bool] = {}
-            for asset_id, (name, uri) in asset_info_per_apdr[apdr.id].items():
-                key = SerializedAssetUniqueKey(name=name, uri=uri)
-                if timetable.partitioned:
-                    statuses[key] = self._resolve_asset_partition_status(
-                        session=session,
-                        asset_id=asset_id,
-                        name=name,
-                        uri=uri,
-                        apdr=apdr,
-                        timetable=timetable,
-                        actual_by_asset=source_key_by_asset,
-                    )
-                else:
-                    statuses[key] = True
-            if not evaluator.run(timetable.asset_condition, statuses=statuses):
-                continue
+            contributing_assets = asset_info_per_apdr[apdr.id]
+            if RerunPolicy(apdr.rerun_policy).fires_immediately:
+                # A REFRESH-stamped APDR supersedes an already-fired window, so fire
+                # immediately rather than re-checking the wait policy or the asset
+                # condition against it. Still require an active asset.
+                if not contributing_assets:
+                    continue
+            else:
+                statuses: dict[SerializedAssetUniqueKey, bool] = {}
+                for asset_id, (name, uri) in contributing_assets.items():
+                    key = SerializedAssetUniqueKey(name=name, uri=uri)
+                    if timetable.partitioned:
+                        statuses[key] = self._resolve_asset_partition_status(
+                            session=session,
+                            asset_id=asset_id,
+                            name=name,
+                            uri=uri,
+                            apdr=apdr,
+                            timetable=timetable,
+                            actual_by_asset=source_key_by_asset,
+                        )
+                    else:
+                        statuses[key] = True
+                if not evaluator.run(timetable.asset_condition, statuses=statuses):
+                    continue
 
             partition_dag_ids.add(apdr.target_dag_id)
             run_after = timezone.utcnow()

--- a/airflow-core/src/airflow/migrations/versions/0129_3_4_0_add_rerun_policy_to_apdr.py
+++ b/airflow-core/src/airflow/migrations/versions/0129_3_4_0_add_rerun_policy_to_apdr.py
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Add rerun_policy to AssetPartitionDagRun.
+
+The ``rerun_policy`` column stores the RerunPolicy (as its string value) that
+governs how the scheduler fires this provisional partition Dag run. A run stamped
+``"refresh"`` fires immediately after an upstream partition was cleared and
+re-run; everything else is stamped ``"hold"`` and goes through normal evaluation.
+
+Revision ID: 623bce373cdf
+Revises: b2f1a9c7d4e0
+Create Date: 2026-06-17 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+from airflow.migrations.utils import disable_sqlite_fkeys
+
+revision = "623bce373cdf"
+down_revision = "b2f1a9c7d4e0"
+branch_labels = None
+depends_on = None
+airflow_version = "3.4.0"
+
+
+def upgrade():
+    """Add ``rerun_policy`` to ``asset_partition_dag_run``."""
+    with disable_sqlite_fkeys(op):
+        with op.batch_alter_table("asset_partition_dag_run", schema=None) as batch_op:
+            batch_op.add_column(
+                sa.Column("rerun_policy", sa.String(length=20), nullable=False, server_default="hold")
+            )
+
+
+def downgrade():
+    """Drop the APDR ``rerun_policy`` column."""
+    with disable_sqlite_fkeys(op):
+        with op.batch_alter_table("asset_partition_dag_run", schema=None) as batch_op:
+            batch_op.drop_column("rerun_policy")

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -947,6 +947,11 @@ class AssetPartitionDagRun(Base):
     # legacy rows that pre-date the column; they are treated as stale on the
     # next scheduler tick.
     rollup_fingerprint: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    # The RerunPolicy that governs how the scheduler fires this provisional run.
+    # ``RerunPolicy.REFRESH`` fires immediately, skipping the wait policy.
+    # Everything else (first materialization, non-rollup, explicit HOLD) is ``"hold"``
+    # and goes through normal evaluation.
+    rerun_policy: Mapped[str] = mapped_column(String(20), nullable=False, server_default="hold")
     created_at: Mapped[datetime] = mapped_column(UtcDateTime, default=timezone.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         UtcDateTime, default=timezone.utcnow, onupdate=timezone.utcnow, nullable=False

--- a/airflow-core/src/airflow/partition_mappers/__init__.py
+++ b/airflow-core/src/airflow/partition_mappers/__init__.py
@@ -22,6 +22,7 @@ from airflow.partition_mappers.chain import ChainMapper
 from airflow.partition_mappers.fixed_key import FixedKeyMapper
 from airflow.partition_mappers.identity import IdentityMapper
 from airflow.partition_mappers.product import ProductMapper
+from airflow.partition_mappers.rerun_policy import RerunPolicy
 from airflow.partition_mappers.temporal import (
     FanOutMapper,
     StartOfDayMapper,
@@ -56,6 +57,7 @@ __all__ = [
     "PartitionMapper",
     "ProductMapper",
     "QuarterWindow",
+    "RerunPolicy",
     "RollupMapper",
     "SegmentWindow",
     "StartOfDayMapper",

--- a/airflow-core/src/airflow/partition_mappers/base.py
+++ b/airflow-core/src/airflow/partition_mappers/base.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, ClassVar, TypeGuard
 
+from airflow.partition_mappers.rerun_policy import RerunPolicy
 from airflow.partition_mappers.wait_policy import WaitForAll, WaitPolicy
 
 if TYPE_CHECKING:
@@ -37,6 +38,7 @@ class PartitionMapper(ABC):
     """
 
     is_rollup: ClassVar[bool] = False
+    rerun_policy: RerunPolicy = RerunPolicy.HOLD
 
     max_downstream_keys: int | None = None
 
@@ -158,6 +160,11 @@ class RollupMapper(PartitionMapper):
     ``wait_policy`` that decides when the downstream Dag run fires given
     the expected window and the upstream keys that have actually arrived.
     The default policy waits for every expected upstream key.
+
+    ``rerun_policy`` decides what happens when an upstream partition that the
+    fired window already consumed is cleared and re-run; see :class:`RerunPolicy`.
+    The default :attr:`RerunPolicy.HOLD` re-evaluates the window through the wait
+    policy.
     """
 
     is_rollup: ClassVar[bool] = True
@@ -168,6 +175,7 @@ class RollupMapper(PartitionMapper):
         upstream_mapper: PartitionMapper,
         window: Window,
         wait_policy: WaitPolicy | None = None,
+        rerun_policy: RerunPolicy = RerunPolicy.HOLD,
         max_downstream_keys: int | None = None,
     ) -> None:
         if upstream_mapper.expected_decoded_type is not window.expected_decoded_type:
@@ -184,6 +192,7 @@ class RollupMapper(PartitionMapper):
         self.upstream_mapper = upstream_mapper
         self.window = window
         self.wait_policy = wait_policy
+        self.rerun_policy = rerun_policy
 
     def to_downstream(self, key: str) -> str | Iterable[str]:
         return self.upstream_mapper.to_downstream(key)
@@ -216,6 +225,7 @@ class RollupMapper(PartitionMapper):
             "upstream_mapper": encode_partition_mapper(self.upstream_mapper),
             "window": encode_window(self.window),
             "wait_policy": encode_wait_policy(self.wait_policy),
+            "rerun_policy": self.rerun_policy.value,
         }
         if self.max_downstream_keys is not None:
             data["max_downstream_keys"] = self.max_downstream_keys
@@ -233,6 +243,7 @@ class RollupMapper(PartitionMapper):
             upstream_mapper=decode_partition_mapper(data["upstream_mapper"]),
             window=decode_window(data["window"]),
             wait_policy=decode_wait_policy(data["wait_policy"]),
+            rerun_policy=RerunPolicy(data.get("rerun_policy", RerunPolicy.HOLD)),
             max_downstream_keys=data.get("max_downstream_keys"),
         )
 

--- a/airflow-core/src/airflow/partition_mappers/rerun_policy.py
+++ b/airflow-core/src/airflow/partition_mappers/rerun_policy.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RerunPolicy(str, Enum):
+    """
+    Core-side mirror of the SDK :class:`airflow.sdk.RerunPolicy`.
+
+    Decides what the scheduler does when an upstream partition is cleared and
+    re-run after a rollup's downstream window has already fired. See the SDK
+    class for the authoring-facing documentation; the two are serialized by
+    string value so they round-trip across the Dag-parse / scheduler boundary.
+
+    ``HOLD`` (default): queue a provisional run that re-evaluates the window
+    through the wait policy before firing again.
+
+    ``REFRESH``: re-fire the downstream Dag run immediately so it reprocesses with
+    the corrected upstream data. Neither the wait policy nor the Dag's schedule
+    condition is re-evaluated.
+
+    ``IGNORE``: drop the late upstream event; do not re-fire.
+    """
+
+    REFRESH = "refresh"
+    HOLD = "hold"
+    IGNORE = "ignore"
+
+    @property
+    def fires_immediately(self) -> bool:
+        """Whether a provisional run stamped with this policy fires at once, skipping the wait policy."""
+        return self is RerunPolicy.REFRESH
+
+    @property
+    def drops_event(self) -> bool:
+        """Whether a re-arriving event for an already-fired window is dropped without queuing a run."""
+        return self is RerunPolicy.IGNORE

--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -533,6 +533,7 @@ class _Serializer:
             "upstream_mapper": encode_partition_mapper(partition_mapper.upstream_mapper),
             "window": encode_window(partition_mapper.window),
             "wait_policy": encode_wait_policy(partition_mapper.wait_policy),
+            "rerun_policy": partition_mapper.rerun_policy.value,
         }
         if partition_mapper.max_downstream_keys is not None:
             data["max_downstream_keys"] = partition_mapper.max_downstream_keys

--- a/airflow-core/src/airflow/timetables/base.py
+++ b/airflow-core/src/airflow/timetables/base.py
@@ -520,6 +520,30 @@ class Timetable(Protocol):
         )
 
 
+def _encode_partition_mapper_for_fingerprint(mapper: PartitionMapper) -> dict[str, Any]:
+    """
+    Encode *mapper* for the rollup fingerprint, excluding ``rerun_policy``.
+
+    ``rerun_policy`` only decides what happens after a window has fired, not
+    which upstream keys the window requires, so it must not feed the fingerprint:
+    including it would let a policy-only edit discard in-flight APDRs, and would
+    make every pending partition run look stale on upgrade (stored fingerprints
+    pre-date the key). It lives only on :class:`RollupMapper`, so it is dropped
+    only there, at its known top-level location — gating on ``is_rollup`` keeps a
+    custom mapper that happens to use the same field name untouched.
+    """
+    # Local import to avoid a circular dependency: encoders.py imports Timetable
+    # from this module at the top level, so a top-level import here would cycle.
+    from airflow.partition_mappers.base import is_rollup
+    from airflow.serialization.encoders import encode_partition_mapper
+    from airflow.serialization.enums import Encoding
+
+    encoded = encode_partition_mapper(mapper)
+    if is_rollup(mapper):
+        encoded.get(Encoding.VAR, {}).pop("rerun_policy", None)
+    return encoded
+
+
 def compute_rollup_fingerprint(timetable: Timetable) -> dict:
     """
     Return the rollup-definition fingerprint for *timetable*.
@@ -535,6 +559,11 @@ def compute_rollup_fingerprint(timetable: Timetable) -> dict:
     trigger cleanup of a stale partition Dag run, leaving unrelated Dag edits
     untouched.
 
+    The mapper's ``rerun_policy`` is deliberately excluded (see
+    :func:`_encode_partition_mapper_for_fingerprint`): it governs only post-fire
+    behavior, not which upstream keys a window requires, so it must not
+    invalidate in-flight APDRs.
+
     Both the creation side (``assets/manager.py``) and the cleanup side
     (``jobs/scheduler_job_runner.py``) call this helper to guarantee the two
     fingerprints are computed by identical logic.
@@ -542,26 +571,22 @@ def compute_rollup_fingerprint(timetable: Timetable) -> dict:
     if not timetable.partitioned:
         return {}
 
-    # Local import to avoid a circular dependency: encoders.py already imports
-    # Timetable from this module at the top level, so a top-level import of
-    # encode_partition_mapper here would create a cycle.
     from airflow.serialization.definitions.assets import SerializedAssetNameRef, SerializedAssetUriRef
-    from airflow.serialization.encoders import encode_partition_mapper
 
     entries: dict[str, dict[str, Any]] = {}
     for unique_key, _ in timetable.asset_condition.iter_assets():
         mapper = timetable.get_partition_mapper(name=unique_key.name, uri=unique_key.uri)
         key = f"{unique_key.name}|{unique_key.uri}"
-        entries[key] = encode_partition_mapper(mapper)
+        entries[key] = _encode_partition_mapper_for_fingerprint(mapper)
 
     for s_asset_ref in timetable.asset_condition.iter_asset_refs():
         if isinstance(s_asset_ref, SerializedAssetNameRef):
             mapper = timetable.get_partition_mapper(name=s_asset_ref.name)
             key = f"{s_asset_ref.name}|"
-            entries[key] = encode_partition_mapper(mapper)
+            entries[key] = _encode_partition_mapper_for_fingerprint(mapper)
         elif isinstance(s_asset_ref, SerializedAssetUriRef):
             mapper = timetable.get_partition_mapper(uri=s_asset_ref.uri)
             key = f"|{s_asset_ref.uri}"
-            entries[key] = encode_partition_mapper(mapper)
+            entries[key] = _encode_partition_mapper_for_fingerprint(mapper)
 
     return dict(sorted(entries.items()))

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -117,7 +117,7 @@ _REVISION_HEADS_MAP: dict[str, str] = {
     "3.1.8": "509b94a1042d",
     "3.2.0": "1d6611b6ab7c",
     "3.3.0": "d2f4e1b3c5a7",
-    "3.4.0": "b2f1a9c7d4e0",
+    "3.4.0": "623bce373cdf",
 }
 
 # Prefix used to identify tables holding data moved during migration.

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -47,6 +47,7 @@ from airflow.models.dagbundle import DagBundleModel
 from airflow.models.log import Log
 from airflow.models.team import Team
 from airflow.partition_mappers.identity import IdentityMapper
+from airflow.partition_mappers.rerun_policy import RerunPolicy
 from airflow.partition_mappers.temporal import FanOutMapper, StartOfWeekMapper
 from airflow.partition_mappers.window import WeekWindow
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -396,6 +397,7 @@ class TestAssetManager:
                     target_dag=testing_dag,
                     rollup_fingerprint=rollup_fingerprint,
                     asset_id=asm.id,
+                    rerun_policy=RerunPolicy.HOLD,
                     session=_session,
                 ).id
             finally:
@@ -434,6 +436,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            rerun_policy=RerunPolicy.HOLD,
             session=session,
         )
         assert first.partition_date == timezone.parse("2026-05-20T00:00:00")
@@ -445,6 +448,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            rerun_policy=RerunPolicy.HOLD,
             session=session,
         )
         assert second.id == first.id  # same pending APDR
@@ -465,6 +469,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            rerun_policy=RerunPolicy.HOLD,
             session=session,
         )
         first = AssetManager._get_or_create_apdr(target_partition_date=source_date, **kwargs)
@@ -493,6 +498,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            rerun_policy=RerunPolicy.HOLD,
             session=session,
         )
         # First event carries no date (e.g. producer had no partition_date).
@@ -519,6 +525,7 @@ class TestAssetManager:
             target_dag=testing_dag,
             rollup_fingerprint=fp,
             asset_id=asm.id,
+            rerun_policy=RerunPolicy.HOLD,
             session=session,
         )
         first = AssetManager._get_or_create_apdr(target_partition_date=date_1, **kwargs)
@@ -646,6 +653,98 @@ class TestAssetManager:
         assert apdr.rollup_fingerprint == expected_fp, (
             "APDR rollup_fingerprint must match compute_rollup_fingerprint(timetable)"
         )
+
+    @pytest.mark.need_serialized_dag
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    @pytest.mark.parametrize(
+        ("rerun_policy", "expect_created", "expect_stamped"),
+        [
+            pytest.param(RerunPolicy.REFRESH, True, "refresh", id="refresh-creates-refresh-apdr"),
+            pytest.param(RerunPolicy.HOLD, True, "hold", id="hold-creates-plain-apdr"),
+            pytest.param(RerunPolicy.IGNORE, False, None, id="ignore-drops-event"),
+        ],
+    )
+    def test_get_or_create_apdr_rerun_policy_after_window_fired(
+        self, session, dag_maker, rerun_policy, expect_created, expect_stamped
+    ):
+        """When the latest APDR already fired, the rerun policy decides what a re-arriving event does."""
+        suffix = rerun_policy.value
+        dag_id = f"rerun-consumer-{suffix}"
+        asm = AssetModel(uri=f"test://rerun/{suffix}", name=f"rerun_asset_{suffix}", group="asset")
+        session.add(asm)
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id="t")
+        dr = dag_maker.create_dagrun(session=session)
+        session.commit()
+        consumer = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id))
+
+        # Seed a fired APDR for ("all", consumer): a window that already materialized.
+        session.add(
+            AssetPartitionDagRun(
+                target_dag_id=dag_id,
+                partition_key="all",
+                created_dag_run_id=dr.id,
+                rollup_fingerprint={},
+            )
+        )
+        session.commit()
+
+        result = AssetManager._get_or_create_apdr(
+            target_key="all",
+            target_partition_date=None,
+            target_dag=consumer,
+            rollup_fingerprint={},
+            asset_id=asm.id,
+            rerun_policy=rerun_policy,
+            session=session,
+        )
+        total = session.scalar(
+            select(func.count())
+            .select_from(AssetPartitionDagRun)
+            .where(AssetPartitionDagRun.target_dag_id == dag_id)
+        )
+        if not expect_created:
+            assert result is None
+            assert total == 1  # only the fired APDR; the late event was dropped
+        else:
+            assert result is not None
+            assert result.created_dag_run_id is None
+            assert result.rerun_policy == expect_stamped
+            assert total == 2
+
+    @pytest.mark.need_serialized_dag
+    @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_get_or_create_apdr_reuses_pending_regardless_of_policy(self, session, dag_maker):
+        """A not-yet-fired APDR is always reused, so events accumulating toward the first firing are never dropped."""
+        asm = AssetModel(uri="test://reuse/", name="reuse_asset", group="asset")
+        session.add(asm)
+        with dag_maker(dag_id="reuse-consumer", session=session):
+            EmptyOperator(task_id="t")
+        session.commit()
+        consumer = session.scalar(select(DagModel).where(DagModel.dag_id == "reuse-consumer"))
+
+        first = AssetManager._get_or_create_apdr(
+            target_key="all",
+            target_partition_date=None,
+            target_dag=consumer,
+            rollup_fingerprint={},
+            asset_id=asm.id,
+            rerun_policy=RerunPolicy.REFRESH,
+            session=session,
+        )
+        # Even IGNORE reuses the still-pending APDR rather than dropping the event.
+        second = AssetManager._get_or_create_apdr(
+            target_key="all",
+            target_partition_date=None,
+            target_dag=consumer,
+            rollup_fingerprint={},
+            asset_id=asm.id,
+            rerun_policy=RerunPolicy.IGNORE,
+            session=session,
+        )
+        assert second is not None
+        assert second.id == first.id
+        assert second.rerun_policy == RerunPolicy.HOLD.value
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_register_asset_change_queues_stale_dag(self, session, mock_task_instance):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -127,6 +127,7 @@ from airflow.sdk import (
     HourWindow,
     IdentityMapper,
     MinimumCount,
+    RerunPolicy,
     RollupMapper,
     SegmentWindow,
     StartOfDayMapper,
@@ -11879,6 +11880,152 @@ def test_partitioned_dag_run_rollup_holds_until_window_complete(
 
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
+def test_partitioned_dag_run_rollup_refresh_refires_on_upstream_rerun(
+    dag_maker: DagMaker,
+    session: Session,
+):
+    """
+    RerunPolicy.REFRESH re-fires immediately when an upstream partition is re-run.
+
+    After the window already fired, re-running a single upstream key creates a fresh
+    REFRESH-stamped APDR that fires on the next tick — it does NOT wait for the whole
+    window to re-materialize, because the rest of the window is still materialized.
+    """
+    asset_1 = Asset(name="asset-1")
+    with dag_maker(
+        dag_id="refresh-rollup-consumer",
+        schedule=PartitionedAssetTimetable(
+            assets=asset_1,
+            default_partition_mapper=RollupMapper(
+                upstream_mapper=FixedKeyMapper("all_regions"),
+                window=SegmentWindow(["us", "eu"]),
+                rerun_policy=RerunPolicy.REFRESH,
+            ),
+        ),
+        session=session,
+    ):
+        EmptyOperator(task_id="hi")
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+
+    # Both regions collapse onto the single "all_regions" partition; once both are
+    # present the window is complete and the rollup fires once.
+    for region in ("us", "eu"):
+        apdr = _produce_and_register_asset_event(
+            dag_id=f"refresh-producer-{region}",
+            asset=asset_1,
+            partition_key=region,
+            session=session,
+            dag_maker=dag_maker,
+            expected_partition_key="all_regions",
+        )
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    session.refresh(apdr)
+    first_run_id = apdr.created_dag_run_id
+    assert first_run_id is not None
+    assert partition_dags == {"refresh-rollup-consumer"}
+
+    # Clear & re-run only "us". REFRESH creates a new, refresh APDR ...
+    refresh_apdr = _produce_and_register_asset_event(
+        dag_id="refresh-producer-us-rerun",
+        asset=asset_1,
+        partition_key="us",
+        session=session,
+        dag_maker=dag_maker,
+        expected_partition_key="all_regions",
+    )
+    assert refresh_apdr.id != apdr.id
+    assert refresh_apdr.rerun_policy == "refresh"
+
+    # ... that fires on the next tick even though "eu" did not re-arrive (1/2 of window).
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    session.refresh(refresh_apdr)
+    assert refresh_apdr.created_dag_run_id is not None
+    assert refresh_apdr.created_dag_run_id != first_run_id
+    assert partition_dags == {"refresh-rollup-consumer"}
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows")
+def test_partitioned_dag_run_rollup_hold_waits_for_full_window_on_rerun(
+    dag_maker: DagMaker,
+    session: Session,
+):
+    """
+    RerunPolicy.HOLD makes a re-run wait for the entire window to re-materialize.
+
+    After the window fired, re-running a single upstream key creates a fresh
+    non-refresh APDR that holds until every key in the window arrives again.
+    """
+    asset_1 = Asset(name="asset-1")
+    with dag_maker(
+        dag_id="hold-rollup-consumer",
+        schedule=PartitionedAssetTimetable(
+            assets=asset_1,
+            default_partition_mapper=RollupMapper(
+                upstream_mapper=FixedKeyMapper("all_regions"),
+                window=SegmentWindow(["us", "eu"]),
+                rerun_policy=RerunPolicy.HOLD,
+            ),
+        ),
+        session=session,
+    ):
+        EmptyOperator(task_id="hi")
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+
+    for region in ("us", "eu"):
+        apdr = _produce_and_register_asset_event(
+            dag_id=f"hold-producer-{region}",
+            asset=asset_1,
+            partition_key=region,
+            session=session,
+            dag_maker=dag_maker,
+            expected_partition_key="all_regions",
+        )
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    session.refresh(apdr)
+    assert apdr.created_dag_run_id is not None
+
+    # Re-run only "us": HOLD creates a non-refresh APDR that must wait.
+    hold_apdr = _produce_and_register_asset_event(
+        dag_id="hold-producer-us-rerun",
+        asset=asset_1,
+        partition_key="us",
+        session=session,
+        dag_maker=dag_maker,
+        expected_partition_key="all_regions",
+    )
+    assert hold_apdr.id != apdr.id
+    assert hold_apdr.rerun_policy == "hold"
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    session.refresh(hold_apdr)
+    assert hold_apdr.created_dag_run_id is None  # held: only 1 / 2 of the window present
+    assert partition_dags == set()
+
+    # When "eu" also re-arrives the window is complete again and the run fires.
+    _produce_and_register_asset_event(
+        dag_id="hold-producer-eu-rerun",
+        asset=asset_1,
+        partition_key="eu",
+        session=session,
+        dag_maker=dag_maker,
+        expected_partition_key="all_regions",
+    )
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    session.refresh(hold_apdr)
+    assert hold_apdr.created_dag_run_id is not None
+    assert partition_dags == {"hold-rollup-consumer"}
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows")
 def test_partitioned_dag_run_segment_rollup_holds_until_all_segments_arrive(
     dag_maker: DagMaker,
     session: Session,
@@ -12773,6 +12920,39 @@ def test_partitioned_dag_run_skips_when_asset_is_inactive(dag_maker: DagMaker, s
         session=session,
         dag_maker=dag_maker,
     )
+    _set_asset_active(name=asset.name, uri=asset.uri, session=session, active=False)
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    session.refresh(apdr)
+    assert apdr.created_dag_run_id is None
+    assert partition_dags == set()
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows")
+def test_partitioned_dag_run_refresh_apdr_freezes_when_asset_inactive(dag_maker: DagMaker, session: Session):
+    """
+    A refresh APDR also freezes while its only contributing asset is inactive.
+
+    The refresh fast-path skips the wait policy, so it must keep the same
+    freeze-on-inactive guard the normal path has — otherwise it would fire a run
+    that consumes no events. Without the ``if not contributing_assets`` guard this
+    APDR would fire immediately.
+    """
+    asset = Asset(name="asset-refresh-inactive")
+    [apdr] = _make_n_satisfied_apdrs(
+        consumer_dag_id="refresh-inactive-consumer",
+        asset=asset,
+        partition_keys=["k1"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+    apdr.rerun_policy = RerunPolicy.REFRESH.value
+    session.commit()
     _set_asset_active(name=asset.name, uri=asset.uri, session=session, active=False)
 
     runner = SchedulerJobRunner(

--- a/airflow-core/tests/unit/partition_mappers/test_base.py
+++ b/airflow-core/tests/unit/partition_mappers/test_base.py
@@ -24,6 +24,7 @@ import pytest
 from airflow.partition_mappers.base import PartitionMapper, RollupMapper
 from airflow.partition_mappers.fixed_key import FixedKeyMapper
 from airflow.partition_mappers.identity import IdentityMapper
+from airflow.partition_mappers.rerun_policy import RerunPolicy
 from airflow.partition_mappers.temporal import StartOfDayMapper
 from airflow.partition_mappers.window import DayWindow, SegmentWindow
 from airflow.serialization.decoders import decode_partition_mapper
@@ -270,3 +271,66 @@ class TestRollupMapperMaxDownstreamKeys:
         mapper = RollupMapper(upstream_mapper=StartOfDayMapper(), window=DayWindow())
         encoded_var = encode_partition_mapper(mapper)[Encoding.VAR]
         assert "max_downstream_keys" not in encoded_var
+
+
+class TestRollupMapperRerunPolicy:
+    @pytest.mark.parametrize("policy", list(RerunPolicy))
+    def test_encode_decode_roundtrip(self, policy):
+        mapper = RollupMapper(upstream_mapper=StartOfDayMapper(), window=DayWindow(), rerun_policy=policy)
+        encoded = encode_partition_mapper(mapper)
+        assert encoded[Encoding.VAR]["rerun_policy"] == policy.value
+        assert decode_partition_mapper(encoded).rerun_policy is policy
+
+    def test_default_is_hold_in_encoded_payload(self):
+        mapper = RollupMapper(upstream_mapper=StartOfDayMapper(), window=DayWindow())
+        assert encode_partition_mapper(mapper)[Encoding.VAR]["rerun_policy"] == "hold"
+
+    def test_missing_key_decodes_to_hold(self):
+        """A Dag serialized before rerun_policy existed has no key; it must default to HOLD (pre-feature behavior)."""
+        encoded = encode_partition_mapper(
+            RollupMapper(
+                upstream_mapper=StartOfDayMapper(), window=DayWindow(), rerun_policy=RerunPolicy.REFRESH
+            )
+        )
+        del encoded[Encoding.VAR]["rerun_policy"]
+        assert decode_partition_mapper(encoded).rerun_policy is RerunPolicy.HOLD
+
+    def test_non_rollup_mapper_reports_hold(self):
+        """A non-rollup mapper reports the neutral HOLD, so the manager reads mapper.rerun_policy without a rollup check."""
+        assert IdentityMapper().rerun_policy is RerunPolicy.HOLD
+
+    @pytest.mark.parametrize(
+        "make_mapper",
+        [
+            pytest.param(lambda **kw: IdentityMapper(**kw), id="identity"),
+            pytest.param(lambda **kw: StartOfDayMapper(**kw), id="temporal"),
+        ],
+    )
+    def test_only_rollup_accepts_rerun_policy_kwarg(self, make_mapper):
+        """``rerun_policy`` is a constructor arg only on RollupMapper; other mappers reject it."""
+        # RollupMapper accepts it ...
+        assert (
+            RollupMapper(
+                upstream_mapper=StartOfDayMapper(), window=DayWindow(), rerun_policy=RerunPolicy.REFRESH
+            ).rerun_policy
+            is RerunPolicy.REFRESH
+        )
+        # ... while a non-rollup mapper has no such parameter.
+        with pytest.raises(TypeError, match="rerun_policy"):
+            make_mapper(rerun_policy=RerunPolicy.REFRESH)
+
+
+class TestRerunPolicyMethods:
+    """The scheduler/manager ask the enum directly, so the behavior must live on it."""
+
+    @pytest.mark.parametrize(
+        ("policy", "fires", "drops"),
+        [
+            (RerunPolicy.REFRESH, True, False),
+            (RerunPolicy.HOLD, False, False),
+            (RerunPolicy.IGNORE, False, True),
+        ],
+    )
+    def test_behavior(self, policy, fires, drops):
+        assert policy.fires_immediately is fires
+        assert policy.drops_event is drops

--- a/airflow-core/tests/unit/timetables/test_base_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_base_timetable.py
@@ -19,7 +19,19 @@ from __future__ import annotations
 import pytest
 
 from airflow._shared.module_loading import qualname
-from airflow.timetables.simple import NullTimetable
+from airflow.sdk import (
+    Asset,
+    DayWindow,
+    HourWindow,
+    IdentityMapper,
+    RerunPolicy,
+    RollupMapper,
+    StartOfHourMapper,
+)
+from airflow.sdk.definitions.asset import AssetNameRef, AssetUriRef
+from airflow.serialization.encoders import encode_partition_mapper
+from airflow.timetables.base import Timetable, compute_rollup_fingerprint
+from airflow.timetables.simple import NullTimetable, PartitionedAssetTimetable
 
 
 def test_builtin_timetable_type_name_returns_class_name():
@@ -31,11 +43,10 @@ def test_builtin_timetable_type_name_returns_class_name():
 
 def test_custom_timetable_type_name_returns_qualname():
     """Custom/user-defined timetables should return the full import path (qualname)."""
+
     # Define a custom timetable class that inherits from Timetable so it uses
     # the default property implementation. Its module will not start with
     # "airflow.timetables." so type_name should be the qualname.
-    from airflow.timetables.base import Timetable
-
     class CustomTimetable(Timetable):
         pass
 
@@ -53,17 +64,11 @@ def test_custom_timetable_type_name_returns_qualname():
 
 def test_compute_rollup_fingerprint_non_partitioned_returns_empty():
     """Non-partitioned timetables return an empty dict."""
-    from airflow.timetables.base import compute_rollup_fingerprint
-
     assert compute_rollup_fingerprint(NullTimetable()) == {}
 
 
 def test_compute_rollup_fingerprint_stable_across_calls():
     """Same timetable produces identical fingerprints on repeated calls."""
-    from airflow.sdk import Asset, HourWindow, RollupMapper, StartOfHourMapper
-    from airflow.timetables.base import compute_rollup_fingerprint
-    from airflow.timetables.simple import PartitionedAssetTimetable
-
     tt = PartitionedAssetTimetable(
         assets=Asset(name="asset-a"),
         default_partition_mapper=RollupMapper(upstream_mapper=StartOfHourMapper(), window=HourWindow()),
@@ -73,10 +78,6 @@ def test_compute_rollup_fingerprint_stable_across_calls():
 
 def test_compute_rollup_fingerprint_keys_sorted():
     """Keys are sorted, making the dict stable regardless of asset order."""
-    from airflow.sdk import Asset, HourWindow, RollupMapper, StartOfHourMapper
-    from airflow.timetables.base import compute_rollup_fingerprint
-    from airflow.timetables.simple import PartitionedAssetTimetable
-
     asset_a = Asset(name="asset-a")
     asset_b = Asset(name="asset-b")
 
@@ -96,10 +97,6 @@ def test_compute_rollup_fingerprint_keys_sorted():
 
 def test_compute_rollup_fingerprint_window_change_produces_different_fingerprint():
     """Changing window (Hour → Day) produces a different fingerprint."""
-    from airflow.sdk import Asset, DayWindow, HourWindow, RollupMapper, StartOfHourMapper
-    from airflow.timetables.base import compute_rollup_fingerprint
-    from airflow.timetables.simple import PartitionedAssetTimetable
-
     asset_1 = Asset(name="asset-1")
     tt_hour = PartitionedAssetTimetable(
         assets=asset_1,
@@ -114,12 +111,51 @@ def test_compute_rollup_fingerprint_window_change_produces_different_fingerprint
     assert fp_hour != fp_day
 
 
+def test_compute_rollup_fingerprint_excludes_rerun_policy():
+    """
+    Changing only ``rerun_policy`` must NOT change the fingerprint.
+
+    ``rerun_policy`` governs post-fire behavior, not which upstream keys a window
+    requires. If it fed the fingerprint, a policy-only edit would discard in-flight
+    APDRs, and upgrading from a version that pre-dates the key would invalidate
+    every pending partition run (stored fingerprints lack the key).
+    """
+    asset_1 = Asset(name="asset-1")
+
+    def fingerprint(policy):
+        tt = PartitionedAssetTimetable(
+            assets=asset_1,
+            default_partition_mapper=RollupMapper(
+                upstream_mapper=StartOfHourMapper(), window=HourWindow(), rerun_policy=policy
+            ),
+        )
+        return compute_rollup_fingerprint(tt)
+
+    fingerprints = [fingerprint(policy) for policy in RerunPolicy]
+    assert all(fp == fingerprints[0] for fp in fingerprints)
+    assert "rerun_policy" not in str(fingerprints[0])
+
+
+def test_compute_rollup_fingerprint_non_rollup_mapper_unaffected():
+    """
+    A non-rollup partition mapper is fingerprinted unchanged.
+
+    The ``rerun_policy`` exclusion is gated on ``is_rollup``, so a non-rollup
+    mapper (which never carries ``rerun_policy``) is passed through untouched —
+    this also guards against the exclusion ever stripping a same-named field
+    from some other mapper.
+    """
+    asset_1 = Asset(name="asset-1")
+    mapper = IdentityMapper()
+    tt = PartitionedAssetTimetable(assets=asset_1, default_partition_mapper=mapper)
+
+    fp = compute_rollup_fingerprint(tt)
+    # The entry is the full encoded mapper, identical to encoding it directly.
+    assert fp[f"{asset_1.name}|{asset_1.uri}"] == encode_partition_mapper(mapper)
+
+
 def test_compute_rollup_fingerprint_multi_asset_all_keys_present():
     """All assets appear as keys in the fingerprint."""
-    from airflow.sdk import Asset, HourWindow, RollupMapper, StartOfHourMapper
-    from airflow.timetables.base import compute_rollup_fingerprint
-    from airflow.timetables.simple import PartitionedAssetTimetable
-
     assets = [Asset(name=f"asset-{i}") for i in range(3)]
     condition = assets[0]
     for a in assets[1:]:
@@ -157,11 +193,6 @@ def test_compute_rollup_fingerprint_multi_asset_all_keys_present():
 )
 def test_compute_rollup_fingerprint_key_format(asset_or_ref, expected_key):
     """Keys follow the ``{name}|{uri}`` format for full assets and ``{name}|`` / ``|{uri}`` for refs."""
-    from airflow.sdk import Asset, HourWindow, RollupMapper, StartOfHourMapper
-    from airflow.sdk.definitions.asset import AssetNameRef, AssetUriRef
-    from airflow.timetables.base import compute_rollup_fingerprint
-    from airflow.timetables.simple import PartitionedAssetTimetable
-
     kind, name, uri = asset_or_ref
     if kind == "asset":
         asset_input = Asset(name=name, uri=uri)

--- a/scripts/ci/prek/check_rerun_policy_in_sync.py
+++ b/scripts/ci/prek/check_rerun_policy_in_sync.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "rich>=13.6.0",
+# ]
+# ///
+"""
+Verify ``RerunPolicy`` stays in sync between core and the Task SDK.
+
+The enum is defined twice — once in core and once in the SDK — because the two
+sides are independent (the SDK cannot import core) and the value is serialized
+by its string value to round-trip across the Dag-parse / scheduler boundary. If
+the member cases drift, a Dag authored against the SDK could serialize a value
+the core side cannot resolve, and the behavior methods would disagree.
+
+This check parses both files via AST and asserts the following are identical:
+
+- ``RerunPolicy`` enum member values (``{member_name: value}``)
+- the bodies of the behavior methods (``fires_immediately``, ``drops_event``)
+
+Run from the repo root:
+
+    uv run --project scripts python scripts/ci/prek/check_rerun_policy_in_sync.py
+
+Exits 0 if synced, 1 (with a diff) otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+from common_prek_utils import (
+    AIRFLOW_CORE_SOURCES_PATH,
+    AIRFLOW_TASK_SDK_SOURCES_PATH,
+)
+from rich.console import Console
+
+console = Console(color_system="standard", width=200)
+
+CORE_FILE = AIRFLOW_CORE_SOURCES_PATH / "airflow" / "partition_mappers" / "rerun_policy.py"
+SDK_FILE = (
+    AIRFLOW_TASK_SDK_SOURCES_PATH
+    / "airflow"
+    / "sdk"
+    / "definitions"
+    / "partition_mappers"
+    / "rerun_policy.py"
+)
+
+BEHAVIOR_METHODS = ["fires_immediately", "drops_event"]
+
+
+def _find_class(tree: ast.Module, name: str, file_path: Path) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise ValueError(f"{file_path}: no class {name!r} found.")
+
+
+def _extract_members(cls: ast.ClassDef) -> dict[str, str]:
+    members: dict[str, str] = {}
+    for stmt in cls.body:
+        if (
+            isinstance(stmt, ast.Assign)
+            and len(stmt.targets) == 1
+            and isinstance(stmt.targets[0], ast.Name)
+            and isinstance(stmt.value, ast.Constant)
+            and isinstance(stmt.value.value, str)
+        ):
+            members[stmt.targets[0].id] = stmt.value.value
+    return members
+
+
+def _extract_method_body(cls: ast.ClassDef, name: str, file_path: Path) -> str:
+    for stmt in cls.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name == name:
+            # Drop the docstring so wording differences do not trip the check.
+            body = stmt.body[1:] if ast.get_docstring(stmt) is not None else stmt.body
+            return "\n".join(ast.unparse(node) for node in body)
+    raise ValueError(f"{file_path}: RerunPolicy has no method {name!r}.")
+
+
+def _build_surface(file_path: Path) -> dict[str, object]:
+    cls = _find_class(
+        ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path)), "RerunPolicy", file_path
+    )
+    return {
+        "members": _extract_members(cls),
+        "methods": {name: _extract_method_body(cls, name, file_path) for name in BEHAVIOR_METHODS},
+    }
+
+
+def main() -> int:
+    try:
+        core_surface = _build_surface(CORE_FILE)
+        sdk_surface = _build_surface(SDK_FILE)
+    except ValueError as exc:
+        console.print(f"[red]Could not read the RerunPolicy definitions:[/red] {exc}")
+        return 1
+
+    if core_surface == sdk_surface:
+        return 0
+
+    console.print("[red]RerunPolicy is out of sync between core and the Task SDK.[/red]\n")
+    for key in sorted(set(core_surface) | set(sdk_surface)):
+        core_val = core_surface.get(key, "<missing>")
+        sdk_val = sdk_surface.get(key, "<missing>")
+        if core_val != sdk_val:
+            console.print(f"[red]-> {key}: core={core_val!r} sdk={sdk_val!r}[/red]")
+    console.print(f"\nMake both copies match:\n  core: {CORE_FILE}\n  sdk:  {SDK_FILE}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/task-sdk/docs/api.rst
+++ b/task-sdk/docs/api.rst
@@ -246,6 +246,8 @@ Partition Mapper
 
 .. autoapiclass:: airflow.sdk.RollupMapper
 
+.. autoapiclass:: airflow.sdk.RerunPolicy
+
 .. autoapiclass:: airflow.sdk.WaitForAll
 
 .. autoapiclass:: airflow.sdk.MinimumCount

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -74,6 +74,7 @@ __all__ = [
     "PokeReturnValue",
     "ProductMapper",
     "QuarterWindow",
+    "RerunPolicy",
     "ResumableJobMixin",
     "RetryAction",
     "RetryDecision",
@@ -172,6 +173,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.partition_mappers.fixed_key import FixedKeyMapper
     from airflow.sdk.definitions.partition_mappers.identity import IdentityMapper
     from airflow.sdk.definitions.partition_mappers.product import ProductMapper
+    from airflow.sdk.definitions.partition_mappers.rerun_policy import RerunPolicy
     from airflow.sdk.definitions.partition_mappers.temporal import (
         FanOutMapper,
         StartOfDayMapper,
@@ -288,6 +290,7 @@ __lazy_imports: dict[str, str] = {
     "RetryDecision": ".definitions.retry_policy",
     "RetryPolicy": ".definitions.retry_policy",
     "RetryRule": ".definitions.retry_policy",
+    "RerunPolicy": ".definitions.partition_mappers.rerun_policy",
     "RollupMapper": ".definitions.partition_mappers.base",
     "SecretCache": ".execution_time.cache",
     "SegmentWindow": ".definitions.partition_mappers.window",

--- a/task-sdk/src/airflow/sdk/__init__.pyi
+++ b/task-sdk/src/airflow/sdk/__init__.pyi
@@ -75,6 +75,7 @@ from airflow.sdk.definitions.partition_mappers.chain import ChainMapper
 from airflow.sdk.definitions.partition_mappers.fixed_key import FixedKeyMapper
 from airflow.sdk.definitions.partition_mappers.identity import IdentityMapper
 from airflow.sdk.definitions.partition_mappers.product import ProductMapper
+from airflow.sdk.definitions.partition_mappers.rerun_policy import RerunPolicy
 from airflow.sdk.definitions.partition_mappers.temporal import (
     FanOutMapper,
     StartOfDayMapper,
@@ -182,6 +183,7 @@ __all__ = [
     "PartitionMapper",
     "ProductMapper",
     "QuarterWindow",
+    "RerunPolicy",
     "RetryAction",
     "RetryDecision",
     "RetryPolicy",

--- a/task-sdk/src/airflow/sdk/definitions/partition_mappers/base.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mappers/base.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import attrs
 
+from airflow.sdk.definitions.partition_mappers.rerun_policy import RerunPolicy
 from airflow.sdk.definitions.partition_mappers.wait_policy import WaitForAll, WaitPolicy
 
 if TYPE_CHECKING:
@@ -45,6 +46,7 @@ class PartitionMapper:
     #: identity ``str`` but the window needs a different type (e.g. ``datetime``).
     #: Temporal mappers override to ``datetime``.
     expected_decoded_type: ClassVar[type] = str
+    rerun_policy = RerunPolicy.HOLD
 
     max_downstream_keys: int | None = attrs.field(
         default=None, kw_only=True, validator=_validate_max_downstream_keys
@@ -67,6 +69,11 @@ class RollupMapper(PartitionMapper):
     ``MinimumCount(n)`` fires once at least ``n`` keys have arrived when
     ``n`` is positive, or once at most ``-n`` keys are still missing when
     ``n`` is negative.
+
+    The ``rerun_policy`` is a :class:`RerunPolicy` that decides what happens when
+    an upstream partition is cleared and re-run after the downstream window has
+    already fired. The default ``RerunPolicy.HOLD`` re-evaluates the window through
+    the wait policy. ``RerunPolicy.REFRESH`` re-fires immediately with the corrected data.
     """
 
     is_rollup: ClassVar[bool] = True
@@ -74,6 +81,7 @@ class RollupMapper(PartitionMapper):
     upstream_mapper: PartitionMapper = attrs.field(kw_only=True)
     window: Window = attrs.field(kw_only=True)
     wait_policy: WaitPolicy = attrs.field(factory=WaitForAll, kw_only=True)
+    rerun_policy: RerunPolicy = attrs.field(default=RerunPolicy.HOLD, kw_only=True, converter=RerunPolicy)
 
     def __attrs_post_init__(self) -> None:
         # Mirrors the core-side ``RollupMapper.__init__`` check so user code

--- a/task-sdk/src/airflow/sdk/definitions/partition_mappers/rerun_policy.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mappers/rerun_policy.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RerunPolicy(str, Enum):
+    """
+    How a rollup reacts when an upstream partition is re-emitted after its downstream window already fired.
+
+    A rollup fires its downstream Dag run once the window is satisfied (e.g. a
+    monthly rollup fires once all of March's daily partitions arrive). If an
+    upstream partition that the fired window already consumed is later cleared
+    and re-run, a fresh asset event arrives for an already-materialized window.
+    This policy decides what the scheduler does with it.
+
+    ``HOLD`` (default): queue a provisional run that re-evaluates the window
+    through the wait policy before firing again.
+
+    ``REFRESH``: re-fire the downstream Dag run so it reprocesses with the
+    corrected upstream data. Neither the wait policy nor the Dag's schedule
+    condition is re-evaluated.
+
+    ``IGNORE``: drop the late upstream event. The downstream Dag run is not
+    re-fired and no provisional run is queued.
+    """
+
+    REFRESH = "refresh"
+    HOLD = "hold"
+    IGNORE = "ignore"
+
+    @property
+    def fires_immediately(self) -> bool:
+        """Whether a provisional run stamped with this policy fires at once, skipping the wait policy."""
+        return self is RerunPolicy.REFRESH
+
+    @property
+    def drops_event(self) -> bool:
+        """Whether a re-arriving event for an already-fired window is dropped without queuing a run."""
+        return self is RerunPolicy.IGNORE

--- a/task-sdk/tests/task_sdk/definitions/test_partition_mappers.py
+++ b/task-sdk/tests/task_sdk/definitions/test_partition_mappers.py
@@ -24,6 +24,7 @@ import pytest
 from airflow.sdk.definitions.partition_mappers.base import PartitionMapper, RollupMapper
 from airflow.sdk.definitions.partition_mappers.fixed_key import FixedKeyMapper
 from airflow.sdk.definitions.partition_mappers.identity import IdentityMapper
+from airflow.sdk.definitions.partition_mappers.rerun_policy import RerunPolicy
 from airflow.sdk.definitions.partition_mappers.temporal import StartOfDayMapper
 from airflow.sdk.definitions.partition_mappers.window import (
     DayWindow,
@@ -65,6 +66,75 @@ class TestSdkRollupMapperInit:
 
         # Should not raise.
         RollupMapper(upstream_mapper=_StringOnlyMapper(), window=_AlphaWindow())
+
+
+class TestSdkRollupMapperRerunPolicy:
+    """``rerun_policy`` defaults to HOLD, coerces strings, and rejects junk."""
+
+    def _make_mapper(self, **kwargs):
+        return RollupMapper(upstream_mapper=StartOfDayMapper(), window=DayWindow(), **kwargs)
+
+    def test_defaults_to_hold(self):
+        assert self._make_mapper().rerun_policy is RerunPolicy.HOLD
+
+    @pytest.mark.parametrize("policy", list(RerunPolicy))
+    def test_accepts_enum_member(self, policy):
+        assert self._make_mapper(rerun_policy=policy).rerun_policy is policy
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("refresh", RerunPolicy.REFRESH),
+            ("hold", RerunPolicy.HOLD),
+            ("ignore", RerunPolicy.IGNORE),
+        ],
+    )
+    def test_coerces_string(self, value, expected):
+        assert self._make_mapper(rerun_policy=value).rerun_policy is expected
+
+    def test_rejects_unknown_value(self):
+        with pytest.raises(ValueError, match="reprocess"):
+            self._make_mapper(rerun_policy="reprocess")
+
+    def test_non_rollup_mapper_reports_hold(self):
+        """A non-rollup mapper carries the neutral HOLD default, which the scheduler reads off any mapper."""
+        assert IdentityMapper().rerun_policy is RerunPolicy.HOLD
+        assert FixedKeyMapper("all").rerun_policy is RerunPolicy.HOLD
+
+    @pytest.mark.parametrize(
+        "make_mapper",
+        [
+            pytest.param(lambda **kw: IdentityMapper(**kw), id="identity"),
+            pytest.param(lambda **kw: StartOfDayMapper(**kw), id="temporal"),
+            pytest.param(lambda **kw: FixedKeyMapper("all", **kw), id="fixed_key"),
+        ],
+    )
+    def test_only_rollup_accepts_rerun_policy_kwarg(self, make_mapper):
+        """``rerun_policy`` is a constructor field only on RollupMapper; other mappers reject it."""
+        assert (
+            RollupMapper(
+                upstream_mapper=StartOfDayMapper(), window=DayWindow(), rerun_policy=RerunPolicy.REFRESH
+            ).rerun_policy
+            is RerunPolicy.REFRESH
+        )
+        with pytest.raises(TypeError, match="rerun_policy"):
+            make_mapper(rerun_policy=RerunPolicy.REFRESH)
+
+
+class TestRerunPolicyMethods:
+    """The behavior lives on the enum so the scheduler/manager ask it directly."""
+
+    @pytest.mark.parametrize(
+        ("policy", "fires", "drops"),
+        [
+            (RerunPolicy.REFRESH, True, False),
+            (RerunPolicy.HOLD, False, False),
+            (RerunPolicy.IGNORE, False, True),
+        ],
+    )
+    def test_behavior(self, policy, fires, drops):
+        assert policy.fires_immediately is fires
+        assert policy.drops_event is drops
 
 
 class TestSdkDirectionValidation:


### PR DESCRIPTION
When an upstream partition that a rollup's downstream window already consumed is cleared and re-run, the framework had no defined behavior. The de-facto outcome silently depended on the rollup's wait policy: WaitForAll left a provisional run stuck waiting for keys that never re-arrive, while MinimumCount re-fired the downstream run on partial data. Neither is something a Dag author can rely on.

Give RollupMapper an explicit rerun_policy so the author chooses what happens. The default preserves the historical behavior, so existing Dags are unchanged; re-firing with the corrected data is opt-in.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
closes: #65923
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code with Opus 4.8

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
