### PR TITLE
Fix potentially misleading comment on task state store model

### DIFF
--- a/airflow-core/src/airflow/models/task_state_store.py
+++ b/airflow-core/src/airflow/models/task_state_store.py
@@ -50,11 +50,10 @@ class TaskStateStoreModel(Base):
 
     value: Mapped[str] = mapped_column(Text().with_variant(MEDIUMTEXT, "mysql"), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(UtcDateTime, default=timezone.utcnow, nullable=False)
-    # Optional override for early expiry. When set, garbage collection deletes this row when
-    # expires_at < now(), even if updated_at is recent. NULL means no early expiry —
-    # the row is still cleaned up by the global `updated_at + default_retention_days` check.
-    # Populated via task_state_store.set(retention_days=N) for keys that should expire differently
-    # than the deployment wide default.
+    # Absolute UTC timestamp which denotes expiry of this row. CLI cleanup will delete this row once
+    # (WHERE expires_at < now()). Computed at write time from the explicit
+    # ``retention`` argument or the global ``default_retention_days`` config.
+    # NULL means the row is never deleted by cleanup.
     expires_at: Mapped[datetime | None] = mapped_column(UtcDateTime, nullable=True)
 
     __table_args__ = (


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

The `expires_at` field in `TaskStateStoreModel` had a comment describing a "global updated_at + default_retention_days check" in `cleanup()` that was never implemented or was leftover from earlier. This led to a false bug report claiming cleanup ignores default_retention_days 🤷🏽: https://github.com/apache/airflow/issues/68794 but in reality the SDK computes `expires_at` at write time, so the existing `WHERE expires_at < now` pass handles retention correctly. The comment is updated to reflect actual behavior.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
