### PR TITLE
Filter stale Dag tags from public API (#66827)

### DIFF
--- a/airflow-core/newsfragments/69156.bugfix.rst
+++ b/airflow-core/newsfragments/69156.bugfix.rst
@@ -1,1 +1,0 @@
-Hide stale-only Dag tags from the public Dag tags API.

--- a/airflow-core/newsfragments/69156.bugfix.rst
+++ b/airflow-core/newsfragments/69156.bugfix.rst
@@ -1,0 +1,1 @@
+Hide stale-only Dag tags from the public Dag tags API.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py
@@ -21,7 +21,7 @@ from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import Depends
-from sqlalchemy import select
+from sqlalchemy import false, select
 
 from airflow.api_fastapi.common.db.common import (
     SessionDep,
@@ -37,7 +37,7 @@ from airflow.api_fastapi.common.parameters import (
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.dag_tags import DAGTagCollectionResponse
 from airflow.api_fastapi.core_api.security import ReadableTagsFilterDep, requires_access_dag
-from airflow.models.dag import DagTag
+from airflow.models.dag import DagModel, DagTag
 
 dag_tags_router = AirflowRouter(tags=["DAG"], prefix="/dagTags")
 
@@ -61,7 +61,12 @@ def get_dag_tags(
     session: SessionDep,
 ) -> DAGTagCollectionResponse:
     """Get all Dag tags."""
-    query = select(DagTag.name).group_by(DagTag.name)
+    query = (
+        select(DagTag.name)
+        .join(DagModel, DagModel.dag_id == DagTag.dag_id)
+        .where(DagModel.is_stale == false())
+        .group_by(DagTag.name)
+    )
     dag_tags_select, total_entries = paginated_select(
         statement=query,
         filters=[tag_name_pattern, tag_name_prefix_pattern, readable_tags_filter],

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py
@@ -100,8 +100,8 @@ class TestDagEndpoint:
 
     def _create_dag_tags(self, session=None):
         session.add(DagTag(dag_id=DAG1_ID, name="tag_2"))
-        session.add(DagTag(dag_id=DAG2_ID, name="tag_1"))
         session.add(DagTag(dag_id=DAG3_ID, name="tag_1"))
+        session.add(DagTag(dag_id=DAG3_ID, name="stale_only"))
 
     @pytest.fixture(autouse=True)
     @provide_session
@@ -130,6 +130,7 @@ class TestDagEndpoint:
             params={"foo": 1},
             max_active_tasks=16,
             max_active_runs=16,
+            tags=["tag_1"],
         ):
             EmptyOperator(task_id=TASK_ID)
 
@@ -192,6 +193,12 @@ class TestDagTags(TestDagEndpoint):
             # test with tag_name_pattern
             (
                 {"tag_name_pattern": "invalid"},
+                200,
+                [],
+                0,
+            ),
+            (
+                {"tag_name_pattern": "stale_only"},
                 200,
                 [],
                 0,


### PR DESCRIPTION
**Title:** Filter stale Dag tags from public API (#66827)

## Summary
The public Dag tags endpoint returned tag names directly from `dag_tag`, so tags attached only to stale Dags could remain visible in the UI filter after the Dag file was removed. This filters tags through non-stale `DagModel` rows while preserving tags that are still attached to active Dags.

## Changes
- **`airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py`** -- join `DagTag` through `DagModel` and exclude stale Dag rows before grouping tag names.
- **`airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py`** -- add a stale-only tag case while keeping a shared active/stale tag to prove active tags are not dropped.

## Screenshot
![PR 69156 stale Dag tags comparison](https://raw.githubusercontent.com/deepujain/airflow/pr-artifacts/69156-dag-tags-screenshot/pr-artifacts/69156-dag-tags-comparison.png)

## Test plan
- [x] `ruff format --check airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py`
- [x] `ruff check airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_tags.py airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py`
- [x] `AIRFLOW_HOME=/private/tmp/airflow-test-66827 uvx --from uv==0.11.21 uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_tags.py::TestDagTags::test_get_dag_tags -xvs --with-db-init`
- [x] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #66827
