### PR TITLE
Fix lang-SDK k8s system test dropping the api-server auth manager

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -2810,6 +2810,12 @@ def _lang_sdk_deploy_airflow(python: str, kubernetes_version: str, output: Outpu
             get_kubectl_cluster_name(python=python, kubernetes_version=kubernetes_version),
             "--namespace",
             HELM_AIRFLOW_NAMESPACE,
+            # Layer the lang-SDK values on top of the already-deployed release rather than
+            # re-rendering from chart defaults. Without this, helm discards the base deploy's
+            # --set overrides (notably config.core.auth_manager=SimpleAuthManager on Python 3.13),
+            # reverting the api-server to the chart-default FabAuthManager so it never writes
+            # simple_auth_manager_passwords.json.generated and the API-login tests error out.
+            "--reuse-values",
             "--set",
             f"defaultAirflowRepository={image}",
             "--set",


### PR DESCRIPTION
The `KubernetesExecutor-3.13` k8s system test job started failing on main
after #68709 with 9 `FileNotFoundError: /tmp/simple_auth_manager_passwords.json.generated`
errors (every API-login test), e.g.
https://github.com/apache/airflow/actions/runs/28526595970/job/84584069072

Root cause: the lang-SDK provisioning (`breeze k8s setup-lang-sdk-test`)
helm-upgrades the already-deployed release with only `lang_sdk/config/values.yaml`.
Without `--reuse-values`, Helm re-renders from chart defaults and drops the base
deploy's `--set` overrides — notably `config.core.auth_manager=SimpleAuthManager`
(set on Python 3.13, where FAB is unavailable). The api-server reverts to the
chart-default `FabAuthManager` and never writes the generated password file the
tests fetch.

Fix: add `--reuse-values` so the lang-SDK values layer on top of the existing
release instead of replacing it — matching the intent (the same PR already made
`dagBundleConfigList` additive for exactly this reason).

The change is only exercised by the K8s system test job itself (no unit-test
harness exists for these breeze helm-command builders), so verification is that
job going green.

related: #68709

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8 1M)

Generated-by: Claude Code (Opus 4.8 1M) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
