### PR TITLE
Show clear error for invalid sql_alchemy_conn at startup

### DIFF
--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -241,12 +241,33 @@ def load_policy_plugins(pm: pluggy.PluginManager):
 
 
 def _get_async_conn_uri_from_sync(sync_uri):
-    # Mapping of backend to async driver:
+    """
+    Convert a sync SQLAlchemy URI to its async equivalent.
+
+    Args:
+        sync_uri: The synchronous SQLAlchemy connection URI
+
+    Returns:
+        The async URI with appropriate async driver (e.g., aiosqlite, asyncpg, aiomysql),
+        or the original URI if no async driver mapping exists
+
+    Raises:
+        ValueError: If the URI is malformed (missing ':' scheme separator)
+    """
+    # Mapping of backend to async driver.
     AIO_LIBS_MAPPING = {
         "sqlite": "aiosqlite",
         "postgresql": "psycopg_async" if _USE_PSYCOPG3 else "asyncpg",
         "mysql": "aiomysql",
     }
+
+    if not sync_uri or ":" not in sync_uri:
+        raise ValueError(
+            f"Invalid SQLAlchemy connection URI: {sync_uri!r}. "
+            "The URI must be in the format 'scheme://host/path' or similar with a ':' separator. "
+            "Check that AIRFLOW__DATABASE__SQL_ALCHEMY_CONN environment variable or "
+            "sql_alchemy_conn in airflow.cfg contains a valid database URI."
+        )
 
     scheme, rest = sync_uri.split(":", maxsplit=1)
     scheme = scheme.split("+", maxsplit=1)[0]

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -533,3 +533,58 @@ class TestDisposeOrm:
             settings.dispose_orm(do_log=False)
 
         mock_close.assert_not_called()
+
+
+class TestGetAsyncConnUriFromSync:
+    """Tests for _get_async_conn_uri_from_sync function."""
+
+    def test_sqlite_uri_conversion(self):
+        """Test conversion of SQLite sync URI to async with aiosqlite."""
+        result = settings._get_async_conn_uri_from_sync("sqlite:///path/to/db.sqlite")
+        assert result == "sqlite+aiosqlite:///path/to/db.sqlite"
+
+    def test_postgresql_uri_conversion(self):
+        """Test conversion of PostgreSQL sync URI to async with asyncpg."""
+        result = settings._get_async_conn_uri_from_sync("postgresql://user:pass@localhost/dbname")
+        assert result == "postgresql+asyncpg://user:pass@localhost/dbname"
+
+    def test_mysql_uri_conversion(self):
+        """Test conversion of MySQL sync URI to async with aiomysql."""
+        result = settings._get_async_conn_uri_from_sync("mysql://user:pass@localhost/dbname")
+        assert result == "mysql+aiomysql://user:pass@localhost/dbname"
+
+    def test_postgresql_psycopg2_uri_conversion(self):
+        """Test conversion of PostgreSQL with psycopg2 driver to asyncpg."""
+        result = settings._get_async_conn_uri_from_sync("postgresql+psycopg2://user@localhost/db")
+        assert result == "postgresql+asyncpg://user@localhost/db"
+
+    def test_unsupported_scheme_returns_original_uri(self):
+        """Test that unsupported schemes return the original URI unchanged."""
+        uri = "oracle://user:pass@localhost:1521/dbname"
+        result = settings._get_async_conn_uri_from_sync(uri)
+        assert result == uri
+
+    def test_empty_string_raises_value_error(self):
+        """Test that empty string raises ValueError with helpful message."""
+        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI"):
+            settings._get_async_conn_uri_from_sync("")
+
+    def test_none_raises_value_error(self):
+        """Test that None raises ValueError with helpful message."""
+        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI"):
+            settings._get_async_conn_uri_from_sync(None)
+
+    def test_malformed_uri_without_colon_raises_value_error(self):
+        """Test that URI without ':' separator raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI.*':' separator"):
+            settings._get_async_conn_uri_from_sync("notavaliduri")
+
+    def test_error_message_is_helpful(self):
+        """Test that error message contains helpful guidance."""
+        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI") as exc_info:
+            settings._get_async_conn_uri_from_sync("invalid_value")
+
+        error_msg = str(exc_info.value)
+        assert "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN" in error_msg
+        assert "sql_alchemy_conn" in error_msg
+        assert "airflow.cfg" in error_msg

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -538,25 +538,19 @@ class TestDisposeOrm:
 class TestGetAsyncConnUriFromSync:
     """Tests for _get_async_conn_uri_from_sync function."""
 
-    def test_sqlite_uri_conversion(self):
-        """Test conversion of SQLite sync URI to async with aiosqlite."""
-        result = settings._get_async_conn_uri_from_sync("sqlite:///path/to/db.sqlite")
-        assert result == "sqlite+aiosqlite:///path/to/db.sqlite"
-
-    def test_postgresql_uri_conversion(self):
-        """Test conversion of PostgreSQL sync URI to async with asyncpg."""
-        result = settings._get_async_conn_uri_from_sync("postgresql://user:pass@localhost/dbname")
-        assert result == "postgresql+asyncpg://user:pass@localhost/dbname"
-
-    def test_mysql_uri_conversion(self):
-        """Test conversion of MySQL sync URI to async with aiomysql."""
-        result = settings._get_async_conn_uri_from_sync("mysql://user:pass@localhost/dbname")
-        assert result == "mysql+aiomysql://user:pass@localhost/dbname"
-
-    def test_postgresql_psycopg2_uri_conversion(self):
-        """Test conversion of PostgreSQL with psycopg2 driver to asyncpg."""
-        result = settings._get_async_conn_uri_from_sync("postgresql+psycopg2://user@localhost/db")
-        assert result == "postgresql+asyncpg://user@localhost/db"
+    @pytest.mark.parametrize(
+        ("sync_uri", "expected"),
+        [
+            ("sqlite:///path/to/db.sqlite", "sqlite+aiosqlite:///path/to/db.sqlite"),
+            ("postgresql://user:pass@localhost/dbname", "postgresql+asyncpg://user:pass@localhost/dbname"),
+            ("mysql://user:pass@localhost/dbname", "mysql+aiomysql://user:pass@localhost/dbname"),
+            ("postgresql+psycopg2://user@localhost/db", "postgresql+asyncpg://user@localhost/db"),
+        ],
+    )
+    def test_supported_scheme_conversion(self, sync_uri, expected):
+        """Test conversion of supported sync SQLAlchemy URIs to async driver variants."""
+        result = settings._get_async_conn_uri_from_sync(sync_uri)
+        assert result == expected
 
     def test_unsupported_scheme_returns_original_uri(self):
         """Test that unsupported schemes return the original URI unchanged."""
@@ -564,20 +558,18 @@ class TestGetAsyncConnUriFromSync:
         result = settings._get_async_conn_uri_from_sync(uri)
         assert result == uri
 
-    def test_empty_string_raises_value_error(self):
-        """Test that empty string raises ValueError with helpful message."""
-        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI"):
-            settings._get_async_conn_uri_from_sync("")
-
-    def test_none_raises_value_error(self):
-        """Test that None raises ValueError with helpful message."""
-        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI"):
-            settings._get_async_conn_uri_from_sync(None)
-
-    def test_malformed_uri_without_colon_raises_value_error(self):
-        """Test that URI without ':' separator raises ValueError."""
-        with pytest.raises(ValueError, match="Invalid SQLAlchemy connection URI.*':' separator"):
-            settings._get_async_conn_uri_from_sync("notavaliduri")
+    @pytest.mark.parametrize(
+        ("invalid_uri", "error_match"),
+        [
+            ("", "Invalid SQLAlchemy connection URI"),
+            (None, "Invalid SQLAlchemy connection URI"),
+            ("notavaliduri", "Invalid SQLAlchemy connection URI.*':' separator"),
+        ],
+    )
+    def test_invalid_uri_raises_value_error(self, invalid_uri, error_match):
+        """Test that invalid URIs raise ValueError with actionable guidance."""
+        with pytest.raises(ValueError, match=error_match):
+            settings._get_async_conn_uri_from_sync(invalid_uri)
 
     def test_error_message_is_helpful(self):
         """Test that error message contains helpful guidance."""

--- a/airflow-core/tests/unit/core/test_settings.py
+++ b/airflow-core/tests/unit/core/test_settings.py
@@ -542,15 +542,27 @@ class TestGetAsyncConnUriFromSync:
         ("sync_uri", "expected"),
         [
             ("sqlite:///path/to/db.sqlite", "sqlite+aiosqlite:///path/to/db.sqlite"),
-            ("postgresql://user:pass@localhost/dbname", "postgresql+asyncpg://user:pass@localhost/dbname"),
             ("mysql://user:pass@localhost/dbname", "mysql+aiomysql://user:pass@localhost/dbname"),
-            ("postgresql+psycopg2://user@localhost/db", "postgresql+asyncpg://user@localhost/db"),
         ],
     )
     def test_supported_scheme_conversion(self, sync_uri, expected):
         """Test conversion of supported sync SQLAlchemy URIs to async driver variants."""
         result = settings._get_async_conn_uri_from_sync(sync_uri)
         assert result == expected
+
+    @pytest.mark.parametrize(
+        ("sync_uri", "expected_template"),
+        [
+            ("postgresql://user:pass@localhost/dbname", "postgresql+{driver}://user:pass@localhost/dbname"),
+            ("postgresql+psycopg2://user@localhost/db", "postgresql+{driver}://user@localhost/db"),
+        ],
+    )
+    def test_postgresql_scheme_conversion(self, sync_uri, expected_template):
+        """Test conversion of PostgreSQL sync URIs to the configured async driver."""
+        postgres_async_driver = "psycopg_async" if settings._USE_PSYCOPG3 else "asyncpg"
+        assert settings._get_async_conn_uri_from_sync(sync_uri) == expected_template.format(
+            driver=postgres_async_driver
+        )
 
     def test_unsupported_scheme_returns_original_uri(self):
         """Test that unsupported schemes return the original URI unchanged."""


### PR DESCRIPTION
This improves startup diagnostics when database connection configuration is malformed.

Context: this came from investigation in the discussion thread about slow CLI/help startup and the confusing unpacking traceback:
https://github.com/apache/airflow/discussions/68707

`_get_async_conn_uri_from_sync` now validates malformed/empty sync URIs and raises a clear, actionable error message that points users to `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN` / `sql_alchemy_conn` in `airflow.cfg`, instead of failing with a cryptic unpacking error.

Changes in this PR:
1. Add validation for malformed sync SQLAlchemy URI input in startup path.
2. Raise a clearer `ValueError` with direct guidance to relevant config knobs.
3. Add focused unit tests for:
- valid URI conversions to async driver schemes
- unsupported schemes passthrough
- malformed/empty input behavior and error messaging

Discussion reference:
- https://github.com/apache/airflow/discussions/68707

 