### PR TITLE
Export FanOutMapper and wait policies from airflow.partition_mappers

### DIFF
--- a/airflow-core/src/airflow/partition_mappers/__init__.py
+++ b/airflow-core/src/airflow/partition_mappers/__init__.py
@@ -23,6 +23,7 @@ from airflow.partition_mappers.fixed_key import FixedKeyMapper
 from airflow.partition_mappers.identity import IdentityMapper
 from airflow.partition_mappers.product import ProductMapper
 from airflow.partition_mappers.temporal import (
+    FanOutMapper,
     StartOfDayMapper,
     StartOfHourMapper,
     StartOfMonthMapper,
@@ -30,6 +31,7 @@ from airflow.partition_mappers.temporal import (
     StartOfWeekMapper,
     StartOfYearMapper,
 )
+from airflow.partition_mappers.wait_policy import MinimumCount, WaitForAll
 from airflow.partition_mappers.window import (
     DayWindow,
     HourWindow,
@@ -45,9 +47,11 @@ __all__ = [
     "AllowedKeyMapper",
     "ChainMapper",
     "DayWindow",
+    "FanOutMapper",
     "FixedKeyMapper",
     "HourWindow",
     "IdentityMapper",
+    "MinimumCount",
     "MonthWindow",
     "PartitionMapper",
     "ProductMapper",
@@ -60,6 +64,7 @@ __all__ = [
     "StartOfQuarterMapper",
     "StartOfWeekMapper",
     "StartOfYearMapper",
+    "WaitForAll",
     "WeekWindow",
     "Window",
     "YearWindow",

--- a/airflow-core/tests/unit/partition_mappers/test_init.py
+++ b/airflow-core/tests/unit/partition_mappers/test_init.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import airflow.partition_mappers
+import airflow.sdk
+
+
+def test_package_root_exports_match_sdk():
+    """Every partition-mapper symbol exported from airflow.sdk must also be exported from the core package root."""
+    sdk_names = {
+        name
+        for name, module in airflow.sdk.__lazy_imports.items()
+        if module.startswith(".definitions.partition_mappers")
+    }
+    assert sdk_names == set(airflow.partition_mappers.__all__)


### PR DESCRIPTION
### Why
- Core package root already exports all sibling mappers/windows — these 3 were the only gap.
- Task SDK's matching package exports all three, so core was inconsistent with it.
- Not a user-blocking issue — the deep-import path (e.g. `airflow.partition_mappers.temporal.FanOutMapper`) always worked, and serialization uses the full submodule path regardless.

### What

- Add `FanOutMapper` (from `.temporal`), plus `MinimumCount` and `WaitForAll` (from `.wait_policy`), to the package root imports and `__all__`.
- Add a test asserting all three are importable from the root and present in `__all__`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
