### PR TITLE
Point provider agents at the cross-provider dependency-bump rule

### DIFF
--- a/providers/AGENTS.md
+++ b/providers/AGENTS.md
@@ -15,6 +15,7 @@ Each provider is an independent package with its own `pyproject.toml`, tests, an
 
 - Keep `provider.yaml` metadata, docs, and tests in sync.
 - Don't upper-bound dependencies by default; add limits only with justification.
+- Changing a symbol another provider imports from yours? Bump the consuming provider's dependency with a `# use next version` marker so independently-released packages stay compatible — see [`contributing-docs/13_airflow_dependencies_and_extras.rst`](../contributing-docs/13_airflow_dependencies_and_extras.rst).
 - Tests live alongside the provider — mirror source paths in test directories.
 - Full guide: [`contributing-docs/12_provider_distributions.rst`](../contributing-docs/12_provider_distributions.rst)
 


### PR DESCRIPTION
Adds a one-line pointer in `providers/AGENTS.md` (the checklist an agent reads before touching provider code) to the existing `# use next version` cross-provider dependency rule in `contributing-docs/13_airflow_dependencies_and_extras.rst`.

The rule itself is unchanged and stays where it is — this only improves discoverability. Noticed while reviewing #68557, where a cross-provider signature change (`cncf.kubernetes._enable_tcp_keepalive` consumed by the google provider) was made without bumping the consuming provider's minimum dependency; that guard is only auto-enforced for `common.compat`, so the manual `# use next version` step is easy to miss.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)