### PR TITLE
Fix mapped task group XCom collapsing to a bare value for a single expansion

### DIFF
--- a/airflow-core/newsfragments/69075.bugfix.rst
+++ b/airflow-core/newsfragments/69075.bugfix.rst
@@ -1,0 +1,1 @@
+Fix mapped task group return value handed to a downstream task being a bare value instead of a one-element list when the group expanded only once (and ``None`` instead of an empty list when every expansion returned ``None``).

--- a/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
+++ b/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
@@ -354,8 +354,11 @@ class PlainXComArg(XComArg):
                     ti_count=ti_count,
                     session=None,  # Not used in SDK implementation
                 )
-                # None means "no filtering needed" -> use NOTSET to pull all values
-                map_indexes = NOTSET if computed is None else computed
+                if computed is None:
+                    # Aggregate the mapped task group as a list, even for a single expansion (#69036) or all-None values (#48005)
+                    # Materialise eagerly (one slice request) so a task returning the value unchanged can still serialize it
+                    return LazyXComSequence(xcom_arg=self, ti=ti)[:]
+                map_indexes = computed
         result = ti.xcom_pull(
             task_ids=task_id,
             key=self.key,

--- a/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
+++ b/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
@@ -355,9 +355,10 @@ class PlainXComArg(XComArg):
                     session=None,  # Not used in SDK implementation
                 )
                 if computed is None:
-                    # Aggregate the mapped task group as a list, even for a single expansion (#69036) or all-None values (#48005)
-                    # Materialise eagerly (one slice request) so a task returning the value unchanged can still serialize it
-                    return LazyXComSequence(xcom_arg=self, ti=ti)[:]
+                    # Resolve the mapped task group as a list, even for a single expansion (#69036)
+                    # or all-None values (#48005). Stay lazy: serde materialises the sequence only if
+                    # the value is actually returned and pushed to XCom (see airflow.sdk.serde.serialize).
+                    return LazyXComSequence(xcom_arg=self, ti=ti)
                 map_indexes = computed
         result = ti.xcom_pull(
             task_ids=task_id,

--- a/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
+++ b/task-sdk/src/airflow/sdk/definitions/xcom_arg.py
@@ -30,7 +30,7 @@ from airflow.sdk import TriggerRule
 from airflow.sdk.definitions._internal.abstractoperator import AbstractOperator
 from airflow.sdk.definitions._internal.mixins import DependencyMixin, ResolveMixin
 from airflow.sdk.definitions._internal.setup_teardown import SetupTeardownContext
-from airflow.sdk.definitions._internal.types import NOTSET, ArgNotSet, is_arg_set
+from airflow.sdk.definitions._internal.types import NOTSET, is_arg_set
 from airflow.sdk.exceptions import AirflowException, XComNotFound
 from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
 from airflow.sdk.execution_time.xcom import BaseXCom
@@ -338,7 +338,7 @@ class PlainXComArg(XComArg):
         tg = self.operator.get_closest_mapped_task_group()
         if tg is None:
             # No mapped task group - pull from unmapped instance
-            map_indexes: int | range | None | ArgNotSet = None
+            map_indexes: int | range | None = None
         else:
             # Check for pre-computed value from server (backward compatibility)
             upstream_map_indexes = getattr(ti, "_upstream_map_indexes", None)

--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -254,6 +254,14 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
         return o
 
+    # Materialise a lazily-resolved mapped XCom (e.g. mapped task group output) to a list here;
+    # otherwise the attrs branch below would serialize its internal fields. The single slice fetch
+    # happens only if the value is actually returned and serialized.
+    from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
+
+    if isinstance(o, LazyXComSequence):
+        return serialize(o[:], depth + 1)
+
     # custom serializers
     dct = {
         CLASSNAME: qn,

--- a/task-sdk/src/airflow/sdk/serde/__init__.py
+++ b/task-sdk/src/airflow/sdk/serde/__init__.py
@@ -254,14 +254,6 @@ def serialize(o: object, depth: int = 0) -> U | None:
 
         return o
 
-    # Materialise a lazily-resolved mapped XCom (e.g. mapped task group output) to a list here;
-    # otherwise the attrs branch below would serialize its internal fields. The single slice fetch
-    # happens only if the value is actually returned and serialized.
-    from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
-
-    if isinstance(o, LazyXComSequence):
-        return serialize(o[:], depth + 1)
-
     # custom serializers
     dct = {
         CLASSNAME: qn,

--- a/task-sdk/src/airflow/sdk/serde/serializers/lazy_xcom_sequence.py
+++ b/task-sdk/src/airflow/sdk/serde/serializers/lazy_xcom_sequence.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.sdk.module_loading import qualname
+
+if TYPE_CHECKING:
+    from airflow.sdk.serde import U
+
+__version__ = 1
+
+serializers = ["airflow.sdk.execution_time.lazy_sequence.LazyXComSequence"]
+deserializers = serializers
+
+
+def serialize(o: object) -> tuple[U, str, int, bool]:
+    """Materialize a lazily-resolved mapped XCom to a list (single slice fetch)."""
+    from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
+
+    if isinstance(o, LazyXComSequence):
+        return list(o[:]), qualname(o), __version__, True
+    return "", "", 0, False
+
+
+def deserialize(cls: type, version: int, data: list) -> list:
+    """Deserialize to a plain list; the lazy sequence cannot be rebuilt off-worker."""
+    if version > __version__:
+        raise TypeError(f"serialized version {version} is newer than class version {__version__}")
+    return list(data)

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -32,12 +32,15 @@ from airflow.sdk.definitions.dag import DAG
 from airflow.sdk.definitions.mappedoperator import MappedOperator
 from airflow.sdk.definitions.xcom_arg import XComArg
 from airflow.sdk.execution_time.comms import (
+    ErrorResponse,
     GetTICount,
     GetXCom,
+    GetXComSequenceItem,
     GetXComSequenceSlice,
     SetXCom,
     TICount,
     XComResult,
+    XComSequenceIndexResult,
     XComSequenceSliceResult,
 )
 
@@ -659,6 +662,13 @@ def test_operator_mapped_task_group_receives_value(create_runtime_ti, mock_super
             task_id = msg.task_id
             values = [v for k, v in expected_values.items() if k[0] == task_id and k[1] is not None]
             return XComSequenceSliceResult(root=values)
+        elif isinstance(msg, GetXComSequenceItem):
+            # The aggregated task-group value now resolves lazily, so iterating it fetches one item at a time.
+            task_id = msg.task_id
+            values = [v for k, v in expected_values.items() if k[0] == task_id and k[1] is not None]
+            if 0 <= msg.offset < len(values):
+                return XComSequenceIndexResult(root=values[msg.offset])
+            return ErrorResponse()
         elif isinstance(msg, GetTICount):
             # Handle TI count queries for upstream_map_indexes computation
             if msg.task_ids:

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -356,12 +356,12 @@ class TestPlainXComArgResolveMappedGroup:
     """Resolving a task inside a mapped task group from a task outside that group.
 
     Regression tests for #69036 and #48005: the combined return value of a
-    mapped task group must always be an eager list (one element per expansion),
-    even when the group expanded only once or every expansion returned ``None``.
-    Previously this case was routed through ``xcom_pull`` pulling all map
-    indexes, which collapsed a single value to a bare scalar and an empty set
-    of values to ``None``. The list must be materialised eagerly so a task that
-    returns the value unchanged can still push it to XCom.
+    mapped task group must always serialize to a list (one element per
+    expansion), even when the group expanded only once or every expansion
+    returned ``None``. Previously this case was routed through ``xcom_pull``
+    pulling all map indexes, which collapsed a single value to a bare scalar
+    and an empty set of values to ``None``. ``resolve`` stays lazy and serde
+    materialises the sequence only when the value is actually returned.
     """
 
     @staticmethod
@@ -392,8 +392,10 @@ class TestPlainXComArgResolveMappedGroup:
             pytest.param(["a", "b"], ["a", "b"], id="multiple-expansions"),
         ],
     )
-    def test_resolve_aggregates_mapped_group_as_eager_list(self, root, expected, mock_supervisor_comms):
+    def test_resolve_stays_lazy_and_serializes_as_list(self, root, expected, mock_supervisor_comms):
         from airflow.sdk.execution_time.comms import XComSequenceSliceResult
+        from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
+        from airflow.sdk.serde import serialize
 
         mock_supervisor_comms.send.return_value = XComSequenceSliceResult(root=root)
 
@@ -402,9 +404,9 @@ class TestPlainXComArgResolveMappedGroup:
 
         resolved = arg.resolve({"ti": ti})
 
-        assert resolved == expected
-        assert isinstance(resolved, list)
+        assert isinstance(resolved, LazyXComSequence)
         ti.xcom_pull.assert_not_called()
+        assert serialize(resolved) == expected
 
     def test_resolve_uses_xcom_pull_for_specific_index(self):
         arg = self._make_arg()

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -395,7 +395,7 @@ class TestPlainXComArgResolveMappedGroup:
     def test_resolve_stays_lazy_and_serializes_as_list(self, root, expected, mock_supervisor_comms):
         from airflow.sdk.execution_time.comms import XComSequenceSliceResult
         from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
-        from airflow.sdk.serde import serialize
+        from airflow.sdk.serde import deserialize, serialize
 
         mock_supervisor_comms.send.return_value = XComSequenceSliceResult(root=root)
 
@@ -406,7 +406,8 @@ class TestPlainXComArgResolveMappedGroup:
 
         assert isinstance(resolved, LazyXComSequence)
         ti.xcom_pull.assert_not_called()
-        assert serialize(resolved) == expected
+        # The lazy sequence materializes to a plain list only when actually serialized.
+        assert deserialize(serialize(resolved)) == expected
 
     def test_resolve_uses_xcom_pull_for_specific_index(self):
         arg = self._make_arg()

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -26,8 +26,11 @@ import structlog
 from airflow.sdk import TaskInstanceState
 from airflow.sdk.bases.xcom import BaseXCom
 from airflow.sdk.definitions.dag import DAG
+from airflow.sdk.definitions.xcom_arg import PlainXComArg
 from airflow.sdk.exceptions import AirflowSkipException
-from airflow.sdk.execution_time.comms import GetXCom, XComResult
+from airflow.sdk.execution_time.comms import GetXCom, XComResult, XComSequenceSliceResult
+from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
+from airflow.sdk.serde import deserialize, serialize
 
 log = structlog.get_logger(__name__)
 
@@ -375,8 +378,6 @@ class TestPlainXComArgResolveMappedGroup:
 
     @staticmethod
     def _make_arg():
-        from airflow.sdk.definitions.xcom_arg import PlainXComArg
-
         operator = mock.MagicMock()
         operator.is_mapped = False
         operator.task_id = "do_something"
@@ -393,10 +394,6 @@ class TestPlainXComArgResolveMappedGroup:
         ],
     )
     def test_resolve_stays_lazy_and_serializes_as_list(self, root, expected, mock_supervisor_comms):
-        from airflow.sdk.execution_time.comms import XComSequenceSliceResult
-        from airflow.sdk.execution_time.lazy_sequence import LazyXComSequence
-        from airflow.sdk.serde import deserialize, serialize
-
         mock_supervisor_comms.send.return_value = XComSequenceSliceResult(root=root)
 
         arg = self._make_arg()

--- a/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
+++ b/task-sdk/tests/task_sdk/definitions/test_xcom_arg.py
@@ -350,3 +350,69 @@ def test_xcom_concat(run_ti, mock_supervisor_comms):
     states = [run_ti(dag, "pull_one", map_index) for map_index in range(5)]
     assert states == [TaskInstanceState.SUCCESS] * 5
     assert agg_results == {"a", "b", "c", 1, 2}
+
+
+class TestPlainXComArgResolveMappedGroup:
+    """Resolving a task inside a mapped task group from a task outside that group.
+
+    Regression tests for #69036 and #48005: the combined return value of a
+    mapped task group must always be an eager list (one element per expansion),
+    even when the group expanded only once or every expansion returned ``None``.
+    Previously this case was routed through ``xcom_pull`` pulling all map
+    indexes, which collapsed a single value to a bare scalar and an empty set
+    of values to ``None``. The list must be materialised eagerly so a task that
+    returns the value unchanged can still push it to XCom.
+    """
+
+    @staticmethod
+    def _make_ti(*, computed):
+        ti = mock.MagicMock()
+        ti._upstream_map_indexes = None
+        ti._cached_template_context = {"expanded_ti_count": 1}
+        ti.run_id = "run-1"
+        ti.get_relevant_upstream_map_indexes.return_value = computed
+        return ti
+
+    @staticmethod
+    def _make_arg():
+        from airflow.sdk.definitions.xcom_arg import PlainXComArg
+
+        operator = mock.MagicMock()
+        operator.is_mapped = False
+        operator.task_id = "do_something"
+        operator.dag_id = "test_dag"
+        operator.get_closest_mapped_task_group.return_value = mock.MagicMock()
+        return PlainXComArg(operator=operator, key="test")
+
+    @pytest.mark.parametrize(
+        ("root", "expected"),
+        [
+            pytest.param(["14"], ["14"], id="single-expansion-stays-a-list"),
+            pytest.param([], [], id="all-none-expansions-give-empty-list"),
+            pytest.param(["a", "b"], ["a", "b"], id="multiple-expansions"),
+        ],
+    )
+    def test_resolve_aggregates_mapped_group_as_eager_list(self, root, expected, mock_supervisor_comms):
+        from airflow.sdk.execution_time.comms import XComSequenceSliceResult
+
+        mock_supervisor_comms.send.return_value = XComSequenceSliceResult(root=root)
+
+        arg = self._make_arg()
+        ti = self._make_ti(computed=None)
+
+        resolved = arg.resolve({"ti": ti})
+
+        assert resolved == expected
+        assert isinstance(resolved, list)
+        ti.xcom_pull.assert_not_called()
+
+    def test_resolve_uses_xcom_pull_for_specific_index(self):
+        arg = self._make_arg()
+        ti = self._make_ti(computed=0)
+        ti.xcom_pull.return_value = "value-0"
+
+        resolved = arg.resolve({"ti": ti})
+
+        assert resolved == "value-0"
+        ti.xcom_pull.assert_called_once()
+        assert ti.xcom_pull.call_args.kwargs["map_indexes"] == 0


### PR DESCRIPTION
closes: #69036

## Human Summary
Currently, when `map_indexes` is left unset, a single mapped result collapses to its bare value instead of staying one-element list.
It started to happen after #60803 was merged, when the upstream map-index computation was relocated to the task-sdk.
This PR fixes it by returning an eagerly-materialized `LazyXComSequence` object.

## AI Summary
<details>
<summary>
Click here
</summary>
A task consuming the output of a mapped task group from **outside** that group must always receive a list with one element per expansion. When the task-start upstream map-index computation moved into the Task SDK (#60803, released in 3.2.0), an unmapped downstream resolving a task inside a mapped task group started falling through to pulling all map indexes via `xcom_pull`, which collapses a single value to a bare scalar and an empty set of values to `None`.

As a result:

- A mapped task group that expanded **only once** handed the raw return value to the downstream task instead of a one-element list (#69036 — e.g. the consumer received `'14'` and iterated `'1'`, `'4'` instead of receiving `['14']`).
- A mapped task group whose expansions **all returned `None`** would hand `None` instead of an empty list (the #48005 class of bug, via the task-group resolution path).

This worked correctly in 3.1.5: the pre-3.2 server returned `list(range(mapped_ti_count))` for this case, guaranteeing a list. The fix resolves this case through a `LazyXComSequence`, mirroring how a directly mapped task already resolves, so the result is always a list regardless of how many times the group expanded or whether every value was `None`.

Verified end to end with `airflow dags test` on the reproduction DAGs from both issues:

- single expansion now yields `['14']` (was `'14'`),
- multiple expansions still yield the full list,
- all-`None` group expansions yield `[]`,
- the directly-mapped all-`None` case from #48005 continues to yield `[]`.
</details>




---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)