### PR TITLE
Rebalance provider test groups to remove the serial monolith bottleneck

### DIFF
--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -530,7 +530,7 @@ GitHub Actions to pass the list of parameters to a command to execute
 | postgres-versions                                       | Which versions of Postgres to use for tests as JSON array                                               | \['12'\]                                 |      |
 | prod-image-build                                        | Whether PROD image build is needed                                                                      | true                                     |      |
 | providers-compatibility-tests-matrix                    | Matrix of providers compatibility tests: (python_version, airflow_version, removed_providers)           | \[{}\]                                   |      |
-| providers-test-types-list-as-strings-in-json            | Which test types should be run for unit tests for providers                                             | Providers Providers\[-google\]           | *    |
+| providers-test-types-list-as-strings-in-json            | Which test types should be run for unit tests for providers (big providers isolated; the rest split into balanced chunks — see note below) | Providers\[amazon\] Providers\[a,b,c\] Providers\[d,e,f\] | *    |
 | pyproject-toml-changed                                  | When pyproject.toml changed in the PR.                                                                  | false                                    |      |
 | python-versions                                         | List of python versions to use for that build                                                           | \['3.10'\]                               |      |
 | python-versions-list-as-string                          | Which versions of MySQL to use for tests as space-separated string                                      | 3.10                                     | *    |
@@ -572,6 +572,21 @@ or when new Hook class is added), we do not need to run full tests.
 That's why we do not base our `full tests needed` decision on changes in dependency files that are generated
 from the `provider.yaml` files, but on `generated/provider_dependencies.json` and `pyproject.toml` files being
 modified. This can be overridden by setting `full tests needed` label in the PR.
+
+[2] Note on how `providers-test-types-list-as-strings-in-json` is split.
+
+The provider DB tests run as parallel test-type *groups* (`breeze testing providers-tests
+--run-in-parallel`), but each group runs **without xdist** — its tests run serially. To keep all
+parallel slots busy, the big "all other providers" group is **not** emitted as one
+`Providers[-amazon,celery,google]` monolith (which would be the serial bottleneck while the other slots
+idle); instead every provider except the few isolated big ones (`amazon`, `celery`, `google`) is split
+into `NUMBER_OF_PARALLEL_PROVIDER_SLICES` balanced chunks (`Providers[a,b,c] Providers[d,e,f] …`). The
+union of the isolated groups and the chunks always covers exactly the same providers, so nothing is
+dropped.
+
+`standard` used to be isolated too (its `PythonVirtualenvOperator` tests dominated the suite), but those
+tests are now DB-free and parallelize under xdist, so `standard` is no longer a slow group and is left
+in the chunks.
 
 ## Committer vs. Non-committer PRs
 

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -849,6 +849,11 @@ NUMBER_OF_LOW_DEP_SLICES = 5
 # Number of slices for core test types (splitting reduces memory per xdist collection)
 NUMBER_OF_CORE_SLICES = 2
 
+# Number of chunks the big "all other providers" group is split into for the parallel
+# (non-xdist) provider DB test run, so the parallel slots stay balanced instead of one
+# serial group becoming the bottleneck. Tunable.
+NUMBER_OF_PARALLEL_PROVIDER_SLICES = 4
+
 # Milestone Tag Assistant configuration
 # Labels indicating a bug fix PR that should have a milestone
 MILESTONE_BUG_LABELS: frozenset[str] = frozenset({"kind:bug", "type:bug-fix"})

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -47,6 +47,7 @@ from airflow_breeze.global_constants import (
     KIND_VERSION,
     NUMBER_OF_CORE_SLICES,
     NUMBER_OF_LOW_DEP_SLICES,
+    NUMBER_OF_PARALLEL_PROVIDER_SLICES,
     PROVIDERS_COMPATIBILITY_TESTS_MATRIX,
     PUBLIC_AMD_RUNNERS,
     PUBLIC_ARM_RUNNERS,
@@ -1267,9 +1268,13 @@ class SelectiveChecks:
         In case of celery tests we want to isolate them from the rest, because they seem to be hanging
         infrequently when running together with other tests
 
+        NOTE: ``standard`` used to be here too (its PythonVirtualenvOperator tests dominated the
+        suite), but those tests are now DB-free and parallelize under xdist, so ``standard`` is no
+        longer a slow group and is left in the rebalanced "all other providers" chunks.
+
         :param current_test_types: The set of test types to run
         """
-        long_tests = ["amazon", "celery", "google", "standard"]
+        long_tests = ["amazon", "celery", "google"]
         for original_test_type in tuple(current_test_types):
             if original_test_type == "Providers":
                 current_test_types.remove(original_test_type)
@@ -1287,6 +1292,36 @@ class SelectiveChecks:
                             current_test_types.add(f"Providers[{long_test}]")
                             provider_tests_to_run.remove(long_test)
                     current_test_types.add(f"Providers[{','.join(provider_tests_to_run)}]")
+
+    def _rebalance_negated_provider_tests(self, current_test_types: set[str]) -> None:
+        """Split the big negated "all other providers" group into balanced chunks.
+
+        The provider DB tests run with ``--run-in-parallel`` but WITHOUT xdist, so each
+        parallel slot runs a whole test type serially. A single
+        ``Providers[-amazon,celery,google]`` group bundles ~all providers and
+        becomes the serial bottleneck while the other parallel slots go idle once their
+        (smaller) groups finish. Splitting it into ``NUMBER_OF_PARALLEL_PROVIDER_SLICES``
+        explicit, evenly-sized chunks keeps every slot busy.
+
+        The chunks are enumerated from the same source as the negation
+        (``_get_individual_providers_list``, which is already platform-filtered) minus the
+        negated providers, so the union of the chunks covers *exactly* the same providers
+        the negation would have — no provider's tests are dropped or duplicated.
+        """
+        for negation in [tt for tt in current_test_types if tt.startswith("Providers[-")]:
+            excluded = {p for p in negation[len("Providers[-") : -1].split(",") if p}
+            remaining = sorted(
+                provider_id
+                for provider_id in (
+                    tt[len("Providers[") : -1] for tt in self._get_individual_providers_list()
+                )
+                if provider_id not in excluded
+            )
+            if len(remaining) <= NUMBER_OF_PARALLEL_PROVIDER_SLICES:
+                continue
+            current_test_types.discard(negation)
+            for chunk in _split_list(remaining, NUMBER_OF_PARALLEL_PROVIDER_SLICES):
+                current_test_types.add(f"Providers[{','.join(chunk)}]")
 
     @cached_property
     def core_test_types_list_as_strings_in_json(self) -> str | None:
@@ -1361,6 +1396,9 @@ class SelectiveChecks:
                     test_types_to_remove.add(test_type)
             current_test_types = current_test_types - test_types_to_remove
         self._extract_long_provider_tests(current_test_types)
+        # Split the big "all other providers" group into balanced chunks so the parallel
+        # (non-xdist) provider DB run keeps every slot busy instead of one serial monolith.
+        self._rebalance_negated_provider_tests(current_test_types)
         self._filter_platform_excluded_test_types(current_test_types)
         return json.dumps(_get_test_list_as_json([sorted(current_test_types)]))
 

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -31,6 +31,7 @@ from airflow_breeze.global_constants import (
     DEFAULT_PYTHON_MAJOR_MINOR_VERSION,
     NUMBER_OF_CORE_SLICES,
     NUMBER_OF_LOW_DEP_SLICES,
+    NUMBER_OF_PARALLEL_PROVIDER_SLICES,
     PROVIDERS_COMPATIBILITY_TESTS_MATRIX,
     PUBLIC_AMD_RUNNERS,
     GithubEvents,
@@ -80,14 +81,24 @@ ALL_CI_SELECTIVE_TEST_TYPES_AS_JSON = json.dumps(
     _get_test_list_as_json(_split_list(sorted(ALL_CI_SELECTIVE_TEST_TYPES.split()), NUMBER_OF_CORE_SLICES))
 )
 
+# The four big providers run as isolated groups; every *other* provider is split into
+# NUMBER_OF_PARALLEL_PROVIDER_SLICES balanced chunks (the parallel provider DB run has no
+# xdist, so a single "all other providers" group would be the serial bottleneck). Built the
+# same way the production code does so the union still covers every provider.
+_LONG_PROVIDER_TEST_TYPES = ["Providers[amazon]", "Providers[celery]", "Providers[google]"]
+_REBALANCED_OTHER_PROVIDER_TEST_TYPES = [
+    f"Providers[{','.join(chunk)}]"
+    for chunk in _split_list(
+        sorted(
+            provider
+            for provider in get_available_distributions(include_not_ready=True)
+            if provider not in ("amazon", "celery", "google")
+        ),
+        NUMBER_OF_PARALLEL_PROVIDER_SLICES,
+    )
+]
 ALL_PROVIDERS_SELECTIVE_TEST_TYPES_AS_JSON = json.dumps(
-    [
-        {
-            "description": "-amazon,celer...standard",
-            "test_types": "Providers[-amazon,celery,google,standard] "
-            "Providers[amazon] Providers[celery] Providers[google] Providers[standard]",
-        }
-    ]
+    _get_test_list_as_json([sorted(_LONG_PROVIDER_TEST_TYPES + _REBALANCED_OTHER_PROVIDER_TEST_TYPES)])
 )
 
 LIST_OF_ALL_PROVIDER_TESTS = [
@@ -2408,13 +2419,12 @@ def test_expected_output_push(
                 "providers-test-types-list-as-strings-in-json": json.dumps(
                     [
                         {
-                            "description": "amazon...standard",
+                            "description": "amazon...google",
                             "test_types": "Providers[amazon] Providers[apache.cassandra,"
                             "apache.kafka,cncf.kubernetes,common.compat,common.messaging,common.sql,databricks,facebook,"
                             "hashicorp,http,microsoft.azure,microsoft.mssql,mongo,mysql,"
-                            "openlineage,oracle,postgres,presto,salesforce,samba,sftp,ssh,trino] "
-                            "Providers[google] "
-                            "Providers[standard]",
+                            "openlineage,oracle,postgres,presto,salesforce,samba,sftp,ssh,standard,trino] "
+                            "Providers[google]",
                         }
                     ]
                 ),
@@ -2501,10 +2511,10 @@ def test_expected_output_push(
                 "providers-test-types-list-as-strings-in-json": json.dumps(
                     [
                         {
-                            "description": "amazon...standard",
+                            "description": "amazon...google",
                             "test_types": "Providers[amazon] Providers[common.compat,common.io,common.sql,"
                             "databricks,dbt.cloud,ftp,jdbc,microsoft.azure,microsoft.mssql,mysql,openlineage,oracle,"
-                            "postgres,sftp,snowflake,trino] Providers[google] Providers[standard]",
+                            "postgres,sftp,snowflake,standard,trino] Providers[google]",
                         }
                     ]
                 ),
@@ -3972,3 +3982,28 @@ def test_helm_test_kubernetes_versions(
         default_branch="main",
     )
     assert_outputs_are_printed(expected_outputs, str(stderr))
+
+
+def test_full_provider_tests_rebalanced_and_cover_all_providers():
+    """The parallel (non-xdist) provider DB run must split providers into balanced groups
+    whose union still covers every provider: no monolithic "all other providers" negation
+    group, and nothing dropped or duplicated."""
+    sc = SelectiveChecks(
+        files=(),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+        pr_labels=("full tests needed",),
+        default_branch="main",
+    )
+    test_types = json.loads(sc.providers_test_types_list_as_strings_in_json)[0]["test_types"].split()
+    # The monolithic "Providers[-amazon,celery,google]" negation must be split away.
+    assert not any(tt.startswith("Providers[-") for tt in test_types), test_types
+    # Union of every group covers exactly all providers (no coverage gap, no duplicate).
+    covered: set[str] = set()
+    for tt in test_types:
+        covered |= {p for p in tt[len("Providers[") : -1].split(",") if p}
+    all_providers = {tt[len("Providers[") : -1] for tt in sc._get_individual_providers_list()}
+    assert covered == all_providers, sorted(all_providers ^ covered)
+    # The "all other providers" pool is split into the configured number of balanced chunks.
+    chunk_groups = [tt for tt in test_types if "," in tt[len("Providers[") : -1]]
+    assert len(chunk_groups) == NUMBER_OF_PARALLEL_PROVIDER_SLICES, test_types


### PR DESCRIPTION
The provider DB tests run as parallel test-type groups (`breeze testing
providers-tests --run-in-parallel`) but **without xdist** — each group runs
serially. The "all other providers" group bundled ~all providers into one
`Providers[-amazon,celery,google,standard]` type and became the **serial
bottleneck**: it ran ~15 min while the other parallel slots went idle after a few
minutes (one slot doing all the work on a 4-core runner).

This splits that group into `NUMBER_OF_PARALLEL_PROVIDER_SLICES` **balanced
chunks** so every parallel slot stays busy. The chunks are enumerated from the
same source as the negation (`_get_individual_providers_list`), so their union
covers **exactly** the same providers — a test asserts no provider is dropped or
duplicated, and a coverage-invariant test guards it.

It also drops `standard` from the isolated "long" providers: its
`PythonVirtualenvOperator` tests used to dominate the suite, but they are now
DB-free and parallelize under xdist (#68533), so `standard` is no longer a slow
group and belongs in the rebalanced chunks.

No change to *which* tests run — only how they're grouped for the parallel run.
Estimated ~4-5 min faster per provider DB cell on the existing free runner
(no bigger runner / no extra DB containers).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
