### PR TITLE
Fix AwsBatchExecutor test_try_adopt_task_instances after TaskInstanceDTO hostname requirement

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
+++ b/providers/amazon/tests/unit/amazon/aws/executors/batch/test_batch_executor.py
@@ -805,6 +805,7 @@ class TestAwsBatchExecutor:
             task.task_id = f"task_{idx}"
             task.dag_id = "test_dag"
             task.run_id = "test_run"
+            task.hostname = "host"
             task.map_index = -1
             task.pool_slots = 1
             task.priority_weight = 1


### PR DESCRIPTION
set `task.hostname` on the orphaned-task mocks so the DTO validates.

**Verified locally** (breeze, py3.10): `test_try_adopt_task_instances` now passes (`1 passed`); previously failed with ValidationError

related: #68027