### PR TITLE
Remove obsolete committer onboarding steps

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -259,16 +259,13 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
    * https://github.com/orgs/apache/teams/airflow-committers/members
    * https://whimsy.apache.org/roster/committee/airflow
 
-5.  Ask in ``#internal-airflow-ci-cd`` channel to be
-    `configured in self-hosted runners <https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers>`_
-    by the CI team. Wait for confirmation that this is done and some helpful tips from the CI team (Temporarily disabled)
-6.  After confirming that step 5 is done, open a PR to include your GitHub ID in:
+5.  After confirming that step 5 is done, open a PR to include your GitHub ID in:
 
     * ``dev/breeze/src/airflow_breeze/global_constants.py`` (COMMITTERS variable)
     * name and GitHub ID in `project.rst <https://github.com/apache/airflow/blob/main/airflow-core/docs/project.rst>`__.
     * If you had been a collaborator role before getting committer, remove your GitHub ID from ``.asf.yaml``.
 
-7.  Raise a PR to `airflow-site <https://github.com/apache/airflow-site>`_ repository with the following additions:
+6.  Raise a PR to `airflow-site <https://github.com/apache/airflow-site>`_ repository with the following additions:
     (A kind request: If there are other committers who joined around the same time, please create a unified PR for
     all of you together.)
 
@@ -277,7 +274,6 @@ To be able to merge PRs, committers have to integrate their GitHub ID with Apach
     * Post an entry in
       `Announcements <https://github.com/apache/airflow-site/blob/main/landing-pages/site/content/en/announcements/_index.md>`__.
 
-8.  Ask a release manager to make Slack announcement
 
 
 New PMC Member Onboarding steps


### PR DESCRIPTION
Remove obsolete committer onboarding steps

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
