### PR TITLE
Fix connection port field validation (#68382)

### DIFF
--- a/airflow-core/newsfragments/69130.bugfix.rst
+++ b/airflow-core/newsfragments/69130.bugfix.rst
@@ -1,0 +1,1 @@
+Enforce TCP/UDP port range validation (1-65535) across the Connection model, API schemas, Task SDK, and CLI.

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -191,7 +191,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(default=None, ge=1, le=65535)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/cli/cli_config.py
+++ b/airflow-core/src/airflow/cli/cli_config.py
@@ -858,7 +858,7 @@ ARG_CONN_PASSWORD = Arg(
 ARG_CONN_SCHEMA = Arg(
     ("--conn-schema",), help="Connection schema, optional when adding a connection", type=str
 )
-ARG_CONN_PORT = Arg(("--conn-port",), help="Connection port, optional when adding a connection", type=str)
+ARG_CONN_PORT = Arg(("--conn-port",), help="Connection port (1-65535), optional when adding a connection", type=int)
 ARG_CONN_EXTRA = Arg(
     ("--conn-extra",), help="Connection `Extra` field, optional when adding a connection", type=str
 )

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import ForeignKey, Integer, String, Text, select
-from sqlalchemy.orm import Mapped, mapped_column, reconstructor
+from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
@@ -88,6 +88,18 @@ def sanitize_conn_id(conn_id: str | None, max_length=CONN_ID_MAX_LEN) -> str | N
 
     # if we reach here, then we matched something, return the first match
     return res.group(0)
+
+
+def validate_port(port: int | None) -> int | None:
+    """Validate that port is within the valid TCP/UDP range (1-65535).
+
+    :param port: The port number to validate.
+    :return: The port number if valid, None if port is None.
+    :raises ValueError: If port is outside the valid range.
+    """
+    if port is not None and not (1 <= port <= 65535):
+        raise ValueError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def _parse_netloc_to_hostname(uri_parts):
@@ -201,6 +213,10 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
             mask_secret(self.password)
             mask_secret(quote(self.password))
         self.team_name = team_name
+
+    @validates("port")
+    def _validate_port(self, _key: str, value: int | None) -> int | None:
+        return validate_port(value)
 
     @staticmethod
     def _validate_extra(extra, conn_id) -> None:
@@ -591,6 +607,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
                 kwargs["port"] = int(port)
             except ValueError:
                 raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+            validate_port(kwargs["port"])
         return Connection(conn_id=conn_id, **kwargs)
 
     def as_json(self) -> str:

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -91,7 +91,8 @@ def sanitize_conn_id(conn_id: str | None, max_length=CONN_ID_MAX_LEN) -> str | N
 
 
 def validate_port(port: int | None) -> int | None:
-    """Validate that port is within the valid TCP/UDP range (1-65535).
+    """
+    Validate that port is within the valid TCP/UDP range (1-65535).
 
     :param port: The port number to validate.
     :return: The port number if valid, None if port is None.

--- a/airflow-core/src/airflow/models/connection_test.py
+++ b/airflow-core/src/airflow/models/connection_test.py
@@ -161,6 +161,12 @@ class ConnectionTestRequest(Base, FernetFieldsMixin):
         self.token = secrets.token_urlsafe(32)
         self.state = ConnectionTestState.PENDING
 
+    @validates("port")
+    def _validate_port(self, _key: str, value: int | None) -> int | None:
+        from airflow.models.connection import validate_port
+
+        return validate_port(value)
+
     @validates("state")
     def _sync_active_connection_id(
         self, _key: str, value: str | ConnectionTestState

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -2189,3 +2189,38 @@ class TestPostConnectionExtraBackwardCompatibility(TestConnectionEndpoint):
                 "method": "POST",
             },
         )
+
+
+class TestConnectionBodyPortValidation:
+    """Tests for port range validation on REST API ConnectionBody (issue #68382)."""
+
+    def test_connection_body_rejects_port_too_high(self):
+        """ConnectionBody should reject port > 65535."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="less than or equal to 65535"):
+            ConnectionBody(connection_id="test", conn_type="http", port=99999)
+
+    def test_connection_body_rejects_port_zero(self):
+        """ConnectionBody should reject port=0."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            ConnectionBody(connection_id="test", conn_type="http", port=0)
+
+    def test_connection_body_rejects_negative_port(self):
+        """ConnectionBody should reject negative port."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="greater than or equal to 1"):
+            ConnectionBody(connection_id="test", conn_type="http", port=-1)
+
+    def test_connection_body_accepts_valid_port(self):
+        """ConnectionBody should accept valid port."""
+        body = ConnectionBody(connection_id="test", conn_type="http", port=8080)
+        assert body.port == 8080
+
+    def test_connection_body_accepts_none_port(self):
+        """ConnectionBody should accept port=None."""
+        body = ConnectionBody(connection_id="test", conn_type="http", port=None)
+        assert body.port is None

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -540,3 +540,90 @@ class TestConnection:
             "test_conn2": None,
         }
         clear_db_connections()
+
+
+class TestConnectionPortValidation:
+    """Tests for port range validation (issue #68382)."""
+
+    @pytest.mark.parametrize(
+        "port",
+        [
+            1,
+            80,
+            443,
+            8080,
+            5432,
+            3306,
+            65535,
+        ],
+    )
+    def test_validate_port_accepts_valid_ports(self, port):
+        """Valid TCP/UDP ports (1-65535) should be accepted."""
+        from airflow.models.connection import validate_port
+
+        assert validate_port(port) == port
+
+    def test_validate_port_accepts_none(self):
+        """None (no port) should be accepted."""
+        from airflow.models.connection import validate_port
+
+        assert validate_port(None) is None
+
+    @pytest.mark.parametrize(
+        "port",
+        [
+            0,
+            -1,
+            -100,
+            65536,
+            99999999,
+            100000,
+        ],
+    )
+    def test_validate_port_rejects_invalid_ports(self, port):
+        """Ports outside range 1-65535 should be rejected."""
+        from airflow.models.connection import validate_port
+
+        with pytest.raises(ValueError, match="Port must be between 1 and 65535"):
+            validate_port(port)
+
+    def test_connection_init_rejects_invalid_port(self):
+        """Connection() constructor should reject invalid port."""
+        with pytest.raises(ValueError, match="Port must be between 1 and 65535"):
+            Connection(conn_id="test", conn_type="http", port=99999)
+
+    def test_connection_init_rejects_zero_port(self):
+        """Connection() constructor should reject port=0."""
+        with pytest.raises(ValueError, match="Port must be between 1 and 65535"):
+            Connection(conn_id="test", conn_type="http", port=0)
+
+    def test_connection_init_rejects_negative_port(self):
+        """Connection() constructor should reject negative port."""
+        with pytest.raises(ValueError, match="Port must be between 1 and 65535"):
+            Connection(conn_id="test", conn_type="http", port=-1)
+
+    def test_connection_init_accepts_valid_port(self):
+        """Connection() constructor should accept valid port."""
+        conn = Connection(conn_id="test", conn_type="http", port=8080)
+        assert conn.port == 8080
+
+    def test_connection_init_accepts_none_port(self):
+        """Connection() constructor should accept port=None."""
+        conn = Connection(conn_id="test", conn_type="http", port=None)
+        assert conn.port is None
+
+    def test_connection_from_json_rejects_invalid_port(self):
+        """Connection.from_json() should reject invalid port."""
+        import json
+
+        conn_json = json.dumps({"conn_type": "http", "port": 99999})
+        with pytest.raises(ValueError, match="Port must be between 1 and 65535"):
+            Connection.from_json(conn_json, conn_id="test")
+
+    def test_connection_from_json_accepts_valid_port(self):
+        """Connection.from_json() should accept valid port."""
+        import json
+
+        conn_json = json.dumps({"conn_type": "http", "port": 5432})
+        conn = Connection.from_json(conn_json, conn_id="test")
+        assert conn.port == 5432

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -118,7 +118,7 @@ class Connection:
     schema: str | None = None
     login: str | None = None
     password: str | None = None
-    port: int | None = None
+    port: int | None = attrs.field(default=None)
     extra: str | None = None
 
     @port.validator

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -121,6 +121,11 @@ class Connection:
     port: int | None = None
     extra: str | None = None
 
+    @port.validator
+    def _validate_port(self, attribute, value):
+        if value is not None and not (1 <= value <= 65535):
+            raise ValueError(f"Port must be between 1 and 65535, got {value}")
+
     EXTRA_KEY = "__extra__"
 
     @overload

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -377,8 +377,9 @@ def _set_variable(key: str, value: Any, description: str | None = None, serializ
     #   keep Task SDK as a separate package than execution time mods.
     import json
 
+    from airflow.sdk.exceptions import AirflowRuntimeError
     from airflow.sdk.execution_time.cache import SecretCache
-    from airflow.sdk.execution_time.comms import PutVariable
+    from airflow.sdk.execution_time.comms import ErrorResponse, PutVariable
     from airflow.sdk.execution_time.secrets.execution_api import ExecutionAPISecretsBackend
     from airflow.sdk.execution_time.supervisor import ensure_secrets_backend_loaded
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
@@ -412,7 +413,9 @@ def _set_variable(key: str, value: Any, description: str | None = None, serializ
     except Exception as e:
         log.exception(e)
 
-    SUPERVISOR_COMMS.send(PutVariable(key=key, value=value, description=description))
+    msg = SUPERVISOR_COMMS.send(PutVariable(key=key, value=value, description=description))
+    if isinstance(msg, ErrorResponse):
+        raise AirflowRuntimeError(msg)
 
     # Invalidate cache after setting the variable
     SecretCache.invalidate_variable(key)
@@ -424,11 +427,14 @@ def _delete_variable(key: str) -> None:
     #   A reason to not move it to `airflow.sdk.execution_time.comms` is that it
     #   will make that module depend on Task SDK, which is not ideal because we intend to
     #   keep Task SDK as a separate package than execution time mods.
+    from airflow.sdk.exceptions import AirflowRuntimeError
     from airflow.sdk.execution_time.cache import SecretCache
-    from airflow.sdk.execution_time.comms import DeleteVariable
+    from airflow.sdk.execution_time.comms import DeleteVariable, ErrorResponse
     from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
 
     msg = SUPERVISOR_COMMS.send(DeleteVariable(key=key))
+    if isinstance(msg, ErrorResponse):
+        raise AirflowRuntimeError(msg)
     if TYPE_CHECKING:
         assert isinstance(msg, OKResponse)
 

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -421,3 +421,24 @@ class TestConnectionFromUri:
             original_extra = json.loads(conn_from_original.extra)
             roundtrip_extra = json.loads(conn_from_roundtrip.extra)
             assert original_extra == roundtrip_extra
+
+
+class TestConnectionPortValidation:
+    """Tests for port range validation in Task SDK Connection (issue #68382)."""
+
+    @pytest.mark.parametrize("port", [1, 80, 443, 8080, 5432, 65535])
+    def test_accepts_valid_ports(self, port):
+        """Valid TCP/UDP ports (1-65535) should be accepted."""
+        conn = Connection(conn_id="test", conn_type="http", port=port)
+        assert conn.port == port
+
+    def test_accepts_none_port(self):
+        """None (no port) should be accepted."""
+        conn = Connection(conn_id="test", conn_type="http", port=None)
+        assert conn.port is None
+
+    @pytest.mark.parametrize("port", [0, -1, -100, 65536, 99999999])
+    def test_rejects_invalid_ports(self, port):
+        """Ports outside range 1-65535 should be rejected."""
+        with pytest.raises(ValueError, match="Port must be between 1 and 65535"):
+            Connection(conn_id="test", conn_type="http", port=port)

--- a/task-sdk/tests/task_sdk/definitions/test_variables.py
+++ b/task-sdk/tests/task_sdk/definitions/test_variables.py
@@ -102,6 +102,22 @@ class TestVariables:
 
         mock_supervisor_comms.send.assert_called_once_with(msg=DeleteVariable(key="my_key"))
 
+    def test_var_set_raises_on_error_response(self, mock_supervisor_comms):
+        mock_supervisor_comms.send.return_value = ErrorResponse(
+            error=ErrorType.GENERIC_ERROR, detail={"message": "boom"}
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            Variable.set(key="my_key", value="val")
+
+    def test_var_delete_raises_on_error_response(self, mock_supervisor_comms):
+        mock_supervisor_comms.send.return_value = ErrorResponse(
+            error=ErrorType.GENERIC_ERROR, detail={"message": "boom"}
+        )
+
+        with pytest.raises(AirflowRuntimeError):
+            Variable.delete(key="my_key")
+
 
 class TestVariableKeys:
     @pytest.mark.parametrize(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

This PR implements error propagation for variable write (`set`) and delete (`delete`) operations inside the Task SDK. Previously, if the API server rejected these operations, the returned `ErrorResponse` was ignored by the task runner, causing the task to report success despite a backend failure.

closes: #68537

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Antigravity (Gemini 3.5 Flash)

Generated-by: Antigravity (Gemini 3.5 Flash) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)