### PR TITLE
Java SDK: Throw MissingXComException instead of NPE for absent XComs

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
@@ -426,6 +426,14 @@ represented as Java objects when read back via ``getXCom``.
      - object
      - ``Map<String, Object>``
 
+.. note::
+
+   An ``@Builder.XCom`` parameter that reads a value which was never pushed resolves to
+   ``null``.  A boxed parameter (``Integer``, ``Long``, ``Boolean``, …) receives ``null``
+   safely, but a primitive parameter (``int``, ``long``, ``boolean``, …) cannot represent
+   ``null`` and the task fails with ``MissingXComException``.  Declare the parameter with a
+   boxed type when the upstream XCom may be absent.
+
 .. _java-sdk/build:
 
 Building and packaging

--- a/java-sdk/processor/src/main/kotlin/org/apache/airflow/sdk/BuilderProcessor.kt
+++ b/java-sdk/processor/src/main/kotlin/org/apache/airflow/sdk/BuilderProcessor.kt
@@ -216,21 +216,36 @@ private val NUMBER_ACCESSORS: Map<TypeName, String> =
   }
 
 private fun xcomAccess(xcom: RequiredXCom): CodeBlock {
-  val call = CodeBlock.of($$"client.getXCom($S)", xcom.taskId)
   val type = TypeName.get(xcom.paramType)
   val accessor = NUMBER_ACCESSORS[type]
   val number = ClassName.get(Number::class.java)
+  val optional = ClassName.get(Optional::class.java)
+  // A primitive parameter cannot hold null, so fail with a clear error instead of an
+  // opaque NullPointerException while unboxing when the XCom is absent.
+  val value =
+    if (type.isPrimitive) {
+      CodeBlock.of(
+        $$"$T.ofNullable(client.getXCom($S)).orElseThrow(() -> new $T($S, $S))",
+        optional,
+        xcom.taskId,
+        ClassName.get(MissingXComException::class.java),
+        xcom.taskId,
+        xcom.paramName,
+      )
+    } else {
+      CodeBlock.of($$"client.getXCom($S)", xcom.taskId)
+    }
   // Wire integers decode to Long and floats to Double, so a direct (Integer)/(Float)
   // cast throws ClassCastException; widen via Number instead.
   return when {
-    accessor == null -> CodeBlock.of($$"($T) $L", if (type.isPrimitive) type.box() else type, call)
-    type.isPrimitive -> CodeBlock.of($$"(($T) $L).$L()", number, call, accessor)
+    accessor == null -> CodeBlock.of($$"($T) $L", if (type.isPrimitive) type.box() else type, value)
+    type.isPrimitive -> CodeBlock.of($$"(($T) $L).$L()", number, value, accessor)
     else ->
       CodeBlock.of(
         $$"$T.ofNullable(($T) $L).map($T::$L).orElse(null)",
-        ClassName.get(Optional::class.java),
+        optional,
         number,
-        call,
+        value,
         number,
         accessor,
       )

--- a/java-sdk/processor/src/test/kotlin/org/apache/airflow/sdk/BuilderTest.kt
+++ b/java-sdk/processor/src/test/kotlin/org/apache/airflow/sdk/BuilderTest.kt
@@ -80,9 +80,11 @@ class BuilderTest {
          import java.lang.Exception;
          import java.lang.Number;
          import java.lang.Override;
+         import java.util.Optional;
          import org.apache.airflow.sdk.Client;
          import org.apache.airflow.sdk.Context;
          import org.apache.airflow.sdk.Dag;
+         import org.apache.airflow.sdk.MissingXComException;
          import org.apache.airflow.sdk.Task;
 
          public final class TestExampleBuilder {
@@ -108,7 +110,7 @@ class BuilderTest {
            public static final class T3 implements Task {
              @Override
              public void execute(Context context, Client client) throws Exception {
-               var value = ((Number) client.getXCom("t2")).intValue();
+               var value = ((Number) Optional.ofNullable(client.getXCom("t2")).orElseThrow(() -> new MissingXComException("t2", "value"))).intValue();
                new TestExample().t3(context, value);
              }
            }
@@ -133,7 +135,10 @@ class BuilderTest {
               @Builder.XCom(task = "b") long l,
               @Builder.XCom(task = "c") double d,
               @Builder.XCom(task = "f") float fl,
-              @Builder.XCom(task = "e") Integer boxed) {}
+              @Builder.XCom(task = "e") Integer boxedInteger,
+              @Builder.XCom(task = "g") Long boxedLong,
+              @Builder.XCom(task = "h") Double boxedDouble,
+              @Builder.XCom(task = "j") Float boxedFloat) {}
         }
       """,
       )
@@ -153,6 +158,7 @@ class BuilderTest {
          import org.apache.airflow.sdk.Client;
          import org.apache.airflow.sdk.Context;
          import org.apache.airflow.sdk.Dag;
+         import org.apache.airflow.sdk.MissingXComException;
          import org.apache.airflow.sdk.Task;
 
          public final class TestExampleBuilder {
@@ -164,12 +170,73 @@ class BuilderTest {
            public static final class T implements Task {
              @Override
              public void execute(Context context, Client client) throws Exception {
-               var i = ((Number) client.getXCom("a")).intValue();
-               var l = ((Number) client.getXCom("b")).longValue();
-               var d = ((Number) client.getXCom("c")).doubleValue();
-               var fl = ((Number) client.getXCom("f")).floatValue();
-               var boxed = Optional.ofNullable((Number) client.getXCom("e")).map(Number::intValue).orElse(null);
-               new TestExample().t(i, l, d, fl, boxed);
+               var i = ((Number) Optional.ofNullable(client.getXCom("a")).orElseThrow(() -> new MissingXComException("a", "i"))).intValue();
+               var l = ((Number) Optional.ofNullable(client.getXCom("b")).orElseThrow(() -> new MissingXComException("b", "l"))).longValue();
+               var d = ((Number) Optional.ofNullable(client.getXCom("c")).orElseThrow(() -> new MissingXComException("c", "d"))).doubleValue();
+               var fl = ((Number) Optional.ofNullable(client.getXCom("f")).orElseThrow(() -> new MissingXComException("f", "fl"))).floatValue();
+               var boxedInteger = Optional.ofNullable((Number) client.getXCom("e")).map(Number::intValue).orElse(null);
+               var boxedLong = Optional.ofNullable((Number) client.getXCom("g")).map(Number::longValue).orElse(null);
+               var boxedDouble = Optional.ofNullable((Number) client.getXCom("h")).map(Number::doubleValue).orElse(null);
+               var boxedFloat = Optional.ofNullable((Number) client.getXCom("j")).map(Number::floatValue).orElse(null);
+               new TestExample().t(i, l, d, fl, boxedInteger, boxedLong, boxedDouble, boxedFloat);
+             }
+           }
+         }
+        """,
+      )
+  }
+
+  @Test
+  @DisplayName("guard non-numeric primitives, leave objects and boxed types nullable")
+  fun generateBuilderGuardsNonNumericPrimitiveXCom() {
+    val compilation =
+      compile(
+        """
+        package org.apache.airflow.example;
+        import org.apache.airflow.sdk.Builder;
+        @Builder.Dag
+        public class TestExample {
+          @Builder.Task
+          public void t(
+              @Builder.XCom(task = "a") boolean flag,
+              @Builder.XCom(task = "b") String text,
+              @Builder.XCom(task = "c") Boolean boxed) {}
+        }
+      """,
+      )
+
+    assertThat(compilation).succeeded()
+    assertThat(compilation)
+      .generatedSourceFile("org.apache.airflow.example.TestExampleBuilder")
+      .hasSourceEquivalentTo(
+        "org.apache.airflow.example.TestExampleBuilder",
+        """
+         package org.apache.airflow.example;
+
+         import java.lang.Boolean;
+         import java.lang.Exception;
+         import java.lang.Override;
+         import java.lang.String;
+         import java.util.Optional;
+         import org.apache.airflow.sdk.Client;
+         import org.apache.airflow.sdk.Context;
+         import org.apache.airflow.sdk.Dag;
+         import org.apache.airflow.sdk.MissingXComException;
+         import org.apache.airflow.sdk.Task;
+
+         public final class TestExampleBuilder {
+           public static Dag build() {
+             var dag = new Dag("TestExample");
+             dag.addTask("t", T.class);
+             return dag;
+           }
+           public static final class T implements Task {
+             @Override
+             public void execute(Context context, Client client) throws Exception {
+               var flag = (Boolean) Optional.ofNullable(client.getXCom("a")).orElseThrow(() -> new MissingXComException("a", "flag"));
+               var text = (String) client.getXCom("b");
+               var boxed = (Boolean) client.getXCom("c");
+               new TestExample().t(flag, text, boxed);
              }
            }
          }

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
@@ -153,3 +153,19 @@ class Client internal constructor(
     mapIndex = details.ti.mapIndex ?: -1,
   )
 }
+
+/**
+ * Thrown when a task parameter with a primitive type reads an XCom that was never pushed.
+ */
+class MissingXComException(
+  message: String,
+) : IllegalStateException(message) {
+  constructor(
+    taskId: String,
+    paramName: String,
+  ) : this(
+    "Task parameter '$paramName' requires an XCom from task '$taskId', but none was pushed. " +
+      "This parameter has a primitive type that cannot be null; declare it with a boxed type " +
+      "(e.g. Integer instead of int) to receive null.",
+  )
+}

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/ClientTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/ClientTest.kt
@@ -89,4 +89,16 @@ class ClientTest {
 
     Assertions.assertNull(connection.port)
   }
+
+  @Test
+  @DisplayName("MissingXComException builds the full message naming the task and parameter")
+  fun missingXComExceptionBuildsFullMessage() {
+    val ex = MissingXComException("produce", "value")
+    Assertions.assertEquals(
+      "Task parameter 'value' requires an XCom from task 'produce', but none was pushed. " +
+        "This parameter has a primitive type that cannot be null; declare it with a boxed type " +
+        "(e.g. Integer instead of int) to receive null.",
+      ex.message,
+    )
+  }
 }


### PR DESCRIPTION
### Why

A Java SDK task that reads an XCom into a primitive parameter (e.g. int) fails with an opaque `NullPointerException` when the upstream task pushed nothing. The error names neither the task nor the parameter, so the author cannot tell what to fix.

### How

The generated task now throws a `MissingXComException` for absent value instead of NPE.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
related: #68983
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code with Opus 4.8

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
