### PR TITLE
preserve Gantt tooltip task end date

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/GanttTimeline.tsx
@@ -85,7 +85,7 @@ const toTooltipSummary = (
 
   return {
     child_states: null,
-    max_end_date: dayjs(segment.x[1]).toISOString(),
+    max_end_date: segment.end_when ?? dayjs(segment.x[1]).toISOString(),
     min_start_date: segment.start_when ?? dayjs(segment.x[0]).toISOString(),
     state: segment.state ?? null,
     task_display_name: segment.y,

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.test.ts
@@ -257,6 +257,14 @@ describe("transformGanttData", () => {
     });
 
     expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      end_when: "2024-03-14T10:05:00+00:00",
+      state: "queued",
+    });
+    expect(result[1]).toMatchObject({
+      end_when: "2024-03-14T10:05:00+00:00",
+      state: "success",
+    });
     expect(result[0]?.state).toBe("queued");
     expect(result[1]?.state).toBe("success");
   });

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -35,6 +35,8 @@ export type GanttDataItem = {
   scheduled_when?: string | null;
   /** Actual task execution start_date — consistent across all segments of the same try. */
   start_when?: string | null;
+  /** Actual task execution end_date — consistent across all segments of the same try. */
+  end_when?: string | null;
   state?: TaskInstanceState | null;
   taskId: string;
   tryNumber?: number;
@@ -140,6 +142,7 @@ export const transformGanttData = ({
               ...(scheduledMs === undefined ? {} : { scheduled_when: scheduledDttm }),
               ...(queuedMs === undefined ? {} : { queued_when: queuedDttm }),
               ...(startDate === null ? {} : { start_when: startDate }),
+              ...(endDate === null ? {} : { end_when: endDate }),
             };
 
             let endMs: number;

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Gantt/utils.ts
@@ -28,6 +28,8 @@ import { renderDuration } from "src/utils/datetimeUtils";
 import { buildTaskInstanceUrl } from "src/utils/links";
 
 export type GanttDataItem = {
+  /** Actual task execution end_date — consistent across all segments of the same try. */
+  end_when?: string | null;
   isGroup?: boolean | null;
   isMapped?: boolean | null;
   /** Source try times for tooltips (matches TaskInstance `*_when` fields). */
@@ -35,8 +37,6 @@ export type GanttDataItem = {
   scheduled_when?: string | null;
   /** Actual task execution start_date — consistent across all segments of the same try. */
   start_when?: string | null;
-  /** Actual task execution end_date — consistent across all segments of the same try. */
-  end_when?: string | null;
   state?: TaskInstanceState | null;
   taskId: string;
   tryNumber?: number;


### PR DESCRIPTION
## Why

Fixes #68174.

The Gantt timeline splits a task instance into visual segments such as scheduled, queued, and execution. For queued segments, the visual segment ends at `start_date`, which is correct for rendering the queued portion of the bar.

However, the tooltip summary used the visual segment end (`segment.x[1]`) as `max_end_date`. This caused the queued segment tooltip to show the end of the queued interval as the task `End Date`, instead of the real task instance `end_date`.

## What changed

- Preserve the real task instance `end_date` on each Gantt segment as `end_when`.
- Use `segment.end_when` for the tooltip `max_end_date` when available.
- Keep the existing visual segment boundaries unchanged.
- Add unit test coverage to ensure queued and execution segments retain the real task end date.

## Testing

- `git diff --check`
- `cd airflow-core/src/airflow/ui && pnpm test src/layouts/Details/Gantt/utils.test.ts`

Result:

- 1 test file passed
- 15 tests passed
