### PR TITLE
Fix DatabricksSqlHook crash on empty result with fetch_one handler

### DIFF
--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -839,7 +839,7 @@ class DbApiHook(BaseHook):
             return _last_result
         return results
 
-    def _make_common_data_structure(self, result: T | Sequence[T]) -> tuple | list[tuple]:
+    def _make_common_data_structure(self, result: T | Sequence[T]) -> tuple | list[tuple] | None:
         """
         Ensure the data returned from an SQL command is a standard tuple or list[tuple].
 

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -298,7 +298,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         split_statements: bool = ...,
         return_last: bool = ...,
         execution_timeout: timedelta | None = None,
-    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None: ...
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple | None] | None: ...
 
     def run(
         self,
@@ -309,7 +309,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         split_statements: bool = True,
         return_last: bool = True,
         execution_timeout: timedelta | None = None,
-    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None:
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple | None] | None:
         """
         Run a command or a list of commands.
 
@@ -401,10 +401,14 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
             return results[-1]
         return results
 
-    def _make_common_data_structure(self, result: T | Sequence[T]) -> tuple[Any, ...] | list[tuple[Any, ...]]:
+    def _make_common_data_structure(
+        self, result: T | Sequence[T] | None
+    ) -> tuple[Any, ...] | list[tuple[Any, ...]] | None:
         """Transform the databricks Row objects into namedtuple."""
         # Below ignored lines respect namedtuple docstring, but mypy do not support dynamically
         # instantiated namedtuple, and will never do: https://github.com/python/mypy/issues/848
+        if result is None:
+            return None
         if isinstance(result, list):
             rows: Sequence[Row] = result
             if not rows:

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -31,7 +31,7 @@ from databricks.sql.types import Row
 
 from airflow.models import Connection
 from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
-from airflow.providers.common.sql.hooks.handlers import fetch_all_handler
+from airflow.providers.common.sql.hooks.handlers import fetch_all_handler, fetch_one_handler
 from airflow.providers.databricks.hooks.databricks_sql import (
     DatabricksSqlHook,
     _format_query_tag_value,
@@ -375,6 +375,23 @@ def test_query(
     for index, cur in enumerate(cursors):
         cur.execute.assert_has_calls([mock.call(cursor_calls[index])])
     cur.close.assert_called()
+
+
+def test_make_common_data_structure_none_result():
+    assert DatabricksSqlHook()._make_common_data_structure(None) is None
+
+
+def test_query_with_fetch_one_handler_on_empty_result(mock_get_conn, mock_get_requests):
+    conn = mock.MagicMock()
+    cur = mock.MagicMock(rowcount=0, description=get_cursor_descriptions(["id"]))
+    cur.fetchone.return_value = None
+    conn.cursor.return_value = cur
+    mock_get_conn.side_effect = [conn]
+
+    databricks_hook = DatabricksSqlHook(sql_endpoint_name="Test")
+    result = databricks_hook.run(sql="select * from test.test", handler=fetch_one_handler)
+
+    assert result is None
 
 
 @pytest.mark.parametrize(

--- a/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
+++ b/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
@@ -287,7 +287,7 @@ class ExasolHook(DbApiHook):
         handler: Callable[[Any], T] = ...,
         split_statements: bool = ...,
         return_last: bool = ...,
-    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None: ...
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple | None] | None: ...
 
     def run(
         self,
@@ -297,7 +297,7 @@ class ExasolHook(DbApiHook):
         handler: Callable[[Any], T] | None = None,
         split_statements: bool = False,
         return_last: bool = True,
-    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None:
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple | None] | None:
         """
         Run a command or a list of commands.
 

--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake.py
@@ -893,7 +893,7 @@ class SnowflakeHook(DbApiHook):
         split_statements: bool = ...,
         return_last: bool = ...,
         return_dictionaries: bool = ...,
-    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None: ...
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple | None] | None: ...
 
     def run(
         self,
@@ -904,7 +904,7 @@ class SnowflakeHook(DbApiHook):
         split_statements: bool = True,
         return_last: bool = True,
         return_dictionaries: bool = False,
-    ) -> tuple | list[tuple] | list[list[tuple] | tuple] | None:
+    ) -> tuple | list[tuple] | list[list[tuple] | tuple | None] | None:
         """
         Run a command or list of commands.
 


### PR DESCRIPTION
Fixes a `TypeError` in `DatabricksSqlHook.run()` when a scalar handler is used and the query returns no rows.

DBAPI `fetchone()` returns `None` on an empty result set, and common.sql's `fetch_one_handler` is typed `-> tuple | None` accordingly (it also returns `None` for statements where `cursor.description` is `None`). The base `DbApiHook._make_common_data_structure` passes `None` through unchanged, and `DbApiHook.run()` is annotated `... | None`. The Databricks override, however, only accepted `Row` or `Sequence[Row]` and raised `TypeError: Expected Sequence[Row] or Row, but got <class 'NoneType'>`.

User-visible impact: `DatabricksSqlHook.get_first(...)` — which is just `run(handler=fetch_one_handler)` — crashed on any query returning no rows, where every non-overriding `DbApiHook` (postgres, snowflake, ...) returns `None`. With this change the Databricks hook follows the common.sql contract and passes `None` through.

(The odbc hook's override maps falsy results to `[]` instead; `None` is deliberately chosen here to preserve `fetchone` semantics — "no row" and "empty row set" stay distinguishable — and to match the base contract.)

Found while validating #39448 against a live Databricks SQL warehouse; verified there that with this change `run(..., handler=fetch_one_handler)` on an empty result returns `None` and serializes cleanly through XCom.

related: #39448

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)