### PR TITLE
Update multi-node executor guidance (#48605)

### DIFF
--- a/airflow-core/docs/administration-and-deployment/production-deployment.rst
+++ b/airflow-core/docs/administration-and-deployment/production-deployment.rst
@@ -63,7 +63,7 @@ the :doc:`Kubernetes executor <apache-airflow-providers-cncf-kubernetes:kubernet
 Amazon provider executors such as :doc:`Batch <apache-airflow-providers-amazon:executors/batch-executor>`
 or :doc:`ECS <apache-airflow-providers-amazon:executors/ecs-executor>`, and the
 :doc:`Edge executor <apache-airflow-providers-edge3:edge_executor>`. See the
-:ref:`executor comparison <executor-types-comparison>` for the current list and tradeoffs.
+:ref:`executor comparison <executor-types-comparison>` for the current list and trade-offs.
 
 
 Once you have configured the executor, it is necessary to make sure that every node in the cluster contains

--- a/airflow-core/docs/administration-and-deployment/production-deployment.rst
+++ b/airflow-core/docs/administration-and-deployment/production-deployment.rst
@@ -57,8 +57,13 @@ Multi-Node Cluster
 ==================
 
 Airflow uses :class:`~airflow.executors.local_executor.LocalExecutor` by default. For a multi-node setup,
-you should use the :doc:`Kubernetes executor <apache-airflow-providers-cncf-kubernetes:kubernetes_executor>` or
-the :doc:`Celery executor <apache-airflow-providers-celery:celery_executor>`.
+choose a remote executor, or a multi-executor configuration, that matches where tasks should run.
+Common choices include the :doc:`Celery executor <apache-airflow-providers-celery:celery_executor>`,
+the :doc:`Kubernetes executor <apache-airflow-providers-cncf-kubernetes:kubernetes_executor>`,
+Amazon provider executors such as :doc:`Batch <apache-airflow-providers-amazon:executors/batch-executor>`
+or :doc:`ECS <apache-airflow-providers-amazon:executors/ecs-executor>`, and the
+:doc:`Edge executor <apache-airflow-providers-edge3:edge_executor>`. See the
+:ref:`executor comparison <executor-types-comparison>` for the current list and tradeoffs.
 
 
 Once you have configured the executor, it is necessary to make sure that every node in the cluster contains


### PR DESCRIPTION
## Summary

Update the production deployment guide so multi-node deployments point readers to the current remote-executor and multi-executor guidance instead of naming only Celery and Kubernetes.

## Changes

- **`airflow-core/docs/administration-and-deployment/production-deployment.rst`** -- mention remote executors, multi-executor configuration, current executor examples, and the executor comparison.

## Test plan

- [x] `git diff --check`
- [x] `prek run --stage pre-commit --files airflow-core/docs/administration-and-deployment/production-deployment.rst`
- [ ] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #48605
