### PR TITLE
Fix msgraph/Power BI auth failure from empty allowed_hosts list

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -311,7 +311,7 @@ class KiotaRequestAdapterHook(BaseHook):
             scopes = scopes.split(",")
         verify = config.get("verify", True)
         trust_env = config.get("trust_env", False)
-        allowed_hosts = (config.get("allowed_hosts", authority) or "").split(",")
+        allowed_hosts = [host for host in (config.get("allowed_hosts", authority) or "").split(",") if host]
 
         self.log.info(
             "Creating Microsoft Graph SDK client %s for conn_id: %s",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -294,6 +294,13 @@ class KiotaRequestAdapterHook(BaseHook):
             return proxies
         return None
 
+    @staticmethod
+    def get_allowed_hosts(authority: str, config: dict) -> list[str]:
+        allowed_hosts = config.get("allowed_hosts", authority)
+        if not allowed_hosts:
+            return []
+        return allowed_hosts.split(",")
+
     def _build_request_adapter(self, connection) -> tuple[str, RequestAdapter]:
         client_id = connection.login
         client_secret = connection.password
@@ -311,7 +318,7 @@ class KiotaRequestAdapterHook(BaseHook):
             scopes = scopes.split(",")
         verify = config.get("verify", True)
         trust_env = config.get("trust_env", False)
-        allowed_hosts = [host for host in (config.get("allowed_hosts", authority) or "").split(",") if host]
+        allowed_hosts = self.get_allowed_hosts(authority, config)
 
         self.log.info(
             "Creating Microsoft Graph SDK client %s for conn_id: %s",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -295,11 +295,11 @@ class KiotaRequestAdapterHook(BaseHook):
         return None
 
     @staticmethod
-    def get_allowed_hosts(authority: str, config: dict) -> list[str]:
+    def get_allowed_hosts(authority: str | None, config: dict) -> list[str]:
         allowed_hosts = config.get("allowed_hosts", authority)
         if not allowed_hosts:
             return []
-        return allowed_hosts.split(",")
+        return [host for host in allowed_hosts.split(",") if host]
 
     def _build_request_adapter(self, connection) -> tuple[str, RequestAdapter]:
         client_id = connection.login

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -570,18 +570,19 @@ class TestKiotaRequestAdapterHook:
             adapter.send_no_response_content_async.assert_called_once()
             assert hook.conn_id not in hook.cached_request_adapters
 
-    @pytest.mark.asyncio
-    async def test_allowed_hosts_is_empty_list_when_not_configured(self):
-        """an unset allowed_hosts/authority must yield []."""
-        KiotaRequestAdapterHook.cached_request_adapters.clear()
-        with patch_hook():
-            with patch(
-                "airflow.providers.microsoft.azure.hooks.msgraph.AzureIdentityAuthenticationProvider"
-            ) as mock_auth_provider:
-                hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
-                await hook.get_async_conn()
+    def test_allowed_hosts_is_empty_list_when_not_configured(self):
+    """An unset allowed_hosts/authority must yield []."""
+        actual = KiotaRequestAdapterHook.get_allowed_hosts(None, {})
 
-                assert mock_auth_provider.call_args.kwargs["allowed_hosts"] == []
+        assert actual == []
+
+    def test_allowed_hosts_from_config(self):
+    """A configured allowed_hosts string must be split into a list."""
+        actual = KiotaRequestAdapterHook.get_allowed_hosts(
+            None, {"allowed_hosts": "api.powerbi.com,login.microsoftonline.com"}
+        )
+
+        assert actual == ["api.powerbi.com", "login.microsoftonline.com"]
 
 
 class TestKiotaRequestAdapterHookProtocol:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -570,6 +570,19 @@ class TestKiotaRequestAdapterHook:
             adapter.send_no_response_content_async.assert_called_once()
             assert hook.conn_id not in hook.cached_request_adapters
 
+    @pytest.mark.asyncio
+    async def test_allowed_hosts_is_empty_list_when_not_configured(self):
+        """an unset allowed_hosts/authority must yield []."""
+        KiotaRequestAdapterHook.cached_request_adapters.clear()
+        with patch_hook():
+            with patch(
+                "airflow.providers.microsoft.azure.hooks.msgraph.AzureIdentityAuthenticationProvider"
+            ) as mock_auth_provider:
+                hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
+                await hook.get_async_conn()
+
+                assert mock_auth_provider.call_args.kwargs["allowed_hosts"] == []
+
 
 class TestKiotaRequestAdapterHookProtocol:
     """Test protocol handling in KiotaRequestAdapterHook."""

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -571,13 +571,13 @@ class TestKiotaRequestAdapterHook:
             assert hook.conn_id not in hook.cached_request_adapters
 
     def test_allowed_hosts_is_empty_list_when_not_configured(self):
-    """An unset allowed_hosts/authority must yield []."""
+        """An unset allowed_hosts/authority must yield []."""
         actual = KiotaRequestAdapterHook.get_allowed_hosts(None, {})
 
         assert actual == []
 
     def test_allowed_hosts_from_config(self):
-    """A configured allowed_hosts string must be split into a list."""
+        """A configured allowed_hosts string must be split into a list."""
         actual = KiotaRequestAdapterHook.get_allowed_hosts(
             None, {"allowed_hosts": "api.powerbi.com,login.microsoftonline.com"}
         )


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## What
`KiotaRequestAdapterHook._build_request_adapter` derives `allowed_hosts` from the connection's `extra` field and passes it to `AzureIdentityAuthenticationProvider`. When neither `allowed_hosts` nor `authority` is configured, `allowed_hosts` returned `[""]` rather than a true empty list.

When this value eventually flows through to kiota's `AllowedHostsValidator.is_url_host_valid` method, it fails to skip validation via the early return:
```python
if not self.get_allowed_hosts():
    return True
```

This PR filters out blank strings so an unconfigured connection yields `[]` and correctly takes the early exit described above.

## Why
A recent change in the microsoft-kiota-abstractions package ([microsoft/kiota-python@8755f70](https://github.com/microsoft/kiota-python/commit/8755f7026763e0cf30d13d01ac46f48fd26798ff)) fixed the `AllowedHostsValidator` to actually enforce a list of allowed hosts. Previously, it only checked whether a URL was structurally valid and ignored the configured `allowed_hosts` set entirely. The `is_url_host_valid` method now correctly extracts the hostname from the URL and checks is against the allow list.

This seemed to break existing Power BI connections which did not configure `allowed_hosts` or `authority` (which is the default for Power BI connections), as the validator receives a list with an empty string instead of a true empty list, causing requests to fail validation.

Note that before the Microsoft change this was harmless, as the validator method never actually compared against the configured hosts (`return all([scheme, netloc])` -> `True`). This PR restores kiota's "skip validation" pathway for the default case where no `allowed_hosts` are set.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6, following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
