### PR TITLE
Bump Amazon provider boto3/botocore to 1.43.0, aiobotocore to 3.6.0

### DIFF
--- a/providers/amazon/pyproject.toml
+++ b/providers/amazon/pyproject.toml
@@ -66,8 +66,8 @@ dependencies = [
     # We should update minimum version of boto3 and here regularly to avoid `pip` backtracking with the number
     # of candidates to consider. Make sure to configure boto3 version here as well as in all the tools below
     # in the `devel-dependencies` section to be the same minimum version.
-    "boto3>=1.41.0",
-    "botocore>=1.41.0",
+    "boto3>=1.43.0",
+    "botocore>=1.43.0",
     "inflection>=0.5.1",
     # Allow a wider range of watchtower versions for flexibility among users
     "watchtower>=3.3.1,<4",
@@ -89,7 +89,7 @@ dependencies = [
 [project.optional-dependencies]
 # TODO: Remove aiobotocore when boto3 has native async support (and we transition to it)
 "aiobotocore" = [
-    "aiobotocore>=3.0.0",
+    "aiobotocore>=3.6.0",
 ]
 "cncf.kubernetes" = [
     "apache-airflow-providers-cncf-kubernetes>=7.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3132,7 +3132,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiobotocore", marker = "extra == 'aiobotocore'", specifier = ">=3.0.0" },
+    { name = "aiobotocore", marker = "extra == 'aiobotocore'", specifier = ">=3.6.0" },
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-apache-hive", marker = "extra == 'apache-hive'", editable = "providers/apache/hive" },
     { name = "apache-airflow-providers-cncf-kubernetes", marker = "extra == 'cncf-kubernetes'", editable = "providers/cncf/kubernetes" },
@@ -3153,8 +3153,8 @@ requires-dist = [
     { name = "apache-airflow-providers-standard", marker = "extra == 'standard'", editable = "providers/standard" },
     { name = "asgiref", marker = "python_full_version < '3.14'", specifier = ">=2.3.0" },
     { name = "asgiref", marker = "python_full_version >= '3.14'", specifier = ">=3.11.1" },
-    { name = "boto3", specifier = ">=1.41.0" },
-    { name = "botocore", specifier = ">=1.41.0" },
+    { name = "boto3", specifier = ">=1.43.0" },
+    { name = "botocore", specifier = ">=1.43.0" },
     { name = "inflection", specifier = ">=0.5.1" },
     { name = "jmespath", specifier = ">=0.7.0" },
     { name = "jsonpath-ng", specifier = ">=1.5.3" },


### PR DESCRIPTION
The EMR Serverless interactive session APIs (StartSession, GetSession,
GetSessionEndpoint, TerminateSession) are only available in botocore 1.43.0+.
aiobotocore 3.6.0 is the first release whose botocore pin (>=1.42.90,<1.43.1)
admits botocore 1.43.0, so the async/deferrable code paths resolve on the
minimum supported versions.

Split out from the EMR Serverless interactive session feature so the
dependency change can be reviewed on its own.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Kiro (AI coding assistant)

Generated-by: Kiro, following the Gen-AI guidelines in contributing-docs/05_pull_requests.rst

<!-- pr-triage-fold: triaged=2026-07-28T17:14:15Z head=fd82c59 action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @vgkowski** · by `@potiuk` · 2026-07-28 17:14 UTC
>
> This draft PR has had no activity for several weeks. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
