### PR TITLE
Reduce noise in the daily CI duration trend alert

### DIFF
--- a/.github/workflows/ci-duration-monitor.yml
+++ b/.github/workflows/ci-duration-monitor.yml
@@ -49,7 +49,20 @@ jobs:
           # main coverage comes from the scheduled canary runs of the AMD workflow.
           WORKFLOW_NAME: "ci-amd.yml"
           BRANCH: "main"
+          # Only successful (green) canary runs feed the baseline — a failed or cancelled
+          # canary stops partway, so its truncated wall-clock and per-job durations would
+          # skew the trend downwards and mask real regressions. Set explicitly so the
+          # green-only guarantee is visible at the call site and can't be silently changed.
+          ONLY_SUCCESSFUL: "true"
           MAX_RUNS: "25"
+          # Compare the median of the last few nightly runs (not a single run) against the
+          # baseline so one unlucky run — slow PyPI, runner queue pressure, cold cache — does
+          # not trip the alert. With LATEST_RUNS=1 both sides were asymmetric (raw point vs
+          # median) and the alert fired most nights on whichever jobs happened to be slow.
+          LATEST_RUNS: "3"
+          # Network-bound jobs (constraint resolution, provider installs) legitimately swing
+          # tens of minutes run-to-run; require a larger sustained jump before flagging them.
+          JOB_MIN_ABS_INCREASE_MINUTES: "6"
           OUTPUT_FILE: "slack-message.json"
 
       - name: "Post duration alert to Slack"


### PR DESCRIPTION
The daily **CI Duration Trend Alert** (`.github/workflows/ci-duration-monitor.yml` + `scripts/ci/analyze_ci_job_durations.py`) has been firing most nights with a wildly varying set of "jobs that got slower", carrying little real signal.

**Root cause:** the monitor compared a **single** nightly canary run against the median of the preceding ~24 runs (`LATEST_RUNS` defaulted to `1`). The two sides were asymmetric — a raw, unsmoothed point against a robust median — so any one unlucky run (slow PyPI, GitHub runner queue pressure, a cold cache) tripped the alert. Because a different run is "latest" each day, a different set of jobs got flagged each day. Network-bound constraint-resolution jobs (`Finalize tests / Deps 3.x:constraints`, `Generate constraints`, provider installs), which legitimately swing tens of minutes run-to-run, dominated nearly every alert and only needed to clear a 3-minute absolute floor.

**Fix:**

- `LATEST_RUNS: "3"` — compare the median of the last 3 nightly runs against the baseline so the two sides are symmetric and one unlucky run no longer trips it.
- `JOB_MIN_ABS_INCREASE_MINUTES: "6"` — require a larger sustained absolute jump before flagging an individual job, so ordinary network variance on the long constraint jobs stops alerting.
- `ONLY_SUCCESSFUL: "true"` — pin the baseline to successful (green) canary runs. The script already defaulted to this, but a failed/cancelled canary stops partway and its truncated durations would skew the trend downwards and mask regressions; setting it explicitly keeps the green-only guarantee visible and unchangeable-by-accident at the call site.

No script logic changes — the existing env knobs already support this, so the behaviour is config-only and the script's tests are unaffected. Genuine sustained regressions still trip the alert.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
