### PR TITLE
Allow git-sync env vars to be overridden via values and loaded from Secrets

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -204,6 +204,26 @@ If release name contains chart name it will be used as a full name.
     defaultMode: 288
 {{- end }}
 
+{{/*
+Check if a git-sync env var name is NOT overridden by the user's dags.gitSync.env list.
+Returns "true" if the env var is not found in the user list (i.e., the default should be used).
+Returns empty string if it IS found (i.e., the user override takes precedence).
+Usage: include "git_sync_env_not_overridden" (list "ENV_VAR_NAME" .Values.dags.gitSync.env)
+*/}}
+{{- define "git_sync_env_not_overridden" -}}
+{{- $envName := index . 0 -}}
+{{- $envList := index . 1 -}}
+{{- $found := false -}}
+{{- range $envList -}}
+{{- if eq .name $envName -}}
+{{- $found = true -}}
+{{- end -}}
+{{- end -}}
+{{- if not $found -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{/* Git sync container */}}
 {{- define "git_sync_container" }}
 - name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
@@ -212,98 +232,248 @@ If release name contains chart name it will be used as a full name.
   securityContext: {{- include "localContainerSecurityContext" .Values.dags.gitSync | nindent 4 }}
   envFrom: {{- include "custom_git_sync_environment_from" . | default "\n  []" | indent 2 }}
   env:
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_REV" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_REV
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GIT_SYNC_REV
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.rev | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_REF" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_REF
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GITSYNC_REF
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.ref | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_BRANCH" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_BRANCH
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GIT_SYNC_BRANCH
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.branch | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_REPO" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_REPO
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GIT_SYNC_REPO
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.repo | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_REPO" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_REPO
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GITSYNC_REPO
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.repo | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_DEPTH" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_DEPTH
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GIT_SYNC_DEPTH
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.depth | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_DEPTH" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_DEPTH
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GITSYNC_DEPTH
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.depth | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_ROOT" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_ROOT
       value: "/git"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_ROOT" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_ROOT
       value: "/git"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_DEST" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_DEST
       value: "repo"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_LINK" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_LINK
       value: "repo"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_ADD_USER" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_ADD_USER
       value: "true"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_ADD_USER" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_ADD_USER
       value: "true"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_PERIOD" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_PERIOD
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GITSYNC_PERIOD
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.period | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_MAX_SYNC_FAILURES" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_MAX_SYNC_FAILURES
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GIT_SYNC_MAX_SYNC_FAILURES
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
+      {{- end }}
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_MAX_FAILURES" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_MAX_FAILURES
+      {{- if .Values.dags.gitSync.envVarsSecret }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.dags.gitSync.envVarsSecret | quote }}
+          key: GITSYNC_MAX_FAILURES
+          optional: true
+      {{- else }}
       value: {{ .Values.dags.gitSync.maxFailures | quote }}
+      {{- end }}
+    {{- end }}
     {{- if or .Values.dags.gitSync.sshKeySecret .Values.dags.gitSync.sshKey }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SSH_KEY_FILE" .Values.dags.gitSync.env)) }}
     - name: GIT_SSH_KEY_FILE
       value: "/etc/git-secret/ssh"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_SSH_KEY_FILE" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_SSH_KEY_FILE
       value: "/etc/git-secret/ssh"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_SSH" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_SSH
       value: "true"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_SSH" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_SSH
       value: "true"
+    {{- end }}
     {{- if .Values.dags.gitSync.knownHosts }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_KNOWN_HOSTS" .Values.dags.gitSync.env)) }}
     - name: GIT_KNOWN_HOSTS
       value: "true"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_SSH_KNOWN_HOSTS" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "true"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SSH_KNOWN_HOSTS_FILE" .Values.dags.gitSync.env)) }}
     - name: GIT_SSH_KNOWN_HOSTS_FILE
       value: "/etc/git-secret/known_hosts"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_SSH_KNOWN_HOSTS_FILE" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_SSH_KNOWN_HOSTS_FILE
       value: "/etc/git-secret/known_hosts"
+    {{- end }}
     {{- else }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_KNOWN_HOSTS" .Values.dags.gitSync.env)) }}
     - name: GIT_KNOWN_HOSTS
       value: "false"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_SSH_KNOWN_HOSTS" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end }}
+    {{- end }}
     {{ else if .Values.dags.gitSync.credentialsSecret }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_USERNAME" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_USERNAME
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_USERNAME
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_USERNAME" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_USERNAME
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_USERNAME
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_PASSWORD" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GIT_SYNC_PASSWORD
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_PASSWORD" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_PASSWORD
       valueFrom:
         secretKeyRef:
           name: {{ .Values.dags.gitSync.credentialsSecret | quote }}
           key: GITSYNC_PASSWORD
     {{- end }}
+    {{- end }}
     {{- if .Values.dags.gitSync.wait }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_WAIT" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_WAIT
       value: {{ .Values.dags.gitSync.wait | quote }}
     {{- end }}
+    {{- end }}
     {{- if .is_init }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_ONE_TIME" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_ONE_TIME
       value: "true"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_ONE_TIME" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_ONE_TIME
       value: "true"
+    {{- end }}
     {{- else }}
+    {{- if (include "git_sync_env_not_overridden" (list "GIT_SYNC_HTTP_BIND" .Values.dags.gitSync.env)) }}
     - name: GIT_SYNC_HTTP_BIND
       value: ":{{ .Values.dags.gitSync.httpPort }}"
+    {{- end }}
+    {{- if (include "git_sync_env_not_overridden" (list "GITSYNC_HTTP_BIND" .Values.dags.gitSync.env)) }}
     - name: GITSYNC_HTTP_BIND
       value: ":{{ .Values.dags.gitSync.httpPort }}"
+    {{- end }}
     {{- end }}
     {{- with .Values.dags.gitSync.env }}
     {{- toYaml . | nindent 4 }}

--- a/chart/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/chart/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -418,6 +418,191 @@ class TestGitSyncSchedulerTest:
             "spec.template.spec.containers[1].env", docs[0]
         )
 
+    def test_env_override_replaces_hardcoded_value(self):
+        """User-provided env should replace the hardcoded default without duplicates."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://default.example.com/repo.git",
+                        "env": [
+                            {"name": "GIT_SYNC_REPO", "value": "https://override.example.com/repo.git"},
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        git_sync_repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(git_sync_repo_entries) == 1, "Expected exactly one GIT_SYNC_REPO entry, no duplicates"
+        assert git_sync_repo_entries[0]["value"] == "https://override.example.com/repo.git"
+
+    def test_env_override_with_secret_ref(self):
+        """User-provided env with valueFrom.secretKeyRef should replace the hardcoded default."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://default.example.com/repo.git",
+                        "env": [
+                            {
+                                "name": "GIT_SYNC_REPO",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "my-git-secret",
+                                        "key": "repo-url",
+                                    }
+                                },
+                            },
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        git_sync_repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(git_sync_repo_entries) == 1, "Expected exactly one GIT_SYNC_REPO entry, no duplicates"
+        assert git_sync_repo_entries[0]["valueFrom"]["secretKeyRef"]["name"] == "my-git-secret"
+        assert git_sync_repo_entries[0]["valueFrom"]["secretKeyRef"]["key"] == "repo-url"
+
+    def test_env_override_multiple_vars_no_duplicates(self):
+        """Multiple user overrides should each replace their hardcoded counterpart."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://default.example.com/repo.git",
+                        "depth": 1,
+                        "env": [
+                            {"name": "GIT_SYNC_REPO", "value": "https://override.example.com/repo.git"},
+                            {"name": "GITSYNC_REPO", "value": "https://override.example.com/repo.git"},
+                            {"name": "GIT_SYNC_DEPTH", "value": "0"},
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        for var_name in ["GIT_SYNC_REPO", "GITSYNC_REPO", "GIT_SYNC_DEPTH"]:
+            entries = [e for e in env if e["name"] == var_name]
+            assert len(entries) == 1, f"Expected exactly one {var_name} entry, got {len(entries)}"
+
+    def test_env_override_does_not_affect_other_vars(self):
+        """Overriding one env var should not remove other hardcoded env vars."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "env": [
+                            {"name": "GIT_SYNC_REPO", "value": "https://override.example.com/repo.git"},
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        env_names = [e["name"] for e in env]
+        # These should still be present since they were not overridden
+        assert "GITSYNC_REPO" in env_names
+        assert "GIT_SYNC_REV" in env_names
+        assert "GIT_SYNC_DEPTH" in env_names
+        assert "GIT_SYNC_ROOT" in env_names
+
+    def test_env_vars_secret_loads_from_secret_key_ref(self):
+        """When envVarsSecret is set, main env vars should use valueFrom.secretKeyRef."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "envVarsSecret": "git-sync-env-secret",
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(repo_entries) == 1
+        assert repo_entries[0]["valueFrom"]["secretKeyRef"]["name"] == "git-sync-env-secret"
+        assert repo_entries[0]["valueFrom"]["secretKeyRef"]["key"] == "GIT_SYNC_REPO"
+        assert repo_entries[0]["valueFrom"]["secretKeyRef"]["optional"] is True
+
+        # GITSYNC_REPO should also use the secret
+        gitsync_repo = [e for e in env if e["name"] == "GITSYNC_REPO"]
+        assert len(gitsync_repo) == 1
+        assert gitsync_repo[0]["valueFrom"]["secretKeyRef"]["name"] == "git-sync-env-secret"
+
+        # GIT_SYNC_REV should also use the secret
+        rev_entries = [e for e in env if e["name"] == "GIT_SYNC_REV"]
+        assert len(rev_entries) == 1
+        assert rev_entries[0]["valueFrom"]["secretKeyRef"]["name"] == "git-sync-env-secret"
+
+    def test_env_vars_secret_does_not_affect_constants(self):
+        """Constants like GIT_SYNC_ROOT should keep their hardcoded values even with envVarsSecret."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "envVarsSecret": "git-sync-env-secret",
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        root_entries = [e for e in env if e["name"] == "GIT_SYNC_ROOT"]
+        assert len(root_entries) == 1
+        assert root_entries[0]["value"] == "/git"
+
+        dest_entries = [e for e in env if e["name"] == "GIT_SYNC_DEST"]
+        assert len(dest_entries) == 1
+        assert dest_entries[0]["value"] == "repo"
+
+    def test_env_override_takes_precedence_over_env_vars_secret(self):
+        """dags.gitSync.env should override envVarsSecret (no duplicates)."""
+        docs = render_chart(
+            values={
+                "airflowVersion": "2.11.0",
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "envVarsSecret": "git-sync-env-secret",
+                        "env": [
+                            {"name": "GIT_SYNC_REPO", "value": "https://explicit.example.com/repo.git"},
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(repo_entries) == 1, "Expected exactly one GIT_SYNC_REPO entry"
+        assert repo_entries[0]["value"] == "https://explicit.example.com/repo.git"
+
     def test_resources_are_configurable(self):
         docs = render_chart(
             values={

--- a/chart/tests/helm_tests/other/test_git_sync_worker.py
+++ b/chart/tests/helm_tests/other/test_git_sync_worker.py
@@ -92,6 +92,79 @@ class TestGitSyncWorker:
             "spec.template.spec.containers[1].env", docs[0]
         )
 
+    def test_env_override_replaces_hardcoded_value(self):
+        """User-provided env should replace the hardcoded default without duplicates."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://default.example.com/repo.git",
+                        "env": [
+                            {"name": "GIT_SYNC_REPO", "value": "https://override.example.com/repo.git"},
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        git_sync_repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(git_sync_repo_entries) == 1, "Expected exactly one GIT_SYNC_REPO entry, no duplicates"
+        assert git_sync_repo_entries[0]["value"] == "https://override.example.com/repo.git"
+
+    def test_env_override_with_secret_ref(self):
+        """User-provided env with valueFrom.secretKeyRef should replace the hardcoded default."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "repo": "https://default.example.com/repo.git",
+                        "env": [
+                            {
+                                "name": "GIT_SYNC_REPO",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "my-git-secret",
+                                        "key": "repo-url",
+                                    }
+                                },
+                            },
+                        ],
+                    }
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        git_sync_repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(git_sync_repo_entries) == 1, "Expected exactly one GIT_SYNC_REPO entry, no duplicates"
+        assert git_sync_repo_entries[0]["valueFrom"]["secretKeyRef"]["name"] == "my-git-secret"
+
+    def test_env_vars_secret_loads_from_secret_key_ref(self):
+        """When envVarsSecret is set, main env vars should use valueFrom.secretKeyRef."""
+        docs = render_chart(
+            values={
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "envVarsSecret": "git-sync-env-secret",
+                    }
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        env = jmespath.search("spec.template.spec.containers[1].env", docs[0])
+        repo_entries = [e for e in env if e["name"] == "GIT_SYNC_REPO"]
+        assert len(repo_entries) == 1
+        assert repo_entries[0]["valueFrom"]["secretKeyRef"]["name"] == "git-sync-env-secret"
+        assert repo_entries[0]["valueFrom"]["secretKeyRef"]["key"] == "GIT_SYNC_REPO"
+        assert repo_entries[0]["valueFrom"]["secretKeyRef"]["optional"] is True
+
     def test_resources_are_configurable(self):
         docs = render_chart(
             values={

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -10022,6 +10022,14 @@
                                 "- configMapRef:\n    name: 'proxy-config"
                             ]
                         },
+                        "envVarsSecret": {
+                            "description": "Name of a Secret whose keys are mapped to git-sync environment variables (GIT_SYNC_REPO, GIT_SYNC_REV, GIT_SYNC_BRANCH, etc.) via secretKeyRef with optional: true.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
                         "resources": {
                             "description": "Resources on workers git-sync sidecar",
                             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3549,7 +3549,28 @@ dags:
     #      mountPath: "{{ .Values.my_custom_path }}"
     #      readOnly: true
 
+    # Name of an existing Kubernetes Secret whose keys are mapped to git-sync
+    # environment variables (GIT_SYNC_REV, GITSYNC_REF, GIT_SYNC_BRANCH,
+    # GIT_SYNC_REPO, GITSYNC_REPO, GIT_SYNC_DEPTH, GITSYNC_DEPTH,
+    # GITSYNC_PERIOD, GIT_SYNC_MAX_SYNC_FAILURES, GITSYNC_MAX_FAILURES).
+    # When set, these variables are loaded from the Secret via secretKeyRef
+    # (with optional: true) instead of from the values above.
+    # This is useful when the repo URL or branch contain sensitive tokens.
+    #
+    # envVarsSecret: git-sync-env-secret
+    #
+    # Secret example:
+    #  apiVersion: v1
+    #  kind: Secret
+    #  metadata:
+    #    name: git-sync-env-secret
+    #  data:
+    #    GIT_SYNC_REPO: <base64_encoded_repo_url>
+    #    GITSYNC_REPO: <base64_encoded_repo_url>
+    #    GIT_SYNC_BRANCH: <base64_encoded_branch>
+
     # Supported env vars for gitsync can be found at https://github.com/kubernetes/git-sync
+    # Variables specified here override the hardcoded defaults above (no duplicates).
     env: []
     # - name: ""
     #   value: ""

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -587,6 +587,7 @@ environ
 envs
 EnvVar
 envvar
+envVarsSecret
 eof
 EOL
 equest
@@ -1477,6 +1478,7 @@ sdk
 sdks
 searchpath
 SearchResultGenerator
+secretKeyRef
 secretmanager
 SecretManagerClient
 SecretManagerServiceClient


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Summary

  Fixes a duplicate-environment-variable behaviour in the git-sync container
  helper and adds first-class Secret-based configuration for the standard
  git-sync variables (`GIT_SYNC_REPO`, `GIT_SYNC_BRANCH`, `GIT_SYNC_REV`, …).

  ## Motivation

  Today the `git_sync_container` helper always renders the git-sync environment
  variables from the hardcoded `values.yaml` fields. If a user provides the
  same variable via `dags.gitSync.env` — for example to load `GIT_SYNC_REPO`
  (which often embeds a PAT for private HTTPS repos) from a Kubernetes Secret
  via `secretKeyRef` — the container ends up with two entries of the same
  variable name in its `env` list. That is undefined behaviour, gets flagged
  by GitOps tooling (ArgoCD/Flux) and linters (kube-score, kubeval), and in
  practice forces the credential-bearing repo URL to sit in cleartext in
  `values.yaml`, defeating the point of GitOps + external secret managers.

  The typical setup this affects is a `HelmRelease` reconciled by Flux (or
  ArgoCD), with git-sync configuration synced from an external secret store
  (Azure Key Vault, HashiCorp Vault, AWS Secrets Manager, …) via
  ExternalSecrets Operator into a Kubernetes Secret.

  ## Changes

  * **New helper `git_sync_env_not_overridden`** in
    `chart/templates/_helpers.yaml`: skips the hardcoded default when the
    same variable name is present in `dags.gitSync.env`. All hardcoded
    variables in `git_sync_container` are wrapped with this check, so
    overriding one no longer produces duplicate entries in the pod spec.
  * **New value `dags.gitSync.envVarsSecret`**: name of a Kubernetes Secret
    whose keys are mapped to the configurable git-sync variables
    (`GIT_SYNC_REPO`, `GITSYNC_REPO`, `GIT_SYNC_REV`, `GITSYNC_REF`,
    `GIT_SYNC_BRANCH`, `GIT_SYNC_DEPTH`, `GITSYNC_DEPTH`, `GITSYNC_PERIOD`,
    `GIT_SYNC_MAX_SYNC_FAILURES`, `GITSYNC_MAX_FAILURES`) via `secretKeyRef`
    with `optional: true`. Mirrors the existing `credentialsSecret` pattern
    used for `GIT_SYNC_USERNAME` / `GIT_SYNC_PASSWORD`. In-pod constants
    (`GIT_SYNC_ROOT`, `GIT_SYNC_DEST`, `GIT_SYNC_ADD_USER`) intentionally
    stay hardcoded.
  * **`values.schema.json`** extended with the new `envVarsSecret` property
    (string / null, defaults to null).
  * **Helm tests** covering: value override, Secret-based override via
    `secretKeyRef`, multiple simultaneous overrides without duplicates,
    `envVarsSecret` producing correct `secretKeyRef` entries, precedence of
    explicit `env` entries over `envVarsSecret`, and the fact that in-pod
    constants remain unaffected.
  * **`docs/spelling_wordlist.txt`** updated with `envVarsSecret` and
    `secretKeyRef` for the docs spellcheck.

  The change is fully additive. Users who do not set `envVarsSecret` and do
  not override anything via `dags.gitSync.env` see exactly the same rendered
  pod spec as before, so existing deployments are unaffected.

  ## Usage examples

  Override a single variable from an existing Secret via `env`:

  ```yaml
  dags:
    gitSync:
      enabled: true
      env:
        - name: GIT_SYNC_REPO
          valueFrom:
            secretKeyRef:
              name: git-sync-creds
              key: repo-url
  ```

  Or load a set of variables from one Secret via `envVarsSecret`:

  ```yaml
  dags:
    gitSync:
      enabled: true
      envVarsSecret: git-sync-config   # keys: GIT_SYNC_REPO, GIT_SYNC_BRANCH, …
  ```

  ## Test plan

  - [x] Added unit tests for scheduler and worker git-sync containers
  - [x] Verified rendered pod spec against a Flux + ExternalSecrets
        deployment
  - [x] Static checks: `values.schema.json` validation, spellcheck

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-28T16:10:00Z head=7df537b action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @sokratis1988** · by `@potiuk` · 2026-07-28 16:10 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Helm tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/testing/helm_unit_tests.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **598 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
