### PR TITLE
Fix SageMakerTransformOperator succeeding on a failed deferred job

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -852,6 +852,9 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
     def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> dict[str, dict]:
         validated_event = validate_execute_complete_event(event)
 
+        if validated_event["status"] != "success":
+            raise RuntimeError(f"Error while running transform job: {validated_event}")
+
         self.log.info("SageMaker job %s completed.", validated_event["job_name"])
         return self.serialize_result(validated_event["job_name"])
 

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_transform.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_sagemaker_transform.py
@@ -341,6 +341,33 @@ class TestSageMakerTransformOperator:
             self.sagemaker.execute(context=None)
         assert not mock_defer.called
 
+    @mock.patch.object(sagemaker, "serialize", return_value="")
+    @mock.patch.object(SageMakerHook, "describe_model", return_value={"ModelName": "model_name"})
+    @mock.patch.object(
+        SageMakerHook,
+        "describe_transform_job",
+        return_value={
+            "ModelName": "model_name",
+            "TransformJobStatus": "Failed",
+            "FailureReason": "it failed",
+        },
+    )
+    def test_execute_complete_raises_when_job_failed_during_deferred_wait(
+        self, mock_describe_transform_job, mock_describe_model, mock_serialize
+    ):
+        # When the transform job fails during the deferred wait, the trigger (an
+        # AwsBaseWaiterTrigger) yields {"status": "error", ...} instead of raising, so
+        # execute_complete must reject a non-success status rather than report the task as
+        # successful — matching every other SageMaker operator's execute_complete.
+        event = {
+            "status": "error",
+            "message": "Error while waiting for transform job: terminal failure",
+            "job_name": "job_name",
+        }
+
+        with pytest.raises(RuntimeError, match="Error while running transform job"):
+            self.sagemaker.execute_complete(context=None, event=event)
+
     @mock.patch("airflow.providers.amazon.aws.operators.sagemaker.SageMakerTransformOperator.defer")
     @mock.patch.object(SageMakerHook, "describe_model")
     @mock.patch.object(


### PR DESCRIPTION
## Problem

`SageMakerTransformOperator` with `deferrable=True` (which is the default whenever a deployment sets `[operators] default_deferrable=True`) can mark a task **successful even though the SageMaker batch-transform job failed**. The failed job's description is pushed as the XCom result, so downstream tasks run against missing/invalid transform output with no error surfaced.

## Root cause

The operator defers while the job is still `InProgress`, so the job can fail *during* the deferred wait. The trigger is `SageMakerTrigger`, which since #68927 inherits `AwsBaseWaiterTrigger.run()`. On waiter failure that base **yields** `TriggerEvent({"status": "error", ...})` instead of raising — so `execute_complete` is resumed with an error event. `SageMakerTransformOperator.execute_complete` never checked the status: it logged `"SageMaker job ... completed."` and returned `serialize_result(...)`, so the task succeeded.

Every other SageMaker operator's `execute_complete` already guards this (`if status != "success": raise`). Transform was the only one missing it. Before #68927 the previous trigger *raised* on failure, so the missing guard was dormant; migrating to the yielding base class turned it into a live silent-success.

## Fix

Reject a non-success status in `SageMakerTransformOperator.execute_complete`, matching the sibling operators, and add a regression test (a deferred transform that fails during the wait now fails the task instead of reporting success).

**Note on the exception type:** the sibling operators raise `AirflowException`, but the `check-no-new-airflow-exceptions` hook forbids *new* `raise AirflowException` usages, so this raises `RuntimeError` (identical task-failure/retry semantics, and already used elsewhere in this provider, e.g. `dms.py`).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)