### PR TITLE
Refactor Snowflake provider tests to remove legacy unittest imports

### DIFF
--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import unittest
 import uuid
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
@@ -619,9 +618,7 @@ class TestSnowflakeSqlApiHook:
                 "private_key_content": base64_encoded_encrypted_private_key,
             },
         }
-        with unittest.mock.patch.dict(
-            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-        ):
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()):
             hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
             private_key = hook.get_private_key()
             assert private_key is not None
@@ -648,9 +645,7 @@ class TestSnowflakeSqlApiHook:
         }
         hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
         with (
-            unittest.mock.patch.dict(
-                "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-            ),
+            mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()),
             pytest.raises(
                 ValueError,
                 match="The private_key_file and private_key_content extra fields are mutually "
@@ -675,9 +670,7 @@ class TestSnowflakeSqlApiHook:
                 "private_key_file": str(encrypted_temporary_private_key),
             },
         }
-        with unittest.mock.patch.dict(
-            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-        ):
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()):
             hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
             private_key = hook.get_private_key()
             assert private_key is not None
@@ -698,24 +691,18 @@ class TestSnowflakeSqlApiHook:
                 "private_key_file": str(unencrypted_temporary_private_key),
             },
         }
-        with unittest.mock.patch.dict(
-            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-        ):
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()):
             hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
             private_key = hook.get_private_key()
             assert private_key is not None
         connection_kwargs["password"] = ""
-        with unittest.mock.patch.dict(
-            "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-        ):
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()):
             hook = SnowflakeSqlApiHook(snowflake_conn_id="test_conn")
             private_key = hook.get_private_key()
             assert private_key is not None
         connection_kwargs["password"] = _PASSWORD
         with (
-            unittest.mock.patch.dict(
-                "os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-            ),
+            mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()),
             pytest.raises(TypeError, match="Password was given but private key is not encrypted."),
         ):
             SnowflakeSqlApiHook(snowflake_conn_id="test_conn").get_private_key()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->


This PR refactors the test file for the Snowflake SQL API hook to fully align with Airflow's pytest migration guidelines. 

Specifically, it:
- Removes the unused `import unittest` statement
- Cleans up legacy references from `unittest.mock.patch.dict` to `mock.patch.dict` (since `from unittest import mock` is already imported)

### Modified Files:
- `providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py`

---

### Tests Run

We executed the Snowflake provider tests inside Breeze:
```bash
breeze run pytest providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_sql_api.py -xvs
```
---
Result: All 70 tests passed successfully.
 <!--

##### Was generative AI tooling used to co-author this PR?


<!--

If generative AI tooling has been used in the process of authoring this PR, please

change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".

-->


- [ X] Yes — Antigravity (Gemini 3.5 Flash)

Generated-by: Antigravity (Gemini 3.5 Flash) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


<!--

Generated-by: Antigravity (Gemini 3.5 Flash) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---


* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.

* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.

* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

