### PR TITLE
Remove dependabot updates for the v2-11-test branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,19 +42,6 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    cooldown:
-      default-days: 4
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
-    target-branch: v2-11-test
-    groups:
-      github-actions-updates:
-        patterns:
-          - "*"
-
   - package-ecosystem: pip
     cooldown:
       default-days: 4
@@ -256,39 +243,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Repeat dependency updates on 2.11 branch as well
-  - package-ecosystem: pip
-    cooldown:
-      default-days: 4
-    directories:
-      - /clients/python
-      - /dev/breeze
-      - /docker_tests
-      - /
-    schedule:
-      interval: "weekly"
-    target-branch: v2-11-test
-    groups:
-      pip-dependency-updates:
-        patterns:
-          - "*"
-
-  - package-ecosystem: npm
-    cooldown:
-      default-days: 4
-    directories:
-      - /airflow/www/
-    schedule:
-      interval: "weekly"
-    target-branch: v2-11-test
-    groups:
-      legacy-ui-package-updates:
-        patterns:
-          - "*"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
The v2-11-test maintenance branch no longer needs automated dependency-update PRs, so drop the three dependabot update blocks targeting it (`github-actions`, `pip`, `npm`) along with the "Repeat dependency updates on 2.11 branch as well" section.

The `main` and `v3-3-test` update blocks are unchanged (13 update entries remain). YAML validated.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)