### PR TITLE
Fix blank Assets dependency graph from missing Dag nodes

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/dependencies.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/dependencies.py
@@ -135,6 +135,19 @@ def get_scheduling_dependencies(readable_dag_ids: set[str] | None = None) -> dic
                     target = dep.target if ":" in dep.target else f"dag:{dep.target}"
                     edge_tuples.add((source, target))
 
+    # Create missing ``dag:`` nodes which may have been skipped by the loop above.
+    # A DAG referenced only as a trigger target or a sensor source may have no
+    # scheduling dependencies of its own. Without this loop, these DAGs will not be
+    # materialised and will result in dangling edges.
+    for source, target in edge_tuples:
+        for endpoint in (source, target):
+            if endpoint.startswith("dag:") and endpoint not in nodes_dict:
+                nodes_dict[endpoint] = {
+                    "id": endpoint,
+                    "label": endpoint.removeprefix("dag:"),
+                    "type": "dag",
+                }
+
     dag_ids = [node["label"] for node in nodes_dict.values() if node["type"] == "dag"]
     if dag_ids:
         dag_id_to_team = DagModel.get_dag_id_to_team_name_mapping(dag_ids)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_dependencies.py
@@ -147,6 +147,12 @@ def expected_primary_component_response(asset1_id):
                 "type": "dag",
                 "team": None,
             },
+            {
+                "id": "dag:other_dag",
+                "label": "other_dag",
+                "type": "dag",
+                "team": None,
+            },
         ],
     }
 
@@ -551,3 +557,27 @@ class TestGetDependencies:
         task_nodes = [node for node in result["nodes"] if node["type"] == "task"]
         assert len(task_nodes) == 1
         assert task_nodes[0]["team"] == "data-team"
+
+    def test_trigger_target_without_scheduling_dependencies_is_materialised(self, dag_maker, test_client):
+        """A DAG triggered via TriggerDagRunOperator that has no scheduling dependencies must still appear as a node"""
+        with dag_maker(dag_id="parent_dag", serialized=True):
+            TriggerDagRunOperator(task_id="trigger_child_dag", trigger_dag_id="child_dag")
+
+        with dag_maker(dag_id="child_dag", serialized=True):
+            EmptyOperator(task_id="some_task")
+
+        dag_maker.sync_dagbag_to_db()
+
+        response = test_client.get("/dependencies")
+        assert response.status_code == 200
+
+        result = response.json()
+        node_ids = {node["id"] for node in result["nodes"]}
+        assert "dag:child_dag" in node_ids
+
+        expected_edge = (
+            "trigger:parent_dag:child_dag:trigger_child_dag",
+            "dag:child_dag",
+        )
+        actual_edges = {(edge["source_id"], edge["target_id"]) for edge in result["edges"]}
+        assert expected_edge in actual_edges


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

# What
The scheduling dependencies endpoint is currently able to return an edge with a `dag:` endpoint that is never materialised as a node. This appears to be causing problems for the ELK renderer when creating the dependency graph in the Assets UI.

This PR adds a loop to backfill any `dag:` nodes that are referenced by an edge but are missing from the nodes set.

# Why

The scheduling view of the Assets dependency graph fails to render whenever it contains a Dag referenced by another Dag (e.g. via `TriggerDagRunOperator` or `ExternalTaskSensor`) and has no scheduling dependencies of its own.

The `get_scheduling_dependencies` function iterates over each Dag's dependencies to build a list of nodes and edges. A Dag is only materialised as a `dag:` node if it has at least one dependency of its own, but it is possible for the same Dag to be an endpoint of an edge if it is referenced by another Dag. This leaves a dangling edge whose endpoint is missing from the node set.

# Reproduction

Parent Dag

```python
from datetime import datetime

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
from airflow.sdk import DAG, Asset

PARENT_ASSET = Asset(name="parent_dag_asset", uri="s3://some-bucket/parent_dag_asset")

with DAG(dag_id="parent_dag", schedule=None, start_date=datetime(2021, 1, 1), catchup=False):
    emit = EmptyOperator(task_id="emit", outlets=[PARENT_ASSET])
    trigger = TriggerDagRunOperator(
        task_id="trigger_child_dag",
        trigger_dag_id="child_dag",
        wait_for_completion=False,
    )
    emit >> trigger
```

Child Dag

```python
from datetime import datetime

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.sdk import DAG

with DAG(dag_id="child_dag", schedule=None, start_date=datetime(2021, 1, 1), catchup=False):
    EmptyOperator(task_id="some_task")
```

## Before

Scheduling view

<img width="440" height="442" alt="image" src="https://github.com/user-attachments/assets/c3915e55-c21e-4a30-a6c7-f4af685168da" /><br>

`/ui/dependencies?dependency_type=scheduling` Response

```json
{
    "edges": [
        {
            "source_id": "dag:parent_dag",
            "target_id": "asset:1"
        },
        {
            "source_id": "dag:parent_dag",
            "target_id": "trigger:parent_dag:child_dag:trigger_child_dag"
        },
        {
            "source_id": "trigger:parent_dag:child_dag:trigger_child_dag",
            "target_id": "dag:child_dag"
        }
    ],
    "nodes": [
        {
            "id": "dag:parent_dag",
            "label": "parent_dag",
            "type": "dag",
            "team": null
        },
        {
            "id": "asset:1",
            "label": "parent_dag_asset",
            "type": "asset",
            "team": null
        },
        {
            "id": "trigger:parent_dag:child_dag:trigger_child_dag",
            "label": "trigger_child_dag",
            "type": "trigger",
            "team": null
        }
    ]
}
```

## After

Scheduling view
<img width="1206" height="1212" alt="image" src="https://github.com/user-attachments/assets/18bf8d41-f799-42cf-b130-04e2ed7c7211" /><br>

`/ui/dependencies?dependency_type=scheduling` Response
```json
{
    "edges": [
        {
            "source_id": "dag:parent_dag",
            "target_id": "asset:1"
        },
        {
            "source_id": "dag:parent_dag",
            "target_id": "trigger:parent_dag:child_dag:trigger_child_dag"
        },
        {
            "source_id": "trigger:parent_dag:child_dag:trigger_child_dag",
            "target_id": "dag:child_dag"
        }
    ],
    "nodes": [
        {
            "id": "dag:parent_dag",
            "label": "parent_dag",
            "type": "dag",
            "team": null
        },
        {
            "id": "asset:1",
            "label": "parent_dag_asset",
            "type": "asset",
            "team": null
        },
        {
            "id": "trigger:parent_dag:child_dag:trigger_child_dag",
            "label": "trigger_child_dag",
            "type": "trigger",
            "team": null
        },
        {
            "id": "dag:child_dag",
            "label": "child_dag",
            "type": "dag",
            "team": null
        }
    ]
}
```

Note node set now correctly includes id: `dag:child_dag`, so edge below is no longer dangling:
```json
{
      "source_id": "trigger:parent_dag:child_dag:trigger_child_dag",
      "target_id": "dag:child_dag"
  }
```


<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
