### PR TITLE
OpenLineage: reuse per-process adapter in dag-state-change pool workers

### DIFF
--- a/providers/openlineage/docs/troubleshooting.rst
+++ b/providers/openlineage/docs/troubleshooting.rst
@@ -43,6 +43,22 @@ as well as the `task_success_overtime <https://airflow.apache.org/docs/apache-ai
 configuration in Airflow config.
 
 
+Scheduler CPU or memory growing steadily while OpenLineage is enabled
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In provider versions that submit bound adapter methods to the DAG-run event process pool, each pool worker
+built a new OpenLineage client — including a new transport set — for every DAG-run state change, and the
+clients were never closed. With transports that start background worker threads (e.g. the ``datadog``
+transport), each DAG-run event leaked one thread inside the scheduler, so scheduler CPU and memory climbed
+steadily over hours and recovered only on a scheduler restart.
+
+**Possible Solution**
+
+Upgrade to a provider version that reuses a single per-process adapter in the pool workers. If you cannot
+upgrade yet, prefer a transport that does not start background worker threads (e.g. plain ``http``) for the
+affected destination, or restart the scheduler to reclaim the leaked threads as a stopgap.
+
+
 Missing lineage from EmptyOperators
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -113,9 +113,7 @@ def _executor_initializer():
         log.debug("Exception details:", exc_info=True)
 
 
-_process_adapter: OpenLineageAdapter | None = None
-
-
+@cache
 def _get_process_adapter() -> OpenLineageAdapter:
     """
     Return the per-process ``OpenLineageAdapter`` used inside pool worker processes.
@@ -123,10 +121,7 @@ def _get_process_adapter() -> OpenLineageAdapter:
     Each ``ProcessPoolExecutor`` worker keeps exactly one adapter — and therefore one
     ``OpenLineageClient`` with one set of transports — for its whole lifetime.
     """
-    global _process_adapter
-    if _process_adapter is None:
-        _process_adapter = OpenLineageAdapter()
-    return _process_adapter
+    return OpenLineageAdapter()
 
 
 def _run_adapter_method(method_name: str, /, *args, **kwargs):

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -113,15 +113,47 @@ def _executor_initializer():
         log.debug("Exception details:", exc_info=True)
 
 
-def _emit_manual_state_change_event(adapter_method, stats_key, **kwargs):
+_process_adapter: OpenLineageAdapter | None = None
+
+
+def _get_process_adapter() -> OpenLineageAdapter:
     """
-    Emit an OL event via the given adapter method and record its serialized size.
+    Return the per-process ``OpenLineageAdapter`` used inside pool worker processes.
+
+    Each ``ProcessPoolExecutor`` worker keeps exactly one adapter — and therefore one
+    ``OpenLineageClient`` with one set of transports — for its whole lifetime.
+    """
+    global _process_adapter
+    if _process_adapter is None:
+        _process_adapter = OpenLineageAdapter()
+    return _process_adapter
+
+
+def _run_adapter_method(method_name: str, /, *args, **kwargs):
+    """
+    Run the named ``OpenLineageAdapter`` method on the per-process adapter.
+
+    Module-level so it is picklable across the ProcessPoolExecutor boundary. Bound adapter
+    methods must not be submitted to the pool directly: pickling them serializes the whole
+    adapter, so the worker unpickles a fresh adapter per event and builds a new
+    ``OpenLineageClient`` (with new transports) on every emit. Transports that start
+    background worker threads (e.g. the ``datadog`` transport, which always starts an async
+    HTTP worker thread) are never closed, so this leaks one thread per event and steadily
+    consumes scheduler CPU and memory until restart.
+    """
+    return getattr(_get_process_adapter(), method_name)(*args, **kwargs)
+
+
+def _emit_manual_state_change_event(adapter_method_name: str, stats_key: str, **kwargs):
+    """
+    Emit an OL event via the named adapter method and record its serialized size.
 
     Module-level so it is picklable across the ProcessPoolExecutor boundary used by
     `_on_task_instance_manual_state_change` for scheduler-side "task state changed
-    externally" emissions.
+    externally" emissions. The method is resolved on the per-process adapter so the
+    pool worker reuses one client across events (see ``_run_adapter_method``).
     """
-    event = adapter_method(**kwargs)
+    event = getattr(_get_process_adapter(), adapter_method_name)(**kwargs)
     Stats.gauge(stats_key, len(Serde.to_json(event).encode("utf-8")))
     return event
 
@@ -782,10 +814,10 @@ class OpenLineageListener:
                 return
 
             if ti_state == TaskInstanceState.FAILED:
-                adapter_method = self.adapter.fail_task
+                adapter_method_name = "fail_task"
                 event_type = RunState.FAIL.value.lower()
             elif ti_state in (TaskInstanceState.SUCCESS, TaskInstanceState.SKIPPED):
-                adapter_method = self.adapter.complete_task
+                adapter_method_name = "complete_task"
                 event_type = RunState.COMPLETE.value.lower()
             else:
                 raise ValueError(f"Unsupported ti_state: `{ti_state}`.")
@@ -867,7 +899,7 @@ class OpenLineageListener:
             operator_name = (ti.operator or "unknown").lower()
             self.submit_callable(
                 _emit_manual_state_change_event,
-                adapter_method,
+                adapter_method_name,
                 f"ol.event.size.{event_type}.{operator_name}",
                 **adapter_kwargs,
             )
@@ -979,7 +1011,8 @@ class OpenLineageListener:
             doc, doc_type = get_dag_documentation(dag_run.dag)
 
             self.submit_callable(
-                self.adapter.dag_started,
+                _run_adapter_method,
+                "dag_started",
                 dag_id=dag_run.dag_id,
                 run_id=dag_run.run_id,
                 logical_date=date,
@@ -1031,7 +1064,8 @@ class OpenLineageListener:
             doc, doc_type = get_dag_documentation(dag_run.dag)
 
             self.submit_callable(
-                self.adapter.dag_success,
+                _run_adapter_method,
+                "dag_success",
                 dag_id=dag_run.dag_id,
                 run_id=dag_run.run_id,
                 end_date=dag_run.end_date,
@@ -1082,7 +1116,8 @@ class OpenLineageListener:
             doc, doc_type = get_dag_documentation(dag_run.dag)
 
             self.submit_callable(
-                self.adapter.dag_failed,
+                _run_adapter_method,
+                "dag_failed",
                 dag_id=dag_run.dag_id,
                 run_id=dag_run.run_id,
                 end_date=dag_run.end_date,

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -92,15 +92,23 @@ def direct_submit_call(self, callable, *args, **kwargs):
 
     Bypasses the ``ProcessPoolExecutor`` so tests can assert against mocked
     adapter methods without hitting pickling of ``unittest.mock.Mock``.
-    When the submitted callable is ``_emit_manual_state_change_event``, skip
-    its ``Stats.gauge`` side effect (which would try to ``Serde.to_json`` a
-    ``MagicMock`` return value) and invoke the adapter method directly.
+    The module-level pool wrappers pass adapter method *names* and resolve them
+    on the per-process adapter; here we resolve them on this listener's adapter
+    instead, so assertions against mocked adapter methods keep working. For
+    ``_emit_manual_state_change_event`` this also skips its ``Stats.gauge``
+    side effect (which would try to ``Serde.to_json`` a ``MagicMock`` return).
     """
-    from airflow.providers.openlineage.plugins.listener import _emit_manual_state_change_event
+    from airflow.providers.openlineage.plugins.listener import (
+        _emit_manual_state_change_event,
+        _run_adapter_method,
+    )
 
     if callable is _emit_manual_state_change_event:
-        adapter_method, _stats_key, *_ = args
-        return adapter_method(**kwargs)
+        adapter_method_name, _stats_key, *_ = args
+        return getattr(self.adapter, adapter_method_name)(**kwargs)
+    if callable is _run_adapter_method:
+        adapter_method_name, *rest = args
+        return getattr(self.adapter, adapter_method_name)(*rest, **kwargs)
     return callable(*args, **kwargs)
 
 
@@ -121,6 +129,34 @@ class MockExecutor:
 
     def shutdown(self, *args, **kwargs):
         print("Shutting down")
+
+
+def _probe_process_adapter():
+    """Return (pid, adapter id) from inside a pool worker; module-level so it is picklable."""
+    import os
+
+    from airflow.providers.openlineage.plugins.listener import _get_process_adapter
+
+    return os.getpid(), id(_get_process_adapter())
+
+
+class TestProcessAdapterReuse:
+    def test_process_adapter_reused_across_pool_submissions(self):
+        """
+        A pool worker must reuse one adapter (hence one client/transport set) across events.
+
+        Regression test: submitting bound adapter methods pickled a fresh adapter per event,
+        making the worker build a new OpenLineageClient (and transport worker threads that are
+        never closed) for every DAG-run state change, leaking threads in the scheduler.
+        """
+        from concurrent.futures import ProcessPoolExecutor
+
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            pid_first, adapter_id_first = pool.submit(_probe_process_adapter).result(timeout=60)
+            pid_second, adapter_id_second = pool.submit(_probe_process_adapter).result(timeout=60)
+
+        assert pid_first == pid_second
+        assert adapter_id_first == adapter_id_second
 
 
 class TestExecutorInitializer:


### PR DESCRIPTION
## Summary

The OpenLineage listener submits **bound adapter methods** to its DAG-run event `ProcessPoolExecutor` (`self.adapter.dag_started` / `dag_success` / `dag_failed`, and `self.adapter.fail_task` / `complete_task` via `_emit_manual_state_change_event`). Pickling a bound method serializes the adapter itself, so the long-lived pool worker unpickles a fresh `OpenLineageAdapter` for every event and, on emit, builds a **new `OpenLineageClient` — with a new transport set — per DAG-run state change** (`get_or_create_openlineage_client` caches on `self._client`, an instance attribute). `close()` is never called on those clients.

For transports that start background worker threads this leaks one thread per event inside the scheduler. The `datadog` transport (openlineage-python >= 1.37.0) unconditionally starts an `AsyncHttpTransport` worker thread in its constructor; each idle thread busy-polls at ~100 Hz and costs ~0.45% CPU (measured on openlineage-python 1.47.1 — see repro below; 400 accumulated clients = 401 threads = ~167% CPU doing nothing). Observed in production (Airflow 2.11, Astronomer, KubernetesExecutor, ~50 hourly DAGs, composite transport with a `datadog` leg): scheduler CPU climbs steadily from the moment the datadog leg is enabled until pinned at its limit within ~6 hours, heartbeat dips, and only a scheduler restart recovers it. Even the thread-less `http` transport pays a per-event session/connection-pool rebuild.

## Fix

Route pool submissions through a module-level `_run_adapter_method(method_name, ...)` that resolves the adapter method by name on a per-process adapter singleton (`_get_process_adapter`), so each pool worker keeps exactly one client — and one transport set — for its whole lifetime. `_emit_manual_state_change_event` now takes the adapter method name and resolves it the same way.

### Changes

- `listener.py`: add `_get_process_adapter()` / `_run_adapter_method()`; DAG-run hooks submit method names instead of bound methods; `_emit_manual_state_change_event` resolves the named method on the per-process adapter
- `test_listener.py`: regression test asserting two submissions executed in the same pool worker observe the same adapter instance; `direct_submit_call` test stand-in resolves method names on the listener's adapter so existing mocked-adapter assertions keep working
- `docs/troubleshooting.rst`: known-limitations entry for the steadily-growing scheduler CPU/memory symptom on affected versions

### Design notes

- The fix is scoped to the pool boundary in the listener rather than making the adapter's client cache global: tests (and potentially users) construct adapters with injected per-instance clients, and the fork-based task-event path on workers intentionally uses the in-process adapter — both keep their existing semantics.
- No locking is needed in `_get_process_adapter`: pool workers execute submitted tasks serially, and the scheduler parent only submits (it never runs `_run_adapter_method` itself).

## Test Plan

- [x] New regression test `test_process_adapter_reused_across_pool_submissions` passes
- [x] Full `test_listener.py` suite on `main`: 38 passed, 0 failed (38 Airflow-2 variants skip locally and run in the CI compatibility matrix)
- [x] `ruff check` and `ruff format --check` clean on changed files

<details>
<summary>Thread-leak repro (openlineage-python 1.47.1) — one DatadogTransport instantiation per simulated event</summary>

```python
import threading
import time

from openlineage.client.transport.datadog import DatadogConfig, DatadogTransport


def cpu_pct(interval: float = 3.0) -> float:
    t0, w0 = time.process_time(), time.perf_counter()
    time.sleep(interval)
    return 100 * (time.process_time() - t0) / (time.perf_counter() - w0)


transports = []
print(f"{'clients':>8} {'threads':>8} {'idle CPU%':>10}")
print(f"{0:>8} {threading.active_count():>8} {cpu_pct():>10.1f}")
for target in (50, 150, 400):
    while len(transports) < target:
        # one DAG-run state change == one fresh client == one DatadogTransport
        transports.append(DatadogTransport(DatadogConfig(apiKey="fake-key")))
    time.sleep(1.0)
    print(f"{len(transports):>8} {threading.active_count():>8} {cpu_pct():>10.1f}")
```

| clients created (= events) | threads | idle CPU% |
|---|---|---|
| 0 | 1 | 0.0 |
| 50 | 51 | 29.5 |
| 150 | 151 | 72.0 |
| 400 | 401 | 167.6 |

</details>

A complementary report about the `datadog` transport itself (unconditional thread start, never closed, busy-poll idle loop) is being filed with OpenLineage separately; this provider-side fix removes the per-event client multiplication for all transport types.

closes: #69284

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: Claude Code (Claude Fable 5)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
