### PR TITLE
Java-SDK: replace AirflowJulHandler.install() with setup()

### DIFF
--- a/java-sdk/jul/src/main/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandler.kt
+++ b/java-sdk/jul/src/main/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandler.kt
@@ -77,22 +77,32 @@ class AirflowJulHandler : Handler() {
 
   companion object {
     /**
-     * Route java.util.logging through Airflow.
+     * Route java.util.logging through Airflow by installing a single
+     * [AirflowJulHandler] on the root logger. Call this in the Dag bundle's
+     * `main` method before you create the [org.apache.airflow.sdk.Bundle]
+     * object; repeated calls are idempotent.
      *
-     * Removes every handler currently on the root logger (notably the JDK's
-     * default [java.util.logging.ConsoleHandler], which would otherwise also
+     * By default it first removes the root logger's existing handlers, notably
+     * the JDK's [java.util.logging.ConsoleHandler], which would otherwise also
      * write each record to stderr that Airflow captures separately as
-     * `task.stderr` at ERROR level) and installs a single [AirflowJulHandler]
-     * in their place. Call this in the Dag bundle's `main` method before you
-     * create the [org.apache.airflow.sdk.Bundle] object; add any handler you
-     * want to keep afterwards. Prefer a `logging.properties` file if you need
-     * full control over the root handler set.
+     * `task.stderr` at ERROR level. Pass `clean = false` to instead add the
+     * handler alongside existing ones (e.g. your own
+     * [java.util.logging.FileHandler]); none of them must write to stderr, or
+     * task logs are duplicated. For full control, use a `logging.properties`
+     * file.
+     *
+     * @param clean remove the root logger's existing handlers first (default `true`).
      */
     @JvmStatic
-    fun setup() {
+    @JvmOverloads
+    fun setup(clean: Boolean = true) {
       val root = Logger.getLogger("")
-      root.handlers.forEach { root.removeHandler(it) }
-      root.addHandler(AirflowJulHandler())
+      if (clean) {
+        root.handlers.forEach { root.removeHandler(it) }
+      }
+      if (root.handlers.none { it is AirflowJulHandler }) {
+        root.addHandler(AirflowJulHandler())
+      }
     }
   }
 }

--- a/java-sdk/jul/src/main/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandler.kt
+++ b/java-sdk/jul/src/main/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandler.kt
@@ -77,19 +77,22 @@ class AirflowJulHandler : Handler() {
 
   companion object {
     /**
-     * Install an [AirflowJulHandler] on the root logger.
+     * Route java.util.logging through Airflow.
      *
-     * This is a convenience method to install the handler on all loggers if
-     * you choose to do this programmatically (rather than with a properties
-     * file). You should typically do it in the Dag bundle's `main` method
-     * before you create the [org.apache.airflow.sdk.Bundle] object.
+     * Removes every handler currently on the root logger (notably the JDK's
+     * default [java.util.logging.ConsoleHandler], which would otherwise also
+     * write each record to stderr that Airflow captures separately as
+     * `task.stderr` at ERROR level) and installs a single [AirflowJulHandler]
+     * in their place. Call this in the Dag bundle's `main` method before you
+     * create the [org.apache.airflow.sdk.Bundle] object; add any handler you
+     * want to keep afterwards. Prefer a `logging.properties` file if you need
+     * full control over the root handler set.
      */
     @JvmStatic
-    fun install() {
+    fun setup() {
       val root = Logger.getLogger("")
-      if (root.handlers.none { it is AirflowJulHandler }) {
-        root.addHandler(AirflowJulHandler())
-      }
+      root.handlers.forEach { root.removeHandler(it) }
+      root.addHandler(AirflowJulHandler())
     }
   }
 }

--- a/java-sdk/jul/src/test/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandlerTest.kt
+++ b/java-sdk/jul/src/test/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandlerTest.kt
@@ -30,9 +30,11 @@ import org.apache.airflow.sdk.execution.Level
 import org.apache.airflow.sdk.execution.Log
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.logging.ConsoleHandler
 import java.util.logging.LogRecord
 import java.util.logging.Logger
 import java.util.logging.Level as JLevel
@@ -51,9 +53,34 @@ class AirflowJulHandlerTest {
   @AfterEach
   fun tearDown() {
     unmockkAll()
-    // Remove any handlers installed by install() tests so they don't leak between tests.
+    // Remove any handlers installed by setup() tests so they don't leak between tests.
     val root = Logger.getLogger("")
     root.handlers.filterIsInstance<AirflowJulHandler>().forEach { root.removeHandler(it) }
+  }
+
+  @Test
+  fun `setup replaces root handlers with a single AirflowJulHandler`() {
+    val root = Logger.getLogger("")
+    val original = root.handlers.toList()
+    val preexisting = ConsoleHandler()
+    try {
+      original.forEach { root.removeHandler(it) }
+      root.addHandler(preexisting)
+
+      AirflowJulHandler.setup()
+
+      assertEquals(1, root.handlers.size)
+      assertTrue(root.handlers[0] is AirflowJulHandler)
+      assertFalse(root.handlers.contains(preexisting))
+
+      // Idempotent: a second call still leaves exactly one AirflowJulHandler.
+      AirflowJulHandler.setup()
+      assertEquals(1, root.handlers.size)
+      assertTrue(root.handlers[0] is AirflowJulHandler)
+    } finally {
+      root.handlers.forEach { root.removeHandler(it) }
+      original.forEach { root.addHandler(it) }
+    }
   }
 
   // Mapping:

--- a/java-sdk/jul/src/test/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandlerTest.kt
+++ b/java-sdk/jul/src/test/kotlin/org/apache/airflow/sdk/jul/AirflowJulHandlerTest.kt
@@ -83,6 +83,31 @@ class AirflowJulHandlerTest {
     }
   }
 
+  @Test
+  fun `setup with clean false keeps existing root handlers`() {
+    val root = Logger.getLogger("")
+    val original = root.handlers.toList()
+    val preexisting = ConsoleHandler()
+    try {
+      original.forEach { root.removeHandler(it) }
+      root.addHandler(preexisting)
+
+      AirflowJulHandler.setup(clean = false)
+
+      assertEquals(2, root.handlers.size)
+      assertTrue(root.handlers.contains(preexisting))
+      assertEquals(1, root.handlers.count { it is AirflowJulHandler })
+
+      // Idempotent: a second call does not add another AirflowJulHandler.
+      AirflowJulHandler.setup(clean = false)
+      assertEquals(2, root.handlers.size)
+      assertEquals(1, root.handlers.count { it is AirflowJulHandler })
+    } finally {
+      root.handlers.forEach { root.removeHandler(it) }
+      original.forEach { root.addHandler(it) }
+    }
+  }
+
   // Mapping:
   //   > 1000 -> CRITICAL
   //   > 900  -> ERROR   (SEVERE = 1000)


### PR DESCRIPTION
- **related**: https://github.com/apache/airflow/pull/68938
- **note**: the documentation part of this patch still lives in https://github.com/apache/airflow/pull/68938, as the doc belongs to the airflow-core release cycle.

## Why

`install()` only added the handler and left JUL's default ConsoleHandler on the root logger, so every task log record was also written to stderr, making each line appear twice and mislabeling INFO records as errors.

Users had to strip the root handlers themselves (raised in review on https://github.com/apache/airflow/pull/68938#discussion_r3472453544).

## What

- Rename `AirflowJulHandler.install()` to `setup()` and it now clears the root logger's existing handlers before installing a single AirflowJulHandler, so records flow only through Airflow.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)