### PR TITLE
Fix mypy failure on datadog timer wrapped by shared observability Timer

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/protocols.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/protocols.py
@@ -27,6 +27,14 @@ if TYPE_CHECKING:
 DeltaType = int | float | datetime.timedelta
 
 
+class BackendTimerProtocol(Protocol):
+    """Minimal interface of a backend timer (e.g. pystatsd / dogstatsd) wrapped by :class:`Timer`."""
+
+    def start(self) -> object: ...
+
+    def stop(self) -> object: ...
+
+
 class TimerProtocol(Protocol):
     """Type protocol for StatsLogger.timer."""
 
@@ -100,7 +108,7 @@ class Timer(TimerProtocol):
     _start_time: float | None
     duration: float | None
 
-    def __init__(self, real_timer: Timer | None = None) -> None:
+    def __init__(self, real_timer: BackendTimerProtocol | None = None) -> None:
         self.real_timer = real_timer
 
     def __enter__(self) -> Self:


### PR DESCRIPTION

**Why**
- After the CI environment upgrade, `prek run mypy-shared-observability` fails: `datadog_logger.py` passes dogstatsd's `TimedContextManagerDecorator` into `Timer(...)`, but `real_timer` is typed `Timer | None`, so the types don't match.
- That annotation was never accurate — `real_timer` is never the shared `Timer` itself, it's a third-party backend timer (pystatsd / dogstatsd). It slipped through before only because pystatsd ships no stubs (treated as `Any`); datadog has stubs, which surfaced the mismatch.

**What**
- Add a minimal `BackendTimerProtocol` (just `start()` / `stop()`) and retype `Timer.__init__`'s `real_timer` from `Timer | None` to `BackendTimerProtocol | None`, reflecting the interface it actually accepts.
- Type-annotation-only fix, no runtime behavior change; both the pystatsd and dogstatsd timers are structurally compatible.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
