### PR TITLE
Fix new DAG versions from serializing a retry_policy object

### DIFF
--- a/airflow-core/src/airflow/serialization/definitions/mappedoperator.py
+++ b/airflow-core/src/airflow/serialization/definitions/mappedoperator.py
@@ -263,6 +263,10 @@ class SerializedMappedOperator(DAGNode):
         return self._get_partial_kwargs_or_operator_default("has_on_skipped_callback")
 
     @property
+    def has_retry_policy(self) -> bool:
+        return self._get_partial_kwargs_or_operator_default("has_retry_policy")
+
+    @property
     def run_as_user(self) -> str | None:
         return self._get_partial_kwargs_or_operator_default("run_as_user")
 

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -981,10 +981,7 @@ class OperatorSerialization(DAGNode, BaseSerialization):
                     continue
 
                 if k in _HAS_FLAG_FIELDS:
-                    # These have no serializer; storing the object would str(obj) it and leak
-                    # a non-deterministic memory address. Keep only a has_<field> flag (e.g.
-                    # has_retry_policy, has_on_failure_callback); the live object is recovered
-                    # by re-parsing the DAG source on the worker.
+                    # Store only a has_<field> flag, never the object (see _HAS_FLAG_FIELDS).
                     if bool(v):
                         serialized_op["partial_kwargs"][f"has_{k}"] = True
                     continue

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -974,6 +974,15 @@ class OperatorSerialization(DAGNode, BaseSerialization):
                 if cls._is_excluded(v, k, op):
                     continue
 
+                if k == "retry_policy":
+                    # A RetryPolicy has no serializer, so serializing it falls back to
+                    # str(obj) -- which embeds the object's memory address and makes the
+                    # serialized DAG non-deterministic (a new DagVersion every parse). Mirror
+                    # the non-mapped path and keep only a has_retry_policy flag; the worker
+                    # re-parses the DAG source for the live policy.
+                    if bool(v):
+                        serialized_op["partial_kwargs"]["has_retry_policy"] = True
+                    continue
                 if k in _OPERATOR_CALLBACK_FIELDS:
                     if bool(v):
                         serialized_op["partial_kwargs"][f"has_{k}"] = True

--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -133,6 +133,12 @@ log = logging.getLogger(__name__)
 _CALLBACK_TYPES = ("execute", "failure", "success", "retry", "skipped")
 _OPERATOR_CALLBACK_FIELDS = frozenset(f"on_{x}_callback" for x in _CALLBACK_TYPES)
 _HAS_CALLBACK_FIELDS = frozenset(f"has_on_{x}_callback" for x in _CALLBACK_TYPES)
+# Fields whose value must never be serialized: the object has no serializer, so it would
+# fall back to str(obj) and leak a non-deterministic memory address (a new DagVersion every
+# parse). Only a boolean ``has_<field>`` flag is stored; the live object is recovered by
+# re-parsing the DAG source on the worker. Applies both to a mapped operator's
+# ``partial_kwargs`` and to a DAG's ``default_args``.
+_HAS_FLAG_FIELDS = _OPERATOR_CALLBACK_FIELDS | frozenset({"retry_policy"})
 
 
 def _get_registered_priority_weight_strategy(
@@ -974,16 +980,11 @@ class OperatorSerialization(DAGNode, BaseSerialization):
                 if cls._is_excluded(v, k, op):
                     continue
 
-                if k == "retry_policy":
-                    # A RetryPolicy has no serializer, so serializing it falls back to
-                    # str(obj) -- which embeds the object's memory address and makes the
-                    # serialized DAG non-deterministic (a new DagVersion every parse). Mirror
-                    # the non-mapped path and keep only a has_retry_policy flag; the worker
-                    # re-parses the DAG source for the live policy.
-                    if bool(v):
-                        serialized_op["partial_kwargs"]["has_retry_policy"] = True
-                    continue
-                if k in _OPERATOR_CALLBACK_FIELDS:
+                if k in _HAS_FLAG_FIELDS:
+                    # These have no serializer; storing the object would str(obj) it and leak
+                    # a non-deterministic memory address. Keep only a has_<field> flag (e.g.
+                    # has_retry_policy, has_on_failure_callback); the live object is recovered
+                    # by re-parsing the DAG source on the worker.
                     if bool(v):
                         serialized_op["partial_kwargs"][f"has_{k}"] = True
                     continue
@@ -1737,13 +1738,13 @@ class DagSerialization(BaseSerialization):
             #   Ideally default_args goes through same logic as fields of SerializedBaseOperator.
             if serialized_dag.get("default_args", {}):
                 default_args_dict = serialized_dag["default_args"][Encoding.VAR]
-                callbacks_to_remove = []
+                flags_to_remove = []
                 for k, v in list(default_args_dict.items()):
-                    if k in _OPERATOR_CALLBACK_FIELDS:
+                    if k in _HAS_FLAG_FIELDS:
                         if bool(v):
                             default_args_dict[f"has_{k}"] = True
-                        callbacks_to_remove.append(k)
-                for k in callbacks_to_remove:
+                        flags_to_remove.append(k)
+                for k in flags_to_remove:
                     del default_args_dict[k]
 
             return serialized_dag

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -83,6 +83,7 @@ from airflow.sdk.definitions.deadline import (
 from airflow.sdk.definitions.decorators import task
 from airflow.sdk.definitions.operator_resources import Resources
 from airflow.sdk.definitions.param import Param
+from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
 from airflow.sdk.definitions.taskgroup import TaskGroup
 from airflow.sdk.execution_time.context import OutletEventAccessor, OutletEventAccessors
 from airflow.serialization import serialized_objects
@@ -1279,7 +1280,6 @@ class TestRetryPolicySerialization:
     def test_has_retry_policy_flag_set_when_policy_present(self):
         """When retry_policy is set, has_retry_policy=True in serialized form."""
         from airflow.sdk import DAG, BaseOperator
-        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
         from airflow.serialization.serialized_objects import DagSerialization
 
         policy = ExceptionRetryPolicy(
@@ -1312,7 +1312,6 @@ class TestRetryPolicySerialization:
     def test_mapped_task_retry_policy_serializes_as_flag(self):
         """A mapped task's retry_policy must serialize as has_retry_policy, not the object."""
         from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
-        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
 
         policy = ExceptionRetryPolicy(
             rules=[RetryRule(exception=ValueError, action=RetryAction.FAIL, reason="bad data")],
@@ -1341,7 +1340,6 @@ class TestRetryPolicySerialization:
         (and a spurious new DagVersion).
         """
         from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
-        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
 
         def build():
             policy = ExceptionRetryPolicy(
@@ -1366,7 +1364,6 @@ class TestRetryPolicySerialization:
         though each task's has_retry_policy was set correctly.
         """
         from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
-        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
 
         def build():
             policy = ExceptionRetryPolicy(
@@ -1386,8 +1383,12 @@ class TestRetryPolicySerialization:
             return dag
 
         serialized = DagSerialization.serialize_dag(build())
-        # The RetryPolicy object must never be embedded in serialized default_args.
+        # The RetryPolicy object must never be embedded in serialized default_args...
         assert "ExceptionRetryPolicy object at 0x" not in json.dumps(serialized)
+        # ...and the has_retry_policy flag must be written in its place.
+        default_args_dict = serialized["default_args"][Encoding.VAR]
+        assert default_args_dict.get("has_retry_policy") is True
+        assert "retry_policy" not in default_args_dict
         # Deterministic across independent parses (no embedded memory address).
         assert DagSerialization.serialize_dag(build()) == DagSerialization.serialize_dag(build())
 

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -1311,11 +1311,8 @@ class TestRetryPolicySerialization:
 
     def test_mapped_task_retry_policy_serializes_as_flag(self):
         """A mapped task's retry_policy must serialize as has_retry_policy, not the object."""
-        import json
-
-        from airflow.sdk import DAG, task
+        from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
         from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
-        from airflow.serialization.serialized_objects import DagSerialization
 
         policy = ExceptionRetryPolicy(
             rules=[RetryRule(exception=ValueError, action=RetryAction.FAIL, reason="bad data")],
@@ -1343,9 +1340,8 @@ class TestRetryPolicySerialization:
         per-process memory address, so every re-parse produced a different serialized DAG
         (and a spurious new DagVersion).
         """
-        from airflow.sdk import DAG, task
+        from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
         from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
-        from airflow.serialization.serialized_objects import DagSerialization
 
         def build():
             policy = ExceptionRetryPolicy(
@@ -1360,6 +1356,39 @@ class TestRetryPolicySerialization:
                 mapped.expand(x=[1, 2, 3])
             return dag
 
+        assert DagSerialization.serialize_dag(build()) == DagSerialization.serialize_dag(build())
+
+    def test_dag_default_args_retry_policy_serializes_as_flag(self):
+        """A retry_policy in DAG default_args must not leak the object into serialized default_args.
+
+        Regression test: serialize_dag serializes the raw default_args dict, so a RetryPolicy
+        there hit the str(obj) fallback (memory address -> new DagVersion every parse) even
+        though each task's has_retry_policy was set correctly.
+        """
+        from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
+        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
+
+        def build():
+            policy = ExceptionRetryPolicy(
+                rules=[RetryRule(exception=ValueError, action=RetryAction.FAIL)],
+            )
+            with DAG(
+                dag_id="test_default_args_retry_policy",
+                start_date=DEFAULT_DATE,
+                default_args={"retry_policy": policy},
+            ) as dag:
+
+                @task
+                def plain():
+                    return 1
+
+                plain()
+            return dag
+
+        serialized = DagSerialization.serialize_dag(build())
+        # The RetryPolicy object must never be embedded in serialized default_args.
+        assert "ExceptionRetryPolicy object at 0x" not in json.dumps(serialized)
+        # Deterministic across independent parses (no embedded memory address).
         assert DagSerialization.serialize_dag(build()) == DagSerialization.serialize_dag(build())
 
 

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -1309,6 +1309,59 @@ class TestRetryPolicySerialization:
         task = deserialized.task_dict["op_no_policy"]
         assert task.has_retry_policy is False
 
+    def test_mapped_task_retry_policy_serializes_as_flag(self):
+        """A mapped task's retry_policy must serialize as has_retry_policy, not the object."""
+        import json
+
+        from airflow.sdk import DAG, task
+        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
+        from airflow.serialization.serialized_objects import DagSerialization
+
+        policy = ExceptionRetryPolicy(
+            rules=[RetryRule(exception=ValueError, action=RetryAction.FAIL, reason="bad data")],
+        )
+
+        with DAG(dag_id="test_mapped_retry_policy_ser", start_date=DEFAULT_DATE) as dag:
+
+            @task(retries=3, retry_policy=policy)
+            def mapped(x):
+                return x
+
+            mapped.expand(x=[1, 2, 3])
+
+        serialized = DagSerialization.serialize_dag(dag)
+        # The RetryPolicy object must never be embedded -- str(obj) leaks a memory address.
+        assert "ExceptionRetryPolicy object at 0x" not in json.dumps(serialized)
+
+        deserialized = DagSerialization.deserialize_dag(serialized)
+        assert deserialized.task_dict["mapped"].has_retry_policy is True
+
+    def test_mapped_task_retry_policy_serialization_is_deterministic(self):
+        """Serializing the same mapped-task-with-policy DAG twice yields identical output.
+
+        Regression test: the RetryPolicy object was serialized via str(obj), embedding a
+        per-process memory address, so every re-parse produced a different serialized DAG
+        (and a spurious new DagVersion).
+        """
+        from airflow.sdk import DAG, task
+        from airflow.sdk.definitions.retry_policy import ExceptionRetryPolicy, RetryAction, RetryRule
+        from airflow.serialization.serialized_objects import DagSerialization
+
+        def build():
+            policy = ExceptionRetryPolicy(
+                rules=[RetryRule(exception=ValueError, action=RetryAction.FAIL)],
+            )
+            with DAG(dag_id="test_mapped_retry_policy_determinism", start_date=DEFAULT_DATE) as dag:
+
+                @task(retries=3, retry_policy=policy)
+                def mapped(x):
+                    return x
+
+                mapped.expand(x=[1, 2, 3])
+            return dag
+
+        assert DagSerialization.serialize_dag(build()) == DagSerialization.serialize_dag(build())
+
 
 class TestKubernetesImportAvoidance:
     """Test that serialization doesn't import kubernetes unnecessarily."""

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -1391,6 +1391,27 @@ class TestRetryPolicySerialization:
         # Deterministic across independent parses (no embedded memory address).
         assert DagSerialization.serialize_dag(build()) == DagSerialization.serialize_dag(build())
 
+    def test_mapped_task_no_retry_policy_flag_false(self):
+        """A mapped task without a retry_policy must not spuriously set has_retry_policy.
+
+        Mapped resolves the flag via _get_partial_kwargs_or_operator_default (falling back to
+        SerializedBaseOperator.has_retry_policy=False), a different path than the non-mapped
+        dataclass default — so it needs its own negative test.
+        """
+        from airflow.sdk import DAG  # module-level DAG is airflow.models.dag.DAG
+
+        with DAG(dag_id="test_mapped_no_retry_policy", start_date=DEFAULT_DATE) as dag:
+
+            @task(retries=3)
+            def mapped(x):
+                return x
+
+            mapped.expand(x=[1, 2, 3])
+
+        serialized = DagSerialization.serialize_dag(dag)
+        deserialized = DagSerialization.deserialize_dag(serialized)
+        assert deserialized.task_dict["mapped"].has_retry_policy is False
+
 
 class TestKubernetesImportAvoidance:
     """Test that serialization doesn't import kubernetes unnecessarily."""


### PR DESCRIPTION
### What's wrong

A mapped task that uses a retry policy (`.partial(retry_policy=…).expand(…)` or
`@task(retry_policy=…).expand(…)`) gets a **new DAG version created on nearly every
DAG-processor re-serialization (~30s)** — even when the DAG is idle and never run —
spamming the DAG version history and bloating the metadata DB (`dag_version` /
`serialized_dag`).

### Root cause

A mapped operator keeps `retry_policy` in `partial_kwargs`, and the mapped-operator
serializer has no serializer for a `RetryPolicy`, so it falls back to `str(obj)` —
`"<…ExceptionRetryPolicy object at 0x…>"`. That memory address changes on every parse,
so `dag_hash` changes each time, defeating `write_dag`'s "unchanged" check and creating
a new `DagVersion` on every re-serialization. Non-mapped operators already avoid this by
excluding the object and storing only a `has_retry_policy` flag.

### Fix

Mirror the non-mapped path in the mapped-operator serializer: don't serialize the object,
store only a `has_retry_policy` flag, and add `has_retry_policy` to `SerializedMappedOperator`
so it round-trips. Runtime is unaffected — the worker re-parses the DAG source for the live
policy, so retries still work.

### Testing

Adds regression tests that a mapped task with a `retry_policy` (a) serializes
**deterministically** (identical across parses, no embedded object) and (b) round-trips
`has_retry_policy=True`. Both fail on `main` and pass with the fix.


**Before**
1. Try below DAG and create a dag_run.
2. Execute  SELECT count(*) FROM dag_version WHERE dag_id='aip105_mapped_serialize_repro' and confirm new version is created
```
from airflow.sdk import DAG, ExceptionRetryPolicy, RetryAction, RetryRule, task

POLICY = ExceptionRetryPolicy(
    rules=[
        RetryRule(
            exception=ConnectionError,
            action=RetryAction.RETRY,
            retry_delay=timedelta(seconds=30),
            reason="Transient, backing off 30s",
        ),
    ],
)

with DAG(
    dag_id="aip105_mapped_serialize_repro",
    schedule=None,
    catchup=False,
    tags=["qa", "aip105", "serialization-bug"],
):

    @task(retries=3, retry_policy=POLICY)
    def mapped_with_policy(x):
        return x

    @task(retries=3, retry_policy=POLICY)
    def plain_with_policy():
        return 1

    mapped_with_policy.expand(x=[1, 2, 3])
    plain_with_policy()

```

**After**

1. Run same DAG and check new version is not getting created



##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)