### PR TITLE
Include last error cause in Databricks API when retry is exhausted

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -329,7 +329,7 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
                 f"(last error: {e.last_attempt.exception()}). Giving up."
-            )
+            ) from e
         except requests_exceptions.HTTPError as e:
             msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
             raise AirflowException(msg)
@@ -370,7 +370,7 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
                 f"(last error: {e.last_attempt.exception()}). Giving up."
-            )
+            ) from e
         except requests_exceptions.HTTPError as e:
             msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
             raise AirflowException(msg)
@@ -1223,7 +1223,7 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
                 f"(last error: {e.last_attempt.exception()}). Giving up."
-            )
+            ) from e
         except requests_exceptions.HTTPError as e:
             if wrap_http_errors:
                 msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
@@ -1290,7 +1290,7 @@ class BaseDatabricksHook(BaseHook):
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
                 f"(last error: {e.last_attempt.exception()}). Giving up."
-            )
+            ) from e
         except aiohttp.ClientResponseError as err:
             raise DatabricksApiError(
                 f"Response: {err.message}, Status Code: {err.status}", http_status_code=err.status

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -325,8 +325,11 @@ class BaseDatabricksHook(BaseHook):
                     self._is_oauth_token_valid(jsn)
                     self.oauth_tokens[resource] = jsn
                     break
-        except RetryError:
-            raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
+        except RetryError as e:
+            raise AirflowException(
+                f"API requests to Databricks failed {self.retry_limit} times "
+                f"(last error: {e.last_attempt.exception()}). Giving up."
+            )
         except requests_exceptions.HTTPError as e:
             msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
             raise AirflowException(msg)
@@ -363,8 +366,11 @@ class BaseDatabricksHook(BaseHook):
                     self._is_oauth_token_valid(jsn)
                     self.oauth_tokens[resource] = jsn
                     break
-        except RetryError:
-            raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
+        except RetryError as e:
+            raise AirflowException(
+                f"API requests to Databricks failed {self.retry_limit} times "
+                f"(last error: {e.last_attempt.exception()}). Giving up."
+            )
         except requests_exceptions.HTTPError as e:
             msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
             raise AirflowException(msg)
@@ -1213,8 +1219,11 @@ class BaseDatabricksHook(BaseHook):
                     self.log.debug("Response text: %s", response.text)
                     response.raise_for_status()
                     return response.json()
-        except RetryError:
-            raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
+        except RetryError as e:
+            raise AirflowException(
+                f"API requests to Databricks failed {self.retry_limit} times "
+                f"(last error: {e.last_attempt.exception()}). Giving up."
+            )
         except requests_exceptions.HTTPError as e:
             if wrap_http_errors:
                 msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
@@ -1277,8 +1286,11 @@ class BaseDatabricksHook(BaseHook):
                         self.log.debug("Response text: %s", response.text)
                         response.raise_for_status()
                         return await response.json()
-        except RetryError:
-            raise AirflowException(f"API requests to Databricks failed {self.retry_limit} times. Giving up.")
+        except RetryError as e:
+            raise AirflowException(
+                f"API requests to Databricks failed {self.retry_limit} times "
+                f"(last error: {e.last_attempt.exception()}). Giving up."
+            )
         except aiohttp.ClientResponseError as err:
             raise DatabricksApiError(
                 f"Response: {err.message}, Status Code: {err.status}", http_status_code=err.status

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -92,6 +92,15 @@ class DatabricksProxyConfigurationError(AirflowException):
     """Raised when Databricks connection proxy configuration is invalid."""
 
 
+def _describe_last_retry_error(retry_error: RetryError) -> str:
+    """Best-effort description of a RetryError last exception, some exceptions raise from __str__ when partially initialized."""
+    last_exc = retry_error.last_attempt.exception()
+    try:
+        return str(last_exc)
+    except Exception:
+        return repr(last_exc)
+
+
 class BaseDatabricksHook(BaseHook):
     """
     Base for interaction with Databricks.
@@ -328,7 +337,7 @@ class BaseDatabricksHook(BaseHook):
         except RetryError as e:
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
-                f"(last error: {e.last_attempt.exception()}). Giving up."
+                f"(last error: {_describe_last_retry_error(e)}). Giving up."
             ) from e
         except requests_exceptions.HTTPError as e:
             msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
@@ -369,7 +378,7 @@ class BaseDatabricksHook(BaseHook):
         except RetryError as e:
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
-                f"(last error: {e.last_attempt.exception()}). Giving up."
+                f"(last error: {_describe_last_retry_error(e)}). Giving up."
             ) from e
         except requests_exceptions.HTTPError as e:
             msg = f"Response: {e.response.content.decode()}, Status Code: {e.response.status_code}"
@@ -1222,7 +1231,7 @@ class BaseDatabricksHook(BaseHook):
         except RetryError as e:
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
-                f"(last error: {e.last_attempt.exception()}). Giving up."
+                f"(last error: {_describe_last_retry_error(e)}). Giving up."
             ) from e
         except requests_exceptions.HTTPError as e:
             if wrap_http_errors:
@@ -1289,7 +1298,7 @@ class BaseDatabricksHook(BaseHook):
         except RetryError as e:
             raise AirflowException(
                 f"API requests to Databricks failed {self.retry_limit} times "
-                f"(last error: {e.last_attempt.exception()}). Giving up."
+                f"(last error: {_describe_last_retry_error(e)}). Giving up."
             ) from e
         except aiohttp.ClientResponseError as err:
             raise DatabricksApiError(

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_base.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_base.py
@@ -238,7 +238,7 @@ class TestBaseDatabricksHook:
         hook.user_agent_header = {"User-Agent": "test-agent"}
         resource = ""
 
-        with pytest.raises(AirflowException, match="API requests to Databricks failed 2 times. Giving up."):
+        with pytest.raises(AirflowException, match="API requests to Databricks failed 2 times"):
             hook._get_sp_token(resource)
 
     @pytest.mark.asyncio

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_base.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_base.py
@@ -238,7 +238,10 @@ class TestBaseDatabricksHook:
         hook.user_agent_header = {"User-Agent": "test-agent"}
         resource = ""
 
-        with pytest.raises(AirflowException, match="API requests to Databricks failed 2 times"):
+        with pytest.raises(
+            AirflowException,
+            match=r"API requests to Databricks failed 2 times \(last error: Connection failed\)\. Giving up\.",
+        ):
             hook._get_sp_token(resource)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

The hook was discarding the underlying cause (DNS failure, 503, connection timeout) when raising after tenacity exhausted retries. All failures produced the same string, making the error unclassifiable by a retry policy. Including the last exception gives enough signal to distinguish a permanent config error from a transient API blip.


Earlier:

```python
ERROR - Attempt 1 API Request to Databricks failed with reason: <Future at 0xffff7b93cd90 state=finished raised ConnectionError> source=airflow.task.hooks.airflow.providers.databricks.hooks.databricks.DatabricksHook loc=databricks_base.py:1134
ERROR - Attempt 2 API Request to Databricks failed with reason: <Future at 0xffff7b72e020 state=finished raised ConnectionError> source=airflow.task.hooks.airflow.providers.databricks.hooks.databricks.DatabricksHook loc=databricks_base.py:1134
ERROR - Attempt 3 API Request to Databricks failed with reason: <Future at 0xffff7b13b8e0 state=finished raised ConnectionError> source=airflow.task.hooks.airflow.providers.databricks.hooks.databricks.DatabricksHook loc=databricks_base.py:1134
ERROR - Task failed with exception source=task loc=task_runner.py:1649
AirflowException: API requests to Databricks failed 3 times. Giving up.
```


Now:
```
ERROR - Attempt 1 API Request to Databricks failed with reason: <Future at 0xffff76357df0 state=finished raised ConnectionError> source=airflow.task.hooks.airflow.providers.databricks.hooks.databricks.DatabricksHook loc=databricks_base.py:1140
ERROR - Attempt 2 API Request to Databricks failed with reason: <Future at 0xffff70137cd0 state=finished raised ConnectionError> source=airflow.task.hooks.airflow.providers.databricks.hooks.databricks.DatabricksHook loc=databricks_base.py:1140
ERROR - Attempt 3 API Request to Databricks failed with reason: <Future at 0xffff76354dc0 state=finished raised ConnectionError> source=airflow.task.hooks.airflow.providers.databricks.hooks.databricks.DatabricksHook loc=databricks_base.py:1140
ERROR - Task failed with exception source=task loc=task_runner.py:1649
AirflowException: API requests to Databricks failed 3 times (last error: HTTPSConnectionPool(host='dbc-68473ce9-7672.cloud.databricks.con', port=443): Max retries exceeded with url: /api/2.2/jobs/run-now (Caused by NameResolutionError("HTTPSConnection(host='dbc-68473ce9-7672.cloud.databricks.con', port=443): Failed to resolve 'dbc-68473ce9-7672.cloud.databricks.con' ([Errno -2] Name or service not known)"))). Giving up.
```

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
