### PR TITLE
Make schema_fields templated in GCSToBigQueryOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -196,6 +196,7 @@ class GCSToBigQueryOperator(BaseOperator):
     template_fields: Sequence[str] = (
         "bucket",
         "source_objects",
+        "schema_fields",
         "schema_object",
         "schema_object_bucket",
         "destination_project_dataset_table",
@@ -203,6 +204,7 @@ class GCSToBigQueryOperator(BaseOperator):
         "src_fmt_configs",
         "extra_config",
     )
+    template_fields_renderers = {"schema_fields": "json"}
     template_ext: Sequence[str] = (".sql",)
     ui_color = "#f0eee4"
     operator_extra_links = (BigQueryTableLink(),)

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import functools
 import json
+from datetime import datetime
 from unittest import mock
 from unittest.mock import MagicMock, call
 
@@ -27,6 +28,7 @@ from google.cloud.bigquery import DEFAULT_RETRY, Table
 from google.cloud.exceptions import Conflict
 from sqlalchemy import select
 
+from airflow import DAG
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.trigger import Trigger
 from airflow.providers.common.compat.openlineage.facet import (
@@ -2092,6 +2094,35 @@ class TestGCSToBigQueryOperator:
         # extra_config wins for overlapping key
         assert config["load"]["skipLeadingRows"] == 5
         assert config["load"]["columnNameCharacterMap"] == "STRICT"
+
+    def test_schema_fields_is_templated(self):
+        """Regression test for #31481.
+
+        ``schema_fields`` must be a template field so a value supplied at runtime
+        (the issue used ``.expand()``) is resolved before the operator runs. Before
+        the fix the field was absent from ``template_fields``, so the value was never
+        rendered and reached BigQuery verbatim.
+        """
+        assert "schema_fields" in GCSToBigQueryOperator.template_fields
+        assert GCSToBigQueryOperator.template_fields_renderers["schema_fields"] == "json"
+
+        with DAG(
+            dag_id="test_gcs_to_bq_schema_fields_templating",
+            start_date=datetime(2024, 1, 1),
+            render_template_as_native_obj=True,
+        ) as dag:
+            operator = GCSToBigQueryOperator(
+                task_id=TASK_ID,
+                bucket=TEST_BUCKET,
+                source_objects=TEST_SOURCE_OBJECTS,
+                destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                schema_fields="{{ var.value.schema_fields }}",
+                dag=dag,
+            )
+
+        operator.render_template_fields({"var": {"value": {"schema_fields": SCHEMA_FIELDS}}})
+
+        assert operator.schema_fields == SCHEMA_FIELDS
 
 
 @pytest.fixture


### PR DESCRIPTION
`GCSToBigQueryOperator.schema_fields` was not a template field, so a templated value (a Variable or `XComArg` resolving to a schema) passed to it was never rendered — the raw, unresolved object reached BigQuery (e.g. surfacing as "Object of type MappedArgument is not JSON serializable").

This marks `schema_fields` as templated and registers a `json` renderer, matching how `BigQueryUpdateTableSchemaOperator` already templates `schema_fields_updates`. Callers passing a plain list/dict are unaffected; only the previously-broken templated case changes.

closes: #31481

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-02T17:38:30Z head=8a522d1 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @nikolauspschuetz** · by `@potiuk` · 2026-07-02 17:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - These required **static checks** are failing and need a code fix (a rerun won't help): `CI image checks / Static checks`. Run them locally with `pre-commit`/`prek` and push the fixes.
> - The following required checks are failing: `provider distributions tests / Compat 2.11.1:P3.10:`. Please investigate and push a fix.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->