### PR TITLE
Document S3-compatible remote logging in the Amazon provider

### DIFF
--- a/providers/amazon/docs/logging/s3-compatible-remote-logging.rst
+++ b/providers/amazon/docs/logging/s3-compatible-remote-logging.rst
@@ -1,0 +1,209 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _write-logs-s3-compatible:
+
+Use an S3-compatible object store for Airflow remote task logs
+==============================================================
+
+The Amazon provider talks to any S3-compatible object store, not just Amazon S3. Because the
+:ref:`S3 remote task handler <write-logs-amazon-s3>` issues standard S3 API calls, pointing the
+``aws`` connection at a custom ``endpoint_url`` makes it write Airflow task logs to that
+endpoint with no new provider and no core change. You use the ``s3://`` scheme in
+``[logging]`` exactly as you would for Amazon S3, and the same connection also backs
+``ObjectStoragePath("s3://...")`` for Dag data.
+
+Amazon S3 is the baseline. The same steps work against other services that expose an
+S3-compatible API, for example Backblaze B2, Cloudflare R2, and MinIO. The only per-provider
+differences are the endpoint URL, the region, and whether path-style addressing is required.
+
+This recipe targets Airflow 3.x with ``apache-airflow-providers-amazon``.
+
+Prerequisites
+-------------
+
+- A bucket for logs (private). The examples use ``$S3_BUCKET_NAME``.
+- An access key and secret scoped to that bucket. Prefer a bucket-scoped key over an
+  account-wide one.
+- ``apache-airflow-providers-amazon`` installed. For ``ObjectStoragePath`` you also need the
+  ``s3fs`` extra: ``pip install 'apache-airflow-providers-amazon[s3fs]'``.
+
+Every S3-compatible service issues an access key id and a secret access key. Map them onto the
+AWS connection fields as follows.
+
+============================  =================================  =============================================
+S3-compatible value           Standardized env var               AWS connection field
+============================  =================================  =============================================
+Access key id                 ``S3_ACCESS_KEY_ID``               ``login`` (AWS access key id)
+Secret access key             ``S3_SECRET_ACCESS_KEY``           ``password`` (AWS secret access key)
+Bucket name                   ``S3_BUCKET_NAME``                 used in ``remote_base_log_folder``
+Region                        ``S3_REGION``                      ``extra.region_name``
+S3 endpoint                   ``S3_ENDPOINT``                    ``extra.endpoint_url``
+============================  =================================  =============================================
+
+Find the endpoint and region for your bucket in your provider's console or CLI. For Amazon S3
+the endpoint is the default AWS endpoint and you can omit ``endpoint_url`` entirely; for other
+S3-compatible services set ``endpoint_url`` to the provider's S3 endpoint, such as
+``https://your-s3-endpoint.example.com``. The connection ``extra.endpoint_url`` must include a
+scheme, for example ``https://`` or ``http://``.
+
+Step 1: Create the connection pointing at your endpoint
+-------------------------------------------------------
+
+Create an ``aws`` connection whose ``endpoint_url`` extra is your S3 endpoint. The Amazon
+provider sends every S3 call to that endpoint instead of the AWS default, which is what makes
+the S3 handler talk to your store. For Amazon S3 you can leave ``endpoint_url`` unset and the
+provider uses the default AWS endpoint.
+
+Using an environment-variable connection (no secrets on the command line):
+
+.. code-block:: bash
+
+    export AIRFLOW_CONN_AWS_S3='{
+      "conn_type": "aws",
+      "login": "'"$S3_ACCESS_KEY_ID"'",
+      "password": "'"$S3_SECRET_ACCESS_KEY"'",
+      "extra": {
+        "endpoint_url": "'"$S3_ENDPOINT"'",
+        "region_name": "'"$S3_REGION"'",
+        "config_kwargs": {"s3": {"addressing_style": "path"}}
+      }
+    }'
+
+The ``config_kwargs`` ``addressing_style: path`` selects path-style addressing
+(``endpoint/bucket/key``). Amazon S3 accepts both styles; several S3-compatible services expect
+path-style addressing, so set it when your provider requires it.
+
+The equivalent JSON when you create the connection in the UI (``Admin -> Connections``,
+connection type ``Amazon Web Services``) or store it in a secrets backend:
+
+.. code-block:: json
+
+    {
+      "conn_type": "aws",
+      "login": "<S3_ACCESS_KEY_ID>",
+      "password": "<S3_SECRET_ACCESS_KEY>",
+      "extra": {
+        "endpoint_url": "https://your-s3-endpoint.example.com",
+        "region_name": "us-east-1",
+        "config_kwargs": {"s3": {"addressing_style": "path"}}
+      }
+    }
+
+Never hardcode the secret access key in a Dag, ``airflow.cfg``, or version control. Read it
+from the environment or a secrets backend.
+
+Step 2: Enable remote logging to the bucket
+-------------------------------------------
+
+Configure the ``[logging]`` section of ``airflow.cfg`` (or the equivalent
+``AIRFLOW__LOGGING__*`` environment variables) so Airflow uploads task logs to the bucket
+through the connection from Step 1:
+
+.. code-block:: ini
+
+    [logging]
+    remote_logging = True
+    remote_base_log_folder = s3://<S3_BUCKET_NAME>/logs
+    remote_log_conn_id = aws_s3
+    # Some S3-compatible stores do not support server-side encryption headers; leave this off
+    # unless your store supports them.
+    encrypt_s3_logs = False
+
+The ``s3://`` scheme routes through the same S3 task handler used for Amazon S3
+(``S3TaskHandler``), which resolves ``S3Hook(aws_conn_id="aws_s3")`` and therefore inherits the
+endpoint from the connection extra. Restart the scheduler, the API server, the triggerer, and
+the workers so they pick up the new configuration.
+
+As environment variables:
+
+.. code-block:: bash
+
+    export AIRFLOW__LOGGING__REMOTE_LOGGING=True
+    export AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER="s3://${S3_BUCKET_NAME}/logs"
+    export AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID=aws_s3
+
+The access key needs the equivalent of ``s3:ListBucket`` on the bucket and ``s3:GetObject`` /
+``s3:PutObject`` on the log prefix. A key scoped to the bucket with read and write capabilities
+covers this.
+
+Step 3: Verify
+--------------
+
+- Trigger any example Dag and let a task finish.
+- Confirm the objects appear under ``s3://<S3_BUCKET_NAME>/logs/`` in your provider's console
+  or with any S3 client (for example ``aws s3 ls s3://<S3_BUCKET_NAME>/logs/ --endpoint-url
+  "$S3_ENDPOINT"``).
+- Open the task log in the Airflow UI. The log is served from the remote store; a banner notes
+  that the log was read from the remote location.
+
+Reusing the connection for Dag data
+-----------------------------------
+
+The same ``aws_s3`` connection backs ``ObjectStoragePath`` for reading and writing Dag data,
+because ``ObjectStoragePath("s3://...")`` builds an ``s3fs`` filesystem from the connection and
+inherits the same ``endpoint_url``:
+
+.. code-block:: python
+
+    from airflow.sdk import ObjectStoragePath
+
+    base = ObjectStoragePath("s3://aws_s3@my-bucket/airflow-demo/")
+
+See the example Dag ``example_s3_compatible_object_storage`` for an input to transform to
+output pipeline against an S3-compatible store.
+
+Troubleshooting
+---------------
+
+- ``SignatureDoesNotMatch`` or ``403``: re-check that ``endpoint_url`` includes a URL scheme,
+  that ``region_name`` matches the bucket's region, and that ``login`` / ``password`` hold the
+  access key id and secret access key for a key scoped to the bucket.
+- Logs stay local only: confirm ``remote_logging = True`` and that the components were
+  restarted. ``remote_base_log_folder`` must start with ``s3://``.
+- ``ImportError`` for ``s3fs`` when using ``ObjectStoragePath``: install the extra with
+  ``pip install 'apache-airflow-providers-amazon[s3fs]'``.
+
+Trigger Dags from bucket event notifications
+--------------------------------------------
+
+Beyond logs and data, the same bucket can drive upload-triggered pipelines. Many S3-compatible
+services can send a webhook when an object is created or deleted in a bucket, and Airflow
+exposes a REST endpoint that creates a Dag run. Wiring the two together turns an upload into an
+Airflow Dag run, with no polling sensor.
+
+The flow is: a client uploads an object to the bucket; the object store posts an
+event-notification payload to an HTTPS webhook you control (for example a small function or API
+gateway); that webhook authenticates to the Airflow REST API and triggers the Dag, passing the
+object key in the run configuration. The endpoint is ``POST /api/v2/dags/{dag_id}/dagRuns``
+with a JSON body that accepts ``logical_date``, an optional ``dag_run_id``, and a ``conf``
+object. Put the object key from the notification into ``conf`` so the Dag knows which object to
+process:
+
+.. code-block:: bash
+
+    curl -X POST "$AIRFLOW_API/api/v2/dags/s3_event_ingestion/dagRuns" \
+      -H "Authorization: Bearer $AIRFLOW_JWT" \
+      -H "Content-Type: application/json" \
+      -d '{"logical_date": "2026-01-01T00:00:00Z", "conf": {"object_key": "incoming/file.txt"}}'
+
+A Dag built for this pattern can read ``conf["object_key"]`` and process that object straight
+from the store with ``ObjectStoragePath(f"s3://aws_s3@{bucket}/{object_key}")``, reusing the
+connection from Step 1. Keep the webhook thin: validate the notification, mint or hold a
+short-lived Airflow API token, and forward only the object key. This pattern fits ingestion
+pipelines such as transcode on upload or index on upload, where work should start the moment
+data lands in the bucket.

--- a/providers/amazon/tests/system/amazon/aws/example_s3_compatible_object_storage.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_compatible_object_storage.py
@@ -1,0 +1,104 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Dag: input -> transform -> output on an S3-compatible object store via ``ObjectStoragePath``.
+
+The Amazon provider talks to any S3-compatible object store, so ``ObjectStoragePath("s3://...")``
+reaches the store through the Amazon provider once the ``aws`` connection points at its S3
+endpoint. Amazon S3 is the baseline; the same code works against other S3-compatible services
+(for example Backblaze B2, Cloudflare R2, and MinIO). See the recipe "Use an S3-compatible object
+store for Airflow remote task logs" for connection and ``[logging]`` setup.
+
+Set up an ``aws`` connection (default id ``aws_s3``) whose ``extra`` includes the S3
+``endpoint_url`` and ``region_name``. The bucket name comes from ``S3_BUCKET_NAME``.
+
+Requires the s3fs extra: ``pip install 'apache-airflow-providers-amazon[s3fs]'``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+import pytest
+
+from airflow.sdk import ObjectStoragePath, dag, task
+
+DAG_ID = "example_s3_compatible_object_storage"
+
+# Connection id and bucket are read from the environment so the example carries no secrets.
+S3_CONN_ID = os.environ.get("S3_CONN_ID", "aws_s3")
+S3_BUCKET_NAME_PLACEHOLDER = "replace-with-your-s3-bucket"
+S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", S3_BUCKET_NAME_PLACEHOLDER)
+BASE_URI = f"s3://{S3_CONN_ID}@{S3_BUCKET_NAME}/airflow-demo/"
+
+
+def _base_path() -> ObjectStoragePath:
+    if S3_BUCKET_NAME == S3_BUCKET_NAME_PLACEHOLDER:
+        raise ValueError("Set S3_BUCKET_NAME to a real bucket name before running this Dag.")
+    return ObjectStoragePath(BASE_URI) / os.environ.get("AIRFLOW_CTX_DAG_RUN_ID", "manual")
+
+
+@dag(
+    dag_id=DAG_ID,
+    schedule=None,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    tags=["example", "s3-compatible", "object-storage"],
+)
+def example_s3_compatible_object_storage():
+    """Write input to the object store, transform it, and write the output back."""
+
+    @task
+    def input_to_store() -> str:
+        """Write a raw input object to the store and return its path."""
+        base = _base_path()
+        base.mkdir(exist_ok=True)
+        src = base / "input.txt"
+        src.write_text("s3\ncompatible\nobject\nstorage\n")
+        return str(src)
+
+    @task
+    def transform(src_path: str) -> str:
+        """Read the input from the store, uppercase it, and write the result back."""
+        src = ObjectStoragePath(src_path)
+        text = src.read_text()
+        base = _base_path()
+        dst = base / "output.txt"
+        dst.write_text(text.upper())
+        return str(dst)
+
+    @task
+    def output_from_store(dst_path: str) -> None:
+        """Read the transformed object back from the store to confirm the round-trip."""
+        dst = ObjectStoragePath(dst_path)
+        print(dst.read_text())
+
+    output_from_store(transform(input_to_store()))
+
+
+dag = example_s3_compatible_object_storage()
+
+
+from tests_common.test_utils.system_tests import get_test_run  # noqa: E402
+
+# Needed to run the example DAG with pytest (see: contributing-docs/testing/system_tests.rst)
+test_run = pytest.mark.skipif(
+    S3_BUCKET_NAME == S3_BUCKET_NAME_PLACEHOLDER,
+    reason="Set S3_BUCKET_NAME to run this system test.",
+)(get_test_run(dag))


### PR DESCRIPTION
Add a docs recipe and a system-test example Dag showing how to reuse the existing Amazon provider S3 integration against any S3-compatible object store.

The Amazon provider already talks to S3-compatible endpoints: pointing an `aws` connection at a custom `endpoint_url` makes the S3 task handler and `ObjectStoragePath("s3://...")` write to that endpoint instead of AWS S3. That capability is not documented from the "bring your own S3-compatible bucket" angle, so users rediscover the connection extras (`endpoint_url`, `region_name`, path-style addressing) by trial and error. This change writes that path down. Amazon S3 is the baseline, and the recipe notes that the same steps work against other S3-compatible services (for example Backblaze B2, Cloudflare R2, and MinIO), using placeholder endpoints so the steps are copy-pasteable against any of them.

The change is intentionally small and additive: it adds documentation and one example, and touches no provider or core code.

What is included:

- `providers/amazon/docs/logging/s3-compatible-remote-logging.rst`: a recipe that maps S3-compatible credentials onto the AWS connection fields, configures `[logging]` remote logging through that connection, verifies the logs land in the bucket, reuses the same connection for `ObjectStoragePath` Dag data, and sketches a generic bucket-event ingestion pattern. It cross-references the existing `write-logs-amazon-s3` handler doc rather than restating it, and it is picked up automatically by the globbed toctree in `providers/amazon/docs/logging/index.rst` (no manual index edit needed).
- `providers/amazon/tests/system/amazon/aws/example_s3_compatible_object_storage.py`: an input to transform to output example Dag built on `ObjectStoragePath`, sitting alongside the other `example_s3*.py` system tests and wired through the standard `get_test_run(dag)` harness. Bucket and connection id are read from the environment so the example carries no secrets; the default placeholder skips the system test until a real bucket is configured, and each run writes under a `AIRFLOW_CTX_DAG_RUN_ID` subdirectory to avoid overwriting parallel or repeated runs.

Scope notes for reviewers:

- No new operator, hook, bundle, or `provider.yaml` entry: this documents existing behavior, so there is nothing new for the registry to pick up.
- The framing is generic S3-compatible object storage. AWS S3 is the baseline; other providers are named only as interchangeable examples with placeholder endpoints.
- No newsfragment: per the contributor docs, `providers/` changelogs are regenerated from `git log` by the release managers and do not consume per-PR newsfragments.

Testing:

- Built the provider docs locally and confirmed the new page renders and appears under the Amazon provider "Logging for Tasks" section, with the cross-reference to the S3 task handler resolving.
- The example Dag is a system test (network access to a real bucket required to execute against a live endpoint) and follows the existing `example_s3*.py` structure; the module imports and parses cleanly and exposes `test_run` via `get_test_run(dag)`.
- Ran targeted Ruff format/check on the new Python file after Python review fixes; docs-only follow-ups were checked with `git diff --check`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code, Opus 4.8; Codex, GPT-5)

Generated-by: Claude Code (Opus 4.8) and Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.


<!-- pr-triage-fold: triaged=2026-07-15T16:00:05Z head=50ecc5a action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @goanpeca** · by `@potiuk` · 2026-07-15 16:00 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Other failing CI checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
