### PR TITLE
Check producer/consumer Dag run permissions in create_asset_event

### DIFF
--- a/airflow-core/newsfragments/69175.bugfix.rst
+++ b/airflow-core/newsfragments/69175.bugfix.rst
@@ -1,0 +1,1 @@
+The ``POST /assets/events`` API now enforces Dag-level ``access_control``. Creating an asset event requires permission to create runs on a producing Dag or on all consuming Dags.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, cast
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import and_, delete, func, select
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import joinedload, subqueryload
 
@@ -80,8 +80,11 @@ from airflow.models.asset import (
     AssetEvent,
     AssetModel,
     AssetWatcherModel,
+    DagScheduleAssetNameReference,
+    DagScheduleAssetUriReference,
     TaskOutletAssetReference,
 )
+from airflow.models.dag import DagModel
 from airflow.typing_compat import Unpack
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
@@ -372,6 +375,47 @@ def create_asset_event(
     asset_model = session.scalar(select(AssetModel).where(AssetModel.id == body.asset_id).limit(1))
     if not asset_model:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Asset with ID: `{body.asset_id}` was not found")
+
+    # Posting an asset event queues runs of its consuming Dags, so it must honor Dag-level
+    # access_control: allow only if the user can run a producing Dag or all consuming Dags.
+    # Producers are not pause-filtered because the user could re-run a producing Dag to re-emit
+    # the event; consumers mirror register_asset_change, which only queues unpaused Dags.
+    producer_dag_ids = {ref.dag_id for ref in asset_model.producing_tasks}
+    consumer_dag_ids = {ref.dag_id for ref in asset_model.scheduled_dags if not ref.dag.is_paused}
+    consumer_dag_ids.update(
+        session.scalars(
+            select(DagModel.dag_id)
+            .join(DagModel.schedule_asset_name_references, isouter=True)
+            .join(DagModel.schedule_asset_uri_references, isouter=True)
+            .where(
+                or_(
+                    DagScheduleAssetNameReference.name == asset_model.name,
+                    DagScheduleAssetUriReference.uri == asset_model.uri,
+                ),
+                DagModel.is_paused.is_(False),
+            )
+        )
+    )
+    if producer_dag_ids or consumer_dag_ids:
+        auth_manager = get_auth_manager()
+
+        def _is_authorized_for_dag(dag_id: str) -> bool:
+            return auth_manager.is_authorized_dag(
+                method="POST",
+                access_entity=DagAccessEntity.RUN,
+                details=DagDetails(id=dag_id),
+                user=user,
+            )
+
+        authorized = any(_is_authorized_for_dag(dag_id) for dag_id in producer_dag_ids) or (
+            bool(consumer_dag_ids) and all(_is_authorized_for_dag(dag_id) for dag_id in consumer_dag_ids)
+        )
+        if not authorized:
+            raise HTTPException(
+                status.HTTP_403_FORBIDDEN,
+                "User is not authorized to create an event for this asset.",
+            )
+
     timestamp = timezone.utcnow()
 
     api_user_teams: set[str] = set()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -34,7 +34,9 @@ from airflow.models.asset import (
     AssetEvent,
     AssetModel,
     AssetWatcherModel,
+    DagScheduleAssetNameReference,
     DagScheduleAssetReference,
+    DagScheduleAssetUriReference,
     TaskOutletAssetReference,
 )
 from airflow.models.dagrun import DagRun
@@ -297,6 +299,26 @@ class TestAssets:
     @provide_session
     def create_asset_dag_run(self, num: int = 2, *, session):
         _create_asset_dag_run(num=num, session=session)
+
+    def _make_mock_event(self, asset):
+        m = mock.MagicMock(
+            spec=AssetEvent,
+            id=1,
+            asset_id=asset.id,
+            uri=asset.uri,
+            group=asset.group,
+            extra={"from_rest_api": True},
+            source_map_index=-1,
+            timestamp=DEFAULT_DATE,
+            source_task_id=None,
+            source_dag_id=None,
+            source_run_id=None,
+            partition_key=None,
+            created_dagruns=[],
+        )
+        # MagicMock uses 'name' internally for repr, so it must be set separately.
+        m.name = asset.name
+        return m
 
 
 class TestGetAssets(TestAssets):
@@ -1329,6 +1351,153 @@ class TestPostAssetEvents(TestAssets):
         response = unauthorized_test_client.post("/assets/events", json={"asset_uri": "s3://bucket/key/1"})
         assert response.status_code == 403
 
+    @pytest.mark.usefixtures("time_freezer", "testing_dag_bundle")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager", autospec=True)
+    def test_should_respond_403_when_user_cannot_trigger_producer_or_consumer_dags(
+        self, mock_get_auth_manager, test_client, session
+    ):
+        mock_get_auth_manager.return_value.is_authorized_dag.return_value = False
+        (asset,) = self.create_assets(num=1, session=session)
+        session.add_all(
+            [
+                DagModel(dag_id="producer_dag", bundle_name="testing"),
+                DagModel(dag_id="consumer_dag", bundle_name="testing", is_paused=False),
+                TaskOutletAssetReference(dag_id="producer_dag", task_id="task1", asset=asset),
+                DagScheduleAssetReference(dag_id="consumer_dag", asset=asset),
+            ]
+        )
+        session.commit()
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id, "extra": {"foo": "bar"}})
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("time_freezer", "testing_dag_bundle")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager", autospec=True)
+    def test_should_respond_200_when_user_can_trigger_a_producing_dag(
+        self, mock_get_auth_manager, test_client, session
+    ):
+        mock_get_auth_manager.return_value.is_authorized_dag.side_effect = lambda **kwargs: (
+            kwargs["details"].id == "producer_dag"
+        )
+        (asset,) = self.create_assets(num=1, session=session)
+        session.add_all(
+            [
+                DagModel(dag_id="producer_dag", bundle_name="testing"),
+                DagModel(dag_id="consumer_dag", bundle_name="testing", is_paused=True),
+                TaskOutletAssetReference(dag_id="producer_dag", task_id="task1", asset=asset),
+                DagScheduleAssetReference(dag_id="consumer_dag", asset=asset),
+            ]
+        )
+        session.commit()
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id, "extra": {"foo": "bar"}})
+
+        assert response.status_code == 200
+
+    @pytest.mark.usefixtures("time_freezer", "testing_dag_bundle")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.asset_manager.register_asset_change")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager", autospec=True)
+    def test_should_respond_200_when_user_can_trigger_all_consuming_dags(
+        self, mock_get_auth_manager, mock_register, test_client, session
+    ):
+        mock_get_auth_manager.return_value.is_authorized_dag.return_value = True
+        (asset,) = self.create_assets(num=1, session=session)
+        mock_register.return_value = self._make_mock_event(asset)
+        session.add_all(
+            [
+                DagModel(dag_id="consumer_dag_1", bundle_name="testing", is_paused=False),
+                DagModel(dag_id="consumer_dag_2", bundle_name="testing", is_paused=False),
+                DagScheduleAssetReference(dag_id="consumer_dag_1", asset=asset),
+                DagScheduleAssetReference(dag_id="consumer_dag_2", asset=asset),
+            ]
+        )
+        session.commit()
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id, "extra": {"foo": "bar"}})
+
+        assert response.status_code == 200
+
+    @pytest.mark.usefixtures("time_freezer", "testing_dag_bundle")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager", autospec=True)
+    def test_should_respond_403_when_user_can_trigger_only_some_consuming_dags(
+        self, mock_get_auth_manager, test_client, session
+    ):
+        mock_get_auth_manager.return_value.is_authorized_dag.side_effect = lambda **kwargs: (
+            kwargs["details"].id == "consumer_dag_1"
+        )
+        (asset,) = self.create_assets(num=1, session=session)
+        session.add_all(
+            [
+                DagModel(dag_id="producer_dag", bundle_name="testing"),
+                DagModel(dag_id="consumer_dag_1", bundle_name="testing", is_paused=False),
+                DagModel(dag_id="consumer_dag_2", bundle_name="testing", is_paused=False),
+                TaskOutletAssetReference(dag_id="producer_dag", task_id="task1", asset=asset),
+                DagScheduleAssetReference(dag_id="consumer_dag_1", asset=asset),
+                DagScheduleAssetReference(dag_id="consumer_dag_2", asset=asset),
+            ]
+        )
+        session.commit()
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id, "extra": {"foo": "bar"}})
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("time_freezer", "testing_dag_bundle")
+    @pytest.mark.parametrize(
+        "make_reference",
+        [
+            pytest.param(
+                lambda asset: DagScheduleAssetNameReference(name=asset.name, dag_id="consumer_dag"),
+                id="name",
+            ),
+            pytest.param(
+                lambda asset: DagScheduleAssetUriReference(uri=asset.uri, dag_id="consumer_dag"),
+                id="uri",
+            ),
+        ],
+    )
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager", autospec=True)
+    def test_should_respond_403_when_user_cannot_trigger_name_or_uri_consuming_dag(
+        self, mock_get_auth_manager, test_client, session, make_reference
+    ):
+        mock_get_auth_manager.return_value.is_authorized_dag.return_value = False
+        (asset,) = self.create_assets(num=1, session=session)
+        session.add_all(
+            [
+                DagModel(dag_id="consumer_dag", bundle_name="testing", is_paused=False),
+                make_reference(asset),
+            ]
+        )
+        session.commit()
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id, "extra": {"foo": "bar"}})
+
+        assert response.status_code == 403
+
+    @pytest.mark.usefixtures("time_freezer", "testing_dag_bundle")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.asset_manager.register_asset_change")
+    @mock.patch("airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager", autospec=True)
+    def test_should_respond_200_when_user_can_trigger_name_and_uri_consuming_dags(
+        self, mock_get_auth_manager, mock_register, test_client, session
+    ):
+        mock_get_auth_manager.return_value.is_authorized_dag.return_value = True
+        (asset,) = self.create_assets(num=1, session=session)
+        mock_register.return_value = self._make_mock_event(asset)
+        session.add_all(
+            [
+                DagModel(dag_id="name_consumer_dag", bundle_name="testing", is_paused=False),
+                DagModel(dag_id="uri_consumer_dag", bundle_name="testing", is_paused=False),
+                DagScheduleAssetNameReference(name=asset.name, dag_id="name_consumer_dag"),
+                DagScheduleAssetUriReference(uri=asset.uri, dag_id="uri_consumer_dag"),
+            ]
+        )
+        session.commit()
+
+        response = test_client.post("/assets/events", json={"asset_id": asset.id, "extra": {"foo": "bar"}})
+
+        assert response.status_code == 200
+
     def test_invalid_attr_not_allowed(self, test_client, session):
         self.create_assets(session=session)
         event_invalid_payload = {"asset_uri": "s3://bucket/key/1", "extra": {"foo": "bar"}, "fake": {}}
@@ -1395,26 +1564,6 @@ class TestPostAssetEvents(TestAssets):
 
 class TestPostAssetEventsTeamResolution(TestAssets):
     """Tests for team-based filtering in create_asset_event."""
-
-    def _make_mock_event(self, asset):
-        m = mock.MagicMock(
-            spec=AssetEvent,
-            id=1,
-            asset_id=asset.id,
-            uri=asset.uri,
-            group=asset.group,
-            extra={"from_rest_api": True},
-            source_map_index=-1,
-            timestamp=DEFAULT_DATE,
-            source_task_id=None,
-            source_dag_id=None,
-            source_run_id=None,
-            partition_key=None,
-            created_dagruns=[],
-        )
-        # MagicMock uses 'name' internally for repr, so it must be set separately.
-        m.name = asset.name
-        return m
 
     @pytest.mark.usefixtures("time_freezer")
     @pytest.mark.parametrize(


### PR DESCRIPTION
The `create_asset_event` handler behind `POST /assets/events` is only guarded by `requires_access_asset(method="POST")` — the asset-level "create on Assets" permission. The event it creates is passed to `asset_manager.register_asset_change`, which enqueues `AssetDagRunQueue` rows for every consuming Dag scheduled on that asset, so the call effectively triggers downstream Dag runs without ever evaluating the Dag-level `access_control` those Dags define. A principal holding only the Assets "create" permission can therefore enqueue runs for Dags it has no run access to.

This adds the missing check. Before the event is created, the endpoint now confirms the caller can run at least one producing Dag, or every consuming Dag the event would trigger. The consuming Dags are resolved the same way `register_asset_change` does when it queues runs: a Dag counts if it schedules on the asset directly, or by the asset's name or URI and isn't paused. That keeps the permission check aligned with the Dags the event would actually trigger, so it never blocks more or less than it should. Producers aren't pause-filtered, since re-running a producing Dag would re-emit the event anyway.

Tests cover the producer-authorized, all-consumers-authorized, partial-consumer, and name/URI consumer cases.

closes: #42846