### PR TITLE
Revert Cassandra docs to upstream WhiteListRoundRobinPolicy class name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -755,6 +755,7 @@ repos:
           ^providers/amazon/src/airflow/providers/amazon/aws/operators/emr\.py$|
           ^providers/.*/get_provider_info\.py$|
           ^providers/.*/provider\.yaml$|
+          ^providers/apache/cassandra/docs/connections/cassandra\.rst$|
           ^providers/apache/cassandra/src/airflow/providers/apache/cassandra/hooks/cassandra\.py$|
           ^providers/apache/hdfs/docs/connections\.rst$|
           ^providers/apache/hive/src/airflow/providers/apache/hive/operators/hive_stats\.py$|

--- a/providers/apache/cassandra/docs/connections/cassandra.rst
+++ b/providers/apache/cassandra/docs/connections/cassandra.rst
@@ -50,7 +50,7 @@ Extra (optional)
     are supported:
 
     * ``load_balancing_policy`` - This parameter specifies the load balancing policy to be used. There are four available policies:
-      ``RoundRobinPolicy``, ``DCAwareRoundRobinPolicy``, ``AllowListRoundRobinPolicy`` and ``TokenAwarePolicy``. ``RoundRobinPolicy`` is the default load balancing policy.
+      ``RoundRobinPolicy``, ``DCAwareRoundRobinPolicy``, ``WhiteListRoundRobinPolicy`` and ``TokenAwarePolicy``. ``RoundRobinPolicy`` is the default load balancing policy.
     * ``load_balancing_policy_args`` - This parameter specifies the arguments for the load balancing policy being used.
     * ``cql_version`` - This parameter specifies the CQL version of cassandra.
     * ``protocol_version`` - This parameter specifies the maximum version of the native protocol to use.
@@ -88,12 +88,12 @@ DCAwareRoundRobinPolicy:
       }
     }
 
-AllowListRoundRobinPolicy
+WhiteListRoundRobinPolicy
 
 .. code-block:: json
 
     {
-      "load_balancing_policy": "AllowListRoundRobinPolicy",
+      "load_balancing_policy": "WhiteListRoundRobinPolicy",
       "load_balancing_policy_args": {
         "hosts": ["HOST1", "HOST2", "HOST3"]
       }


### PR DESCRIPTION
## Summary

The Cassandra connection docs reference `AllowListRoundRobinPolicy`, which does not exist in `cassandra-driver` — the actual class is `cassandra.policies.WhiteListRoundRobinPolicy`. The hook matches only on the real name, so users following the docs silently fall through to `RoundRobinPolicy()` in `CassandraHook.get_lb_policy`: they believe their cluster is restricted to an allowlist of hosts; it isn't.

## Origin

Introduced in #46171 ("Moved Apache/Cassandra provider to new structure"), where the `check-for-inclusive-language` pre-commit rewrote `WhiteList...` → `AllowList...` in the docs. The hook source was already in the inclusive-language `exclude:` list, so its references were left intact — but the docs file wasn't, so the rename ended up referring to a class that doesn't exist upstream.

## Changes

- `providers/apache/cassandra/docs/connections/cassandra.rst` — restore `WhiteListRoundRobinPolicy` (3 substitutions).
- `.pre-commit-config.yaml` — add the docs file to the `check-for-inclusive-language` `exclude:` list, mirroring the existing exemption for the hook source.

