### PR TITLE
Fix reversed direction examples in FanOutMapper docs

### DIFF
--- a/airflow-core/src/airflow/partition_mappers/temporal.py
+++ b/airflow-core/src/airflow/partition_mappers/temporal.py
@@ -469,9 +469,11 @@ class FanOutMapper(PartitionMapper):
     is N→1 (downstream waits until all members arrive), fan-out is 1→N (one
     upstream event creates one downstream Dag run per member).
 
-    For forward fan-out (emit the trailing period ending at the upstream key,
-    instead of the period it represents), pass ``direction=Window.Direction.FORWARD``
-    to the window:
+    ``window``'s direction controls which period each upstream key fans out to.
+    The default, ``Window.Direction.FORWARD``, yields the period *starting at*
+    the upstream key (the period it represents); ``Window.Direction.BACKWARD``
+    yields the trailing period *ending at* the upstream key. Pass
+    ``direction=Window.Direction.BACKWARD`` to the window for the latter:
 
     .. code-block:: python
 
@@ -482,8 +484,8 @@ class FanOutMapper(PartitionMapper):
         FanOutMapper(upstream_mapper=StartOfWeekMapper(), window=WeekWindow())
 
         # Weekly upstream → the 7 days ending at the upstream Monday (trailing period)
-        forward_window = WeekWindow(direction=Window.Direction.FORWARD)
-        FanOutMapper(upstream_mapper=StartOfWeekMapper(), window=forward_window)
+        backward_window = WeekWindow(direction=Window.Direction.BACKWARD)
+        FanOutMapper(upstream_mapper=StartOfWeekMapper(), window=backward_window)
     """
 
     # Keep ``FanOutMapper.default_downstream_mapper_by_window_name`` in sync with

--- a/task-sdk/src/airflow/sdk/definitions/partition_mappers/temporal.py
+++ b/task-sdk/src/airflow/sdk/definitions/partition_mappers/temporal.py
@@ -137,20 +137,23 @@ class FanOutMapper(PartitionMapper):
     waits for all members), fan-out is 1→N (one upstream event creates many
     downstream Dag runs).
 
-    For forward fan-out (emit the *next* period's members instead of the current
-    one), pass ``direction=Window.Direction.FORWARD`` to the window:
+    ``window``'s direction controls which period each upstream key fans out to.
+    The default, ``Window.Direction.FORWARD``, yields the period *starting at*
+    the upstream key (the period it represents); ``Window.Direction.BACKWARD``
+    yields the trailing period *ending at* the upstream key. Pass
+    ``direction=Window.Direction.BACKWARD`` to the window for the latter:
 
     .. code-block:: python
 
         from airflow.sdk import WeekWindow, Window
         from airflow.sdk.definitions.partition_mappers.temporal import FanOutMapper, StartOfWeekMapper
 
-        # Weekly upstream → 7 daily downstream Dag runs (current week)
+        # Weekly upstream → 7 daily downstream Dag runs (the 7 days the upstream Monday represents)
         FanOutMapper(upstream_mapper=StartOfWeekMapper(), window=WeekWindow())
 
-        # Weekly upstream → 7 daily keys for the *following* week
-        forward_window = WeekWindow(direction=Window.Direction.FORWARD)
-        FanOutMapper(upstream_mapper=StartOfWeekMapper(), window=forward_window)
+        # Weekly upstream → the 7 days ending at the upstream Monday (trailing period)
+        backward_window = WeekWindow(direction=Window.Direction.BACKWARD)
+        FanOutMapper(upstream_mapper=StartOfWeekMapper(), window=backward_window)
     """
 
     # Keep ``FanOutMapper.default_downstream_mapper_by_window_name`` in sync with


### PR DESCRIPTION
### Why
`Window.Direction.FORWARD` (the default) yields the period *starting at* the upstream key — the period it represents — while `BACKWARD` yields the trailing period *ending at* the key. The docstrings described it the other way around: they claimed `FORWARD` produced the trailing/"next" period, and the code examples set `direction=Window.Direction.FORWARD` to get the trailing window. An author following either docstring would pick the opposite direction from what they intended.

### What
- Rewrote the direction explanation in `airflow-core/src/airflow/partition_mappers/temporal.py` and `task-sdk/src/airflow/sdk/definitions/partition_mappers/temporal.py` to state that `FORWARD` starts at the upstream key and `BACKWARD` trails it.
- Fixed the code examples to use `Window.Direction.BACKWARD` for the trailing period, and corrected the accompanying comments (e.g. "the 7 days the upstream Monday represents" vs. "the 7 days ending at the upstream Monday").



 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
