### PR TITLE
[AIP-94] Mark tasks CLI commands as migrated to airflowctl

### DIFF
--- a/airflow-core/src/airflow/cli/commands/task_command.py
+++ b/airflow-core/src/airflow/cli/commands/task_command.py
@@ -262,6 +262,7 @@ class TaskCommandMarker:
     """Marker for listener hooks, to properly detect from which component they are called."""
 
 
+@deprecated_for_airflowctl("airflowctl tasks failed-deps")
 @cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def task_failed_deps(args) -> None:
@@ -290,6 +291,7 @@ def task_failed_deps(args) -> None:
         print("Task instance dependencies are all met.")
 
 
+@deprecated_for_airflowctl("airflowctl tasks state")
 @cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
 @providers_configuration_loaded
@@ -307,6 +309,7 @@ def task_state(args) -> None:
     print(ti.state)
 
 
+@deprecated_for_airflowctl("airflowctl tasks list")
 @cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
 @providers_configuration_loaded

--- a/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
+++ b/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
@@ -75,6 +75,9 @@ MIGRATED_CLI_COMMANDS = [
     (provider_command.providers_list, "airflowctl providers list"),
     (config_command.get_value, "airflowctl config get"),
     (config_command.show_config, "airflowctl config list"),
+    (task_command.task_failed_deps, "airflowctl tasks failed-deps"),
+    (task_command.task_state, "airflowctl tasks state"),
+    (task_command.task_list, "airflowctl tasks list"),
     (task_command.task_states_for_dag_run, "airflowctl tasks states-for-dag-run"),
     (task_command.task_clear, "airflowctl tasks clear"),
 ]


### PR DESCRIPTION
Add the `@deprecated_for_airflowctl` marker decorator to the 5 tasks CLI 
commands that have airflowctl equivalents:

- `tasks failed-deps`
- `tasks state`
- `tasks list`
- `tasks states-for-dag-run`
- `tasks clear`

This follows the simplified marker-only direction described in #68402 
(comment by @bugraoz93) and the same pattern as #68932 (variables) and 
#68958 (config).

related: #68402