### PR TITLE
Test fix in main Celery worker tests leaking logging handler onto captured stdout

### DIFF
--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -45,6 +45,17 @@ from tests_common.test_utils.version_compat import (
 PY313 = sys.version_info >= (3, 13)
 
 
+@pytest.fixture(autouse=True)
+def _stub_worker_configure_logging():
+    # On Airflow 3.0+, worker() calls the real configure_logging(output=sys.stdout.buffer), leaking a
+    # handler onto pytest's captured stdout that raises "I/O operation on closed file" in later tests.
+    if not AIRFLOW_V_3_0_PLUS:
+        yield
+        return
+    with mock.patch("airflow.sdk.log.configure_logging"):
+        yield
+
+
 @pytest.fixture(autouse=False)
 def conf_stale_bundle_cleanup_disabled():
     with conf_vars({("dag_processor", "stale_bundle_cleanup_interval"): "0"}):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

The Celery worker CLI tests call the real `configure_logging(output=sys.stdout.buffer)`, which installs a logging handler on pytest's captured stdout. Once the capture buffer closes, every later test's setup/teardown logging fails with `I/O operation on closed file`, surfacing in the Postgres-backed Special test jobs (Pendulum2 / LatestBoto).

This adds an autouse fixture stubbing `configure_logging` (matching what `TestWorkerJsonLogs` already does per-test), so the handler is never installed

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
