### PR TITLE
Fix race condition on sort param when returning dagRuns

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -718,7 +718,7 @@ class SortParam(BaseParam[list[str]]):
         )
 
         def inner(order_by: list[str] = _order_by_query) -> SortParam:
-            return self.set_value(order_by)
+            return SortParam(self.allowed_attrs, self.model, self.to_replace).set_value(order_by)
 
         return inner
 

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -165,6 +165,27 @@ class TestSortParam:
         resolved = param.get_resolved_columns()
         assert [name for name, _col, _desc in resolved] == ["import_error_id"]
 
+    def test_dynamic_depends_returns_independent_instances(self):
+        """Each call to the inner closure must produce a separate SortParam instance.
+
+        Two concurrent requests with different order_by values must not share state —
+        a mutation on one must not affect the other.
+        """
+        sort_param = SortParam(["id", "run_id", "logical_date"], DagRun, {"dag_run_id": "run_id"})
+        inner = sort_param.dynamic_depends(default="id")
+
+        instance_a = inner(order_by=["logical_date"])
+        instance_b = inner(order_by=["run_id"])
+
+        assert instance_a is not instance_b
+        assert instance_a.value == ["logical_date"]
+        assert instance_b.value == ["run_id"]
+        # Resolving one must not affect the other.
+        cols_a = [name for name, _col, _desc in instance_a.get_resolved_columns()]
+        cols_b = [name for name, _col, _desc in instance_b.get_resolved_columns()]
+        assert cols_a[0] == "logical_date"
+        assert cols_b[0] == "run_id"
+
 
 def _compile(statement):
     return str(statement.compile(compile_kwargs={"literal_binds": True})).lower()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
I have a use case where I continously poll the GET: /api/v2/dags/{dag_id}/dagRuns endpoint with a sort parameter defined. The response of the endpoint is fine, but once in a couple of hours, it will return the wrong ordering.

I traced it to this change in the PR, essentially, the instantiated object state is mutated if there is a race condition between two requests with different sort parameters, leading to incorrect results for one of the requests.

An example to reproduce:

```python
session = requests.Session()
## AIRFLOW_BASE_URL is internal airflow hostname + /api/v2
def fetch_runs(order_by, limit=5):
    url = f"{AIRFLOW_BASE_URL}/dags/{DAG_ID}/dagRuns"
    resp = session.get(url, params={"order_by": order_by, "limit": limit}, headers=auth_headers)
    print(f"order_by='{order_by}', limit={limit} (HTTP {resp.status_code})")
    runs = resp.json().get("dag_runs", [])
    for r in runs:
        print(f" dag_run_id={r['dag_run_id']}  logical_date={r['logical_date']}  state={r['state']}")
    return runs

a = fetch_runs("-id")

for _ in range(10000):
    assert a = fetch_runs("-id")
```

This raises AssertionError after a couple thousand iterations. And the print statements show the returned results have suddenly changed (older dagRuns being returned, probably because default sort args got used in the race condition). The airflow instance is accessed by other users, so I suspect the race is happening between different user's requests. Mostly it would go unnoticed if people were using default sort params, but using descending sort makes this surface.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
