### PR TITLE
UI: Fix Storage tab content overlap

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/StorageLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/StorageLayout.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { Box } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { MdOutlineStorage, MdSyncAlt } from "react-icons/md";
 import { Outlet } from "react-router-dom";
@@ -34,7 +35,9 @@ export const StorageLayout = () => {
           { icon: <MdSyncAlt />, label: translate("tabs.xcom"), value: "xcom" },
         ]}
       />
-      <Outlet />
+      <Box ps={6}>
+        <Outlet />
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
closes: #68754

The details-panel collapse control is absolutely positioned over the left edge of the tab content, so on the Storage tab it covered the start of the Task State Store and XCom Key column. This adds start spacing to the Storage sub-tabs so
their content no longer sits under that control.

The spacing is applied only to the Storage sub-tabs, so Logs, Code, Details, and other task tabs keep their existing layout.

Before:
<img width="1453" height="758" alt="bef1" src="https://github.com/user-attachments/assets/f5045c9a-21ba-4060-b632-50b0caaaf212" />
<img width="1512" height="721" alt="bef2" src="https://github.com/user-attachments/assets/082ff8e1-03b8-471a-ba56-d6c6a2152b50" />


After:
<img width="1507" height="688" alt="af1" src="https://github.com/user-attachments/assets/d6bc4b5f-b445-4506-bdff-019e4095d117" />
<img width="1512" height="593" alt="af2" src="https://github.com/user-attachments/assets/13de0b7e-e81a-48eb-8486-0429a065ab12" />

