### PR TITLE
Document LocalFilesystemBackend config secrets (#41512)

### DIFF
--- a/airflow-core/docs/howto/set-config.rst
+++ b/airflow-core/docs/howto/set-config.rst
@@ -95,6 +95,9 @@ the key like this:
 
 This will retrieve config option from Secret Backends e.g Hashicorp Vault. See
 :ref:`Secrets Backends<secrets_backend_configuration>` for more details.
+For the :ref:`Local Filesystem Secrets Backend <local_filesystem_secrets>`, configuration values
+are read from ``configs_file_path``. They are separate from values loaded through
+``variables_file_path`` or ``connections_file_path``.
 
 The following config options support this ``_cmd`` and ``_secret`` version:
 

--- a/airflow-core/docs/security/secrets/secrets-backend/local-filesystem-secrets-backend.rst
+++ b/airflow-core/docs/security/secrets/secrets-backend/local-filesystem-secrets-backend.rst
@@ -35,6 +35,7 @@ Available parameters to ``backend_kwargs``:
 
 * ``variables_file_path``: File location with variables data.
 * ``connections_file_path``: File location with connections data.
+* ``configs_file_path``: File location with configuration data used by ``*_secret`` config options.
 
 Here is a sample configuration:
 
@@ -42,7 +43,7 @@ Here is a sample configuration:
 
     [secrets]
     backend = airflow.secrets.local_filesystem.LocalFilesystemBackend
-    backend_kwargs = {"variables_file_path": "/files/var.json", "connections_file_path": "/files/conn.json"}
+    backend_kwargs = {"variables_file_path": "/files/var.json", "connections_file_path": "/files/conn.json", "configs_file_path": "/files/config.json"}
 
 ``JSON``, ``YAML`` and ``.env`` files are supported. All parameters are optional. If the file path is not passed,
 the backend returns an empty collection.
@@ -143,3 +144,27 @@ describe the variable value. The following is a sample file.
 
     VAR_A=some_value
     var_B=different_value
+
+Storing and Retrieving Configuration Values
+"""""""""""""""""""""""""""""""""""""""""""
+
+If you have set ``configs_file_path`` as ``/files/my_config.json``, then the backend will read the
+file ``/files/my_config.json`` when a supported Airflow configuration option uses a ``*_secret``
+setting. For example, ``sql_alchemy_conn_secret = sql_alchemy_conn`` looks up ``sql_alchemy_conn``
+in the configuration file, not in the variables or connections files.
+
+The file can be defined in ``JSON``, ``YAML`` or ``env`` format. The JSON file must contain an object
+where the key contains the configuration secret name and the value contains the configuration value.
+The following is a sample JSON file.
+
+  .. code-block:: json
+
+    {
+        "sql_alchemy_conn": "postgresql+psycopg2://airflow_user:airflow_pass@localhost/airflow_db"
+    }
+
+The following is the same configuration in a ``.env`` file.
+
+  .. code-block:: text
+
+    sql_alchemy_conn=postgresql+psycopg2://airflow_user:airflow_pass@localhost/airflow_db


### PR DESCRIPTION
**Title:** Document LocalFilesystemBackend config secrets (#41512)

## Summary

Document how `LocalFilesystemBackend` serves Airflow configuration values for `*_secret` options. The backend uses `configs_file_path` for configuration lookups, so users should not expect values from `variables_file_path` or `connections_file_path` to populate config options such as `sql_alchemy_conn_secret`.

## Changes

- **`airflow-core/docs/security/secrets/secrets-backend/local-filesystem-secrets-backend.rst`** -- document `configs_file_path` and add examples for config secret files.
- **`airflow-core/docs/howto/set-config.rst`** -- clarify that Local Filesystem config secrets are separate from variables and connections.

## Evidence it works

- `LocalFilesystemBackend.__init__` accepts a separate `configs_file_path`.
- `LocalFilesystemBackend.get_config()` reads from `_local_configs`, while `get_variable()` and `get_connection()` read from separate variable and connection files.
- This PR only documents the current behavior and does not claim that variable or connection files populate config secrets.

## Test plan

- [x] `git diff --check`
- [x] `prek run --stage pre-commit --files airflow-core/docs/security/secrets/secrets-backend/local-filesystem-secrets-backend.rst airflow-core/docs/howto/set-config.rst`
- [x] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #41512
