### PR TITLE
Rename apache-steward references to apache-magpie and default PR review to it

### DIFF
--- a/.agents/skills/magpie-setup/adopt.md
+++ b/.agents/skills/magpie-setup/adopt.md
@@ -1120,6 +1120,24 @@ framework before they hit a "skill not found" error:
    [`apache/magpie`](https://github.com/apache/magpie).
    ```
 
+   **If the adopter installed the `pr-management-*` family**
+   (Step 5), append the following subsection to the
+   `AGENTS.md` block above, so the adopter's agent defaults to
+   the framework's review skill. Skip it entirely for adopters
+   who did not take that family.
+
+   ```markdown
+   ### Reviewing pull requests
+
+   With apache-magpie installed locally, use the
+   `magpie-pr-management-code-review` skill for PR code
+   review. It posts findings as **inline review comments**
+   anchored to `file:line`, presented **individually for
+   accept/skip** before anything is submitted — prefer it
+   over an ad-hoc review pass or a generic review command. A
+   body-only review is the explicit opt-out (`inline:off`).
+   ```
+
    Do not create `AGENTS.md` if it does not already exist —
    the contributor-facing section in `README.md` is the
    authoritative entry-point, and an empty `AGENTS.md` would

--- a/.apache-magpie-overrides/README.md
+++ b/.apache-magpie-overrides/README.md
@@ -17,19 +17,19 @@
  under the License.
  -->
 
-# apache-steward overrides
+# apache-magpie overrides
 
 Agent-readable instructions that override specific steps or
-behaviours of apache-steward framework skills, scoped to
+behaviours of apache-magpie framework skills, scoped to
 this adopter repo. Each override file is named after the
 framework skill it modifies (e.g. `pr-management-triage.md`
 overrides the `pr-management-triage` skill).
 
 The framework skills consult this directory at run-time
 before executing default behaviour. See
-[`docs/setup/agentic-overrides.md`](https://github.com/apache/airflow-steward/blob/main/docs/setup/agentic-overrides.md)
+[`docs/setup/agentic-overrides.md`](https://github.com/apache/magpie/blob/main/docs/setup/agentic-overrides.md)
 in the framework for the full contract.
 
 **Hard rule**: never modify the snapshot under
-`<repo-root>/.apache-steward/`. Local mods go here.
-Framework changes go via PR to `apache/airflow-steward`.
+`<repo-root>/.apache-magpie/`. Local mods go here.
+Framework changes go via PR to `apache/magpie`.

--- a/.apache-magpie.lock
+++ b/.apache-magpie.lock
@@ -2,5 +2,5 @@
 # Edited only by /magpie-setup; do not modify by hand.
 
 method: git-branch
-url:    https://github.com/apache/airflow-steward.git
+url:    https://github.com/apache/magpie.git
 ref:    main

--- a/.gitignore
+++ b/.gitignore
@@ -322,12 +322,12 @@ dev/registry/providers.json
 # Per-machine session-state file. Records adopter-local persistence
 # anchors written by magpie skills (e.g. the session-history gist
 # URL written by pr-management-triage Step 6b, per
-# https://github.com/apache/airflow-steward/pull/343).
+# https://github.com/apache/magpie/pull/343).
 /.apache-magpie.session-state.json
 
 # Per-machine project-scope Claude Code settings (sandbox-allowlist
 # absolute paths written by sandbox-add-project-root.sh; per
-# https://github.com/apache/airflow-steward/issues/197).
+# https://github.com/apache/magpie/issues/197).
 /.claude/settings.local.json
 
 # Symlinks created by /magpie-setup into the gitignored snapshot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,9 +470,9 @@ including the `@<github-handle>` in the `Drafted-by: … reviewed by
 message — and replying within a thread to people already actively
 participating in that same PR/issue discussion.
 
-## apache-steward framework
+## apache-magpie framework
 
-This repo adopts the [`apache/airflow-steward`](https://github.com/apache/airflow-steward)
+This repo adopts the [`apache/magpie`](https://github.com/apache/magpie)
 framework via the snapshot mechanism. The framework provides the
 `pr-management-*` skills (triage, code-review, stats, mentor); they are
 gitignored symlinks into the `.apache-magpie/` snapshot directory.
@@ -482,12 +482,21 @@ invocable. Run `/magpie-setup` (or follow
 [`.claude/skills/magpie-setup/`](.claude/skills/magpie-setup/)) to fetch
 it per the committed [`.apache-magpie.lock`](.apache-magpie.lock). The
 contributor-facing summary of the adoption + setup flow lives in the
-[Agent-assisted contribution section of `README.md`](README.md#agent-assisted-contribution-apache-steward).
+[Agent-assisted contribution section of `README.md`](README.md#agent-assisted-contribution-apache-magpie).
 
 Adopter-specific modifications to framework-skill workflows live in
 [`.apache-magpie-overrides/`](.apache-magpie-overrides/) — never edit
 the snapshot directly. Framework changes go via PR to
-[`apache/airflow-steward`](https://github.com/apache/airflow-steward).
+[`apache/magpie`](https://github.com/apache/magpie).
+
+### Reviewing pull requests
+
+With apache-magpie installed locally, use the
+`magpie-pr-management-code-review` skill for PR code review. It posts
+findings as **inline review comments** anchored to `file:line`, presented
+**individually for accept/skip** before anything is submitted — prefer it
+over an ad-hoc review pass or a generic review command. A body-only review
+is the explicit opt-out (`inline:off`).
 
 ## Boundaries
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use Airflow to author workflows (Dags) that orchestrate tasks. The Airflow sched
 - [Approach to dependencies of Airflow](#approach-to-dependencies-of-airflow)
 - [Contributing](#contributing)
 - [Community standards](#community-standards)
-- [Agent-assisted contribution (apache-steward)](#agent-assisted-contribution-apache-steward)
+- [Agent-assisted contribution (apache-magpie)](#agent-assisted-contribution-apache-magpie)
 - [Voting Policy](#voting-policy)
 - [Who uses Apache Airflow?](#who-uses-apache-airflow)
 - [Who maintains Apache Airflow?](#who-maintains-apache-airflow)
@@ -449,9 +449,9 @@ blocks and reporting accounts to GitHub — and how affected
 contributors can appeal a decision by emailing the PMC at
 `private@airflow.apache.org`.
 
-## Agent-assisted contribution (apache-steward)
+## Agent-assisted contribution (apache-magpie)
 
-This repo adopts the [`apache/airflow-steward`](https://github.com/apache/airflow-steward)
+This repo adopts the [`apache/magpie`](https://github.com/apache/magpie)
 framework via a snapshot mechanism. The framework provides
 maintainer-facing PR-management skills (`pr-management-triage`,
 `pr-management-code-review`, `pr-management-stats`, `pr-management-mentor`)
@@ -479,7 +479,7 @@ each worktree checkout.
 Adopter-specific modifications to framework workflows live in
 [`.apache-magpie-overrides/`](.apache-magpie-overrides/) (committed) —
 never edit the snapshot directly. Framework changes go via PR to
-[`apache/airflow-steward`](https://github.com/apache/airflow-steward).
+[`apache/magpie`](https://github.com/apache/magpie).
 
 <!-- START Who uses Apache Airflow, please keep comment here to allow auto update of PyPI readme.md -->
 

--- a/contributing-docs/25_maintainer_pr_triage.md
+++ b/contributing-docs/25_maintainer_pr_triage.md
@@ -22,7 +22,7 @@
 This document describes how Apache Airflow maintainers triage incoming Pull Requests
 using **agentic skills** that run inside [Claude Code](https://claude.com/claude-code).
 The triage workflow that used to live in the `breeze pr auto-triage` command has been
-replaced by the [`pr-management-triage`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/SKILL.md) skill, which is
+replaced by the [`pr-management-triage`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/SKILL.md) skill, which is
 maintained as plain Markdown alongside the codebase and is invoked from a maintainer's
 local Claude Code session.
 
@@ -57,7 +57,7 @@ weigh. That time is finite and irreplaceable.
 To protect it, the project splits PR handling into two stages:
 
 1. **First pass — automated, mechanical, fast.** A maintainer invokes the
-   [`pr-management-triage`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/SKILL.md) skill, which sweeps the open
+   [`pr-management-triage`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/SKILL.md) skill, which sweeps the open
    PR queue, runs purely deterministic checks (CI status, merge conflicts, unresolved
    review threads, workflow-approval state, draft staleness), and proposes a
    disposition for each PR. The maintainer confirms in batches — accepting a group of
@@ -106,11 +106,11 @@ alongside `pr-management-triage` is out of scope here.
 
 ## Stage 1: invoking the `pr-management-triage` skill
 
-The skill is provided by the [`apache/airflow-steward`](https://github.com/apache/airflow-steward) framework,
-adopted via its snapshot mechanism (see [`README.md` → "Agent-assisted contribution"](../README.md#agent-assisted-contribution-apache-steward) for first-time setup). After running `/setup-steward` the
-framework lives gitignored at `.apache-steward/` and a `.claude/skills/pr-management-triage` symlink picks it up
+The skill is provided by the [`apache/magpie`](https://github.com/apache/magpie) framework,
+adopted via its snapshot mechanism (see [`README.md` → "Agent-assisted contribution"](../README.md#agent-assisted-contribution-apache-magpie) for first-time setup). After running `/magpie-setup` the
+framework lives gitignored at `.apache-magpie/` and a `.claude/skills/pr-management-triage` symlink picks it up
 so Claude Code finds it without any per-developer config. Its entry point is
-[`SKILL.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/SKILL.md); the rest of the directory breaks
+[`SKILL.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/SKILL.md); the rest of the directory breaks
 the logic out by topic (classification, fetch-and-batch, stale sweeps, comment
 templates, etc.).
 
@@ -125,13 +125,13 @@ for a triage. Common phrasings the skill recognises:
 - `run the stale sweep` — close stale drafts / convert inactive PRs to draft
 - `morning triage` — same as the default sweep
 
-The skill's `when_to_use` block (in [`SKILL.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/SKILL.md))
+The skill's `when_to_use` block (in [`SKILL.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/SKILL.md))
 lists the full set of recognised invocation patterns.
 
 ### What the triage skill checks
 
 The first-pass classification is purely deterministic — see
-[`classify-and-act.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/classify-and-act.md) for the full decision matrix
+[`classify-and-act.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/classify-and-act.md) for the full decision matrix
 — and runs against data fetched in a single aliased GraphQL call per page of PRs:
 
 1. **Pending workflow approval** — first-time-contributor PRs whose CI workflows
@@ -144,14 +144,14 @@ The first-pass classification is purely deterministic — see
    `GET /repos/.../actions/runs?status=action_required` endpoint as the primary
    signal, then cross-referenced against `statusCheckRollup`. The REST call is
    needed because the rollup can return `SUCCESS` while real CI is still pending —
-   see Golden rule 1b in [`SKILL.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/SKILL.md#golden-rules).
+   see Golden rule 1b in [`SKILL.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/SKILL.md#golden-rules).
 4. **Unresolved review threads** — open conversations from collaborators or from
    `copilot*[bot]` (Copilot threads are evaluated separately, with a 7-day grace
    window).
 5. **Staleness** — drafts older than 7 days with no author reply after a triage
    comment, untriaged drafts older than 2 weeks, non-draft PRs with 4+ weeks of
    inactivity, and workflow-approval PRs with 4+ weeks of inactivity. See
-   [`stale-sweeps.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/stale-sweeps.md).
+   [`stale-sweeps.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/stale-sweeps.md).
 
 ### Available triage actions
 
@@ -173,14 +173,14 @@ available. The full set of actions:
 | `skip` | Leave the PR alone this run. |
 
 The full action recipes (the `gh` / GraphQL calls each action issues) are in
-[`actions.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/actions.md); the comment bodies posted by
+[`actions.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/actions.md); the comment bodies posted by
 the `draft` / `comment` / `close` / `ping` actions are in
-[`comment-templates.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/comment-templates.md).
+[`comment-templates.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/comment-templates.md).
 
 ### AI-attribution footer on every contributor-facing comment
 
 Every comment the skill posts to a contributor ends with the same AI-attribution
-footer (see [`comment-templates.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/comment-templates.md#ai-attribution-footer)).
+footer (see [`comment-templates.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/comment-templates.md#ai-attribution-footer)).
 The footer:
 
 - tells the contributor the comment was drafted by an AI-assisted tool and may
@@ -191,7 +191,7 @@ The footer:
   section above so the contributor can read the rationale for the two-stage process.
 
 This is non-negotiable per Golden rule 8 in
-[`SKILL.md`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-triage/SKILL.md#golden-rules) — only the
+[`SKILL.md`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-triage/SKILL.md#golden-rules) — only the
 intentionally-terse `suspicious-changes` template is exempt.
 
 ## Stage 2: human review
@@ -208,7 +208,7 @@ decisions belongs in that future skill, not in `pr-management-triage`.
 
 ## Backlog statistics — the `pr-management-stats` skill
 
-The [`pr-management-stats`](https://github.com/apache/airflow-steward/blob/main/.claude/skills/pr-management-stats/SKILL.md) skill is the read-only,
+The [`pr-management-stats`](https://github.com/apache/magpie/blob/main/.claude/skills/pr-management-stats/SKILL.md) skill is the read-only,
 no-mutations counterpart of `pr-management-triage`. It is the successor to the now-removed
 `breeze pr stats` command and produces two summary tables grouped by `area:*` label:
 


### PR DESCRIPTION
The apache-steward framework was renamed to **apache-magpie** — the GitHub repo
`apache/airflow-steward` now redirects to `apache/magpie`. This renames the
adopter-side references across `AGENTS.md`, `README.md`, the overrides README,
`contributing-docs/25_maintainer_pr_triage.md`, the `.gitignore` tracking-issue
links, and the committed `.apache-magpie.lock` URL so the docs and the pinned
fetch URL are canonical. The framework bootstrap `upgrade.md` is intentionally
left untouched — its `steward` references are the source side of the framework's
own migration logic.

It also adds a "Reviewing pull requests" subsection to `AGENTS.md` so agents
default to the locally-installed `magpie-pr-management-code-review` skill (inline
review comments anchored to `file:line`, accept/skip per finding) instead of an
ad-hoc pass or a generic review command — following through on guidance the
magpie adopt flow now emits (framework #675). The committed `magpie-setup`
bootstrap is refreshed to the current framework tip to pick that guidance up;
the snapshot, symlinks, and local hooks are gitignored and untouched.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8 1M)

Generated-by: Claude Code (Opus 4.8 1M) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
