### PR TITLE
Add command to clean expired sessions

### DIFF
--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -1784,6 +1784,18 @@ DB_COMMANDS = (
         ),
     ),
     ActionCommand(
+        name="clean-all-expired-sessions",
+        help="Purge expired session records in the metastore",
+        func=lazy_load_command("airflow.cli.commands.db_command.cleanup_expired_sessions"),
+        args=(
+            ARG_DB_DRY_RUN,
+            ARG_VERBOSE,
+            ARG_YES,
+            ARG_DB_BATCH_SIZE,
+            ARG_DB_ERROR_ON_CLEANUP_FAILURE,
+        ),
+    ),
+    ActionCommand(
         name="export-archived",
         help="Export archived data from the archive tables",
         func=lazy_load_command("airflow.cli.commands.db_command.export_archived"),

--- a/airflow-core/src/airflow/cli/commands/db_command.py
+++ b/airflow-core/src/airflow/cli/commands/db_command.py
@@ -28,7 +28,7 @@ from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from airflow import settings
 from airflow.exceptions import AirflowException
-from airflow.utils import cli as cli_utils, db
+from airflow.utils import cli as cli_utils, db, timezone
 from airflow.utils.db import _REVISION_HEADS_MAP
 from airflow.utils.db_cleanup import config_dict, drop_archived_tables, export_archived_records, run_cleanup
 from airflow.utils.db_manager import _callable_accepts_use_migration_files
@@ -365,6 +365,24 @@ def cleanup_tables(args):
         batch_size=args.batch_size,
         dag_ids=args.dag_ids,
         exclude_dag_ids=args.exclude_dag_ids,
+        error_on_cleanup_failure=args.error_on_cleanup_failure,
+    )
+
+
+@cli_utils.action_cli(check_db=False)
+@providers_configuration_loaded
+def cleanup_expired_sessions(args):
+    """Purge expired session records in metadata database."""
+    run_cleanup(
+        table_names=["session"],
+        dry_run=args.dry_run,
+        clean_before_timestamp=timezone.utcnow(),
+        verbose=args.verbose,
+        confirm=not args.yes,
+        skip_archive=True,
+        batch_size=args.batch_size,
+        dag_ids=None,
+        exclude_dag_ids=None,
         error_on_cleanup_failure=args.error_on_cleanup_failure,
     )
 

--- a/airflow-core/tests/unit/cli/commands/test_db_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_db_command.py
@@ -791,6 +791,28 @@ class TestCLIDBClean:
     def setup_class(cls):
         cls.parser = cli_parser.get_parser()
 
+    @patch("airflow.cli.commands.db_command.timezone.utcnow")
+    @patch("airflow.cli.commands.db_command.run_cleanup")
+    def test_clean_all_expired_sessions(self, run_cleanup_mock, utcnow_mock):
+        now = pendulum.datetime(2024, 1, 1, tz="UTC")
+        utcnow_mock.return_value = now
+
+        args = self.parser.parse_args(["db", "clean-all-expired-sessions", "-y"])
+        db_command.cleanup_expired_sessions(args)
+
+        run_cleanup_mock.assert_called_once_with(
+            table_names=["session"],
+            dag_ids=None,
+            exclude_dag_ids=None,
+            dry_run=False,
+            clean_before_timestamp=now,
+            verbose=False,
+            confirm=False,
+            skip_archive=True,
+            batch_size=None,
+            error_on_cleanup_failure=False,
+        )
+
     @pytest.mark.parametrize("timezone", ["UTC", "Europe/Berlin", "America/Los_Angeles"])
     @patch("airflow.cli.commands.db_command.run_cleanup")
     def test_date_timezone_omitted(self, run_cleanup_mock, timezone):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

```md
Adds a new `airflow db clean-all-expired-sessions` command.

This reuses the existing database cleanup path and limits it to the `session` table, which already has cleanup configured using the `expiry` column. The goal is to give users a direct way to remove expired session rows without running the broader `airflow db clean` command.

I also added a CLI unit test to check that the new command calls `run_cleanup` with the expected session-table arguments.

closes: #33370

Testing:

```bash
pytest airflow-core/tests/unit/cli/commands/test_db_command.py::TestCLIDBClean::test_clean_all_expired_sessions
pytest airflow-core/tests/unit/cli/commands/test_db_command.py::TestCLIDBClean
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
