### PR TITLE
Allow slashes in connection IDs fetched via the Execution API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 
 
 @router.get(
-    "/{connection_id}",
+    "/{connection_id:path}",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the connection"},

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
@@ -86,6 +86,38 @@ class TestGetConnection:
         session.delete(connection)
         session.commit()
 
+    def test_connection_get_with_slash(self, client, session):
+        connection = Connection(
+            conn_id="dev/test_conn",
+            conn_type="http",
+            description="description",
+            host="localhost",
+            login="root",
+            password="admin",
+            schema="http",
+            port=8080,
+            extra='{"x_secret": "testsecret", "y_secret": "test"}',
+        )
+        session.add(connection)
+        session.commit()
+
+        response = client.get("/execution/connections/dev/test_conn")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "conn_id": "dev/test_conn",
+            "conn_type": "http",
+            "host": "localhost",
+            "login": "root",
+            "password": "admin",
+            "schema": "http",
+            "port": 8080,
+            "extra": '{"x_secret": "testsecret", "y_secret": "test"}',
+        }
+
+        session.delete(connection)
+        session.commit()
+
     @mock.patch.dict(
         "os.environ",
         {"AIRFLOW_CONN_TEST_CONN2": '{"uri": "http://root:admin@localhost:8080/https?headers=header"}'},

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -461,7 +461,7 @@ class ConnectionOperations:
     def get(self, conn_id: str) -> ConnectionResponse | ErrorResponse:
         """Get a connection from the API server."""
         try:
-            resp = self.client.get(f"connections/{conn_id}")
+            resp = self.client.get(f"connections/{quote(conn_id, safe='')}")
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug(

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -467,7 +467,7 @@ class ConnectionOperations:
     def get(self, conn_id: str) -> ConnectionResponse | ErrorResponse:
         """Get a connection from the API server."""
         try:
-            resp = self.client.get(f"connections/{conn_id}")
+            resp = self.client.get(f"connections/{quote(conn_id, safe='')}")
         except ServerResponseError as e:
             if e.response.status_code == HTTPStatus.NOT_FOUND:
                 log.debug(

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1157,6 +1157,22 @@ class TestConnectionOperations:
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.CONNECTION_NOT_FOUND
 
+    def test_connection_get_url_encodes_conn_id(self):
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                status_code=200,
+                json={"conn_id": "dev/my_conn", "conn_type": "http"},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.connections.get(conn_id="dev/my_conn")
+
+        assert isinstance(result, ConnectionResponse)
+        assert requests_seen[0].url.raw_path == b"/connections/dev%2Fmy_conn"
+
     @pytest.mark.parametrize("status_code", [401, 403])
     def test_connection_get_authz_returns_permission_denied(self, status_code):
         """401/403 from the API server is reported as PERMISSION_DENIED, not raised."""

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1163,6 +1163,22 @@ class TestConnectionOperations:
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.CONNECTION_NOT_FOUND
 
+    def test_connection_get_url_encodes_conn_id(self):
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                status_code=200,
+                json={"conn_id": "dev/my_conn", "conn_type": "http"},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.connections.get(conn_id="dev/my_conn")
+
+        assert isinstance(result, ConnectionResponse)
+        assert requests_seen[0].url.raw_path == b"/connections/dev%2Fmy_conn"
+
     @pytest.mark.parametrize("status_code", [401, 403])
     def test_connection_get_authz_returns_permission_denied(self, status_code):
         """401/403 from the API server is reported as PERMISSION_DENIED, not raised."""

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1180,6 +1180,22 @@ class TestConnectionOperations:
         assert isinstance(result, ErrorResponse)
         assert result.error == ErrorType.CONNECTION_NOT_FOUND
 
+    def test_connection_get_url_encodes_conn_id(self):
+        requests_seen = []
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            return httpx.Response(
+                status_code=200,
+                json={"conn_id": "dev/my_conn", "conn_type": "http"},
+            )
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        result = client.connections.get(conn_id="dev/my_conn")
+
+        assert isinstance(result, ConnectionResponse)
+        assert requests_seen[0].url.raw_path == b"/connections/dev%2Fmy_conn"
+
     @pytest.mark.parametrize("status_code", [401, 403])
     def test_connection_get_authz_returns_permission_denied(self, status_code):
         """401/403 from the API server is reported as PERMISSION_DENIED, not raised."""

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1187,7 +1187,16 @@ class TestConnectionOperations:
             requests_seen.append(request)
             return httpx.Response(
                 status_code=200,
-                json={"conn_id": "dev/my_conn", "conn_type": "http"},
+                json={
+                    "conn_id": "dev/my_conn",
+                    "conn_type": "http",
+                    "host": None,
+                    "schema": None,
+                    "login": None,
+                    "password": None,
+                    "port": None,
+                    "extra": None,
+                },
             )
 
         client = make_client(transport=httpx.MockTransport(handle_request))

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1170,7 +1170,16 @@ class TestConnectionOperations:
             requests_seen.append(request)
             return httpx.Response(
                 status_code=200,
-                json={"conn_id": "dev/my_conn", "conn_type": "http"},
+                json={
+                    "conn_id": "dev/my_conn",
+                    "conn_type": "http",
+                    "host": None,
+                    "schema": None,
+                    "login": None,
+                    "password": None,
+                    "port": None,
+                    "extra": None,
+                },
             )
 
         client = make_client(transport=httpx.MockTransport(handle_request))


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
This PR adds a path converter to the `get_connection` route in the Execution API so that connections whose IDs contain forward slashes can be fetched. Currently, the endpoint returns a 404 when fetching a connection with an ID such as `dev/my_conn`. This fix is mainly applicable for secrets backends, as connections created via the REST API/CLI do not allow slashes in the `conn_id` (although the Connection model itself does). Client-side encoding of the `conn_id` was also added. Additional test cases were added to cover the new behavior (client and endpoint).

related: #57864
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
