### PR TITLE
Remove stale `dag_` parameter from create_test_pipeline docstring

### DIFF
--- a/airflow-core/src/airflow/example_dags/example_skip_dag.py
+++ b/airflow-core/src/airflow/example_dags/example_skip_dag.py
@@ -48,7 +48,6 @@ def create_test_pipeline(suffix, trigger_rule):
 
     :param str suffix: Suffix to append to the operator task_ids
     :param str trigger_rule: TriggerRule for the join task
-    :param DAG dag_: The DAG to run the operators on
     """
     skip_operator = EmptySkipOperator(task_id=f"skip_operator_{suffix}")
     always_true = EmptyOperator(task_id=f"always_true_{suffix}")


### PR DESCRIPTION
### Description

Remove a stale `:param DAG dag_:` docstring entry from the `create_test_pipeline` function in `example_skip_dag.py`.

The parameter is not present in the function signature and is not used anywhere in the code or call sites.

This change aligns the documentation with the actual implementation.

No functional changes are introduced.

### Change Type

- [x] Documentation / Examples

---

##### Was generative AI tooling used to co-author this PR? No

- [ ] Yes (please specify the tool below)