### PR TITLE
Fix scheduled CI upgrade failing when its PR already exists

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -906,7 +906,9 @@ def upgrade(
         pr_title = f"[{target_branch}] Upgrade important CI environment"
         pr_body = "This PR upgrades important dependencies of the CI environment."
 
-        # Check if there's already an open PR for this branch
+        # Check if there's already an open PR for this branch.
+        # gh pr list / gh pr ready filter by the bare head-branch name, not the
+        # "owner:branch" label that gh pr create needs for cross-fork PRs.
         existing_pr_result = run_command(
             [
                 "gh",
@@ -915,7 +917,7 @@ def upgrade(
                 "--repo",
                 "apache/airflow",
                 "--head",
-                head_ref,
+                branch_name,
                 "--base",
                 target_branch,
                 "--state",
@@ -945,7 +947,7 @@ def upgrade(
                         "--repo",
                         "apache/airflow",
                         "--undo",
-                        head_ref,
+                        branch_name,
                     ],
                     capture_output=True,
                     text=True,
@@ -981,10 +983,15 @@ def upgrade(
                 env=command_env,
             )
             if pr_result.returncode != 0:
-                console_print(f"[error]Failed to create PR:\n{pr_result.stdout}\n{pr_result.stderr}[/]")
-                sys.exit(1)
-            pr_url = pr_result.stdout.strip() if pr_result.returncode == 0 else ""
-            console_print(f"[success]PR created successfully: {pr_url}.[/]")
+                # The branch was already force-pushed, so an existing PR is already
+                # up to date — treat a duplicate as success rather than failing the run.
+                if "already exists" in pr_result.stderr:
+                    console_print(f"[success]PR already exists for {head_ref}, updated with force push.[/]")
+                else:
+                    console_print(f"[error]Failed to create PR:\n{pr_result.stdout}\n{pr_result.stderr}[/]")
+                    sys.exit(1)
+            else:
+                console_print(f"[success]PR created successfully: {pr_result.stdout.strip()}.[/]")
 
         # Switch back to appropriate branch and delete the temporary branch
         console_print(f"[info]Cleaning up temporary branch {branch_name}...[/]")


### PR DESCRIPTION
The scheduled `breeze ci upgrade` job (`.github/workflows/...` → "Scheduled CI upgrade check") force-pushes a stable branch `ci-upgrade-<branch>` and then looks for an existing PR before creating one. The lookup passed the `owner:branch` head label (e.g. `apache:ci-upgrade-main`) to `gh pr list --head`, but that flag filters by the **bare branch name only** and explicitly does not support `<owner>:<branch>` syntax. So the existing PR was never found, the code fell through to `gh pr create`, and GitHub rejected the duplicate — failing the run:

```
pull request create failed: GraphQL: A pull request already exists for apache:ci-upgrade-main.
```

(see [run 28223885557](https://github.com/apache/airflow/actions/runs/28223885557/job/83611163873))

Fix:
- Use the bare branch name for the `gh pr list` and `gh pr ready` lookups. Only `gh pr create --head` needs the cross-fork `owner:branch` label.
- Treat an `already exists` creation error as success (the branch has already been force-pushed, so the existing PR is up to date) — guards against a list/create race.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)