### PR TITLE
Handle all Dag deserialization failures gracefully on the API

### DIFF
--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 import time
 import zlib
 from collections.abc import MutableMapping
@@ -45,8 +44,6 @@ if TYPE_CHECKING:
     from airflow.models import DagRun
     from airflow.models.serialized_dag import SerializedDagModel
     from airflow.serialization.definitions.dag import SerializedDAG
-
-log = logging.getLogger(__name__)
 
 
 class _CacheEntry(NamedTuple):
@@ -111,17 +108,16 @@ class DBDagBag:
         serdag.load_op_links = self.load_op_links
         try:
             dag = serdag.dag
-        # Only failures that mean "this stored blob cannot be turned back into a DAG" are caught, so
-        # read-only callers return 404 instead of 500. Anything else (DB errors, bugs in the serving
-        # path) propagates unchanged. The set is exhaustive for SerializedDagModel.dag:
-        #   - DeserializationError: deserialize_dag's wrapper for a malformed/incompatible blob
-        #   - ValueError: unknown __version, bad JSON (JSONDecodeError), non-dict/str data, and
-        #     TimetableNotRegistered (a ValueError subclass) for an unregistered custom timetable
-        #   - KeyError: blob missing the top-level "dag" key
-        #   - zlib.error: a corrupt compressed data_compressed column
-        except (DeserializationError, ValueError, KeyError, zlib.error):
-            log.warning("Failed to deserialize DAG from %r; treating as not found", serdag, exc_info=True)
-            return None
+        except (ValueError, KeyError, zlib.error) as e:
+            # SerializedDagModel.dag raises these for the "stored blob cannot be turned back into a
+            # DAG" cases that deserialize_dag does not already wrap: unknown __version, missing
+            # top-level "dag" key, bad JSON, non-dict data, TimetableNotRegistered (a ValueError
+            # subclass), and a corrupt compressed data_compressed column. Normalize them to
+            # DeserializationError so they reach the app-wide DagErrorHandler and surface as one
+            # consistent, safe response instead of an unhandled raw 500. DeserializationError itself
+            # is not caught here -- it already propagates to that handler -- and unrelated failures
+            # (DB errors, serving-path bugs) are left untouched so they are not masked.
+            raise DeserializationError(serdag.dag_id) from e
         if not dag:
             return None
         with self._lock:

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import time
+import zlib
 from collections.abc import MutableMapping
 from contextlib import nullcontext
 from threading import RLock
@@ -32,6 +33,7 @@ from sqlalchemy.orm import Mapped, joinedload, mapped_column
 
 from airflow._shared.observability.metrics import stats
 from airflow.configuration import conf
+from airflow.exceptions import DeserializationError
 from airflow.models.base import Base, StringID
 from airflow.models.dag_version import DagVersion
 
@@ -109,10 +111,15 @@ class DBDagBag:
         serdag.load_op_links = self.load_op_links
         try:
             dag = serdag.dag
-        except Exception:
-            # A serialized blob that exists but cannot be reconstructed (unimportable operator class,
-            # incompatible serialization version, blob written under a synthetic bundle by
-            # dag.test()) is treated as "no live definition" so read-only callers return 404, not 500.
+        # Only failures that mean "this stored blob cannot be turned back into a DAG" are caught, so
+        # read-only callers return 404 instead of 500. Anything else (DB errors, bugs in the serving
+        # path) propagates unchanged. The set is exhaustive for SerializedDagModel.dag:
+        #   - DeserializationError: deserialize_dag's wrapper for a malformed/incompatible blob
+        #   - ValueError: unknown __version, bad JSON (JSONDecodeError), non-dict/str data, and
+        #     TimetableNotRegistered (a ValueError subclass) for an unregistered custom timetable
+        #   - KeyError: blob missing the top-level "dag" key
+        #   - zlib.error: a corrupt compressed data_compressed column
+        except (DeserializationError, ValueError, KeyError, zlib.error):
             log.warning("Failed to deserialize DAG from %r; treating as not found", serdag, exc_info=True)
             return None
         if not dag:

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import time
 from collections.abc import MutableMapping
 from contextlib import nullcontext
@@ -42,6 +43,8 @@ if TYPE_CHECKING:
     from airflow.models import DagRun
     from airflow.models.serialized_dag import SerializedDagModel
     from airflow.serialization.definitions.dag import SerializedDAG
+
+log = logging.getLogger(__name__)
 
 
 class _CacheEntry(NamedTuple):
@@ -104,7 +107,14 @@ class DBDagBag:
     def _read_dag(self, serdag: SerializedDagModel) -> SerializedDAG | None:
         """Read and cache a SerializedDAG (with its ``dag_hash`` for staleness detection)."""
         serdag.load_op_links = self.load_op_links
-        dag = serdag.dag
+        try:
+            dag = serdag.dag
+        except Exception:
+            # A serialized blob that exists but cannot be reconstructed (unimportable operator class,
+            # incompatible serialization version, blob written under a synthetic bundle by
+            # dag.test()) is treated as "no live definition" so read-only callers return 404, not 500.
+            log.warning("Failed to deserialize DAG from %r; treating as not found", serdag, exc_info=True)
+            return None
         if not dag:
             return None
         with self._lock:

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -83,40 +83,61 @@ class TestDBDagBag:
     @pytest.mark.parametrize(
         "exc",
         [
-            DeserializationError("malformed blob"),
             ValueError("Unsure how to deserialize version 99"),
             TimetableNotRegistered("custom.Timetable"),
             KeyError("dag"),
             zlib.error("incorrect header check"),
         ],
     )
-    def test__read_dag_returns_none_when_deserialization_fails(self, exc):
-        """A blob that exists but cannot be reconstructed is treated as absent, not propagated.
+    def test__read_dag_normalizes_deserialization_failures(self, exc):
+        """A blob that cannot be reconstructed is normalized to DeserializationError.
 
-        Keeps read-only API callers (e.g. the DAG detail page) returning 404 instead of 500 for a
-        Dag whose serialized definition is malformed, on an incompatible version, references an
-        unregistered timetable, or is stored as a corrupt compressed blob.
+        Routes every such failure (incompatible version, missing key, unregistered timetable,
+        corrupt compressed blob) through the app-wide DagErrorHandler instead of an unhandled 500,
+        and preserves the original error as the cause.
         """
 
         class _Undeserializable:
             load_op_links = True
             dag_version_id = "v1"
+            dag_id = "ghost"
 
             @property
             def dag(self):
                 raise exc
 
-        result = self.db_dag_bag._read_dag(_Undeserializable())
+        with pytest.raises(DeserializationError) as exc_info:
+            self.db_dag_bag._read_dag(_Undeserializable())
 
-        assert result is None
+        assert exc_info.value.__cause__ is exc
         assert "v1" not in self.db_dag_bag._dags
 
+    def test__read_dag_propagates_deserialization_error_unchanged(self):
+        """A DeserializationError already flows to the handler, so it must pass through as-is."""
+
+        original = DeserializationError("ghost")
+
+        class _Undeserializable:
+            load_op_links = True
+            dag_version_id = "v1"
+            dag_id = "ghost"
+
+            @property
+            def dag(self):
+                raise original
+
+        with pytest.raises(DeserializationError) as exc_info:
+            self.db_dag_bag._read_dag(_Undeserializable())
+
+        assert exc_info.value is original
+
     def test__read_dag_propagates_unrelated_errors(self):
-        """Errors that are not deserialization failures must surface (500), not be masked as 404."""
+        """Errors that are not deserialization failures must surface, not be masked or relabeled."""
 
         class _BuggyServingPath:
             load_op_links = True
             dag_version_id = "v1"
+            dag_id = "ghost"
 
             @property
             def dag(self):

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import time
+import zlib
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +25,7 @@ import pytest
 import time_machine
 from cachetools import LRUCache, TTLCache
 
+from airflow.exceptions import DeserializationError
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag, _CacheEntry
@@ -31,6 +33,7 @@ from airflow.models.dagbundle import DagBundleModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk import DAG
+from airflow.serialization.helpers import TimetableNotRegistered
 from airflow.serialization.serialized_objects import LazyDeserializedDAG, SerializedDAG
 from airflow.utils.session import create_session
 
@@ -77,11 +80,22 @@ class TestDBDagBag:
         assert result is None
         assert "v1" not in self.db_dag_bag._dags
 
-    def test__read_dag_returns_none_when_deserialization_fails(self):
-        """A blob that exists but cannot be deserialized is treated as absent, not propagated.
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            DeserializationError("malformed blob"),
+            ValueError("Unsure how to deserialize version 99"),
+            TimetableNotRegistered("custom.Timetable"),
+            KeyError("dag"),
+            zlib.error("incorrect header check"),
+        ],
+    )
+    def test__read_dag_returns_none_when_deserialization_fails(self, exc):
+        """A blob that exists but cannot be reconstructed is treated as absent, not propagated.
 
         Keeps read-only API callers (e.g. the DAG detail page) returning 404 instead of 500 for a
-        Dag whose serialized definition references an unimportable class or an incompatible version.
+        Dag whose serialized definition is malformed, on an incompatible version, references an
+        unregistered timetable, or is stored as a corrupt compressed blob.
         """
 
         class _Undeserializable:
@@ -90,12 +104,26 @@ class TestDBDagBag:
 
             @property
             def dag(self):
-                raise ValueError("cannot deserialize")
+                raise exc
 
         result = self.db_dag_bag._read_dag(_Undeserializable())
 
         assert result is None
         assert "v1" not in self.db_dag_bag._dags
+
+    def test__read_dag_propagates_unrelated_errors(self):
+        """Errors that are not deserialization failures must surface (500), not be masked as 404."""
+
+        class _BuggyServingPath:
+            load_op_links = True
+            dag_version_id = "v1"
+
+            @property
+            def dag(self):
+                raise RuntimeError("unrelated serving-path bug")
+
+        with pytest.raises(RuntimeError, match="unrelated serving-path bug"):
+            self.db_dag_bag._read_dag(_BuggyServingPath())
 
     def test_get_dag_fetches_from_db_on_miss(self):
         """It should query the DB and cache the result (with its hash) when not in cache."""

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -77,6 +77,26 @@ class TestDBDagBag:
         assert result is None
         assert "v1" not in self.db_dag_bag._dags
 
+    def test__read_dag_returns_none_when_deserialization_fails(self):
+        """A blob that exists but cannot be deserialized is treated as absent, not propagated.
+
+        Keeps read-only API callers (e.g. the DAG detail page) returning 404 instead of 500 for a
+        Dag whose serialized definition references an unimportable class or an incompatible version.
+        """
+
+        class _Undeserializable:
+            load_op_links = True
+            dag_version_id = "v1"
+
+            @property
+            def dag(self):
+                raise ValueError("cannot deserialize")
+
+        result = self.db_dag_bag._read_dag(_Undeserializable())
+
+        assert result is None
+        assert "v1" not in self.db_dag_bag._dags
+
     def test_get_dag_fetches_from_db_on_miss(self):
         """It should query the DB and cache the result (with its hash) when not in cache."""
         mock_dag = MagicMock(spec=SerializedDAG)


### PR DESCRIPTION
A Dag can have run history and a serialized row in the metadata DB while its definition can no longer be reconstructed — e.g. it was serialized by a newer Airflow and read after a downgrade (unknown `__version`), it references a custom timetable whose plugin is no longer installed (`TimetableNotRegistered`), or its stored blob is otherwise malformed/corrupt. Opening such a Dag's detail page produced **HTTP 500s** and infinite loading in the UI.

The codebase already routes `DeserializationError` to an app-wide `DagErrorHandler` that returns one consistent, safe response (no internals leaked, correlation id logged). But the sibling failures raised while reading the blob — unknown `__version` (`ValueError`), a missing top-level `dag` key (`KeyError`), bad JSON, a non-dict payload, `TimetableNotRegistered`, or a corrupt compressed column (`zlib.error`) — escaped that handler as **unhandled raw 500s**.

This normalizes those failures to `DeserializationError` at the serving read boundary (`DBDagBag._read_dag`) so every deserialization failure flows through the existing `DagErrorHandler` and is handled identically. `DeserializationError` itself is not caught (it already propagates to the handler), and unrelated failures — database errors, serving-path bugs — are left untouched so they are not masked.

closes: #69035

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)