### PR TITLE
Disable branch protection on v3-3-stable

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -115,6 +115,11 @@ github:
           - "providers-fab/v*"
           - "airflow-ctl/v*-stable"
           - "chart/v*-stable"
+        excludes:
+          # Temporarily exclude `v3-3-stable` from branch protection. It is matched by the
+          # `v*-stable` include above; exclusions take precedence, so this leaves the branch
+          # unprotected while the other `v*-stable` branches stay protected.
+          - "v3-3-stable"
       required_pull_request_reviews:
         required_approving_review_count: 1
       required_linear_history: true


### PR DESCRIPTION
## Summary

Temporarily removes branch protection from `v3-3-stable` so the `3.3.0rc1` release can be cut.

The `v3-3-stable` branch is covered by the "Branch protection" ruleset because it matches the `v*-stable` pattern in [`branches.includes`](https://github.com/apache/airflow/blob/main/.asf.yaml#L114). This adds it to a new `branches.excludes` list so the branch is left unprotected for now.

## Why excludes rather than editing the include glob

Narrowing or removing `v*-stable` would also un-protect every other stable branch (`v3-2-stable`, `v3-1-stable`, etc.). GitHub ruleset exclusions take precedence over inclusions, so an explicit `excludes` entry drops protection on just `v3-3-stable` and leaves the rest intact.

## Re-enabling

Remove the `v3-3-stable` entry from `branches.excludes` (or drop the whole block) to restore protection once the release is out.

## Note

`.asf.yaml` ruleset settings are applied from the default branch only, so this takes effect once merged to `main`.
