### PR TITLE
Propagate rendered_map_index through the reschedule state path

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -166,6 +166,7 @@ class TIRescheduleStatePayload(StrictBaseModel):
     ]
     reschedule_date: UtcDateTime
     end_date: UtcDateTime
+    rendered_map_index: str | None = None
 
 
 class TIAwaitingInputStatePayload(StrictBaseModel):

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -789,7 +789,12 @@ def _create_ti_state_update_query_and_update_state(
             query = TI.duration_expression_update(ti_patch_payload.end_date, query, session.bind)
         # clear the next_method and next_kwargs so that none of the retries pick them up
         updated_state = TaskInstanceState.UP_FOR_RESCHEDULE
-        query = query.values(state=updated_state, next_method=None, next_kwargs=None)
+        query = query.values(
+            state=updated_state,
+            next_method=None,
+            next_kwargs=None,
+            _rendered_map_index=ti_patch_payload.rendered_map_index,
+        )
     else:
         raise ValueError(f"Unexpected Payload Type {type(ti_patch_payload)}")
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -45,6 +45,7 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
     AddAwaitingInputStatePayload,
     AddConnectionTestEndpoint,
     AddPartitionDateField,
+    AddRenderedMapIndexToReschedulePayload,
     AddRetryPolicyFields,
     AddTaskAndAssetStateStoreEndpoints,
     AddTaskInstanceQueueField,
@@ -64,6 +65,7 @@ bundle = VersionBundle(
         AddTeamNameField,
         AddTaskAndAssetStateStoreEndpoints,
         AddAssetsByAliasEndpoint,
+        AddRenderedMapIndexToReschedulePayload,
         AddPartitionDateField,
     ),
     Version(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
@@ -29,6 +29,7 @@ from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
     DagRun,
     TaskInstance,
     TIAwaitingInputStatePayload,
+    TIRescheduleStatePayload,
     TIRetryStatePayload,
     TIRunContext,
 )
@@ -141,3 +142,13 @@ class AddPartitionDateField(VersionChange):
         """Strip ``partition_date`` from the nested ``dag_run`` payload for older clients."""
         if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
             response.body["dag_run"].pop("partition_date", None)
+
+
+class AddRenderedMapIndexToReschedulePayload(VersionChange):
+    """Add ``rendered_map_index`` field to ``TIRescheduleStatePayload``."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(TIRescheduleStatePayload).field("rendered_map_index").didnt_exist,
+    )

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -317,6 +317,7 @@ class TIRescheduleStatePayload(BaseModel):
     state: Annotated[Literal["up_for_reschedule"] | None, Field(title="State")] = "up_for_reschedule"
     reschedule_date: Annotated[AwareDatetime, Field(title="Reschedule Date")]
     end_date: Annotated[AwareDatetime, Field(title="End Date")]
+    rendered_map_index: Annotated[str | None, Field(title="Rendered Map Index")] = None
 
 
 class TIRetryStatePayload(BaseModel):

--- a/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
+++ b/task-sdk/src/airflow/sdk/execution_time/schema/schema.json
@@ -3306,6 +3306,18 @@
           "title": "End Date",
           "type": "string"
         },
+        "rendered_map_index": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rendered Map Index"
+        },
         "type": {
           "const": "RescheduleTask",
           "default": "RescheduleTask",

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1496,6 +1496,7 @@ class ActivitySubprocess(WatchedSubprocess):
             self.client.task_instances.defer(self.id, msg)
             self._terminal_state = TaskInstanceState.DEFERRED
         elif isinstance(msg, RescheduleTask):
+            self._rendered_map_index = msg.rendered_map_index
             self.client.task_instances.reschedule(self.id, msg)
             self._terminal_state = TaskInstanceState.UP_FOR_RESCHEDULE
         elif isinstance(msg, AwaitInputTask):
@@ -1727,6 +1728,7 @@ class ActivitySubprocess(WatchedSubprocess):
             self._rendered_map_index = msg.rendered_map_index
             self._send_terminal_state_msg(msg)
         elif isinstance(msg, RescheduleTask):
+            self._rendered_map_index = msg.rendered_map_index
             self._send_terminal_state_msg(msg)
         elif isinstance(msg, SkipDownstreamTasks):
             self.client.task_instances.skip_downstream_tasks(self.id, msg)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1628,7 +1628,9 @@ def run(
         log.info("::group::Post Execute")
         log.info("Rescheduling task, marking task as UP_FOR_RESCHEDULE")
         msg = RescheduleTask(
-            reschedule_date=reschedule.reschedule_date, end_date=datetime.now(tz=timezone.utc)
+            reschedule_date=reschedule.reschedule_date,
+            end_date=datetime.now(tz=timezone.utc),
+            rendered_map_index=ti.rendered_map_index,
         )
         state = TaskInstanceState.UP_FOR_RESCHEDULE
     except (AirflowFailException, AirflowSensorTimeout) as e:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -540,6 +540,45 @@ def test_run_signals_fail_closed_when_failure_terminal_send_fails(create_runtime
     assert runtime_ti._terminal_state_send_failed is True
 
 
+@time_machine.travel("2025-01-01 00:00:00", tick=False)
+def test_run_reschedule_includes_rendered_map_index(create_runtime_ti, mock_supervisor_comms):
+    """Regression test for #67521.
+
+    When a mapped sensor sets ``context["map_index_template"]`` and then raises
+    ``AirflowRescheduleException``, the ``RescheduleTask`` message sent to the
+    supervisor must carry ``rendered_map_index`` so the UI can show the human-readable
+    label on each up_for_reschedule row — not the raw integer map_index.
+    """
+    from datetime import datetime, timezone as dt_timezone
+
+    from airflow.sdk.exceptions import AirflowRescheduleException
+
+    reschedule_date = datetime(2025, 1, 1, 0, 1, 0, tzinfo=dt_timezone.utc)
+
+    def _execute_with_reschedule(context):
+        context["map_index_template"] = "item-{{ ti.map_index }}"
+        raise AirflowRescheduleException(reschedule_date=reschedule_date)
+
+    from airflow.sdk.bases.operator import BaseOperator
+
+    class _ReschedulingSensor(BaseOperator):
+        def execute(self, context):
+            _execute_with_reschedule(context)
+
+    task = _ReschedulingSensor(task_id="sensor")
+    ti = create_runtime_ti(dag_id="test_reschedule_map_index", task=task)
+
+    run(ti, context=ti.get_template_context(), log=mock.MagicMock())
+
+    assert ti.state == TaskInstanceState.UP_FOR_RESCHEDULE
+
+    send_call = mock_supervisor_comms.send.call_args
+    msg = send_call.kwargs.get("msg") or send_call[1].get("msg") or send_call[0][0]
+    assert isinstance(msg, RescheduleTask), f"Expected RescheduleTask, got {type(msg)}"
+    assert msg.reschedule_date == reschedule_date
+    assert msg.rendered_map_index is not None
+
+
 @pytest.mark.parametrize(
     ("state_when_send_fails", "should_fail_closed"),
     [

--- a/ts-sdk/src/generated/supervisor.ts
+++ b/ts-sdk/src/generated/supervisor.ts
@@ -507,11 +507,12 @@ export type Type61 = "PutVariable";
 export type State5 = "up_for_reschedule" | null;
 export type RescheduleDate = string;
 export type EndDate5 = string;
+export type RenderedMapIndex2 = string | null;
 export type Type62 = "RescheduleTask";
 export type Type63 = "ResendLoggingFD";
 export type State6 = "up_for_retry" | null;
 export type EndDate6 = string;
-export type RenderedMapIndex2 = string | null;
+export type RenderedMapIndex3 = string | null;
 export type RetryDelaySeconds = number | null;
 export type RetryReason = string | null;
 export type Type64 = "RetryTask";
@@ -524,7 +525,7 @@ export type Uri9 = string;
 export type Key16 = string;
 export type Type67 = "SetAssetStateStoreByUri";
 export type Type68 = "SetRenderedFields";
-export type RenderedMapIndex3 = string;
+export type RenderedMapIndex4 = string;
 export type Type69 = "SetRenderedMapIndex";
 export type TiId8 = string;
 export type Key17 = string;
@@ -552,7 +553,7 @@ export type OutletEvents =
       [k: string]: unknown;
     }[]
   | null;
-export type RenderedMapIndex4 = string | null;
+export type RenderedMapIndex5 = string | null;
 export type Type74 = "SucceedTask";
 export type Count1 = number;
 export type Type75 = "TICount";
@@ -565,7 +566,7 @@ export type Type77 = "TaskRescheduleStartDate";
 export type State8 = "failed" | "skipped" | "removed";
 export type EndDate8 = string | null;
 export type Type78 = "TaskState";
-export type RenderedMapIndex5 = string | null;
+export type RenderedMapIndex6 = string | null;
 export type Type79 = "TaskStateStoreResult";
 export type Type80 = "TaskStatesResult";
 export type LogicalDate6 = string | null;
@@ -1572,6 +1573,7 @@ export interface RescheduleTask {
   state?: State5;
   reschedule_date: RescheduleDate;
   end_date: EndDate5;
+  rendered_map_index?: RenderedMapIndex2;
   type?: Type62;
 }
 /**
@@ -1590,7 +1592,7 @@ export interface ResendLoggingFD {
 export interface RetryTask {
   state?: State6;
   end_date: EndDate6;
-  rendered_map_index?: RenderedMapIndex2;
+  rendered_map_index?: RenderedMapIndex3;
   retry_delay_seconds?: RetryDelaySeconds;
   retry_reason?: RetryReason;
   type?: Type64;
@@ -1643,7 +1645,7 @@ export interface RenderedFields {
  * via the `definition` "SetRenderedMapIndex".
  */
 export interface SetRenderedMapIndex {
-  rendered_map_index: RenderedMapIndex3;
+  rendered_map_index: RenderedMapIndex4;
   type?: Type69;
 }
 /**
@@ -1706,7 +1708,7 @@ export interface SucceedTask {
   end_date: EndDate7;
   task_outlets?: TaskOutlets;
   outlet_events?: OutletEvents;
-  rendered_map_index?: RenderedMapIndex4;
+  rendered_map_index?: RenderedMapIndex5;
   type?: Type74;
 }
 /**
@@ -1751,7 +1753,7 @@ export interface TaskState {
   state: State8;
   end_date?: EndDate8;
   type?: Type78;
-  rendered_map_index?: RenderedMapIndex5;
+  rendered_map_index?: RenderedMapIndex6;
 }
 /**
  * Response to GetTaskStateStore; wraps the generated API response for supervisor to worker comms.


### PR DESCRIPTION
## What's the problem?

`TIRescheduleStatePayload` was the only intermediate-state payload missing `rendered_map_index`. As a result, when a mapped sensor sets `context["map_index_template"]` inside its `poke()` body and then raises `AirflowRescheduleException` to reschedule, the `rendered_map_index` value is never persisted to the database. The UI displays the raw integer `map_index` (e.g. `0`, `1`) on every `up_for_reschedule` row instead of the human-readable rendered label.

The final successful poke **does** show the rendered label (because the success path already serialises `rendered_map_index` via `TaskState`), so the column appears intermittently.

Fixes #67521

## Root cause

The full data path for a reschedule is:

```
sensor.poke()
  ↓ raises AirflowRescheduleException
task_runner.run()
  ↓ except AirflowRescheduleException: builds RescheduleTask(…)   ← missing rendered_map_index
supervisor._handle_requests()
  ↓ client.task_instances.reschedule(id, msg)                      ← msg has no rendered_map_index
execution API PATCH /task-instances/{id}
  ↓ TIRescheduleStatePayload                                       ← model had no field
  ↓ query.values(state=…, next_method=None, next_kwargs=None)      ← _rendered_map_index never written
```

All other intermediate states (`TIDeferredStatePayload`, `TIAwaitingInputStatePayload`, `TIRetryStatePayload`, `TITerminalStatePayload`, `TISuccessStatePayload`) already carry `rendered_map_index`. The reschedule path was the only one left out.

Note: `_render_map_index()` **is** called in the `except Exception:` block (line ~1576 of `task_runner.py`) before re-raising `AirflowRescheduleException`, so `ti.rendered_map_index` is correctly populated by the time we build `RescheduleTask`. We only need to pass it through.

## Changes

| File | Change |
|------|--------|
| `airflow-core/…/datamodels/taskinstance.py` | Add `rendered_map_index: str \| None = None` to `TIRescheduleStatePayload` (server-side model) |
| `task-sdk/…/api/datamodels/_generated.py` | Same field on the client-side generated model |
| `task-sdk/…/execution_time/task_runner.py` | Pass `rendered_map_index=ti.rendered_map_index` when constructing `RescheduleTask` |
| `task-sdk/…/execution_time/supervisor.py` | Set `self._rendered_map_index = msg.rendered_map_index` in both `RescheduleTask` handler branches |
| `airflow-core/…/routes/task_instances.py` | Include `_rendered_map_index=ti_patch_payload.rendered_map_index` in the `UP_FOR_RESCHEDULE` query |
| `airflow-core/…/versions/v2026_06_30.py` | Cadwyn migration `AddRenderedMapIndexToReschedulePayload` |
| `airflow-core/…/versions/__init__.py` | Register the migration in the `2026-06-30` version bundle |
| `task-sdk/tests/…/test_task_runner.py` | Regression test `test_run_reschedule_includes_rendered_map_index` |

## Testing

New regression test verifies that when a sensor sets `map_index_template` and rescheduled, the `RescheduleTask` message carries `rendered_map_index`:

```python
def test_run_reschedule_includes_rendered_map_index(create_runtime_ti, mock_supervisor_comms):
    ...
    assert msg.rendered_map_index is not None
```
