### PR TITLE
Add running_pod_log_lines config option to KubernetesExecutor

### DIFF
--- a/providers/cncf/kubernetes/provider.yaml
+++ b/providers/cncf/kubernetes/provider.yaml
@@ -287,6 +287,15 @@ config:
         type: boolean
         example: ~
         default: "False"
+      running_pod_log_lines:
+        description: |
+          Number of lines read from the end of a running task's pod log when the task log
+          is served through the kube API, e.g. when viewing logs of a running task in the UI.
+          The value must be greater than 0.
+        version_added: 10.20.0
+        type: integer
+        example: ~
+        default: "100"
       pod_template_file:
         description: |
           Path to the YAML pod file that forms the basis for KubernetesExecutor workers.

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -155,7 +155,7 @@ class KubernetesExecutor(BaseExecutor):
         # scheduler's adopt_or_reset_orphaned_tasks(), which re-queues it with a fresh attempt.
         self.pod_launch_attempts: dict[TaskInstanceKey, _PodLaunchAttempt] = {}
         self.RUNNING_POD_LOG_LINES = self.conf.getint(
-            "kubernetes_executor", "running_pod_log_lines", fallback=self.RUNNING_POD_LOG_LINES
+            "kubernetes_executor", "running_pod_log_lines", fallback=KubernetesExecutor.RUNNING_POD_LOG_LINES
         )
         if self.RUNNING_POD_LOG_LINES <= 0:
             raise ValueError(

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -154,6 +154,14 @@ class KubernetesExecutor(BaseExecutor):
         # instead of requeuing. The orphaned task instance itself is still recovered by the
         # scheduler's adopt_or_reset_orphaned_tasks(), which re-queues it with a fresh attempt.
         self.pod_launch_attempts: dict[TaskInstanceKey, _PodLaunchAttempt] = {}
+        self.RUNNING_POD_LOG_LINES = self.conf.getint(
+            "kubernetes_executor", "running_pod_log_lines", fallback=self.RUNNING_POD_LOG_LINES
+        )
+        if self.RUNNING_POD_LOG_LINES <= 0:
+            raise ValueError(
+                "The [kubernetes_executor] running_pod_log_lines configuration must be greater than 0, "
+                f"got {self.RUNNING_POD_LOG_LINES}."
+            )
         self.completed: dict[tuple[str, str], KubernetesResults] = {}
         self.create_pods_after: datetime | None = None
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/get_provider_info.py
@@ -158,6 +158,13 @@ def get_provider_info():
                         "example": None,
                         "default": "False",
                     },
+                    "running_pod_log_lines": {
+                        "description": "Number of lines read from the end of a running task's pod log when the task log\nis served through the kube API, e.g. when viewing logs of a running task in the UI.\nThe value must be greater than 0.\n",
+                        "version_added": "10.20.0",
+                        "type": "integer",
+                        "example": None,
+                        "default": "100",
+                    },
                     "pod_template_file": {
                         "description": "Path to the YAML pod file that forms the basis for KubernetesExecutor workers.\n",
                         "version_added": None,

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -641,6 +641,21 @@ class TestAirflowKubernetesScheduler:
         assert kube_executor.RUNNING_POD_LOG_LINES == 100
         assert kube_executor_2.RUNNING_POD_LOG_LINES == 200
 
+    @conf_vars({("kubernetes_executor", "running_pod_log_lines"): "500"})
+    def test_running_pod_log_lines_from_config(self):
+        kube_executor = KubernetesExecutor()
+
+        assert kube_executor.RUNNING_POD_LOG_LINES == 500
+        assert KubernetesExecutor.RUNNING_POD_LOG_LINES == 100
+
+    @pytest.mark.parametrize("invalid_value", ["0", "-1"])
+    def test_running_pod_log_lines_invalid_config(self, invalid_value):
+        with conf_vars({("kubernetes_executor", "running_pod_log_lines"): invalid_value}):
+            with pytest.raises(
+                ValueError, match="running_pod_log_lines configuration must be greater than 0"
+            ):
+                KubernetesExecutor()
+
 
 class TestKubernetesExecutor:
     """


### PR DESCRIPTION
- closes: https://github.com/apache/airflow/issues/48710

**part of the streaming task log series**
- merge #69299 first
- no conflict with #69300 (any order after core).
- Raising the cap well above the default is only memory-safe for the API server once the streaming PRs land.

## Why

The number of pod log lines fetched for a running task is a hardcoded class constant (`RUNNING_POD_LOG_LINES = 100`), so deployments cannot tune how much of a running task's log the UI shows.

## What

- Add `[kubernetes_executor] running_pod_log_lines` config option (default `100`, the previous hardcoded value).
- `KubernetesExecutor.__init__` reads it through the team-aware executor conf, shadowing the class default per instance.
- Values `<= 0` are rejected with a `ValueError` at executor construction, so a misconfiguration fails fast instead of silently serving empty or unbounded logs.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

