### PR TITLE
UI: Wrap long plugin source path in import-error dialog

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrorsModal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Heading, Text, HStack } from "@chakra-ui/react";
+import { Box, ClipboardRoot, Heading, Text, HStack } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuFileWarning } from "react-icons/lu";
@@ -24,7 +24,7 @@ import { PiFilePy } from "react-icons/pi";
 
 import type { PluginImportErrorResponse } from "openapi/requests/types.gen";
 import { SearchBar } from "src/components/SearchBar";
-import { Accordion, Dialog } from "src/components/ui";
+import { Accordion, ClipboardIconButton, Dialog } from "src/components/ui";
 import { Pagination } from "src/components/ui/Pagination";
 
 type PluginImportErrorsModalProps = {
@@ -84,10 +84,21 @@ export const PluginImportErrorsModal: React.FC<PluginImportErrorsModalProps> = (
           <Accordion.Root collapsible multiple size="md" variant="enclosed">
             {visibleItems.map((importError) => (
               <Accordion.Item key={importError.error} value={importError.source}>
-                <Accordion.ItemTrigger cursor="pointer">
-                  <PiFilePy />
-                  {importError.source}
-                </Accordion.ItemTrigger>
+                <HStack align="stretch" gap={0} w="100%">
+                  <Accordion.ItemTrigger cursor="pointer" flex="1">
+                    <HStack alignItems="center" gap={2} minW={0} w="100%">
+                      <PiFilePy />
+                      <Text minW={0} overflowWrap="anywhere">
+                        {importError.source}
+                      </Text>
+                    </HStack>
+                  </Accordion.ItemTrigger>
+                  <Box alignItems="center" display="flex" flexShrink={0} pr={2}>
+                    <ClipboardRoot value={importError.source}>
+                      <ClipboardIconButton variant="outline" />
+                    </ClipboardRoot>
+                  </Box>
+                </HStack>
                 <Accordion.ItemContent>
                   <Text color="fg.error" fontSize="sm" whiteSpace="pre-wrap">
                     <code>{importError.error}</code>


### PR DESCRIPTION
A plugin that fails to import is listed in the plugin import-errors dialog by its source path ($PLUGINS_FOLDER/...). A long, deeply nested path is a single unbroken token, so it could not wrap and pushed the centered dialog wider than the viewport, hiding which file failed.

Let the path wrap within the dialog and add a copy-to-clipboard button, matching the Dag import-errors dialog.

Before:
<img width="1032" height="469" alt="plugin-bug" src="https://github.com/user-attachments/assets/326fbe02-fee4-472b-a5be-977e4db53a8b" />


After:
<img width="968" height="396" alt="image" src="https://github.com/user-attachments/assets/9f68777d-0b95-4856-ae96-e349ba1350e5" />


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
ClaudeCode Opus 4.8

