### PR TITLE
fix(celery): cache Celery apps to stop per-send memory leak in CeleryExecutor

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -117,9 +117,21 @@ def _get_celery_app() -> Celery:
     return Celery(celery_app_name, config_source=get_celery_configuration())
 
 
+# Cache of Celery apps keyed by their resolved (team-suffixed) name. See create_celery_app.
+_celery_app_cache: dict[str | None, Celery] = {}
+
+
 def create_celery_app(team_conf: ExecutorConf | AirflowConfigParser) -> Celery:
     """
-    Create a Celery app, supporting team-specific configuration.
+    Create (or reuse) a Celery app, supporting team-specific configuration.
+
+    Apps are cached by their resolved (team-suffixed) name and reused on subsequent
+    calls. ``create_celery_app`` is invoked on every task send via
+    ``send_workload_to_executor``; when sends run in the main scheduler process
+    (a single task per heartbeat, or ``sync_parallelism == 1``) rebuilding the app
+    each time leaks memory through repeated Celery task-class creation and broker
+    connections. The cache is module-level, so the ``ProcessPoolExecutor`` send
+    workers each keep their own (initially empty) cache and discard it on exit.
 
     :param team_conf: ExecutorConf instance with team-specific configuration, or global conf
     :return: Celery app instance
@@ -139,6 +151,9 @@ def create_celery_app(team_conf: ExecutorConf | AirflowConfigParser) -> Celery:
     if team_name:
         celery_app_name = f"{celery_app_name}_{team_name}"
 
+    if celery_app_name in _celery_app_cache:
+        return _celery_app_cache[celery_app_name]
+
     config = get_default_celery_config(team_conf)
 
     # Apply user-provided celery_config_options on top of team config.
@@ -157,6 +172,7 @@ def create_celery_app(team_conf: ExecutorConf | AirflowConfigParser) -> Celery:
     if not AIRFLOW_V_3_0_PLUS:
         celery_app.task(name="execute_command")(execute_command)
 
+    _celery_app_cache[celery_app_name] = celery_app
     return celery_app
 
 
@@ -388,8 +404,11 @@ def send_workload_to_executor(
     """
     Send workload to executor (serialized and executed as a Celery task).
 
-    This function is called in ProcessPoolExecutor subprocesses. To avoid pickling issues with
-    team-specific Celery apps, we pass the team_name and reconstruct the Celery app here.
+    This runs either in a ``ProcessPoolExecutor`` subprocess (when several tasks are sent
+    in parallel) or directly in the calling process (a single task per heartbeat, or
+    ``sync_parallelism == 1``). In both cases the Celery app is rebuilt from configuration
+    here to avoid pickling team-specific apps across processes; ``create_celery_app`` caches
+    the app by name so the in-process path does not recreate it on every send.
     """
     key, args, queue, team_name = workload_tuple
 

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -743,10 +743,12 @@ class TestMultiTeamCeleryExecutor:
     """Test multi-team functionality in CeleryExecutor."""
 
     def setup_method(self) -> None:
+        celery_executor_utils._celery_app_cache.clear()
         db.clear_db_runs()
         db.clear_db_jobs()
 
     def teardown_method(self) -> None:
+        celery_executor_utils._celery_app_cache.clear()
         db.clear_db_runs()
         db.clear_db_jobs()
 
@@ -1258,6 +1260,13 @@ class TestAmqpsSslConfig:
 class TestCreateCeleryAppTeamIsolation:
     """Tests for create_celery_app() multi-team config isolation."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_celery_app_cache(self):
+        """Reset the create_celery_app cache so apps built in one test don't leak into the next."""
+        celery_executor_utils._celery_app_cache.clear()
+        yield
+        celery_executor_utils._celery_app_cache.clear()
+
     @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="ExecutorConf requires Airflow 3.2+")
     def test_custom_celery_config_options_applied(self):
         """User-provided celery_config_options (non-default) should be merged into team config."""
@@ -1330,3 +1339,22 @@ class TestCreateCeleryAppTeamIsolation:
         team_conf = ExecutorConf(team_name="team_beta")
         celery_app = celery_executor_utils.create_celery_app(team_conf)
         assert "team_beta" in celery_app.main
+
+    def test_app_is_cached_and_reused(self):
+        """Repeated create_celery_app() calls for the same name reuse one app.
+
+        This guards against the per-send app rebuild that leaks memory in the
+        scheduler when sends run in-process (single task per heartbeat or
+        sync_parallelism == 1).
+        """
+        first = celery_executor_utils.create_celery_app(conf)
+        second = celery_executor_utils.create_celery_app(conf)
+        assert first is second
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="ExecutorConf requires Airflow 3.2+")
+    def test_distinct_teams_get_distinct_apps(self):
+        """Different team names must not share a cached app (broker isolation)."""
+        app_alpha = celery_executor_utils.create_celery_app(ExecutorConf(team_name="team_alpha"))
+        app_beta = celery_executor_utils.create_celery_app(ExecutorConf(team_name="team_beta"))
+        assert app_alpha is not app_beta
+        assert app_alpha is celery_executor_utils.create_celery_app(ExecutorConf(team_name="team_alpha"))


### PR DESCRIPTION
## What

`create_celery_app()` is now cached by the resolved (team-aware) app name, so a
Celery app is built once per process and reused on subsequent sends instead of
being rebuilt on every workload send.

## Why / Root cause

`CeleryExecutor._send_workloads_to_celery()` has two paths:

- **Parallel path** — sends are fanned out across a `ProcessPoolExecutor`. Each
  subprocess builds its own Celery app and is then torn down, so a fresh app per
  send is harmless.
- **In-process hot path** — when there is a single task per heartbeat, or
  `sync_parallelism == 1`, `send_workload_to_executor()` runs **directly in the
  long-lived scheduler/executor process**.

`send_workload_to_executor()` calls `create_celery_app()` on every invocation.
On the in-process path this meant a brand-new Celery app (with new broker /
result-backend connection pools) was constructed for **every single send** and
never released — a steady memory leak in a long-running scheduler process.

PR #60675 introduced the team-aware app construction under the assumption that
sends always happen in throwaway subprocesses. That assumption does not hold for
the in-process path.

## Why this matters in practice (Helm / Kubernetes)

Since #58733, the official Helm chart derives
`celery.sync_parallelism` from the scheduler's CPU limit (millicores rounded up
to whole cores). Any scheduler with a CPU limit of **≤ 1000m (≤ 1 core)** —
a very common configuration — therefore renders `sync_parallelism = 1`, which
makes `_send_workloads_to_celery()` take the **in-process hot path on every
send**. These deployments hit the leak continuously.

## Fix

- Add a module-level `_celery_app_cache: dict[str, Celery]` keyed by the
  resolved (team-suffixed) app name.
- In `create_celery_app()`, return the cached app if one exists for that name,
  otherwise build it and store it before returning.

Celery config is static per app-name per process, so reuse is safe for both call
sites:
- Subprocesses still build their app once (cache is per-process).
- The in-process path stops recreating the app on every send, eliminating the leak.

## Testing

- `test_app_is_cached_and_reused` — `create_celery_app(conf)` returns the same
  instance on repeated calls.
- `test_distinct_teams_get_distinct_apps` (3.2+) — different teams get distinct
  apps, same team reuses one app.
- A `_clear_celery_app_cache` autouse fixture isolates the cache within
  `TestCreateCeleryAppTeamIsolation`, and `TestMultiTeamCeleryExecutor`
  setup/teardown clear it too (the cache, being keyed by app name, otherwise
  leaks built apps across tests). Both clears are required — verified empirically:
  removing them makes `test_team_specific_broker_not_overwritten` fail.

## Notes

The regression tests fail when the production cache change is reverted.

## Reproducing
<details>
  <summary>details</summary>

  - apache-airflow-providers-celery==3.20.0, CeleryExecutor, [sync_parallelism](https://airflow.apache.org/docs/apache-airflow-providers-celery/stable/configurations-ref.html#sync-parallelism)=1
  - test_dag
    ``` 
    def test(**context):
        time.sleep(1)
  
    dag = DAG(
        dag_id='test',
        schedule=timedelta(minutes=1),
        start_date=datetime(2026, 6, 1),
        catchup=False,
        max_active_runs=1,
    )
    
    with dag:
        # 50 tasks on Celery worker
        for i in range(50):
            PythonOperator(
                task_id=f"celery_{i}",
                python_callable=test,
            )
    
        # 50 tasks on Triggerer (deferrable async sleep)
        for i in range(50):
            WaitSensor(
                task_id=f"triggerer_{i}",
                time_to_wait=timedelta(seconds=1),
                deferrable=True,
            )
    ```
   - let it run for some time, it leaks

---

##### Was generative AI tooling used to co-author this PR?
- [X] Yes
Generated-by: [Claude Opus 4.8] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
<!--

-->

