### PR TITLE
cli: Fix TypeError in 'airflow db shell' when database name is missing

### DIFF
--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -306,6 +306,12 @@ def shell(args):
     url = settings.get_engine().url
     print(f"DB: {url!r}")
 
+    if not url.database:
+        raise ValueError(
+            "The metadata database name is missing from the connection URI. "
+            "Please check your AIRFLOW__DATABASE__SQL_ALCHEMY_CONN configuration."
+        )
+
     if url.get_backend_name() == "mysql":
         with NamedTemporaryFile(suffix="my.cnf") as f:
             f.write(_build_mysql_cnf(url))

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -534,6 +534,23 @@ class TestCliDb:
         with pytest.raises(AirflowException, match=r"Unknown driver: invalid\+psycopg"):
             db_command.shell(self.parser.parse_args(["db", "shell"]))
 
+    @mock.patch(
+        "airflow.cli.commands.db_command.settings.engine.url",
+        make_url("postgresql+psycopg2://postgres:airflow@postgres/"),
+    )
+    @pytest.mark.parametrize(
+        "conn_uri",
+        [
+            pytest.param("postgresql://postgres:postgres@postgres:5432", id="db-name-none"),
+            pytest.param("postgresql://postgres:postgres@postgres:5432/", id="db-name-empty"),
+        ],
+    )
+    def test_db_shell_missing_database_name(self, conn_uri):
+        """Assert that an explicit ValueError is raised when the database name is missing."""
+        with mock.patch("airflow.cli.commands.db_command.settings.engine.url", make_url(conn_uri)):
+            with pytest.raises(ValueError, match="The metadata database name is missing"):
+                db_command.shell(self.parser.parse_args(["db", "shell"]))
+
     def test_run_db_downgrade_command_success_and_messages(self, capsys):
         class Args:
             to_revision = "abc"


### PR DESCRIPTION
closes: #68897

### Problem
When configuring the `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN` environment variable without explicitly appending a database name component to the URI path (e.g., `postgresql://postgres:postgres@postgres:5432`), the command `airflow db check` passes gracefully. However, running `airflow db shell` crashes with an unhandled, cryptic `TypeError: expected str, bytes or os.PathLike object, not NoneType`. 

### Solution
Updated the `shell` command function inside `airflow/cli/commands/db_command.py` to add a global validation guardrail check right after retrieving the database URL structure. If `url.database` evaluates to `None` or is empty, the command now proactively raises a clean, standard Python built-in `ValueError` detailing that the configuration is invalid. 