### PR TITLE
Upgrade the Airflow version to 3.4.0 and Task SDK version to 1.4.0

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -64,7 +64,7 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by prek hook
-version = "3.3.0"
+version = "3.4.0"
 
 dependencies = [
     "a2wsgi>=1.10.8",
@@ -153,7 +153,7 @@ dependencies = [
     "typing-extensions>=4.14.1",
     "universal-pathlib>=0.3.8",
     "uuid6>=2024.7.10",
-    "apache-airflow-task-sdk<1.4.0,>=1.3.0",
+    "apache-airflow-task-sdk<1.5.0,>=1.4.0",
     # pre-installed providers
     "apache-airflow-providers-common-compat>=1.7.4",
     "apache-airflow-providers-common-io>=1.6.3",

--- a/airflow-core/src/airflow/__init__.py
+++ b/airflow-core/src/airflow/__init__.py
@@ -25,7 +25,7 @@
 # lib.)  This is required by some IDEs to resolve the import paths.
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 
 import os

--- a/docker-stack-docs/README.md
+++ b/docker-stack-docs/README.md
@@ -31,12 +31,12 @@ Every time a new version of Airflow is released, the images are prepared in the
 [apache/airflow DockerHub](https://hub.docker.com/r/apache/airflow)
 for all the supported Python versions.
 
-You can find the following images there (Assuming Airflow version `3.3.0`):
+You can find the following images there (Assuming Airflow version `3.4.0`):
 
 * `apache/airflow:latest` - the latest released Airflow image with default Python version (3.12 currently)
 * `apache/airflow:latest-pythonX.Y` - the latest released Airflow image with specific Python version
-* `apache/airflow:3.3.0` - the versioned Airflow image with default Python version (3.12 currently)
-* `apache/airflow:3.3.0-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:3.4.0` - the versioned Airflow image with default Python version (3.12 currently)
+* `apache/airflow:3.4.0-pythonX.Y` - the versioned Airflow image with specific Python version
 
 Those are "reference" regular images. They contain the most common set of extras, dependencies and providers that are
 often used by the users and they are good to "try-things-out" when you want to just take Airflow for a spin,
@@ -47,8 +47,8 @@ via [Building the image](https://airflow.apache.org/docs/docker-stack/build.html
 
 * `apache/airflow:slim-latest`              - the latest released Airflow image with default Python version (3.12 currently)
 * `apache/airflow:slim-latest-pythonX.Y`    - the latest released Airflow image with specific Python version
-* `apache/airflow:slim-3.3.0`           - the versioned Airflow image with default Python version (3.12 currently)
-* `apache/airflow:slim-3.3.0-pythonX.Y` - the versioned Airflow image with specific Python version
+* `apache/airflow:slim-3.4.0`           - the versioned Airflow image with default Python version (3.12 currently)
+* `apache/airflow:slim-3.4.0-pythonX.Y` - the versioned Airflow image with specific Python version
 
 The Apache Airflow image provided as convenience package is optimized for size, and
 it provides just a bare minimal set of the extras and dependencies installed and in most cases

--- a/docker-stack-docs/docker-examples/extending/add-airflow-configuration/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-airflow-configuration/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 ENV AIRFLOW__CORE__LOAD_EXAMPLES=True
 ENV AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=my_conn_string
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-apt-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-apt-packages/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-build-essential-extend/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-build-essential-extend/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-providers/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages-constraints/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages-constraints/Dockerfile
@@ -17,6 +17,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml --constraint "${HOME}/constraints.txt"
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages-uv/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages-uv/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 
 # The `uv` tools is Rust packaging tool that is much faster than `pip` and other installers
 # Support for uv as installation tool is experimental

--- a/docker-stack-docs/docker-examples/extending/add-pypi-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-pypi-packages/Dockerfile
@@ -17,6 +17,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" lxml
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/add-requirement-packages/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/add-requirement-packages/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 COPY requirements.txt /
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}" -r /requirements.txt
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/custom-providers/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/custom-providers/Dockerfile
@@ -17,6 +17,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 RUN pip install "apache-airflow==${AIRFLOW_VERSION}" --no-cache-dir apache-airflow-providers-docker==2.5.1
 # [END Dockerfile]

--- a/docker-stack-docs/docker-examples/extending/embedding-dags/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/embedding-dags/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 
 COPY --chown=airflow:root test_dag.py /opt/airflow/dags
 

--- a/docker-stack-docs/docker-examples/extending/writable-directory/Dockerfile
+++ b/docker-stack-docs/docker-examples/extending/writable-directory/Dockerfile
@@ -17,7 +17,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:3.3.0
+FROM apache/airflow:3.4.0
 RUN umask 0002; \
     mkdir -p ~/writeable-directory
 # [END Dockerfile]

--- a/docker-stack-docs/entrypoint.rst
+++ b/docker-stack-docs/entrypoint.rst
@@ -132,7 +132,7 @@ if you specify extra arguments. For example:
 
 .. code-block:: bash
 
-  docker run -it apache/airflow:3.3.0-python3.10 bash -c "ls -la"
+  docker run -it apache/airflow:3.4.0-python3.10 bash -c "ls -la"
   total 16
   drwxr-xr-x 4 airflow root 4096 Jun  5 18:12 .
   drwxr-xr-x 1 root    root 4096 Jun  5 18:12 ..
@@ -144,7 +144,7 @@ you pass extra parameters. For example:
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:3.3.0-python3.10 python -c "print('test')"
+  > docker run -it apache/airflow:3.4.0-python3.10 python -c "print('test')"
   test
 
 If first argument equals to ``airflow`` - the rest of the arguments is treated as an Airflow command
@@ -152,13 +152,13 @@ to execute. Example:
 
 .. code-block:: bash
 
-   docker run -it apache/airflow:3.3.0-python3.10 airflow webserver
+   docker run -it apache/airflow:3.4.0-python3.10 airflow webserver
 
 If there are any other arguments - they are simply passed to the "airflow" command
 
 .. code-block:: bash
 
-  > docker run -it apache/airflow:3.3.0-python3.10 help
+  > docker run -it apache/airflow:3.4.0-python3.10 help
     usage: airflow [-h] GROUP_OR_COMMAND ...
 
     Positional Arguments:
@@ -366,7 +366,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD=admin" \
-      apache/airflow:3.3.0-python3.10 webserver
+      apache/airflow:3.4.0-python3.10 webserver
 
 
 .. code-block:: bash
@@ -375,7 +375,7 @@ database and creating an ``admin/admin`` Admin user with the following command:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:3.3.0-python3.10 webserver
+      apache/airflow:3.4.0-python3.10 webserver
 
 The commands above perform initialization of the SQLite database, create admin user with admin password
 and Admin role. They also forward local port ``8080`` to the webserver port and finally start the webserver.
@@ -415,6 +415,6 @@ Example:
     --env "_AIRFLOW_DB_MIGRATE=true" \
     --env "_AIRFLOW_WWW_USER_CREATE=true" \
     --env "_AIRFLOW_WWW_USER_PASSWORD_CMD=echo admin" \
-      apache/airflow:3.3.0-python3.10 webserver
+      apache/airflow:3.4.0-python3.10 webserver
 
 This method is only available starting from Docker image of Airflow 2.1.1 and above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by prek
-version = "3.3.0"
+version = "3.4.0"
 
 dependencies = [
-    "apache-airflow-task-sdk<1.4.0,>=1.3.0",
-    "apache-airflow-core==3.3.0",
+    "apache-airflow-task-sdk<1.5.0,>=1.4.0",
+    "apache-airflow-core==3.4.0",
 ]
 
 packages = []

--- a/task-sdk/pyproject.toml
+++ b/task-sdk/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "apache-airflow-core<3.4.0,>=3.3.0",
+    "apache-airflow-core<3.5.0,>=3.4.0",
     "asgiref>=2.3.0; python_version < '3.14'",
     "asgiref>=3.11.1; python_version >= '3.14'",
     "attrs>=24.2.0, !=25.2.0",

--- a/task-sdk/src/airflow/sdk/__init__.py
+++ b/task-sdk/src/airflow/sdk/__init__.py
@@ -117,7 +117,7 @@ __all__ = [
     "teardown",
 ]
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import DagRunState, TaskInstanceState, TriggerRule, WeightRule


### PR DESCRIPTION
Now that the `v3-3-stable` branch has been cut, bump `main` to target the next minor release: Airflow `3.3.0` → `3.4.0` and Task SDK `1.3.0` → `1.4.0`.

This follows the same pattern as #65317 (3.3) and #55493 (3.2): core/SDK versions, inter-package dependency bounds, and the `docker-stack-docs` image references.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)