### PR TITLE
Raise a warning instead of an error if extra teams are defined in the auth manager

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
+++ b/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py
@@ -127,8 +127,16 @@ class BaseAuthManager(Generic[T], LoggingMixin, metaclass=ABCMeta):
             db_teams = Team.get_all_team_names()
 
             if not db_teams.issuperset(am_teams):
-                raise ValueError(
-                    f"Teams defined in the auth manager ({am_teams}) are not present in the database ({db_teams})."
+                warnings.warn(
+                    f"Teams defined in the auth manager are not present in the database ({am_teams.difference(db_teams)}).",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            if not am_teams.issuperset(db_teams):
+                warnings.warn(
+                    f"Teams defined in the database are not present in the auth manager ({db_teams.difference(am_teams)}).",
+                    UserWarning,
+                    stacklevel=2,
                 )
 
     @abstractmethod

--- a/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
+++ b/airflow-core/tests/unit/api_fastapi/auth/managers/test_base_auth_manager.py
@@ -161,10 +161,11 @@ class TestBaseAuthManager:
     @pytest.mark.parametrize(
         ("auth_manager_teams", "db_teams", "expected"),
         [
-            ({"teamA", "teamB"}, {"teamA", "teamB"}, True),
-            ({"teamA", "teamB"}, {"teamA", "teamB", "teamC"}, True),
-            (set(), set(), True),
-            ({"teamA", "teamB"}, {"teamA", "teamC"}, False),
+            pytest.param({"teamA", "teamB"}, {"teamA", "teamB"}, "same", id="same teams"),
+            pytest.param({"teamA", "teamB"}, {"teamA", "teamB", "teamC"}, "extra_db", id="extra teams db"),
+            pytest.param(set(), set(), "same", id="no teams"),
+            pytest.param({"teamA", "teamB"}, {"teamA"}, "extra_auth", id="extra teams auth"),
+            pytest.param({"teamA", "teamB"}, {"teamA", "teamC"}, "extra_both", id="extra teams both"),
         ],
     )
     @patch.object(Team, "get_all_team_names")
@@ -175,10 +176,19 @@ class TestBaseAuthManager:
         mock_get_teams.return_value = auth_manager_teams
         mock_get_all_team_names.return_value = db_teams
 
-        if expected:
+        if expected == "same":
             assert auth_manager.init() is None
+        elif expected == "extra_auth":
+            with pytest.warns(UserWarning, match="Teams defined in the auth manager"):
+                auth_manager.init()
+        elif expected == "extra_db":
+            with pytest.warns(UserWarning, match="Teams defined in the database"):
+                auth_manager.init()
         else:
-            with pytest.raises(ValueError, match="Teams defined in the auth manager"):
+            with (
+                pytest.warns(UserWarning, match="Teams defined in the database"),
+                pytest.warns(UserWarning, match="Teams defined in the auth manager"),
+            ):
                 auth_manager.init()
 
     def test_get_cli_commands_return_empty_list(self, auth_manager):


### PR DESCRIPTION
Don't raise an error on startup if the Auth Manager has additional teams
---

In the case of the `KeycloakAuthManager`, defining additional teams in the Auth Manager should not interact with the airflow system in a negative way, as the Auth Manager will only issue auth requests to keycloak based on access of resources. These must be mapped to teams that actually exist in the database, as they are created in Airflow. 
Despite this, adding additional team resources to the keycloak client will cause the api server to crash on startup until the teams are added to the database as well. This makes the system more brittle by introducing an implicit order of actions which new teams must go through to be added. (i.e. 1. add to database, 2. add to auth manager 3. add to dags) 

Raising a warning at startup instead tells admins that they need to update their configuration without affecting the normal running of the api server.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

