### PR TITLE
Add per-component image overrides to Helm chart

### DIFF
--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -318,6 +318,39 @@ See :ref:`Extending Airflow Image <quick-start:extending-airflow-image>` and/or
 `Building the image <https://airflow.apache.org/docs/docker-stack/build.html>`_ for more
 details on how you can extend, customize and test the modifications of Airflow image.
 
+Per-component image overrides
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can set a different image for the API server, scheduler, DAG processor, and triggerer
+main containers under ``images.airflow``. This is useful when you build component-specific
+images (for example slimmer images per role) while keeping a shared default for other
+Airflow containers.
+
+Omitted fields in a component block inherit from ``images.airflow`` and then from
+``defaultAirflowRepository``, ``defaultAirflowTag``, and ``defaultAirflowDigest``.
+When both tag and digest are set for a component, digest takes precedence.
+
+.. code-block:: yaml
+   :caption: values.yaml
+
+   images:
+     airflow:
+       repository: my-registry/airflow
+       tag: "3.1.0"
+       scheduler:
+         repository: my-registry/airflow-scheduler
+         tag: "3.1.0-slim"
+       apiServer:
+         tag: "3.1.0-api"
+
+.. code-block:: bash
+
+   helm upgrade --install my-release apache-airflow/airflow \
+     --set images.airflow.scheduler.repository=my-registry/airflow-scheduler \
+     --set images.airflow.scheduler.tag=3.1.0-slim
+
+See :doc:`parameters-ref` for the full list of ``images.airflow`` parameters.
+
 Managing Dag Files
 ------------------
 

--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -321,14 +321,17 @@ details on how you can extend, customize and test the modifications of Airflow i
 Per-component image overrides
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can set a different image for the API server, scheduler, DAG processor, and triggerer
-main containers under ``images.airflow``. This is useful when you build component-specific
-images (for example slimmer images per role) while keeping a shared default for other
-Airflow containers.
+You can set a different Airflow image for the API server, scheduler, DAG processor, and
+triggerer under each component's ``image`` block. This is useful when you build
+component-specific images (for example slimmer images per role) while keeping a shared default
+in ``images.airflow`` for jobs, workers, and other containers.
 
-Omitted fields in a component block inherit from ``images.airflow`` and then from
+Omitted fields in a component ``image`` block inherit from ``images.airflow`` and then from
 ``defaultAirflowRepository``, ``defaultAirflowTag``, and ``defaultAirflowDigest``.
-When both tag and digest are set for a component, digest takes precedence.
+When both tag and digest are set, digest takes precedence.
+
+Set ``applyToSidecars: true`` on a component to use the same override for log-groomer and
+wait-for-migrations containers in that pod. The default is ``false``.
 
 .. code-block:: yaml
    :caption: values.yaml
@@ -337,19 +340,21 @@ When both tag and digest are set for a component, digest takes precedence.
      airflow:
        repository: my-registry/airflow
        tag: "3.1.0"
-       scheduler:
-         repository: my-registry/airflow-scheduler
-         tag: "3.1.0-slim"
-       apiServer:
-         tag: "3.1.0-api"
+   scheduler:
+     image:
+       repository: my-registry/airflow-scheduler
+       tag: "3.1.0-slim"
+   apiServer:
+     image:
+       tag: "3.1.0-api"
 
 .. code-block:: bash
 
    helm upgrade --install my-release apache-airflow/airflow \
-     --set images.airflow.scheduler.repository=my-registry/airflow-scheduler \
-     --set images.airflow.scheduler.tag=3.1.0-slim
+     --set scheduler.image.repository=my-registry/airflow-scheduler \
+     --set scheduler.image.tag=3.1.0-slim
 
-See :doc:`parameters-ref` for the full list of ``images.airflow`` parameters.
+See :doc:`parameters-ref` for the full list of per-component ``image`` parameters.
 
 Managing Dag Files
 ------------------

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1169,23 +1169,49 @@ Usage:
 {{- end -}}
 
 {{/*
-Configure the image for the different components.
+Per-component image helpers. Set ``component`` to the values key (apiServer, scheduler,
+dagProcessor, triggerer). Pass ``isSidecar`` true for log-groomer and wait-for-migrations containers.
 
 Usage:
-  {{ include "airflow_component_image" (merge (dict "component" "apiServer") .) }}
+  {{ include "airflow_component_image" (merge (dict "component" $airflowComponent) .) }}
+  {{ include "airflow_component_image" (merge (dict "component" $airflowComponent "isSidecar" true) .) }}
 */}}
 {{- define "airflow_component_image" -}}
-  {{- $override := index .Values.images.airflow .component | default dict -}}
-  {{- $repository := $override.repository | default .Values.images.airflow.repository | default .Values.defaultAirflowRepository -}}
-  {{- $defaultTag := .Values.images.airflow.tag | default .Values.defaultAirflowTag -}}
-  {{- $defaultDigest := .Values.images.airflow.digest | default .Values.defaultAirflowDigest -}}
-  {{- if $override.digest }}
-    {{- printf "%s@%s" $repository $override.digest -}}
-  {{- else if $override.tag }}
-    {{- printf "%s:%s" $repository $override.tag -}}
-  {{- else if $defaultDigest }}
-    {{- printf "%s@%s" $repository $defaultDigest -}}
-  {{- else }}
-    {{- printf "%s:%s" $repository $defaultTag -}}
-  {{- end }}
-{{- end }}
+  {{- $componentImage := index (index .Values .component) "image" | default dict -}}
+  {{- $applyToSidecars := $componentImage.applyToSidecars | default false -}}
+  {{- if and .isSidecar (not $applyToSidecars) -}}
+    {{- include "airflow_image" . -}}
+  {{- else -}}
+    {{- $override := $componentImage -}}
+    {{- $repository := $override.repository | default .Values.images.airflow.repository | default .Values.defaultAirflowRepository -}}
+    {{- $defaultTag := .Values.images.airflow.tag | default .Values.defaultAirflowTag -}}
+    {{- $defaultDigest := .Values.images.airflow.digest | default .Values.defaultAirflowDigest -}}
+    {{- if $override.digest -}}
+      {{- printf "%s@%s" $repository $override.digest -}}
+    {{- else if $override.tag -}}
+      {{- printf "%s:%s" $repository $override.tag -}}
+    {{- else if $defaultDigest -}}
+      {{- printf "%s@%s" $repository $defaultDigest -}}
+    {{- else -}}
+      {{- printf "%s:%s" $repository $defaultTag -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "airflow_component_image_pull_policy" -}}
+  {{- $componentImage := index (index .Values .component) "image" | default dict -}}
+  {{- $applyToSidecars := $componentImage.applyToSidecars | default false -}}
+  {{- if and .isSidecar (not $applyToSidecars) -}}
+    {{- .Values.images.airflow.pullPolicy -}}
+  {{- else -}}
+    {{- $componentImage.pullPolicy | default .Values.images.airflow.pullPolicy -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "airflow_component_image_for_migrations" -}}
+  {{- if .Values.images.useDefaultImageForMigration -}}
+    {{- include "default_airflow_image" . -}}
+  {{- else -}}
+    {{- include "airflow_component_image" . -}}
+  {{- end -}}
+{{- end -}}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -1167,3 +1167,25 @@ Usage:
           path: namespace
   {{- end }}
 {{- end -}}
+
+{{/*
+Configure the image for the different components.
+
+Usage:
+  {{ include "airflow_component_image" (merge (dict "component" "apiServer") .) }}
+*/}}
+{{- define "airflow_component_image" -}}
+  {{- $override := index .Values.images.airflow .component | default dict -}}
+  {{- $repository := $override.repository | default .Values.images.airflow.repository | default .Values.defaultAirflowRepository -}}
+  {{- $defaultTag := .Values.images.airflow.tag | default .Values.defaultAirflowTag -}}
+  {{- $defaultDigest := .Values.images.airflow.digest | default .Values.defaultAirflowDigest -}}
+  {{- if $override.digest }}
+    {{- printf "%s@%s" $repository $override.digest -}}
+  {{- else if $override.tag }}
+    {{- printf "%s:%s" $repository $override.tag -}}
+  {{- else if $defaultDigest }}
+    {{- printf "%s@%s" $repository $defaultDigest -}}
+  {{- else }}
+    {{- printf "%s:%s" $repository $defaultTag -}}
+  {{- end }}
+{{- end }}

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -136,8 +136,8 @@ spec:
         {{- if .Values.apiServer.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
           resources: {{- toYaml .Values.apiServer.resources | nindent 12 }}
-          image: {{ template "airflow_image_for_migrations" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image_for_migrations" (merge (dict "component" "apiServer" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "apiServer" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextWaitForMigrations | nindent 12 }}
           volumeMounts:
             {{- include "airflow_config_mount" . | nindent 12 }}
@@ -162,7 +162,7 @@ spec:
       containers:
         - name: api-server
           image: {{ include "airflow_component_image" (merge (dict "component" "apiServer") .) }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "apiServer") .) }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -161,7 +161,7 @@ spec:
         {{- end }}
       containers:
         - name: api-server
-          image: {{ template "airflow_image" . }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "apiServer") .) }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -145,7 +145,7 @@ spec:
         {{- end }}
       containers:
         - name: dag-processor
-          image: {{ template "airflow_image" . }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "dagProcessor") .) }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -117,8 +117,8 @@ spec:
         {{- if .Values.dagProcessor.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
           resources: {{- toYaml .Values.dagProcessor.resources | nindent 12 }}
-          image: {{ template "airflow_image_for_migrations" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image_for_migrations" (merge (dict "component" "dagProcessor" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "dagProcessor" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextWaitForMigrations | nindent 12 }}
           volumeMounts:
             {{- if .Values.volumeMounts }}
@@ -146,7 +146,7 @@ spec:
       containers:
         - name: dag-processor
           image: {{ include "airflow_component_image" (merge (dict "component" "dagProcessor") .) }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "dagProcessor") .) }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks  }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
@@ -197,8 +197,8 @@ spec:
         {{- if .Values.dagProcessor.logGroomerSidecar.enabled }}
         - name: dag-processor-log-groomer
           resources: {{- toYaml .Values.dagProcessor.logGroomerSidecar.resources | nindent 12 }}
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "dagProcessor" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "dagProcessor" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextLogGroomerSidecar | nindent 12 }}
           {{- if .Values.dagProcessor.logGroomerSidecar.command }}
           command: {{ tpl (toYaml .Values.dagProcessor.logGroomerSidecar.command) . | nindent 12 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -177,7 +177,7 @@ spec:
         {{- end }}
       containers:
         - name: scheduler
-          image: {{ template "airflow_image" . }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "scheduler") .) }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -144,8 +144,8 @@ spec:
         {{- if .Values.scheduler.waitForMigrations.enabled }}
         - name: wait-for-airflow-migrations
           resources: {{- toYaml .Values.scheduler.resources | nindent 12 }}
-          image: {{ template "airflow_image_for_migrations" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image_for_migrations" (merge (dict "component" "scheduler" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "scheduler" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextWaitForMigrations | nindent 12 }}
           volumeMounts:
             - name: logs
@@ -178,7 +178,7 @@ spec:
       containers:
         - name: scheduler
           image: {{ include "airflow_component_image" (merge (dict "component" "scheduler") .) }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "scheduler") .) }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
@@ -252,8 +252,8 @@ spec:
         {{- if .Values.scheduler.logGroomerSidecar.enabled }}
         - name: scheduler-log-groomer
           resources: {{- toYaml .Values.scheduler.logGroomerSidecar.resources | nindent 12 }}
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "scheduler" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "scheduler" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextLogGroomerSidecar | nindent 12 }}
           {{- if $containerLifecycleHooksLogGroomerSidecar  }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) . | nindent 12 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -135,8 +135,8 @@ spec:
         - name: wait-for-airflow-migrations
           resources:
             {{- toYaml .Values.triggerer.resources | nindent 12 }}
-          image: {{ template "airflow_image_for_migrations" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image_for_migrations" (merge (dict "component" "triggerer" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "triggerer" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextWaitForMigrations | nindent 12 }}
           volumeMounts:
             - name: logs
@@ -169,7 +169,7 @@ spec:
       containers:
         - name: triggerer
           image: {{ include "airflow_component_image" (merge (dict "component" "triggerer") .) }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "triggerer") .) }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
@@ -223,8 +223,8 @@ spec:
         {{- if .Values.triggerer.logGroomerSidecar.enabled }}
         - name: triggerer-log-groomer
           resources: {{- toYaml .Values.triggerer.logGroomerSidecar.resources | nindent 12 }}
-          image: {{ template "airflow_image" . }}
-          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "triggerer" "isSidecar" true) .) }}
+          imagePullPolicy: {{ include "airflow_component_image_pull_policy" (merge (dict "component" "triggerer" "isSidecar" true) .) }}
           securityContext: {{ $containerSecurityContextLogGroomer | nindent 12 }}
           {{- if $containerLifecycleHooksLogGroomerSidecar }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) . | nindent 12 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -168,7 +168,7 @@ spec:
         {{- end }}
       containers:
         - name: triggerer
-          image: {{ template "airflow_image" . }}
+          image: {{ include "airflow_component_image" (merge (dict "component" "triggerer") .) }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           securityContext: {{ $containerSecurityContext | nindent 12 }}
           {{- if $containerLifecycleHooks }}

--- a/chart/tests/helm_tests/airflow_aux/test_airflow_common.py
+++ b/chart/tests/helm_tests/airflow_aux/test_airflow_common.py
@@ -319,6 +319,39 @@ class TestAirflowCommon:
         for doc in docs:
             assert expected_image == jmespath.search("spec.template.spec.initContainers[0].image", doc)
 
+    @pytest.mark.parametrize(
+        ("component", "component_key", "expected_image", "digest"),
+        [
+            ("api-server", "apiServer", "apache/airflow-api-server@api-server-digest", "api-server-digest"),
+            ("scheduler", "scheduler", "apache/airflow-scheduler:scheduler-tag", None),
+            ("dag-processor", "dagProcessor", "apache/airflow-dag-processor@test-digest", "test-digest"),
+            ("triggerer", "triggerer", "apache/airflow-triggerer:triggerer-tag", None),
+        ],
+    )
+    def test_should_use_correct_component_image(self, component, component_key, expected_image, digest):
+        docs = render_chart(
+            values={
+                "defaultAirflowRepository": "apache/airflow",
+                "defaultAirflowTag": "default-tag",
+                "defaultAirflowDigest": "default-digest",
+                "images": {
+                    "airflow": {
+                        component_key: {
+                            "repository": f"apache/airflow-{component}",
+                            "tag": f"{component}-tag",
+                            "digest": digest,
+                        },
+                    },
+                },
+            },
+            show_only=[
+                f"templates/{component}/{component}-deployment.yaml",
+            ],
+        )
+
+        for doc in docs:
+            assert expected_image == jmespath.search("spec.template.spec.containers[0].image", doc)
+
     def test_should_set_correct_helm_hooks_weight(self):
         docs = render_chart(
             show_only=["templates/secrets/fernetkey-secret.yaml"],

--- a/chart/tests/helm_tests/airflow_aux/test_airflow_common.py
+++ b/chart/tests/helm_tests/airflow_aux/test_airflow_common.py
@@ -329,19 +329,19 @@ class TestAirflowCommon:
         ],
     )
     def test_should_use_correct_component_image(self, component, component_key, expected_image, digest):
+        image_values = {
+            "repository": f"apache/airflow-{component}",
+            "tag": f"{component}-tag",
+        }
+        if digest:
+            image_values["digest"] = digest
         docs = render_chart(
             values={
                 "defaultAirflowRepository": "apache/airflow",
                 "defaultAirflowTag": "default-tag",
                 "defaultAirflowDigest": "default-digest",
-                "images": {
-                    "airflow": {
-                        component_key: {
-                            "repository": f"apache/airflow-{component}",
-                            "tag": f"{component}-tag",
-                            "digest": digest,
-                        },
-                    },
+                component_key: {
+                    "image": image_values,
                 },
             },
             show_only=[
@@ -351,6 +351,171 @@ class TestAirflowCommon:
 
         for doc in docs:
             assert expected_image == jmespath.search("spec.template.spec.containers[0].image", doc)
+
+    @pytest.mark.parametrize(
+        ("component", "component_key", "image_jmespath"),
+        [
+            ("api-server", "apiServer", "initContainers[?name=='wait-for-airflow-migrations'] | [0].image"),
+            ("scheduler", "scheduler", "containers[?name=='scheduler-log-groomer'] | [0].image"),
+            ("scheduler", "scheduler", "initContainers[?name=='wait-for-airflow-migrations'] | [0].image"),
+            ("dag-processor", "dagProcessor", "containers[?name=='dag-processor-log-groomer'] | [0].image"),
+            (
+                "dag-processor",
+                "dagProcessor",
+                "initContainers[?name=='wait-for-airflow-migrations'] | [0].image",
+            ),
+            ("triggerer", "triggerer", "initContainers[?name=='wait-for-airflow-migrations'] | [0].image"),
+            ("triggerer", "triggerer", "containers[?name=='triggerer-log-groomer'] | [0].image"),
+        ],
+    )
+    def test_component_image_does_not_apply_to_sidecars_by_default(
+        self, component, component_key, image_jmespath
+    ):
+        docs = render_chart(
+            values={
+                "defaultAirflowRepository": "apache/airflow",
+                "defaultAirflowTag": "global-tag",
+                component_key: {
+                    "image": {
+                        "repository": "custom/airflow",
+                        "tag": "component-tag",
+                    },
+                },
+            },
+            show_only=[f"templates/{component}/{component}-deployment.yaml"],
+        )
+
+        sidecar_image = jmespath.search(f"spec.template.spec.{image_jmespath}", docs[0])
+        assert sidecar_image == "apache/airflow:global-tag"
+
+    def test_scheduler_image_applies_to_sidecars_when_configured(self):
+        docs = render_chart(
+            values={
+                "defaultAirflowRepository": "apache/airflow",
+                "defaultAirflowTag": "global-tag",
+                "scheduler": {
+                    "image": {
+                        "repository": "custom/airflow",
+                        "tag": "scheduler-tag",
+                        "applyToSidecars": True,
+                    },
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        log_groomer = jmespath.search(
+            "spec.template.spec.containers[?name=='scheduler-log-groomer'] | [0].image",
+            docs[0],
+        )
+        assert log_groomer == "custom/airflow:scheduler-tag"
+
+        migrations_image = jmespath.search(
+            "spec.template.spec.initContainers[?name=='wait-for-airflow-migrations'] | [0].image",
+            docs[0],
+        )
+        assert migrations_image == "custom/airflow:scheduler-tag"
+
+    @pytest.mark.parametrize(
+        ("component", "component_key", "values", "expected_image"),
+        [
+            (
+                "scheduler",
+                "scheduler",
+                {
+                    "images": {"airflow": {"repository": "apache/airflow", "digest": "global-digest"}},
+                    "scheduler": {"image": {"tag": "scheduler-tag"}},
+                },
+                "apache/airflow:scheduler-tag",
+            ),
+            (
+                "api-server",
+                "apiServer",
+                {
+                    "images": {
+                        "airflow": {"repository": "my-registry/airflow", "tag": "global-tag"},
+                    },
+                    "apiServer": {"image": {"tag": "api-only-tag"}},
+                },
+                "my-registry/airflow:api-only-tag",
+            ),
+        ],
+    )
+    def test_component_main_image_inheritance(self, component, component_key, values, expected_image):
+        docs = render_chart(
+            values=values,
+            show_only=[f"templates/{component}/{component}-deployment.yaml"],
+        )
+
+        main_image = jmespath.search(
+            f"spec.template.spec.containers[?name=='{component}'] | [0].image",
+            docs[0],
+        )
+        assert main_image == expected_image
+
+    @pytest.mark.parametrize(
+        "apply_to_sidecars",
+        [False, True],
+        ids=["apply_to_sidecars_false", "apply_to_sidecars_true"],
+    )
+    def test_component_pull_policy_apply_to_sidecars(self, apply_to_sidecars):
+        scheduler_image = {
+            "repository": "custom/airflow",
+            "tag": "scheduler-tag",
+            "pullPolicy": "Always",
+        }
+        if apply_to_sidecars:
+            scheduler_image["applyToSidecars"] = True
+
+        docs = render_chart(
+            values={
+                "images": {"airflow": {"pullPolicy": "IfNotPresent"}},
+                "scheduler": {"image": scheduler_image},
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        main_pull_policy = jmespath.search(
+            "spec.template.spec.containers[?name=='scheduler'] | [0].imagePullPolicy",
+            docs[0],
+        )
+        assert main_pull_policy == "Always"
+
+        sidecar_pull_policy = jmespath.search(
+            "spec.template.spec.containers[?name=='scheduler-log-groomer'] | [0].imagePullPolicy",
+            docs[0],
+        )
+        expected_sidecar_policy = "Always" if apply_to_sidecars else "IfNotPresent"
+        assert sidecar_pull_policy == expected_sidecar_policy
+
+    def test_use_default_image_for_migration_ignores_component_override(self):
+        docs = render_chart(
+            values={
+                "defaultAirflowRepository": "apache/airflow",
+                "defaultAirflowTag": "default-tag",
+                "images": {"useDefaultImageForMigration": True},
+                "scheduler": {
+                    "image": {
+                        "repository": "custom/airflow",
+                        "tag": "scheduler-tag",
+                        "applyToSidecars": True,
+                    },
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        migrations_image = jmespath.search(
+            "spec.template.spec.initContainers[?name=='wait-for-airflow-migrations'] | [0].image",
+            docs[0],
+        )
+        assert migrations_image == "apache/airflow:default-tag"
+
+        scheduler_image = jmespath.search(
+            "spec.template.spec.containers[?name=='scheduler'] | [0].image",
+            docs[0],
+        )
+        assert scheduler_image == "custom/airflow:scheduler-tag"
 
     def test_should_set_correct_helm_hooks_weight(self):
         docs = render_chart(

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -865,133 +865,6 @@
                                 "IfNotPresent"
                             ],
                             "default": "IfNotPresent"
-                        },
-                        "apiServer": {
-                            "description": "Optional image override for the API server deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "repository": {
-                                    "description": "The image repository for the API server main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "tag": {
-                                    "description": "The image tag for the API server main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "digest": {
-                                    "description": "The image digest for the API server main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                }
-                            }
-                        },
-                        "scheduler": {
-                            "description": "Optional image override for the scheduler deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "repository": {
-                                    "description": "The image repository for the scheduler main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null,
-                                    "examples": [
-                                        "my-registry/airflow-scheduler"
-                                    ]
-                                },
-                                "tag": {
-                                    "description": "The image tag for the scheduler main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "digest": {
-                                    "description": "The image digest for the scheduler main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                }
-                            }
-                        },
-                        "triggerer": {
-                            "description": "Optional image override for the triggerer deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "repository": {
-                                    "description": "The image repository for the triggerer main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "tag": {
-                                    "description": "The image tag for the triggerer main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "digest": {
-                                    "description": "The image digest for the triggerer main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                }
-                            }
-                        },
-                        "dagProcessor": {
-                            "description": "Optional image override for the DAG processor deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "repository": {
-                                    "description": "The image repository for the DAG processor main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "tag": {
-                                    "description": "The image tag for the DAG processor main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                },
-                                "digest": {
-                                    "description": "The image digest for the DAG processor main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "default": null
-                                }
-                            }
                         }
                     }
                 },
@@ -3436,6 +3309,10 @@
                     "type": "boolean",
                     "default": true
                 },
+                "image": {
+                    "description": "Optional image override for the scheduler. Omitted fields inherit from ``images.airflow`` and ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``. Set ``applyToSidecars`` to propagate the override to log-groomer and wait-for-migrations containers in the same pod.",
+                    "$ref": "#/definitions/airflow.componentImage"
+                },
                 "hostAliases": {
                     "description": "HostAliases for the scheduler pod.",
                     "items": {
@@ -4021,6 +3898,10 @@
                     "description": "Enable triggerer",
                     "type": "boolean",
                     "default": true
+                },
+                "image": {
+                    "description": "Optional image override for the triggerer. Omitted fields inherit from ``images.airflow`` and ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``. Set ``applyToSidecars`` to propagate the override to log-groomer and wait-for-migrations containers in the same pod.",
+                    "$ref": "#/definitions/airflow.componentImage"
                 },
                 "hostAliases": {
                     "description": "HostAliases for the triggerer pod.",
@@ -4648,6 +4529,10 @@
                     "description": "Enable standalone dag processor.",
                     "type": "boolean",
                     "default": true
+                },
+                "image": {
+                    "description": "Optional image override for the DAG processor. Omitted fields inherit from ``images.airflow`` and ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``. Set ``applyToSidecars`` to propagate the override to log-groomer and wait-for-migrations containers in the same pod.",
+                    "$ref": "#/definitions/airflow.componentImage"
                 },
                 "dagBundleConfigList": {
                     "description": "Define Dag bundles in a structured YAML format. This will be automatically converted to JSON string format for config.dag_processor.dag_bundle_config_list.",
@@ -5860,6 +5745,10 @@
                     "description": "Enable Airflow API server deployment.",
                     "type": "boolean",
                     "default": true
+                },
+                "image": {
+                    "description": "Optional image override for the API server. Omitted fields inherit from ``images.airflow`` and ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``. Set ``applyToSidecars`` to propagate the override to wait-for-migrations in the same pod.",
+                    "$ref": "#/definitions/airflow.componentImage"
                 },
                 "configMapAnnotations": {
                     "description": "Extra annotations to apply to the API server configmap.",
@@ -10240,6 +10129,56 @@
         }
     },
     "definitions": {
+        "airflow.componentImage": {
+            "description": "Per-component Airflow image override.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "repository": {
+                    "description": "Image repository. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
+                "tag": {
+                    "description": "Image tag. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
+                "digest": {
+                    "description": "Image digest. If set, overrides tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
+                "pullPolicy": {
+                    "description": "Image pull policy. If omitted, inherits from ``images.airflow.pullPolicy``.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "enum": [
+                        "Always",
+                        "Never",
+                        "IfNotPresent",
+                        null
+                    ],
+                    "default": null
+                },
+                "applyToSidecars": {
+                    "description": "When true, log-groomer and wait-for-migrations containers in the same pod use this image override.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
         "io.k8s.api.apps.v1.DeploymentStrategy": {
             "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
             "properties": {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -865,6 +865,133 @@
                                 "IfNotPresent"
                             ],
                             "default": "IfNotPresent"
+                        },
+                        "apiServer": {
+                            "description": "Optional image override for the API server deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "repository": {
+                                    "description": "The image repository for the API server main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "tag": {
+                                    "description": "The image tag for the API server main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "digest": {
+                                    "description": "The image digest for the API server main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                }
+                            }
+                        },
+                        "scheduler": {
+                            "description": "Optional image override for the scheduler deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "repository": {
+                                    "description": "The image repository for the scheduler main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null,
+                                    "examples": [
+                                        "my-registry/airflow-scheduler"
+                                    ]
+                                },
+                                "tag": {
+                                    "description": "The image tag for the scheduler main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "digest": {
+                                    "description": "The image digest for the scheduler main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                }
+                            }
+                        },
+                        "triggerer": {
+                            "description": "Optional image override for the triggerer deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "repository": {
+                                    "description": "The image repository for the triggerer main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "tag": {
+                                    "description": "The image tag for the triggerer main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "digest": {
+                                    "description": "The image digest for the triggerer main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                }
+                            }
+                        },
+                        "dagProcessor": {
+                            "description": "Optional image override for the DAG processor deployment main container. Omitted fields inherit from ``images.airflow`` and then ``defaultAirflowRepository`` / ``defaultAirflowTag`` / ``defaultAirflowDigest``.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "repository": {
+                                    "description": "The image repository for the DAG processor main container. If omitted, inherits from ``images.airflow.repository`` or ``defaultAirflowRepository``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "tag": {
+                                    "description": "The image tag for the DAG processor main container. If omitted, inherits from ``images.airflow.tag`` or ``defaultAirflowTag``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "digest": {
+                                    "description": "The image digest for the DAG processor main container. If set, it overrides the tag. If omitted, inherits from ``images.airflow.digest`` or ``defaultAirflowDigest``.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                }
+                            }
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,12 +75,6 @@ images:
     # Specifying digest takes precedence over tag.
     digest: ~
     pullPolicy: IfNotPresent
-    # Optional per-component image (repository, tag, digest). Omitted fields inherit from
-    # this images.airflow block and defaultAirflowRepository / defaultAirflowTag / defaultAirflowDigest.
-    apiServer: {}
-    scheduler: {}
-    triggerer: {}
-    dagProcessor: {}
   # To avoid images with user code, you can turn this to 'true' and
   # all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' jobs/containers
   # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
@@ -1220,6 +1214,18 @@ workers:
 # Airflow scheduler settings
 scheduler:
   enabled: true
+
+  # Override the Airflow image for the scheduler main container.
+  # Omitted fields inherit from images.airflow
+  # and defaultAirflowRepository/defaultAirflowTag/defaultAirflowDigest.
+  # When applyToSidecars is true, sidecars use the same override.
+  image:
+    repository: ~
+    tag: ~
+    digest: ~
+    pullPolicy: ~
+    applyToSidecars: false
+
   #  hostAliases for the scheduler pod
   hostAliases: []
   #  - ip: "127.0.0.1"
@@ -1655,6 +1661,17 @@ migrateDatabaseJob:
 apiServer:
   enabled: true
 
+  # Override the Airflow image for the API server main container.
+  # Omitted fields inherit from images.airflow
+  # and defaultAirflowRepository/defaultAirflowTag/defaultAirflowDigest.
+  # When applyToSidecars is true, sidecars use the same override.
+  image:
+    repository: ~
+    tag: ~
+    digest: ~
+    pullPolicy: ~
+    applyToSidecars: false
+
   # Number of Airflow API servers in the Deployment.
   # Omitted from the Deployment, when HPA is enabled.
   replicas: 1
@@ -1865,6 +1882,17 @@ apiServer:
 # Airflow Triggerer Config
 triggerer:
   enabled: true
+
+  # Override the Airflow image for the triggerer main container.
+  # Omitted fields inherit from images.airflow
+  # and defaultAirflowRepository/defaultAirflowTag/defaultAirflowDigest.
+  # When applyToSidecars is true, sidecars use the same override.
+  image:
+    repository: ~
+    tag: ~
+    digest: ~
+    pullPolicy: ~
+    applyToSidecars: false
 
   # Number of Airflow triggerers in the Deployment
   replicas: 1
@@ -2118,6 +2146,17 @@ triggerer:
 # Airflow Dag Processor Config
 dagProcessor:
   enabled: true
+
+  # Override the Airflow image for the DAG processor main container.
+  # Omitted fields inherit from images.airflow
+  # and defaultAirflowRepository/defaultAirflowTag/defaultAirflowDigest.
+  # When applyToSidecars is true, sidecars use the same override.
+  image:
+    repository: ~
+    tag: ~
+    digest: ~
+    pullPolicy: ~
+    applyToSidecars: false
 
   # Dag Bundle Configuration
   # Define Dag bundles in a structured YAML format. This will be automatically

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -75,6 +75,12 @@ images:
     # Specifying digest takes precedence over tag.
     digest: ~
     pullPolicy: IfNotPresent
+    # Optional per-component image (repository, tag, digest). Omitted fields inherit from
+    # this images.airflow block and defaultAirflowRepository / defaultAirflowTag / defaultAirflowDigest.
+    apiServer: {}
+    scheduler: {}
+    triggerer: {}
+    dagProcessor: {}
   # To avoid images with user code, you can turn this to 'true' and
   # all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' jobs/containers
   # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values


### PR DESCRIPTION
Add optional per-component Airflow image overrides in the Helm chart.

A different repository, tag, digest, and pullPolicy can be set for each component via that component’s image block:

- API server (`apiServer.image`)
- Scheduler (`scheduler.image`)
- DAG processor (`dagProcessor.image`)
- Triggerer (`triggerer.image`)

Omitted fields inherit from the global `images.airflow` settings, then from `defaultAirflowRepository`, `defaultAirflowTag`, and `defaultAirflowDigest`. When both tag and digest are set, digest takes precedence (same behavior as the existing `airflow_image` helper).

By default, sidecar containers in these pods (log-groomer, wait-for-migrations) continue to use the global `images.airflow` image. Set `applyToSidecars: true` on a component’s image block to apply the same override to those sidecars as well.

All new fields are unset by default, so existing deployments are unchanged unless overrides are explicitly set.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

<!--
Generated-by: [Cursor Composer] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
