### PR TITLE
Fix XCom get_value outside task runner

### DIFF
--- a/airflow-core/src/airflow/models/xcom.py
+++ b/airflow-core/src/airflow/models/xcom.py
@@ -54,6 +54,8 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from sqlalchemy.sql.expression import Select, TextClause
 
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
 
 XCOM_RETURN_KEY = "return_value"
 
@@ -331,6 +333,57 @@ class XComModel(TaskInstanceDependencies):
         if limit:
             return query.limit(limit)
         return query
+
+    @classmethod
+    @provide_session
+    def get_one(
+        cls,
+        *,
+        key: str,
+        dag_id: str,
+        task_id: str,
+        run_id: str,
+        map_index: int | None = None,
+        include_prior_dates: bool = False,
+        session: Session = NEW_SESSION,
+    ) -> Any | None:
+        """Retrieve and deserialize a single XCom value from the metadata database."""
+        result = session.execute(
+            cls.get_many(
+                key=key,
+                dag_ids=dag_id,
+                task_ids=task_id,
+                run_id=run_id,
+                map_indexes=map_index,
+                include_prior_dates=include_prior_dates,
+                limit=1,
+            ).with_only_columns(cls.value)
+        ).first()
+        if result is None:
+            return None
+        from airflow.sdk.bases.xcom import BaseXCom
+        from airflow.sdk.execution_time.xcom import resolve_xcom_backend
+
+        XCom = resolve_xcom_backend()
+        if XCom is BaseXCom:
+            return cls.deserialize_value(result)
+        return XCom.deserialize_value(result)
+
+    @classmethod
+    def get_value(
+        cls,
+        *,
+        ti_key: TaskInstanceKey,
+        key: str,
+    ) -> Any | None:
+        """Retrieve and deserialize an XCom value for a task instance key."""
+        return cls.get_one(
+            key=key,
+            dag_id=ti_key.dag_id,
+            task_id=ti_key.task_id,
+            run_id=ti_key.run_id,
+            map_index=ti_key.map_index,
+        )
 
     @staticmethod
     def serialize_value(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py
@@ -72,6 +72,21 @@ class TryNumberPlugin(AirflowPlugin):
     operator_extra_links = [TryNumberLink()]
 
 
+class XComModelLink(BaseOperatorLink):
+    name = "XCom Model"
+    operators = [CustomOperator]
+
+    def get_link(self, operator, *, ti_key):
+        from airflow.providers.common.compat.sdk import XComModel
+
+        return XComModel.get_value(key="plugin_link", ti_key=ti_key) or ""
+
+
+class XComModelPlugin(AirflowPlugin):
+    name = "xcom_model_plugin"
+    operator_extra_links = [XComModelLink()]
+
+
 @pytest.mark.mock_plugin_manager(plugins=[])
 class TestGetExtraLinks:
     dag_id = "TEST_DAG_ID"
@@ -264,6 +279,23 @@ class TestGetExtraLinks:
                 total_entries=3,
             ).model_dump()
         )
+
+    @pytest.mark.mock_plugin_manager(plugins=[XComModelPlugin])
+    def test_plugin_link_can_read_xcom_with_xcommodel(self, test_client):
+        XCom.set(
+            key="plugin_link",
+            value="https://example.com/plugin-link",
+            task_id=self.task_single_link,
+            dag_id=self.dag_id,
+            run_id=self.dag_run_id,
+        )
+
+        response = test_client.get(
+            f"/dags/{self.dag_id}/dagRuns/{self.dag_run_id}/taskInstances/{self.task_single_link}/links",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["extra_links"]["XCom Model"] == "https://example.com/plugin-link"
 
     def test_should_respond_200_mapped_task_instance(self, test_client, session):
         for map_index, value in enumerate(["TEST_LINK_VALUE_1", "TEST_LINK_VALUE_2"]):

--- a/airflow-core/tests/unit/models/test_xcom.py
+++ b/airflow-core/tests/unit/models/test_xcom.py
@@ -240,6 +240,16 @@ class TestXComGet:
         ).first()
         assert XComModel.deserialize_value(stored_value) == {"key": "value"}
 
+    def test_xcommodel_get_value(self, task_instance, push_simple_json_xcom):
+        push_simple_json_xcom(ti=task_instance, key="xcom_1", value={"key": "value"})
+
+        value = XComModel.get_value(
+            ti_key=task_instance.key,
+            key="xcom_1",
+        )
+
+        assert value == {"key": "value"}
+
     @pytest.fixture
     def tis_for_xcom_get_one_from_prior_date(self, task_instance_factory, push_simple_json_xcom):
         date1 = timezone.datetime(2021, 12, 3, 4, 56)

--- a/providers/common/compat/src/airflow/providers/common/compat/sdk.py
+++ b/providers/common/compat/src/airflow/providers/common/compat/sdk.py
@@ -30,7 +30,7 @@ from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_0_PLUS
 if TYPE_CHECKING:
     import airflow.sdk.io as io  # noqa: F401
     import airflow.sdk.timezone as timezone  # noqa: F401
-    from airflow.models.xcom import XCOM_RETURN_KEY as XCOM_RETURN_KEY
+    from airflow.models.xcom import XCOM_RETURN_KEY as XCOM_RETURN_KEY, XComModel as XComModel
     from airflow.sdk import (
         DAG as DAG,
         Asset as Asset,
@@ -135,6 +135,7 @@ _RENAME_MAP: dict[str, tuple[str, str, str]] = {
     "AssetAlias": ("airflow.sdk", "airflow.datasets", "DatasetAlias"),
     "AssetAll": ("airflow.sdk", "airflow.datasets", "DatasetAll"),
     "AssetAny": ("airflow.sdk", "airflow.datasets", "DatasetAny"),
+    "XComModel": ("airflow.models.xcom", "airflow.models.xcom", "XCom"),
 }
 
 # Airflow 3-only renames (not available in Airflow 2)

--- a/providers/common/compat/tests/unit/common/compat/test_sdk.py
+++ b/providers/common/compat/tests/unit/common/compat/test_sdk.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import pytest
 
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+
 
 def test_all_compat_imports_work():
     """
@@ -52,3 +54,15 @@ def test_invalid_import_raises_attribute_error():
 
     with pytest.raises(AttributeError, match="has no attribute 'NonExistentClass'"):
         _ = sdk.NonExistentClass
+
+
+def test_xcom_model_imports_server_side_model_or_airflow2_fallback():
+    from airflow.models.xcom import XCom
+    from airflow.providers.common.compat import sdk
+
+    if AIRFLOW_V_3_0_PLUS:
+        from airflow.models.xcom import XComModel
+
+        assert sdk.XComModel is XComModel
+    else:
+        assert sdk.XComModel is XCom

--- a/providers/common/io/pyproject.toml
+++ b/providers/common/io/pyproject.toml
@@ -60,7 +60,7 @@ requires-python = ">=3.10"
 # After you modify the dependencies, and rebuild your Breeze CI image with ``breeze ci-image build``
 dependencies = [
     "apache-airflow>=2.11.0",
-    "apache-airflow-providers-common-compat>=1.12.0",
+    "apache-airflow-providers-common-compat>=1.12.0",  # use next version
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/common/io/tests/unit/common/io/xcom/test_backend.py
+++ b/providers/common/io/tests/unit/common/io/xcom/test_backend.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -42,6 +43,12 @@ if AIRFLOW_V_3_0_PLUS:
 else:
     from airflow.io.path import ObjectStoragePath  # type: ignore[no-redef]
     from airflow.models.xcom import BaseXCom, resolve_xcom_backend  # type: ignore[no-redef]
+
+
+def _xcommodel_supports_get_value_backend_regression() -> bool:
+    if not AIRFLOW_V_3_0_PLUS or not hasattr(XComModel, "get_value"):
+        return False
+    return "serialize" in inspect.signature(XComModel.set).parameters
 
 
 @pytest.fixture(autouse=True)
@@ -221,6 +228,35 @@ class TestXComObjectStorageBackend:
                 session=session,
             )
             assert str(p) == qry.first().value
+
+    @pytest.mark.skipif(
+        not _xcommodel_supports_get_value_backend_regression(),
+        reason="XComModel.get_value backend regression requires the current server-side XComModel helpers",
+    )
+    def test_xcommodel_get_value_uses_configured_backend(self, task_instance, session):
+        session.add(task_instance)
+        session.commit()
+        XCom = resolve_xcom_backend()
+        airflow.models.xcom.XCom = XCom
+
+        expected_value = {"key": "bigvaluebigvaluebigvalue" * 100}
+        stored_value = XCom.serialize_value(
+            value=expected_value,
+            key=XCOM_RETURN_KEY,
+            dag_id=task_instance.dag_id,
+            task_id=task_instance.task_id,
+            run_id=task_instance.run_id,
+        )
+        XComModel.set(
+            key=XCOM_RETURN_KEY,
+            value=stored_value,
+            dag_id=task_instance.dag_id,
+            task_id=task_instance.task_id,
+            run_id=task_instance.run_id,
+            serialize=False,
+        )
+
+        assert XComModel.get_value(key=XCOM_RETURN_KEY, ti_key=task_instance.key) == expected_value
 
     def test_clear(self, task_instance, session, mock_supervisor_comms):
         session.add(task_instance)


### PR DESCRIPTION
Plugin-registered extra links are resolved in the API server, but examples can naturally reach for `XCom.get_value()` from the SDK/compat SDK. In Airflow 3 that SDK XCom path is task-runner scoped, so it expects `SUPERVISOR_COMMS` and is not suitable for API-server extra-link code.

This adds a server-side `XComModel.get_one()` / `XComModel.get_value()` convenience path that reuses the existing metadata DB query. For the default backend it preserves `XComModel` JSON-row deserialization, and for configured custom XCom backends it routes the stored row through the configured backend so server-side extra-link code keeps the compat behavior of resolving the actual XCom value rather than an object-storage reference.

The common compat SDK now exposes `XComModel`, so plugin extra links can use an API-server-safe XCom reader without importing task-runtime SDK XCom.

This also adds route coverage showing a plugin-registered extra link resolving through `/links` and reading an XCom value with `XComModel.get_value()`, plus `XComObjectStorageBackend` regression coverage for custom backend deserialization.

Closes #59093

Tests:
- `uv run pytest --rootdir=providers/common/io providers/common/io/tests/unit/common/io/xcom/test_backend.py::TestXComObjectStorageBackend`
- `uv run pytest airflow-core/tests/unit/models/test_xcom.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py task-sdk/tests/task_sdk/bases/test_xcom.py`
- `uv run pytest --rootdir=providers/common/compat providers/common/compat/tests/unit/common/compat/test_sdk.py`
- `uv run ruff check airflow-core/src/airflow/models/xcom.py airflow-core/tests/unit/models/test_xcom.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py providers/common/compat/src/airflow/providers/common/compat/sdk.py providers/common/compat/tests/unit/common/compat/test_sdk.py providers/common/io/tests/unit/common/io/xcom/test_backend.py`
- `uv run ruff format --check airflow-core/src/airflow/models/xcom.py airflow-core/tests/unit/models/test_xcom.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_extra_links.py providers/common/compat/src/airflow/providers/common/compat/sdk.py providers/common/compat/tests/unit/common/compat/test_sdk.py providers/common/io/tests/unit/common/io/xcom/test_backend.py`
- `git diff --check`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: OpenAI Codex

Generated-by: OpenAI Codex following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
