### PR TITLE
Allow for relative paths to be branched to in a `TaskGroup`

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/branch.py
+++ b/providers/standard/src/airflow/providers/standard/operators/branch.py
@@ -27,6 +27,7 @@ from airflow.providers.standard.version_compat import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
+    from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.types import RuntimeTaskInstanceProtocol
 
 
@@ -62,13 +63,43 @@ class BranchMixIn(SkipMixin):
             branches_to_execute = [branches_to_execute]
 
         for branch in branches_to_execute:
-            if branch in dag.task_group_dict:
-                tg = dag.task_group_dict[branch]
+            # Use the task, dag, and branch to resolve the branch ID
+            resolved = self._resolve_branch_id(task, dag, branch)
+
+            if resolved in dag.task_group_dict:
+                tg = dag.task_group_dict[resolved]
                 root_ids = [root.task_id for root in tg.roots]
                 self.log.info("Expanding task group %s into %s", tg.group_id, root_ids)
                 yield from root_ids
             else:
-                yield branch
+                yield resolved
+
+    def _resolve_branch_id(self, task: BaseOperator, dag: DAG, branch: str) -> str:
+        """
+        Resolve a branch id, allowing relative ids when called from inside a task group. This came logic
+        exists in task-sdk/src/airflow/sdk/bases/branch.py.
+
+        :param task: BaseOperator task
+        :param dag: DAG
+        :param branch: Branch ID
+        :return: Resolved branch ID
+        """
+        # Tasks that are NOT in the TaskGroup take precedence over those that may be in a TaskGroup
+        if branch in dag.task_group_dict or branch in dag.task_dict:
+            return branch
+
+        # Attempt to extract the task_group from the
+        tg = getattr(task, "task_group", None)
+
+        # Create a candidate using a task_group ID and specified branch
+        if tg is not None and tg.group_id and tg.prefix_group_id:
+            candidate = f"{tg.group_id}.{branch}"
+
+            if candidate in dag.task_group_dict or candidate in dag.task_dict:
+                self.log.info("Resolving relative branch %s as %s", branch, candidate)
+                return candidate
+
+        return branch
 
 
 class BaseBranchOperator(BaseOperator, BranchMixIn):

--- a/providers/standard/tests/unit/standard/operators/test_branch_operator.py
+++ b/providers/standard/tests/unit/standard/operators/test_branch_operator.py
@@ -26,6 +26,7 @@ from airflow.models.taskinstance import TaskInstance as TI
 from airflow.providers.standard.operators.branch import BaseBranchOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.utils.skipmixin import XCOM_SKIPMIXIN_FOLLOWED, XCOM_SKIPMIXIN_KEY
+from airflow.sdk import task
 from airflow.timetables.base import DataInterval
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -358,3 +359,52 @@ class TestBranchOperator:
                     assert ti.state == State.NONE
                 else:
                     raise Exception
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="TaskGroup branching via SDK requires Airflow 3+")
+    @pytest.mark.parametrize(
+        "branch_return",
+        [
+            pytest.param("tg.path_a", id="absolute-task-id"),
+            pytest.param("path_a", id="relative-task-id"),
+        ],
+    )
+    def test_branch_inside_task_group(self, dag_maker, branch_return):
+        """
+        Branch inside a TaskGroup must skip non-selected siblings, whether the branch
+        callable returns the fully-qualified task id ("tg.path_a") or the id relative to
+        the enclosing group ("path_a"). Regression test for branching inside TaskGroups.
+        """
+
+        dag_id = f"branch_in_task_group_{branch_return.replace('.', '_')}"
+
+        with dag_maker(
+            dag_id,
+            default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
+            schedule=INTERVAL,
+            serialized=True,
+        ):
+            with TaskGroup(group_id="tg"):
+
+                @task.branch
+                def choose_path():
+                    return branch_return
+
+                path_a = EmptyOperator(task_id="path_a")
+                path_b = EmptyOperator(task_id="path_b")
+                choose_path() >> [path_a, path_b]
+
+        dr = dag_maker.create_dagrun(
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            logical_date=DEFAULT_DATE,
+            data_interval=DataInterval(DEFAULT_DATE, DEFAULT_DATE),
+            triggered_by=DagRunTriggeredByType.TEST,
+        )
+        dag_maker.run_ti("tg.choose_path", dr)
+
+        states = {
+            ti.task_id: ti.state for ti in dag_maker.session.scalars(select(TI).where(TI.dag_id == dag_id))
+        }
+        assert states["tg.choose_path"] == State.SUCCESS
+        assert states["tg.path_a"] is None
+        assert states["tg.path_b"] == State.SKIPPED

--- a/providers/standard/tests/unit/standard/operators/test_branch_operator.py
+++ b/providers/standard/tests/unit/standard/operators/test_branch_operator.py
@@ -26,7 +26,6 @@ from airflow.models.taskinstance import TaskInstance as TI
 from airflow.providers.standard.operators.branch import BaseBranchOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.utils.skipmixin import XCOM_SKIPMIXIN_FOLLOWED, XCOM_SKIPMIXIN_KEY
-from airflow.sdk import task
 from airflow.timetables.base import DataInterval
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -369,16 +368,13 @@ class TestBranchOperator:
         ],
     )
     def test_branch_inside_task_group(self, dag_maker, branch_return):
-        """
-        Branch inside a TaskGroup must skip non-selected siblings, whether the branch
-        callable returns the fully-qualified task id ("tg.path_a") or the id relative to
-        the enclosing group ("path_a"). Regression test for branching inside TaskGroups.
-        """
+        """Branch inside a TaskGroup skips non-selected siblings, for full-qualified or relative paths."""
+        from airflow.sdk import task
 
         dag_id = f"branch_in_task_group_{branch_return.replace('.', '_')}"
 
         with dag_maker(
-            dag_id,
+            dag_id=dag_id,
             default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
             schedule=INTERVAL,
             serialized=True,
@@ -405,6 +401,7 @@ class TestBranchOperator:
         states = {
             ti.task_id: ti.state for ti in dag_maker.session.scalars(select(TI).where(TI.dag_id == dag_id))
         }
+
         assert states["tg.choose_path"] == State.SUCCESS
         assert states["tg.path_a"] is None
         assert states["tg.path_b"] == State.SKIPPED

--- a/task-sdk/src/airflow/sdk/bases/branch.py
+++ b/task-sdk/src/airflow/sdk/bases/branch.py
@@ -27,6 +27,7 @@ from airflow.sdk.bases.skipmixin import SkipMixin
 
 if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
+    from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.types import RuntimeTaskInstanceProtocol
 
 
@@ -61,13 +62,43 @@ class BranchMixIn(SkipMixin):
             branches_to_execute = [branches_to_execute]
 
         for branch in branches_to_execute:
-            if branch in dag.task_group_dict:
-                tg = dag.task_group_dict[branch]
+            # Use the task, dag, and branch to resolve the branch ID
+            resolved = self._resolve_branch_id(task, dag, branch)
+
+            if resolved in dag.task_group_dict:
+                tg = dag.task_group_dict[resolved]
                 root_ids = [root.task_id for root in tg.roots]
                 self.log.info("Expanding task group %s into %s", tg.group_id, root_ids)
                 yield from root_ids
             else:
-                yield branch
+                yield resolved
+
+    def _resolve_branch_id(self, task: BaseOperator, dag: DAG, branch: str) -> str:
+        """
+        Resolve a branch id, allowing relative ids when called from inside a task group. This came logic
+        exists in task-sdk/src/airflow/sdk/bases/branch.py.
+
+        :param task: BaseOperator task
+        :param dag: DAG
+        :param branch: Branch ID
+        :return: Resolved branch ID
+        """
+        # Tasks that are NOT in the TaskGroup take precedence over those that may be in a TaskGroup
+        if branch in dag.task_group_dict or branch in dag.task_dict:
+            return branch
+
+        # Attempt to extract the task_group from the
+        tg = getattr(task, "task_group", None)
+
+        # Create a candidate using a task_group ID and specified branch
+        if tg is not None and tg.group_id and tg.prefix_group_id:
+            candidate = f"{tg.group_id}.{branch}"
+
+            if candidate in dag.task_group_dict or candidate in dag.task_dict:
+                self.log.info("Resolving relative branch %s as %s", branch, candidate)
+                return candidate
+
+        return branch
 
 
 class BaseBranchOperator(BaseOperator, BranchMixIn):

--- a/task-sdk/tests/task_sdk/bases/test_branch.py
+++ b/task-sdk/tests/task_sdk/bases/test_branch.py
@@ -61,10 +61,12 @@ class TestBranchMixIn:
 
         mock_task = MagicMock(spec=BaseOperator)
         mock_task.downstream_list = [downstream1, downstream2]
+        mock_task.task_group = None
         mock_dag = MagicMock(spec=DAG)
         mock_dag.task_ids = ["branch", "down1", "down2"]
         mock_dag.get_task.return_value = downstream1
         mock_dag.task_group_dict = {}
+        mock_dag.task_dict = {"branch": mock_task, "down1": downstream1, "down2": downstream2}
         mock_task.dag = mock_dag
 
         ti = Mock(spec=RuntimeTaskInstanceProtocol, map_index=-1, task=mock_task)
@@ -101,13 +103,35 @@ class TestBranchMixIn:
 
         mock_dag = MagicMock(spec=DAG)
         mock_dag.task_group_dict = {}
+        mock_dag.task_dict = {"regular_task": object()}
         mock_task = MagicMock(spec=BaseOperator)
+        mock_task.task_group = None
         mock_task.dag = mock_dag
 
         ti = Mock(spec=RuntimeTaskInstanceProtocol, task=mock_task)
 
         result = list(mixin._expand_task_group_roots(ti, "regular_task"))
         assert result == ["regular_task"]
+
+    def test_expand_task_group_roots_resolves_relative_id_inside_group(self):
+        """A relative branch ID should resolve to the fully-qualified id ("path_a" -> "tg.path_a")."""
+        mixin = BranchMixIn()
+
+        mock_tg = MagicMock(spec=TaskGroup)
+        mock_tg.group_id = "tg"
+        mock_tg.prefix_group_id = True
+
+        mock_dag = MagicMock(spec=DAG)
+        mock_dag.task_group_dict = {"tg": mock_tg}
+        mock_dag.task_dict = {"tg.choose": object(), "tg.path_a": object()}
+        mock_task = MagicMock(spec=BaseOperator)
+        mock_task.task_group = mock_tg
+        mock_task.dag = mock_dag
+
+        ti = Mock(spec=RuntimeTaskInstanceProtocol, task=mock_task)
+
+        assert list(mixin._expand_task_group_roots(ti, "path_a")) == ["tg.path_a"]
+        assert list(mixin._expand_task_group_roots(ti, "tg.path_a")) == ["tg.path_a"]
 
 
 class TestBaseBranchOperator:


### PR DESCRIPTION
## Description

This PR allows for the proper resolution of relative paths when branching within a Task Group.

For example, if a Task Group `tg` has a branching task and a task `a` and `b`, returning `"a"` from the branching task will result in `a` executing and `b` getting skipped. This is shown in the DAG/screenshot below.

However, if there is both a top-level `a` and an `a` in the Task Group, `a` will be skipped in the Task Group.

related: #65751

## Testing

These changes were tested in two different ways; via unit tests, as well as E2E testing. To execute the unit tests added as part of this PR, the commands below can be run:

```bash
breeze testing providers-tests providers/standard/tests/unit/standard/operators/test_branch_operator.py

breeze testing task-sdk-tests providers/standard/tests/unit/standard/operators/test_branch_operator.py
```

To test these changes E2E, the DAG below was used. To ensure the changes were correct, the behavior expected would be:

- Task `a` in `tg` executes
- Task `tg.c` executes
- Task `e` **inside of `tg`** executes

```python
from airflow.sdk import DAG, task, task_group
from datetime import datetime

with DAG(
    dag_id="fix_task_group_branching",
    start_date=datetime(2026, 1, 1),
    schedule="@once"
) as dag:

    @task_group()
    def tg():

        @task.branch
        def choose_tg_relative():
            return "a"

        @task
        def a():
            # Should execute
            return None

        @task
        def b():
            # Should be skipped
            return None

        choose_tg_relative() >> [a(), b()]

        @task.branch
        def choose_tg_absolute():
            return "tg.c"

        @task
        def c():
            return None

        @task
        def d():
            return None

        choose_tg_absolute() >> [c(), d()]

    tg()


```

<img width="1489" height="1124" alt="image" src="https://github.com/user-attachments/assets/648c1615-df24-4c3d-941a-495c6a0bc9a0" />

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=455e665 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @jroachgolf84** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
