### PR TITLE
Add deferrable support for Cloud Functions invocation

### DIFF
--- a/providers/google/docs/operators/cloud/functions.rst
+++ b/providers/google/docs/operators/cloud/functions.rst
@@ -179,6 +179,16 @@ See Google Cloud API documentation `to create a function
 <https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/create>`_.
 
 
+.. _howto/operator:CloudFunctionInvokeOperator:
+
+CloudFunctionInvokeOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the operator to invoke a deployed Cloud Function via its HTTP Trigger URL.
+
+For parameter definition, take a look at
+:class:`~airflow.providers.google.cloud.operators.functions.CloudFunctionInvokeOperator`.
+
 Reference
 ---------
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/functions.py
@@ -500,6 +500,7 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
 
         return result
 
+
 class CloudFunctionInvokeOperator(GoogleCloudBaseOperator):
     """
     Invokes a deployed Cloud Function via its HTTP Trigger URL.
@@ -561,9 +562,9 @@ class CloudFunctionInvokeOperator(GoogleCloudBaseOperator):
             "function_name": self.function_id,
         }
 
-    def _get_id_token(self, hook, audience: str) -> str:
+    def _get_id_token(self, hook: CloudFunctionsHook, audience: str) -> str:
         import google.auth.transport.requests
-        from google.oauth2 import service_account, id_token
+        from google.oauth2 import id_token, service_account
 
         credentials = hook.get_credentials()
         request = google.auth.transport.requests.Request()
@@ -573,23 +574,27 @@ class CloudFunctionInvokeOperator(GoogleCloudBaseOperator):
                 jwt_creds = credentials.with_target_audience(audience)
                 jwt_creds.refresh(request)
                 return jwt_creds.token
-            elif hasattr(credentials, "with_claims"):
+            if hasattr(credentials, "with_claims"):
                 jwt_creds = credentials.with_claims({"aud": audience})
                 jwt_creds.refresh(request)
                 return jwt_creds.token
 
         try:
             from google.auth import compute_engine
+
             if isinstance(credentials, compute_engine.Credentials):
                 from google.auth.compute_engine import _metadata
+
                 return _metadata.get_service_account_id_token(request, audience=audience)
         except ImportError:
             pass
-            
+
         try:
             from google.auth import impersonated
+
             if isinstance(credentials, impersonated.Credentials):
                 from google.auth.impersonated import IDTokenCredentials
+
                 id_token_creds = IDTokenCredentials(
                     credentials,
                     target_principal=credentials.target_principal,
@@ -604,9 +609,10 @@ class CloudFunctionInvokeOperator(GoogleCloudBaseOperator):
         # Fallback to fetch_id_token (ADC)
         return id_token.fetch_id_token(request, audience)
 
-    def execute(self, context: Context):
-        from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
+    def execute(self, context: Context) -> Any:
         import requests
+
+        from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
 
         hook = CloudFunctionsHook(
             api_version=self.api_version,
@@ -615,19 +621,21 @@ class CloudFunctionInvokeOperator(GoogleCloudBaseOperator):
         )
         project_id = self.project_id or hook.project_id
         self.log.info("Fetching function details for %s.", self.function_id)
-        function = hook.get_function(name=f"projects/{project_id}/locations/{self.location}/functions/{self.function_id}")
-        
+        function = hook.get_function(
+            name=f"projects/{project_id}/locations/{self.location}/functions/{self.function_id}"
+        )
+
         url = None
         if "httpsTrigger" in function and "url" in function["httpsTrigger"]:
             url = function["httpsTrigger"]["url"]
         elif "serviceConfig" in function and "uri" in function["serviceConfig"]:
             url = function["serviceConfig"]["uri"]
-            
+
         if not url:
             raise AirflowException(f"Function {self.function_id} does not have an HTTP trigger URL.")
 
         self.log.info("Function HTTP URL: %s", url)
-        
+
         # Get ID token for authentication
         token = self._get_id_token(hook, url)
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}

--- a/providers/google/src/airflow/providers/google/cloud/operators/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/functions.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from googleapiclient.errors import HttpError
 
+from airflow.configuration import conf
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.hooks.functions import CloudFunctionsHook
 from airflow.providers.google.cloud.links.cloud_functions import (
@@ -498,3 +499,166 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
             )
 
         return result
+
+class CloudFunctionInvokeOperator(GoogleCloudBaseOperator):
+    """
+    Invokes a deployed Cloud Function via its HTTP Trigger URL.
+
+    Unlike CloudFunctionInvokeFunctionOperator which uses the testing-only `functions.call` API,
+    this operator makes an authenticated HTTP request to the function's URL. This makes it
+    suitable for production workloads.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudFunctionInvokeOperator`
+
+    :param function_id: ID of the function to be called
+    :param input_data: Input to be passed to the function
+    :param location: The location where the function is located.
+    :param project_id: Optional, Google Cloud Project project_id where the function belongs.
+    :param deferrable: Run operator in the deferrable mode
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+    """
+
+    template_fields: Sequence[str] = (
+        "function_id",
+        "input_data",
+        "location",
+        "project_id",
+        "impersonation_chain",
+    )
+    operator_extra_links = (CloudFunctionsDetailsLink(),)
+
+    def __init__(
+        self,
+        *,
+        function_id: str,
+        input_data: dict | None = None,
+        location: str,
+        project_id: str = PROVIDE_PROJECT_ID,
+        gcp_conn_id: str = "google_cloud_default",
+        api_version: str = "v1",
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
+        impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.function_id = function_id
+        self.input_data = input_data or {}
+        self.location = location
+        self.project_id = project_id
+        self.gcp_conn_id = gcp_conn_id
+        self.api_version = api_version
+        self.deferrable = deferrable
+        self.impersonation_chain = impersonation_chain
+
+    @property
+    def extra_links_params(self) -> dict[str, Any]:
+        return {
+            "location": self.location,
+            "function_name": self.function_id,
+        }
+
+    def _get_id_token(self, hook, audience: str) -> str:
+        import google.auth.transport.requests
+        from google.oauth2 import service_account, id_token
+
+        credentials = hook.get_credentials()
+        request = google.auth.transport.requests.Request()
+
+        if isinstance(credentials, service_account.Credentials):
+            if hasattr(credentials, "with_target_audience"):
+                jwt_creds = credentials.with_target_audience(audience)
+                jwt_creds.refresh(request)
+                return jwt_creds.token
+            elif hasattr(credentials, "with_claims"):
+                jwt_creds = credentials.with_claims({"aud": audience})
+                jwt_creds.refresh(request)
+                return jwt_creds.token
+
+        try:
+            from google.auth import compute_engine
+            if isinstance(credentials, compute_engine.Credentials):
+                from google.auth.compute_engine import _metadata
+                return _metadata.get_service_account_id_token(request, audience=audience)
+        except ImportError:
+            pass
+            
+        try:
+            from google.auth import impersonated
+            if isinstance(credentials, impersonated.Credentials):
+                from google.auth.impersonated import IDTokenCredentials
+                id_token_creds = IDTokenCredentials(
+                    credentials,
+                    target_principal=credentials.target_principal,
+                    target_audience=audience,
+                    include_email=True,
+                )
+                id_token_creds.refresh(request)
+                return id_token_creds.token
+        except ImportError:
+            pass
+
+        # Fallback to fetch_id_token (ADC)
+        return id_token.fetch_id_token(request, audience)
+
+    def execute(self, context: Context):
+        from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
+        import requests
+
+        hook = CloudFunctionsHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
+        project_id = self.project_id or hook.project_id
+        self.log.info("Fetching function details for %s.", self.function_id)
+        function = hook.get_function(name=f"projects/{project_id}/locations/{self.location}/functions/{self.function_id}")
+        
+        url = None
+        if "httpsTrigger" in function and "url" in function["httpsTrigger"]:
+            url = function["httpsTrigger"]["url"]
+        elif "serviceConfig" in function and "uri" in function["serviceConfig"]:
+            url = function["serviceConfig"]["uri"]
+            
+        if not url:
+            raise AirflowException(f"Function {self.function_id} does not have an HTTP trigger URL.")
+
+        self.log.info("Function HTTP URL: %s", url)
+        
+        # Get ID token for authentication
+        token = self._get_id_token(hook, url)
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+        if project_id:
+            CloudFunctionsDetailsLink.persist(
+                context=context,
+                project_id=project_id,
+            )
+
+        if self.deferrable:
+            self.log.info("Deferring execution to CloudFunctionInvokeTrigger.")
+            self.defer(
+                trigger=CloudFunctionInvokeTrigger(
+                    function_uri=url,
+                    json_payload=self.input_data,
+                    headers=headers,
+                ),
+                method_name="execute_complete",
+            )
+        else:
+            self.log.info("Invoking function synchronously.")
+            response = requests.post(url, json=self.input_data, headers=headers)
+            try:
+                response.raise_for_status()
+                return response.json()
+            except requests.exceptions.JSONDecodeError:
+                return response.text
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
+        if event["status"] == "error":
+            raise AirflowException(event["message"])
+        self.log.info("Function invoked successfully.")
+        return event["response"]

--- a/providers/google/src/airflow/providers/google/cloud/triggers/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/functions.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import aiohttp
+
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class CloudFunctionInvokeTrigger(BaseTrigger):
+    """
+    Trigger that makes an HTTP POST request to a Google Cloud Function and waits for the response.
+
+    :param function_uri: The HTTPS trigger URL of the Cloud Function.
+    :param json_payload: The JSON payload to send in the request body.
+    :param headers: The headers to send in the request, including authentication headers.
+    :param timeout: Optional. The timeout in seconds for the HTTP request.
+    """
+
+    def __init__(
+        self,
+        function_uri: str,
+        json_payload: dict[str, Any] | None,
+        headers: dict[str, str],
+        timeout: float | None = None,
+    ):
+        super().__init__()
+        self.function_uri = function_uri
+        self.json_payload = json_payload
+        self.headers = headers
+        self.timeout = timeout
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize class arguments and classpath."""
+        return (
+            "airflow.providers.google.cloud.triggers.functions.CloudFunctionInvokeTrigger",
+            {
+                "function_uri": self.function_uri,
+                "json_payload": self.json_payload,
+                "headers": self.headers,
+                "timeout": self.timeout,
+            },
+        )
+
+    async def run(self):
+        """Make an async HTTP request to the Cloud Function."""
+        try:
+            # We use aiohttp instead of the synchronous requests library
+            timeout_obj = aiohttp.ClientTimeout(total=self.timeout) if self.timeout else aiohttp.ClientTimeout()
+            async with aiohttp.ClientSession(timeout=timeout_obj) as session:
+                async with session.post(
+                    self.function_uri,
+                    json=self.json_payload,
+                    headers=self.headers,
+                ) as response:
+                    # Cloud Functions return whatever the user code returns.
+                    # We capture the status code and text/json.
+                    status_code = response.status
+                    response_text = await response.text()
+
+                    if status_code >= 400:
+                        yield TriggerEvent(
+                            {
+                                "status": "error",
+                                "message": f"Cloud Function invocation failed with status {status_code}: {response_text}",
+                                "status_code": status_code,
+                            }
+                        )
+                    else:
+                        try:
+                            response_json = await response.json()
+                            yield TriggerEvent(
+                                {
+                                    "status": "success",
+                                    "response": response_json,
+                                    "status_code": status_code,
+                                }
+                            )
+                        except Exception:
+                            # If response is not JSON, yield the text
+                            yield TriggerEvent(
+                                {
+                                    "status": "success",
+                                    "response": response_text,
+                                    "status_code": status_code,
+                                }
+                            )
+        except asyncio.TimeoutError:
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "message": "Cloud Function invocation timed out.",
+                    "status_code": None,
+                }
+            )
+        except Exception as e:
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "message": str(e),
+                    "status_code": None,
+                }
+            )

--- a/providers/google/src/airflow/providers/google/cloud/triggers/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/functions.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, AsyncIterator
 
 import aiohttp
 
@@ -59,11 +59,13 @@ class CloudFunctionInvokeTrigger(BaseTrigger):
             },
         )
 
-    async def run(self):
+    async def run(self) -> AsyncIterator[TriggerEvent]:
         """Make an async HTTP request to the Cloud Function."""
         try:
             # We use aiohttp instead of the synchronous requests library
-            timeout_obj = aiohttp.ClientTimeout(total=self.timeout) if self.timeout else aiohttp.ClientTimeout()
+            timeout_obj = (
+                aiohttp.ClientTimeout(total=self.timeout) if self.timeout else aiohttp.ClientTimeout()
+            )
             async with aiohttp.ClientSession(timeout=timeout_obj) as session:
                 async with session.post(
                     self.function_uri,

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -736,3 +736,97 @@ class TestGcfFunctionInvokeOperator:
             key="execution_id",
             value=exec_id,
         )
+
+class TestCloudFunctionInvokeOperator:
+    @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
+    @mock.patch("airflow.providers.google.cloud.operators.functions.requests.post")
+    def test_execute_sync(self, mock_post, mock_hook):
+        mock_hook.return_value.get_function.return_value = {
+            "httpsTrigger": {"url": "https://example.com/function"}
+        }
+        
+        mock_response = mock.MagicMock()
+        mock_response.json.return_value = {"status": "ok"}
+        mock_post.return_value = mock_response
+
+        from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+        op = CloudFunctionInvokeOperator(
+            task_id="test",
+            function_id="my_func",
+            location="us-central1",
+            project_id="test_project",
+            input_data={"data": "test"},
+            deferrable=False,
+        )
+        
+        op._get_id_token = mock.MagicMock(return_value="mocked-token")
+        
+        result = op.execute(context=mock.MagicMock())
+        
+        assert result == {"status": "ok"}
+        mock_hook.return_value.get_function.assert_called_once_with(
+            name="projects/test_project/locations/us-central1/functions/my_func"
+        )
+        mock_post.assert_called_once_with(
+            "https://example.com/function",
+            json={"data": "test"},
+            headers={"Authorization": "Bearer mocked-token", "Content-Type": "application/json"}
+        )
+
+    @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
+    def test_execute_deferrable(self, mock_hook):
+        from airflow.exceptions import TaskDeferred
+        from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
+        from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+
+        mock_hook.return_value.get_function.return_value = {
+            "httpsTrigger": {"url": "https://example.com/function"}
+        }
+
+        op = CloudFunctionInvokeOperator(
+            task_id="test",
+            function_id="my_func",
+            location="us-central1",
+            project_id="test_project",
+            input_data={"data": "test"},
+            deferrable=True,
+        )
+        op._get_id_token = mock.MagicMock(return_value="mocked-token")
+        
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(context=mock.MagicMock())
+
+        assert isinstance(exc.value.trigger, CloudFunctionInvokeTrigger)
+        assert exc.value.trigger.function_uri == "https://example.com/function"
+        assert exc.value.trigger.headers == {
+            "Authorization": "Bearer mocked-token",
+            "Content-Type": "application/json",
+        }
+
+    def test_execute_complete_success(self):
+        from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+        op = CloudFunctionInvokeOperator(
+            task_id="test",
+            function_id="my_func",
+            location="us-central1",
+            project_id="test_project",
+        )
+        
+        event = {"status": "success", "response": {"result": "ok"}}
+        result = op.execute_complete(context=mock.MagicMock(), event=event)
+        
+        assert result == {"result": "ok"}
+
+    def test_execute_complete_error(self):
+        from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+        op = CloudFunctionInvokeOperator(
+            task_id="test",
+            function_id="my_func",
+            location="us-central1",
+            project_id="test_project",
+        )
+        
+        event = {"status": "error", "message": "Failed"}
+        with pytest.raises(AirflowException, match="Failed"):
+            op.execute_complete(context=mock.MagicMock(), event=event)
+

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -737,6 +737,7 @@ class TestGcfFunctionInvokeOperator:
             value=exec_id,
         )
 
+
 class TestCloudFunctionInvokeOperator:
     @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
     @mock.patch("airflow.providers.google.cloud.operators.functions.requests.post")
@@ -744,12 +745,13 @@ class TestCloudFunctionInvokeOperator:
         mock_hook.return_value.get_function.return_value = {
             "httpsTrigger": {"url": "https://example.com/function"}
         }
-        
+
         mock_response = mock.MagicMock()
         mock_response.json.return_value = {"status": "ok"}
         mock_post.return_value = mock_response
 
         from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+
         op = CloudFunctionInvokeOperator(
             task_id="test",
             function_id="my_func",
@@ -758,11 +760,11 @@ class TestCloudFunctionInvokeOperator:
             input_data={"data": "test"},
             deferrable=False,
         )
-        
+
         op._get_id_token = mock.MagicMock(return_value="mocked-token")
-        
+
         result = op.execute(context=mock.MagicMock())
-        
+
         assert result == {"status": "ok"}
         mock_hook.return_value.get_function.assert_called_once_with(
             name="projects/test_project/locations/us-central1/functions/my_func"
@@ -770,14 +772,14 @@ class TestCloudFunctionInvokeOperator:
         mock_post.assert_called_once_with(
             "https://example.com/function",
             json={"data": "test"},
-            headers={"Authorization": "Bearer mocked-token", "Content-Type": "application/json"}
+            headers={"Authorization": "Bearer mocked-token", "Content-Type": "application/json"},
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionsHook")
     def test_execute_deferrable(self, mock_hook):
         from airflow.exceptions import TaskDeferred
-        from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
         from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+        from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
 
         mock_hook.return_value.get_function.return_value = {
             "httpsTrigger": {"url": "https://example.com/function"}
@@ -792,7 +794,7 @@ class TestCloudFunctionInvokeOperator:
             deferrable=True,
         )
         op._get_id_token = mock.MagicMock(return_value="mocked-token")
-        
+
         with pytest.raises(TaskDeferred) as exc:
             op.execute(context=mock.MagicMock())
 
@@ -805,28 +807,29 @@ class TestCloudFunctionInvokeOperator:
 
     def test_execute_complete_success(self):
         from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+
         op = CloudFunctionInvokeOperator(
             task_id="test",
             function_id="my_func",
             location="us-central1",
             project_id="test_project",
         )
-        
+
         event = {"status": "success", "response": {"result": "ok"}}
         result = op.execute_complete(context=mock.MagicMock(), event=event)
-        
+
         assert result == {"result": "ok"}
 
     def test_execute_complete_error(self):
         from airflow.providers.google.cloud.operators.functions import CloudFunctionInvokeOperator
+
         op = CloudFunctionInvokeOperator(
             task_id="test",
             function_id="my_func",
             location="us-central1",
             project_id="test_project",
         )
-        
+
         event = {"status": "error", "message": "Failed"}
         with pytest.raises(AirflowException, match="Failed"):
             op.execute_complete(context=mock.MagicMock(), event=event)
-

--- a/providers/google/tests/unit/google/cloud/triggers/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_functions.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from airflow.providers.google.cloud.triggers.functions import CloudFunctionInvokeTrigger
+from airflow.triggers.base import TriggerEvent
+
+FUNCTION_URI = "https://example.com/function"
+JSON_PAYLOAD = {"key": "value"}
+HEADERS = {"Authorization": "Bearer token"}
+
+
+class TestCloudFunctionInvokeTrigger:
+    def test_serialization(self):
+        trigger = CloudFunctionInvokeTrigger(
+            function_uri=FUNCTION_URI,
+            json_payload=JSON_PAYLOAD,
+            headers=HEADERS,
+            timeout=30.0,
+        )
+        classpath, kwargs = trigger.serialize()
+        assert classpath == "airflow.providers.google.cloud.triggers.functions.CloudFunctionInvokeTrigger"
+        assert kwargs == {
+            "function_uri": FUNCTION_URI,
+            "json_payload": JSON_PAYLOAD,
+            "headers": HEADERS,
+            "timeout": 30.0,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("aiohttp.ClientSession.post")
+    async def test_run_success(self, mock_post):
+        mock_response = mock.AsyncMock()
+        mock_response.status = 200
+        mock_response.json = mock.AsyncMock(return_value={"result": "success"})
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        trigger = CloudFunctionInvokeTrigger(
+            function_uri=FUNCTION_URI,
+            json_payload=JSON_PAYLOAD,
+            headers=HEADERS,
+        )
+
+        generator = trigger.run()
+        event = await generator.asend(None)
+
+        assert isinstance(event, TriggerEvent)
+        assert event.payload["status"] == "success"
+        assert event.payload["response"] == {"result": "success"}
+
+    @pytest.mark.asyncio
+    @mock.patch("aiohttp.ClientSession.post")
+    async def test_run_error(self, mock_post):
+        mock_response = mock.AsyncMock()
+        mock_response.status = 400
+        mock_response.text = mock.AsyncMock(return_value="Bad Request")
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        trigger = CloudFunctionInvokeTrigger(
+            function_uri=FUNCTION_URI,
+            json_payload=JSON_PAYLOAD,
+            headers=HEADERS,
+        )
+
+        generator = trigger.run()
+        event = await generator.asend(None)
+
+        assert isinstance(event, TriggerEvent)
+        assert event.payload["status"] == "error"
+        assert event.payload["status_code"] == 400
+
+    @pytest.mark.asyncio
+    @mock.patch("aiohttp.ClientSession.post")
+    async def test_run_timeout(self, mock_post):
+        mock_post.side_effect = asyncio.TimeoutError()
+
+        trigger = CloudFunctionInvokeTrigger(
+            function_uri=FUNCTION_URI,
+            json_payload=JSON_PAYLOAD,
+            headers=HEADERS,
+            timeout=10.0,
+        )
+
+        generator = trigger.run()
+        event = await generator.asend(None)
+
+        assert isinstance(event, TriggerEvent)
+        assert event.payload["status"] == "error"
+        assert "timed out" in event.payload["message"]


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.




Add deferrable support for invoking and waiting on Google Cloud Functions and HTTP Cloud Run functions.

This PR introduces a production-ready operator and trigger for invoking Cloud Functions via their HTTP trigger URL, addressing the limitations of the existing `CloudFunctionInvokeFunctionOperator` (which uses the testing-only `functions.call` API).

**Changes include:**
* **`CloudFunctionInvokeTrigger`**: A new trigger using `aiohttp` to perform asynchronous, non-blocking HTTP POST requests to the Cloud Function's HTTPS trigger URL.
* **`CloudFunctionInvokeOperator`**: A new operator that natively generates OIDC ID Tokens from the Airflow `gcp_conn_id` credentials and makes authenticated HTTP requests to the function. It supports both synchronous execution and deferrable execution (via `deferrable=True`).
* Unit tests for the new trigger and operator.

<!-- pr-triage-fold: triaged=2026-07-28T17:13:22Z head=1beb12a action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @anushkagupta200615-jpg** · by `@potiuk` · 2026-07-28 17:13 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
