### PR TITLE
Fix details panel header overlapping the tabs

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
+++ b/airflow-core/src/airflow/ui/src/components/HeaderCard.tsx
@@ -39,7 +39,7 @@ export const HeaderCard = ({ actions, icon, state, stats, subTitle, title }: Pro
   const { t: translate } = useTranslation();
 
   return (
-    <Box data-testid="header-card" overflow="hidden">
+    <Box data-testid="header-card" flexShrink={0} overflow="hidden">
       <DagDeactivatedBanner />
       <Box p={2}>
         <Flex alignItems="center" flexWrap="wrap" justifyContent="space-between" mb={2}>


### PR DESCRIPTION
The page header in the details panel is a `HeaderCard`, which clips its own overflow. As a flex child of the details-panel column it could shrink when vertical space is tight — most visibly on **Dag** pages, whose header has the most rows (schedule, latest/next run, max active runs, owner, tags, version) — cropping its content so the tabs appear to overlap the scheduling information.

Setting `flexShrink={0}` keeps the header at its natural height; the scrollable tab-content outlet (already `overflow="auto"`, so it gets `min-height:0` as a scroll container) absorbs the reduced space instead.

closes: #69247

### Before / After

- Before: (for instance here, the full header is collapsed and hidden)
<img width="1412" height="565" alt="Screenshot 2026-07-02 at 16 52 19" src="https://github.com/user-attachments/assets/f2493349-aeb2-4153-9fd6-4ca46c50aaa9" />

- After:
<img width="1434" height="644" alt="Screenshot 2026-07-02 at 16 51 46" src="https://github.com/user-attachments/assets/5059ff2b-f88c-4c43-b8ad-1484921b26d7" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)