### PR TITLE
Fix Cloud Function invoke operator docs link

### DIFF
--- a/providers/google/docs/operators/cloud/functions.rst
+++ b/providers/google/docs/operators/cloud/functions.rst
@@ -179,6 +179,32 @@ See Google Cloud API documentation `to create a function
 <https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/create>`_.
 
 
+.. _howto/operator:CloudFunctionInvokeFunctionOperator:
+
+CloudFunctionInvokeFunctionOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the operator to invoke a deployed function in Google Cloud Functions.
+
+For parameter definition, take a look at
+:class:`~airflow.providers.google.cloud.operators.functions.CloudFunctionInvokeFunctionOperator`.
+
+Using the operator
+""""""""""""""""""
+
+.. exampleinclude:: /../../google/tests/system/google/cloud/cloud_functions/example_functions.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcf_invoke_function]
+    :end-before: [END howto_operator_gcf_invoke_function]
+
+More information
+""""""""""""""""
+
+See Google Cloud Functions API documentation to `call a function
+<https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/call>`_.
+
+
 Reference
 ---------
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/functions.py
@@ -418,7 +418,7 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:CloudFunctionDeployFunctionOperator`
+        :ref:`howto/operator:CloudFunctionInvokeFunctionOperator`
 
     :param function_id: ID of the function to be called
     :param input_data: Input to be passed to the function


### PR DESCRIPTION
Add a dedicated CloudFunctionInvokeFunctionOperator section to the Google Cloud Functions operator docs and point the operator docstring's seealso link at that section instead of the deploy operator guide.

This addresses the docs bug called out in apache/airflow#68908 where the API docs for CloudFunctionInvokeFunctionOperator linked to a how-to guide for a different operator.

related: #68908

Validation performed:

- `ruff format --check providers/google/src/airflow/providers/google/cloud/operators/functions.py`
- `ruff check providers/google/src/airflow/providers/google/cloud/operators/functions.py`
- `git diff --check`

Limitations:

- Full docs build was not run locally; `uv` and `breeze` are not installed in this environment.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex/ChatGPT)

Generated-by: OpenAI Codex/ChatGPT following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-28T16:09:51Z head=4b83e90 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @EltonChang1** · by `@potiuk` · 2026-07-28 16:09 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **618 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
