### PR TITLE
Document native template rendering type coercion (#34641)

### DIFF
--- a/airflow-core/docs/core-concepts/operators.rst
+++ b/airflow-core/docs/core-concepts/operators.rst
@@ -303,6 +303,13 @@ Alternatively, Jinja can also be instructed to render a native Python object. Th
             python_callable=transform,
         )
 
+.. note::
+
+    ``NativeEnvironment`` renders values according to Python literal rules. This is useful when a template
+    should produce a list, dict, number, or boolean, but it also means a string that looks like a number,
+    such as ``"42"``, can be rendered as the integer ``42``. Keep the default string rendering, use a
+    callable template field, or add explicit quoting if the task needs the value to stay a string.
+
 
 .. _concepts:reserved-keywords:
 

--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -145,6 +145,11 @@ This way, the :class:`~airflow.sdk.definitions.param.Param`'s type is respected 
         ),
     )
 
+Because ``render_template_as_native_obj=True`` uses Jinja's native rendering, values that look like
+Python literals can also be converted. For example, a string value of ``"42"`` may be rendered as the
+integer ``42``. Leave native rendering disabled, use a callable template field, or quote the value
+explicitly when the task must receive a string.
+
 Another way to access your param is via a task's ``context`` kwarg.
 
 .. code-block::


### PR DESCRIPTION
**Title:** Document native template rendering type coercion (#34641)

## Summary

Document that `render_template_as_native_obj=True` uses Jinja native rendering and can coerce numeric-looking strings into Python numbers. This keeps the current behavior intact while making the tradeoff clear in both the operator templating docs and the Params docs.

## Changes

- **`airflow-core/docs/core-concepts/operators.rst`** -- add a note that `NativeEnvironment` follows Python literal rules and can convert strings such as `"42"` to `42`.
- **`airflow-core/docs/core-concepts/params.rst`** -- add the same caution where typed Params and native template rendering are introduced.

## Test plan

- [x] `git diff --check`
- [x] `prek run --stage pre-commit --files airflow-core/docs/core-concepts/operators.rst airflow-core/docs/core-concepts/params.rst`
- [ ] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #34641
