### PR TITLE
Fix nil sdk.XComClient injected into Go SDK tasks

### DIFF
--- a/go-sdk/bundle/bundlev1/registry.go
+++ b/go-sdk/bundle/bundlev1/registry.go
@@ -48,8 +48,8 @@ type (
 		// and may appear in any order. Recognised parameters are:
 		//   - context.Context: cancelled when the task is asked to stop
 		//   - *slog.Logger: writes to the task's Airflow log
-		//   - sdk.Client (or a narrower sdk.VariableClient / sdk.ConnectionClient):
-		//     access to Variables, Connections, and XCom
+		//   - sdk.Client (or a narrower sdk.VariableClient / sdk.ConnectionClient /
+		//     sdk.XComClient): access to Variables, Connections, and XCom
 		//
 		// fn must return either error or (result, error): a non-nil error fails
 		// the task, and a non-nil first result is pushed as the task's

--- a/go-sdk/bundle/bundlev1/task.go
+++ b/go-sdk/bundle/bundlev1/task.go
@@ -170,6 +170,7 @@ var (
 
 	connClientType = reflect.TypeFor[sdk.ConnectionClient]()
 	varClientType  = reflect.TypeFor[sdk.VariableClient]()
+	xcomClientType = reflect.TypeFor[sdk.XComClient]()
 	clientType     = reflect.TypeFor[sdk.Client]()
 )
 
@@ -192,5 +193,6 @@ func isLogger(inType reflect.Type) bool {
 func isClient(inType reflect.Type) bool {
 	return inType != nil && (inType.AssignableTo(clientType) ||
 		inType.AssignableTo(connClientType) ||
-		inType.AssignableTo(varClientType))
+		inType.AssignableTo(varClientType) ||
+		inType.AssignableTo(xcomClientType))
 }

--- a/go-sdk/bundle/bundlev1/task_test.go
+++ b/go-sdk/bundle/bundlev1/task_test.go
@@ -105,6 +105,13 @@ func (s *TaskSuite) TestArgumentBinding() {
 				return nil
 			},
 		},
+		"xcom-client": {
+			func(client sdk.XComClient) error {
+				s.NotNil(client)
+
+				return nil
+			},
+		},
 	}
 
 	for name, tt := range cases {


### PR DESCRIPTION
## Why

`sdk.XComClient` is documented as an injectable task parameter, but the dependency-injection matcher only recognised `sdk.Client`, `VariableClient`, and `ConnectionClient`.

## What

- Recognise sdk.XComClient in the DI matcher so the runtime injects a working client.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)