### PR TITLE
Reduce canary schedule frequency (AMD 4→2/day, ARM 8→2/day)

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -26,10 +26,11 @@
 name: Tests (AMD)
 on:  # yamllint disable-line rule:truthy
   schedule:
-    # Mirror of the previous AMD canary cron from before the AMD/ARM split (PR #66348),
-    # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
-    # canaries don't compete for runners at exactly the same minute.
-    - cron: '58 1,7,13,19 * * *'
+    # AMD canary runs 2x/day (01:58, 13:58), interleaved with ARM's 2x/day (07:28, 19:28)
+    # in `ci-arm.yml` so a full-matrix canary still runs roughly every ~6h (alternating
+    # architecture) while halving the scheduled AMD compute. The `:58` vs ARM's `:28`
+    # offset keeps the two from competing for runners at exactly the same minute.
+    - cron: '58 1,13 * * *'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -26,7 +26,11 @@
 name: Tests (ARM)
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: '28 1,3,7,9,13,15,19,21 * * *'
+    # ARM canary runs 2x/day (07:28, 19:28), interleaved with AMD's 2x/day (01:58, 13:58)
+    # in `ci-amd.yml` so a full-matrix canary still runs roughly every ~6h (alternating
+    # architecture). The `:28` vs AMD's `:58` offset keeps the two from competing for
+    # runners at exactly the same minute.
+    - cron: '28 7,19 * * *'
   push:
     # Post-merge pushes to release-prep / providers branches run on both
     # AMD and ARM (the matching block lives in the other wrapper too —

--- a/scripts/ci/prek/check_ci_workflows_in_sync.py
+++ b/scripts/ci/prek/check_ci_workflows_in_sync.py
@@ -107,14 +107,19 @@ LINE_RULES: list[tuple[str, str]] = [
 # file and must NOT appear in the other. The blocks are stripped before
 # diffing so they don't show up as drift.
 ARM_ONLY_BLOCK = """  schedule:
-    - cron: '28 1,3,7,9,13,15,19,21 * * *'
+    # ARM canary runs 2x/day (07:28, 19:28), interleaved with AMD's 2x/day (01:58, 13:58)
+    # in `ci-amd.yml` so a full-matrix canary still runs roughly every ~6h (alternating
+    # architecture). The `:28` vs AMD's `:58` offset keeps the two from competing for
+    # runners at exactly the same minute.
+    - cron: '28 7,19 * * *'
 """
 
 AMD_ONLY_BLOCK = """  schedule:
-    # Mirror of the previous AMD canary cron from before the AMD/ARM split (PR #66348),
-    # offset by 30 min from ARM's `:28` slot in `ci-arm.yml` so the two scheduled
-    # canaries don't compete for runners at exactly the same minute.
-    - cron: '58 1,7,13,19 * * *'
+    # AMD canary runs 2x/day (01:58, 13:58), interleaved with ARM's 2x/day (07:28, 19:28)
+    # in `ci-arm.yml` so a full-matrix canary still runs roughly every ~6h (alternating
+    # architecture) while halving the scheduled AMD compute. The `:58` vs ARM's `:28`
+    # offset keeps the two from competing for runners at exactly the same minute.
+    - cron: '58 1,13 * * *'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The scheduled **canary** runs the full matrix on all versions and is by far the
most expensive run type. AMD ran **4×/day** and ARM **8×/day**.

This takes both to **2×/day**, **interleaved** so a full-matrix canary still
runs roughly every ~6 h, alternating architecture:

- AMD: `58 1,13 * * *` → 01:58, 13:58
- ARM: `28 7,19 * * *` → 07:28, 19:28

**Savings:** halving AMD alone is ~**1,900 compute-h / 2 weeks (~6 % of AMD CI)**;
cutting ARM 8→2/day removes **75 %** of the ARM canary schedule. It also relieves
runner-pool queuing — each canary is the heaviest job-flood (~269 jobs).

**Trade-off (latency, not correctness):** the canary is the "trust earned on
`main`" backstop. Interleaving keeps a ~6 h effective cadence for arch-agnostic
regressions; an *architecture-specific* regression now has up to a ~12 h
detection gap (each arch runs 2×/day) instead of ~6 h / ~3 h. Cron-only change,
no test logic touched.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
