### PR TITLE
Gate provider release on artifact completeness check before vote

### DIFF
--- a/dev/README_RELEASE_PROVIDERS.md
+++ b/dev/README_RELEASE_PROVIDERS.md
@@ -592,6 +592,20 @@ svn commit -m "Add artifacts for Airflow Providers ${RELEASE_DATE}"
 cd "$AIRFLOW_REPO_ROOT"
 ```
 
+* Before sending the vote email, gate on the same completeness check the PMC verifiers run, so a
+  missing artifact (e.g. the `-source.tar.gz` tarball) fails here instead of in the vote thread.
+  Put the package list from the upcoming vote email into `dev/packages.txt`, then run:
+
+```shell script
+cd "$AIRFLOW_REPO_ROOT"
+breeze release-management check-release-files providers --release-date "${RELEASE_DATE}" \
+  --packages-file ./dev/packages.txt \
+  --path-to-airflow-svn "$(cd ../asf-dist/dev/airflow && pwd -P)"
+```
+
+  It exits non-zero and lists every missing file (including `.asc`/`.sha512` variants) if anything is
+  absent. Only proceed to the vote once it prints `All expected files are present!`.
+
 Verify that the files are available in the ${RELEASE_DATE} folder under
 [providers](https://dist.apache.org/repos/dist/dev/airflow/providers/)
 


### PR DESCRIPTION
A recent ad-hoc provider release reached the vote thread missing the all-providers `-source.tar.gz` tarball, which drew a -1 from PMC verifiers.

The completeness check that catches this already exists — `breeze release-management check-release-files providers` asserts the source tarball plus its `.asc`/`.sha512` and every per-provider file. But the release-manager runbook only invoked it as a *PMC-reviewer* step (after upload), so a release manager never ran it before sending the vote email, and the missing artifact surfaced only in the vote thread.

This adds a gate right after the SVN commit in `dev/README_RELEASE_PROVIDERS.md` telling the release manager to run that same check against their own checkout, and to proceed to the vote only once it prints `All expected files are present!`.

Docs-only; no code change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)