### PR TITLE
Add LDAP Authentication Support to Teradata Provider

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1012,6 +1012,7 @@ lodash
 logfile
 logformat
 loglevel
+logmech
 Logstash
 logstash
 longblob

--- a/providers/teradata/docs/connections/teradata.rst
+++ b/providers/teradata/docs/connections/teradata.rst
@@ -37,12 +37,25 @@ Login (required)
 Password (required)
     Specify the password to connect.
 
+Port (optional)
+    Specify the port to connect to. Default is 1025 for Teradata.
+
 Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Teradata
     connection. The following parameters out of the standard python parameters
     are supported:
 
-    * ``tmode`` - Specifies the transaction mode.Possible values are DEFAULT (the default), ANSI, or TERA
+    **Authentication:**
+
+    * ``logmech`` - Specifies the login mechanism. Possible values are:
+      ``TD2`` (native Teradata authentication, the default), or ``LDAP``.
+
+    **Transaction Mode:**
+
+    * ``tmode`` - Specifies the transaction mode. Possible values are DEFAULT (the default), ANSI, or TERA.
+
+    **SSL/TLS Configuration:**
+
     * ``sslmode`` - This option specifies the mode for connections to the database.
       There are six modes:
       ``disable``, ``allow``, ``prefer``, ``require``, ``verify-ca``, ``verify-full``.
@@ -58,7 +71,7 @@ Extra (optional)
     More details on all Teradata parameters supported can be found in
     `Teradata documentation <https://github.com/Teradata/python-driver?tab=readme-ov-file#connection-parameters>`_.
 
-    Example "extras" field:
+    Example "extras" field for native Teradata (TD2) authentication with SSL:
 
     .. code-block:: json
 
@@ -70,16 +83,61 @@ Extra (optional)
           "sslkey": "/tmp/client-key.pem"
        }
 
+    Example "extras" field for LDAP authentication:
+
+    .. code-block:: json
+
+       {
+          "logmech": "LDAP",
+          "tmode": "TERA",
+          "sslmode": "verify-ca",
+          "sslca": "/tmp/server-ca.pem"
+       }
+
 
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
     following the standard syntax of DB connections, where extras are passed as parameters
     of the URI (note that all components of the URI should be URL-encoded).
 
-    For example:
+    For example (native Teradata authentication):
 
     .. code-block:: bash
 
         export AIRFLOW_CONN_TERADATA_DEFAULT='teradata://teradata_user:XXXXXXXXXXXX@1.1.1.1:/teradatadb?tmode=tera&sslmode=verify-ca&sslca=%2Ftmp%2Fserver-ca.pem'
+
+    For example (LDAP authentication):
+
+    .. code-block:: bash
+
+        export AIRFLOW_CONN_TERADATA_DEFAULT='teradata://ldap_user:ldap_password@1.1.1.1:/teradatadb?logmech=LDAP&tmode=tera&sslmode=verify-ca&sslca=%2Ftmp%2Fserver-ca.pem'
+
+Authentication Mechanisms
+--------------------------
+
+The Teradata provider supports multiple authentication mechanisms:
+
+**Native Teradata Authentication (TD2 - Default)**
+    Uses native Teradata username and password authentication.
+    No special configuration required; simply provide ``login`` and ``password`` in the connection.
+
+**LDAP Authentication**
+    Uses LDAP server for authentication. To enable LDAP:
+
+    1. Set ``logmech`` to ``"LDAP"`` in the connection extras
+    2. Provide LDAP username in ``login`` field
+    3. Provide LDAP password in ``password`` field
+
+    Example:
+
+    .. code-block:: json
+
+       {
+          "logmech": "LDAP"
+       }
+
+    The Teradata server must be configured to accept LDAP authentication.
+    The ``host`` field still specifies the Teradata database server address;
+    the teradatasql driver negotiates LDAP authentication with that server.
 
 Setting QueryBand
 -----------------

--- a/providers/teradata/src/airflow/providers/teradata/auth/__init__.py
+++ b/providers/teradata/src/airflow/providers/teradata/auth/__init__.py
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Teradata authentication mechanisms framework."""
+
+from airflow.providers.teradata.auth.base import TeradataAuthMechanism
+from airflow.providers.teradata.auth.ldap import LDAPAuthMechanism
+from airflow.providers.teradata.auth.registry import TeradataAuthRegistry
+from airflow.providers.teradata.auth.td2 import TD2AuthMechanism
+
+
+def _register_mechanisms() -> None:
+    """Register all available Teradata authentication mechanisms."""
+    TeradataAuthRegistry.register(TD2AuthMechanism())
+    TeradataAuthRegistry.register(LDAPAuthMechanism())
+
+
+_register_mechanisms()
+
+__all__ = [
+    "TeradataAuthMechanism",
+    "TeradataAuthRegistry",
+]

--- a/providers/teradata/src/airflow/providers/teradata/auth/base.py
+++ b/providers/teradata/src/airflow/providers/teradata/auth/base.py
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Abstract base class for Teradata authentication mechanisms."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    try:
+        from airflow.sdk import Connection
+    except ImportError:
+        from airflow.models.connection import Connection  # type: ignore
+
+
+class TeradataAuthMechanism(ABC):
+    """Abstract base class for Teradata authentication mechanisms."""
+
+    @property
+    @abstractmethod
+    def mechanism_name(self) -> str:
+        """Return the machine-readable mechanism identifier."""
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Return the human-readable mechanism name."""
+
+    @abstractmethod
+    def get_connection_config(
+        self,
+        connection: Connection,
+        base_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Transform Airflow Connection into teradatasql driver configuration."""
+
+    @abstractmethod
+    def validate_config(self, config: dict[str, Any]) -> None:
+        """Validate mechanism-specific configuration parameters."""

--- a/providers/teradata/src/airflow/providers/teradata/auth/ldap.py
+++ b/providers/teradata/src/airflow/providers/teradata/auth/ldap.py
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""LDAP authentication mechanism for Teradata."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.teradata.auth.base import TeradataAuthMechanism
+
+if TYPE_CHECKING:
+    try:
+        from airflow.sdk import Connection
+    except ImportError:
+        from airflow.models.connection import Connection  # type: ignore
+
+
+class LDAPAuthMechanism(TeradataAuthMechanism):
+    """LDAP authentication mechanism for Teradata."""
+
+    @property
+    def mechanism_name(self) -> str:
+        """Return 'LDAP' as the mechanism identifier."""
+        return "LDAP"
+
+    @property
+    def display_name(self) -> str:
+        """Return human-readable name."""
+        return "LDAP Authentication"
+
+    def get_connection_config(
+        self,
+        connection: Connection,
+        base_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build LDAP authentication configuration."""
+        config = base_config.copy()
+        config["logmech"] = "LDAP"
+        return config
+
+    def validate_config(self, config: dict[str, Any]) -> None:
+        """Validate LDAP authentication configuration."""
+        logmech = config.get("logmech")
+        if logmech != "LDAP":
+            raise ValueError(f"LDAP mechanism expects logmech='LDAP', got '{logmech}'")
+
+        # logdata carries the credentials directly to the driver, so an explicit
+        # user/password pair is not required in that case.
+        if config.get("logdata"):
+            return
+
+        user = config.get("user")
+        password = config.get("password")
+
+        if not user:
+            raise ValueError("LDAP authentication requires LDAP username (Login field)")
+        if password is None:
+            raise ValueError("LDAP authentication requires LDAP password (Password field)")

--- a/providers/teradata/src/airflow/providers/teradata/auth/registry.py
+++ b/providers/teradata/src/airflow/providers/teradata/auth/registry.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Registry for Teradata authentication mechanisms."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from airflow.providers.teradata.auth.base import TeradataAuthMechanism
+
+
+class TeradataAuthRegistry:
+    """Registry for Teradata authentication mechanisms."""
+
+    _mechanisms: ClassVar[dict[str, TeradataAuthMechanism]] = {}
+
+    @classmethod
+    def register(cls, mechanism: TeradataAuthMechanism) -> None:
+        """Register an authentication mechanism."""
+        cls._mechanisms.setdefault(mechanism.mechanism_name, mechanism)
+
+    @classmethod
+    def get(cls, mechanism_name: str) -> TeradataAuthMechanism:
+        """Get authentication mechanism by name."""
+        if mechanism_name in cls._mechanisms:
+            return cls._mechanisms[mechanism_name]
+        supported = ", ".join(sorted(cls._mechanisms.keys()))
+        raise ValueError(f"Unknown authentication mechanism: '{mechanism_name}'. Supported: {supported}")
+
+    @classmethod
+    def get_default(cls) -> TeradataAuthMechanism:
+        """
+        Get the default authentication mechanism (TD2).
+
+        Returns:
+            TD2 mechanism instance
+        """
+        return cls.get("TD2")
+
+    @classmethod
+    def available_mechanisms(cls) -> list[str]:
+        """
+        Get list of all registered mechanism names.
+
+        Returns:
+            List of mechanism names, sorted alphabetically
+        """
+        return sorted(cls._mechanisms.keys())

--- a/providers/teradata/src/airflow/providers/teradata/auth/td2.py
+++ b/providers/teradata/src/airflow/providers/teradata/auth/td2.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Native Teradata (TD2) authentication mechanism."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.teradata.auth.base import TeradataAuthMechanism
+
+if TYPE_CHECKING:
+    try:
+        from airflow.sdk import Connection
+    except ImportError:
+        from airflow.models.connection import Connection  # type: ignore
+
+
+class TD2AuthMechanism(TeradataAuthMechanism):
+    """Native Teradata (TD2) authentication mechanism."""
+
+    @property
+    def mechanism_name(self) -> str:
+        """Return 'TD2' as the mechanism identifier."""
+        return "TD2"
+
+    @property
+    def display_name(self) -> str:
+        """Return human-readable name."""
+        return "Native Teradata Authentication"
+
+    def get_connection_config(
+        self,
+        connection: Connection,
+        base_config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build native Teradata authentication configuration."""
+        config = base_config.copy()
+        config["user"] = config.get("user") or "dbc"
+        config["password"] = config.get("password") or "dbc"
+        return config
+
+    def validate_config(self, config: dict[str, Any]) -> None:
+        """Validate native Teradata authentication configuration."""
+        user = config.get("user")
+        password = config.get("password")
+
+        if not user:
+            raise ValueError("Teradata connection requires 'user' (Login) to be specified")
+        if password is None:
+            raise ValueError("Teradata connection requires 'password' (Password) to be specified")

--- a/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/hooks/teradata.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -27,6 +28,7 @@ from teradatasql import TeradataConnection
 
 from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 from airflow.providers.common.sql.hooks.sql import DbApiHook
+from airflow.providers.teradata.auth import TeradataAuthRegistry
 
 if TYPE_CHECKING:
     try:
@@ -104,8 +106,12 @@ class TeradataHook(DbApiHook):
     Teradata DB Server URL, username, password and database name are fetched from the predefined connection
     config connection_id. It raises an airflow error if the given connection id doesn't exist.
 
+    Supports multiple authentication mechanisms:
+    - Native Teradata (default, when logmech not specified)
+    - LDAP (when logmech: "LDAP" is specified)
+
     You can also specify ssl parameters in the extra field of your connection
-    as ``{"sslmode": "require", "sslcert": "/path/to/cert.pem", etc}``.
+    as ``{"sslmode": "require", "sslca": "/path/to/ca.pem", "logmech": "LDAP", etc}``.
 
     .. seealso::
         - :ref:`Teradata API connection <howto/connection:teradata>`
@@ -175,20 +181,73 @@ class TeradataHook(DbApiHook):
             self.log.error("Error occurred while setting session query band: %s ", str(ex))
 
     def _get_conn_config_teradatasql(self) -> dict[str, Any]:
-        """Return set of config params required for connecting to Teradata DB using teradatasql client."""
+        """
+        Return connection config with mechanism-specific parameters.
+
+        Flow:
+        1. Build base_config with common parameters (host, port, db, user, pwd)
+        2. Get auth mechanism from registry (default: TD2)
+        3. Get mechanism-specific config
+        4. Validate mechanism-specific config
+        5. Add shared parameters (SSL, tmode, query_band)
+        6. Return complete config ready for teradatasql.connect()
+
+        Returns:
+            Connection configuration dict
+
+        Raises:
+            ValueError: If the mechanism-specific config is invalid
+        """
         conn: Connection = self.get_connection(self.get_conn_id())
-        conn_config = {
+
+        base_config = {
             "host": conn.host or "localhost",
             "dbs_port": conn.port or DEFAULT_DB_PORT,
             "database": conn.schema or "",
-            "user": conn.login or "dbc",
-            "password": conn.password or "dbc",
+            "user": conn.login,
+            "password": conn.password,
         }
 
+        # logdata carries mechanism-specific auth payloads (e.g. LDAP/JWT single-string
+        # credentials). It must be present before validate_config so a mechanism can accept
+        # logdata-only auth without a separate user/password.
+        if conn.extra_dejson.get("logdata"):
+            base_config["logdata"] = conn.extra_dejson["logdata"]
+
+        # teradatasql treats logmech case-insensitively; normalise so registry lookup matches.
+        logmech = str(conn.extra_dejson.get("logmech", "TD2")).upper()
+        auth_mechanism = TeradataAuthRegistry.get(logmech)
+
+        conn_config = auth_mechanism.get_connection_config(conn, base_config)
+
+        auth_mechanism.validate_config(conn_config)
+
+        self._add_shared_connection_params(conn, conn_config)
+
+        return {k: v for k, v in conn_config.items() if v is not None}
+
+    def _add_shared_connection_params(
+        self,
+        conn: Connection,
+        conn_config: dict[str, Any],
+    ) -> None:
+        """
+        Add shared connection parameters (work with any auth mechanism).
+
+        Adds parameters that are independent of authentication mechanism:
+        - SSL/TLS configuration (sslmode, sslca, sslcapath, etc.)
+        - Transaction mode (tmode)
+        - Session query band
+
+        These parameters are applied after mechanism-specific config,
+        so they work correctly with any authentication mechanism.
+
+        Args:
+            conn: Airflow Connection object with extra_dejson
+            conn_config: Config dict to be updated in-place
+        """
         if conn.extra_dejson.get("tmode", False):
             conn_config["tmode"] = conn.extra_dejson["tmode"]
-
-        # Handling SSL connection parameters
 
         if conn.extra_dejson.get("sslmode", False):
             conn_config["sslmode"] = conn.extra_dejson["sslmode"]
@@ -197,16 +256,18 @@ class TeradataHook(DbApiHook):
                     conn_config["sslca"] = conn.extra_dejson["sslca"]
                 if conn.extra_dejson.get("sslcapath", False):
                     conn_config["sslcapath"] = conn.extra_dejson["sslcapath"]
+
         if conn.extra_dejson.get("sslcipher", False):
             conn_config["sslcipher"] = conn.extra_dejson["sslcipher"]
+
         if conn.extra_dejson.get("sslcrc", False):
             conn_config["sslcrc"] = conn.extra_dejson["sslcrc"]
+
         if conn.extra_dejson.get("sslprotocol", False):
             conn_config["sslprotocol"] = conn.extra_dejson["sslprotocol"]
+
         if conn.extra_dejson.get("query_band", False):
             conn_config["query_band"] = conn.extra_dejson["query_band"]
-
-        return conn_config
 
     @property
     def sqlalchemy_url(self):
@@ -217,6 +278,20 @@ class TeradataHook(DbApiHook):
         """
         URL = _get_sqlalchemy_url()
         connection = self.get_connection(self.get_conn_id())
+        # Carry the authentication mechanism onto the SQLAlchemy path so engines created via
+        # get_sqlalchemy_engine()/get_uri() use the same auth as get_conn(); otherwise a
+        # non-TD2 connection (e.g. LDAP) would silently fall back to native authentication.
+        if connection.extra_dejson.get("logdata"):
+            raise ValueError(
+                "logdata-based authentication is not supported on the SQLAlchemy path "
+                "(get_uri()/get_sqlalchemy_engine()). Use get_conn() for logdata auth."
+            )
+        query: dict[str, str] = {}
+        if connection.extra_dejson.get("logmech"):
+            query["logmech"] = str(connection.extra_dejson["logmech"]).upper()
+        # logdata is intentionally excluded from the SQLAlchemy URL: it commonly embeds
+        # credentials (e.g. "password=...") that would appear in get_uri() output and
+        # engine debug logs. The DB-API path (get_conn) handles logdata safely.
         # Adding only teradatasqlalchemy supported connection parameters.
         # https://pypi.org/project/teradatasqlalchemy/#ConnectionParameters
         return URL.create(
@@ -226,6 +301,7 @@ class TeradataHook(DbApiHook):
             host=connection.host,
             port=connection.port,
             database=connection.schema if connection.schema else None,
+            query=query,
         )
 
     def get_uri(self) -> str:
@@ -234,9 +310,7 @@ class TeradataHook(DbApiHook):
 
     @staticmethod
     def get_ui_field_behaviour() -> dict:
-        """Return custom field behaviour."""
-        import json
-
+        """Return custom field behaviour for connection UI."""
         return {
             "hidden_fields": ["port"],
             "relabeling": {
@@ -246,7 +320,12 @@ class TeradataHook(DbApiHook):
             },
             "placeholders": {
                 "extra": json.dumps(
-                    {"tmode": "TERA", "sslmode": "verify-ca", "sslca": "/tmp/server-ca.pem"}, indent=4
+                    {
+                        "tmode": "TERA",
+                        "sslmode": "verify-ca",
+                        "sslca": "/tmp/server-ca.pem",
+                    },
+                    indent=4,
                 ),
                 "login": "dbc",
                 "password": "dbc",

--- a/providers/teradata/src/airflow/providers/teradata/transfers/teradata_to_teradata.py
+++ b/providers/teradata/src/airflow/providers/teradata/transfers/teradata_to_teradata.py
@@ -86,7 +86,10 @@ class TeradataToTeradataOperator(BaseOperator):
         dest_hook = self.dest_hook
         with src_hook.get_conn() as src_conn:
             cursor = src_conn.cursor()
-            cursor.execute(self.sql, self.sql_params)
+            if self.sql_params:
+                cursor.execute(self.sql, self.sql_params)
+            else:
+                cursor.execute(self.sql)
             target_fields = [field[0] for field in cursor.description]
             rows_total = 0
             if len(target_fields) != 0:

--- a/providers/teradata/tests/unit/teradata/auth/__init__.py
+++ b/providers/teradata/tests/unit/teradata/auth/__init__.py
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for Teradata authentication mechanisms."""

--- a/providers/teradata/tests/unit/teradata/auth/test_base.py
+++ b/providers/teradata/tests/unit/teradata/auth/test_base.py
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for TeradataAuthMechanism base class."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from airflow.providers.teradata.auth.base import TeradataAuthMechanism
+
+
+class ConcreteAuthMechanism(TeradataAuthMechanism):
+    """Concrete implementation for testing abstract base class."""
+
+    @property
+    def mechanism_name(self) -> str:
+        return "TEST"
+
+    @property
+    def display_name(self) -> str:
+        return "Test Mechanism"
+
+    def get_connection_config(self, connection, base_config):
+        return base_config.copy()
+
+    def validate_config(self, config):
+        pass
+
+
+class TestTeradataAuthMechanism:
+    """Test cases for TeradataAuthMechanism abstract base class."""
+
+    def test_abstract_class_cannot_instantiate(self):
+        """Verify TeradataAuthMechanism is abstract and cannot be instantiated."""
+        with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+            TeradataAuthMechanism()
+
+    def test_concrete_implementation_instantiates(self):
+        """Verify concrete implementation can be instantiated."""
+        mechanism = ConcreteAuthMechanism()
+        assert mechanism is not None
+
+    def test_mechanism_name_property(self):
+        """Verify mechanism_name property is defined."""
+        mechanism = ConcreteAuthMechanism()
+        assert mechanism.mechanism_name == "TEST"
+
+    def test_display_name_property(self):
+        """Verify display_name property is defined."""
+        mechanism = ConcreteAuthMechanism()
+        assert mechanism.display_name == "Test Mechanism"
+
+    def test_get_connection_config_method(self):
+        """Verify get_connection_config method is callable."""
+        mechanism = ConcreteAuthMechanism()
+        connection = Mock(spec_set=[])
+        base_config = {"host": "localhost"}
+
+        result = mechanism.get_connection_config(connection, base_config)
+
+        assert result == base_config
+
+    def test_validate_config_method(self):
+        """Verify validate_config method is callable."""
+        mechanism = ConcreteAuthMechanism()
+        config = {"host": "localhost"}
+
+        mechanism.validate_config(config)

--- a/providers/teradata/tests/unit/teradata/auth/test_ldap.py
+++ b/providers/teradata/tests/unit/teradata/auth/test_ldap.py
@@ -1,0 +1,119 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for LDAPAuthMechanism."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from airflow.providers.teradata.auth.ldap import LDAPAuthMechanism
+
+
+class TestLDAPAuthMechanism:
+    """Test cases for LDAPAuthMechanism."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mechanism = LDAPAuthMechanism()
+
+    def test_mechanism_properties(self):
+        """Verify LDAP mechanism properties."""
+        assert self.mechanism.mechanism_name == "LDAP"
+        assert "LDAP" in self.mechanism.display_name
+
+    def test_get_connection_config(self):
+        """Verify LDAP adds logmech parameter."""
+        connection = Mock(spec_set=[])
+        base_config = {
+            "host": "ldap.example.com",
+            "dbs_port": 1025,
+            "database": "mydb",
+            "user": "john.doe",
+            "password": "xxxxx",
+        }
+
+        result = self.mechanism.get_connection_config(connection, base_config)
+
+        for key in base_config:
+            assert result[key] == base_config[key]
+        assert result["logmech"] == "LDAP"
+
+    def test_get_connection_config_immutable(self):
+        """Verify LDAP doesn't modify base_config."""
+        connection = Mock(spec_set=[])
+        base_config = {"host": "ldap", "user": "john", "password": "xxx"}
+        original = base_config.copy()
+
+        self.mechanism.get_connection_config(connection, base_config)
+
+        assert base_config == original
+
+    def test_validate_config_success(self):
+        """Verify validation passes with logmech, user, password."""
+        config = {
+            "logmech": "LDAP",
+            "user": "john.doe",
+            "password": "xxxxx",
+        }
+
+        self.mechanism.validate_config(config)
+
+    def test_validate_missing_user(self):
+        """Verify error when LDAP user missing."""
+        config = {"logmech": "LDAP", "password": "xxxxx"}
+
+        with pytest.raises(ValueError, match="username"):
+            self.mechanism.validate_config(config)
+
+    def test_validate_missing_password(self):
+        """Verify error when LDAP password missing."""
+        config = {"logmech": "LDAP", "user": "john.doe"}
+
+        with pytest.raises(ValueError, match="password"):
+            self.mechanism.validate_config(config)
+
+    def test_validate_logdata_allows_missing_user_password(self):
+        """Verify logdata-based auth is accepted without user/password."""
+        config = {"logmech": "LDAP", "logdata": "authcid=john password=xxx"}
+
+        self.mechanism.validate_config(config)
+
+    def test_validate_invalid_logmech(self):
+        """Verify error if logmech not set to LDAP."""
+        config = {
+            "logmech": "TD2",
+            "user": "john",
+            "password": "xxx",
+        }
+
+        with pytest.raises(ValueError, match="LDAP"):
+            self.mechanism.validate_config(config)
+
+    def test_validate_with_ssl_params(self):
+        """Verify LDAP validation works with SSL parameters."""
+        config = {
+            "logmech": "LDAP",
+            "user": "john",
+            "password": "xxx",
+            "sslmode": "verify-ca",
+            "sslca": "/path/to/ca.pem",
+        }
+
+        self.mechanism.validate_config(config)

--- a/providers/teradata/tests/unit/teradata/auth/test_registry.py
+++ b/providers/teradata/tests/unit/teradata/auth/test_registry.py
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for TeradataAuthRegistry."""
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.providers.teradata.auth import TeradataAuthRegistry
+from airflow.providers.teradata.auth.td2 import TD2AuthMechanism
+
+
+class TestTeradataAuthRegistry:
+    """Test cases for TeradataAuthRegistry."""
+
+    def test_get_mechanism_td2(self):
+        """Verify TD2 mechanism can be retrieved."""
+        mechanism = TeradataAuthRegistry.get("TD2")
+        assert mechanism.mechanism_name == "TD2"
+
+    def test_get_mechanism_ldap(self):
+        """Verify LDAP mechanism can be retrieved."""
+        mechanism = TeradataAuthRegistry.get("LDAP")
+        assert mechanism.mechanism_name == "LDAP"
+
+    def test_get_unregistered_mechanism_raises(self):
+        """Verify unregistered mechanism name raises ValueError with supported list."""
+        with pytest.raises(ValueError, match="KRB5"):
+            TeradataAuthRegistry.get("KRB5")
+
+    def test_register_is_idempotent(self):
+        """Verify re-registering an existing mechanism does not raise."""
+        TeradataAuthRegistry.register(TD2AuthMechanism())
+
+        assert TeradataAuthRegistry.get("TD2").mechanism_name == "TD2"
+
+    def test_available_mechanisms(self):
+        """Verify list of available mechanisms."""
+        mechanisms = TeradataAuthRegistry.available_mechanisms()
+        assert isinstance(mechanisms, list)
+        assert "TD2" in mechanisms
+        assert "LDAP" in mechanisms
+        assert mechanisms == sorted(mechanisms)
+
+    def test_get_default_mechanism(self):
+        """Verify TD2 is the default mechanism."""
+        default = TeradataAuthRegistry.get_default()
+        assert default.mechanism_name == "TD2"

--- a/providers/teradata/tests/unit/teradata/auth/test_td2.py
+++ b/providers/teradata/tests/unit/teradata/auth/test_td2.py
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for TD2AuthMechanism."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from airflow.providers.teradata.auth.td2 import TD2AuthMechanism
+
+
+class TestTD2AuthMechanism:
+    """Test cases for TD2AuthMechanism."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mechanism = TD2AuthMechanism()
+
+    def test_mechanism_properties(self):
+        """Verify TD2 mechanism properties."""
+        assert self.mechanism.mechanism_name == "TD2"
+        assert "Native" in self.mechanism.display_name
+
+    def test_get_connection_config(self):
+        """Verify TD2 keeps provided credentials and adds no logmech."""
+        connection = Mock(spec_set=[])
+        base_config = {
+            "host": "localhost",
+            "dbs_port": 1025,
+            "database": "mydb",
+            "user": "myuser",
+            "password": "mypwd",
+        }
+
+        result = self.mechanism.get_connection_config(connection, base_config)
+
+        assert result == base_config
+        assert "logmech" not in result
+
+    def test_get_connection_config_applies_dbc_default(self):
+        """Verify empty user/password fall back to the historical 'dbc' default."""
+        connection = Mock(spec_set=[])
+        base_config = {"host": "localhost", "user": None, "password": None}
+
+        result = self.mechanism.get_connection_config(connection, base_config)
+
+        assert result["user"] == "dbc"
+        assert result["password"] == "dbc"
+
+    def test_validate_config_success(self):
+        """Verify validation passes with user and password."""
+        config = {
+            "user": "dbc",
+            "password": "dbc",
+        }
+
+        self.mechanism.validate_config(config)
+
+    def test_validate_missing_user(self):
+        """Verify error when user is missing."""
+        config = {"password": "dbc"}
+
+        with pytest.raises(ValueError, match="user"):
+            self.mechanism.validate_config(config)
+
+    def test_validate_missing_password(self):
+        """Verify error when password is missing."""
+        config = {"user": "dbc"}
+
+        with pytest.raises(ValueError, match="password"):
+            self.mechanism.validate_config(config)
+
+    def test_validate_empty_password_allowed(self):
+        """Verify empty string password is allowed (None is not)."""
+        config = {"user": "dbc", "password": ""}
+
+        self.mechanism.validate_config(config)

--- a/providers/teradata/tests/unit/teradata/hooks/test_teradata.py
+++ b/providers/teradata/tests/unit/teradata/hooks/test_teradata.py
@@ -21,6 +21,8 @@ import json
 from datetime import datetime
 from unittest import mock
 
+import pytest
+
 from airflow.models import Connection
 from airflow.providers.teradata.hooks.teradata import TeradataHook, _handle_user_query_band_text
 
@@ -178,6 +180,53 @@ class TestTeradataHook:
         assert kwargs["user"] == "login"
         assert kwargs["password"] == "password"
         assert kwargs["sslcipher"] == "cipher"
+
+    @mock.patch("teradatasql.connect")
+    def test_get_ldap_conn(self, mock_connect):
+        self.connection.extra = json.dumps({"logmech": "LDAP"})
+        self.db_hook.get_conn()
+        args, kwargs = mock_connect.call_args
+        assert kwargs["logmech"] == "LDAP"
+        assert kwargs["user"] == "login"
+        assert kwargs["password"] == "password"
+
+    @mock.patch("teradatasql.connect")
+    def test_get_ldap_conn_logmech_case_insensitive(self, mock_connect):
+        self.connection.extra = json.dumps({"logmech": "ldap"})
+        self.db_hook.get_conn()
+        _, kwargs = mock_connect.call_args
+        assert kwargs["logmech"] == "LDAP"
+
+    def test_get_unregistered_logmech_raises(self):
+        self.connection.extra = json.dumps({"logmech": "KRB5"})
+        with pytest.raises(ValueError, match="KRB5"):
+            self.db_hook._get_conn_config_teradatasql()
+
+    def test_ldap_missing_credentials_raises(self):
+        self.connection.login = None
+        self.connection.password = None
+        self.connection.extra = json.dumps({"logmech": "LDAP"})
+        with pytest.raises(ValueError, match="username"):
+            self.db_hook._get_conn_config_teradatasql()
+
+    def test_ldap_logdata_allows_missing_credentials(self):
+        self.connection.login = None
+        self.connection.password = None
+        self.connection.extra = json.dumps({"logmech": "LDAP", "logdata": "authcid=john password=xxx"})
+        config = self.db_hook._get_conn_config_teradatasql()
+        assert config["logmech"] == "LDAP"
+        assert config["logdata"] == "authcid=john password=xxx"
+        assert not any(v is None for v in config.values())
+
+    def test_get_uri_includes_logmech(self):
+        self.connection.extra = json.dumps({"logmech": "LDAP"})
+        uri = self.db_hook.get_uri()
+        assert "logmech=LDAP" in uri
+
+    def test_get_uri_raises_for_logdata(self):
+        self.connection.extra = json.dumps({"logmech": "LDAP", "logdata": "authcid=john password=xxx"})
+        with pytest.raises(ValueError, match="logdata"):
+            self.db_hook.get_uri()
 
     def test_get_uri_without_schema(self):
         self.connection.schema = ""  # simulate missing schema


### PR DESCRIPTION
This PR introduces a pluggable authentication framework to the Teradata provider, enabling support for multiple authentication mechanisms including native Teradata (TD2) and LDAP.

### Changes
New Authentication Framework (providers/teradata/src/airflow/providers/teradata/auth/)

1. base.py: Abstract TeradataAuthMechanism base class
2. td2.py: Native Teradata (TD2) authentication (default)
3. ldap.py: New LDAP authentication support
4. registry.py: Mechanism registry for dynamic auth provider lookup

### Enhanced Teradata Hook

1. Refactored _get_conn_config_teradatasql() to use authentication registry
2. New _add_shared_connection_params() for SSL/TLS and transaction mode config
3. Updated sqlalchemy_url property to carry logmech parameter

### Documentation Updates

1. Added LDAP authentication configuration examples
2. Documented logmech parameter and connection URI format
3. Added Port field documentation


### Bug Fix

1. teradata_to_teradata.py: Fixed cursor.execute() when sql_params is empty

### Comprehensive Tests

1. Auth mechanism tests (TD2, LDAP, registry)
2. Hook integration tests with LDAP and logdata support

### Configuration Example
LDAP Authentication:

JSON
{
  "logmech": "LDAP",
  "sslmode": "verify-ca",
  "sslca": "/tmp/server-ca.pem"
}

### Backward Compatibility
✅ Fully backward compatible - TD2 remains default when logmech is not specified.

**Teradata Provider System Health Dashboard**: https://teradata.github.io/airflow/

**Teradata Provider documentation build status:**  https://github.com/Teradata/airflow/actions/workflows/ci-teradata-push-branch-documentation-unit-tests.yml


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=66c7c9c action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @sc250072** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
