### PR TITLE
[AIP-94] Mark dags state and next-execution CLI commands as migrated to airflowctl

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -408,6 +408,7 @@ def _get_dagbag_dag_details(dag: DAG) -> dict:
     }
 
 
+@deprecated_for_airflowctl("airflowctl dags state")
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -437,6 +438,7 @@ def dag_state(args, *, session: Session = NEW_SESSION) -> None:
         print(dr.state)
 
 
+@deprecated_for_airflowctl("airflowctl dags next-execution")
 @cli_utils.action_cli
 @providers_configuration_loaded
 def dag_next_execution(args) -> None:

--- a/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
+++ b/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
@@ -57,6 +57,8 @@ MIGRATED_CLI_COMMANDS = [
     (dag_command.dag_pause, "airflowctl dags pause"),
     (dag_command.dag_unpause, "airflowctl dags unpause"),
     (dag_command.dag_list_dag_runs, "airflowctl dagrun list"),
+    (dag_command.dag_state, "airflowctl dags state"),
+    (dag_command.dag_next_execution, "airflowctl dags next-execution"),
     (pool_command.pool_list, "airflowctl pools list"),
     (pool_command.pool_get, "airflowctl pools get"),
     (pool_command.pool_set, "airflowctl pools create"),


### PR DESCRIPTION
Add the `@deprecated_for_airflowctl` marker decorator to two `dags` CLI
commands whose airflowctl equivalents already exist:

- `dags state` → `airflowctl dags state`
- `dags next-execution` → `airflowctl dags next-execution`

Both airflowctl commands are already implemented and registered in
`airflow-ctl`, so functional parity is met. This follows the same
marker-only direction as #68932 (variables), #68958 (config), and
#68650 (dags pause/unpause).

related: #68402