### PR TITLE
Fix drifting data intervals for monthly/yearly schedules with catchup disabled

### DIFF
--- a/airflow-core/newsfragments/69143.bugfix.rst
+++ b/airflow-core/newsfragments/69143.bugfix.rst
@@ -1,0 +1,1 @@
+Fix drifting, mis-aligned data intervals for monthly and yearly (``relativedelta``) schedules when ``catchup`` is disabled. The first interval is now anchored to the Dag's ``start_date`` instead of a fixed 30-day/365-day grid, matching the boundaries produced with ``catchup=True``.

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -243,8 +243,19 @@ class DeltaDataIntervalTimetable(DeltaMixin, _DataIntervalTimetable):
 
         This is slightly different from the cron version at terminal values.
         """
-        round_current_time = self._round(coerce_datetime(utcnow()))
-        new_start = self._get_prev(round_current_time)
+        now = coerce_datetime(utcnow())
+        if isinstance(self._delta, relativedelta) and (self._delta.months or self._delta.years):
+            # Months/years have no fixed second count, so the epoch-grid
+            # rounding used below would drift. Anchor on ``earliest`` and advance
+            # one period at a time so boundaries match the catchup=True grid
+            # (relativedelta day-clamping is path-dependent, e.g. Jan 31 -> Feb
+            # 28 -> Mar 28, so a multiplied jump would land elsewhere).
+            new_start = earliest if earliest is not None else now
+            while self._get_next(new_start) <= now:
+                new_start = self._get_next(new_start)
+            new_start = self._get_prev(new_start)
+        else:
+            new_start = self._get_prev(self._round(now))
         if earliest is None:
             return new_start
         return max(new_start, earliest)

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -235,6 +235,9 @@ class DeltaDataIntervalTimetable(DeltaMixin, _DataIntervalTimetable):
         (e.g. Jan 31 -> Feb 28 -> Mar 28), so a multiplied jump would land
         elsewhere. Fixed deltas keep the historical epoch rounding and ignore
         ``anchor``.
+
+        ``anchor`` must be at or before ``dt``; otherwise the forward stepping
+        cannot reach ``dt`` and the result is meaningless.
         """
         if isinstance(self._delta, relativedelta) and (self._delta.months or self._delta.years):
             boundary = anchor
@@ -259,7 +262,7 @@ class DeltaDataIntervalTimetable(DeltaMixin, _DataIntervalTimetable):
         This is slightly different from the cron version at terminal values.
         """
         now = coerce_datetime(utcnow())
-        new_start = self._get_prev(self._round(now, earliest if earliest is not None else now))
+        new_start = self._get_prev(self._round(now, earliest or now))
         if earliest is None:
             return new_start
         return max(new_start, earliest)

--- a/airflow-core/src/airflow/timetables/interval.py
+++ b/airflow-core/src/airflow/timetables/interval.py
@@ -224,8 +224,23 @@ class DeltaDataIntervalTimetable(DeltaMixin, _DataIntervalTimetable):
             + delta.seconds
         )
 
-    def _round(self, dt: DateTime) -> DateTime:
-        """Round the given time to the nearest interval."""
+    def _round(self, dt: DateTime, anchor: DateTime) -> DateTime:
+        """
+        Floor ``dt`` to the latest schedule boundary at or before it.
+
+        Months/years have no fixed second count, so the epoch-grid rounding
+        used for fixed deltas would drift. For them we anchor on ``anchor``
+        (the start_date) and advance one period at a time, so boundaries match
+        the catchup=True grid -- relativedelta day-clamping is path-dependent
+        (e.g. Jan 31 -> Feb 28 -> Mar 28), so a multiplied jump would land
+        elsewhere. Fixed deltas keep the historical epoch rounding and ignore
+        ``anchor``.
+        """
+        if isinstance(self._delta, relativedelta) and (self._delta.months or self._delta.years):
+            boundary = anchor
+            while self._get_next(boundary) <= dt:
+                boundary = self._get_next(boundary)
+            return boundary
         if isinstance(self._delta, datetime.timedelta):
             delta_in_seconds = self._delta.total_seconds()
         else:
@@ -244,18 +259,7 @@ class DeltaDataIntervalTimetable(DeltaMixin, _DataIntervalTimetable):
         This is slightly different from the cron version at terminal values.
         """
         now = coerce_datetime(utcnow())
-        if isinstance(self._delta, relativedelta) and (self._delta.months or self._delta.years):
-            # Months/years have no fixed second count, so the epoch-grid
-            # rounding used below would drift. Anchor on ``earliest`` and advance
-            # one period at a time so boundaries match the catchup=True grid
-            # (relativedelta day-clamping is path-dependent, e.g. Jan 31 -> Feb
-            # 28 -> Mar 28, so a multiplied jump would land elsewhere).
-            new_start = earliest if earliest is not None else now
-            while self._get_next(new_start) <= now:
-                new_start = self._get_next(new_start)
-            new_start = self._get_prev(new_start)
-        else:
-            new_start = self._get_prev(self._round(now))
+        new_start = self._get_prev(self._round(now, earliest if earliest is not None else now))
         if earliest is None:
             return new_start
         return max(new_start, earliest)

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -205,8 +205,12 @@ def test_no_catchup_calendar_delta_without_start_date_ends_now() -> None:
 
 @time_machine.travel(pendulum.DateTime(2026, 6, 29, tzinfo=utc))
 def test_no_catchup_calendar_delta_uses_one_period_at_a_time_clamping() -> None:
-    """Boundaries must follow relativedelta day-clamping period by period
-    (Jan 31 -> Feb 28 -> Mar 28 ...), not a multiplied jump off ``start_date``."""
+    """Boundaries advance one relativedelta period at a time, so day-clamping is
+    path-dependent: Jan 31 + 1 month clamps to Feb 28, and because each step starts
+    from the previous boundary (not from Jan 31), the 28 then sticks --
+    Feb 28 -> Mar 28 -> ... -> May 28 -> Jun 28. A single multiplied jump off
+    ``start_date`` would instead re-clamp from the 31st and land elsewhere
+    (Jan 31 + 5 months -> Jun 30)."""
     next_info = MONTHLY_RELATIVEDELTA_TIMETABLE.next_dagrun_info(
         last_automated_data_interval=None,
         restriction=TimeRestriction(

--- a/airflow-core/tests/unit/timetables/test_interval_timetable.py
+++ b/airflow-core/tests/unit/timetables/test_interval_timetable.py
@@ -43,6 +43,8 @@ OLD_INTERVAL = DataInterval(start=YESTERDAY, end=CURRENT_TIME)
 HOURLY_CRON_TIMETABLE = CronDataIntervalTimetable("@hourly", utc)
 HOURLY_TIMEDELTA_TIMETABLE = DeltaDataIntervalTimetable(datetime.timedelta(hours=1))
 HOURLY_RELATIVEDELTA_TIMETABLE = DeltaDataIntervalTimetable(dateutil.relativedelta.relativedelta(hours=1))
+MONTHLY_RELATIVEDELTA_TIMETABLE = DeltaDataIntervalTimetable(dateutil.relativedelta.relativedelta(months=1))
+YEARLY_RELATIVEDELTA_TIMETABLE = DeltaDataIntervalTimetable(dateutil.relativedelta.relativedelta(years=1))
 
 CRON_TIMETABLE = CronDataIntervalTimetable("30 16 * * *", utc)
 DELTA_FROM_MIDNIGHT = datetime.timedelta(minutes=30, hours=16)
@@ -137,6 +139,84 @@ def test_no_catchup_next_info_starts_at_current_time(
     )
     expected_start = CURRENT_TIME - datetime.timedelta(hours=1)
     assert next_info == DagRunInfo.interval(start=expected_start, end=CURRENT_TIME)
+
+
+@pytest.mark.parametrize(
+    "last_automated_data_interval",
+    [
+        pytest.param(None, id="first-run"),
+        pytest.param(
+            DataInterval(
+                pendulum.DateTime(2020, 1, 1, tzinfo=utc),
+                pendulum.DateTime(2020, 2, 1, tzinfo=utc),
+            ),
+            id="subsequent",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("timetable", "start_date", "expected_start", "expected_end"),
+    [
+        pytest.param(
+            MONTHLY_RELATIVEDELTA_TIMETABLE,
+            pendulum.DateTime(2025, 1, 15, tzinfo=utc),
+            pendulum.DateTime(2026, 5, 15, tzinfo=utc),
+            pendulum.DateTime(2026, 6, 15, tzinfo=utc),
+            id="monthly",
+        ),
+        pytest.param(
+            YEARLY_RELATIVEDELTA_TIMETABLE,
+            pendulum.DateTime(2020, 3, 10, tzinfo=utc),
+            pendulum.DateTime(2025, 3, 10, tzinfo=utc),
+            pendulum.DateTime(2026, 3, 10, tzinfo=utc),
+            id="yearly",
+        ),
+    ],
+)
+@time_machine.travel(pendulum.DateTime(2026, 6, 29, tzinfo=utc))
+def test_no_catchup_calendar_delta_aligns_to_start_date(
+    timetable: Timetable,
+    start_date: pendulum.DateTime,
+    expected_start: pendulum.DateTime,
+    expected_end: pendulum.DateTime,
+    last_automated_data_interval: DataInterval | None,
+) -> None:
+    """``catchup=False`` with a relativedelta in months/years must stay aligned
+    to ``start_date`` and not drift onto a fixed 30-day/365-day epoch grid."""
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=last_automated_data_interval,
+        restriction=TimeRestriction(earliest=start_date, latest=None, catchup=False),
+    )
+    assert next_info == DagRunInfo.interval(start=expected_start, end=expected_end)
+
+
+@time_machine.travel(pendulum.DateTime(2026, 6, 29, 12, tzinfo=utc))
+def test_no_catchup_calendar_delta_without_start_date_ends_now() -> None:
+    """With no ``start_date`` to anchor on, the interval simply ends at now."""
+    next_info = MONTHLY_RELATIVEDELTA_TIMETABLE.next_dagrun_info(
+        last_automated_data_interval=None,
+        restriction=TimeRestriction(earliest=None, latest=None, catchup=False),
+    )
+    assert next_info == DagRunInfo.interval(
+        start=pendulum.DateTime(2026, 5, 29, 12, tzinfo=utc),
+        end=pendulum.DateTime(2026, 6, 29, 12, tzinfo=utc),
+    )
+
+
+@time_machine.travel(pendulum.DateTime(2026, 6, 29, tzinfo=utc))
+def test_no_catchup_calendar_delta_uses_one_period_at_a_time_clamping() -> None:
+    """Boundaries must follow relativedelta day-clamping period by period
+    (Jan 31 -> Feb 28 -> Mar 28 ...), not a multiplied jump off ``start_date``."""
+    next_info = MONTHLY_RELATIVEDELTA_TIMETABLE.next_dagrun_info(
+        last_automated_data_interval=None,
+        restriction=TimeRestriction(
+            earliest=pendulum.DateTime(2025, 1, 31, tzinfo=utc), latest=None, catchup=False
+        ),
+    )
+    assert next_info == DagRunInfo.interval(
+        start=pendulum.DateTime(2026, 5, 28, tzinfo=utc),
+        end=pendulum.DateTime(2026, 6, 28, tzinfo=utc),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Human Summary
We encountered this issue in my work when we scheduled a Dag on a past `start_date` with `catchup=False` and schedule of `relativedelta(months=1)`. In the specific case, the data interval of the first run drifted in about 5 days that it should be (e..g, `2026-05-01` became `2025-05-06`). The problem was that in these case it calculates the date over multiplications of fixed 30 days since the Unix epoch (`1970-01-01`), which naturally leads to a drift due to different number of days in a month since then (there's an equivalent issue for using years due to leap years). This PR should fix it.


## AI Summary
<details>
<summary>Click here</summary>
Monthly and yearly schedules (`relativedelta(months=...)` / `relativedelta(years=...)`) produced mis-aligned, drifting data intervals when `catchup=False`.

`DeltaDataIntervalTimetable._skip_to_latest` (only reached on the `catchup=False` path) rounded "now" to a fixed **30-day / 365-day** grid anchored at the Unix epoch. Calendar months and years are not constant in length, so the first data interval after a Dag is unpaused never aligned to the Dag's `start_date`, and the chosen day-of-month walked backwards over time (e.g. `06-06 → 07-06 → 08-05 → 09-04`). The logical date a monthly Dag received therefore depended on *when* it happened to be unpaused rather than being a stable function of its schedule.

The fix anchors calendar-based deltas on `start_date` and advances one period at a time, so the boundaries match what `catchup=True` produces (including `relativedelta`'s path-dependent day-clamping, e.g. Jan 31 → Feb 28 → Mar 28). `timedelta` and fixed-unit `relativedelta` schedules are untouched — they keep the existing O(1) epoch rounding, which is correct for fixed deltas.

Added unit tests for monthly/yearly alignment, the no-`start_date` case, and day-clamping; all fail on the previous code and pass with the fix. The existing hourly `timedelta`/`relativedelta` and `catchup=True` tests guard the unchanged path.

</summary>
</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)