### PR TITLE
Use bounded DBDagBag cache in scheduler

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/dagbag.py
+++ b/airflow-core/src/airflow/api_fastapi/common/dagbag.py
@@ -47,12 +47,16 @@ def create_dag_bag() -> DBDagBag:
 
     # Use unbounded dict (no eviction) if cache_size is 0
     if cache_size <= 0:
-        return DBDagBag(cache_size=0)
+        return DBDagBag(cache_size=0, stats_prefix="api_server.dag_bag")
 
     # Disable TTL if cache_ttl is 0
     cache_ttl: int | None = cache_ttl_config if cache_ttl_config > 0 else None
 
-    return DBDagBag(cache_size=cache_size, cache_ttl=cache_ttl)
+    return DBDagBag(
+        cache_size=cache_size,
+        cache_ttl=cache_ttl,
+        stats_prefix="api_server.dag_bag",
+    )
 
 
 def dag_bag_from_app(request: Request) -> DBDagBag:

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2760,7 +2760,7 @@ scheduler:
       version_added: 3.3.0
       type: integer
       example: ~
-      default: "3600"
+      default: "10800"
     partition_mapper_max_downstream_keys:
       description: |
         Maximum number of downstream partition keys produced by a single

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2743,6 +2743,24 @@ scheduler:
       type: integer
       default: "20"
       see_also: ":ref:`scheduler:ha:tunables`"
+    dag_cache_size:
+      description: |
+        Size of the LRU cache for SerializedDAG objects in the scheduler.
+        Set to 0 to use an unbounded dict with no eviction.
+        The cache is keyed by Dag version ID.
+      version_added: 3.3.0
+      type: integer
+      example: ~
+      default: "1024"
+    dag_cache_ttl:
+      description: |
+        Time-to-live in seconds for cached SerializedDAG objects in the scheduler.
+        After this time, cached DAGs will be re-fetched from the database on next access.
+        Set to 0 to disable TTL, so entries will only be evicted by the LRU policy.
+      version_added: 3.3.0
+      type: integer
+      example: ~
+      default: "3600"
     partition_mapper_max_downstream_keys:
       description: |
         Maximum number of downstream partition keys produced by a single

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -347,8 +347,24 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         if log:
             self._log = log
+        dag_cache_size = conf.getint("scheduler", "dag_cache_size", fallback=1024)
+        dag_cache_ttl_config = conf.getint("scheduler", "dag_cache_ttl", fallback=3600)
 
-        self.scheduler_dag_bag = DBDagBag(load_op_links=False)
+        if dag_cache_size < 0:
+            self.log.warning("scheduler dag_cache_size must be >= 0, using unbounded dict")
+            dag_cache_size = 0
+
+        if dag_cache_ttl_config < 0:
+            self.log.warning("scheduler dag_cache_ttl must be >= 0, disabling TTL")
+            dag_cache_ttl_config = 0
+
+        dag_cache_ttl = dag_cache_ttl_config if dag_cache_ttl_config > 0 else None
+
+        self.scheduler_dag_bag = DBDagBag(
+            load_op_links=False,
+            cache_size=dag_cache_size,
+            cache_ttl=dag_cache_ttl,
+        )
 
         # Set of (dag_id, asset_name, asset_uri) tuples for trigger policies that
         # are permanently unreachable for the rollup window's cardinality — the

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -348,7 +348,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if log:
             self._log = log
         dag_cache_size = conf.getint("scheduler", "dag_cache_size", fallback=1024)
-        dag_cache_ttl_config = conf.getint("scheduler", "dag_cache_ttl", fallback=3600)
+        dag_cache_ttl_config = conf.getint("scheduler", "dag_cache_ttl", fallback=10800)
 
         if dag_cache_size < 0:
             self.log.warning("scheduler dag_cache_size must be >= 0, using unbounded dict")
@@ -364,6 +364,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             load_op_links=False,
             cache_size=dag_cache_size,
             cache_ttl=dag_cache_ttl,
+            stats_prefix="scheduler.dag_bag",
         )
 
         # Set of (dag_id, asset_name, asset_uri) tuples for trigger policies that

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -73,6 +73,7 @@ class DBDagBag:
         load_op_links: bool = True,
         cache_size: int | None = None,
         cache_ttl: int | None = None,
+        stats_prefix: str = "api_server.dag_bag",
     ) -> None:
         """
         Initialize DBDagBag.
@@ -80,8 +81,10 @@ class DBDagBag:
         :param load_op_links: Should the extra operator link be loaded when de-serializing the DAG?
         :param cache_size: Size of LRU cache. If None or 0, uses unbounded dict (no eviction).
         :param cache_ttl: Time-to-live for cache entries in seconds. If None or 0, no TTL (LRU only).
+        :param stats_prefix: Prefix for cache-related metrics emitted by this DBDagBag.
         """
         self.load_op_links = load_op_links
+        self._stats_prefix = stats_prefix
         self._dags: MutableMapping[UUID | str, _CacheEntry] = {}
         self._use_cache = False
 
@@ -110,7 +113,7 @@ class DBDagBag:
             self._dags[serdag.dag_version_id] = _CacheEntry(dag, serdag.dag_hash, time.monotonic())
             cache_size = len(self._dags)
         if self._use_cache:
-            stats.gauge("api_server.dag_bag.cache_size", cache_size, rate=0.1)
+            stats.gauge(f"{self._stats_prefix}.cache_size", cache_size, rate=0.1)
         return dag
 
     @staticmethod
@@ -133,7 +136,7 @@ class DBDagBag:
             # cannot have gone stale yet -- serve it without touching the DB.
             if now - cached.last_validated < self._revalidation_interval:
                 if self._use_cache:
-                    stats.incr("api_server.dag_bag.cache_hit")
+                    stats.incr(f"{self._stats_prefix}.cache_hit")
                 return cached.dag
             # Past the window: a version may have been updated in place (same dag_version_id, new
             # content + new dag_hash) by SerializedDagModel.write_dag, so confirm the cached copy
@@ -148,7 +151,7 @@ class DBDagBag:
                     if current is not None and current.dag_hash == cached.dag_hash:
                         self._dags[version_id] = current._replace(last_validated=now)
                 if self._use_cache:
-                    stats.incr("api_server.dag_bag.cache_hit")
+                    stats.incr(f"{self._stats_prefix}.cache_hit")
                 return cached.dag
             # Stale (updated in place) or the version no longer exists: drop and reload below.
             with self._lock:
@@ -168,9 +171,9 @@ class DBDagBag:
         if self._use_cache:
             with self._lock:
                 if (cached := self._dags.get(version_id)) is not None:
-                    stats.incr("api_server.dag_bag.cache_hit")
+                    stats.incr(f"{self._stats_prefix}.cache_hit")
                     return cached.dag
-            stats.incr("api_server.dag_bag.cache_miss")
+            stats.incr(f"{self._stats_prefix}.cache_miss")
         return self._read_dag(serdag)
 
     def get_dag(self, version_id: UUID | str, session: Session) -> SerializedDAG | None:
@@ -202,8 +205,8 @@ class DBDagBag:
             self._dags.clear()
 
         if self._use_cache:
-            stats.incr("api_server.dag_bag.cache_clear")
-            stats.gauge("api_server.dag_bag.cache_size", 0)
+            stats.incr(f"{self._stats_prefix}.cache_clear")
+            stats.gauge(f"{self._stats_prefix}.cache_size", 0)
         return count
 
     @staticmethod

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -63,8 +63,7 @@ class DBDagBag:
     Internal class for retrieving dags from the database.
 
     Optionally supports LRU+TTL caching when cache_size is provided.
-    The scheduler uses this without caching, while the API server can
-    enable caching via configuration.
+    Callers can enable bounded caching by passing cache_size and cache_ttl.
 
     :meta private:
     """

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -408,6 +408,23 @@ class TestSchedulerJob:
             _ = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
             assert scheduler_job.heartrate == heartrate
 
+    @patch("airflow.jobs.scheduler_job_runner.DBDagBag")
+    def test_scheduler_dag_bag_uses_scheduler_cache_config(self, mock_db_dag_bag):
+        with conf_vars(
+            {
+                ("scheduler", "dag_cache_size"): "123",
+                ("scheduler", "dag_cache_ttl"): "456",
+            }
+        ):
+            scheduler_job = Job()
+            SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        mock_db_dag_bag.assert_called_once_with(
+            load_op_links=False,
+            cache_size=123,
+            cache_ttl=456,
+        )
+
     def test_no_orphan_process_will_be_left(self):
         current_process = psutil.Process()
         old_children = current_process.children(recursive=True)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -423,6 +423,7 @@ class TestSchedulerJob:
             load_op_links=False,
             cache_size=123,
             cache_ttl=456,
+            stats_prefix="scheduler.dag_bag",
         )
 
     def test_no_orphan_process_will_be_left(self):

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -345,6 +345,24 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "scheduler.dag_bag.cache_hit"
+    description: "Number of cache hits when retrieving SerializedDAG from DBDagBag in the scheduler"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.dag_bag.cache_miss"
+    description: "Number of cache misses when retrieving SerializedDAG from DBDagBag in the scheduler"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.dag_bag.cache_clear"
+    description: "Number of times the DBDagBag cache was cleared in the scheduler"
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "connection_test.success"
     description: "Number of worker-dispatched connection tests that completed successfully."
     type: "counter"
@@ -375,6 +393,12 @@ metrics:
 
   - name: "api_server.dag_bag.cache_size"
     description: "Current number of SerializedDAG objects cached in the API server's DBDagBag"
+    type: "gauge"
+    legacy_name: "-"
+    name_variables: []
+
+  - name: "scheduler.dag_bag.cache_size"
+    description: "Number of SerializedDAG objects currently cached in DBDagBag in the scheduler"
     type: "gauge"
     legacy_name: "-"
     name_variables: []


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Use bounded `DBDagBag` caching in the scheduler.

The scheduler was creating `DBDagBag(load_op_links=False)` without cache settings, which meant it used the default unbounded dictionary for cached deserialized DAGs. This PR makes the scheduler use the existing `DBDagBag` LRU/TTL cache support instead.

Changes:
- Added `[scheduler] dag_cache_size` and `[scheduler] dag_cache_ttl` config options.
- Updated `SchedulerJobRunner` to pass those config values into `DBDagBag`.
- Added a `stats_prefix` parameter to `DBDagBag` so scheduler cache metrics are emitted under `scheduler.dag_bag` instead of the API server prefix.
- Added scheduler DagBag cache metrics to the metrics template.
- Handles negative config values safely by falling back to unbounded cache / disabled TTL behavior.
- Updated the `DBDagBag` class docstring to reflect that callers can enable bounded caching.
- Added a unit test confirming the scheduler passes the cache config into `DBDagBag`.

closes: #69001

Testing:

```bash
python -m py_compile airflow-core/src/airflow/models/dagbag.py
python -m py_compile airflow-core/src/airflow/jobs/scheduler_job_runner.py
pytest airflow-core/tests/unit/jobs/test_scheduler_job.py::TestSchedulerJob::test_scheduler_dag_bag_uses_scheduler_cache_config
pytest airflow-core/tests/unit/models/test_dagbag.py

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=5b2d41b action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Mady356** · by `@potiuk` · 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
