### PR TITLE
Add team_name tag to Edge executor sync metric

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
+++ b/providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py
@@ -35,6 +35,7 @@ from airflow.providers.edge3.models.edge_logs import EdgeLogsModel
 from airflow.providers.edge3.models.edge_worker import EdgeWorkerModel, EdgeWorkerState, reset_metrics
 from airflow.providers.edge3.models.types import is_callback_execute
 from airflow.utils.db import DBLocks, create_global_lock
+from airflow.utils.helpers import prune_dict
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
@@ -340,7 +341,7 @@ class EdgeExecutor(BaseExecutor):
     @provide_session
     def sync(self, *, session: Session = NEW_SESSION) -> None:
         """Sync will get called periodically by the heartbeat method."""
-        with Stats.timer("edge_executor.sync.duration"):
+        with Stats.timer("edge_executor.sync.duration", tags=prune_dict({"team_name": self.team_name})):
             orphaned = self._update_orphaned_jobs(session)
             purged = self._purge_jobs(session)
             liveness = self._check_worker_liveness(session)

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -120,9 +120,17 @@ class TestEdgeExecutor:
             assert jobs[0].task_id == "started_running_orphaned"
             assert jobs[0].state == TaskInstanceState.REMOVED
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_2_PLUS, reason="team_name is only available in Airflow 3.2+")
+    @pytest.mark.parametrize(
+        ("team_name", "expected_tags"),
+        [
+            ("team_a", {"team_name": "team_a"}),
+            (None, {}),
+        ],
+    )
     @patch(f"{Stats.__module__}.Stats.timer")
-    def test_sync_duration_metric_includes_team_name(self, mock_stats_timer):
-        executor = EdgeExecutor(team_name="team_a")
+    def test_sync_duration_metric_tags_team_name(self, mock_stats_timer, team_name, expected_tags):
+        executor = EdgeExecutor(team_name=team_name)
 
         with (
             mock.patch.object(executor, "_update_orphaned_jobs", return_value=False),
@@ -133,23 +141,7 @@ class TestEdgeExecutor:
 
         mock_stats_timer.assert_called_once_with(
             "edge_executor.sync.duration",
-            tags={"team_name": "team_a"},
-        )
-
-    @patch(f"{Stats.__module__}.Stats.timer")
-    def test_sync_duration_metric_omits_team_name_for_global_executor(self, mock_stats_timer):
-        executor = EdgeExecutor()
-
-        with (
-            mock.patch.object(executor, "_update_orphaned_jobs", return_value=False),
-            mock.patch.object(executor, "_purge_jobs", return_value=False),
-            mock.patch.object(executor, "_check_worker_liveness", return_value=False),
-        ):
-            executor.sync(session=MagicMock())
-
-        mock_stats_timer.assert_called_once_with(
-            "edge_executor.sync.duration",
-            tags={},
+            tags=expected_tags,
         )
 
     @patch("airflow.providers.edge3.executors.edge_executor.EdgeExecutor.running_state")

--- a/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
+++ b/providers/edge3/tests/unit/edge3/executors/test_edge_executor.py
@@ -120,6 +120,38 @@ class TestEdgeExecutor:
             assert jobs[0].task_id == "started_running_orphaned"
             assert jobs[0].state == TaskInstanceState.REMOVED
 
+    @patch(f"{Stats.__module__}.Stats.timer")
+    def test_sync_duration_metric_includes_team_name(self, mock_stats_timer):
+        executor = EdgeExecutor(team_name="team_a")
+
+        with (
+            mock.patch.object(executor, "_update_orphaned_jobs", return_value=False),
+            mock.patch.object(executor, "_purge_jobs", return_value=False),
+            mock.patch.object(executor, "_check_worker_liveness", return_value=False),
+        ):
+            executor.sync(session=MagicMock())
+
+        mock_stats_timer.assert_called_once_with(
+            "edge_executor.sync.duration",
+            tags={"team_name": "team_a"},
+        )
+
+    @patch(f"{Stats.__module__}.Stats.timer")
+    def test_sync_duration_metric_omits_team_name_for_global_executor(self, mock_stats_timer):
+        executor = EdgeExecutor()
+
+        with (
+            mock.patch.object(executor, "_update_orphaned_jobs", return_value=False),
+            mock.patch.object(executor, "_purge_jobs", return_value=False),
+            mock.patch.object(executor, "_check_worker_liveness", return_value=False),
+        ):
+            executor.sync(session=MagicMock())
+
+        mock_stats_timer.assert_called_once_with(
+            "edge_executor.sync.duration",
+            tags={},
+        )
+
     @patch("airflow.providers.edge3.executors.edge_executor.EdgeExecutor.running_state")
     @patch("airflow.providers.edge3.executors.edge_executor.EdgeExecutor.success")
     @patch("airflow.providers.edge3.executors.edge_executor.EdgeExecutor.fail")


### PR DESCRIPTION
Add the `team_name` tag to the Edge executor sync duration metric for multi-team deployments.

This follows the same pattern as #68593 for executor metrics:
- use `self.team_name` as the metric tag source
- wrap tags with `prune_dict` so global/no-team executors keep the existing empty tag set
- keep the change scoped to the Edge executor metric only

This PR covers the `edge_executor.sync.duration` item from #68996. Edge worker metrics and ECS executor metrics are being kept in separate PRs.

Tests:
- `uv run ruff format --check providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py providers/edge3/tests/unit/edge3/executors/test_edge_executor.py`
- `uv run ruff check providers/edge3/src/airflow/providers/edge3/executors/edge_executor.py providers/edge3/tests/unit/edge3/executors/test_edge_executor.py`
- `git diff --check`
- `uv run pytest providers/edge3/tests/unit/edge3/executors/test_edge_executor.py -q`
- `breeze run pytest providers/edge3/tests/unit/edge3/executors/test_edge_executor.py -q`
- `uvx prek run --from-ref upstream/main --stage pre-commit`

Results:
- ruff format/check passed
- diff check clean
- `20 passed, 1 warning`
- pre-commit stage passed

Related: #68996

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: OpenAI Codex (no human review before posting)
