### PR TITLE
Re-enable branch protection on v3-3-stable

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -115,11 +115,6 @@ github:
           - "providers-fab/v*"
           - "airflow-ctl/v*-stable"
           - "chart/v*-stable"
-        excludes:
-          # Temporarily exclude `v3-3-stable` from branch protection. It is matched by the
-          # `v*-stable` include above; exclusions take precedence, so this leaves the branch
-          # unprotected while the other `v*-stable` branches stay protected.
-          - "v3-3-stable"
       required_pull_request_reviews:
         required_approving_review_count: 1
       required_linear_history: true


### PR DESCRIPTION
Now that 3.3.0 is in the RC phase, bring `v3-3-stable` back under the `v*-stable` ruleset by reverting the temporary exclusion added in #68993.

#68993 excluded `v3-3-stable` from branch protection so the branch could be **created** — under the rulesets migration (#66523) the linear-history rule rejects creating a new `v*-stable` branch because its ancestry contains historical merge commits. Now that the branch exists, that exclusion is no longer needed: the RC sync is a fast-forward of an approved PR with a linear delta, the same operation 3.2.2 performed against a protected `v3-2-stable`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)