### PR TITLE
Fix OTel integration test for new task.execute detail span

### DIFF
--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -469,7 +469,10 @@ class TestOtelIntegration:
                     "_execute_task": "run",
                     "finalize": "worker.task1",
                     "run": "worker.task1",
-                    "sub_span1": "_execute_task",
+                    # At detail level > 1 the execute callable is wrapped in its own
+                    # task.execute span, so operator-emitted spans nest under it.
+                    "task.execute": "_execute_task",
+                    "sub_span1": "task.execute",
                     "dag_run.otel_test_dag": None,
                     "task_run.task1": "dag_run.otel_test_dag",
                     "worker.task1": "task_run.task1",


### PR DESCRIPTION
`test_dag_execution_succeeds[detail_spans]` has been failing on main's
scheduled/canary runs, e.g.
https://github.com/apache/airflow/actions/runs/28562105904

Root cause: #67877 ("Add task.execute detail span around task execute callable")
wraps the execute callable in its own `task.execute` span at task span detail
level > 1, so operator-emitted spans nest under `task.execute` rather than
directly under `_execute_task`. The OTel integration test's expected hierarchy
was not updated in that PR — and since the OTel integration suite only runs on
schedule/canary (not per-PR), it merged without catching the break.

Update the `detail_spans` expected hierarchy to include the `task.execute` span
(`sub_span1` -> `task.execute` -> `_execute_task`), matching the actual output.
Only the `detail_spans` variant is affected; `default_spans` (detail level <= 1)
is unchanged.

related: #67877

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8 1M)

Generated-by: Claude Code (Opus 4.8 1M) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
