### PR TITLE
Add input validation to ExecutorConfigType bind and result processors

### DIFF
--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -344,8 +344,12 @@ class ExecutorConfigType(PickleType):
         super_process = super().bind_processor(dialect)
 
         def process(value):
+            if value is None:
+                return super_process(None)
+            if not isinstance(val_copy, dict):# and "pod_override" in val_copy:
+                raise TypeError(f"ExecutorConfigType bind expected a dict, got {type(value).__name__!r}")
             val_copy = copy.copy(value)
-            if isinstance(val_copy, dict) and "pod_override" in val_copy:
+            if "pod_override" in val_copy:
                 val_copy["pod_override"] = BaseSerialization.serialize(val_copy["pod_override"])
             return super_process(val_copy)
 
@@ -359,7 +363,13 @@ class ExecutorConfigType(PickleType):
         def process(value):
             value = super_process(value)  # unpickle
 
-            if isinstance(value, dict) and "pod_override" in value:
+            if value is None:
+                return(None)
+
+            if not isinstance(value, dict):
+                raise TypeError(f"ExecutorConfigType result expected a dict, got {type(value).__name__!r}")
+
+            if "pod_override" in value:
                 pod_override = value["pod_override"]
 
                 if isinstance(pod_override, dict) and pod_override.get(Encoding.TYPE):

--- a/airflow-core/tests/unit/utils/test_sqlalchemy.py
+++ b/airflow-core/tests/unit/utils/test_sqlalchemy.py
@@ -21,6 +21,7 @@ import datetime
 import pickle
 from copy import deepcopy
 from unittest import mock
+import dill
 
 import pytest
 from kubernetes.client import Configuration, models as k8s
@@ -380,3 +381,40 @@ class TestExecutorConfigType:
         pickle.dumps(fixed_pod)
         assert fixed_pod.local_vars_configuration.refresh_api_key_hook is None
         assert fixed_pod.spec.containers[0].local_vars_configuration.refresh_api_key_hook is None
+
+class TestExecutorConfigTypeValidation:
+    def setup_method(self):
+        self.session = Session()
+
+    def teardown_method(self):
+        self.session.close()
+
+    def test_bind_processor_rejects_non_dict(self):
+        col_type = ExecutorConfigType(pickler=dill)
+        process = col_type.bind_processor(self.session.bind.dialect)
+        with pytest.raises(TypeError, match="ExecutorConfigType bind expected a dict"):
+            process("not a dict")
+
+    def test_bind_processor_allows_none(self):
+        col_type = ExecutorConfigType(pickler=dill)
+        process = col_type.bind_processor(self.session.bind.dialect)
+        result = process(None)
+        assert result is None
+
+    def test_bind_processor_allows_valid_dict(self):
+        col_type = ExecutorConfigType(pickler=dill)
+        process = col_type.bind_processor(self.session.bind.dialect)
+        process({"key": "value"})  # should not raise
+
+    def test_result_processor_allows_none(self):
+        col_type = ExecutorConfigType(pickler=dill)
+        bind = col_type.bind_processor(self.session.bind.dialect)
+        result_proc = col_type.result_processor(self.session.bind.dialect, None)
+        assert result_proc(bind(None)) is None
+
+    def test_result_processor_rejects_non_dict(self):
+        col_type = ExecutorConfigType(pickler=dill)
+        result_proc = col_type.result_processor(self.session.bind.dialect, None)
+        raw = dill.dumps("corrupted string")
+        with pytest.raises(TypeError, match="ExecutorConfigType result expected a dict"):
+            result_proc(raw)


### PR DESCRIPTION
 Add input validation to ExecutorConfigType bind and result processors

ExecutorConfigType.bind_processor and result_processor did not validate their inputs. Passing a non-dict value would silently bypass the pod_override logic and either store unexpected data in the DB (on write) or return incorrect data (on read), with no helpful error message.
This PR adds:

- A None early-return in both processors (NULL is valid for DB columns)

- A TypeError with a descriptive message when the value is not a dict

- Tests covering both valid and invalid inputs for both processors

closes: #69011

Was generative AI tooling used to co-author this PR?

- [x]  Yes (please specify the tool below)
Claude, to help word this PR and to navigate the codebase

