### PR TITLE
Accept BLOCKED and WAITING_FOR_RETRY Databricks run states

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -99,9 +99,9 @@ class RunState:
         "TERMINATED",
         "SKIPPED",
         "INTERNAL_ERROR",
-        "QUEUED",
         "BLOCKED",
         "WAITING_FOR_RETRY",
+        "QUEUED",
     ]
 
     def __init__(

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -100,6 +100,8 @@ class RunState:
         "SKIPPED",
         "INTERNAL_ERROR",
         "QUEUED",
+        "BLOCKED",
+        "WAITING_FOR_RETRY",
     ]
 
     def __init__(

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -1560,7 +1560,7 @@ class TestRunState:
             assert run_state.is_terminal
 
     def test_is_terminal_false(self):
-        non_terminal_states = ["PENDING", "RUNNING", "TERMINATING", "QUEUED"]
+        non_terminal_states = ["PENDING", "RUNNING", "TERMINATING", "QUEUED", "BLOCKED", "WAITING_FOR_RETRY"]
         for state in non_terminal_states:
             run_state = RunState(state, "", "")
             assert not run_state.is_terminal


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Forked off of: https://github.com/apache/airflow/pull/69174


### What

`RunState` (the class that parses a Databricks run state) raises `AirflowException("Unexpected life cycle state")` for any life-cycle state outside its hardcoded `RUN_LIFE_CYCLE_STATES` allowlist. That allowlist is a hand maintained duplicate of the `RunLifeCycleState` enum and has drifted: it is missing `BLOCKED` and `WAITING_FOR_RETRY`, both of which the enum (and the Databricks API) define.

### Why it matters

`BLOCKED` and `WAITING_FOR_RETRY` are normal in-flight states:
- `BLOCKED` - the run cannot start yet because it is gated (max concurrent runs, a dependency, queueing). Routine for `DatabricksRunNowOperator`, which triggers existing jobs that are often concurrency- or dependency-gated.
- `WAITING_FOR_RETRY` - a task failed and Databricks is waiting to retry it.

Because `RunState` rejects them, an operator polling a run that enters either state fails with `AirflowException` instead of continuing to wait. This affects the normal (synchronous) poll loop and `get_run_state` for both `DatabricksSubmitRunOperator` and `DatabricksRunNowOperator`, on clean runs today - no crash or retry required to hit it.

### Fix

Add `BLOCKED` and `WAITING_FOR_RETRY` to `RunState.RUN_LIFE_CYCLE_STATES` so they parse as valid states. No change to `is_terminal`: it already lists only `TERMINATED`/`SKIPPED`/`INTERNAL_ERROR`, so both new states are correctly treated as non-terminal and the poll loop keeps waiting until the run actually finishes.

### Backcompat

No behavior change other than not crashing: a run in one of these two states is now parsed and polled through instead of raising. Nothing that previously succeeded changes. The strict "unknown state raises" behavior is retained for genuinely unrecognized states.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
