### PR TITLE
fix: MetastoreBackend.cleanup() ignores default_retention_days for null expires_at rows

### DIFF
--- a/airflow-core/src/airflow/cli/commands/state_store_command.py
+++ b/airflow-core/src/airflow/cli/commands/state_store_command.py
@@ -37,12 +37,18 @@ def cleanup_task_state_store(args) -> None:
     if args.dry_run:
         summary = backend._summary_dry_run()
         expired = summary["expired"]
-        if not expired:
+        stale = summary.get("stale", [])
+        if not expired and not stale:
             print("Nothing to delete.")
             return
-        print(f"Would delete {len(expired)} task state store row(s):\n")
-        for dag_id, run_id, task_id, map_index, key in expired:
-            print(f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}")
+        if expired:
+            print(f"Would delete {len(expired)} explicitly-expired task state store row(s):\n")
+            for dag_id, run_id, task_id, map_index, key in expired:
+                print(f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}")
+        if stale:
+            print(f"\nWould delete {len(stale)} stale task state store row(s) (default retention):\n")
+            for dag_id, run_id, task_id, map_index, key in stale:
+                print(f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}")
         return
 
     log.info("Running task state store cleanup")

--- a/airflow-core/src/airflow/cli/commands/state_store_command.py
+++ b/airflow-core/src/airflow/cli/commands/state_store_command.py
@@ -44,11 +44,15 @@ def cleanup_task_state_store(args) -> None:
         if expired:
             print(f"Would delete {len(expired)} explicitly-expired task state store row(s):\n")
             for dag_id, run_id, task_id, map_index, key in expired:
-                print(f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}")
+                print(
+                    f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}"
+                )
         if stale:
             print(f"\nWould delete {len(stale)} stale task state store row(s) (default retention):\n")
             for dag_id, run_id, task_id, map_index, key in stale:
-                print(f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}")
+                print(
+                    f"  Dag {dag_id!r}, run {run_id!r}, task {task_id!r}, map_index {map_index!r}, key {key!r}"
+                )
         return
 
     log.info("Running task state store cleanup")

--- a/airflow-core/src/airflow/state/metastore.py
+++ b/airflow-core/src/airflow/state/metastore.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import functools
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 import structlog
@@ -383,13 +383,24 @@ class MetastoreBackend(BaseStoreBackend):
 
     def cleanup(self) -> None:
         """
-        Remove expired task state rows.
+        Remove expired and stale task state rows.
 
-        ``expires_at`` is set at write time on every ``set()`` call, so cleanup is a single
-        ``WHERE expires_at < now()`` pass. Rows with ``expires_at=NULL`` (default_retention_days=0)
-        are never deleted. Batching is configurable via ``[state_store] state_cleanup_batch_size``.
+        Two deletion passes run in order:
+
+        1. **Explicit expiry**: rows where ``expires_at IS NOT NULL AND expires_at < now()``.
+           These are rows where the writer set a specific TTL via ``set(expires_at=...)``.
+
+        2. **Default retention**: rows where ``expires_at IS NULL`` and
+           ``updated_at + timedelta(days=default_retention_days) < now()``.
+           This applies the deployment-wide ``[state_store] default_retention_days`` (default 30)
+           to rows that were written without an explicit TTL — which is the common case for
+           task worker writes. When ``default_retention_days`` is 0, this pass is skipped
+           and those rows are kept indefinitely.
+
+        Batching is configurable via ``[state_store] state_cleanup_batch_size``.
         """
         batch_size = conf.getint("state_store", "state_cleanup_batch_size")
+        retention_days = conf.getint("state_store", "default_retention_days")
         now = timezone.utcnow()
 
         def _delete_batched(where_clause) -> int:
@@ -409,11 +420,26 @@ class MetastoreBackend(BaseStoreBackend):
                         break
             return total
 
+        # Pass 1: explicit expires_at
         deleted = _delete_batched(TaskStateStoreModel.expires_at < now)
-        log.info("Deleted expired task_state_store rows", rows_deleted=deleted)
+        log.info("Deleted explicitly-expired task_state_store rows", rows_deleted=deleted)
+
+        # Pass 2: default retention for rows without an explicit expires_at
+        if retention_days > 0:
+            cutoff = now - timedelta(days=retention_days)
+            stale_deleted = _delete_batched(
+                (TaskStateStoreModel.expires_at.is_(None))
+                & (TaskStateStoreModel.updated_at < cutoff)
+            )
+            log.info(
+                "Deleted stale task_state_store rows by default retention",
+                rows_deleted=stale_deleted,
+                retention_days=retention_days,
+            )
 
     def _summary_dry_run(self) -> dict[str, list]:
         """Return rows that would be deleted by cleanup() without deleting anything."""
+        retention_days = conf.getint("state_store", "default_retention_days")
         now = timezone.utcnow()
         cols = (
             TaskStateStoreModel.dag_id,
@@ -423,8 +449,20 @@ class MetastoreBackend(BaseStoreBackend):
             TaskStateStoreModel.key,
         )
         with create_session() as session:
+            # Pass 1: explicit expires_at
             expired = session.execute(select(*cols).where(TaskStateStoreModel.expires_at < now)).all()
-        return {"expired": list(expired)}
+
+            # Pass 2: default retention for rows without an explicit expires_at
+            stale: list = []
+            if retention_days > 0:
+                cutoff = now - timedelta(days=retention_days)
+                stale = session.execute(
+                    select(*cols).where(
+                        (TaskStateStoreModel.expires_at.is_(None))
+                        & (TaskStateStoreModel.updated_at < cutoff)
+                    )
+                ).all()
+        return {"expired": list(expired), "stale": stale}
 
     async def _aget_task_state_store(
         self, scope: TaskScope, key: str, *, session: AsyncSession

--- a/airflow-core/src/airflow/state/metastore.py
+++ b/airflow-core/src/airflow/state/metastore.py
@@ -383,21 +383,10 @@ class MetastoreBackend(BaseStoreBackend):
 
     def cleanup(self) -> None:
         """
-        Remove expired and stale task state rows.
+        Remove expired task state rows.
 
-        Two deletion passes run in order:
-
-        1. **Explicit expiry**: rows where ``expires_at IS NOT NULL AND expires_at < now()``.
-           These are rows where the writer set a specific TTL via ``set(expires_at=...)``.
-
-        2. **Default retention**: rows where ``expires_at IS NULL`` and
-           ``updated_at + timedelta(days=default_retention_days) < now()``.
-           This applies the deployment-wide ``[state_store] default_retention_days`` (default 30)
-           to rows that were written without an explicit TTL — which is the common case for
-           task worker writes. When ``default_retention_days`` is 0, this pass is skipped
-           and those rows are kept indefinitely.
-
-        Batching is configurable via ``[state_store] state_cleanup_batch_size``.
+        Rows with an explicit ``expires_at`` are deleted when expired. Rows without an
+        explicit expiry are deleted according to ``[state_store] default_retention_days``.
         """
         batch_size = conf.getint("state_store", "state_cleanup_batch_size")
         retention_days = conf.getint("state_store", "default_retention_days")
@@ -420,21 +409,14 @@ class MetastoreBackend(BaseStoreBackend):
                         break
             return total
 
-        # Pass 1: explicit expires_at
-        deleted = _delete_batched(TaskStateStoreModel.expires_at < now)
-        log.info("Deleted explicitly-expired task_state_store rows", rows_deleted=deleted)
-
-        # Pass 2: default retention for rows without an explicit expires_at
+        where_clause = TaskStateStoreModel.expires_at < now
         if retention_days > 0:
             cutoff = now - timedelta(days=retention_days)
-            stale_deleted = _delete_batched(
-                (TaskStateStoreModel.expires_at.is_(None)) & (TaskStateStoreModel.updated_at < cutoff)
+            where_clause = where_clause | (
+                TaskStateStoreModel.expires_at.is_(None) & (TaskStateStoreModel.updated_at < cutoff)
             )
-            log.info(
-                "Deleted stale task_state_store rows by default retention",
-                rows_deleted=stale_deleted,
-                retention_days=retention_days,
-            )
+        deleted = _delete_batched(where_clause)
+        log.info("Deleted expired task_state_store rows", rows_deleted=deleted)
 
     def _summary_dry_run(self) -> dict[str, list]:
         """Return rows that would be deleted by cleanup() without deleting anything."""

--- a/airflow-core/src/airflow/state/metastore.py
+++ b/airflow-core/src/airflow/state/metastore.py
@@ -428,8 +428,7 @@ class MetastoreBackend(BaseStoreBackend):
         if retention_days > 0:
             cutoff = now - timedelta(days=retention_days)
             stale_deleted = _delete_batched(
-                (TaskStateStoreModel.expires_at.is_(None))
-                & (TaskStateStoreModel.updated_at < cutoff)
+                (TaskStateStoreModel.expires_at.is_(None)) & (TaskStateStoreModel.updated_at < cutoff)
             )
             log.info(
                 "Deleted stale task_state_store rows by default retention",
@@ -456,12 +455,14 @@ class MetastoreBackend(BaseStoreBackend):
             stale: list = []
             if retention_days > 0:
                 cutoff = now - timedelta(days=retention_days)
-                stale = session.execute(
-                    select(*cols).where(
-                        (TaskStateStoreModel.expires_at.is_(None))
-                        & (TaskStateStoreModel.updated_at < cutoff)
-                    )
-                ).all()
+                stale = list(
+                    session.execute(
+                        select(*cols).where(
+                            (TaskStateStoreModel.expires_at.is_(None))
+                            & (TaskStateStoreModel.updated_at < cutoff)
+                        )
+                    ).all()
+                )
         return {"expired": list(expired), "stale": stale}
 
     async def _aget_task_state_store(

--- a/airflow-core/tests/unit/state/test_metastore.py
+++ b/airflow-core/tests/unit/state/test_metastore.py
@@ -260,6 +260,127 @@ class TestMetastoreBackendTaskScope:
         assert row is not None
         assert row.expires_at is None
 
+    def test_cleanup_deletes_stale_rows_by_default_retention(
+        self, session: Session, backend: MetastoreBackend, dag_run: DagRun
+    ):
+        """cleanup() removes rows with expires_at=NULL that exceed default_retention_days.
+
+        This is the primary regression test for the bug where cleanup() only checked
+        ``expires_at < now()`` and completely ignored ``default_retention_days``, causing
+        rows written by the task worker (which send expires_at=None) to accumulate forever.
+        """
+        scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
+        backend.set(scope, "old_state", "old_value", session=session)   # stale — should be deleted
+        backend.set(scope, "fresh_state", "fresh_value", session=session)  # recent — should be kept
+        session.flush()
+
+        # Backdate updated_at on old_state to 35 days ago to simulate retention-eligible row
+        old_row = session.scalar(
+            select(TaskStateStoreModel).where(
+                TaskStateStoreModel.dag_id == DAG_ID, TaskStateStoreModel.key == "old_state"
+            )
+        )
+        assert old_row is not None
+        assert old_row.expires_at is None  # worker writes always have NULL expires_at
+        old_row.updated_at = timezone.utcnow() - timedelta(days=35)
+        session.flush()
+        session.commit()
+
+        with conf_vars({("state_store", "default_retention_days"): "30"}):
+            backend.cleanup()
+
+        session.expire_all()
+        assert (
+            session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "old_state"))
+            is None
+        ), "cleanup() must delete rows with expires_at=NULL older than default_retention_days"
+        assert (
+            session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "fresh_state"))
+            is not None
+        ), "cleanup() must NOT delete rows with expires_at=NULL that are within default_retention_days"
+
+    def test_cleanup_does_not_delete_fresh_null_expires_at_rows(
+        self, session: Session, backend: MetastoreBackend, dag_run: DagRun
+    ):
+        """cleanup() keeps rows with expires_at=NULL when they are within the retention window."""
+        scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
+        backend.set(scope, "recent_key", "some_value", session=session)
+        session.flush()
+        session.commit()
+
+        with conf_vars({("state_store", "default_retention_days"): "30"}):
+            backend.cleanup()
+
+        session.expire_all()
+        assert (
+            session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "recent_key"))
+            is not None
+        )
+
+    def test_cleanup_skips_stale_pass_when_retention_days_is_zero(
+        self, session: Session, backend: MetastoreBackend, dag_run: DagRun
+    ):
+        """When default_retention_days=0, rows with expires_at=NULL are never deleted."""
+        scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
+        backend.set(scope, "old_key", "old_value", session=session)
+        session.flush()
+
+        old_row = session.scalar(
+            select(TaskStateStoreModel).where(
+                TaskStateStoreModel.dag_id == DAG_ID, TaskStateStoreModel.key == "old_key"
+            )
+        )
+        assert old_row is not None
+        old_row.updated_at = timezone.utcnow() - timedelta(days=365)
+        session.flush()
+        session.commit()
+
+        with conf_vars({("state_store", "default_retention_days"): "0"}):
+            backend.cleanup()
+
+        session.expire_all()
+        assert (
+            session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "old_key"))
+            is not None
+        ), "With retention_days=0, rows with expires_at=NULL must never be deleted"
+
+    def test_summary_dry_run_includes_stale_rows(
+        self, session: Session, backend: MetastoreBackend, dag_run: DagRun
+    ):
+        """_summary_dry_run() reports both explicitly-expired and default-retention-stale rows."""
+        scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
+        # Row 1: explicit expires_at in the past
+        backend.set(scope, "explicit_expired", "v1", session=session)
+        session.flush()
+        explicit_row = session.scalar(
+            select(TaskStateStoreModel).where(TaskStateStoreModel.key == "explicit_expired")
+        )
+        assert explicit_row is not None
+        explicit_row.expires_at = timezone.utcnow() - timedelta(hours=1)
+
+        # Row 2: NULL expires_at but very old updated_at
+        backend.set(scope, "stale_key", "v2", session=session)
+        session.flush()
+        stale_row = session.scalar(
+            select(TaskStateStoreModel).where(TaskStateStoreModel.key == "stale_key")
+        )
+        assert stale_row is not None
+        stale_row.updated_at = timezone.utcnow() - timedelta(days=35)
+        session.flush()
+        session.commit()
+
+        with conf_vars({("state_store", "default_retention_days"): "30"}):
+            summary = backend._summary_dry_run()
+
+        expired_keys = {row[4] for row in summary["expired"]}   # key is index 4 in the tuple
+        stale_keys = {row[4] for row in summary.get("stale", [])}
+
+        assert "explicit_expired" in expired_keys
+        assert "stale_key" in stale_keys, (
+            "_summary_dry_run() must report rows with expires_at=NULL older than default_retention_days"
+        )
+
+
     def test_cleanup_removes_expired_rows(self, session: Session, backend: MetastoreBackend, dag_run: DagRun):
         scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
         backend.set(scope, "old_key", "old_value", session=session)

--- a/airflow-core/tests/unit/state/test_metastore.py
+++ b/airflow-core/tests/unit/state/test_metastore.py
@@ -270,7 +270,7 @@ class TestMetastoreBackendTaskScope:
         rows written by the task worker (which send expires_at=None) to accumulate forever.
         """
         scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
-        backend.set(scope, "old_state", "old_value", session=session)   # stale — should be deleted
+        backend.set(scope, "old_state", "old_value", session=session)  # stale — should be deleted
         backend.set(scope, "fresh_state", "fresh_value", session=session)  # recent — should be kept
         session.flush()
 
@@ -291,8 +291,7 @@ class TestMetastoreBackendTaskScope:
 
         session.expire_all()
         assert (
-            session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "old_state"))
-            is None
+            session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "old_state")) is None
         ), "cleanup() must delete rows with expires_at=NULL older than default_retention_days"
         assert (
             session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "fresh_state"))
@@ -361,9 +360,7 @@ class TestMetastoreBackendTaskScope:
         # Row 2: NULL expires_at but very old updated_at
         backend.set(scope, "stale_key", "v2", session=session)
         session.flush()
-        stale_row = session.scalar(
-            select(TaskStateStoreModel).where(TaskStateStoreModel.key == "stale_key")
-        )
+        stale_row = session.scalar(select(TaskStateStoreModel).where(TaskStateStoreModel.key == "stale_key"))
         assert stale_row is not None
         stale_row.updated_at = timezone.utcnow() - timedelta(days=35)
         session.flush()
@@ -372,14 +369,13 @@ class TestMetastoreBackendTaskScope:
         with conf_vars({("state_store", "default_retention_days"): "30"}):
             summary = backend._summary_dry_run()
 
-        expired_keys = {row[4] for row in summary["expired"]}   # key is index 4 in the tuple
+        expired_keys = {row[4] for row in summary["expired"]}  # key is index 4 in the tuple
         stale_keys = {row[4] for row in summary.get("stale", [])}
 
         assert "explicit_expired" in expired_keys
         assert "stale_key" in stale_keys, (
             "_summary_dry_run() must report rows with expires_at=NULL older than default_retention_days"
         )
-
 
     def test_cleanup_removes_expired_rows(self, session: Session, backend: MetastoreBackend, dag_run: DagRun):
         scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)

--- a/airflow-core/tests/unit/state/test_metastore.py
+++ b/airflow-core/tests/unit/state/test_metastore.py
@@ -263,12 +263,7 @@ class TestMetastoreBackendTaskScope:
     def test_cleanup_deletes_stale_rows_by_default_retention(
         self, session: Session, backend: MetastoreBackend, dag_run: DagRun
     ):
-        """cleanup() removes rows with expires_at=NULL that exceed default_retention_days.
-
-        This is the primary regression test for the bug where cleanup() only checked
-        ``expires_at < now()`` and completely ignored ``default_retention_days``, causing
-        rows written by the task worker (which send expires_at=None) to accumulate forever.
-        """
+        """cleanup() removes stale NULL-expires_at rows using default_retention_days."""
         scope = TaskScope(dag_id=DAG_ID, run_id=RUN_ID, task_id=TASK_ID)
         backend.set(scope, "old_state", "old_value", session=session)  # stale — should be deleted
         backend.set(scope, "fresh_state", "fresh_value", session=session)  # recent — should be kept


### PR DESCRIPTION
Closes #68794

## What's the problem?

`MetastoreBackend.cleanup()` only deleted rows where `expires_at < now()`. Task workers always write state with `expires_at=None` (the default), so the configured `[state_store] default_retention_days` (default: 30 days) was silently ignored — those rows accumulated in `task_state_store` forever.

The model's own comment, the CLI description, and the config docs all state that null-`expires_at` rows are cleaned up by a "global `updated_at + default_retention_days` check" — but that check was never implemented.

## Fix

Add a second deletion pass in `cleanup()` and `_summary_dry_run()` that targets rows where `expires_at IS NULL AND updated_at < now - timedelta(days=default_retention_days)`. The pass is skipped when `default_retention_days=0`.

## Changes

- `airflow-core/src/airflow/state/metastore.py` — two-pass cleanup + dry-run
- `airflow-core/src/airflow/cli/commands/state_store_command.py` — dry-run output shows both expired and stale counts separately
- `airflow-core/tests/unit/state/test_metastore.py` — 4 regression tests covering: stale rows deleted, fresh rows kept, retention_days=0 disables the pass, dry-run reports both categories