### PR TITLE
Replace deprecated `pydantic-ai` MCP classes with `MCPToolset` in `common.ai`

### DIFF
--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -42,11 +42,10 @@ passed to any pydantic-ai ``Agent``, including via
 .. note::
 
     ``AgentOperator`` accepts **any** ``AbstractToolset`` implementation — not
-    just the Airflow-native toolsets above. PydanticAI's own MCP server
-    classes (``MCPServerStreamableHTTP``, ``MCPServerSSE``, ``MCPServerStdio``)
-    and third-party toolsets work too. The Airflow-native toolsets add
-    connection management, secret backend integration, and the connection UI,
-    but you are not locked in.
+    just the Airflow-native toolsets above. PydanticAI's own ``MCPToolset``
+    (built over a FastMCP transport) and third-party toolsets work too. The
+    Airflow-native toolsets add connection management, secret backend
+    integration, and the connection UI, but you are not locked in.
 
 
 Using Toolsets Directly with PydanticAI
@@ -336,29 +335,30 @@ Using Multiple MCP Servers
         ],
     )
 
-Direct PydanticAI MCP Servers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Direct PydanticAI MCP Toolsets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For prototyping or when you want full PydanticAI control, you can pass MCP
-server instances directly — no Airflow connection needed:
+For prototyping or when you want full PydanticAI control, you can pass
+``MCPToolset`` instances directly — no Airflow connection needed:
 
 .. code-block:: python
 
-    from pydantic_ai.mcp import MCPServerStreamableHTTP, MCPServerStdio
+    from fastmcp.client.transports import StdioTransport
+    from pydantic_ai.mcp import MCPToolset
 
     AgentOperator(
         task_id="direct_mcp",
         prompt="What tools are available?",
         llm_conn_id="pydanticai_default",
         toolsets=[
-            MCPServerStreamableHTTP("http://localhost:3001/mcp"),
-            MCPServerStdio("uvx", args=["mcp-run-python"]),
+            MCPToolset("http://localhost:3001/mcp"),
+            MCPToolset(StdioTransport(command="uvx", args=["mcp-run-python"])),
         ],
     )
 
-This works because PydanticAI's MCP server classes implement
-``AbstractToolset``. The tradeoff: URLs and credentials are hardcoded in DAG
-code instead of being managed through Airflow connections and secret backends.
+This works because PydanticAI's ``MCPToolset`` implements ``AbstractToolset``.
+The tradeoff: URLs and credentials are hardcoded in DAG code instead of being
+managed through Airflow connections and secret backends.
 
 
 .. _agent-skills:

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_mcp.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_mcp.py
@@ -74,19 +74,20 @@ example_mcp_multiple_servers()
 
 
 # ---------------------------------------------------------------------------
-# 3. Direct PydanticAI MCP servers (no Airflow connection needed)
+# 3. Direct PydanticAI MCP toolsets (no Airflow connection needed)
 # ---------------------------------------------------------------------------
-# AgentOperator accepts any PydanticAI AbstractToolset, including MCP servers
+# AgentOperator accepts any PydanticAI AbstractToolset, including MCPToolset
 # directly. Use this for prototyping or when you want full PydanticAI control.
 #
-#   from pydantic_ai.mcp import MCPServerStreamableHTTP, MCPServerStdio
+#   from fastmcp.client.transports import StdioTransport
+#   from pydantic_ai.mcp import MCPToolset
 #
 #   AgentOperator(
 #       task_id="direct_mcp",
 #       prompt="What tools are available?",
 #       llm_conn_id="pydanticai_default",
 #       toolsets=[
-#           MCPServerStreamableHTTP("http://localhost:3001/mcp"),
-#           MCPServerStdio("uvx", args=["mcp-run-python"]),
+#           MCPToolset("http://localhost:3001/mcp"),
+#           MCPToolset(StdioTransport(command="uvx", args=["mcp-run-python"])),
 #       ],
 #   )

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/mcp.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/mcp.py
@@ -47,7 +47,7 @@ class MCPHook(BaseHook):
         - **Extra.transport**: Transport type — ``http`` (default), ``sse``, or ``stdio``
         - **Extra.command**: Command to run for stdio transport (e.g. ``uvx``)
         - **Extra.args**: Command arguments for stdio transport (e.g. ``["mcp-run-python"]``)
-        - **Extra.timeout**: Connection timeout in seconds for stdio (default: 10)
+        - **Extra.timeout**: Connection init timeout in seconds for stdio (default: 10)
 
     For HTTP/SSE transports the ``Authorization`` header is, by default, a static
     ``Bearer`` token taken from the connection ``password``. Endpoints that require
@@ -121,14 +121,18 @@ class MCPHook(BaseHook):
 
     def get_conn(self) -> Any:
         """
-        Return a configured PydanticAI MCP server instance.
+        Return a configured PydanticAI MCP toolset instance.
 
-        Creates the appropriate MCP server based on the transport type
-        in the connection's extra field:
+        Builds a :class:`~pydantic_ai.mcp.MCPToolset` over the FastMCP transport
+        matching the transport type in the connection's extra field:
 
-        - ``http`` (default): :class:`~pydantic_ai.mcp.MCPServerStreamableHTTP`
-        - ``sse``: :class:`~pydantic_ai.mcp.MCPServerSSE`
-        - ``stdio``: :class:`~pydantic_ai.mcp.MCPServerStdio`
+        - ``http`` (default): ``fastmcp.client.transports.StreamableHttpTransport``
+        - ``sse``: ``fastmcp.client.transports.SSETransport``
+        - ``stdio``: ``fastmcp.client.transports.StdioTransport``
+
+        When ``tool_prefix`` is set the toolset is wrapped via
+        :meth:`~pydantic_ai.toolsets.abstract.AbstractToolset.prefixed`, so a
+        prefix of ``"weather"`` yields tool names like ``weather_get_forecast``.
 
         The result is cached for the lifetime of this hook instance.
         """
@@ -136,7 +140,8 @@ class MCPHook(BaseHook):
             return self._server
 
         try:
-            from pydantic_ai.mcp import MCPServerSSE, MCPServerStdio, MCPServerStreamableHTTP
+            from fastmcp.client.transports import SSETransport, StdioTransport, StreamableHttpTransport
+            from pydantic_ai.mcp import MCPToolset
         except ImportError:
             raise ImportError(
                 'MCP support requires the `mcp` package. Install it with: pip install "pydantic-ai-slim[mcp]"'
@@ -149,15 +154,11 @@ class MCPHook(BaseHook):
         if transport == "http":
             if not conn.host:
                 raise ValueError(f"Connection {self.mcp_conn_id!r} requires a host URL for HTTP transport.")
-            self._server = MCPServerStreamableHTTP(
-                conn.host, headers=self._auth_headers(conn), tool_prefix=self.tool_prefix
-            )
+            toolset = MCPToolset(StreamableHttpTransport(conn.host, headers=self._auth_headers(conn)))
         elif transport == "sse":
             if not conn.host:
                 raise ValueError(f"Connection {self.mcp_conn_id!r} requires a host URL for SSE transport.")
-            self._server = MCPServerSSE(
-                conn.host, headers=self._auth_headers(conn), tool_prefix=self.tool_prefix
-            )
+            toolset = MCPToolset(SSETransport(conn.host, headers=self._auth_headers(conn)))
         elif transport == "stdio":
             command = extra.get("command")
             if not command:
@@ -168,13 +169,14 @@ class MCPHook(BaseHook):
             if isinstance(args, str):
                 args = [args]
             timeout = extra.get("timeout", 10)
-            self._server = MCPServerStdio(command, args=args, timeout=timeout, tool_prefix=self.tool_prefix)
+            toolset = MCPToolset(StdioTransport(command=command, args=args), init_timeout=timeout)
         else:
             raise ValueError(
                 f"Unknown transport {transport!r} in connection {self.mcp_conn_id!r}. "
                 "Supported: 'http', 'sse', 'stdio'."
             )
 
+        self._server = toolset.prefixed(self.tool_prefix) if self.tool_prefix else toolset
         return self._server
 
     def test_connection(self) -> tuple[bool, str]:

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/langchain_bridge.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/langchain_bridge.py
@@ -97,9 +97,9 @@ def airflow_toolset_to_langchain_tools(
         and every ``call_tool`` each run under their own event loop, and pydantic-ai
         opens and tears the connection down around each one. For ``MCPToolset`` this
         means the server is reconnected on every tool call. That is fine for
-        stateless tools (and for HTTP/SSE servers, modulo per-call latency), but an
-        ``MCPServerStdio`` server, or any server that keeps state between calls,
-        will lose that state because each call starts a fresh process/session.
+        stateless tools (and for HTTP/SSE servers, modulo per-call latency), but a
+        stdio server, or any server that keeps state between calls, will lose that
+        state because each call starts a fresh process/session.
 
     .. note::
         A pydantic-ai toolset is normally driven inside an agent run, where a

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/mcp.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/mcp.py
@@ -35,18 +35,17 @@ class MCPToolset(AbstractToolset[Any]):
 
     Reads MCP server transport type, URL, command, and credentials from the
     connection via :class:`~airflow.providers.common.ai.hooks.mcp.MCPHook` and
-    creates the appropriate PydanticAI MCP server instance.
-    All ``AbstractToolset`` methods delegate to the underlying MCP server.
+    builds the matching PydanticAI :class:`~pydantic_ai.mcp.MCPToolset`.
+    All ``AbstractToolset`` methods delegate to the underlying MCP toolset.
 
     This is the recommended way to use MCP servers in Airflow — it stores
     server configuration in Airflow connections (and secret backends) rather
     than hard-coding URLs and credentials in DAG code.
 
-    If you prefer full PydanticAI control, you can pass MCP server instances
-    directly to ``AgentOperator(toolsets=[...])``, since
-    :class:`~pydantic_ai.mcp.MCPServerStreamableHTTP`,
-    :class:`~pydantic_ai.mcp.MCPServerSSE`, and
-    :class:`~pydantic_ai.mcp.MCPServerStdio` all implement ``AbstractToolset``.
+    If you prefer full PydanticAI control, you can pass a
+    :class:`~pydantic_ai.mcp.MCPToolset` (built over a FastMCP transport)
+    directly to ``AgentOperator(toolsets=[...])``, since it implements
+    ``AbstractToolset``.
 
     For MCP endpoints that need a freshly minted or short-lived token (e.g. a
     Snowflake managed MCP server authenticated with a key-pair JWT, or OAuth /

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_mcp.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_mcp.py
@@ -24,11 +24,13 @@ import pytest
 from airflow.models.connection import Connection
 from airflow.providers.common.ai.hooks.mcp import MCPHook
 
-# The hook imports MCP classes lazily inside get_conn(), so we must patch
-# them at their source in pydantic_ai.mcp rather than on the hook module.
-_MCP_HTTP = "pydantic_ai.mcp.MCPServerStreamableHTTP"
-_MCP_SSE = "pydantic_ai.mcp.MCPServerSSE"
-_MCP_STDIO = "pydantic_ai.mcp.MCPServerStdio"
+# The hook imports these lazily inside get_conn(), so we patch them at their
+# source modules rather than on the hook module. MCPToolset is the unified
+# pydantic-ai entrypoint; the three transports come from FastMCP.
+_MCP_TOOLSET = "pydantic_ai.mcp.MCPToolset"
+_HTTP_TRANSPORT = "fastmcp.client.transports.StreamableHttpTransport"
+_SSE_TRANSPORT = "fastmcp.client.transports.SSETransport"
+_STDIO_TRANSPORT = "fastmcp.client.transports.StdioTransport"
 
 
 class TestMCPHookInit:
@@ -46,8 +48,9 @@ class TestMCPHookInit:
 
 
 class TestMCPHookGetConn:
-    @patch(_MCP_HTTP)
-    def test_http_transport(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_http_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -57,11 +60,13 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             result = hook.get_conn()
 
-        mock_server_cls.assert_called_once_with("http://localhost:3001/mcp", headers=None, tool_prefix=None)
-        assert result is mock_server_cls.return_value
+        mock_transport_cls.assert_called_once_with("http://localhost:3001/mcp", headers=None)
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
+        assert result is mock_toolset_cls.return_value
 
-    @patch(_MCP_HTTP)
-    def test_http_is_default_transport(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_http_is_default_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -71,10 +76,12 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with("http://localhost:3001/mcp", headers=None, tool_prefix=None)
+        mock_transport_cls.assert_called_once_with("http://localhost:3001/mcp", headers=None)
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
 
-    @patch(_MCP_HTTP)
-    def test_http_with_auth_token(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_http_with_auth_token(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -85,14 +92,14 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with(
+        mock_transport_cls.assert_called_once_with(
             "http://localhost:3001/mcp",
             headers={"Authorization": "Bearer my-secret-token"},
-            tool_prefix=None,
         )
 
-    @patch(_MCP_HTTP)
-    def test_passes_tool_prefix(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_passes_tool_prefix(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", tool_prefix="weather")
         conn = Connection(
             conn_id="test_conn",
@@ -100,14 +107,16 @@ class TestMCPHookGetConn:
             host="http://localhost:3001/mcp",
         )
         with patch.object(hook, "get_connection", return_value=conn):
-            hook.get_conn()
+            result = hook.get_conn()
 
-        mock_server_cls.assert_called_once_with(
-            "http://localhost:3001/mcp", headers=None, tool_prefix="weather"
-        )
+        # tool_prefix is applied by wrapping the toolset, not via a constructor arg.
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
+        mock_toolset_cls.return_value.prefixed.assert_called_once_with("weather")
+        assert result is mock_toolset_cls.return_value.prefixed.return_value
 
-    @patch(_MCP_SSE)
-    def test_sse_transport(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_SSE_TRANSPORT)
+    def test_sse_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -118,11 +127,13 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             result = hook.get_conn()
 
-        mock_server_cls.assert_called_once_with("http://localhost:3001/sse", headers=None, tool_prefix=None)
-        assert result is mock_server_cls.return_value
+        mock_transport_cls.assert_called_once_with("http://localhost:3001/sse", headers=None)
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
+        assert result is mock_toolset_cls.return_value
 
-    @patch(_MCP_STDIO)
-    def test_stdio_transport(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_STDIO_TRANSPORT)
+    def test_stdio_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -132,11 +143,13 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             result = hook.get_conn()
 
-        mock_server_cls.assert_called_once_with("uvx", args=["mcp-run-python"], timeout=10, tool_prefix=None)
-        assert result is mock_server_cls.return_value
+        mock_transport_cls.assert_called_once_with(command="uvx", args=["mcp-run-python"])
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value, init_timeout=10)
+        assert result is mock_toolset_cls.return_value
 
-    @patch(_MCP_STDIO)
-    def test_stdio_custom_timeout(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_STDIO_TRANSPORT)
+    def test_stdio_custom_timeout(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -148,10 +161,12 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with("python", args=["-m", "server"], timeout=30, tool_prefix=None)
+        mock_transport_cls.assert_called_once_with(command="python", args=["-m", "server"])
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value, init_timeout=30)
 
-    @patch(_MCP_STDIO)
-    def test_args_string_converted_to_list(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_STDIO_TRANSPORT)
+    def test_args_string_converted_to_list(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
             conn_id="test_conn",
@@ -161,7 +176,7 @@ class TestMCPHookGetConn:
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with("uvx", args=["mcp-run-python"], timeout=10, tool_prefix=None)
+        mock_transport_cls.assert_called_once_with(command="uvx", args=["mcp-run-python"])
 
     def test_http_without_host_raises(self):
         hook = MCPHook(mcp_conn_id="test_conn")
@@ -203,8 +218,9 @@ class TestMCPHookGetConn:
             with pytest.raises(ValueError, match="Unknown transport"):
                 hook.get_conn()
 
-    @patch(_MCP_HTTP)
-    def test_caches_server(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_caches_server(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
         with patch.object(hook, "get_connection", return_value=conn):
@@ -212,12 +228,13 @@ class TestMCPHookGetConn:
             second = hook.get_conn()
 
         assert first is second
-        mock_server_cls.assert_called_once()
+        mock_toolset_cls.assert_called_once()
 
 
 class TestMCPHookTestConnection:
-    @patch(_MCP_HTTP)
-    def test_successful_config(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_successful_config(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
         with patch.object(hook, "get_connection", return_value=conn):
@@ -249,21 +266,22 @@ class TestMCPHookUIFieldBehaviour:
 
 
 class TestMCPHookTokenProvider:
-    @patch(_MCP_HTTP)
-    def test_http_uses_token_provider(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_http_uses_token_provider(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "minted-jwt")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with(
+        mock_transport_cls.assert_called_once_with(
             "http://localhost:3001/mcp",
             headers={"Authorization": "Bearer minted-jwt"},
-            tool_prefix=None,
         )
 
-    @patch(_MCP_HTTP)
-    def test_token_provider_overrides_static_password(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_token_provider_overrides_static_password(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "fresh")
         conn = Connection(
             conn_id="test_conn",
@@ -274,14 +292,14 @@ class TestMCPHookTokenProvider:
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with(
+        mock_transport_cls.assert_called_once_with(
             "http://localhost:3001/mcp",
             headers={"Authorization": "Bearer fresh"},
-            tool_prefix=None,
         )
 
-    @patch(_MCP_HTTP)
-    def test_token_provider_called_when_establishing_connection(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_token_provider_called_when_establishing_connection(self, mock_transport_cls, mock_toolset_cls):
         provider = MagicMock(return_value="tok")
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=provider)
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
@@ -290,8 +308,9 @@ class TestMCPHookTokenProvider:
 
         provider.assert_called_once_with()
 
-    @patch(_MCP_HTTP)
-    def test_masks_minted_token(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_HTTP_TRANSPORT)
+    def test_masks_minted_token(self, mock_transport_cls, mock_toolset_cls):
         """The minted token must be registered with secret masking, like conn.password."""
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "minted-jwt")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
@@ -304,8 +323,7 @@ class TestMCPHookTokenProvider:
         mock_mask.assert_called_once_with("minted-jwt")
 
     @pytest.mark.parametrize("bad_token", ["", None], ids=["empty", "non_string"])
-    @patch(_MCP_HTTP)
-    def test_invalid_token_raises(self, mock_server_cls, bad_token):
+    def test_invalid_token_raises(self, bad_token):
         """A token_provider returning a non-string or empty value fails loud."""
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: bad_token)
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
@@ -313,8 +331,9 @@ class TestMCPHookTokenProvider:
             with pytest.raises(ValueError, match="must return a non-empty string token"):
                 hook.get_conn()
 
-    @patch(_MCP_SSE)
-    def test_sse_uses_token_provider(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_SSE_TRANSPORT)
+    def test_sse_uses_token_provider(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "minted")
         conn = Connection(
             conn_id="test_conn",
@@ -325,14 +344,14 @@ class TestMCPHookTokenProvider:
         with patch.object(hook, "get_connection", return_value=conn):
             hook.get_conn()
 
-        mock_server_cls.assert_called_once_with(
+        mock_transport_cls.assert_called_once_with(
             "http://localhost:3001/sse",
             headers={"Authorization": "Bearer minted"},
-            tool_prefix=None,
         )
 
-    @patch(_MCP_STDIO)
-    def test_stdio_does_not_invoke_token_provider(self, mock_server_cls):
+    @patch(_MCP_TOOLSET)
+    @patch(_STDIO_TRANSPORT)
+    def test_stdio_does_not_invoke_token_provider(self, mock_transport_cls, mock_toolset_cls):
         """stdio has no HTTP headers, so the token provider must not be called."""
         provider = MagicMock(return_value="tok")
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=provider)
@@ -345,4 +364,5 @@ class TestMCPHookTokenProvider:
             hook.get_conn()
 
         provider.assert_not_called()
-        mock_server_cls.assert_called_once_with("uvx", args=["mcp-run-python"], timeout=10, tool_prefix=None)
+        mock_transport_cls.assert_called_once_with(command="uvx", args=["mcp-run-python"])
+        mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value, init_timeout=10)

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_mcp.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_mcp.py
@@ -48,8 +48,8 @@ class TestMCPHookInit:
 
 
 class TestMCPHookGetConn:
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_http_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -64,8 +64,8 @@ class TestMCPHookGetConn:
         mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
         assert result is mock_toolset_cls.return_value
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_http_is_default_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -79,8 +79,8 @@ class TestMCPHookGetConn:
         mock_transport_cls.assert_called_once_with("http://localhost:3001/mcp", headers=None)
         mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_http_with_auth_token(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -97,8 +97,8 @@ class TestMCPHookGetConn:
             headers={"Authorization": "Bearer my-secret-token"},
         )
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_passes_tool_prefix(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", tool_prefix="weather")
         conn = Connection(
@@ -114,8 +114,8 @@ class TestMCPHookGetConn:
         mock_toolset_cls.return_value.prefixed.assert_called_once_with("weather")
         assert result is mock_toolset_cls.return_value.prefixed.return_value
 
-    @patch(_MCP_TOOLSET)
-    @patch(_SSE_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_SSE_TRANSPORT, autospec=True)
     def test_sse_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -131,8 +131,8 @@ class TestMCPHookGetConn:
         mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value)
         assert result is mock_toolset_cls.return_value
 
-    @patch(_MCP_TOOLSET)
-    @patch(_STDIO_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_STDIO_TRANSPORT, autospec=True)
     def test_stdio_transport(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -147,8 +147,8 @@ class TestMCPHookGetConn:
         mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value, init_timeout=10)
         assert result is mock_toolset_cls.return_value
 
-    @patch(_MCP_TOOLSET)
-    @patch(_STDIO_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_STDIO_TRANSPORT, autospec=True)
     def test_stdio_custom_timeout(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -164,8 +164,8 @@ class TestMCPHookGetConn:
         mock_transport_cls.assert_called_once_with(command="python", args=["-m", "server"])
         mock_toolset_cls.assert_called_once_with(mock_transport_cls.return_value, init_timeout=30)
 
-    @patch(_MCP_TOOLSET)
-    @patch(_STDIO_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_STDIO_TRANSPORT, autospec=True)
     def test_args_string_converted_to_list(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(
@@ -218,8 +218,8 @@ class TestMCPHookGetConn:
             with pytest.raises(ValueError, match="Unknown transport"):
                 hook.get_conn()
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_caches_server(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
@@ -232,8 +232,8 @@ class TestMCPHookGetConn:
 
 
 class TestMCPHookTestConnection:
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_successful_config(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
@@ -266,8 +266,8 @@ class TestMCPHookUIFieldBehaviour:
 
 
 class TestMCPHookTokenProvider:
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_http_uses_token_provider(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "minted-jwt")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
@@ -279,8 +279,8 @@ class TestMCPHookTokenProvider:
             headers={"Authorization": "Bearer minted-jwt"},
         )
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_token_provider_overrides_static_password(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "fresh")
         conn = Connection(
@@ -297,8 +297,8 @@ class TestMCPHookTokenProvider:
             headers={"Authorization": "Bearer fresh"},
         )
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_token_provider_called_when_establishing_connection(self, mock_transport_cls, mock_toolset_cls):
         provider = MagicMock(return_value="tok")
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=provider)
@@ -308,15 +308,15 @@ class TestMCPHookTokenProvider:
 
         provider.assert_called_once_with()
 
-    @patch(_MCP_TOOLSET)
-    @patch(_HTTP_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_HTTP_TRANSPORT, autospec=True)
     def test_masks_minted_token(self, mock_transport_cls, mock_toolset_cls):
         """The minted token must be registered with secret masking, like conn.password."""
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "minted-jwt")
         conn = Connection(conn_id="test_conn", conn_type="mcp", host="http://localhost:3001/mcp")
         with (
             patch.object(hook, "get_connection", return_value=conn),
-            patch("airflow.providers.common.ai.hooks.mcp.mask_secret") as mock_mask,
+            patch("airflow.providers.common.ai.hooks.mcp.mask_secret", autospec=True) as mock_mask,
         ):
             hook.get_conn()
 
@@ -331,8 +331,8 @@ class TestMCPHookTokenProvider:
             with pytest.raises(ValueError, match="must return a non-empty string token"):
                 hook.get_conn()
 
-    @patch(_MCP_TOOLSET)
-    @patch(_SSE_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_SSE_TRANSPORT, autospec=True)
     def test_sse_uses_token_provider(self, mock_transport_cls, mock_toolset_cls):
         hook = MCPHook(mcp_conn_id="test_conn", token_provider=lambda: "minted")
         conn = Connection(
@@ -349,8 +349,8 @@ class TestMCPHookTokenProvider:
             headers={"Authorization": "Bearer minted"},
         )
 
-    @patch(_MCP_TOOLSET)
-    @patch(_STDIO_TRANSPORT)
+    @patch(_MCP_TOOLSET, autospec=True)
+    @patch(_STDIO_TRANSPORT, autospec=True)
     def test_stdio_does_not_invoke_token_provider(self, mock_transport_cls, mock_toolset_cls):
         """stdio has no HTTP headers, so the token provider must not be called."""
         provider = MagicMock(return_value="tok")


### PR DESCRIPTION
pydantic-ai deprecated `MCPServerStdio`, `MCPServerSSE`, and `MCPServerStreamableHTTP` in favor of a unified `MCPToolset`, and removes all three in pydantic-ai v2. The common.ai `MCPHook` constructed all three directly, so it emits `DeprecationWarning`s today and would break on the v2 upgrade.

This migrates `MCPHook.get_conn()` to build an `MCPToolset` over the matching FastMCP transport.

## What changed

| Transport | Before | After |
|---|---|---|
| `http` | `MCPServerStreamableHTTP(host, headers=…, tool_prefix=…)` | `MCPToolset(StreamableHttpTransport(host, headers=…))` |
| `sse` | `MCPServerSSE(host, headers=…, tool_prefix=…)` | `MCPToolset(SSETransport(host, headers=…))` |
| `stdio` | `MCPServerStdio(cmd, args=…, timeout=…, tool_prefix=…)` | `MCPToolset(StdioTransport(command=cmd, args=…), init_timeout=…)` |
| prefix | `tool_prefix=` constructor arg | `.prefixed(prefix)` |

## Design rationale

- **Explicit transports instead of URL inference.** `MCPToolset` can infer a transport from a bare URL, but FastMCP only picks SSE when the URL ends in `/sse`. The connection has an explicit `transport` field, so the hook builds the transport explicitly to honor that choice regardless of URL shape, and to keep attaching the `Authorization` header.
- **`StdioTransport` for stdio.** The connection supplies an arbitrary `command` + `args`, which is the case pydantic-ai's deprecation message prescribes `StdioTransport(...)` for; the `MCPToolset("script.py")` shorthand only covers literal script paths.
- **`.prefixed()` for `tool_prefix`.** `MCPToolset` has no `tool_prefix` argument. `.prefixed(prefix)` produces the same `<prefix>_<tool>` names as before and matches pydantic-ai's own `load_mcp_toolsets`. It returns a `PrefixedToolset` that proxies the async-context-manager protocol, so the connection-backed `MCPToolset` wrapper keeps working unchanged.
- **`init_timeout` is the successor to the old stdio `timeout`;** the hook keeps its default of 10s.

## Tradeoffs / notes

- Behavior-preserving: tool names, auth headers, caching defaults, and the no-auth path are unchanged.
- `fastmcp.client.transports` is the canonical public import path. `pydantic_ai.mcp` imports from it, and pydantic-ai's own deprecation message recommends `MCPToolset(fastmcp.client.transports.StdioTransport(...))`.
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.