### PR TITLE
Fix task state store custom expiry datetime missing timezone on save

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/TaskStateStore/TaskStateStoreModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskStateStore/TaskStateStoreModal.tsx
@@ -117,6 +117,17 @@ export const TaskStateStoreModal = ({
     }),
   );
 
+  const getExpiresAt = () => {
+    if (expiresAt === "never") {
+      return null;
+    }
+    if (expiresAt === "custom") {
+      return dayjs.tz(customExpiresAt, selectedTimezone).toISOString();
+    }
+
+    return "default";
+  };
+
   const onSave = () => {
     setTaskStore({
       dagId,
@@ -124,7 +135,7 @@ export const TaskStateStoreModal = ({
       key: isEditMode ? (storeKey ?? "") : key,
       mapIndex,
       requestBody: {
-        expires_at: expiresAt === "never" ? null : expiresAt === "custom" ? customExpiresAt : "default",
+        expires_at: getExpiresAt(),
         value: JSON.parse(value),
       },
       taskId,


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

closes: https://github.com/apache/airflow/issues/68747

### What

Saving a task state store entry with a custom expiry date fails with a 422. The `datetime-local` input returns a bare `YYYY-MM-DDTHH:mm` string, but the API requires a timezone-aware datetime.

Error was:

```python
{
    "detail": [
        {
            "type": "timezone_aware",
            "loc": [
                "body",
                "expires_at",
                "datetime"
            ],
            "msg": "Input should have timezone info",
            "input": "2026-07-22T10:25"
        },
        {
            "type": "literal_error",
            "loc": [
                "body",
                "expires_at",
                "literal['default']"
            ],
            "msg": "Input should be 'default'",
            "input": "2026-07-22T10:25",
            "ctx": {
                "expected": "'default'"
            }
        }
    ]
}

```

### Current behaviour

Editing an existing entry auto-selects "Custom" expiry (the API always returns a resolved absolute datetime). Clicking Save sends `"2026-07-22T10:25"` and the API rejects it with `Input should have timezone info`.

### Proposed change

Convert the picker value to a timezone-aware ISO string via `dayjs.tz(customExpiresAt, selectedTimezone).toISOString()` before sending. Extracted into a `getExpiresAt()` helper to replace the nested ternary in `onSave`. Applies to both add and edit flows.

Same flow works fine now:
<img width="1721" height="903" alt="image" src="https://github.com/user-attachments/assets/aad3aa0d-15ac-479d-b457-f6e185fc1a60" />


```shell
curl 'http://localhost:28080/api/v2/dags/example_task_state_store/dagRuns/manual__2026-06-22T05%3A13%3A57.081200%2B00%3A00/taskInstances/run_job/state-store/abcd?map_index=-1' \
  -X 'PUT' \
  -H 'Accept: application/json' \
  -H 'Accept-Language: en-GB,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  --data-raw '{"expires_at":"2026-07-22T05:14:00.000Z","value":1000}'
```


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
