### PR TITLE
Document PostgreSQL fallback host connection strings

### DIFF
--- a/airflow-core/docs/howto/set-up-database.rst
+++ b/airflow-core/docs/howto/set-up-database.rst
@@ -278,6 +278,14 @@ For more information regarding setup of the PostgreSQL connection, see `PostgreS
 
 .. note::
 
+   PostgreSQL connection strings can include multiple fallback hosts when you use the ``psycopg2`` driver.
+   Use SQLAlchemy's documented PostgreSQL URL format for this setup, because each fallback host must be
+   passed in a form that the SQLAlchemy dialect forwards correctly to libpq. See
+   `Specifying multiple fallback hosts <https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#specifying-multiple-fallback-hosts>`__
+   in the SQLAlchemy documentation.
+
+.. note::
+
    Airflow is known - especially in high-performance setup - to open many connections to metadata database. This might cause problems for
    Postgres resource usage, because in Postgres, each connection creates a new process and it makes Postgres resource-hungry when a lot
    of connections are opened. Therefore we recommend to use `PGBouncer <https://www.pgbouncer.org/>`_ as database proxy for all Postgres

--- a/airflow-core/docs/howto/set-up-database.rst
+++ b/airflow-core/docs/howto/set-up-database.rst
@@ -278,9 +278,8 @@ For more information regarding setup of the PostgreSQL connection, see `PostgreS
 
 .. note::
 
-   PostgreSQL connection strings can include multiple fallback hosts when you use the ``psycopg2`` driver.
-   Use SQLAlchemy's documented PostgreSQL URL format for this setup, because each fallback host must be
-   passed in a form that the SQLAlchemy dialect forwards correctly to libpq. See
+   PostgreSQL connection strings can include multiple fallback hosts. Use SQLAlchemy's documented PostgreSQL
+   URL format for this setup so each fallback host is passed correctly to the selected PostgreSQL driver. See
    `Specifying multiple fallback hosts <https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#specifying-multiple-fallback-hosts>`__
    in the SQLAlchemy documentation.
 

--- a/airflow-core/docs/howto/set-up-database.rst
+++ b/airflow-core/docs/howto/set-up-database.rst
@@ -278,10 +278,12 @@ For more information regarding setup of the PostgreSQL connection, see `PostgreS
 
 .. note::
 
-   PostgreSQL connection strings can include multiple fallback hosts. Use SQLAlchemy's documented PostgreSQL
-   URL format for this setup so each fallback host is passed correctly to the selected PostgreSQL driver. See
+   SQLAlchemy supports multiple fallback hosts for the psycopg2, psycopg, and asyncpg PostgreSQL dialects.
+   These dialects accept repeated ``host=<host>:<port>`` query parameters, with driver-specific port
+   requirements. See
    `Specifying multiple fallback hosts <https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#specifying-multiple-fallback-hosts>`__
-   in the SQLAlchemy documentation.
+   and `asyncpg Multihost Connections <https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#multihost-connections>`__
+   in the SQLAlchemy documentation for details.
 
 .. note::
 


### PR DESCRIPTION
**Title:** Document PostgreSQL fallback host connection strings (#25461)

## Summary

Document where Airflow users should look when they need PostgreSQL metadata database URLs with multiple fallback hosts. Airflow delegates this URL handling to SQLAlchemy's PostgreSQL dialects, so the setup guidance now points users to SQLAlchemy's current multiple-host syntax instead of leaving them to infer it from the generic PostgreSQL section.

## Changes

- **`airflow-core/docs/howto/set-up-database.rst`** -- add a PostgreSQL note that links to SQLAlchemy's documented multiple fallback host URL format.

## Evidence it works

- This is a docs-only change that points users to SQLAlchemy's PostgreSQL multiple-host URL syntax, which is the layer Airflow delegates database URL parsing to.
- The reviewer suggestion to avoid `psycopg2`-specific wording is already applied, so the note now refers to PostgreSQL drivers generally.

## Test plan

- [x] `git diff --check`
- [x] `prek run --stage pre-commit --files airflow-core/docs/howto/set-up-database.rst`
- [x] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #25461
