### PR TITLE
Run OTel integration tests when span-emitting task runner code changes

### DIFF
--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -244,6 +244,7 @@ representative examples (file → effect):
 | `scripts/ci/prek/check_*.py` (static-check hook)       | CI image + static checks, **no full matrix**                         | prek hooks are static checks → `Prek files` carve-out |
 | the generated OpenAPI spec                             | **full matrix**                                                      | the API *contract* ripples to UI codegen + every client |
 | `chart/templates/...yaml` (on `main`)                  | `run_helm_tests` (+ PROD image)                                      | matches `HELM_FILES`; Helm tests only on `main` |
+| `task-sdk/.../task_runner.py` or `airflow-core/tests/integration/otel/...` | the `otel` core integration                       | matches `OTEL_FILES`; the otel integration tests assert the span hierarchy task_runner emits |
 | `airflow-core/src/airflow/ui/...tsx` only              | `run_ui_tests`, **no** unit tests                                    | "only new-UI files" short-circuit skips Python unit tests |
 
 The "complexity" you feel reading the code is just *many* such rules stacked up — each one on its own

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -464,6 +464,10 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
             r"^airflow-core/src/airflow/observability/.*",
             r"^shared/observability/src/airflow_shared/observability/.*",
             r"^airflow-core/src/airflow/utils/span_status\.py$",
+            # The otel integration tests assert the exact span hierarchy that
+            # task_runner emits, so changes to either must exercise the integration.
+            r"^airflow-core/tests/integration/otel/.*",
+            r"^task-sdk/src/airflow/sdk/execution_time/task_runner\.py$",
         ],
         FileGroupForCi.CELERY_FILES: [
             # Core executor sources - redis is celery's broker/result backend, so the

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3419,6 +3419,8 @@ def test_testable_providers_integrations_excludes_arm_disabled_on_arm():
     [
         pytest.param("airflow-core/src/airflow/security/kerberos.py", "kerberos", id="kerberos-source"),
         pytest.param("airflow-core/src/airflow/observability/stats.py", "otel", id="otel-source"),
+        pytest.param("airflow-core/tests/integration/otel/test_otel.py", "otel", id="otel-integration-tests"),
+        pytest.param("task-sdk/src/airflow/sdk/execution_time/task_runner.py", "otel", id="otel-task-runner"),
         pytest.param("airflow-core/src/airflow/executors/executor_loader.py", "redis", id="celery-source"),
     ],
 )


### PR DESCRIPTION
- related: #67877, follow-up of #69236

## Why

#67877 changed the spans emitted by the task runner and broke the OTel integration test, but its CI never ran that test: neither `task_runner.py` nor the otel integration tests themselves are in the `OTEL_FILES` selective-checks group, so `testable-core-integrations` stayed empty and the failure only surfaced in the canary build (fixed in #69236).

## What

- Add `airflow-core/tests/integration/otel/` and `task-sdk/.../task_runner.py` to `OTEL_FILES` so touching either triggers the `otel` core integration.
- Sync `dev/breeze/doc/ci/04_selective_checks.md` and `test_selective_checks.py` accordingly.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)