### PR TITLE
[Serialization] Fix: Serialize DagParam like a normal Param.

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -60,7 +60,7 @@ from airflow.sdk.definitions.asset import (
 from airflow.sdk.definitions.deadline import DeadlineAlert
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.operator_resources import Resources
-from airflow.sdk.definitions.param import Param, ParamsDict
+from airflow.sdk.definitions.param import DagParam, Param, ParamsDict
 from airflow.sdk.definitions.taskgroup import MappedTaskGroup, TaskGroup
 from airflow.sdk.definitions.xcom_arg import serialize_xcom_arg
 from airflow.sdk.execution_time.context import OutletEventAccessor, OutletEventAccessors
@@ -579,6 +579,10 @@ class BaseSerialization:
             return TaskGroupSerialization.serialize_task_group(var)
         elif isinstance(var, Param):
             return cls._encode(cls._serialize_param(var), type_=DAT.PARAM)
+        elif isinstance(var, DagParam):
+            return cls._encode(
+                cls._serialize_param(Param(default=var._default, source="dag")), type_=DAT.PARAM
+            )
         elif isinstance(var, XComArg):
             return cls._encode(serialize_xcom_arg(var), type_=DAT.XCOM_REF)
         elif isinstance(var, LazySelectSequence):

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -4768,6 +4768,47 @@ class TestMappedOperatorSerializationAndClientDefaults:
         assert deserialized_task.partial_kwargs["retry_delay"] == timedelta(seconds=600)
         assert deserialized_task.partial_kwargs["owner"] == "custom_owner"
 
+    def test_partial_kwargs_dag_param_serialization_is_stable(self):
+        """DagParam passed to a mapped task's partial() must serialize to a stable representation.
+
+        Without dedicated handling the serializer falls back to ``str(var)`` which embeds the
+        object's memory address, producing a different serialized Dag on every parse.
+        """
+        from airflow.sdk import task
+
+        with DAG(dag_id="test_dag_param_partial") as dag:
+
+            @task
+            def add(value):
+                return value
+
+            add.partial(value=dag.param("p", "default_value")).expand(value=[1, 2, 3])
+
+        serialized_dag = DagSerialization.to_dict(dag)
+        mapped_task = serialized_dag["dag"]["tasks"][0]["__var"]
+        serialized_value = mapped_task["partial_kwargs"]["op_kwargs"]["__var"]["value"]
+
+        # The DagParam must encode to its stable structure, not a repr with a memory address.
+        assert serialized_value["__type"] == "param"
+        assert serialized_value["__var"] == {
+            "__class": "airflow.sdk.definitions.param.Param",
+            "description": None,
+            "source": "dag",
+            "default": "default_value",
+            "schema": {"__var": {}, "__type": "dict"},
+        }
+
+        # Serializing the same Dag twice must produce identical output.
+        assert DagSerialization.to_dict(dag) == serialized_dag
+
+        # And the round-trip restores a real DagParam bound to the Dag.
+        deserialized_dag = DagSerialization.from_dict(serialized_dag)
+        deserialized_task = deserialized_dag.get_task("add")
+        restored_param = deserialized_task.partial_kwargs["op_kwargs"]["value"]
+        assert isinstance(restored_param, SerializedParam)
+        assert restored_param.value == "default_value"
+        assert restored_param.source == "dag"
+
 
 @pytest.mark.parametrize(
     ("callbacks", "expected_has_flags", "absent_keys"),


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
When we use a DagParam as a kwarg to `partial()` of a dynamically mapped task, the DagParam will be serialized with its memory address. This leads to a DAG version inflation, as the memory address is not stable. 

This is a simple repro: 
```python
from __future__ import annotations

import json

from airflow.sdk import DAG
from airflow.sdk import task
from airflow.serialization.definitions.param import SerializedParam
from airflow.serialization.serialized_objects import DagSerialization

if __name__ == "__main__":
    with DAG(dag_id="repro_dagparam") as dag:

        @task
        def add(value):
            return value

        @task
        def do(something):
            return something

        do(dag.param("some", "some_default_val"))

        add.partial(value=dag.param("p", "p_default_val")).expand(value=[1, 2, 3])

    ser = DagSerialization.to_dict(dag)
    mapped = ser["dag"]["tasks"][1]["__var"]
    print(json.dumps(mapped.get("partial_kwargs"), indent=2, default=str))
    print("ROUNDTRIP:")
    deser = DagSerialization.from_dict(ser)
    t = deser.get_task("add")
    print(type(t.partial_kwargs.get("op_kwargs")), t.partial_kwargs.get("op_kwargs"))
```


This PR fixes this issue by serializing the DagParam as a normal Param. This behavior matches the serialization that using the `DagParam` as a normal arg does (like in the `do` task - it ends up being serialized as a `Param`). 

 __Note: I am not 100% sure that this is the correct fix as I'm not super deep in the DAG serialization code, but it seems to work.__
 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [] Yes (please specify the tool below)
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
