### PR TITLE
Fix flaky test_trigger_logger_fd_closed_when_removed on slow runners

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -947,8 +947,15 @@ def test_trigger_logger_fd_closed_when_removed(session):
         trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
         trigger_runner_supervisor.load_triggers()
 
-        for _ in range(30):
+        # The 0.5s trigger must fire and its finished-trigger cleanup must run before the log FD is
+        # closed. How many service iterations that takes depends on real wall-clock timing and runner
+        # speed (_service_subprocess returns as soon as there is I/O, not after a full 0.1s), so poll
+        # until the close happens rather than relying on a fixed iteration count -- a fixed count is
+        # flaky on slow/loaded runners where the trigger has not fired yet within the window.
+        for _ in range(300):
             trigger_runner_supervisor._service_subprocess(0.1)
+            if mock_file.close.called:
+                break
 
     mock_file.close.assert_called_once()
 


### PR DESCRIPTION
### Problem

`test_trigger_logger_fd_closed_when_removed` starts a **real** 0.5s `TimeDeltaTrigger` and then asserts the log file descriptor was closed after a **fixed** `for _ in range(30): _service_subprocess(0.1)`.

`_service_subprocess(0.1)` returns as soon as there is subprocess I/O — not after a full 0.1s — so 30 iterations is *not* a reliable amount of wall-clock time. On a slow or loaded runner (the failing run logged *"Triggerer's async thread was blocked for 0.33 seconds"*) the trigger hasn't fired and been cleaned up yet within those iterations, so the FD isn't closed and the test fails with `close … Called 0 times`. Seen on the Py3.14 / MySQL canary job; the sibling `test_trigger_log` avoids this by patching `time.monotonic`.

### Fix

Poll until the close happens (bounded to 300 iterations) instead of relying on a fixed count, so the test is deterministic regardless of runner speed. It breaks out as soon as the FD is closed (~1s locally) and still fails fast if the close genuinely never happens.

Test-only change; ran it repeatedly locally to confirm determinism.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)