### PR TITLE
Remove stray instruction on example

### DIFF
--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -263,9 +263,6 @@ task-sdk/tests/coordinators/java/             # Python-side unit and integration
 
 # Run a specific test class
 ./gradlew :sdk:test --tests "org.apache.airflow.sdk.execution.CommTest"
-
-# Smoke-check the example bundle
-./gradlew :example:bundle
 ```
 
 For the Python coordinator, use Breeze (never run pytest on the host directly):


### PR DESCRIPTION
This command does not work anymore. We also have a separate section on building the example, so this is not needed.