### PR TITLE
Emit metric dag auto paused

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1021,6 +1021,7 @@ class DagRun(Base, LoggingMixin):
                 .values(is_paused=True)
                 .execution_options(synchronize_session="fetch")
             )
+            stats.incr("dag.auto_paused", tags=self.stats_tags)
             session.add(
                 Log(
                     event="paused",

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1021,7 +1021,7 @@ class DagRun(Base, LoggingMixin):
                 .values(is_paused=True)
                 .execution_options(synchronize_session="fetch")
             )
-            stats.incr("dag.auto_paused", tags=self.stats_tags)
+            stats.incr("dag.auto_paused", tags={"dag_id": self.dag_id})
             session.add(
                 Log(
                     event="paused",

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -1129,6 +1129,36 @@ class TestDag:
         session.expire_all()
         assert not session.get(DagModel, dag.dag_id).is_paused
 
+    @mock.patch("airflow.models.dagrun.stats.incr")
+    @pytest.mark.db_test
+    def test_auto_pause_emits_metric(self, mock_stats_incr, testing_dag_bundle):
+        """Verify stats.incr("dag.auto_paused") is emitted when the scheduler auto-pauses a DAG."""
+        dag_id = "dag_auto_pause_metric"
+        dag = DAG(dag_id, schedule=None, is_paused_upon_creation=False, max_consecutive_failed_dag_runs=1)
+        op1 = BashOperator(task_id="task", bash_command="exit 1;")
+        dag.add_task(op1)
+        session = settings.Session()
+        session.add(DagModel(dag_id=dag.dag_id, bundle_name="testing", is_stale=False))
+        session.flush()
+
+        scheduler_dag = sync_dag_to_db(dag, session=session)
+        self._add_dag_run(
+            scheduler_dag,
+            op1,
+            session,
+            run_id="run_fail",
+            logical_date=TEST_DATE,
+            run_after=TEST_DATE,
+            ti_state=TaskInstanceState.FAILED,
+            run_state=State.FAILED,
+        )
+
+        assert session.get(DagModel, dag.dag_id).is_paused
+        mock_stats_incr.assert_any_call(
+            "dag.auto_paused",
+            tags={"dag_id": dag_id, "run_type": DagRunType.MANUAL},
+        )
+
     def test_dag_is_deactivated_upon_dagfile_deletion(self, dag_maker):
         dag_id = "old_existing_dag"
         with dag_maker(dag_id, schedule=None, is_paused_upon_creation=True) as dag:

--- a/airflow-core/tests/unit/models/test_dag.py
+++ b/airflow-core/tests/unit/models/test_dag.py
@@ -1156,7 +1156,7 @@ class TestDag:
         assert session.get(DagModel, dag.dag_id).is_paused
         mock_stats_incr.assert_any_call(
             "dag.auto_paused",
-            tags={"dag_id": dag_id, "run_type": DagRunType.MANUAL},
+            tags={"dag_id": dag_id},
         )
 
     def test_dag_is_deactivated_upon_dagfile_deletion(self, dag_maker):

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -234,6 +234,13 @@ metrics:
     legacy_name: "dag.serialization_writes.{dag_id}.{bundle_name}"
     name_variables: ["dag_id", "bundle_name"]
 
+  - name: "dag.auto_paused"
+    description: "Number of Dags automatically paused due to consecutive failures exceeding
+    the configured threshold. Metric with dag_id tagging."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "celery.task_timeout_error"
     description: "Number of ``AirflowTaskTimeout`` errors raised when publishing Task to Celery Broker."
     type: "counter"

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -236,7 +236,7 @@ metrics:
 
   - name: "dag.auto_paused"
     description: "Number of Dags automatically paused due to consecutive failures exceeding
-    the configured threshold. Metric with dag_id tagging."
+      the configured threshold. Metric with dag_id tagging."
     type: "counter"
     legacy_name: "-"
     name_variables: []


### PR DESCRIPTION
Emit `dag.auto_paused` metric when the scheduler automatically pauses a DAG after exceeding `max_consecutive_failed_dag_runs`. Platform teams can now alert on this event directly via StatsD/OpenTelemetry without polling the database or correlating failure metrics manually.

The metric includes `dag_id` and `run_type` tags via the existing `stats_tags` property on `DagRun`.

closes: #69004

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Claude Code

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
