### PR TITLE
Fix Celery worker JSON logging config for teams

### DIFF
--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -263,11 +263,11 @@ def worker(args):
     if AIRFLOW_V_3_0_PLUS:
         from airflow.sdk.log import configure_logging
 
-        _celery_json = conf.get("celery", "json_logs", fallback="")
+        _celery_json = config.get("celery", "json_logs", fallback="")
         if _celery_json and _celery_json.lower() != "none":
-            json_output = conf.getboolean("celery", "json_logs")
+            json_output = config.getboolean("celery", "json_logs")
         else:
-            json_output = conf.getboolean("logging", "json_logs", fallback=False)
+            json_output = config.getboolean("logging", "json_logs", fallback=False)
         configure_logging(output=sys.stdout.buffer, json_output=json_output)
     else:
         # Disable connection pool so that celery worker does not hold an unnecessary db connection


### PR DESCRIPTION
We should use `config` instead of  `conf`

Error:
https://github.com/apache/airflow/actions/runs/28381801726

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
