### PR TITLE
Clarify custom-time parameterized timetable logic (#34897)

### DIFF
--- a/airflow-core/docs/howto/timetable.rst
+++ b/airflow-core/docs/howto/timetable.rst
@@ -229,6 +229,13 @@ purpose, we'd want to do something like:
                 run_after=DateTime.combine(end.date(), self._schedule_at).replace(tzinfo=UTC),
             )
 
+If you adapt the first-run logic from ``AfterWorkdayTimetable`` for a custom
+``schedule_at`` value, compare the candidate time with ``self._schedule_at``.
+The midnight-specific check in the earlier example is only correct when runs
+are scheduled at ``00:00``. For example, an earliest time of ``06:00`` should
+still allow an ``08:00`` same-day run, while an earliest time of ``09:00`` should
+move to the next workday.
+
 However, since the timetable is a part of the Dag, we need to tell Airflow how
 to serialize it with the context we provide in ``__init__``. This is done by
 implementing two additional methods on our timetable class:


### PR DESCRIPTION
**Title:** Clarify custom-time parameterized timetable logic (#34897)

## Summary

Clarify the parameterized timetable example so users know to compare the candidate time against their custom `schedule_at` value. The earlier midnight-specific rule from `AfterWorkdayTimetable` does not carry over once the run time is configurable.

## Changes

- **`airflow-core/docs/howto/timetable.rst`** -- add a short note explaining the same-day versus next-workday boundary for parameterized run times.

## Test plan

- [x] `git diff --check`
- [x] `prek run --stage pre-commit --files airflow-core/docs/howto/timetable.rst`
- [ ] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #34897
