### PR TITLE
Detect supervisor-subprocess trigger count mismatch in Triggerer

### DIFF
--- a/airflow-core/newsfragments/68792.bugfix.rst
+++ b/airflow-core/newsfragments/68792.bugfix.rst
@@ -1,0 +1,1 @@
+Recover Triggerer triggers that the supervisor tracked as running but for which the runner had no live coroutine. Their task instances previously stayed in ``deferred`` indefinitely; the trigger is now re-created on the next sync so the task can resume. A new ``triggers.state_mismatch`` counter is emitted when this is detected.

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -332,6 +332,7 @@ class messages:
         # Format of list[str] is the exc traceback format
         failures: list[tuple[int, list[str] | None]] | None = None
         finished: list[int] | None = None
+        num_running: int = 0
 
     class TriggerStateSync(BaseModel):
         type: Literal["TriggerStateSync"] = "TriggerStateSync"
@@ -603,6 +604,8 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                         # handle leaks for every failed upload.
                         factory.close()
 
+            self.check_for_unhandled_triggers(msg.num_running)
+
             # Drain the persist confirmations accumulated since the last sync.
             events_persisted: list[int] = []
             while self.persisted_event_seqs:
@@ -782,6 +785,21 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
     def clean_unused(self) -> None:
         """Remove triggers that are no longer needed."""
         Trigger.clean_unused()
+
+    def check_for_unhandled_triggers(self, num_running: int) -> None:
+        """
+        Shut down if the subprocess trigger count disagrees with the supervisor.
+
+        Only valid between finished-removal and to_create-addition in ``_handle_request``.
+        """
+        expected = len(self.running_triggers)
+        if expected != num_running:
+            log.error(
+                "Trigger count mismatch: expected %d, subprocess reports %d. Shutting down.",
+                expected,
+                num_running,
+            )
+            self.stop = True
 
     def handle_failed_triggers(self):
         """
@@ -1513,6 +1531,7 @@ class TriggerRunner:
             events=events_to_send if events_to_send else None,
             finished=finished_ids if finished_ids else None,
             failures=failures_to_send if failures_to_send else None,
+            num_running=len(self.triggers),
         )
 
     def sanitize_trigger_events(self, msg: messages.TriggerStateChanges) -> messages.TriggerStateChanges:
@@ -1541,6 +1560,7 @@ class TriggerRunner:
             events=events_to_send if events_to_send else None,
             finished=msg.finished,
             failures=msg.failures,
+            num_running=msg.num_running,
         )
 
     async def sync_state_to_supervisor(self, finished_ids: list[int]) -> None:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -332,7 +332,8 @@ class messages:
         # Format of list[str] is the exc traceback format
         failures: list[tuple[int, list[str] | None]] | None = None
         finished: list[int] | None = None
-        num_running: int = 0
+        # Ids the runner has a live coroutine for
+        running_ids: set[int] = set()
 
     class TriggerStateSync(BaseModel):
         type: Literal["TriggerStateSync"] = "TriggerStateSync"
@@ -604,7 +605,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                         # handle leaks for every failed upload.
                         factory.close()
 
-            self.check_for_unhandled_triggers(msg.num_running)
+            self.check_for_unhandled_triggers(msg.running_ids)
 
             # Drain the persist confirmations accumulated since the last sync.
             events_persisted: list[int] = []
@@ -786,20 +787,20 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         """Remove triggers that are no longer needed."""
         Trigger.clean_unused()
 
-    def check_for_unhandled_triggers(self, num_running: int) -> None:
+    def check_for_unhandled_triggers(self, running_ids: set[int]) -> None:
         """
-        Shut down if the subprocess trigger count disagrees with the supervisor.
+        Re-create triggers we track as running that the runner has no coroutine for.
 
-        Only valid between finished-removal and to_create-addition in ``_handle_request``.
+        Only valid between finished-removal and to_create-addition in ``_handle_request``, where the
+        two sides agree. Dropping the leftovers lets :meth:`update_triggers` rebuild them.
         """
-        expected = len(self.running_triggers)
-        if expected != num_running:
-            log.error(
-                "Trigger count mismatch: expected %d, subprocess reports %d. Shutting down.",
-                expected,
-                num_running,
-            )
-            self.stop = True
+        unhandled = self.running_triggers - running_ids
+        if not unhandled:
+            return
+        log.error("Triggers have no coroutine in the runner; re-creating", trigger_ids=sorted(unhandled))
+        self.running_triggers -= unhandled
+        self.cancelling_triggers -= unhandled
+        stats.incr("triggers.state_mismatch", len(unhandled), tags=prune_dict({"team_name": self.team_name}))
 
     def handle_failed_triggers(self):
         """
@@ -1518,6 +1519,7 @@ class TriggerRunner:
         # Copy out of our dequeues in threadsafe manner to sync state with parent
         events_to_send: list[TriggerEventEntry] = []
         failures_to_send: list[tuple[int, list[str] | None]] = []
+        finished_to_send = list(finished_ids)
 
         while self.events:
             events_to_send.append(self.events.popleft())
@@ -1527,13 +1529,13 @@ class TriggerRunner:
             tb = format_exception(type(exc), exc, exc.__traceback__) if exc else None
             failures_to_send.append((trigger_id, tb))
             if trigger_id not in self.triggers:
-                finished_ids.append(trigger_id)
+                finished_to_send.append(trigger_id)
 
         return messages.TriggerStateChanges(
             events=events_to_send if events_to_send else None,
-            finished=finished_ids if finished_ids else None,
+            finished=finished_to_send if finished_to_send else None,
             failures=failures_to_send if failures_to_send else None,
-            num_running=len(self.triggers),
+            running_ids=set(self.triggers),
         )
 
     def sanitize_trigger_events(self, msg: messages.TriggerStateChanges) -> messages.TriggerStateChanges:
@@ -1562,7 +1564,7 @@ class TriggerRunner:
             events=events_to_send if events_to_send else None,
             finished=msg.finished,
             failures=msg.failures,
-            num_running=msg.num_running,
+            running_ids=msg.running_ids,
         )
 
     async def sync_state_to_supervisor(self, finished_ids: list[int]) -> None:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1526,6 +1526,8 @@ class TriggerRunner:
             trigger_id, exc = self.failed_triggers.popleft()
             tb = format_exception(type(exc), exc, exc.__traceback__) if exc else None
             failures_to_send.append((trigger_id, tb))
+            if trigger_id not in self.triggers:
+                finished_ids.append(trigger_id)
 
         return messages.TriggerStateChanges(
             events=events_to_send if events_to_send else None,

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -331,7 +331,8 @@ class messages:
         # Format of list[str] is the exc traceback format
         failures: list[tuple[int, list[str] | None]] | None = None
         finished: list[int] | None = None
-        num_running: int = 0
+        # Ids the runner has a live coroutine for
+        running_ids: set[int] = set()
 
     class TriggerStateSync(BaseModel):
         type: Literal["TriggerStateSync"] = "TriggerStateSync"
@@ -603,7 +604,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                         # handle leaks for every failed upload.
                         factory.close()
 
-            self.check_for_unhandled_triggers(msg.num_running)
+            self.check_for_unhandled_triggers(msg.running_ids)
 
             # Drain the persist confirmations accumulated since the last sync.
             events_persisted: list[int] = []
@@ -785,20 +786,20 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         """Remove triggers that are no longer needed."""
         Trigger.clean_unused()
 
-    def check_for_unhandled_triggers(self, num_running: int) -> None:
+    def check_for_unhandled_triggers(self, running_ids: set[int]) -> None:
         """
-        Shut down if the subprocess trigger count disagrees with the supervisor.
+        Re-create triggers we track as running that the runner has no coroutine for.
 
-        Only valid between finished-removal and to_create-addition in ``_handle_request``.
+        Only valid between finished-removal and to_create-addition in ``_handle_request``, where the
+        two sides agree. Dropping the leftovers lets :meth:`update_triggers` rebuild them.
         """
-        expected = len(self.running_triggers)
-        if expected != num_running:
-            log.error(
-                "Trigger count mismatch: expected %d, subprocess reports %d. Shutting down.",
-                expected,
-                num_running,
-            )
-            self.stop = True
+        unhandled = self.running_triggers - running_ids
+        if not unhandled:
+            return
+        log.error("Triggers have no coroutine in the runner; re-creating", trigger_ids=sorted(unhandled))
+        self.running_triggers -= unhandled
+        self.cancelling_triggers -= unhandled
+        stats.incr("triggers.state_mismatch", len(unhandled), tags=prune_dict({"team_name": self.team_name}))
 
     def handle_failed_triggers(self):
         """
@@ -1526,6 +1527,7 @@ class TriggerRunner:
         # Copy out of our dequeues in threadsafe manner to sync state with parent
         events_to_send: list[TriggerEventEntry] = []
         failures_to_send: list[tuple[int, list[str] | None]] = []
+        finished_to_send = list(finished_ids)
 
         while self.events:
             events_to_send.append(self.events.popleft())
@@ -1535,13 +1537,13 @@ class TriggerRunner:
             tb = format_exception(type(exc), exc, exc.__traceback__) if exc else None
             failures_to_send.append((trigger_id, tb))
             if trigger_id not in self.triggers:
-                finished_ids.append(trigger_id)
+                finished_to_send.append(trigger_id)
 
         return messages.TriggerStateChanges(
             events=events_to_send if events_to_send else None,
-            finished=finished_ids if finished_ids else None,
+            finished=finished_to_send if finished_to_send else None,
             failures=failures_to_send if failures_to_send else None,
-            num_running=len(self.triggers),
+            running_ids=set(self.triggers),
         )
 
     def sanitize_trigger_events(self, msg: messages.TriggerStateChanges) -> messages.TriggerStateChanges:
@@ -1570,7 +1572,7 @@ class TriggerRunner:
             events=events_to_send if events_to_send else None,
             finished=msg.finished,
             failures=msg.failures,
-            num_running=msg.num_running,
+            running_ids=msg.running_ids,
         )
 
     async def sync_state_to_supervisor(self, finished_ids: list[int]) -> None:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1534,6 +1534,8 @@ class TriggerRunner:
             trigger_id, exc = self.failed_triggers.popleft()
             tb = format_exception(type(exc), exc, exc.__traceback__) if exc else None
             failures_to_send.append((trigger_id, tb))
+            if trigger_id not in self.triggers:
+                finished_ids.append(trigger_id)
 
         return messages.TriggerStateChanges(
             events=events_to_send if events_to_send else None,

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -331,8 +331,8 @@ class messages:
         # Format of list[str] is the exc traceback format
         failures: list[tuple[int, list[str] | None]] | None = None
         finished: list[int] | None = None
-        # Ids the runner has a live coroutine for
-        running_ids: set[int] = set()
+        # Ids the runner has a live coroutine for; None when the message carries no information
+        running_ids: set[int] | None = None
 
     class TriggerStateSync(BaseModel):
         type: Literal["TriggerStateSync"] = "TriggerStateSync"
@@ -786,13 +786,15 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
         """Remove triggers that are no longer needed."""
         Trigger.clean_unused()
 
-    def check_for_unhandled_triggers(self, running_ids: set[int]) -> None:
+    def check_for_unhandled_triggers(self, running_ids: set[int] | None) -> None:
         """
         Re-create triggers we track as running that the runner has no coroutine for.
 
         Only valid between finished-removal and to_create-addition in ``_handle_request``, where the
         two sides agree. Dropping the leftovers lets :meth:`update_triggers` rebuild them.
         """
+        if running_ids is None:
+            return
         unhandled = self.running_triggers - running_ids
         if not unhandled:
             return

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -331,6 +331,7 @@ class messages:
         # Format of list[str] is the exc traceback format
         failures: list[tuple[int, list[str] | None]] | None = None
         finished: list[int] | None = None
+        num_running: int = 0
 
     class TriggerStateSync(BaseModel):
         type: Literal["TriggerStateSync"] = "TriggerStateSync"
@@ -602,6 +603,8 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                         # handle leaks for every failed upload.
                         factory.close()
 
+            self.check_for_unhandled_triggers(msg.num_running)
+
             # Drain the persist confirmations accumulated since the last sync.
             events_persisted: list[int] = []
             while self.persisted_event_seqs:
@@ -781,6 +784,21 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
     def clean_unused(self) -> None:
         """Remove triggers that are no longer needed."""
         Trigger.clean_unused()
+
+    def check_for_unhandled_triggers(self, num_running: int) -> None:
+        """
+        Shut down if the subprocess trigger count disagrees with the supervisor.
+
+        Only valid between finished-removal and to_create-addition in ``_handle_request``.
+        """
+        expected = len(self.running_triggers)
+        if expected != num_running:
+            log.error(
+                "Trigger count mismatch: expected %d, subprocess reports %d. Shutting down.",
+                expected,
+                num_running,
+            )
+            self.stop = True
 
     def handle_failed_triggers(self):
         """
@@ -1521,6 +1539,7 @@ class TriggerRunner:
             events=events_to_send if events_to_send else None,
             finished=finished_ids if finished_ids else None,
             failures=failures_to_send if failures_to_send else None,
+            num_running=len(self.triggers),
         )
 
     def sanitize_trigger_events(self, msg: messages.TriggerStateChanges) -> messages.TriggerStateChanges:
@@ -1549,6 +1568,7 @@ class TriggerRunner:
             events=events_to_send if events_to_send else None,
             finished=msg.finished,
             failures=msg.failures,
+            num_running=msg.num_running,
         )
 
     async def sync_state_to_supervisor(self, finished_ids: list[int]) -> None:

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -1538,7 +1538,7 @@ class TriggerRunner:
             trigger_id, exc = self.failed_triggers.popleft()
             tb = format_exception(type(exc), exc, exc.__traceback__) if exc else None
             failures_to_send.append((trigger_id, tb))
-            if trigger_id not in self.triggers:
+            if trigger_id not in self.triggers and trigger_id not in finished_to_send:
                 finished_to_send.append(trigger_id)
 
         return messages.TriggerStateChanges(

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3303,3 +3303,45 @@ class TestCheckForUnhandledTriggers:
 
         assert jobless_supervisor.stop is False
         assert jobless_supervisor.running_triggers == {2, 3}
+
+    def test_creation_failure_reported_in_finished(self, jobless_supervisor, mocker):
+        """A creation failure appears in both failures and finished, so running_triggers stays in sync."""
+        mocker.patch.object(TriggerRunnerSupervisor, "send_msg", autospec=True)
+        jobless_supervisor.running_triggers = {1, 2, 3}
+
+        jobless_supervisor._handle_request(
+            messages.TriggerStateChanges(
+                events=None,
+                failures=[(3, ["Traceback..."])],
+                finished=[3],
+                num_running=2,
+            ),
+            log=MagicMock(spec=FilteringBoundLogger),
+            req_id=1,
+        )
+
+        assert jobless_supervisor.stop is False
+        assert 3 not in jobless_supervisor.running_triggers
+
+
+class TestCreationFailureInFinished:
+    """Tests that creation failures (not in self.triggers) are included in finished_ids."""
+
+    def test_creation_failure_included_in_finished(self):
+        runner = TriggerRunner()
+        runner.failed_triggers.append((42, ValueError("bad classpath")))
+
+        msg = runner.process_trigger_events(finished_ids=[10])
+
+        assert msg.finished == [10, 42]
+        assert msg.num_running == 0
+
+    def test_serialization_failure_not_in_finished(self):
+        runner = TriggerRunner()
+        runner.triggers = {42: {"task": MagicMock(), "is_watcher": False, "name": "t", "events": 0}}
+        runner.failed_triggers.append((42, ValueError("not serializable")))
+
+        msg = runner.process_trigger_events(finished_ids=[])
+
+        assert msg.finished is None
+        assert msg.num_running == 1

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3253,3 +3253,53 @@ def test_run_trigger_appends_none_seq_for_non_shared_trigger():
     trigger_id, _event, seq = events[0]
     assert trigger_id == 1
     assert seq is None
+
+
+class TestCheckForUnhandledTriggers:
+    """Tests for supervisor-vs-subprocess trigger count mismatch detection."""
+
+    def test_mismatch_shuts_down(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = {1, 2, 3}
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
+        assert jobless_supervisor.stop is True
+
+    def test_matching_counts_no_shutdown(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = {1, 2, 3}
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
+        assert jobless_supervisor.stop is False
+
+    def test_no_triggers_no_shutdown(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = set()
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
+        assert jobless_supervisor.stop is False
+
+    def test_subprocess_more_than_expected_shuts_down(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = {1}
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
+        assert jobless_supervisor.stop is True
+
+    def test_handle_request_checks_before_adding_to_create(self, jobless_supervisor, mocker):
+        """The check fires after finished processing but before to_create is added to running_triggers."""
+        mocker.patch.object(TriggerRunnerSupervisor, "send_msg", autospec=True)
+        jobless_supervisor.running_triggers = {1, 2}
+        jobless_supervisor.creating_triggers.append(
+            mocker.MagicMock(id=3),
+        )
+
+        jobless_supervisor._handle_request(
+            messages.TriggerStateChanges(
+                events=None,
+                failures=None,
+                finished=[1],
+                num_running=1,
+            ),
+            log=MagicMock(spec=FilteringBoundLogger),
+            req_id=1,
+        )
+
+        assert jobless_supervisor.stop is False
+        assert jobless_supervisor.running_triggers == {2, 3}

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3256,31 +3256,45 @@ def test_run_trigger_appends_none_seq_for_non_shared_trigger():
 
 
 class TestCheckForUnhandledTriggers:
-    """Tests for supervisor-vs-subprocess trigger count mismatch detection."""
+    """Tests for recovery of triggers the runner has no coroutine for."""
 
-    def test_mismatch_shuts_down(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = {1, 2, 3}
+    @pytest.mark.parametrize(
+        ("running_triggers", "running_ids", "expected_after"),
+        [
+            pytest.param({1, 2, 3}, {1, 2, 3}, {1, 2, 3}, id="in-sync"),
+            pytest.param(set(), set(), set(), id="no-triggers"),
+            pytest.param({1, 2, 3}, {1, 2}, {1, 2}, id="one-unhandled"),
+            pytest.param({1, 2, 3}, set(), set(), id="all-unhandled"),
+        ],
+    )
+    def test_unhandled_triggers_are_dropped_not_shut_down(
+        self, jobless_supervisor, mocker, running_triggers, running_ids, expected_after
+    ):
+        incr = mocker.patch("airflow.jobs.triggerer_job_runner.stats.incr", autospec=True)
+        jobless_supervisor.running_triggers = set(running_triggers)
+        jobless_supervisor.cancelling_triggers = set(running_triggers)
 
-        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
-        assert jobless_supervisor.stop is True
+        jobless_supervisor.check_for_unhandled_triggers(running_ids)
 
-    def test_matching_counts_no_shutdown(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = {1, 2, 3}
-
-        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
+        unhandled = running_triggers - running_ids
         assert jobless_supervisor.stop is False
+        assert jobless_supervisor.running_triggers == expected_after
+        assert jobless_supervisor.cancelling_triggers == expected_after
+        assert (
+            mocker.call("triggers.state_mismatch", len(unhandled), tags={}) in incr.call_args_list
+        ) is bool(unhandled)
 
-    def test_no_triggers_no_shutdown(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = set()
+    def test_dropped_trigger_is_recreated_next_loop(self, jobless_supervisor, mocker):
+        """Dropping an unhandled id is what lets update_triggers rebuild its workload."""
+        build = mocker.patch.object(
+            TriggerRunnerSupervisor, "build_trigger_workloads", autospec=True, return_value=[]
+        )
+        jobless_supervisor.running_triggers = {1, 2}
 
-        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
-        assert jobless_supervisor.stop is False
+        jobless_supervisor.check_for_unhandled_triggers({1})
+        jobless_supervisor.update_triggers({1, 2})
 
-    def test_subprocess_more_than_expected_shuts_down(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = {1}
-
-        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
-        assert jobless_supervisor.stop is True
+        assert build.call_args.args[1] == {2}
 
     def test_handle_request_checks_before_adding_to_create(self, jobless_supervisor, mocker):
         """The check fires after finished processing but before to_create is added to running_triggers."""
@@ -3295,7 +3309,7 @@ class TestCheckForUnhandledTriggers:
                 events=None,
                 failures=None,
                 finished=[1],
-                num_running=1,
+                running_ids={2},
             ),
             log=MagicMock(spec=FilteringBoundLogger),
             req_id=1,
@@ -3314,7 +3328,7 @@ class TestCheckForUnhandledTriggers:
                 events=None,
                 failures=[(3, ["Traceback..."])],
                 finished=[3],
-                num_running=2,
+                running_ids={1, 2},
             ),
             log=MagicMock(spec=FilteringBoundLogger),
             req_id=1,
@@ -3334,7 +3348,7 @@ class TestCreationFailureInFinished:
         msg = runner.process_trigger_events(finished_ids=[10])
 
         assert msg.finished == [10, 42]
-        assert msg.num_running == 0
+        assert msg.running_ids == set()
 
     def test_serialization_failure_not_in_finished(self):
         runner = TriggerRunner()
@@ -3344,4 +3358,13 @@ class TestCreationFailureInFinished:
         msg = runner.process_trigger_events(finished_ids=[])
 
         assert msg.finished is None
-        assert msg.num_running == 1
+        assert msg.running_ids == {42}
+
+    def test_caller_finished_ids_not_mutated(self):
+        runner = TriggerRunner()
+        runner.failed_triggers.append((42, ValueError("bad classpath")))
+        finished_ids = [10]
+
+        runner.process_trigger_events(finished_ids=finished_ids)
+
+        assert finished_ids == [10]

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3414,6 +3414,16 @@ class TestCheckForUnhandledTriggers:
 
         assert build.call_args.args[1] == {2}
 
+    def test_message_without_running_ids_is_ignored(self, jobless_supervisor):
+        """``None`` means the message carried no information, which must not read as "nothing running"."""
+        jobless_supervisor.running_triggers = {1, 2, 3}
+        jobless_supervisor.cancelling_triggers = {1, 2, 3}
+
+        jobless_supervisor.check_for_unhandled_triggers(None)
+
+        assert jobless_supervisor.running_triggers == {1, 2, 3}
+        assert jobless_supervisor.cancelling_triggers == {1, 2, 3}
+
     def test_handle_request_checks_before_adding_to_create(self, jobless_supervisor, mocker):
         """The check fires after finished processing but before to_create is added to running_triggers."""
         mocker.patch.object(TriggerRunnerSupervisor, "send_msg", autospec=True)

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3374,31 +3374,45 @@ def test_run_trigger_appends_none_seq_for_non_shared_trigger():
 
 
 class TestCheckForUnhandledTriggers:
-    """Tests for supervisor-vs-subprocess trigger count mismatch detection."""
+    """Tests for recovery of triggers the runner has no coroutine for."""
 
-    def test_mismatch_shuts_down(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = {1, 2, 3}
+    @pytest.mark.parametrize(
+        ("running_triggers", "running_ids", "expected_after"),
+        [
+            pytest.param({1, 2, 3}, {1, 2, 3}, {1, 2, 3}, id="in-sync"),
+            pytest.param(set(), set(), set(), id="no-triggers"),
+            pytest.param({1, 2, 3}, {1, 2}, {1, 2}, id="one-unhandled"),
+            pytest.param({1, 2, 3}, set(), set(), id="all-unhandled"),
+        ],
+    )
+    def test_unhandled_triggers_are_dropped_not_shut_down(
+        self, jobless_supervisor, mocker, running_triggers, running_ids, expected_after
+    ):
+        incr = mocker.patch("airflow.jobs.triggerer_job_runner.stats.incr", autospec=True)
+        jobless_supervisor.running_triggers = set(running_triggers)
+        jobless_supervisor.cancelling_triggers = set(running_triggers)
 
-        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
-        assert jobless_supervisor.stop is True
+        jobless_supervisor.check_for_unhandled_triggers(running_ids)
 
-    def test_matching_counts_no_shutdown(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = {1, 2, 3}
-
-        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
+        unhandled = running_triggers - running_ids
         assert jobless_supervisor.stop is False
+        assert jobless_supervisor.running_triggers == expected_after
+        assert jobless_supervisor.cancelling_triggers == expected_after
+        assert (
+            mocker.call("triggers.state_mismatch", len(unhandled), tags={}) in incr.call_args_list
+        ) is bool(unhandled)
 
-    def test_no_triggers_no_shutdown(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = set()
+    def test_dropped_trigger_is_recreated_next_loop(self, jobless_supervisor, mocker):
+        """Dropping an unhandled id is what lets update_triggers rebuild its workload."""
+        build = mocker.patch.object(
+            TriggerRunnerSupervisor, "build_trigger_workloads", autospec=True, return_value=[]
+        )
+        jobless_supervisor.running_triggers = {1, 2}
 
-        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
-        assert jobless_supervisor.stop is False
+        jobless_supervisor.check_for_unhandled_triggers({1})
+        jobless_supervisor.update_triggers({1, 2})
 
-    def test_subprocess_more_than_expected_shuts_down(self, jobless_supervisor):
-        jobless_supervisor.running_triggers = {1}
-
-        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
-        assert jobless_supervisor.stop is True
+        assert build.call_args.args[1] == {2}
 
     def test_handle_request_checks_before_adding_to_create(self, jobless_supervisor, mocker):
         """The check fires after finished processing but before to_create is added to running_triggers."""
@@ -3413,7 +3427,7 @@ class TestCheckForUnhandledTriggers:
                 events=None,
                 failures=None,
                 finished=[1],
-                num_running=1,
+                running_ids={2},
             ),
             log=MagicMock(spec=FilteringBoundLogger),
             req_id=1,
@@ -3432,7 +3446,7 @@ class TestCheckForUnhandledTriggers:
                 events=None,
                 failures=[(3, ["Traceback..."])],
                 finished=[3],
-                num_running=2,
+                running_ids={1, 2},
             ),
             log=MagicMock(spec=FilteringBoundLogger),
             req_id=1,
@@ -3452,7 +3466,7 @@ class TestCreationFailureInFinished:
         msg = runner.process_trigger_events(finished_ids=[10])
 
         assert msg.finished == [10, 42]
-        assert msg.num_running == 0
+        assert msg.running_ids == set()
 
     def test_serialization_failure_not_in_finished(self):
         runner = TriggerRunner()
@@ -3462,4 +3476,13 @@ class TestCreationFailureInFinished:
         msg = runner.process_trigger_events(finished_ids=[])
 
         assert msg.finished is None
-        assert msg.num_running == 1
+        assert msg.running_ids == {42}
+
+    def test_caller_finished_ids_not_mutated(self):
+        runner = TriggerRunner()
+        runner.failed_triggers.append((42, ValueError("bad classpath")))
+        finished_ids = [10]
+
+        runner.process_trigger_events(finished_ids=finished_ids)
+
+        assert finished_ids == [10]

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3421,3 +3421,45 @@ class TestCheckForUnhandledTriggers:
 
         assert jobless_supervisor.stop is False
         assert jobless_supervisor.running_triggers == {2, 3}
+
+    def test_creation_failure_reported_in_finished(self, jobless_supervisor, mocker):
+        """A creation failure appears in both failures and finished, so running_triggers stays in sync."""
+        mocker.patch.object(TriggerRunnerSupervisor, "send_msg", autospec=True)
+        jobless_supervisor.running_triggers = {1, 2, 3}
+
+        jobless_supervisor._handle_request(
+            messages.TriggerStateChanges(
+                events=None,
+                failures=[(3, ["Traceback..."])],
+                finished=[3],
+                num_running=2,
+            ),
+            log=MagicMock(spec=FilteringBoundLogger),
+            req_id=1,
+        )
+
+        assert jobless_supervisor.stop is False
+        assert 3 not in jobless_supervisor.running_triggers
+
+
+class TestCreationFailureInFinished:
+    """Tests that creation failures (not in self.triggers) are included in finished_ids."""
+
+    def test_creation_failure_included_in_finished(self):
+        runner = TriggerRunner()
+        runner.failed_triggers.append((42, ValueError("bad classpath")))
+
+        msg = runner.process_trigger_events(finished_ids=[10])
+
+        assert msg.finished == [10, 42]
+        assert msg.num_running == 0
+
+    def test_serialization_failure_not_in_finished(self):
+        runner = TriggerRunner()
+        runner.triggers = {42: {"task": MagicMock(), "is_watcher": False, "name": "t", "events": 0}}
+        runner.failed_triggers.append((42, ValueError("not serializable")))
+
+        msg = runner.process_trigger_events(finished_ids=[])
+
+        assert msg.finished is None
+        assert msg.num_running == 1

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3371,3 +3371,53 @@ def test_run_trigger_appends_none_seq_for_non_shared_trigger():
     trigger_id, _event, seq = events[0]
     assert trigger_id == 1
     assert seq is None
+
+
+class TestCheckForUnhandledTriggers:
+    """Tests for supervisor-vs-subprocess trigger count mismatch detection."""
+
+    def test_mismatch_shuts_down(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = {1, 2, 3}
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
+        assert jobless_supervisor.stop is True
+
+    def test_matching_counts_no_shutdown(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = {1, 2, 3}
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
+        assert jobless_supervisor.stop is False
+
+    def test_no_triggers_no_shutdown(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = set()
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=0)
+        assert jobless_supervisor.stop is False
+
+    def test_subprocess_more_than_expected_shuts_down(self, jobless_supervisor):
+        jobless_supervisor.running_triggers = {1}
+
+        jobless_supervisor.check_for_unhandled_triggers(num_running=3)
+        assert jobless_supervisor.stop is True
+
+    def test_handle_request_checks_before_adding_to_create(self, jobless_supervisor, mocker):
+        """The check fires after finished processing but before to_create is added to running_triggers."""
+        mocker.patch.object(TriggerRunnerSupervisor, "send_msg", autospec=True)
+        jobless_supervisor.running_triggers = {1, 2}
+        jobless_supervisor.creating_triggers.append(
+            mocker.MagicMock(id=3),
+        )
+
+        jobless_supervisor._handle_request(
+            messages.TriggerStateChanges(
+                events=None,
+                failures=None,
+                finished=[1],
+                num_running=1,
+            ),
+            log=MagicMock(spec=FilteringBoundLogger),
+            req_id=1,
+        )
+
+        assert jobless_supervisor.stop is False
+        assert jobless_supervisor.running_triggers == {2, 3}

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -3385,7 +3385,7 @@ class TestCheckForUnhandledTriggers:
             pytest.param({1, 2, 3}, set(), set(), id="all-unhandled"),
         ],
     )
-    def test_unhandled_triggers_are_dropped_not_shut_down(
+    def test_unhandled_triggers_are_dropped(
         self, jobless_supervisor, mocker, running_triggers, running_ids, expected_after
     ):
         incr = mocker.patch("airflow.jobs.triggerer_job_runner.stats.incr", autospec=True)
@@ -3395,7 +3395,6 @@ class TestCheckForUnhandledTriggers:
         jobless_supervisor.check_for_unhandled_triggers(running_ids)
 
         unhandled = running_triggers - running_ids
-        assert jobless_supervisor.stop is False
         assert jobless_supervisor.running_triggers == expected_after
         assert jobless_supervisor.cancelling_triggers == expected_after
         assert (
@@ -3443,7 +3442,6 @@ class TestCheckForUnhandledTriggers:
             req_id=1,
         )
 
-        assert jobless_supervisor.stop is False
         assert jobless_supervisor.running_triggers == {2, 3}
 
     def test_creation_failure_reported_in_finished(self, jobless_supervisor, mocker):
@@ -3462,7 +3460,6 @@ class TestCheckForUnhandledTriggers:
             req_id=1,
         )
 
-        assert jobless_supervisor.stop is False
         assert 3 not in jobless_supervisor.running_triggers
 
 
@@ -3487,6 +3484,14 @@ class TestCreationFailureInFinished:
 
         assert msg.finished is None
         assert msg.running_ids == {42}
+
+    def test_failure_already_in_finished_ids_not_duplicated(self):
+        runner = TriggerRunner()
+        runner.failed_triggers.append((42, ValueError("exited without an event")))
+
+        msg = runner.process_trigger_events(finished_ids=[42])
+
+        assert msg.finished == [42]
 
     def test_caller_finished_ids_not_mutated(self):
         runner = TriggerRunner()

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -294,6 +294,13 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "triggers.state_mismatch"
+    description: "Number of triggers the Triggerer tracked as running that the trigger runner
+    had no coroutine for, and which were re-created"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "triggers.succeeded"
     description: "Number of triggers that have fired at least one event"
     type: "counter"

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -286,6 +286,13 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "triggers.state_mismatch"
+    description: "Number of triggers the Triggerer tracked as running that the trigger runner
+    had no coroutine for, and which were re-created"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "triggers.succeeded"
     description: "Number of triggers that have fired at least one event"
     type: "counter"


### PR DESCRIPTION
In rare cases the Triggerer subprocess can lose track of a trigger — it
is assigned in the supervisor's `running_triggers` but no coroutine is
actually running. The affected task instance stays in `deferred`
permanently.

**Changes:**

1. Supervisor compares `len(running_triggers)` against the subprocess's
   actual trigger count each sync cycle. If they diverge, it shuts down
   so the orchestrator can restart and recover stuck tasks.

2. Creation failures are included in `finished_ids` so the supervisor
   removes them from `running_triggers` naturally (prevents false-positive
   shutdown).

related: #63913

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.6)

Generated-by: Claude Code (Opus 4.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)