### PR TITLE
Fix flaky CloudSQL custom-universe trigger test on loaded runners

### DIFF
--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_sql.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_sql.py
@@ -181,7 +181,14 @@ class TestCloudSQLExportTrigger:
         }
 
         task = asyncio.create_task(trigger.run().__anext__())
-        await asyncio.sleep(0.1)
+        # The custom-universe branch runs get_operation via sync_to_async, i.e. in a thread-pool
+        # executor, so the call can land a little later than a fixed short sleep -- flaky on loaded
+        # runners. Poll until it is observed; poke_interval is 10s, so no second call happens within
+        # this window and assert_called_once stays valid.
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            if sync_hook_mock.get_operation.called:
+                break
 
         sync_hook_mock.is_default_universe.assert_called_once()
         sync_hook_mock.get_operation.assert_called_once_with(


### PR DESCRIPTION
### Problem

`test_async_export_trigger_executes_successfully_in_custom_universe` failed on the Non-DB providers job (Py3.14) with `Expected 'get_operation' to be called once. Called 0 times.`

The custom-universe branch of `CloudSQLExportTrigger.run()` fetches the operation via `sync_to_async(sync_hook.get_operation)`, which dispatches the call to a **thread-pool executor**. The test waited a fixed `await asyncio.sleep(0.1)` before asserting `get_operation` had been called — but on a loaded runner the thread-dispatched call can land slightly later, so the assertion intermittently saw it called 0 times. (The default-universe path doesn't hit this because it awaits the async hook directly in the event loop, no thread.)

### Fix

Poll until the call is observed instead of a fixed sleep. The trigger's `poke_interval` is 10s, so no second call can happen within the poll window and `assert_called_once` stays valid. Deterministic regardless of runner speed; breaks out as soon as the call lands.

Test-only; ran the trigger test class repeatedly locally to confirm.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)