### PR TITLE
Update local Otel Collector and Prometheus Versions to support Exponential Histograms

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/metrics.rst
@@ -115,6 +115,42 @@ You need to configure the SSL certificate and key within the OpenTelemetry colle
              cert_file: "/path/to/cert/cert.crt"
              key_file: "/path/to/key/key.pem"
 
+Histogram Metrics and Backend Requirements
+------------------------------------------
+
+Airflow's timing metrics (``timing()`` / ``timer()``) are emitted as OpenTelemetry
+histograms aggregated with
+`exponential bucket histograms <https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram>`_,
+so bucket boundaries adapt automatically to the observed range and you do not have to
+hand-tune explicit buckets for metrics that span very different scales (milliseconds to
+hours).
+
+To ingest these correctly end-to-end, the metrics backend you connect to must support
+OpenTelemetry exponential histograms and (for Prometheus) their conversion to native
+histograms:
+
+* **OpenTelemetry Collector** — use ``opentelemetry-collector-contrib`` version 0.115.0
+  or above. Older versions do not translate OTLP exponential histograms into Prometheus
+  native histograms.
+* **Prometheus** — native histograms must be enabled explicitly, and how you do that
+  depends on the Prometheus version:
+
+  * **2.40 to 3.8** — start Prometheus with the ``--enable-feature=native-histograms``
+    flag.
+  * **3.8 and above** — set ``scrape_native_histograms: true`` in the scrape
+    configuration (this option was added in 3.8, and from 3.9 the feature flag is a
+    no-op so the config setting is required):
+
+    .. code-block:: yaml
+
+        global:
+            scrape_native_histograms: true
+
+If the backend does not support native histograms, exponential-histogram data points may
+be dropped or rendered incorrectly. A reference stack (Collector, Prometheus, and Grafana)
+wired up for local development is available via ``breeze start-airflow --integration otel``;
+see the contributor docs for details.
+
 Allow/Block Lists
 -----------------
 

--- a/scripts/ci/docker-compose/integration-otel.yml
+++ b/scripts/ci/docker-compose/integration-otel.yml
@@ -17,7 +17,7 @@
 ---
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.70.0
+    image: otel/opentelemetry-collector-contrib:0.155.0
     labels:
       breeze.description: "Integration required for OTEL/opentelemetry hooks."
     container_name: "breeze-otel-collector"
@@ -29,9 +29,12 @@ services:
       - "28889:8889"    # Prometheus exporter metrics
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.5.4
     container_name: "breeze-prometheus"
     user: "0"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--enable-feature=native-histograms"
     ports:
       - "29090:9090"
     volumes:

--- a/scripts/ci/docker-compose/otel-collector-config.yml
+++ b/scripts/ci/docker-compose/otel-collector-config.yml
@@ -22,6 +22,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:
@@ -32,7 +33,7 @@ exporters:
     tls:
       insecure: true
 
-  logging:
+  debug:
     verbosity: detailed
   prometheus:
     endpoint: 0.0.0.0:8889
@@ -44,9 +45,9 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, otlp/jaeger]
+      exporters: [debug, otlp/jaeger]
 
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, prometheus]
+      exporters: [debug, prometheus]


### PR DESCRIPTION
### Background/Problem

Exponential Histogram metrics was implemented in PR #64207 but the histogram metrics are dropped in local dev environment due to outdated Otel Collector and Prometheus Version and missing configuration.

### Changes made

- Otel Collector version is upgraded to latest version `0.155.0` to support exponential histogram metrics export feature.
- Otel Collector config is also updated to support new version (the `logging` exporter is renamed to `debug` exporter and the address was set to `0.0.0.0` since the default address is `localhost` in later versions).
- Prometheus version is pinned to `3.5.4` (the latest LTS version). 
- Feature flag `native-histograms` is set in Prometheus command to support exponential histogram.

### Documentation Update

Requirements are added to support exponential histogram metrics. (The Otel Collector, prometheus version requirements and feature flag, configuration requirements for prometheus.)

### Testing
The changes are manually tested and the histogram metrics are showing up locally.

To reproduce the issue locally, run `breeze start-airflow --integration otel --load-example-dags` and find `airflow_dag_processing_last_duration` in prometheus metrics. Try the same with statsd. Compare the results before and after changes.
 
### References 
- https://prometheus.io/docs/specs/native_histograms/
- https://prometheus.io/docs/prometheus/latest/configuration/configuration/ 
- https://prometheus.io/download/

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Claude Opus 4.8 for debugging and Gemini Pro 3.1 for research. 

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
