### PR TITLE
Close S3 download_file handle after download or failure

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/s3.py
@@ -1629,12 +1629,18 @@ class S3Hook(AwsBaseHook):
         extra_args = {**self.extra_args}
         if self._requester_pays:
             extra_args["RequestPayer"] = "requester"
-        s3_obj.download_fileobj(
-            file,
-            ExtraArgs=extra_args,
-            Config=self.transfer_config,
-        )
-        file.flush()
+        try:
+            s3_obj.download_fileobj(
+                file,
+                ExtraArgs=extra_args,
+                Config=self.transfer_config,
+            )
+            file.flush()
+        finally:
+            # The file is created with delete=False / opened by us, so closing the
+            # handle keeps the data on disk while releasing the descriptor even when
+            # the download raises.
+            file.close()
         get_hook_lineage_collector().add_input_asset(
             context=self, scheme="s3", asset_kwargs={"bucket": bucket_name, "key": key}
         )

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -1531,6 +1531,21 @@ class TestAwsS3Hook:
         assert mock_file.name == output_file
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.NamedTemporaryFile")
+    def test_download_file_closes_handle_on_error(self, mock_temp_file, tmp_path):
+        mock_file = mock_temp_file.return_value
+        mock_file.name = str(tmp_path / "airflow_tmp_test_s3_hook")
+        s3_hook = S3Hook(aws_conn_id="s3_test")
+        s3_hook.check_for_key = Mock(return_value=True)
+        s3_obj = Mock()
+        s3_obj.download_fileobj = Mock(side_effect=OSError("download failed"))
+        s3_hook.get_key = Mock(return_value=s3_obj)
+
+        with pytest.raises(OSError, match="download failed"):
+            s3_hook.download_file(key="test_key", bucket_name="test_bucket")
+
+        mock_file.close.assert_called_once_with()
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.NamedTemporaryFile")
     def test_download_file_exposes_lineage(self, mock_temp_file, tmp_path, hook_lineage_collector):
         mock_file = mock_temp_file.return_value
         mock_file.name = str(tmp_path / "airflow_tmp_test_s3_hook")


### PR DESCRIPTION
`S3Hook.download_file` opened a local file (or a `NamedTemporaryFile` with `delete=False`), streamed the object into it, and returned the path **without ever closing the handle** — relying on garbage collection to release the descriptor. On a download error the handle leaked the same way.

Closing it in a `finally` releases the descriptor on every path (success and failure) while keeping the downloaded file on disk for the caller. Adds a regression test asserting the handle is closed when the download raises.

related: #69077

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)