### PR TITLE
Fix crossed-bound XCom slices returning wrong rows via negative SQL L…

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -139,6 +139,28 @@ class GetXComSliceFilterParams(BaseModel):
     include_prior_dates: bool = False
 
 
+def _sliced_or_empty(query: Select, low: int, high: int) -> Select:
+    """
+    Apply ``.slice(low, high)`` but return no rows when the bounds are crossed.
+
+    SQLAlchemy's ``Query.slice(low, high)`` compiles to::
+
+        OFFSET low
+        LIMIT (high - low)
+
+    It does not clamp a negative ``LIMIT``. A crossed slice (``high <= low``),
+    which Python evaluates as an empty sequence, therefore becomes backend-
+    dependent:
+
+    * SQLite interprets a negative ``LIMIT`` as "no limit", returning incorrect rows.
+    * PostgreSQL/MySQL reject the query because ``LIMIT`` cannot be negative.
+    """
+    if high <= low:
+        return query.limit(0)
+
+    return query.slice(low, high)
+
+
 @router.get(
     "/{dag_id}/{run_id}/{task_id}/{key:path}/slice",
     description="Get XCom values from a mapped task by sequence slice",
@@ -196,9 +218,9 @@ def get_mapped_xcom_by_slice(
             if stop < 0:
                 stop += get_query_count(query, session=session)
             if step >= 0:
-                query = query.slice(start, stop)
+                query = _sliced_or_empty(query, start, stop)
             else:
-                query = query.slice(stop + 1, start + 1)
+                query = _sliced_or_empty(query, stop + 1, start + 1)
     else:
         query = query.order_by(XComModel.map_index.desc())
         step = -step
@@ -211,9 +233,9 @@ def get_mapped_xcom_by_slice(
             if stop >= 0:
                 stop -= get_query_count(query, session=session)
             if step > 0:
-                query = query.slice(-1 - start, -1 - stop)
+                query = _sliced_or_empty(query, -1 - start, -1 - stop)
             else:
-                query = query.slice(-stop, -start)
+                query = _sliced_or_empty(query, -stop, -start)
 
     values = [row.value for row in session.execute(query.with_only_columns(XComModel.value)).all()]
     if step != 1:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -274,6 +274,59 @@ class TestXComsGetEndpoint:
         assert response.json() == ["f", "o", "b"][key]
 
     @pytest.mark.parametrize(
+        "key",
+        [
+            # start >= 0, stop given, step >= 0: query.slice(start, stop)
+            pytest.param(slice(4, 2, None), id="4:2"),
+            # start >= 0, stop given, step < 0: query.slice(stop + 1, start + 1)
+            pytest.param(slice(2, -3, -1), id="2:-3:-1"),
+            # start < 0, stop given, step <= 0 internally: query.slice(-stop, -start)
+            pytest.param(slice(-2, -5, None), id="-2:-5"),
+            # start < 0, stop given, step > 0 internally: query.slice(-1 - start, -1 - stop)
+            pytest.param(slice(-5, -2, -1), id="-5:-2:-1"),
+        ],
+    )
+    def test_xcom_get_with_crossed_bound_slice(self, client, dag_maker, session, key):
+        """Crossed-bound slices (effective stop before effective start) must return []."""
+        xcom_values = ["v0", "v1", "v2", "v3", "v4", "v5"]
+
+        class MyOperator(EmptyOperator):
+            def __init__(self, *, x, **kwargs):
+                super().__init__(**kwargs)
+                self.x = x
+
+        with dag_maker(dag_id="dag"):
+            MyOperator.partial(task_id="task").expand(x=xcom_values)
+        dag_run = dag_maker.create_dagrun(run_id="runid")
+        tis = {ti.map_index: ti for ti in dag_run.task_instances}
+
+        for map_index, db_value in enumerate(xcom_values):
+            ti = tis[map_index]
+            x = XComModel(
+                key="xcom_1",
+                value=db_value,
+                dag_run_id=ti.dag_run.id,
+                run_id=ti.run_id,
+                task_id=ti.task_id,
+                dag_id=ti.dag_id,
+                map_index=map_index,
+            )
+            session.add(x)
+        session.commit()
+
+        qs = {}
+        if key.start is not None:
+            qs["start"] = key.start
+        if key.stop is not None:
+            qs["stop"] = key.stop
+        if key.step is not None:
+            qs["step"] = key.step
+
+        response = client.get(f"/execution/xcoms/dag/runid/task/xcom_1/slice?{urllib.parse.urlencode(qs)}")
+        assert response.status_code == 200
+        assert response.json() == xcom_values[key] == []
+
+    @pytest.mark.parametrize(
         ("include_prior_dates", "expected_xcoms"),
         [[True, ["earlier_value", "later_value"]], [False, ["later_value"]]],
     )


### PR DESCRIPTION
## Summary

Fixes the XCom sequence-slice endpoint (`get_mapped_xcom_by_slice`) returning incorrect rows — or erroring, depending on the database backend — when a requested slice has crossed bounds (i.e. the effective stop comes before the effective start, which Python evaluates as an empty result).

## Root cause

The endpoint maps Python slice semantics onto SQLAlchemy's `Query.slice(low, high)`, which compiles to:

```sql
OFFSET low
LIMIT (high - low)
```

When `high <= low`, this produces a negative `LIMIT`, which SQLAlchemy does not clamp:

- **SQLite** treats a negative `LIMIT` as "no limit" and silently returns the wrong (extra) rows instead of an empty result.
- **PostgreSQL / MySQL** reject the query outright, since `LIMIT` cannot be negative.

This affects 4 of the branches in `get_mapped_xcom_by_slice` — specifically where both `start` and `stop` are provided and a `COUNT` query is needed to resolve a mixed-sign bound (e.g. `start=2, stop=-3`), since that's where a crossed slice can occur without either individual bound being invalid on its own.

## Fix

Added a small helper, `_sliced_or_empty()`, that checks for crossed bounds before calling `.slice()` and returns `.limit(0)` instead:

```python
def _sliced_or_empty(query: Select, low: int, high: int) -> Select:
    if high <= low:
        return query.limit(0)
    return query.slice(low, high)
```

Replaced the 4 affected `query.slice(...)` calls with `_sliced_or_empty(query, ...)`. No other logic changes — non-crossed slices behave exactly as before.

## Files changed

- `airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py`
- `airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py`

## Testing

Added tests covering all 4 previously-affected branches, verified against real Python slice semantics.

Fixes #69204

**Gen-AI disclosure:** I used a generative AI tool to help identify the root
cause, write tests, and draft the PR description. I reviewed, tested, and
verified all changes locally before submitting.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)