### PR TITLE
Add streaming task log support to BaseExecutor and FileTaskHandler

### DIFF
--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -175,7 +175,6 @@ class BaseExecutor(LoggingMixin):
     # The connection-test supervisor uses ``signal.SIGALRM`` (via ``TimeoutPosix``)
     # to bound hook execution. Executors that opt in must run on POSIX systems.
     supports_connection_test: bool = False
-    supports_streaming_logs: bool = False
     sentry_integration: str = ""
 
     is_local: bool = False
@@ -565,8 +564,8 @@ class BaseExecutor(LoggingMixin):
         """
         Return a streaming response for task logs.
 
-        Executors that implement this method must also set the ``supports_streaming_logs`` class
-        attribute to ``True``.
+        Executors that don't implement this method raise ``NotImplementedError``; callers should
+        catch that and fall back to :meth:`get_task_log`.
 
         :param ti: A TaskInstance object
         :param try_number: current try_number to read log from

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.orm import Session
 
+    from airflow._shared.logging.remote import StreamingLogResponse
     from airflow.api_fastapi.auth.tokens import JWTGenerator
     from airflow.callbacks.base_callback_sink import BaseCallbackSink
     from airflow.callbacks.callback_requests import CallbackRequest
@@ -174,6 +175,7 @@ class BaseExecutor(LoggingMixin):
     # The connection-test supervisor uses ``signal.SIGALRM`` (via ``TimeoutPosix``)
     # to bound hook execution. Executors that opt in must run on POSIX systems.
     supports_connection_test: bool = False
+    supports_streaming_logs: bool = False
     sentry_integration: str = ""
 
     is_local: bool = False
@@ -558,6 +560,19 @@ class BaseExecutor(LoggingMixin):
         :return: tuple of logs and messages
         """
         return [], []
+
+    def get_streaming_task_log(self, ti: TaskInstance, try_number: int) -> StreamingLogResponse:
+        """
+        Return a streaming response for task logs.
+
+        Executors that implement this method must also set the ``supports_streaming_logs`` class
+        attribute to ``True``.
+
+        :param ti: A TaskInstance object
+        :param try_number: current try_number to read log from
+        :return: StreamingLogResponse
+        """
+        raise NotImplementedError
 
     def end(self) -> None:  # pragma: no cover
         """Wait synchronously for the previously submitted job to complete."""

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -23,14 +23,14 @@ import heapq
 import io
 import logging
 import os
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Generator, Iterator
 from contextlib import suppress
 from datetime import datetime
 from enum import Enum
 from itertools import chain, islice
 from pathlib import Path
 from types import GeneratorType
-from typing import IO, TYPE_CHECKING, Literal, TypedDict, cast, overload
+from typing import IO, TYPE_CHECKING, TypedDict, cast
 from urllib.parse import urljoin
 
 import pendulum
@@ -557,31 +557,14 @@ class FileTaskHandler(logging.Handler):
             )
         raise RuntimeError(f"Unable to render log filename for {ti}. This should never happen")
 
-    @overload
-    def _get_executor_log_callable(
-        self, ti: TaskInstance | TaskInstanceHistory, *, streaming: Literal[True]
-    ) -> Callable[[TaskInstance | TaskInstanceHistory, int], StreamingLogResponse] | None: ...
-
-    @overload
-    def _get_executor_log_callable(
-        self, ti: TaskInstance | TaskInstanceHistory, *, streaming: Literal[False] = ...
-    ) -> Callable[[TaskInstance | TaskInstanceHistory, int], tuple[list[str], list[str]]]: ...
-
-    def _get_executor_log_callable(
-        self, ti: TaskInstance | TaskInstanceHistory, *, streaming: bool = False
-    ) -> (
-        Callable[[TaskInstance | TaskInstanceHistory, int], StreamingLogResponse]
-        | None
-        | Callable[[TaskInstance | TaskInstanceHistory, int], tuple[list[str], list[str]]]
-    ):
+    def _get_executor(self, ti: TaskInstance | TaskInstanceHistory) -> BaseExecutor:
         """
-        Get the get_task_log or get_streaming_task_log method from executor of current task instance.
+        Get the executor of current task instance.
 
         Since there might be multiple executors, so we need to get the executor of current task instance instead of getting from default executor.
 
         :param ti: task instance object
-        :param streaming: if True, get the get_streaming_task_log method, otherwise get the get_task_log method
-        :return: get_task_log or get_streaming_task_log method of the executor
+        :return: executor of the task instance
         """
         executor_name = ti.executor or self.DEFAULT_EXECUTOR_KEY
         executor = self.executor_instances.get(executor_name)
@@ -592,17 +575,7 @@ class FileTaskHandler(logging.Handler):
                 executor = ExecutorLoader.load_executor(executor_name)
             self.executor_instances[executor_name] = executor
 
-        if streaming:
-            # The `supports_streaming_logs` class attribute and `get_streaming_task_log` method was added in Airflow 3.2.0.
-            # And some of the provider executors or custom executors haven't supported `get_streaming_task_log` yet.
-            # For backward compatibility with earlier versions, we need to check for their existence.
-            if hasattr(executor, "get_streaming_task_log") and getattr(
-                executor, "supports_streaming_logs", False
-            ):
-                return executor.get_streaming_task_log
-            return None
-
-        return executor.get_task_log
+        return executor
 
     def _read(
         self,
@@ -660,12 +633,13 @@ class FileTaskHandler(logging.Handler):
 
         has_executor_log = False
         if ti.state == TaskInstanceState.RUNNING:
-            # check for streaming logs first
-            if executor_streaming_get_task_log := self._get_executor_log_callable(ti, streaming=True):
-                sources, executor_logs = executor_streaming_get_task_log(ti, try_number)
-            else:  # fallback to non-streaming logs if streaming not supported
-                executor_get_task_log = self._get_executor_log_callable(ti)
-                sources, logs = executor_get_task_log(ti, try_number)
+            executor = self._get_executor(ti)
+            try:
+                # check for streaming logs first
+                sources, executor_logs = executor.get_streaming_task_log(ti, try_number)
+            except NotImplementedError:
+                # fallback to non-streaming logs if streaming not supported
+                sources, logs = executor.get_task_log(ti, try_number)
                 # make the logs stream-like compatible
                 executor_logs = [_get_compatible_log_stream(logs)]
 

--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -30,7 +30,7 @@ from enum import Enum
 from itertools import chain, islice
 from pathlib import Path
 from types import GeneratorType
-from typing import IO, TYPE_CHECKING, TypedDict, cast
+from typing import IO, TYPE_CHECKING, Literal, TypedDict, cast, overload
 from urllib.parse import urljoin
 
 import pendulum
@@ -557,27 +557,52 @@ class FileTaskHandler(logging.Handler):
             )
         raise RuntimeError(f"Unable to render log filename for {ti}. This should never happen")
 
-    def _get_executor_get_task_log(
-        self, ti: TaskInstance | TaskInstanceHistory
-    ) -> Callable[[TaskInstance | TaskInstanceHistory, int], tuple[list[str], list[str]]]:
+    @overload
+    def _get_executor_log_callable(
+        self, ti: TaskInstance | TaskInstanceHistory, *, streaming: Literal[True]
+    ) -> Callable[[TaskInstance | TaskInstanceHistory, int], StreamingLogResponse] | None: ...
+
+    @overload
+    def _get_executor_log_callable(
+        self, ti: TaskInstance | TaskInstanceHistory, *, streaming: Literal[False] = ...
+    ) -> Callable[[TaskInstance | TaskInstanceHistory, int], tuple[list[str], list[str]]]: ...
+
+    def _get_executor_log_callable(
+        self, ti: TaskInstance | TaskInstanceHistory, *, streaming: bool = False
+    ) -> (
+        Callable[[TaskInstance | TaskInstanceHistory, int], StreamingLogResponse]
+        | None
+        | Callable[[TaskInstance | TaskInstanceHistory, int], tuple[list[str], list[str]]]
+    ):
         """
-        Get the get_task_log method from executor of current task instance.
+        Get the get_task_log or get_streaming_task_log method from executor of current task instance.
 
         Since there might be multiple executors, so we need to get the executor of current task instance instead of getting from default executor.
 
         :param ti: task instance object
-        :return: get_task_log method of the executor
+        :param streaming: if True, get the get_streaming_task_log method, otherwise get the get_task_log method
+        :return: get_task_log or get_streaming_task_log method of the executor
         """
         executor_name = ti.executor or self.DEFAULT_EXECUTOR_KEY
         executor = self.executor_instances.get(executor_name)
-        if executor is not None:
-            return executor.get_task_log
+        if executor is None:
+            if executor_name == self.DEFAULT_EXECUTOR_KEY:
+                executor = ExecutorLoader.get_default_executor()
+            else:
+                executor = ExecutorLoader.load_executor(executor_name)
+            self.executor_instances[executor_name] = executor
 
-        if executor_name == self.DEFAULT_EXECUTOR_KEY:
-            self.executor_instances[executor_name] = ExecutorLoader.get_default_executor()
-        else:
-            self.executor_instances[executor_name] = ExecutorLoader.load_executor(executor_name)
-        return self.executor_instances[executor_name].get_task_log
+        if streaming:
+            # The `supports_streaming_logs` class attribute and `get_streaming_task_log` method was added in Airflow 3.2.0.
+            # And some of the provider executors or custom executors haven't supported `get_streaming_task_log` yet.
+            # For backward compatibility with earlier versions, we need to check for their existence.
+            if hasattr(executor, "get_streaming_task_log") and getattr(
+                executor, "supports_streaming_logs", False
+            ):
+                return executor.get_streaming_task_log
+            return None
+
+        return executor.get_task_log
 
     def _read(
         self,
@@ -632,23 +657,28 @@ class FileTaskHandler(logging.Handler):
                 raise TypeError("Logs should be either a list of strings or a generator of log lines.")
             # Extend LogSourceInfo
             source_list.extend(sources)
-        has_k8s_exec_pod = False
+
+        has_executor_log = False
         if ti.state == TaskInstanceState.RUNNING:
-            executor_get_task_log = self._get_executor_get_task_log(ti)
-            response = executor_get_task_log(ti, try_number)
-            if response:
-                sources, logs = response
+            # check for streaming logs first
+            if executor_streaming_get_task_log := self._get_executor_log_callable(ti, streaming=True):
+                sources, executor_logs = executor_streaming_get_task_log(ti, try_number)
+            else:  # fallback to non-streaming logs if streaming not supported
+                executor_get_task_log = self._get_executor_log_callable(ti)
+                sources, logs = executor_get_task_log(ti, try_number)
                 # make the logs stream-like compatible
                 executor_logs = [_get_compatible_log_stream(logs)]
+
             if sources:
                 source_list.extend(sources)
-                has_k8s_exec_pod = True
+                has_executor_log = True
+
         if not (remote_logs and ti.state not in State.unfinished):
             # when finished, if we have remote logs, no need to check local
             worker_log_full_path = Path(self.local_base, worker_log_rel_path)
             sources, local_logs = self._read_from_local(worker_log_full_path)
             source_list.extend(sources)
-        if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_k8s_exec_pod:
+        if ti.state in (TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED) and not has_executor_log:
             sources, served_logs = self._read_from_logs_server(ti, worker_log_rel_path)
             source_list.extend(sources)
         elif (ti.state not in State.unfinished or ti.state in _STATES_WITH_COMPLETED_ATTEMPT) and not (

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -67,10 +67,6 @@ def test_supports_multi_team_default_value():
     assert not BaseExecutor.supports_multi_team
 
 
-def test_supports_streaming_logs_default_value():
-    assert not BaseExecutor.supports_streaming_logs
-
-
 def test_invalid_slotspool():
     with pytest.raises(ValueError, match="parallelism is set to 0 or lower"):
         BaseExecutor(0)

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -67,6 +67,10 @@ def test_supports_multi_team_default_value():
     assert not BaseExecutor.supports_multi_team
 
 
+def test_supports_streaming_logs_default_value():
+    assert not BaseExecutor.supports_streaming_logs
+
+
 def test_invalid_slotspool():
     with pytest.raises(ValueError, match="parallelism is set to 0 or lower"):
         BaseExecutor(0)
@@ -76,6 +80,14 @@ def test_get_task_log():
     executor = BaseExecutor()
     ti = TaskInstance(task=SerializedBaseOperator(task_id="dummy"), dag_version_id=mock.MagicMock(spec=UUID))
     assert executor.get_task_log(ti=ti, try_number=1) == ([], [])
+
+
+def test_get_streaming_task_log_not_implemented():
+    executor = BaseExecutor()
+    ti = TaskInstance(task=SerializedBaseOperator(task_id="dummy"), dag_version_id=mock.MagicMock(spec=UUID))
+
+    with pytest.raises(NotImplementedError):
+        executor.get_streaming_task_log(ti=ti, try_number=1)
 
 
 def test_serve_logs_default_value():

--- a/airflow-core/tests/unit/utils/log/test_file_task_handler.py
+++ b/airflow-core/tests/unit/utils/log/test_file_task_handler.py
@@ -237,10 +237,9 @@ class TestFileTaskHandlerExecutorLogs:
         return ti
 
     def test_running_task_prefers_streaming_executor_logs(self):
-        """Use executor streaming logs when the executor advertises streaming support."""
+        """Use executor streaming logs when the executor implements streaming."""
         handler = FileTaskHandler(base_log_folder="")
         executor = MagicMock()
-        executor.supports_streaming_logs = True
         executor.get_streaming_task_log.return_value = (
             ["streaming source"],
             [convert_list_to_stream(["streaming log"])],
@@ -269,10 +268,10 @@ class TestFileTaskHandlerExecutorLogs:
         assert metadata == {"end_of_log": False, "log_pos": 1}
 
     def test_running_task_falls_back_to_legacy_executor_logs(self):
-        """Use legacy executor logs when streaming support is not advertised."""
+        """Use legacy executor logs when the executor doesn't implement streaming."""
         handler = FileTaskHandler(base_log_folder="")
         executor = MagicMock()
-        executor.supports_streaming_logs = False
+        executor.get_streaming_task_log.side_effect = NotImplementedError
         executor.get_task_log.return_value = (["legacy source"], ["legacy log"])
         handler.executor_instances = {"LegacyExecutor": executor}
         ti = self._running_ti("LegacyExecutor")
@@ -285,7 +284,7 @@ class TestFileTaskHandlerExecutorLogs:
         ):
             logs, metadata = handler._read(ti=ti, try_number=1)
 
-        executor.get_streaming_task_log.assert_not_called()
+        executor.get_streaming_task_log.assert_called_once_with(ti, 1)
         executor.get_task_log.assert_called_once_with(ti, 1)
         read_from_logs_server.assert_not_called()
         assert extract_events(logs, skip_source_info=False) == [

--- a/airflow-core/tests/unit/utils/log/test_file_task_handler.py
+++ b/airflow-core/tests/unit/utils/log/test_file_task_handler.py
@@ -21,6 +21,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from airflow.utils.log.file_task_handler import FileTaskHandler
+from airflow.utils.state import TaskInstanceState
+
+from tests_common.test_utils.file_task_handler import convert_list_to_stream, extract_events
 
 
 class TestFileTaskHandlerLogServer:
@@ -220,3 +223,75 @@ class TestFileTaskHandlerReadFromLocal:
 
         assert len(sources) == 1
         assert "through-symlink content" in self._drain(streams[0])
+
+
+class TestFileTaskHandlerExecutorLogs:
+    """Tests for executor log retrieval selection."""
+
+    @staticmethod
+    def _running_ti(executor_name: str) -> MagicMock:
+        ti = MagicMock()
+        ti.executor = executor_name
+        ti.state = TaskInstanceState.RUNNING
+        ti.try_number = 1
+        return ti
+
+    def test_running_task_prefers_streaming_executor_logs(self):
+        """Use executor streaming logs when the executor advertises streaming support."""
+        handler = FileTaskHandler(base_log_folder="")
+        executor = MagicMock()
+        executor.supports_streaming_logs = True
+        executor.get_streaming_task_log.return_value = (
+            ["streaming source"],
+            [convert_list_to_stream(["streaming log"])],
+        )
+        executor.get_task_log.return_value = (["legacy source"], ["legacy log"])
+        handler.executor_instances = {"StreamingExecutor": executor}
+        ti = self._running_ti("StreamingExecutor")
+
+        with (
+            patch.object(handler, "_render_filename", return_value="dag/run/task/1.log"),
+            patch.object(handler, "_read_remote_logs", side_effect=NotImplementedError),
+            patch.object(handler, "_read_from_local", return_value=([], [])),
+            patch.object(handler, "_read_from_logs_server", return_value=([], [])) as read_from_logs_server,
+        ):
+            logs, metadata = handler._read(ti=ti, try_number=1)
+
+        executor.get_streaming_task_log.assert_called_once_with(ti, 1)
+        executor.get_task_log.assert_not_called()
+        read_from_logs_server.assert_not_called()
+        assert extract_events(logs, skip_source_info=False) == [
+            "::group::Log message source details",
+            "streaming source",
+            "::endgroup::",
+            "streaming log",
+        ]
+        assert metadata == {"end_of_log": False, "log_pos": 1}
+
+    def test_running_task_falls_back_to_legacy_executor_logs(self):
+        """Use legacy executor logs when streaming support is not advertised."""
+        handler = FileTaskHandler(base_log_folder="")
+        executor = MagicMock()
+        executor.supports_streaming_logs = False
+        executor.get_task_log.return_value = (["legacy source"], ["legacy log"])
+        handler.executor_instances = {"LegacyExecutor": executor}
+        ti = self._running_ti("LegacyExecutor")
+
+        with (
+            patch.object(handler, "_render_filename", return_value="dag/run/task/1.log"),
+            patch.object(handler, "_read_remote_logs", side_effect=NotImplementedError),
+            patch.object(handler, "_read_from_local", return_value=([], [])),
+            patch.object(handler, "_read_from_logs_server", return_value=([], [])) as read_from_logs_server,
+        ):
+            logs, metadata = handler._read(ti=ti, try_number=1)
+
+        executor.get_streaming_task_log.assert_not_called()
+        executor.get_task_log.assert_called_once_with(ti, 1)
+        read_from_logs_server.assert_not_called()
+        assert extract_events(logs, skip_source_info=False) == [
+            "::group::Log message source details",
+            "legacy source",
+            "::endgroup::",
+            "legacy log",
+        ]
+        assert metadata == {"end_of_log": False, "log_pos": 1}


### PR DESCRIPTION
****part of the streaming task log series****

1. **Merge this first** - the other two build on it.
2. #69300
3. #69301

## Why

When the API server reads logs for a RUNNING task, the executor's `get_task_log` returns the whole log fully materialized, so it sits on the heap at once before the bounded `LogStreamAccumulator` downstream (5000 messages resident, rest spilled to disk) can do its job. Large logs spike the API server's anonymous heap and can OOM it.

## What

- Add `get_streaming_task_log` and a `supports_streaming_logs` class attribute (default `False`) to `BaseExecutor`.
- `FileTaskHandler._read` prefers the streaming method when the executor advertises `supports_streaming_logs`, and falls back to the legacy `get_task_log` otherwise, so provider and custom executors that haven't implemented it keep working unchanged.
- No executor in this PR advertises support yet; the KubernetesExecutor family implementation is the follow-up PR.

## Benchmark

A/B measurement of API server memory serving the same ~415 MB ndjson log (1M lines) of a RUNNING KubernetesExecutor task through `GET .../logs/{try_number}` with `Accept: application/x-ndjson`, sampling the API server cgroup. A = materializing read (before this series), B = streaming read (this PR + the KubernetesExecutor follow-up).

| Metric (API server cgroup) | A: materializing | B: streaming |
| --- | --- | --- |
| Peak anonymous heap growth | +2093.9 MiB | +179.9 MiB (~11.6x lower) |
| Peak RSS (`memory.current`) | 2964.4 MiB | 1193.4 MiB |
| Elapsed | 33.2 s | 19.4 s |

Without streaming the full log lives on the heap at once (~2.1 GiB anonymous, non-reclaimable memory, which is what OOMs the API server). With streaming the executor yields into `LogStreamAccumulator`; B's remaining RSS growth is mostly reclaimable page cache from the accumulator's disk spill.

**Interpretation caveat:** `KubernetesExecutor.RUNNING_POD_LOG_LINES = 100` normally caps the executor read to the last 100 lines, which would hide the difference; the benchmark lifted the cap to 100,000,000 in both builds. Production keeps the cap at 100, so this measures the mechanism's headroom for executors returning large logs, not a shipped memory reduction today (the `running_pod_log_lines` config PR is what makes the cap tunable). Single run per build, and only the ndjson path streams end to end (`Accept: application/json` buffers the whole response regardless).

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

