### PR TITLE
Serialize dag if it is not serialized even if it does not have task instances

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -723,7 +723,7 @@ class SerializedDagModel(Base):
                 )
             )
 
-        if dag_version and not has_task_instances:
+        if dag_version and not has_task_instances and serialized_dag_hash is not None:
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -554,28 +554,6 @@ class SerializedDagModel(Base):
         if not dag_id_list:
             return {}
 
-        # Fetch the serialized_dag (last_updated, dag_hash) of the latest DagVersion per dag_id,
-        # ordering by version_number so it stays consistent with the DagVersion picked by dv_subq.
-        sd_subq = (
-            select(
-                cls.dag_id.label("dag_id"),
-                cls.last_updated.label("last_updated"),
-                cls.dag_hash.label("dag_hash"),
-                func.row_number()
-                .over(partition_by=cls.dag_id, order_by=DagVersion.version_number.desc())
-                .label("rn"),
-            )
-            .join(DagVersion, cls.dag_version_id == DagVersion.id)
-            .where(cls.dag_id.in_(dag_id_list))
-            .subquery()
-        )
-        sd_rows = session.execute(
-            select(sd_subq.c.dag_id, sd_subq.c.last_updated, sd_subq.c.dag_hash).where(sd_subq.c.rn == 1)
-        ).all()
-        sd_by_dag_id: dict[str, tuple[datetime, str]] = {
-            row.dag_id: (row.last_updated, row.dag_hash) for row in sd_rows
-        }
-
         # Fetch latest DagVersion per dag_id, ordering by version_number to match write_dag.
         dv_subq = (
             select(
@@ -592,6 +570,23 @@ class SerializedDagModel(Base):
             select(DagVersion).join(dv_subq, DagVersion.id == dv_subq.c.id).where(dv_subq.c.rn == 1)
         ).all()
         dv_by_dag_id: dict[str, DagVersion] = {dv.dag_id: dv for dv in dag_versions}
+
+        # Fetch the serialized_dag (last_updated, dag_hash) of the latest DagVersion per dag_id,
+        # outer join with dv_subq so None is set when latest dag version has no serialized entry.
+        sd_subq = (
+            select(
+                dv_subq.c.dag_id,
+                cls.last_updated.label("last_updated"),
+                cls.dag_hash.label("dag_hash"),
+            )
+            .where(dv_subq.c.rn == 1)
+            .outerjoin(cls, cls.dag_version_id == dv_subq.c.id)
+            .subquery()
+        )
+        sd_rows = session.execute(select(sd_subq.c.dag_id, sd_subq.c.last_updated, sd_subq.c.dag_hash)).all()
+        sd_by_dag_id: dict[str, tuple[datetime, str]] = {
+            row.dag_id: (row.last_updated, row.dag_hash) for row in sd_rows
+        }
 
         return {
             dag_id: DagWriteMetadata(
@@ -739,7 +734,10 @@ class SerializedDagModel(Base):
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances
+            # exception is when the *latest* dag version has no corresponding serialized dag
+            # which is denoted by serialized_dag_hash == None, then fall through to write
             new_serialized_dag = cls(dag, _dag_hash=new_dag_hash)
+
 
             # Use direct UPDATE to avoid loading the full serialized DAG
             result = session.execute(

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -738,7 +738,6 @@ class SerializedDagModel(Base):
             # which is denoted by serialized_dag_hash == None, then fall through to write
             new_serialized_dag = cls(dag, _dag_hash=new_dag_hash)
 
-
             # Use direct UPDATE to avoid loading the full serialized DAG
             result = session.execute(
                 update(cls)

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -735,7 +735,7 @@ class SerializedDagModel(Base):
                 )
             )
 
-        if dag_version and not has_task_instances:
+        if dag_version and not has_task_instances and serialized_dag_hash is not None:
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -547,28 +547,6 @@ class SerializedDagModel(Base):
         if not dag_id_list:
             return {}
 
-        # Fetch the serialized_dag (last_updated, dag_hash) of the latest DagVersion per dag_id,
-        # ordering by version_number so it stays consistent with the DagVersion picked by dv_subq.
-        sd_subq = (
-            select(
-                cls.dag_id.label("dag_id"),
-                cls.last_updated.label("last_updated"),
-                cls.dag_hash.label("dag_hash"),
-                func.row_number()
-                .over(partition_by=cls.dag_id, order_by=DagVersion.version_number.desc())
-                .label("rn"),
-            )
-            .join(DagVersion, cls.dag_version_id == DagVersion.id)
-            .where(cls.dag_id.in_(dag_id_list))
-            .subquery()
-        )
-        sd_rows = session.execute(
-            select(sd_subq.c.dag_id, sd_subq.c.last_updated, sd_subq.c.dag_hash).where(sd_subq.c.rn == 1)
-        ).all()
-        sd_by_dag_id: dict[str, tuple[datetime, str]] = {
-            row.dag_id: (row.last_updated, row.dag_hash) for row in sd_rows
-        }
-
         # Fetch latest DagVersion per dag_id, ordering by version_number to match write_dag.
         dv_subq = (
             select(
@@ -585,6 +563,23 @@ class SerializedDagModel(Base):
             select(DagVersion).join(dv_subq, DagVersion.id == dv_subq.c.id).where(dv_subq.c.rn == 1)
         ).all()
         dv_by_dag_id: dict[str, DagVersion] = {dv.dag_id: dv for dv in dag_versions}
+
+        # Fetch the serialized_dag (last_updated, dag_hash) of the latest DagVersion per dag_id,
+        # outer join with dv_subq so None is set when latest dag version has no serialized entry.
+        sd_subq = (
+            select(
+                dv_subq.c.dag_id,
+                cls.last_updated.label("last_updated"),
+                cls.dag_hash.label("dag_hash"),
+            )
+            .where(dv_subq.c.rn == 1)
+            .outerjoin(cls, cls.dag_version_id == dv_subq.c.id)
+            .subquery()
+        )
+        sd_rows = session.execute(select(sd_subq.c.dag_id, sd_subq.c.last_updated, sd_subq.c.dag_hash)).all()
+        sd_by_dag_id: dict[str, tuple[datetime, str]] = {
+            row.dag_id: (row.last_updated, row.dag_hash) for row in sd_rows
+        }
 
         return {
             dag_id: DagWriteMetadata(
@@ -727,6 +722,9 @@ class SerializedDagModel(Base):
             # This is for dynamic DAGs that the hashes changes often. We should update
             # the serialized dag, the dag_version and the dag_code instead of a new version
             # if the dag_version is not associated with any task instances
+            # exception is when the *latest* dag version has no corresponding serialized dag
+            # which is denoted by serialized_dag_hash == None, then fall through to write
+
             new_serialized_dag = cls(dag)
 
             # Use direct UPDATE to avoid loading the full serialized DAG

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -36,7 +36,7 @@ from airflow.models.asset import AssetActive, AssetAliasModel, AssetModel
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.deadline_alert import DeadlineAlert as DAM
-from airflow.models.serialized_dag import SerializedDagModel as SDM
+from airflow.models.serialized_dag import DagWriteMetadata, SerializedDagModel as SDM
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -693,6 +693,36 @@ class TestSerializedDagModel:
         assert metadata.dag_version is not None
         assert metadata.dag_version.version_number == 2
 
+    def test_prefetch_dag_write_metadata_latest_version_without_sdm_entry(self, dag_maker, session):
+        """When the latest DagVersion has no SDM entry, last_updated and dag_hash are None."""
+        with dag_maker("prefetch_no_sdm_dag") as dag:
+            EmptyOperator(task_id="task1")
+
+        v1 = session.scalar(select(DagVersion).where(DagVersion.dag_id == dag.dag_id))
+        assert v1 is not None
+        assert v1.version_number == 1
+
+        # v1 has an SDM entry (written by dag_maker); create v2 directly without one.
+        v2 = DagVersion.write_dag(
+            dag_id=dag.dag_id,
+            bundle_name="dag_maker",
+            bundle_version="v2",
+            session=session,
+        )
+        session.flush()
+
+        assert v2.version_number == 2
+
+        result = SDM._prefetch_dag_write_metadata([dag.dag_id], session=session)
+        metadata = result[dag.dag_id]
+
+        assert metadata.dag_version is not None
+        assert metadata.dag_version.version_number == 2
+        assert metadata.dag_version.dag_id == dag.dag_id
+        assert metadata.dag_version.bundle_version == "v2"
+        assert metadata.last_updated is None
+        assert metadata.dag_hash is None
+
     def test_new_dag_version_created_when_bundle_name_changes_and_hash_unchanged(self, dag_maker, session):
         """Test that new dag_version is created if bundle_name changes but DAG is unchanged."""
         # Create and write initial DAG
@@ -884,8 +914,7 @@ class TestSerializedDagModel:
         self, dag_maker, session
     ):
         """
-        Test that dynamic DAG update gracefully handles case where SerializedDagModel doesn't exist.
-        This adds the serialized dag entry
+        Test that dynamic DAG update creates a SerializedDagModel if it doesn't exist.
         """
         with dag_maker(dag_id="test_missing_serdag", serialized=True, session=session) as dag:
             EmptyOperator(task_id="task1")
@@ -913,7 +942,7 @@ class TestSerializedDagModel:
         # Verify no SerializedDagModel exists
         assert SDM.get("test_missing_serdag", session=session) is None
 
-        # Try to update - should create the serialized dag
+        # Try to update - should create a new serialized dag row under the latest DagVersion
         result = SDM.write_dag(
             dag=lazy_dag,
             bundle_name="test_bundle",
@@ -923,9 +952,186 @@ class TestSerializedDagModel:
         )
         session.commit()
 
-        serialized_dag = session.scalar(select(SDM).where(SDM.dag_id == "test_missing_serdag").limit(1))
-        assert serialized_dag is not None
         assert result is True
+        latest_version = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_missing_serdag")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert latest_version is not None
+        serialized_dag = SDM.get("test_missing_serdag", session=session)
+        assert serialized_dag is not None
+        assert serialized_dag.dag_version_id == latest_version.id
+
+    def test_write_dag_returns_false_when_update_finds_no_serialized_row(self, dag_maker, session):
+        """
+        Test that write_dag returns False when the UPDATE path finds no serialized row.
+
+        This exercises the rowcount == 0 branch: _prefetched carries a non-None dag_hash
+        (so the dynamic-update UPDATE path is taken), but the SDM row has been deleted
+        between prefetch and execution, so the UPDATE affects 0 rows.
+        """
+        with dag_maker(dag_id="test_rowcount_zero", serialized=True, session=session) as dag:
+            EmptyOperator(task_id="task1")
+
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+        SDM.write_dag(
+            dag=lazy_dag,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            session=session,
+        )
+        session.commit()
+
+        dag_version = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_rowcount_zero")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert dag_version is not None
+
+        # Build prefetched metadata that looks like the SDM row exists (non-None hash),
+        # then delete the actual row so the UPDATE finds nothing.
+        stale_hash = session.scalar(select(SDM.dag_hash).where(SDM.dag_id == "test_rowcount_zero"))
+        assert stale_hash is not None
+        session.execute(delete(SDM).where(SDM.dag_id == "test_rowcount_zero"))
+        session.commit()
+
+        prefetched = DagWriteMetadata(
+            last_updated=None,
+            dag_hash=stale_hash,
+            dag_version=dag_version,
+        )
+        # Change the dag so the hash differs, forcing the dynamic-update branch.
+        from airflow.sdk.definitions.dag import DAG as SdkDAG
+
+        new_dag_obj = SdkDAG(dag_id="test_rowcount_zero", schedule=None)
+        with new_dag_obj:
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+        new_lazy = LazyDeserializedDAG.from_dag(new_dag_obj)
+
+        result = SDM.write_dag(
+            dag=new_lazy,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            min_update_interval=None,
+            session=session,
+            _prefetched=prefetched,
+        )
+
+        assert result is False
+        assert SDM.get("test_rowcount_zero", session=session) is None
+
+    def test_latest_dag_version_with_no_serialized_row_and_changed_hash_heals(self, dag_maker, session):
+        """
+        v1 has a serialized row, v2 is a bare DagVersion (no serialized row), and
+        the incoming Dag hash differs from v1's. The v2 dag should be serialized successfully
+        """
+        with dag_maker(dag_id="test_v2_bare_changed_hash", serialized=True, session=session) as dag:
+            EmptyOperator(task_id="task1")
+
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+        SDM.write_dag(dag=lazy_dag, bundle_name="test_bundle", bundle_version=None, session=session)
+        session.commit()
+
+        # Create a bare v2 DagVersion with no corresponding serialized row.
+        DagVersion.write_dag(dag_id="test_v2_bare_changed_hash", bundle_name="test_bundle", session=session)
+        session.commit()
+
+        v2 = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_changed_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert v2 is not None
+        assert v2.version_number == 2
+
+        # A changed dag produces a different hash — bypasses the unchanged-hash short-circuit.
+        from airflow.sdk.definitions.dag import DAG as SdkDAG
+
+        changed_dag = SdkDAG(dag_id="test_v2_bare_changed_hash", schedule=None)
+        with changed_dag:
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+        changed_lazy = LazyDeserializedDAG.from_dag(changed_dag)
+
+        result = SDM.write_dag(
+            dag=changed_lazy,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            min_update_interval=None,
+            session=session,
+        )
+        session.commit()
+
+        assert result is True
+        # The code falls through to DagVersion.write_dag, creating a new v3 with the serialized
+        # row attached to it — v2 stays bare. Assert the latest version now has a serialized row.
+        latest = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_changed_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert latest is not None
+        assert latest.version_number == 3
+        assert session.scalar(select(SDM).where(SDM.dag_version_id == latest.id)) is not None
+
+    def test_latest_dag_version_with_no_serialized_row_and_unchanged_hash_heals(self, dag_maker, session):
+        """
+        v1 has a serialized row, v2 is a bare DagVersion (no serialized row), and
+        the incoming Dag hash matches v1's. The v2 dag should be serialized successfully
+        """
+        with dag_maker(dag_id="test_v2_bare_unchanged_hash", serialized=True, session=session) as dag:
+            EmptyOperator(task_id="task1")
+
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+        SDM.write_dag(dag=lazy_dag, bundle_name="test_bundle", bundle_version=None, session=session)
+        session.commit()
+
+        v1_hash = session.scalar(select(SDM.dag_hash).where(SDM.dag_id == "test_v2_bare_unchanged_hash"))
+        assert v1_hash is not None
+
+        # Create a bare v2 DagVersion with no corresponding serialized row.
+        DagVersion.write_dag(dag_id="test_v2_bare_unchanged_hash", bundle_name="test_bundle", session=session)
+        session.commit()
+
+        v2 = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_unchanged_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert v2 is not None
+        assert v2.version_number == 2
+
+        # Same dag — same hash as v1. Without the fix the prefetch returns v1's hash (inner
+        # join excludes v2), the unchanged-hash guard fires, and v2 never gets a serialized row.
+        result = SDM.write_dag(
+            dag=lazy_dag,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            min_update_interval=None,
+            session=session,
+        )
+        session.commit()
+
+        assert result is True
+        # The code falls through to DagVersion.write_dag, creating a new v3 with the serialized
+        # row attached to it — v2 stays bare. Assert the latest version now has a serialized row.
+        latest = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_unchanged_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert latest is not None
+        assert latest.version_number == 3
+        assert session.scalar(select(SDM).where(SDM.dag_version_id == latest.id)) is not None
 
     def test_dynamic_dag_update_success(self, dag_maker, session):
         """

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -507,27 +507,6 @@ class TestSerializedDagModel:
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
         assert session.scalar(select(func.count()).select_from(SDM)) == 2
 
-    def test_new_dag_version_is_created_when_version_exists_but_serialized_dag_row_missing(
-        self, dag_maker, session
-    ):
-        with dag_maker("dag1") as dag:
-            PythonOperator(task_id="task1", python_callable=lambda: None)
-        assert session.scalar(select(func.count()).select_from(SDM)) == 1
-        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
-
-        # Simulate the broken state: DagVersion present, serialized_dag row gone.
-        session.execute(delete(SDM).where(SDM.dag_id == dag.dag_id))
-        session.flush()
-        assert session.scalar(select(func.count()).select_from(SDM)) == 0
-        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
-
-        SDM.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="dag_maker")
-
-        # A new version and serialized row must have been created.
-        assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
-        assert session.scalar(select(func.count()).select_from(SDM)) == 1
-        assert SDM.get(dag.dag_id, session=session) is not None
-
     def test_example_dag_sorting_serialised_dag(self, session):
         """
         This test asserts if different dag ids -- simple or complex, can be sorted
@@ -901,10 +880,12 @@ class TestSerializedDagModel:
         # Hashes should be identical
         assert hash_1 == hash_2, "Hashes should be identical when dicts are sorted consistently"
 
-    def test_dynamic_dag_update_preserves_null_check(self, dag_maker, session):
+    def test_new_dag_version_is_created_when_version_exists_but_serialized_dag_row_missing(
+        self, dag_maker, session
+    ):
         """
         Test that dynamic DAG update gracefully handles case where SerializedDagModel doesn't exist.
-        This preserves the null-check fix from PR #56422 and tests the direct UPDATE path.
+        This adds the serialized dag entry
         """
         with dag_maker(dag_id="test_missing_serdag", serialized=True, session=session) as dag:
             EmptyOperator(task_id="task1")
@@ -932,7 +913,7 @@ class TestSerializedDagModel:
         # Verify no SerializedDagModel exists
         assert SDM.get("test_missing_serdag", session=session) is None
 
-        # Try to update - should return False gracefully (not crash)
+        # Try to update - should create the serialized dag
         result = SDM.write_dag(
             dag=lazy_dag,
             bundle_name="test_bundle",
@@ -940,8 +921,11 @@ class TestSerializedDagModel:
             min_update_interval=None,
             session=session,
         )
+        session.commit()
 
-        assert result is False  # Should return False when SerializedDagModel is missing
+        serialized_dag = session.scalar(select(SDM).where(SDM.dag_id == "test_missing_serdag").limit(1))
+        assert serialized_dag is not None
+        assert result is True
 
     def test_dynamic_dag_update_success(self, dag_maker, session):
         """

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -507,6 +507,27 @@ class TestSerializedDagModel:
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
         assert session.scalar(select(func.count()).select_from(SDM)) == 2
 
+    def test_new_dag_version_is_created_when_version_exists_but_serialized_dag_row_missing(
+        self, dag_maker, session
+    ):
+        with dag_maker("dag1") as dag:
+            PythonOperator(task_id="task1", python_callable=lambda: None)
+        assert session.scalar(select(func.count()).select_from(SDM)) == 1
+        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
+
+        # Simulate the broken state: DagVersion present, serialized_dag row gone.
+        session.execute(delete(SDM).where(SDM.dag_id == dag.dag_id))
+        session.flush()
+        assert session.scalar(select(func.count()).select_from(SDM)) == 0
+        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
+
+        SDM.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="dag_maker")
+
+        # A new version and serialized row must have been created.
+        assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
+        assert session.scalar(select(func.count()).select_from(SDM)) == 1
+        assert SDM.get(dag.dag_id, session=session) is not None
+
     def test_example_dag_sorting_serialised_dag(self, session):
         """
         This test asserts if different dag ids -- simple or complex, can be sorted

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -502,6 +502,27 @@ class TestSerializedDagModel:
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
         assert session.scalar(select(func.count()).select_from(SDM)) == 2
 
+    def test_new_dag_version_is_created_when_version_exists_but_serialized_dag_row_missing(
+        self, dag_maker, session
+    ):
+        with dag_maker("dag1") as dag:
+            PythonOperator(task_id="task1", python_callable=lambda: None)
+        assert session.scalar(select(func.count()).select_from(SDM)) == 1
+        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
+
+        # Simulate the broken state: DagVersion present, serialized_dag row gone.
+        session.execute(delete(SDM).where(SDM.dag_id == dag.dag_id))
+        session.flush()
+        assert session.scalar(select(func.count()).select_from(SDM)) == 0
+        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
+
+        SDM.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="dag_maker")
+
+        # A new version and serialized row must have been created.
+        assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
+        assert session.scalar(select(func.count()).select_from(SDM)) == 1
+        assert SDM.get(dag.dag_id, session=session) is not None
+
     def test_example_dag_sorting_serialised_dag(self, session):
         """
         This test asserts if different dag ids -- simple or complex, can be sorted

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -502,27 +502,6 @@ class TestSerializedDagModel:
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
         assert session.scalar(select(func.count()).select_from(SDM)) == 2
 
-    def test_new_dag_version_is_created_when_version_exists_but_serialized_dag_row_missing(
-        self, dag_maker, session
-    ):
-        with dag_maker("dag1") as dag:
-            PythonOperator(task_id="task1", python_callable=lambda: None)
-        assert session.scalar(select(func.count()).select_from(SDM)) == 1
-        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
-
-        # Simulate the broken state: DagVersion present, serialized_dag row gone.
-        session.execute(delete(SDM).where(SDM.dag_id == dag.dag_id))
-        session.flush()
-        assert session.scalar(select(func.count()).select_from(SDM)) == 0
-        assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
-
-        SDM.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name="dag_maker")
-
-        # A new version and serialized row must have been created.
-        assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
-        assert session.scalar(select(func.count()).select_from(SDM)) == 1
-        assert SDM.get(dag.dag_id, session=session) is not None
-
     def test_example_dag_sorting_serialised_dag(self, session):
         """
         This test asserts if different dag ids -- simple or complex, can be sorted
@@ -896,10 +875,12 @@ class TestSerializedDagModel:
         # Hashes should be identical
         assert hash_1 == hash_2, "Hashes should be identical when dicts are sorted consistently"
 
-    def test_dynamic_dag_update_preserves_null_check(self, dag_maker, session):
+    def test_new_dag_version_is_created_when_version_exists_but_serialized_dag_row_missing(
+        self, dag_maker, session
+    ):
         """
         Test that dynamic DAG update gracefully handles case where SerializedDagModel doesn't exist.
-        This preserves the null-check fix from PR #56422 and tests the direct UPDATE path.
+        This adds the serialized dag entry
         """
         with dag_maker(dag_id="test_missing_serdag", serialized=True, session=session) as dag:
             EmptyOperator(task_id="task1")
@@ -927,7 +908,7 @@ class TestSerializedDagModel:
         # Verify no SerializedDagModel exists
         assert SDM.get("test_missing_serdag", session=session) is None
 
-        # Try to update - should return False gracefully (not crash)
+        # Try to update - should create the serialized dag
         result = SDM.write_dag(
             dag=lazy_dag,
             bundle_name="test_bundle",
@@ -935,8 +916,11 @@ class TestSerializedDagModel:
             min_update_interval=None,
             session=session,
         )
+        session.commit()
 
-        assert result is False  # Should return False when SerializedDagModel is missing
+        serialized_dag = session.scalar(select(SDM).where(SDM.dag_id == "test_missing_serdag").limit(1))
+        assert serialized_dag is not None
+        assert result is True
 
     def test_dynamic_dag_update_success(self, dag_maker, session):
         """

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -34,7 +34,7 @@ from airflow.models.asset import AssetActive, AssetAliasModel, AssetModel
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.deadline_alert import DeadlineAlert as DAM
-from airflow.models.serialized_dag import SerializedDagModel as SDM
+from airflow.models.serialized_dag import DagWriteMetadata, SerializedDagModel as SDM
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
@@ -688,6 +688,36 @@ class TestSerializedDagModel:
         assert metadata.dag_version is not None
         assert metadata.dag_version.version_number == 2
 
+    def test_prefetch_dag_write_metadata_latest_version_without_sdm_entry(self, dag_maker, session):
+        """When the latest DagVersion has no SDM entry, last_updated and dag_hash are None."""
+        with dag_maker("prefetch_no_sdm_dag") as dag:
+            EmptyOperator(task_id="task1")
+
+        v1 = session.scalar(select(DagVersion).where(DagVersion.dag_id == dag.dag_id))
+        assert v1 is not None
+        assert v1.version_number == 1
+
+        # v1 has an SDM entry (written by dag_maker); create v2 directly without one.
+        v2 = DagVersion.write_dag(
+            dag_id=dag.dag_id,
+            bundle_name="dag_maker",
+            bundle_version="v2",
+            session=session,
+        )
+        session.flush()
+
+        assert v2.version_number == 2
+
+        result = SDM._prefetch_dag_write_metadata([dag.dag_id], session=session)
+        metadata = result[dag.dag_id]
+
+        assert metadata.dag_version is not None
+        assert metadata.dag_version.version_number == 2
+        assert metadata.dag_version.dag_id == dag.dag_id
+        assert metadata.dag_version.bundle_version == "v2"
+        assert metadata.last_updated is None
+        assert metadata.dag_hash is None
+
     def test_new_dag_version_created_when_bundle_name_changes_and_hash_unchanged(self, dag_maker, session):
         """Test that new dag_version is created if bundle_name changes but DAG is unchanged."""
         # Create and write initial DAG
@@ -879,8 +909,7 @@ class TestSerializedDagModel:
         self, dag_maker, session
     ):
         """
-        Test that dynamic DAG update gracefully handles case where SerializedDagModel doesn't exist.
-        This adds the serialized dag entry
+        Test that dynamic DAG update creates a SerializedDagModel if it doesn't exist.
         """
         with dag_maker(dag_id="test_missing_serdag", serialized=True, session=session) as dag:
             EmptyOperator(task_id="task1")
@@ -908,7 +937,7 @@ class TestSerializedDagModel:
         # Verify no SerializedDagModel exists
         assert SDM.get("test_missing_serdag", session=session) is None
 
-        # Try to update - should create the serialized dag
+        # Try to update - should create a new serialized dag row under the latest DagVersion
         result = SDM.write_dag(
             dag=lazy_dag,
             bundle_name="test_bundle",
@@ -918,9 +947,186 @@ class TestSerializedDagModel:
         )
         session.commit()
 
-        serialized_dag = session.scalar(select(SDM).where(SDM.dag_id == "test_missing_serdag").limit(1))
-        assert serialized_dag is not None
         assert result is True
+        latest_version = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_missing_serdag")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert latest_version is not None
+        serialized_dag = SDM.get("test_missing_serdag", session=session)
+        assert serialized_dag is not None
+        assert serialized_dag.dag_version_id == latest_version.id
+
+    def test_write_dag_returns_false_when_update_finds_no_serialized_row(self, dag_maker, session):
+        """
+        Test that write_dag returns False when the UPDATE path finds no serialized row.
+
+        This exercises the rowcount == 0 branch: _prefetched carries a non-None dag_hash
+        (so the dynamic-update UPDATE path is taken), but the SDM row has been deleted
+        between prefetch and execution, so the UPDATE affects 0 rows.
+        """
+        with dag_maker(dag_id="test_rowcount_zero", serialized=True, session=session) as dag:
+            EmptyOperator(task_id="task1")
+
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+        SDM.write_dag(
+            dag=lazy_dag,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            session=session,
+        )
+        session.commit()
+
+        dag_version = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_rowcount_zero")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert dag_version is not None
+
+        # Build prefetched metadata that looks like the SDM row exists (non-None hash),
+        # then delete the actual row so the UPDATE finds nothing.
+        stale_hash = session.scalar(select(SDM.dag_hash).where(SDM.dag_id == "test_rowcount_zero"))
+        assert stale_hash is not None
+        session.execute(delete(SDM).where(SDM.dag_id == "test_rowcount_zero"))
+        session.commit()
+
+        prefetched = DagWriteMetadata(
+            last_updated=None,
+            dag_hash=stale_hash,
+            dag_version=dag_version,
+        )
+        # Change the dag so the hash differs, forcing the dynamic-update branch.
+        from airflow.sdk.definitions.dag import DAG as SdkDAG
+
+        new_dag_obj = SdkDAG(dag_id="test_rowcount_zero", schedule=None)
+        with new_dag_obj:
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+        new_lazy = LazyDeserializedDAG.from_dag(new_dag_obj)
+
+        result = SDM.write_dag(
+            dag=new_lazy,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            min_update_interval=None,
+            session=session,
+            _prefetched=prefetched,
+        )
+
+        assert result is False
+        assert SDM.get("test_rowcount_zero", session=session) is None
+
+    def test_latest_dag_version_with_no_serialized_row_and_changed_hash_heals(self, dag_maker, session):
+        """
+        v1 has a serialized row, v2 is a bare DagVersion (no serialized row), and
+        the incoming Dag hash differs from v1's. The v2 dag should be serialized successfully
+        """
+        with dag_maker(dag_id="test_v2_bare_changed_hash", serialized=True, session=session) as dag:
+            EmptyOperator(task_id="task1")
+
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+        SDM.write_dag(dag=lazy_dag, bundle_name="test_bundle", bundle_version=None, session=session)
+        session.commit()
+
+        # Create a bare v2 DagVersion with no corresponding serialized row.
+        DagVersion.write_dag(dag_id="test_v2_bare_changed_hash", bundle_name="test_bundle", session=session)
+        session.commit()
+
+        v2 = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_changed_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert v2 is not None
+        assert v2.version_number == 2
+
+        # A changed dag produces a different hash — bypasses the unchanged-hash short-circuit.
+        from airflow.sdk.definitions.dag import DAG as SdkDAG
+
+        changed_dag = SdkDAG(dag_id="test_v2_bare_changed_hash", schedule=None)
+        with changed_dag:
+            EmptyOperator(task_id="task1")
+            EmptyOperator(task_id="task2")
+        changed_lazy = LazyDeserializedDAG.from_dag(changed_dag)
+
+        result = SDM.write_dag(
+            dag=changed_lazy,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            min_update_interval=None,
+            session=session,
+        )
+        session.commit()
+
+        assert result is True
+        # The code falls through to DagVersion.write_dag, creating a new v3 with the serialized
+        # row attached to it — v2 stays bare. Assert the latest version now has a serialized row.
+        latest = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_changed_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert latest is not None
+        assert latest.version_number == 3
+        assert session.scalar(select(SDM).where(SDM.dag_version_id == latest.id)) is not None
+
+    def test_latest_dag_version_with_no_serialized_row_and_unchanged_hash_heals(self, dag_maker, session):
+        """
+        v1 has a serialized row, v2 is a bare DagVersion (no serialized row), and
+        the incoming Dag hash matches v1's. The v2 dag should be serialized successfully
+        """
+        with dag_maker(dag_id="test_v2_bare_unchanged_hash", serialized=True, session=session) as dag:
+            EmptyOperator(task_id="task1")
+
+        lazy_dag = LazyDeserializedDAG.from_dag(dag)
+        SDM.write_dag(dag=lazy_dag, bundle_name="test_bundle", bundle_version=None, session=session)
+        session.commit()
+
+        v1_hash = session.scalar(select(SDM.dag_hash).where(SDM.dag_id == "test_v2_bare_unchanged_hash"))
+        assert v1_hash is not None
+
+        # Create a bare v2 DagVersion with no corresponding serialized row.
+        DagVersion.write_dag(dag_id="test_v2_bare_unchanged_hash", bundle_name="test_bundle", session=session)
+        session.commit()
+
+        v2 = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_unchanged_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert v2 is not None
+        assert v2.version_number == 2
+
+        # Same dag — same hash as v1. Without the fix the prefetch returns v1's hash (inner
+        # join excludes v2), the unchanged-hash guard fires, and v2 never gets a serialized row.
+        result = SDM.write_dag(
+            dag=lazy_dag,
+            bundle_name="test_bundle",
+            bundle_version=None,
+            min_update_interval=None,
+            session=session,
+        )
+        session.commit()
+
+        assert result is True
+        # The code falls through to DagVersion.write_dag, creating a new v3 with the serialized
+        # row attached to it — v2 stays bare. Assert the latest version now has a serialized row.
+        latest = session.scalar(
+            select(DagVersion)
+            .where(DagVersion.dag_id == "test_v2_bare_unchanged_hash")
+            .order_by(DagVersion.version_number.desc())
+            .limit(1)
+        )
+        assert latest is not None
+        assert latest.version_number == 3
+        assert session.scalar(select(SDM).where(SDM.dag_version_id == latest.id)) is not None
 
     def test_dynamic_dag_update_success(self, dag_maker, session):
         """


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Prevent dags from not ever being serialized if they have no entry in `serialized_dag` table, but have one in `dag_version`
closes: #68944

---

Context: 
I ran into this state while running a custom application on top of airflow. It is highly likely that it was caused by custom code and not airflow, but airflow doesn't seem to have any safeguards against entering the state, and it affected all instances of my application. I can't easily tell exactly how it happened exactly (we are in the middle of updating from airflow 2 to 3 and there are lots of changes)
I believe this fix is appropriate given that there should be multiple ways to reach this state e.g. by editing the db manually. 
An alternative would be to try and add safeguards against getting into this state in the first place, but that would be way more complex than handling in this way + currently this is done at no additional cost as we already know whether the serialized dag exists or not by the old hash.
There should be no implications on backwards compatibility.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes 

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
