### PR TITLE
Fix GKE provider 401 on kubernetes client 36.x

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -80,13 +80,20 @@ class GKEClusterConnection:
         return client.ApiClient(configuration)
 
     def _refresh_api_key_hook(self, configuration: client.configuration.Configuration):
-        configuration.api_key = {"authorization": self._get_token(self._credentials)}
+        configuration.api_key = self._bearer_api_key(self._get_token(self._credentials))
+
+    @staticmethod
+    def _bearer_api_key(token: str) -> dict[str, str]:
+        # kubernetes-client 36.x renamed the bearer auth key 'authorization' -> 'BearerToken'
+        # (https://github.com/kubernetes-client/python/issues/2582). Register both so the 'Bearer'
+        # prefix is applied on client 35.x and 36.x alike; otherwise 36.x sends the raw token -> 401.
+        return {"authorization": token, "BearerToken": token}
 
     def _get_config(self) -> client.configuration.Configuration:
         configuration = client.Configuration(
             host=self._cluster_url,
-            api_key_prefix={"authorization": "Bearer"},
-            api_key={"authorization": self._get_token(self._credentials)},
+            api_key_prefix={"authorization": "Bearer", "BearerToken": "Bearer"},
+            api_key=self._bearer_api_key(self._get_token(self._credentials)),
         )
         if not self.use_dns_endpoint:
             configuration.ssl_ca_cert = FileOrData(

--- a/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_kubernetes_engine.py
@@ -31,6 +31,7 @@ from google.cloud.container_v1.types import Cluster
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.hooks.kubernetes_engine import (
     GKEAsyncHook,
+    GKEClusterConnection,
     GKEHook,
     GKEKubernetesAsyncHook,
     GKEKubernetesHook,
@@ -484,6 +485,32 @@ class TestGKEKubernetesHookDeployments:
         if api_client is None:
             mock_get_conn.assert_called_once()
         mock_super.return_value.apply_from_yaml_file.assert_called_once_with(**expected_kwargs)
+
+
+class TestGKEClusterConnection:
+    @pytest.mark.parametrize("expired", [False, True])
+    def test_registers_bearer_token_for_client_35_and_36(self, expired):
+        # The bearer token and its "Bearer" prefix must be registered under both the client-35.x key
+        # ('authorization') and the client-36.x key ('BearerToken', renamed in
+        # https://github.com/kubernetes-client/python/issues/2582). Asserting the registration
+        # directly verifies both-version support regardless of which client CI installed; the
+        # auth_settings() check then confirms the installed client emits the prefixed header.
+        credentials = mock.MagicMock()
+        credentials.token = "the-token"
+        credentials.expired = expired
+        credentials.refresh = lambda request: setattr(credentials, "token", "the-token")
+        conn = GKEClusterConnection(
+            cluster_url="https://cluster",
+            ssl_ca_cert=None,
+            credentials=credentials,
+            use_dns_endpoint=True,
+        )
+
+        config = conn.get_conn().configuration
+
+        assert config.api_key == {"authorization": "the-token", "BearerToken": "the-token"}
+        assert config.api_key_prefix == {"authorization": "Bearer", "BearerToken": "Bearer"}
+        assert config.auth_settings()["BearerToken"]["value"] == "Bearer the-token"
 
 
 class TestGKEKubernetesAsyncHook:


### PR DESCRIPTION
related: #69023

## Human Summary
Kubernetes client 36.x renamed the bearer auth key, which breaks GKE integration.
This PR fixes this behavior by providing both keys for compatibility.

## AI Summary
<details><summary>Click here</summary>
Addresses the GKE 401 regression reported on the cncf.kubernetes 2026-06-16 RC by fixing the **google provider** rather than capping the kubernetes client to `<36` (which would reintroduce the NO_PROXY issue that 36.x fixed).

### Problem

kubernetes-client 36.x renamed the bearer-token auth key from `authorization` to `BearerToken` ([kubernetes-client/python#2582](https://github.com/kubernetes-client/python/issues/2582)). `GKEClusterConnection` hand-builds a `Configuration` and registered the token/prefix only under `authorization`. On 36.x, `auth_settings()` resolves the bearer value via `get_api_key_with_prefix("BearerToken", alias="authorization")`: the token is found through the `authorization` alias, but the **prefix** is looked up by the primary identifier `BearerToken` (absent), so the `Bearer ` prefix is dropped. Requests then go out as `Authorization: <raw token>` and the cluster rejects them with **401**. (36.0.1 fixed this only for `load_incluster_config`/`load_kube_config`, not hand-built configs.)

### Fix

Register the bearer token and prefix under **both** `authorization` (client 35.x) and `BearerToken` (client 36.x), in `_get_config` and the token-refresh hook. Authentication now works on both client lines, so the provider supports 36.x without a downgrade. The refresh-on-expiry behavior is preserved.

### Test

`TestGKEClusterConnection.test_auth_settings_send_bearer_prefixed_token` asserts the real `auth_settings()["BearerToken"]["value"]` is `Bearer <token>` (both valid and expiring credentials). Verified it fails on the pre-fix code under client 36.0.2 and passes after.
</details>


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)