### PR TITLE
Fix collapse button overlapping details panel content

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -355,10 +355,25 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                       justifyContent="center"
                       position="relative"
                       w={0.5}
-                    />
+                    >
+                      <IconButton
+                        bg="fg.subtle"
+                        borderRadius="full"
+                        boxShadow="md"
+                        cursor="pointer"
+                        insetInlineStart="50%"
+                        label={translate("common:collapseDetailsPanel")}
+                        onClick={() => setIsRightPanelCollapsed(true)}
+                        position="absolute"
+                        size="2xs"
+                        top="50%"
+                        transform={direction === "ltr" ? "translate(-50%, -50%)" : "translate(50%, -50%)"}
+                        zIndex={2}
+                      >
+                        {direction === "ltr" ? <FaChevronRight /> : <FaChevronLeft />}
+                      </IconButton>
+                    </Box>
                   </PanelResizeHandle>
-
-                  {/* Collapse button positioned next to the resize handle */}
 
                   <Panel
                     defaultSize={dagView === "graph" ? 30 : 80}
@@ -366,22 +381,13 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                     minSize={20}
                     order={2}
                   >
-                    <Box display="flex" flexDirection="column" h="100%" position="relative">
-                      <IconButton
-                        bg="fg.subtle"
-                        borderRadius={direction === "ltr" ? "0 100% 100% 0" : "100% 0 0 100%"}
-                        boxShadow="md"
-                        label={translate("common:collapseDetailsPanel")}
-                        left={direction === "ltr" ? "0" : undefined}
-                        onClick={() => setIsRightPanelCollapsed(true)}
-                        position="absolute"
-                        right={direction === "rtl" ? "0" : undefined}
-                        size="2xs"
-                        top="50%"
-                        zIndex={2}
-                      >
-                        {direction === "ltr" ? <FaChevronRight /> : <FaChevronLeft />}
-                      </IconButton>
+                    <Box
+                      display="flex"
+                      flexDirection="column"
+                      h="100%"
+                      paddingInlineStart={4}
+                      position="relative"
+                    >
                       {children}
                       {Boolean(error) || (warningData?.dag_warnings.length ?? 0) > 0 ? (
                         <>


### PR DESCRIPTION
The details-panel collapse handle was rendered inside the details panel — which clips overflow — and anchored to the panel's inner edge, so it sat over the panel content and covered the leftmost column (the XCom / Task State Store key reported in the issue). This moves the handle onto the resize separator, where a collapse control belongs, and insets the details content so the handle stays clear of it. Collapse behavior is unchanged.

closes: #68754

### Before / After

- Before:
<img width="1861" height="868" alt="Screenshot 2026-07-02 at 13 23 59" src="https://github.com/user-attachments/assets/621137d5-9293-42d4-b54a-5f81fcd80c34" />

- After:
<img width="1655" height="748" alt="Screenshot 2026-07-02 at 13 22 49" src="https://github.com/user-attachments/assets/02f5813b-24c0-4934-a42a-22f7ab1a1a5b" />

<img width="1758" height="805" alt="Screenshot 2026-07-02 at 13 22 21" src="https://github.com/user-attachments/assets/b399b711-f0c8-4d44-9bb8-4766001d2b5f" />
<img width="1921" height="961" alt="Screenshot 2026-07-02 at 13 22 30" src="https://github.com/user-attachments/assets/0be628a1-4d2b-4427-bc1a-13b11545c823" />

- After (RTL):
<img width="1845" height="817" alt="Screenshot 2026-07-02 at 13 21 56" src="https://github.com/user-attachments/assets/e4f39e99-661d-4ea7-8aef-5958d541104d" />
<img width="1919" height="946" alt="Screenshot 2026-07-02 at 13 22 06" src="https://github.com/user-attachments/assets/d2cdfe00-f5a4-49e1-b4b2-22ae7f82b4b7" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)