### PR TITLE
Exclude agent tooling (.agents, agents.md) from source release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,8 @@ CONTRIBUTING.rst export-ignore
 ISSUE_TRIAGE_PROCESS.rst export-ignore
 
 AGENTS.md export-ignore
+agents.md export-ignore
+.agents export-ignore
 SKILLS.md export-ignore
 CLAUDE.md export-ignore
 


### PR DESCRIPTION
The provider/airflow source release tarball is built with `git archive`, which honors `export-ignore` gitattributes. The existing `AGENTS.md export-ignore` rule is unanchored and case-folds on case-insensitive filesystems (macOS, `core.ignorecase=true`), so it also matches the lowercase `.agents/skills/magpie-setup/agents.md`.

As a result the source tarball is **not byte-reproducible across hosts**: a Linux release manager ships that file, while a macOS verifier's rebuild drops it — breaking the reproducible-build verification step in `dev/README_RELEASE_PROVIDERS.md`. I hit exactly this while verifying the 2026-06-16 providers RC (all 31 wheels/sdists matched byte-for-byte; only the source tarball differed, by this one file).

This makes the exclusion explicit and case-independent so the archive is deterministic on any filesystem, and keeps agent/AI tooling out of the source release alongside the existing `AGENTS.md` / `CLAUDE.md` exclusions.

Verified: `git archive` now yields 0 `.agents/` entries under both `core.ignorecase=true` and `false`, while the existing `AGENTS.md` exclusion is unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)