### PR TITLE
Document what happens when task without inlets / outlets accesses `asset_state_store`

### DIFF
--- a/airflow-core/docs/core-concepts/asset-state-store.rst
+++ b/airflow-core/docs/core-concepts/asset-state-store.rst
@@ -37,6 +37,8 @@ When is ``asset_state_store`` available?
 
 When using asset state store within a task, ``context["asset_state_store"]`` is populated for **concrete** :class:`~airflow.sdk.definitions.asset.Asset` inlets and outlets. A task must declare at least one concrete inlet or outlet for ``asset_state_store`` to contain any entries.
 
+If a task has no inlets or outlets and accesses ``context["asset_state_store"]``, a ``KeyError`` is raised at runtime. Declare at least one asset inlet or outlet on the task to use asset state store.
+
 Accessing asset state store using ``context``
 ---------------------------------------------
 

--- a/airflow-core/docs/core-concepts/asset-state-store.rst
+++ b/airflow-core/docs/core-concepts/asset-state-store.rst
@@ -39,6 +39,28 @@ When using asset state store within a task, ``context["asset_state_store"]`` is 
 
 If a task has no inlets or outlets and accesses ``context["asset_state_store"]``, a ``KeyError`` is raised at runtime. Declare at least one asset inlet or outlet on the task to use asset state store.
 
+This applies to both the ``@asset`` pattern and the ``@task`` pattern:
+
+.. code-block:: python
+
+    from airflow.sdk import Asset, DAG, asset, task
+
+    my_asset = Asset("my_data", uri="s3://bucket/my_data")
+
+
+    # @asset DAGs implicitly declare the asset as an outlet
+    @asset
+    def my_asset_dag(**context):
+        context["asset_state_store"].set("watermark", "2024-06-01")
+
+
+    # @task within a @dag requires explicit inlets or outlets
+    with DAG("example", schedule=None):
+
+        @task(outlets=[my_asset])
+        def my_task(**context):
+            context["asset_state_store"].set("watermark", "2024-06-01")
+
 Accessing asset state store using ``context``
 ---------------------------------------------
 

--- a/airflow-core/docs/core-concepts/asset-state-store.rst
+++ b/airflow-core/docs/core-concepts/asset-state-store.rst
@@ -48,7 +48,7 @@ This applies to both the ``@asset`` pattern and the ``@task`` pattern:
     my_asset = Asset("my_data", uri="s3://bucket/my_data")
 
 
-    # @asset DAGs implicitly declare the asset as an outlet
+    # @asset Dags implicitly declare the asset as an outlet
     @asset
     def my_asset_dag(**context):
         context["asset_state_store"].set("watermark", "2024-06-01")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---

### What

When a task has no inlets or outlets and accesses `context["asset_state_store"]`, it raises a plain `KeyError: 'asset_state_store'` at runtime. The key is only added to the context dict when the task declares at least one asset-typed inlet or outlet and this is intentional, since `AssetStateStoreAccessors.__init__` fires a `SUPERVISOR_COMMS.send(GetAssetsByAlias)` comms roundtrip for `AssetAlias` inlets, and we do not want that cost on every task unconditionally.

### Alternatives I considered

- **Always add `asset_state_store` unconditionally**, dropped it because it triggers the `GetAssetsByAlias` comms call for every task regardless of whether it uses assets.
- **Catch `KeyError("asset_state_store")` in the task runner** felt too specific and fragile.

### Proposed change

Document the behavior in `asset-state-store.rst`: if a task has no inlets or outlets and accesses `context["asset_state_store"]`, a `KeyError` is raised. The fix for users is to declare at least one asset inlet or outlet.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
