### PR TITLE
Fix retry policy overrides not persisted to task instance history

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -644,6 +644,13 @@ def _create_ti_state_update_query_and_update_state(
                 _handle_fail_fast_for_dag(ti=ti, dag_id=dag_id, session=session, dag_bag=dag_bag)
         elif isinstance(ti_patch_payload, TIRetryStatePayload):
             if ti is not None:
+                # Set the overrides on the TI *before* archiving so record_ti()
+                # snapshots them into task_instance_history (it copies attrs off
+                # the ti object). Otherwise the per-try audit trail is always NULL.
+                ti.retry_delay_override = ti_patch_payload.retry_delay_seconds
+                ti.retry_reason = (
+                    ti_patch_payload.retry_reason[:500] if ti_patch_payload.retry_reason else None
+                )
                 ti.prepare_db_for_next_try(session=session)
             # Store retry policy overrides so next_retry_datetime() can read them.
             # These are cleared when the task enters RUNNING (ti_run).

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1888,6 +1888,44 @@ class TestTIUpdateState:
         assert ti.retry_delay_override == 42.5
         assert ti.retry_reason == "Rate limit: backing off"
 
+    def test_ti_update_state_retry_policy_overrides_persisted_in_history(
+        self, client, session, create_task_instance
+    ):
+        """Retry policy override + reason must be archived to task_instance_history.
+
+        record_ti() snapshots columns off the TI object, so the overrides must be set on
+        the TI before prepare_db_for_next_try() archives it. When they were written only
+        to the live-row UPDATE, the per-try audit trail in task_instance_history was
+        always NULL even though the live row was correct.
+        """
+        ti = create_task_instance(
+            task_id="test_retry_policy_override_history",
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": State.UP_FOR_RETRY,
+                "end_date": DEFAULT_END_DATE.isoformat(),
+                "retry_delay_seconds": 42.5,
+                "retry_reason": "Rate limit: backing off",
+            },
+        )
+
+        assert response.status_code == 204
+
+        tih = session.scalars(
+            select(TaskInstanceHistory).where(
+                TaskInstanceHistory.dag_id == ti.dag_id,
+                TaskInstanceHistory.task_id == ti.task_id,
+                TaskInstanceHistory.run_id == ti.run_id,
+            )
+        ).one()
+        assert tih.retry_delay_override == 42.5
+        assert tih.retry_reason == "Rate limit: backing off"
+
     def test_ti_update_state_retry_without_policy_overrides(self, client, session, create_task_instance):
         """Without retry policy fields, the columns remain NULL."""
         ti = create_task_instance(
@@ -1912,6 +1950,16 @@ class TestTIUpdateState:
         assert ti.state == State.UP_FOR_RETRY
         assert ti.retry_delay_override is None
         assert ti.retry_reason is None
+
+        tih = session.scalars(
+            select(TaskInstanceHistory).where(
+                TaskInstanceHistory.dag_id == ti.dag_id,
+                TaskInstanceHistory.task_id == ti.task_id,
+                TaskInstanceHistory.run_id == ti.run_id,
+            )
+        ).one()
+        assert tih.retry_delay_override is None
+        assert tih.retry_reason is None
 
     def test_ti_run_clears_retry_policy_overrides(self, client, session, create_task_instance):
         """When a task enters RUNNING, retry policy overrides from the previous attempt are cleared."""


### PR DESCRIPTION
### What's wrong

AIP-105 lets a retry policy choose a custom retry delay and reason each time a task fails. Those are meant to be recorded per-try in `task_instance_history` as a durable audit trail — "why did the policy wait N seconds on try 3, and for what reason?"

Currently TIH table is  **always empty**: `retry_delay_override` and `retry_reason` come out `NULL` on every `task_instance_history` row, even when a policy clearly set them.

### Root cause

In the Execution API retry handler, the override + reason are written only into the live-row `UPDATE`, and the task instance is archived to history (`prepare_db_for_next_try()` → `TaskInstanceHistory.record_ti()`) **before** those values are set on the object being archived. `record_ti()` snapshots columns off the in-memory task-instance object, so it captures the still-unset (NULL) values.

### Fix

Set `retry_delay_override` / `retry_reason` on the task instance **before** it's archived, so `record_ti()` picks them up. Live-row behaviour and retry timing are unchanged.

### Testing

Adds a regression test that a policy-driven retry persists the override + reason into `task_instance_history` (fails on `main`, passes with the fix). The existing tests only asserted the live row, which is why this shipped.

**Before**
<img width="633" height="446" alt="image" src="https://github.com/user-attachments/assets/50a4145b-f4eb-4d80-aebe-5de7bffdee38" />
 **After**
<img width="1013" height="461" alt="image" src="https://github.com/user-attachments/assets/9bd07bd8-2bce-4af1-8d29-27ee9b7badb8" />


DAG used for testing

```

from __future__ import annotations

from datetime import timedelta

from airflow.sdk import DAG, ExceptionRetryPolicy, RetryAction, RetryRule, task

QA_POLICY = ExceptionRetryPolicy(
    rules=[
        RetryRule(
            exception=PermissionError,
            action=RetryAction.FAIL,
            reason="Auth failure, not retryable",
        ),
        RetryRule(
            exception=ConnectionError,
            action=RetryAction.RETRY,
            retry_delay=timedelta(seconds=30),
            reason="Transient, backing off 30s",
        ),
        RetryRule(
            exception=TimeoutError,
            action=RetryAction.RETRY,
            retry_delay=timedelta(minutes=2),
            reason="Parked long so live row keeps override at downgrade snapshot",
        ),
    ],
    default=RetryAction.DEFAULT,
)

with DAG(
    dag_id="aip105_migration_baseline",
    schedule=None,
    catchup=False,
    tags=["qa", "aip105", "migration", "retry-policy"],
):

    @task
    def succeeds():
        return "ok"

    # F-01: PermissionError -> FAIL immediately, no override columns written.
    @task(retries=3, retry_delay=timedelta(minutes=5), retry_policy=QA_POLICY)
    def fail_fast_on_auth():
        raise PermissionError("403 Forbidden")

    # F-02 / history: ConnectionError -> RETRY 30s. Cycles through retries; each
    # try archived to task_instance_history with override=30, reason set.
    @task(retries=3, retry_delay=timedelta(minutes=5), retry_policy=QA_POLICY)
    def retry_short_cycle():
        raise ConnectionError("connection reset")

    # Live-row populated data: TimeoutError -> RETRY 2h. After the first failure
    # it sits UP_FOR_RETRY; its LIVE task_instance row holds override=7200 and
    # reason until the next attempt (2h out) — snapshot + downgrade before then.
    @task(retries=5, retry_delay=timedelta(minutes=5), retry_policy=QA_POLICY)
    def retry_parked_long():
        raise TimeoutError("parked for downgrade snapshot")

    # F-03: unmatched exception -> DEFAULT -> standard retry, override stays NULL.
    @task(retries=2, retry_delay=timedelta(minutes=5), retry_policy=QA_POLICY)
    def default_path():
        raise ValueError("unmatched error")

    succeeds() >> [fail_fast_on_auth(), retry_short_cycle(), retry_parked_long(), default_path()]


```
---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)