### PR TITLE
Route SQLAlchemyError through global exception handler

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -27,9 +27,9 @@ from fastapi import FastAPI
 from fastapi.routing import Mount
 
 from airflow.api_fastapi.common.dagbag import create_dag_bag
+from airflow.api_fastapi.common.exceptions import init_error_handlers
 from airflow.api_fastapi.core_api.app import (
     init_config,
-    init_error_handlers,
     init_flask_plugins,
     init_middlewares,
     init_views,

--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -128,7 +128,6 @@ def create_app(apps: str = "all") -> FastAPI:
     if "all" in apps_list or "execution" in apps_list:
         task_exec_api_app = create_task_execution_api_app()
         task_exec_api_app.state.dag_bag = dag_bag
-        init_error_handlers(task_exec_api_app)
         app.mount("/execution", task_exec_api_app)
 
     if "all" in apps_list or "core" in apps_list:

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -100,7 +100,6 @@ def _build_database_error_response(
     )
 
 
-
 class _DatabaseErrorHandler(BaseErrorHandler[DBError]):
     """
     Base for handlers that turn a SQLAlchemy error into an actionable HTTP response.

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -178,14 +178,12 @@ class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
 
     def exception_handler(self, request: Request, exc: SQLAlchemyError):
         exception_id = get_random_string()
-        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
         # SQLAlchemyError may not have statement/orig attributes; guard access
         statement = getattr(exc, "statement", "hidden")
         orig_error = getattr(exc, "orig", "hidden")
-        log_message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
-        log.error(log_message)
+        log.exception("Error with id %s, statement: %s", exception_id, statement, exc_info=exc)
         if conf.get("api", "expose_stacktrace") == "True":
-            message = log_message
+            message = f"Error with id {exception_id}, statement: {statement}"
             statement = str(statement)
             orig_error = str(orig_error)
         else:

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -179,13 +179,11 @@ class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
     def exception_handler(self, request: Request, exc: SQLAlchemyError):
         exception_id = get_random_string()
         # SQLAlchemyError may not have statement/orig attributes; guard access
-        statement = getattr(exc, "statement", "hidden")
-        orig_error = getattr(exc, "orig", "hidden")
         log.exception("Error with id %s, statement: %s", exception_id, statement, exc_info=exc)
         if conf.get("api", "expose_stacktrace") == "True":
             message = f"Error with id {exception_id}, statement: {statement}"
-            statement = str(statement)
-            orig_error = str(orig_error)
+            statement = getattr(exc, "statement", None)
+            orig_error = getattr(exc, "orig", None)
         else:
             message = (
                 "Serious error when handling your request. Check logs for more details - "

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Generic, TypeVar
 
-from fastapi import HTTPException, Request, status
+from fastapi import FastAPI, HTTPException, Request, status
 from sqlalchemy.exc import DatabaseError, DataError, IntegrityError, SQLAlchemyError
 
 from airflow.configuration import conf
@@ -212,3 +212,8 @@ ERROR_HANDLERS: list[BaseErrorHandler] = [
     SQLAlchemyErrorHandler(),
     DagErrorHandler(),
 ]
+
+
+def init_error_handlers(app: FastAPI) -> None:
+    for handler in ERROR_HANDLERS:
+        app.add_exception_handler(handler.exception_cls, handler.exception_handler)

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -54,6 +54,53 @@ class _DatabaseDialect(Enum):
     POSTGRES = "postgres"
 
 
+def _build_database_error_response(
+    exc: Exception,
+    status_code: int,
+    reason: str,
+    statement: str | None = None,
+    orig_error: str | None = None,
+) -> None:
+    """
+    Build and raise HTTPException with common database error handling logic.
+
+    Extracts statement and original error, logs them, and constructs an HTTP response
+    based on the expose_stacktrace configuration.
+    """
+    if statement is None:
+        statement = getattr(exc, "statement", "hidden")
+    if orig_error is None:
+        orig_error = getattr(exc, "orig", "hidden")
+
+    exception_id = get_random_string()
+    stacktrace = "".join(traceback.format_tb(exc.__traceback__))
+    log_message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
+    log.error(log_message)
+
+    if conf.get("api", "expose_stacktrace") == "True":
+        message = log_message
+        statement_out = str(statement)
+        orig_error_out = str(orig_error)
+    else:
+        message = (
+            "Serious error when handling your request. Check logs for more details - "
+            f"you will find it in api server when you look for ID {exception_id}"
+        )
+        statement_out = "hidden"
+        orig_error_out = "hidden"
+
+    raise HTTPException(
+        status_code=status_code,
+        detail={
+            "reason": reason,
+            "statement": statement_out,
+            "orig_error": orig_error_out,
+            "message": message,
+        },
+    )
+
+
+
 class _DatabaseErrorHandler(BaseErrorHandler[DBError]):
     """
     Base for handlers that turn a SQLAlchemy error into an actionable HTTP response.
@@ -73,30 +120,12 @@ class _DatabaseErrorHandler(BaseErrorHandler[DBError]):
     def exception_handler(self, request: Request, exc: DBError):
         if not self._should_handle(exc):
             return
-        exception_id = get_random_string()
-        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
-        log_message = f"Error with id {exception_id}, statement: {exc.statement}\n{stacktrace}"
-        log.error(log_message)
-        if conf.get("api", "expose_stacktrace") == "True":
-            message = log_message
-            statement = str(exc.statement)
-            orig_error = str(exc.orig)
-        else:
-            message = (
-                "Serious error when handling your request. Check logs for more details - "
-                f"you will find it in api server when you look for ID {exception_id}"
-            )
-            statement = "hidden"
-            orig_error = "hidden"
-
-        raise HTTPException(
+        _build_database_error_response(
+            exc=exc,
             status_code=self.status_code,
-            detail={
-                "reason": self.reason,
-                "statement": statement,
-                "orig_error": orig_error,
-                "message": message,
-            },
+            reason=self.reason,
+            statement=str(exc.statement),
+            orig_error=str(exc.orig),
         )
 
 
@@ -177,32 +206,16 @@ class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
         super().__init__(SQLAlchemyError)
 
     def exception_handler(self, request: Request, exc: SQLAlchemyError):
-        exception_id = get_random_string()
-        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
         statement = getattr(exc, "statement", "hidden")
         orig_error = getattr(exc, "orig", "hidden")
         # SQLAlchemyError may not have statement/orig attributes; guard access
-        log.exception("Error with id %s, statement: %s", exception_id, statement, exc_info=exc)
-        if conf.get("api", "expose_stacktrace") == "True":
-            message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
-            statement = str(statement)
-            orig_error = str(orig_error)
-        else:
-            message = (
-                "Serious error when handling your request. Check logs for more details - "
-                f"you will find it in api server when you look for ID {exception_id}"
-            )
-            statement = "hidden"
-            orig_error = "hidden"
-
-        raise HTTPException(
+        log.exception("Error with id will be generated for statement: %s", statement, exc_info=exc)
+        _build_database_error_response(
+            exc=exc,
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={
-                "reason": "Database error",
-                "statement": statement,
-                "orig_error": orig_error,
-                "message": message,
-            },
+            reason="Database error",
+            statement=str(statement),
+            orig_error=str(orig_error),
         )
 
 

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -178,6 +178,7 @@ class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
 
     def exception_handler(self, request: Request, exc: SQLAlchemyError):
         exception_id = get_random_string()
+        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
         # SQLAlchemyError may not have statement/orig attributes; guard access
         log.exception("Error with id %s, statement: %s", exception_id, statement, exc_info=exc)
         if conf.get("api", "expose_stacktrace") == "True":

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -24,7 +24,7 @@ from enum import Enum
 from typing import Generic, TypeVar
 
 from fastapi import HTTPException, Request, status
-from sqlalchemy.exc import DatabaseError, DataError, IntegrityError
+from sqlalchemy.exc import DatabaseError, DataError, IntegrityError, SQLAlchemyError
 
 from airflow.configuration import conf
 from airflow.exceptions import DeserializationError
@@ -170,8 +170,46 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
         )
 
 
+class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
+    """Generic handler for SQLAlchemyError -> 500 responses."""
+
+    def __init__(self):
+        super().__init__(SQLAlchemyError)
+
+    def exception_handler(self, request: Request, exc: SQLAlchemyError):
+        exception_id = get_random_string()
+        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
+        # SQLAlchemyError may not have statement/orig attributes; guard access
+        statement = getattr(exc, "statement", "hidden")
+        orig_error = getattr(exc, "orig", "hidden")
+        log_message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
+        log.error(log_message)
+        if conf.get("api", "expose_stacktrace") == "True":
+            message = log_message
+            statement = str(statement)
+            orig_error = str(orig_error)
+        else:
+            message = (
+                "Serious error when handling your request. Check logs for more details - "
+                f"you will find it in api server when you look for ID {exception_id}"
+            )
+            statement = "hidden"
+            orig_error = "hidden"
+
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "reason": "Database error",
+                "statement": statement,
+                "orig_error": orig_error,
+                "message": message,
+            },
+        )
+
+
 ERROR_HANDLERS: list[BaseErrorHandler] = [
     _UniqueConstraintErrorHandler(),
     DataErrorHandler(),
+    SQLAlchemyErrorHandler(),
     DagErrorHandler(),
 ]

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -179,12 +179,14 @@ class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
     def exception_handler(self, request: Request, exc: SQLAlchemyError):
         exception_id = get_random_string()
         stacktrace = "".join(traceback.format_tb(exc.__traceback__))
+        statement = getattr(exc, "statement", "hidden")
+        orig_error = getattr(exc, "orig", "hidden")
         # SQLAlchemyError may not have statement/orig attributes; guard access
         log.exception("Error with id %s, statement: %s", exception_id, statement, exc_info=exc)
         if conf.get("api", "expose_stacktrace") == "True":
             message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
-            statement = getattr(exc, "statement", None)
-            orig_error = getattr(exc, "orig", None)
+            statement = str(statement)
+            orig_error = str(orig_error)
         else:
             message = (
                 "Serious error when handling your request. Check logs for more details - "

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -182,7 +182,7 @@ class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
         # SQLAlchemyError may not have statement/orig attributes; guard access
         log.exception("Error with id %s, statement: %s", exception_id, statement, exc_info=exc)
         if conf.get("api", "expose_stacktrace") == "True":
-            message = f"Error with id {exception_id}, statement: {statement}"
+            message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
             statement = getattr(exc, "statement", None)
             orig_error = getattr(exc, "orig", None)
         else:

--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -24,14 +24,14 @@ from enum import Enum
 from typing import Generic, TypeVar
 
 from fastapi import FastAPI, HTTPException, Request, status
-from sqlalchemy.exc import DatabaseError, DataError, IntegrityError, SQLAlchemyError
+from sqlalchemy.exc import DataError, IntegrityError, SQLAlchemyError
 
 from airflow.configuration import conf
 from airflow.exceptions import DeserializationError
 from airflow.utils.strings import get_random_string
 
 T = TypeVar("T", bound=Exception)
-DBError = TypeVar("DBError", bound=DatabaseError)
+DBError = TypeVar("DBError", bound=SQLAlchemyError)
 
 log = logging.getLogger(__name__)
 
@@ -54,52 +54,6 @@ class _DatabaseDialect(Enum):
     POSTGRES = "postgres"
 
 
-def _build_database_error_response(
-    exc: Exception,
-    status_code: int,
-    reason: str,
-    statement: str | None = None,
-    orig_error: str | None = None,
-) -> None:
-    """
-    Build and raise HTTPException with common database error handling logic.
-
-    Extracts statement and original error, logs them, and constructs an HTTP response
-    based on the expose_stacktrace configuration.
-    """
-    if statement is None:
-        statement = getattr(exc, "statement", "hidden")
-    if orig_error is None:
-        orig_error = getattr(exc, "orig", "hidden")
-
-    exception_id = get_random_string()
-    stacktrace = "".join(traceback.format_tb(exc.__traceback__))
-    log_message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
-    log.error(log_message)
-
-    if conf.get("api", "expose_stacktrace") == "True":
-        message = log_message
-        statement_out = str(statement)
-        orig_error_out = str(orig_error)
-    else:
-        message = (
-            "Serious error when handling your request. Check logs for more details - "
-            f"you will find it in api server when you look for ID {exception_id}"
-        )
-        statement_out = "hidden"
-        orig_error_out = "hidden"
-
-    raise HTTPException(
-        status_code=status_code,
-        detail={
-            "reason": reason,
-            "statement": statement_out,
-            "orig_error": orig_error_out,
-            "message": message,
-        },
-    )
-
-
 class _DatabaseErrorHandler(BaseErrorHandler[DBError]):
     """
     Base for handlers that turn a SQLAlchemy error into an actionable HTTP response.
@@ -116,16 +70,40 @@ class _DatabaseErrorHandler(BaseErrorHandler[DBError]):
     def _should_handle(self, exc: DBError) -> bool:
         return True
 
+    def _raise_database_error_response(self, exc: DBError) -> None:
+        statement = getattr(exc, "statement", "hidden")
+        orig_error = getattr(exc, "orig", "hidden")
+        exception_id = get_random_string()
+        stacktrace = "".join(traceback.format_tb(exc.__traceback__))
+        log_message = f"Error with id {exception_id}, statement: {statement}\n{stacktrace}"
+        log.error(log_message)
+
+        if conf.get("api", "expose_stacktrace") == "True":
+            message = log_message
+            statement_out = str(statement)
+            orig_error_out = str(orig_error)
+        else:
+            message = (
+                "Serious error when handling your request. Check logs for more details - "
+                f"you will find it in api server when you look for ID {exception_id}"
+            )
+            statement_out = "hidden"
+            orig_error_out = "hidden"
+
+        raise HTTPException(
+            status_code=self.status_code,
+            detail={
+                "reason": self.reason,
+                "statement": statement_out,
+                "orig_error": orig_error_out,
+                "message": message,
+            },
+        )
+
     def exception_handler(self, request: Request, exc: DBError):
         if not self._should_handle(exc):
             return
-        _build_database_error_response(
-            exc=exc,
-            status_code=self.status_code,
-            reason=self.reason,
-            statement=str(exc.statement),
-            orig_error=str(exc.orig),
-        )
+        self._raise_database_error_response(exc)
 
 
 class _UniqueConstraintErrorHandler(_DatabaseErrorHandler[IntegrityError]):
@@ -198,24 +176,14 @@ class DagErrorHandler(BaseErrorHandler[DeserializationError]):
         )
 
 
-class SQLAlchemyErrorHandler(BaseErrorHandler[SQLAlchemyError]):
+class SQLAlchemyErrorHandler(_DatabaseErrorHandler[SQLAlchemyError]):
     """Generic handler for SQLAlchemyError -> 500 responses."""
+
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    reason = "Database error"
 
     def __init__(self):
         super().__init__(SQLAlchemyError)
-
-    def exception_handler(self, request: Request, exc: SQLAlchemyError):
-        statement = getattr(exc, "statement", "hidden")
-        orig_error = getattr(exc, "orig", "hidden")
-        # SQLAlchemyError may not have statement/orig attributes; guard access
-        log.exception("Error with id will be generated for statement: %s", statement, exc_info=exc)
-        _build_database_error_response(
-            exc=exc,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            reason="Database error",
-            statement=str(statement),
-            orig_error=str(orig_error),
-        )
 
 
 ERROR_HANDLERS: list[BaseErrorHandler] = [

--- a/airflow-core/src/airflow/api_fastapi/core_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/app.py
@@ -170,13 +170,6 @@ def init_config(app: FastAPI) -> None:
     app.state.secret_key = get_signing_key("api", "secret_key")
 
 
-def init_error_handlers(app: FastAPI) -> None:
-    from airflow.api_fastapi.common.exceptions import ERROR_HANDLERS
-
-    for handler in ERROR_HANDLERS:
-        app.add_exception_handler(handler.exception_cls, handler.exception_handler)
-
-
 def init_middlewares(app: FastAPI) -> None:
     from airflow.api_fastapi.app import get_auth_manager
     from airflow.api_fastapi.auth.middlewares.refresh_token import JWTRefreshMiddleware

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -287,7 +287,7 @@ def _inject_trace_context_dep(routes, mode: str) -> None:
 
 def create_task_execution_api_app(lifespan: svcs.fastapi.lifespan = lifespan) -> FastAPI:
     """Create FastAPI app for task execution API."""
-    from airflow.api_fastapi.core_api.app import init_error_handlers
+    from airflow.api_fastapi.common.exceptions import init_error_handlers
     from airflow.api_fastapi.execution_api.routes import execution_api_router
     from airflow.api_fastapi.execution_api.versions import bundle
     from airflow.configuration import conf

--- a/airflow-core/src/airflow/api_fastapi/execution_api/app.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/app.py
@@ -287,6 +287,7 @@ def _inject_trace_context_dep(routes, mode: str) -> None:
 
 def create_task_execution_api_app(lifespan: svcs.fastapi.lifespan = lifespan) -> FastAPI:
     """Create FastAPI app for task execution API."""
+    from airflow.api_fastapi.core_api.app import init_error_handlers
     from airflow.api_fastapi.execution_api.routes import execution_api_router
     from airflow.api_fastapi.execution_api.versions import bundle
     from airflow.configuration import conf
@@ -314,6 +315,7 @@ def create_task_execution_api_app(lifespan: svcs.fastapi.lifespan = lifespan) ->
     _inject_trace_context_dep(execution_api_router.routes, mode)
 
     app.generate_and_include_versioned_routers(execution_api_router)
+    init_error_handlers(app)
 
     # As we are mounted as a sub app, we don't get any logs for unhandled exceptions without this!
     @app.exception_handler(Exception)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -319,10 +319,8 @@ def ti_run(
         # Let the app-level DataErrorHandler return a 422 (not the opaque 500 below).
         raise
     except SQLAlchemyError:
-        log.exception("Error marking Task Instance state as running")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
-        )
+        # Defer to app-level SQLAlchemyError handler (returns HTTP 500).
+        raise
 
     # JWTReissueMiddleware also writes Refreshed-API-Token but skips workload tokens, so we set it here for the workload→execution swap.
     if token.claims.scope == "workload":
@@ -502,11 +500,9 @@ def ti_update_state(
     except DataError:
         # Let DataErrorHandler return a 422 (not the opaque 500 below).
         raise
-    except SQLAlchemyError as e:
-        log.error("Error updating Task Instance state", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error occurred"
-        )
+    except SQLAlchemyError:
+        # Defer to app-level SQLAlchemyError handler (returns HTTP 500).
+        raise
 
     if updated_state == TaskInstanceState.SUCCESS:
         if conf.getboolean("state_store", "clear_on_success"):

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -497,6 +497,26 @@ class TestDataErrorHandler:
         assert detail["statement"] == "hidden"
         assert detail["orig_error"] == "hidden"
 
+    @conf_vars({("api", "expose_stacktrace"): "False"})
+    @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
+    def test_sqlalchemy_error_dispatched_through_fastapi_app(self, mock_get_random_string) -> None:
+        """End-to-end: a route raising SQLAlchemyError returns 500 via the registered handler."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        app = FastAPI()
+        for h in ERROR_HANDLERS:
+            app.add_exception_handler(h.exception_cls, h.exception_handler)
+
+        @app.post("/test")
+        def trigger_error():
+            raise SQLAlchemyError("boom")
+
+        response = TestClient(app, raise_server_exceptions=False).post("/test")
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        detail = response.json()["detail"]
+        assert detail["reason"] == "Database error"
+        assert detail["message"] == MESSAGE
+
 
 class TestDagErrorHandler:
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -517,6 +517,26 @@ class TestDataErrorHandler:
         assert detail["reason"] == "Database error"
         assert detail["message"] == MESSAGE
 
+    @conf_vars({("api", "expose_stacktrace"): "True"})
+    @patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value=MOCKED_ID)
+    def test_sqlalchemy_error_includes_traceback_with_stacktrace(self, mock_get_random_string) -> None:
+        """End-to-end: SQLAlchemyError exposes traceback details when stacktrace logging is enabled."""
+        from sqlalchemy.exc import SQLAlchemyError
+
+        app = FastAPI()
+        for h in ERROR_HANDLERS:
+            app.add_exception_handler(h.exception_cls, h.exception_handler)
+
+        @app.post("/test")
+        def trigger_error():
+            raise SQLAlchemyError("boom")
+
+        response = TestClient(app, raise_server_exceptions=False).post("/test")
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        detail = response.json()["detail"]
+        assert detail["reason"] == "Database error"
+        assert "trigger_error" in detail["message"]
+
 
 class TestDagErrorHandler:
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/test_app.py
@@ -24,11 +24,12 @@ from uuid import UUID
 
 import httpx
 import pytest
-from fastapi import Request
+from fastapi import Request, status
 from fastapi.params import Security as SecurityParam
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context, propagate as otel_propagate
+from sqlalchemy.exc import SQLAlchemyError
 
 from airflow.api_fastapi.execution_api.app import (
     InProcessExecutionAPI,
@@ -62,6 +63,21 @@ def test_access_api_contract(client):
     response = client.get("/execution/docs")
     assert response.status_code == 200
     assert response.headers["airflow-api-version"] == bundle.versions[0].value
+
+
+@conf_vars({("api", "expose_stacktrace"): "False"})
+@mock.patch("airflow.api_fastapi.common.exceptions.get_random_string", return_value="test-error-id")
+def test_direct_execution_api_app_handles_sqlalchemy_errors(mock_get_random_string):
+    app = create_task_execution_api_app()
+
+    @app.get("/test-sqlalchemy-error")
+    def trigger_error():
+        raise SQLAlchemyError("boom")
+
+    response = TestClient(app, raise_server_exceptions=False).get("/test-sqlalchemy-error")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json()["detail"]["reason"] == "Database error"
 
 
 def test_ti_self_routes_have_task_instance_id_param(client):

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1497,7 +1497,9 @@ class TestTIUpdateState:
             mock_register_asset_changes_in_db.return_value = None
             response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
             assert response.status_code == 500
-            assert response.json()["detail"] == "Database error occurred"
+            detail = response.json()["detail"]
+            assert isinstance(detail, dict)
+            assert detail.get("reason") == "Database error"
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
     def test_ti_update_state_to_deferred(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest import mock
 from uuid import UUID, uuid4
@@ -1500,6 +1501,61 @@ class TestTIUpdateState:
             detail = response.json()["detail"]
             assert isinstance(detail, dict)
             assert detail.get("reason") == "Database error"
+
+    def test_ti_run_database_error(self, client, session, create_task_instance):
+        """
+        Test that a database error is handled correctly when starting the Task Instance.
+        """
+        ti = create_task_instance(
+            task_id="test_ti_run_database_error",
+            state=State.QUEUED,
+            dagrun_state=DagRunState.RUNNING,
+            session=session,
+            dag_id=str(uuid4()),
+        )
+        session.commit()
+
+        payload = {
+            "state": "running",
+            "hostname": "hostname",
+            "unixname": "unixname",
+            "pid": 123,
+            "start_date": "2024-10-31T12:00:00Z",
+        }
+
+        with mock.patch(
+            "airflow.api_fastapi.common.db.common.Session.execute",
+            side_effect=[
+                mock.Mock(
+                    one=mock.Mock(
+                        return_value=SimpleNamespace(
+                            state="queued",
+                            dag_id="dag",
+                            run_id="run",
+                            task_id="task",
+                            map_index=-1,
+                            try_number=1,
+                            max_tries=0,
+                            start_date=None,
+                            next_method=None,
+                            hostname=None,
+                            unixname=None,
+                            pid=None,
+                            next_kwargs=None,
+                            logical_date=timezone.utcnow(),
+                            owners="test_owner",
+                        )
+                    )
+                ),
+                SQLAlchemyError("Database error"),
+            ],
+        ):
+            response = client.patch(f"/execution/task-instances/{ti.id}/run", json=payload)
+
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert isinstance(detail, dict)
+        assert detail.get("reason") == "Database error"
 
     @pytest.mark.parametrize("queues_enabled", [False, True])
     def test_ti_update_state_to_deferred(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Hello

This change removes the route-local SQLAlchemyError-to-HTTPException handling from the task instance execution route and let the FastAPI app-level exception handlers deal with database errors consistently.

DataError still maps to HTTP 422, while generic SQLAlchemyError now returns HTTP 500 through the shared handler in airflow-core/src/airflow/api_fastapi/common/exceptions.py. 
I also added regression coverage to verify both the global handler path and the task_instances route behavior.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
