### PR TITLE
Update SQLAlchemy documentation links from 1.4 to 2.0

### DIFF
--- a/airflow-core/docs/howto/set-up-database.rst
+++ b/airflow-core/docs/howto/set-up-database.rst
@@ -20,7 +20,7 @@
 Set up a Database Backend
 =========================
 
-Airflow was built to interact with its metadata using `SqlAlchemy <https://docs.sqlalchemy.org/en/14/>`__.
+Airflow was built to interact with its metadata using `SqlAlchemy <https://docs.sqlalchemy.org/en/20/>`__.
 
 The document below describes the database engine configurations, the necessary changes to their configuration to be used with Airflow, as well as changes to the Airflow configurations to connect to these databases.
 
@@ -66,7 +66,7 @@ the example below.
     $ airflow config get-value database sql_alchemy_conn
     sqlite:////tmp/airflow/airflow.db
 
-The exact format description is described in the SQLAlchemy documentation, see `Database Urls <https://docs.sqlalchemy.org/en/14/core/engines.html>`__. We will also show you some examples below.
+The exact format description is described in the SQLAlchemy documentation, see `Database Urls <https://docs.sqlalchemy.org/en/20/core/engines.html>`__. We will also show you some examples below.
 
 Setting up a SQLite Database
 ----------------------------
@@ -198,7 +198,7 @@ in the Postgres documentation to learn more.
    If you cannot change the prefix of your URL immediately, Airflow continues to work with SQLAlchemy
    1.3 and you can downgrade SQLAlchemy, but we recommend to update the prefix.
 
-   Details in the `SQLAlchemy Changelog <https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-3687655465c25a39b968b4f5f6e9170b>`_.
+   Details in the `SQLAlchemy Changelog <https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-3687655465c25a39b968b4f5f6e9170b>`_.
 
 We recommend using the ``psycopg2`` driver and specifying it in your SqlAlchemy connection string.
 
@@ -218,7 +218,7 @@ If you use a current Postgres user with custom search_path, search_path can be c
 
    ALTER USER airflow_user SET search_path = public;
 
-For more information regarding setup of the PostgreSQL connection, see `PostgreSQL dialect <https://docs.sqlalchemy.org/en/14/dialects/postgresql.html>`__ in SQLAlchemy documentation.
+For more information regarding setup of the PostgreSQL connection, see `PostgreSQL dialect <https://docs.sqlalchemy.org/en/20/dialects/postgresql.html>`__ in SQLAlchemy documentation.
 
 .. note::
 
@@ -307,7 +307,7 @@ We recommend using the ``mysqlclient`` driver and specifying it in your SqlAlche
     The integration of MySQL backend has only been validated using the ``mysqlclient`` driver
     during Apache Airflow's continuous integration (CI) process.
 
-If you want to use other drivers visit the `MySQL Dialect <https://docs.sqlalchemy.org/en/14/dialects/mysql.html>`__  in SQLAlchemy documentation for more information regarding download
+If you want to use other drivers visit the `MySQL Dialect <https://docs.sqlalchemy.org/en/20/dialects/mysql.html>`__  in SQLAlchemy documentation for more information regarding download
 and setup of the SqlAlchemy connection.
 
 In addition, you also should pay particular attention to MySQL's encoding. Although the ``utf8mb4`` character set is more and more popular for MySQL (actually, ``utf8mb4`` becomes default character set in MySQL8.0), using the ``utf8mb4`` encoding requires additional setting in Airflow 2+ (See more details in `#7570 <https://github.com/apache/airflow/pull/7570>`__.). If you use ``utf8mb4`` as character set, you should also set ``sql_engine_collation_for_ids=utf8mb3_bin``.
@@ -454,7 +454,7 @@ engine configuration).
 - Suitable for non-production environments like staging systems.
 
 You can do it with ``echo=True`` as sqlalchemy engine configuration as explained in the
-`SQLAlchemy logging documentation <https://docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging>`_.
+`SQLAlchemy logging documentation <https://docs.sqlalchemy.org/en/20/core/engines.html#configuring-logging>`_.
 
 Use :ref:`config:database__sql_alchemy_engine_args` configuration parameter to set echo arg to True.
 

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -795,7 +795,7 @@ class AssetManager(LoggingMixin):
         def _queue_dagrun_if_needed(dag: DagModel) -> str | None:
             item = AssetDagRunQueue(target_dag_id=dag.dag_id, asset_id=asset_id)
             # Don't error whole transaction when a single RunQueue item conflicts.
-            # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
+            # https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#using-savepoint
             try:
                 with session.begin_nested():
                     session.merge(item)

--- a/airflow-core/src/airflow/models/base.py
+++ b/airflow-core/src/airflow/models/base.py
@@ -28,7 +28,7 @@ SQL_ALCHEMY_SCHEMA = conf.get("database", "SQL_ALCHEMY_SCHEMA")
 
 # For more information about what the tokens in the naming convention
 # below mean, see:
-# https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention
+# https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention
 naming_convention = {
     "ix": "idx_%(column_0_N_label)s",
     "uq": "%(table_name)s_%(column_0_N_name)s_uq",

--- a/providers/sqlite/src/airflow/providers/sqlite/hooks/sqlite.py
+++ b/providers/sqlite/src/airflow/providers/sqlite/hooks/sqlite.py
@@ -39,7 +39,7 @@ class SqliteHook(DbApiHook):
         """Return SQLite connection object."""
         sqlalchemy_uri = self.get_uri()
         # The sqlite3 connection does not use the sqlite scheme.
-        # See https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#uri-connections for details.
+        # See https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#uri-connections for details.
         sqlite_uri = sqlalchemy_uri.replace("sqlite:///", "file:")
         conn = sqlite3.connect(sqlite_uri, uri=True)
         return conn
@@ -51,6 +51,6 @@ class SqliteHook(DbApiHook):
         # For sqlite, there is no schema in the connection URI. So we need to drop the trailing slash.
         airflow_sqlite_uri = airflow_uri.replace("/?", "?")
         # The sqlite connection has one more slash for path specification.
-        # See https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#connect-strings for details.
+        # See https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#connect-strings for details.
         sqlalchemy_uri = airflow_sqlite_uri.replace("sqlite://", "sqlite:///")
         return sqlalchemy_uri


### PR DESCRIPTION
Update stale SQLAlchemy 1.4 documentation links to the current 2.0 docs across the database setup guide, the asset manager, the base model naming convention comment, and the SQLite provider hook. Every replacement link
and anchor was verified to resolve against the live SQLAlchemy 2.0 docs before this PR was opened.

closes: #69164

Two other PRs are already in flight for this issue — #69167 (covers only the `.rst` doc file) and #69168 (covers `manager.py` and `base.py`, but not the SQLite provider hook). This PR is a superset of both: it additionally fixes the two links in `providers/sqlite/src/airflow/providers/sqlite/hooks/sqlite.py` that neither of those PRs touches. Posting for completeness/comparison — happy to close in favor of either existing PR if a maintainer prefers to extend one of those instead, or to let the "better PR wins" default apply.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)