### PR TITLE
Fix Breeze SIGILL on Apple Silicon caused by OpenSSL 3.0.20 ARM crypto instructions

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -79,7 +79,13 @@ from airflow_breeze.global_constants import (
 )
 from airflow_breeze.utils.console import console_print
 from airflow_breeze.utils.docker_command_utils import is_docker_rootless
-from airflow_breeze.utils.host_info_utils import get_host_group_id, get_host_os, get_host_user_id
+from airflow_breeze.utils.host_info_utils import (
+    Architecture,
+    get_host_architecture,
+    get_host_group_id,
+    get_host_os,
+    get_host_user_id,
+)
 from airflow_breeze.utils.path_utils import (
     AIRFLOW_ROOT_PATH,
     BUILD_CACHE_PATH,
@@ -690,6 +696,8 @@ services:
         _set_var(_env, "PROVIDERS_SKIP_CONSTRAINTS", self.providers_skip_constraints)
         _set_var(_env, "PYTHONDONTWRITEBYTECODE", "true")
         _set_var(_env, "PYTHONWARNINGS", None, None)
+        if get_host_os() == "darwin" and get_host_architecture()[0] == Architecture.ARM:
+            _set_var(_env, "OPENSSL_armcap", None, "0x0")
         _set_var(_env, "PYTHON_MAJOR_MINOR_VERSION", self.python)
         _set_var(_env, "QUIET", self.quiet)
         _set_var(_env, "REDIS_HOST_PORT", None, REDIS_HOST_PORT)


### PR DESCRIPTION
OpenSSL 3.0.20 (shipped in the CI image rebuilt on 2026-06-22, see #68560) uses
aarch64 hardware crypto instructions that the Docker VM on Apple Silicon does not
expose. This causes a fatal `SIGILL` when Python imports the `cryptography` package
during test collection, making `breeze run pytest` unusable on M-series Macs since
that image was published.

Setting `OPENSSL_armcap=0x0` tells OpenSSL to disable ARM hardware acceleration and
fall back to software implementations. The variable is injected into the container
environment only on `darwin`/`ARM` hosts using the existing `get_host_os()` /
`get_host_architecture()` / `Architecture.ARM` pattern already used in Breeze, so
CI (Linux) is unaffected.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Sonnet 4.6 (Claude Code)

Generated-by: Claude Sonnet 4.6 (Claude Code) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)