### PR TITLE
Fix incompat of request.form with anyio 4.14.0 in aws auth manager

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
@@ -18,8 +18,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from starlette.datastructures import FormData
 
 import anyio
 from fastapi import HTTPException, Request, status
@@ -101,7 +104,7 @@ def login_callback(request: Request):
     url = conf.get("api", "base_url", fallback="/")
     token = get_auth_manager().generate_jwt(user)
 
-    form_data = anyio.from_thread.run(request.form)
+    form_data = anyio.from_thread.run(_fetch_form, request)
     relay_state = form_data["RelayState"]
 
     if relay_state == "login-redirect":
@@ -151,12 +154,16 @@ def _prepare_request(request: Request) -> dict:
         "get_data": request.query_params,
         "post_data": {},
     }
-    form_data = anyio.from_thread.run(request.form)
+    form_data = anyio.from_thread.run(_fetch_form, request)
     if "SAMLResponse" in form_data:
         data["post_data"]["SAMLResponse"] = form_data["SAMLResponse"]
     if "RelayState" in form_data:
         data["post_data"]["RelayState"] = form_data["RelayState"]
     return data
+
+
+async def _fetch_form(request: Request) -> FormData:
+    return await request.form()
 
 
 def _get_idp_data() -> dict:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Fixes broken CI as seen in https://github.com/apache/airflow/actions/runs/27941132600/job/82677618222, its due to this diff:

```diff
< anyio==4.13.0
---
> anyio==4.14.0
```

anyio 4.14.0 tightened the type stub for `from_thread.run` to require a callable returning a plain Coroutine. Starlette's `request.form` returns `AwaitableOrContextManager[FormData]` which is awaitable but not a Coroutine, so mypy now rejects it.

Introduce a `small _fetch_form` async helper that wraps `await request.form()` so `from_thread.run` receives a properly-typed coroutine function, without changing the sync handler architecture.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
