### PR TITLE
Match Go SDK client params by method set to prevent injection drift

### DIFF
--- a/go-sdk/bundle/bundlev1/task.go
+++ b/go-sdk/bundle/bundlev1/task.go
@@ -149,6 +149,12 @@ func (f *taskFunction) validateFn(fnType reflect.Type) error {
 			fnType.Out(fnType.NumOut()-1).Kind(),
 		)
 	}
+
+	for i := range fnType.NumIn() {
+		if err := validateParam(fnType.In(i)); err != nil {
+			return fmt.Errorf("task function %s parameter %d: %w", f.fullName, i, err)
+		}
+	}
 	return nil
 }
 
@@ -168,10 +174,7 @@ var (
 	tiRunContextType = reflect.TypeFor[sdk.TIRunContext]()
 	slogLoggerType   = reflect.TypeFor[*slog.Logger]()
 
-	connClientType = reflect.TypeFor[sdk.ConnectionClient]()
-	varClientType  = reflect.TypeFor[sdk.VariableClient]()
-	xcomClientType = reflect.TypeFor[sdk.XComClient]()
-	clientType     = reflect.TypeFor[sdk.Client]()
+	clientType = reflect.TypeFor[sdk.Client]()
 )
 
 func isError(inType reflect.Type) bool {
@@ -190,9 +193,50 @@ func isLogger(inType reflect.Type) bool {
 	return inType != nil && inType.AssignableTo(slogLoggerType)
 }
 
+// isClient reports whether inType's method set is a subset of sdk.Client's,
+// keeping new client capabilities injectable without a hand-kept list.
 func isClient(inType reflect.Type) bool {
-	return inType != nil && (inType.AssignableTo(clientType) ||
-		inType.AssignableTo(connClientType) ||
-		inType.AssignableTo(varClientType) ||
-		inType.AssignableTo(xcomClientType))
+	return inType != nil && inType.Kind() == reflect.Interface &&
+		inType.NumMethod() > 0 && clientType.Implements(inType)
+}
+
+// validateParam rejects interface parameters Execute cannot inject; they
+// would be bound to nil and panic on first use.
+func validateParam(in reflect.Type) error {
+	if in.Kind() != reflect.Interface || isTIRunContext(in) || isClient(in) {
+		return nil
+	}
+	if isContext(in) {
+		// The plain task context injected here cannot satisfy extra methods.
+		if contextType.Implements(in) {
+			return nil
+		}
+		return fmt.Errorf(
+			"interface %s adds methods on top of context.Context; declare sdk.TIRunContext or a separate parameter instead",
+			in,
+		)
+	}
+	return fmt.Errorf(
+		"interface %s is not injectable (want context.Context, sdk.TIRunContext, or a subset of sdk.Client): %s",
+		in,
+		explainClientMismatch(in),
+	)
+}
+
+// explainClientMismatch returns why in is not a subset of sdk.Client.
+func explainClientMismatch(in reflect.Type) string {
+	if in.NumMethod() == 0 {
+		return "empty interfaces cannot be injected"
+	}
+	for i := range in.NumMethod() {
+		m := in.Method(i)
+		cm, ok := clientType.MethodByName(m.Name)
+		if !ok {
+			return fmt.Sprintf("sdk.Client has no method %s", m.Name)
+		}
+		if cm.Type != m.Type {
+			return fmt.Sprintf("method %s is %s on sdk.Client, not %s", m.Name, cm.Type, m.Type)
+		}
+	}
+	return "its method set is not a subset of sdk.Client"
 }

--- a/go-sdk/bundle/bundlev1/task_test.go
+++ b/go-sdk/bundle/bundlev1/task_test.go
@@ -20,6 +20,7 @@ package bundlev1
 import (
 	"context"
 	"log/slog"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -122,6 +123,80 @@ func (s *TaskSuite) TestArgumentBinding() {
 			ctx := context.WithValue(context.Background(), "abc", "def")
 			logger := slog.New(logging.NewTeeLogger())
 			task.Execute(ctx, logger)
+		})
+	}
+}
+
+// TestClientSubsetInjection checks any subset of sdk.Client is injected, even
+// an unnamed one.
+func (s *TaskSuite) TestClientSubsetInjection() {
+	task, err := NewTaskFunction(func(client interface {
+		GetVariable(ctx context.Context, key string) (string, error)
+	},
+	) error {
+		s.NotNil(client)
+		return nil
+	})
+	s.Require().NoError(err)
+	s.Require().NoError(task.Execute(context.Background(), slog.New(logging.NewTeeLogger())))
+}
+
+// TestNamedClientInterfacesAreInjectable guards against sdk.Client dropping an
+// embedded interface, which would break tasks declaring it.
+func (s *TaskSuite) TestNamedClientInterfacesAreInjectable() {
+	for name, typ := range map[string]reflect.Type{
+		"Client":           reflect.TypeFor[sdk.Client](),
+		"VariableClient":   reflect.TypeFor[sdk.VariableClient](),
+		"ConnectionClient": reflect.TypeFor[sdk.ConnectionClient](),
+		"XComClient":       reflect.TypeFor[sdk.XComClient](),
+	} {
+		s.True(isClient(typ), "sdk.%s must stay injectable", name)
+	}
+}
+
+// TestNonInjectableParamsAreRejected checks registration fails fast on
+// interface parameters Execute cannot inject.
+func (s *TaskSuite) TestNonInjectableParamsAreRejected() {
+	cases := map[string]struct {
+		fn          any
+		errContains string
+	}{
+		"non-client-method": {
+			func(x interface{ NotAClientMethod() }) error { return nil },
+			"sdk.Client has no method NotAClientMethod",
+		},
+		"wrong-signature": {
+			func(x interface {
+				GetVariable(key string) (string, error)
+			},
+			) error {
+				return nil
+			},
+			"method GetVariable is func(context.Context, string) (string, error) on sdk.Client",
+		},
+		"empty-interface": {
+			func(x any) error { return nil },
+			"empty interfaces cannot be injected",
+		},
+		"context-with-extra-methods": {
+			func(x interface {
+				context.Context
+				TaskInstance() sdk.TaskInstance
+			},
+			) error {
+				return nil
+			},
+			"adds methods on top of context.Context",
+		},
+	}
+
+	for name, tt := range cases {
+		s.Run(name, func() {
+			_, err := NewTaskFunction(tt.fn)
+			if s.Assert().Error(err) {
+				s.Assert().Contains(err.Error(), "parameter 0")
+				s.Assert().Contains(err.Error(), tt.errContains)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- related: #69192

## Why

As pointed out in https://github.com/apache/airflow/pull/69192#issuecomment-4850752596, the hand-enumerated client interface list can drift: an interface added to `sdk.Client` but forgotten in the matcher is injected as nil and panics on first use.

## What

- Match at runtime instead of a fixed list: `isClient` accepts any interface whose method set is a subset of `sdk.Client`'s. Go reflection cannot enumerate embedded interfaces, so the list cannot be derived at compile time.
- Reject non-injectable interface parameters at registration, naming the first mismatching method, instead of binding them to nil that panics on first use.
- Tests: unnamed subset injection, named `sdk.*Client` interfaces stay injectable, rejection cases.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Opus 4.8, Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
