### PR TITLE
Preserve Dataform workflow invocation config

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataform.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataform.py
@@ -187,6 +187,8 @@ class DataformHook(GoogleBaseHook):
         """
         client = self.get_dataform_client()
         parent = f"projects/{project_id}/locations/{region}/repositories/{repository_id}"
+        if isinstance(workflow_invocation, dict):
+            workflow_invocation = WorkflowInvocation(workflow_invocation)
         return client.create_workflow_invocation(
             request={"parent": parent, "workflow_invocation": workflow_invocation},
             retry=retry,

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataform.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataform.py
@@ -50,6 +50,12 @@ WORKFLOW_INVOCATION = {
         f"{REPOSITORY_ID}/compilationResults/{COMPILATION_RESULT_ID}"
     ),
 }
+FULL_REFRESH_WORKFLOW_INVOCATION = {
+    **WORKFLOW_INVOCATION,
+    "invocation_config": {
+        "fully_refresh_incremental_tables_enabled": True,
+    },
+}
 WORKFLOW_INVOCATION_ID = "test_workflow_invocation_id"
 PATH_TO_FOLDER = "path/to/folder"
 FILEPATH = "path/to/file.txt"
@@ -113,11 +119,26 @@ class TestDataformHook:
         )
         parent = f"projects/{PROJECT_ID}/locations/{REGION}/repositories/{REPOSITORY_ID}"
         mock_client.return_value.create_workflow_invocation.assert_called_once_with(
-            request=dict(parent=parent, workflow_invocation=WORKFLOW_INVOCATION),
+            request=dict(parent=parent, workflow_invocation=WorkflowInvocation(WORKFLOW_INVOCATION)),
             retry=DEFAULT,
             timeout=None,
             metadata=(),
         )
+
+    @mock.patch(DATAFORM_STRING.format("DataformHook.get_dataform_client"))
+    def test_create_workflow_invocation_preserves_invocation_config_from_dict(self, mock_client):
+        self.hook.create_workflow_invocation(
+            project_id=PROJECT_ID,
+            region=REGION,
+            repository_id=REPOSITORY_ID,
+            workflow_invocation=FULL_REFRESH_WORKFLOW_INVOCATION,
+        )
+
+        request = mock_client.return_value.create_workflow_invocation.call_args.kwargs["request"]
+        workflow_invocation = request["workflow_invocation"]
+        assert isinstance(workflow_invocation, WorkflowInvocation)
+        assert workflow_invocation.compilation_result == WORKFLOW_INVOCATION["compilation_result"]
+        assert workflow_invocation.invocation_config.fully_refresh_incremental_tables_enabled is True
 
     @mock.patch(DATAFORM_STRING.format("DataformHook.get_dataform_client"))
     def test_get_workflow_invocation(self, mock_client):


### PR DESCRIPTION
**Title:** Preserve Dataform workflow invocation config

## Summary

`DataformHook.create_workflow_invocation` now normalizes dict-based workflow invocation payloads into a `WorkflowInvocation` proto before passing the request to the generated Dataform client.

This keeps the public operator input unchanged while making nested proto fields explicit. In particular, `invocation_config.fully_refresh_incremental_tables_enabled` is now covered by a regression test so full-refresh workflow invocation configs are not dropped at the hook boundary.

## Changes

- **`providers/google/src/airflow/providers/google/cloud/hooks/dataform.py`** -- coerce dict workflow invocation payloads into the generated `WorkflowInvocation` proto before calling the Dataform client.
- **`providers/google/tests/unit/google/cloud/hooks/test_dataform.py`** -- add a regression that passes the issue's dict-shaped `invocation_config` and verifies `fully_refresh_incremental_tables_enabled=True` reaches the client request.

## Evidence it works

- The regression follows the issue's reported operator input shape: a dict workflow invocation with nested `invocation_config`.
- The test asserts the generated client receives a proto request with the nested full-refresh flag preserved.

## Test plan

- [x] `uvx --from uv==0.11.21 uv run --project providers/google ruff format --check providers/google/src/airflow/providers/google/cloud/hooks/dataform.py providers/google/tests/unit/google/cloud/hooks/test_dataform.py`
- [x] `uvx --from uv==0.11.21 uv run --project providers/google ruff check providers/google/src/airflow/providers/google/cloud/hooks/dataform.py providers/google/tests/unit/google/cloud/hooks/test_dataform.py`
- [x] `AIRFLOW_HOME=/private/tmp/airflow-test-53843 uvx --from uv==0.11.21 uv run --project providers/google pytest providers/google/tests/unit/google/cloud/hooks/test_dataform.py::TestDataformHook::test_create_workflow_invocation providers/google/tests/unit/google/cloud/hooks/test_dataform.py::TestDataformHook::test_create_workflow_invocation_preserves_invocation_config_from_dict -xvs --with-db-init`
- [x] CI passes

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

Fixes #53843
