### PR TITLE
Fix airflowctl connections create-defaults command 

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -739,13 +739,21 @@ class CommandFactory:
                 # Handle delete operation which returns a string of the deleted entity name
                 if isinstance(obj, str):
                     return {"operation": api_operation_name, "entity": obj}
+                # Handle operations that return None (e.g., create_defaults)
+                if obj is None:
+                    return {"operation": api_operation_name, "status": "success"}
                 return obj
 
             def check_operation_and_collect_list_of_dict(dict_obj: dict) -> list:
                 """Check if the object is a nested dictionary and collect list of dictionaries."""
+                # Handle non-dict inputs
+                if not isinstance(dict_obj, dict):
+                    return [dict_obj]
 
                 def is_dict_nested(obj: dict) -> bool:
                     """Check if the object is a nested dictionary."""
+                    if not isinstance(obj, dict) or obj is None:
+                        return False
                     return any(isinstance(i, dict) or isinstance(i, list) for i in obj.values())
 
                 if is_dict_nested(dict_obj):

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -889,13 +889,21 @@ class CommandFactory:
                 # Handle delete operation which returns a string of the deleted entity name
                 if isinstance(obj, str):
                     return {"operation": api_operation_name, "entity": obj}
+                # Handle operations that return None (e.g., create_defaults)
+                if obj is None:
+                    return {"operation": api_operation_name, "status": "success"}
                 return obj
 
             def check_operation_and_collect_list_of_dict(dict_obj: dict) -> list:
                 """Check if the object is a nested dictionary and collect list of dictionaries."""
+                # Handle non-dict inputs
+                if not isinstance(dict_obj, dict):
+                    return [dict_obj]
 
                 def is_dict_nested(obj: dict) -> bool:
                     """Check if the object is a nested dictionary."""
+                    if not isinstance(obj, dict) or obj is None:
+                        return False
                     return any(isinstance(i, dict) or isinstance(i, list) for i in obj.values())
 
                 if is_dict_nested(dict_obj):


### PR DESCRIPTION
 `airflowctl connections create-defaults` shows 
 
```
Traceback (most recent call last):
  File "/usr/python/bin/airflowctl", line 10, in <module>
    sys.exit(main())
  File "/opt/airflow/airflow-ctl/src/airflowctl/__main__.py", line 34, in main
    safe_call_command(args.func, args=args)
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 77, in safe_call_command
    function(args)
  File "/opt/airflow/airflow-ctl/src/airflowctl/api/client.py", line 531, in wrapper
    return func(*args, api_client=api_client, **kwargs)
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 772, in _get_func
    data=check_operation_and_collect_list_of_dict(
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 751, in check_operation_and_collect_list_of_dict
    if is_dict_nested(dict_obj):
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 749, in is_dict_nested
    return any(isinstance(i, dict) or isinstance(i, list) for i in obj.values())
AttributeError: 'NoneType' object has no attribute 'values'

```
Now (after fixed): 
Create-default connections  and  shows 
`[{"operation": "create_defaults", "status": "success"}]`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (copilot)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
