### PR TITLE
Expose owner_display_name in event log API and Audit Log UI

### DIFF
--- a/airflow-core/newsfragments/68334.improvement.rst
+++ b/airflow-core/newsfragments/68334.improvement.rst
@@ -1,0 +1,1 @@
+Expose owner_display_name in the /api/v2/eventLogs response and add owner_display_name, owner_display_name_pattern, and owner_display_name_prefix_pattern filter/sort parameters. The Audit Log UI "User" column now displays the human-readable display name when present, falling back to owner.

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
@@ -38,6 +38,7 @@ class EventLogResponse(BaseModel):
     event: str
     logical_date: datetime | None
     owner: str | None
+    owner_display_name: str | None
     extra: str | None
     dag_display_name: str | None = Field(
         validation_alias=AliasPath("dag_model", "dag_display_name"), default=None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -4522,13 +4522,15 @@ paths:
             type: string
           description: 'Attributes to order by, multi criteria sort is supported.
             Prefix with `-` for descending order. Supported attributes: `id, dttm,
-            dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`'
+            dag_id, task_id, run_id, event, logical_date, owner, owner_display_name,
+            extra, when, event_log_id`'
           default:
           - id
           title: Order By
         description: 'Attributes to order by, multi criteria sort is supported. Prefix
           with `-` for descending order. Supported attributes: `id, dttm, dag_id,
-          task_id, run_id, event, logical_date, owner, extra, when, event_log_id`'
+          task_id, run_id, event, logical_date, owner, owner_display_name, extra,
+          when, event_log_id`'
       - name: dag_id
         in: query
         required: false
@@ -4577,6 +4579,14 @@ paths:
           - type: string
           - type: 'null'
           title: Owner
+      - name: owner_display_name
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Owner Display Name
       - name: event
         in: query
         required: false
@@ -4707,6 +4717,27 @@ paths:
           \ is evaluated as ``ILIKE '%term%'`` and most of the time prevents the database\
           \ from using B-tree indexes, which can be very slow on large tables. Prefer\
           \ the equivalent ``owner_prefix_pattern`` parameter when possible."
+      - name: owner_display_name_pattern
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: "SQL LIKE expression \u2014 use `%` / `_` wildcards (e.g. `%customer_%`).\
+            \ Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular\
+            \ expressions are **not** supported. \n\n**Performance note:** this full-match\
+            \ pattern is evaluated as ``ILIKE '%term%'`` and most of the time prevents\
+            \ the database from using B-tree indexes, which can be very slow on large\
+            \ tables. Prefer the equivalent ``owner_display_name_prefix_pattern`` parameter\
+            \ when possible."
+          title: Owner Display Name Pattern
+        description: "SQL LIKE expression \u2014 use `%` / `_` wildcards (e.g. `%customer_%`).\
+          \ Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions\
+          \ are **not** supported. \n\n**Performance note:** this full-match pattern\
+          \ is evaluated as ``ILIKE '%term%'`` and most of the time prevents the database\
+          \ from using B-tree indexes, which can be very slow on large tables. Prefer\
+          \ the equivalent ``owner_display_name_prefix_pattern`` parameter when possible."
       - name: event_pattern
         in: query
         required: false
@@ -4816,6 +4847,30 @@ paths:
             \ effectively matches items starting with `test`, and `s3://` matches\
             \ items starting with `s3`."
           title: Owner Prefix Pattern
+        description: "Prefix match \u2014 returns items whose value starts with the\
+          \ given string (case-sensitive, index-friendly). Use the pipe `|` operator\
+          \ for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters\
+          \ (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric\
+          \ characters in the prefix are stripped before matching so the range scan\
+          \ stays index-compatible under locale-aware collations \u2014 e.g. `test_`\
+          \ effectively matches items starting with `test`, and `s3://` matches items\
+          \ starting with `s3`."
+      - name: owner_display_name_prefix_pattern
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: "Prefix match \u2014 returns items whose value starts with\
+            \ the given string (case-sensitive, index-friendly). Use the pipe `|`\
+            \ operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard\
+            \ characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric\
+            \ characters in the prefix are stripped before matching so the range scan\
+            \ stays index-compatible under locale-aware collations \u2014 e.g. `test_`\
+            \ effectively matches items starting with `test`, and `s3://` matches\
+            \ items starting with `s3`."
+          title: Owner Display Name Prefix Pattern
         description: "Prefix match \u2014 returns items whose value starts with the\
           \ given string (case-sensitive, index-friendly). Use the pipe `|` operator\
           \ for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters\
@@ -14641,6 +14696,11 @@ components:
           - type: string
           - type: 'null'
           title: Owner
+        owner_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Owner Display Name
         extra:
           anyOf:
           - type: string
@@ -14668,6 +14728,7 @@ components:
       - event
       - logical_date
       - owner
+      - owner_display_name
       - extra
       title: EventLogResponse
       description: Event Log Response.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -100,6 +100,7 @@ def get_event_logs(
                     "event",
                     "logical_date",
                     "owner",
+                    "owner_display_name",
                     "extra",
                 ],
                 Log,
@@ -114,6 +115,9 @@ def get_event_logs(
     map_index: Annotated[FilterParam[int | None], Depends(filter_param_factory(Log.map_index, int | None))],
     try_number: Annotated[FilterParam[int | None], Depends(filter_param_factory(Log.try_number, int | None))],
     owner: Annotated[FilterParam[str | None], Depends(filter_param_factory(Log.owner, str | None))],
+    owner_display_name: Annotated[
+        FilterParam[str | None], Depends(filter_param_factory(Log.owner_display_name, str | None))
+    ],
     event: Annotated[FilterParam[str | None], Depends(filter_param_factory(Log.event, str | None))],
     excluded_events: Annotated[
         FilterParam[list[str] | None],
@@ -138,6 +142,10 @@ def get_event_logs(
     task_id_pattern: Annotated[_SearchParam, Depends(search_param_factory(Log.task_id, "task_id_pattern"))],
     run_id_pattern: Annotated[_SearchParam, Depends(search_param_factory(Log.run_id, "run_id_pattern"))],
     owner_pattern: Annotated[_SearchParam, Depends(search_param_factory(Log.owner, "owner_pattern"))],
+    owner_display_name_pattern: Annotated[
+        _SearchParam,
+        Depends(search_param_factory(Log.owner_display_name, "owner_display_name_pattern")),
+    ],
     event_pattern: Annotated[_SearchParam, Depends(search_param_factory(Log.event, "event_pattern"))],
     # Prefix pattern search filters (index-friendly, case-sensitive)
     dag_id_prefix_pattern: Annotated[
@@ -155,6 +163,10 @@ def get_event_logs(
     owner_prefix_pattern: Annotated[
         _PrefixSearchParam,
         Depends(prefix_search_param_factory(Log.owner, "owner_prefix_pattern")),
+    ],
+    owner_display_name_prefix_pattern: Annotated[
+        _PrefixSearchParam,
+        Depends(prefix_search_param_factory(Log.owner_display_name, "owner_display_name_prefix_pattern")),
     ],
     event_prefix_pattern: Annotated[
         _PrefixSearchParam,
@@ -185,6 +197,7 @@ def get_event_logs(
             map_index,
             try_number,
             owner,
+            owner_display_name,
             event,
             excluded_events,
             included_events,
@@ -199,6 +212,8 @@ def get_event_logs(
             run_id_prefix_pattern,
             owner_pattern,
             owner_prefix_pattern,
+            owner_display_name_pattern,
+            owner_display_name_prefix_pattern,
             event_pattern,
             event_prefix_pattern,
             # Permission

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -2019,13 +2019,14 @@ export class EventLogService {
      * @param data The data for the request.
      * @param data.limit
      * @param data.offset
-     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
      * @param data.dagId
      * @param data.taskId
      * @param data.runId
      * @param data.mapIndex
      * @param data.tryNumber
      * @param data.owner
+     * @param data.ownerDisplayName
      * @param data.event
      * @param data.excludedEvents
      * @param data.includedEvents
@@ -2043,6 +2044,9 @@ export class EventLogService {
      * @param data.ownerPattern SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions are **not** supported.
      *
      * **Performance note:** this full-match pattern is evaluated as ``ILIKE '%term%'`` and most of the time prevents the database from using B-tree indexes, which can be very slow on large tables. Prefer the equivalent ``owner_prefix_pattern`` parameter when possible.
+     * @param data.ownerDisplayNamePattern SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions are **not** supported.
+     *
+     * **Performance note:** this full-match pattern is evaluated as ``ILIKE '%term%'`` and most of the time prevents the database from using B-tree indexes, which can be very slow on large tables. Prefer the equivalent ``owner_display_name_prefix_pattern`` parameter when possible.
      * @param data.eventPattern SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions are **not** supported.
      *
      * **Performance note:** this full-match pattern is evaluated as ``ILIKE '%term%'`` and most of the time prevents the database from using B-tree indexes, which can be very slow on large tables. Prefer the equivalent ``event_prefix_pattern`` parameter when possible.
@@ -2050,6 +2054,7 @@ export class EventLogService {
      * @param data.taskIdPrefixPattern Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
      * @param data.runIdPrefixPattern Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
      * @param data.ownerPrefixPattern Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
+     * @param data.ownerDisplayNamePrefixPattern Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
      * @param data.eventPrefixPattern Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
      * @returns EventLogCollectionResponse Successful Response
      * @throws ApiError
@@ -2068,6 +2073,7 @@ export class EventLogService {
                 map_index: data.mapIndex,
                 try_number: data.tryNumber,
                 owner: data.owner,
+                owner_display_name: data.ownerDisplayName,
                 event: data.event,
                 excluded_events: data.excludedEvents,
                 included_events: data.includedEvents,
@@ -2077,11 +2083,13 @@ export class EventLogService {
                 task_id_pattern: data.taskIdPattern,
                 run_id_pattern: data.runIdPattern,
                 owner_pattern: data.ownerPattern,
+                owner_display_name_pattern: data.ownerDisplayNamePattern,
                 event_pattern: data.eventPattern,
                 dag_id_prefix_pattern: data.dagIdPrefixPattern,
                 task_id_prefix_pattern: data.taskIdPrefixPattern,
                 run_id_prefix_pattern: data.runIdPrefixPattern,
                 owner_prefix_pattern: data.ownerPrefixPattern,
+                owner_display_name_prefix_pattern: data.ownerDisplayNamePrefixPattern,
                 event_prefix_pattern: data.eventPrefixPattern
             },
             errors: {

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1257,6 +1257,7 @@ export type EventLogResponse = {
     event: string;
     logical_date: string | null;
     owner: string | null;
+    owner_display_name: string | null;
     extra: string | null;
     dag_display_name?: string | null;
     task_display_name?: string | null;
@@ -3520,10 +3521,11 @@ export type GetEventLogsData = {
     mapIndex?: number | null;
     offset?: number;
     /**
-     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
      */
     orderBy?: Array<(string)>;
     owner?: string | null;
+    ownerDisplayName?: string | null;
     /**
      * SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions are **not** supported.
      *
@@ -3534,6 +3536,16 @@ export type GetEventLogsData = {
      * Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
      */
     ownerPrefixPattern?: string | null;
+    /**
+     * SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions are **not** supported.
+     *
+     * **Performance note:** this full-match pattern is evaluated as ``ILIKE '%term%'`` and most of the time prevents the database from using B-tree indexes, which can be very slow on large tables. Prefer the equivalent ``owner_display_name_prefix_pattern`` parameter when possible.
+     */
+    ownerDisplayNamePattern?: string | null;
+    /**
+     * Prefix match — returns items whose value starts with the given string (case-sensitive, index-friendly). Use the pipe `|` operator for OR logic (e.g. `dag1|dag2`). Use `~` to match all. Wildcard characters (`%`, `_`) are treated as literal characters. Trailing non-alphanumeric characters in the prefix are stripped before matching so the range scan stays index-compatible under locale-aware collations — e.g. `test_` effectively matches items starting with `test`, and `s3://` matches items starting with `s3`.
+     */
+    ownerDisplayNamePrefixPattern?: string | null;
     runId?: string | null;
     /**
      * SQL LIKE expression — use `%` / `_` wildcards (e.g. `%customer_%`). Use the pipe `|` operator for OR logic (e.g. `dag1 | dag2`). Regular expressions are **not** supported.

--- a/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
@@ -65,6 +65,7 @@ const eventsColumn = (
   },
   {
     accessorKey: "owner",
+    cell: ({ row: { original } }) => original.owner_display_name ?? original.owner,
     enableSorting: true,
     header: translate("auditLog.columns.user"),
     meta: {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -128,6 +128,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                 {
                     "event": EVENT_WITH_OWNER,
                     "owner": OWNER,
+                    "owner_display_name": OWNER_DISPLAY_NAME,
                 },
             ),
             (
@@ -153,6 +154,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                     "event": EVENT_WITH_OWNER_AND_TASK_INSTANCE,
                     "map_index": -1,
                     "owner": OWNER,
+                    "owner_display_name": OWNER_DISPLAY_NAME,
                     "run_id": DAG_RUN_ID,
                     "task_id": TASK_ID,
                     "task_display_name": TASK_DISPLAY_NAME,
@@ -185,6 +187,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
             if event_log.logical_date
             else None,
             "owner": expected_body.get("owner"),
+            "owner_display_name": expected_body.get("owner_display_name"),
             "extra": expected_body.get("extra"),
         }
 
@@ -284,6 +287,13 @@ class TestGetEventLogs(TestEventLogsEndpoint):
                 2,
                 [TASK_INSTANCE_EVENT, EVENT_WITH_OWNER_AND_TASK_INSTANCE],
             ),
+            # owner_display_name exact filter
+            (
+                {"owner_display_name": OWNER_DISPLAY_NAME},
+                200,
+                2,
+                [EVENT_WITH_OWNER, EVENT_WITH_OWNER_AND_TASK_INSTANCE],
+            ),
             # multiple equal filters
             (
                 {"event": EVENT_WITH_OWNER, "owner": OWNER},
@@ -347,6 +357,20 @@ class TestGetEventLogs(TestEventLogsEndpoint):
                 200,
                 2,
                 [EVENT_WITH_OWNER_AND_TASK_INSTANCE],
+            ),
+            # owner_display_name pattern filter
+            (
+                {"owner_display_name_pattern": "%Owner%"},
+                200,
+                2,
+                [EVENT_WITH_OWNER, EVENT_WITH_OWNER_AND_TASK_INSTANCE],
+            ),
+            # owner_display_name prefix pattern filter
+            (
+                {"owner_display_name_prefix_pattern": "Test"},
+                200,
+                2,
+                [EVENT_WITH_OWNER, EVENT_WITH_OWNER_AND_TASK_INSTANCE],
             ),
         ],
     )


### PR DESCRIPTION
## Summary

`Log.owner_display_name` is stored in the database and populated by `action_logging` from the auth manager user display value since Airflow 2.8.0 (via AIP-56), but was never returned by the `/api/v2/eventLogs` endpoint or shown in the Audit Log UI.

Auth managers use `owner` as a stable principal identifier (e.g. `jsmith`, an email, or an opaque ID) while `owner_display_name` holds the human-readable display name (e.g. `John Smith`). Omitting `owner_display_name` from the API forces API consumers and the Audit Log UI to show the raw identifier even when a more readable name has already been stored.

### Changes

**API** (additive — `owner` field unchanged):
- Adds `owner_display_name: str | None` to `EventLogResponse`
- Adds `owner_display_name` exact-match filter
- Adds `owner_display_name_pattern` (ILIKE substring) filter
- Adds `owner_display_name_prefix_pattern` (index-friendly prefix) filter
- Adds `owner_display_name` to the allowed sort attributes

**UI**:
- Audit Log "User" column now renders `owner_display_name ?? owner` — shows the human-readable name when present, falls back to `owner` when `null`

**OpenAPI / TypeScript**:
- `EventLogResponse` schema updated with `owner_display_name` property
- `GetEventLogsData` updated with the new filter parameters and updated `orderBy` description

### Review comment responses

- **ashb** ("does this PR do anything other than create a field that is never set anywhere?"): `owner_display_name` is already being set — `action_logging` in `airflow-core/src/airflow/api_fastapi/logging/decorators.py` (line 159) writes `owner_display_name=user_display` on every logged request. The `Log.__init__` column has existed since the 2.8.0 migration (`0005_2_8_0_add_owner_display_name_to_audit_log_table.py`). This PR only exposes it through the read path.
- **pierrejeambrun** ("needs `owner_display_name_prefix_pattern` and `owner_display_name_pattern`"): Both are added in this PR alongside the existing `owner_pattern`/`owner_prefix_pattern` pair.
- **Vamsi-klu** ("sorting and filtering still target `owner` while the display shows `owner_display_name`"): The new filter/sort parameters operate on `Log.owner_display_name` directly, so search and sort are consistent with the displayed value.

### Data flow

```
DB (Log row)
  owner = "jsmith"
  owner_display_name = "John Smith"
       │
       ▼
API (EventLogResponse)
  { "owner": "jsmith", "owner_display_name": "John Smith", ... }
       │
       ▼
UI (Audit Log "User" column)
  shows: owner_display_name ?? owner
  → "John Smith"  (falls back to "jsmith" if display name is null)
```

### Security

Same access control as `owner` (gated by `requires_access_event_log("GET")` plus per-DAG audit log permission). Same trust boundary — both fields are populated by the auth manager. Same rendering path — React escapes the cell content. Follows the existing `dag_display_name` / `task_display_name` precedent in the same response model.

closes: #68334

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)