### PR TITLE
Fix timezone-dependent symlink test in TestFileProcessorHandler

### DIFF
--- a/airflow-core/tests/unit/utils/log/test_file_processor_handler.py
+++ b/airflow-core/tests/unit/utils/log/test_file_processor_handler.py
@@ -77,13 +77,13 @@ class TestFileProcessorHandler:
 
         link = os.path.join(self.base_log_folder, "latest")
 
-        with time_machine.travel(date1, tick=False):
+        with time_machine.travel(f"{date1} 00:00:00+00:00", tick=False):
             handler.set_context(filename=os.path.join(self.dag_dir, "log1"))
             assert os.path.islink(link)
             assert os.path.basename(os.path.realpath(link)) == date1
             assert os.path.exists(os.path.join(link, "log1"))
 
-        with time_machine.travel(date2, tick=False):
+        with time_machine.travel(f"{date2} 00:00:00+00:00", tick=False):
             handler.set_context(filename=os.path.join(self.dag_dir, "log2"))
             assert os.path.islink(link)
             assert os.path.basename(os.path.realpath(link)) == date2


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

On running the unit tests, `test_symlink_latest_log_directory` was failing for me because of a timezone issue (I'm in BST/UTC+1).

The tests compute the expected log-directory name from `timezone.utcnow()` but then travel to that date with a naive date string: `time_machine.travel("2026-06-24", ...)`. `time_machine` interprets a naive datetime as local time, so under a positive UTC offset, the travel target lands on the previous day in UTC (`2026-06-24 00:00 BST` == `2026-06-23 23:00 UTC`). The handler then builds its directory from `utcnow()` (`2026-06-23`) while the assertion expects `2026-06-24`, producing:
> AssertionError: assert '2026-06-23' == '2026-06-24'

This is a latent test bug that surfaces for any contributor in a positive-offset timezone.

The fix makes the `time_machine.travel` targets explicit UTC instants (`f"{date} 00:00:00+00:00"`) so the day no longer shifts with the host timezone. Behaviour under test is unchanged; only the test's time control is made timezone-independent.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: GitHub Copilot (Claude Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
