### PR TITLE
Handle DB Performance Issues by Adding a New Index for Trigger

### DIFF
--- a/airflow-core/docs/migrations-ref.rst
+++ b/airflow-core/docs/migrations-ref.rst
@@ -39,7 +39,9 @@ Here's the list of all the Database Migrations that are executed via when you ru
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | Revision ID             | Revises ID       | Airflow Version   | Description                                                  |
 +=========================+==================+===================+==============================================================+
-| ``b2f1a9c7d4e0`` (head) | ``7a98f1b7dbd3`` | ``3.4.0``         | Reference the asset event from asset_dag_run_queue (consume- |
+| ``76c46545c91e`` (head) | ``b2f1a9c7d4e0`` | ``3.4.0``         | Add new index for trigger.                                   |
++-------------------------+------------------+-------------------+--------------------------------------------------------------+
+| ``b2f1a9c7d4e0``        | ``7a98f1b7dbd3`` | ``3.4.0``         | Reference the asset event from asset_dag_run_queue (consume- |
 |                         |                  |                   | by-reference).                                               |
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | ``7a98f1b7dbd3``        | ``c4e7a1f9b2d0`` | ``3.4.0``         | Add index on asset_event (asset_id, partition_key).          |

--- a/airflow-core/docs/migrations-ref.rst
+++ b/airflow-core/docs/migrations-ref.rst
@@ -39,7 +39,9 @@ Here's the list of all the Database Migrations that are executed via when you ru
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | Revision ID             | Revises ID       | Airflow Version   | Description                                                  |
 +=========================+==================+===================+==============================================================+
-| ``3c525f44bea8`` (head) | ``b2f1a9c7d4e0`` | ``3.4.0``         | Add indexes on serialized_dag and dag_code.                  |
+| ``76c46545c91e`` (head) | ``3c525f44bea8`` | ``3.4.0``         | Add new index for trigger.                                   |
++-------------------------+------------------+-------------------+--------------------------------------------------------------+
+| ``3c525f44bea8``        | ``b2f1a9c7d4e0`` | ``3.4.0``         | Add indexes on serialized_dag and dag_code.                  |
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | ``b2f1a9c7d4e0``        | ``7a98f1b7dbd3`` | ``3.4.0``         | Reference the asset event from asset_dag_run_queue (consume- |
 |                         |                  |                   | by-reference).                                               |

--- a/airflow-core/src/airflow/migrations/versions/0129_3_4_0_add_new_index_for_trigger.py
+++ b/airflow-core/src/airflow/migrations/versions/0129_3_4_0_add_new_index_for_trigger.py
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Add new index for trigger.
+
+Revision ID: 76c46545c91e
+Revises: b2f1a9c7d4e0
+Create Date: 2026-07-13 11:06:57.281704
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "76c46545c91e"
+down_revision = "b2f1a9c7d4e0"
+branch_labels = None
+depends_on = None
+airflow_version = "3.4.0"
+
+
+def upgrade():
+    """Add new index for trigger."""
+    with op.batch_alter_table("trigger", schema=None) as batch_op:
+        batch_op.create_index("idx_trigger_triggerer_queue_id", ["triggerer_id", "queue", "id"], unique=False)
+
+
+def downgrade():
+    """Remove new index for trigger."""
+    with op.batch_alter_table("trigger", schema=None) as batch_op:
+        batch_op.drop_index("idx_trigger_triggerer_queue_id")

--- a/airflow-core/src/airflow/migrations/versions/0130_3_4_0_add_new_index_for_trigger.py
+++ b/airflow-core/src/airflow/migrations/versions/0130_3_4_0_add_new_index_for_trigger.py
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Add new index for trigger.
+
+Revision ID: 76c46545c91e
+Revises: 3c525f44bea8
+Create Date: 2026-07-13 11:06:57.281704
+
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "76c46545c91e"
+down_revision = "3c525f44bea8"
+branch_labels = None
+depends_on = None
+airflow_version = "3.4.0"
+
+
+def upgrade():
+    """Add new index for trigger."""
+    with op.batch_alter_table("trigger", schema=None) as batch_op:
+        batch_op.create_index("idx_trigger_triggerer_queue_id", ["triggerer_id", "queue", "id"], unique=False)
+
+
+def downgrade():
+    """Remove new index for trigger."""
+    with op.batch_alter_table("trigger", schema=None) as batch_op:
+        batch_op.drop_index("idx_trigger_triggerer_queue_id")

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -24,7 +24,7 @@ from functools import singledispatch
 from traceback import format_exception
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import ForeignKey, Integer, String, Text, delete, func, or_, select, update
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, delete, func, or_, select, update
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship, selectinload
 from sqlalchemy.sql.functions import coalesce
@@ -92,6 +92,7 @@ class Trigger(Base):
     """
 
     __tablename__ = "trigger"
+    __table_args__ = (Index("idx_trigger_triggerer_queue_id", "triggerer_id", "queue", "id"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     classpath: Mapped[str] = mapped_column(String(1000), nullable=False)

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -117,7 +117,7 @@ _REVISION_HEADS_MAP: dict[str, str] = {
     "3.1.8": "509b94a1042d",
     "3.2.0": "1d6611b6ab7c",
     "3.3.0": "d2f4e1b3c5a7",
-    "3.4.0": "3c525f44bea8",
+    "3.4.0": "76c46545c91e",
 }
 
 # Prefix used to identify tables holding data moved during migration.

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -117,7 +117,7 @@ _REVISION_HEADS_MAP: dict[str, str] = {
     "3.1.8": "509b94a1042d",
     "3.2.0": "1d6611b6ab7c",
     "3.3.0": "d2f4e1b3c5a7",
-    "3.4.0": "b2f1a9c7d4e0",
+    "3.4.0": "76c46545c91e",
 }
 
 # Prefix used to identify tables holding data moved during migration.


### PR DESCRIPTION
# Overview

We are currently using Airflow 3.2.2 and have run into the following issue:

We operate an Airflow instance with 45 triggerers, and our database reached 100% CPU utilization. We identified that the high load was caused by two queries originating from the trigger model:

* https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/trigger.py#L348
* https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/models/trigger.py#L388

The high CPU load occurred because these queries resulted in full table scans. To address this, we added the following index:

* `CREATE INDEX idx_trigger_triggerer_queue_id ON public.trigger USING btree (triggerer_id, queue, id)`

CPU utilization dropped immediately after adding the index.


What do you think about this solution? I’m looking forward to your feedback.

# Details of change:
* Add index to solve DB performance issue.

<!-- pr-triage-fold: triaged=2026-07-08T15:51:00Z head=d5a4a83 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @AutomationDev85** · by `@potiuk` · 2026-07-08 15:51 UTC
>
> Some review feedback from the maintainers is waiting on you (2 unresolved threads):
>
> **The ball is in your court** — you've been assigned to this PR. Reply or push a fix in each thread, then mark them resolved. See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
