### PR TITLE
Re-queue worker pods on transient 502/503/504 from the Kubernetes API

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -343,18 +343,26 @@ class KubernetesExecutor(BaseExecutor):
 
                     headers = e.headers or {}
                     retries = self.task_publish_retries[key]
-                    # In case of exceeded quota or conflict errors, requeue the task as per the task_publish_max_retries
-                    # In case of a rate limit, wait and do not create new pods for "Retry-After" seconds
+                    # Requeue transient failures (exceeded-quota / stale-version conflicts and the
+                    # api server's 429 / 5xx) up to task_publish_max_retries; anything else fails.
                     can_retry_publish = (
                         self.task_publish_max_retries == -1 or retries < self.task_publish_max_retries
                     )
                     message = body.get("message", "")
+                    # Retry-After (seconds): the apiserver sets it on 429 (APF throttling) and on 503
+                    # while shutting down. Ignore a malformed value rather than crashing the loop.
+                    retry_after = headers.get("Retry-After")
+                    try:
+                        retry_after_seconds = int(retry_after) if retry_after is not None else None
+                    except (TypeError, ValueError):
+                        retry_after_seconds = None
                     if (
                         (str(e.status) == "403" and "exceeded quota" in message)
                         or (str(e.status) == "409" and "object has been modified" in message)
                         or (str(e.status) == "410" and "too old resource version" in message)
                         or str(e.status) == "500"
                         or str(e.status) == "429"
+                        or str(e.status) in ("502", "503", "504")
                     ) and can_retry_publish:
                         self.log.warning(
                             "[Try %s of %s] Kube ApiException for Task: (%s). Reason: %r. Message: %s",
@@ -368,13 +376,16 @@ class KubernetesExecutor(BaseExecutor):
                         self.task_queue.put(task)
                         self.task_publish_retries[key] = retries + 1
 
-                        if str(e.status) == "429":
+                        # Pause the loop until Retry-After when the server told us to back off (429, or
+                        # 503 on apiserver shutdown); other transient 5xx retry on the next loop.
+                        if str(e.status) == "429" or retry_after_seconds is not None:
                             self.create_pods_after = datetime.now() + timedelta(
-                                seconds=int(headers.get("Retry-After", "0"))
+                                seconds=retry_after_seconds or 0
                             )
                             self.log.warning(
-                                "Got rate limit from k8s api, skipping pod creation until %s",
+                                "Backing off pod creation until %s after status %s from k8s api",
                                 self.create_pods_after,
+                                e.status,
                             )
                             # stop pod creation to stop api requests
                             break

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -529,6 +529,46 @@ class TestKubernetesExecutor:
                 None,
                 id="500 Internal Server Error (webhook failure) (retry failed)",
             ),
+            pytest.param(
+                HTTPResponse(body='{"message": "Bad Gateway"}', status=502),
+                1,
+                True,
+                State.SUCCESS,
+                None,
+                id="502 Bad Gateway (transient, requeued, retry next loop)",
+            ),
+            pytest.param(
+                HTTPResponse(
+                    body='{"message": "apiserver is shutting down"}',
+                    status=503,
+                    headers={"Retry-After": "1"},
+                ),
+                1,
+                True,
+                State.SUCCESS,
+                1,
+                id="503 Service Unavailable (Retry-After honored, requeued after retry delay)",
+            ),
+            pytest.param(
+                HTTPResponse(body='{"message": "Gateway Timeout"}', status=504),
+                1,
+                True,
+                State.SUCCESS,
+                None,
+                id="504 Gateway Timeout (transient, requeued, retry next loop)",
+            ),
+            pytest.param(
+                HTTPResponse(
+                    body='{"message": "apiserver is shutting down"}',
+                    status=503,
+                    headers={"Retry-After": "1"},
+                ),
+                1,
+                True,
+                State.FAILED,
+                1,
+                id="503 Service Unavailable (retries exhausted, failed)",
+            ),
         ],
     )
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")


### PR DESCRIPTION
## Why

Inspired from @jscheffl 's comment https://github.com/apache/airflow/pull/68480#discussion_r3438015729
When `KubernetesExecutor` fails to create a worker pod, it re-queues the task on an
exceeded-quota / stale-version conflict, `500`, or `429`, but lets **`502` / `503` / `504`
fall through and fail the task immediately.** Those are exactly the gateway / unavailable /
timeout codes that spike when the API server or an admission webhook is under load. Concretely,
the API server returns `503` **with `Retry-After: 1`** on every graceful shutdown (rollout, node
drain, control-plane autoscale — see `apiserver` `waitgroup.go`), so a worker pod CREATE that is
in flight during any apiserver roll currently kills the task outright instead of retrying.
`client-go` retries all 5xx and honours `Retry-After`; the executor does not.

## What

Add `502` / `503` / `504` to the transient set, so a task that hits one is re-queued (bounded by
`task_publish_max_retries`) instead of failed. When the response carries `Retry-After` (a
shutting-down apiserver always sends it on `503`), pause pod creation until then via
`create_pods_after`, exactly as the `429` path already does; other transient 5xx without the
header retry on the next scheduler loop like `500`. The `Retry-After` parse is guarded so a
malformed value can't crash the scheduler loop.

This gap was noticed while reviewing #68480 (concurrent pod creation). It is pre-existing on the
current sync path and independent of that change, so it goes as its own PR; the two touch the same
error handler, so whichever lands second will need a trivial rebase.

## Tests

`test_run_next_exception_requeue` gains `502` / `504` (re-queue, retry next loop), `503 + Retry-After`
(re-queue, loop backs off), and `503` with retries exhausted (fails). Each fails without this change.

## E2E

Live `kind` (real API server, real `KubernetesExecutor.sync()`), with a proxy injecting
`503 + Retry-After: 1` on the first CREATE per task — identical config (`task_publish_max_retries=3`),
only the fix differs:

| Run (`retries=3`) | behaviour | **pods created** |
|---|---|---|
| before (`main`) | `503` → task failed | **0 / 6** |
| after (this PR) | `503` → re-queued, retried | **6 / 6** |

<details><summary>Raw — after</summary>

```
loop 0..5: queue 6->6 failed_events=0     # each loop: one task hits 503+Retry-After, re-queues, loop backs off
loop 6:    queue 6->0 failed_events=0     # backoff elapsed -> retries succeed, all pods created
FINAL failed_events=0 queue_remaining=0
# injector: INJECT 503 (Retry-After=1) x6 (first attempt) -> PASS 201 x6 (retry)
# cluster: retrydag-t000..t005  Running
```
</details>

## Risk

Behaviour change on the default path: a `502` / `503` / `504` now re-queues instead of failing the
task — bounded by `task_publish_max_retries` (default `0`, i.e. inert unless retries are already
enabled). The existing `429` / `500` / quota / conflict handling is unchanged.