### PR TITLE
Fix asset materialization dropping partition date on partitioned Dag runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -464,6 +464,7 @@ def materialize_asset(
             triggering_user_name=user.get_name(),
             state=DagRunState.QUEUED,
             partition_key=params["partition_key"],
+            partition_date=params["partition_date"],
             note=params["note"],
             session=session,
         )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -41,7 +41,9 @@ from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.trigger import Trigger
 from airflow.providers.standard.operators.empty import EmptyOperator
+from airflow.sdk import Asset
 from airflow.timetables.simple import PartitionedAtRuntime
+from airflow.timetables.trigger import CronPartitionTimetable
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
@@ -1683,6 +1685,40 @@ class TestPostAssetMaterialize(TestAssets):
         )
         assert response.status_code == 400
         assert "must not contain '..'" in response.json()["detail"]
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_should_respond_200_with_partition_date_for_partitioned_dag(
+        self, test_client, dag_maker, session
+    ):
+        """Materializing a Dag with a real partitioned timetable must populate partition_date.
+
+        Regression guard: before this fix, `partition_date` resolved by `validate_context` was
+        dropped when creating the run, unlike the sibling `/dags/{dag_id}/dagRuns` trigger route.
+        """
+        partitioned_dag_id = "test_materialize_populates_partition_date"
+        asset = Asset(name="materialize_partition_date_asset", uri="s3://bucket/materialize-partition-date")
+        with dag_maker(
+            dag_id=partitioned_dag_id,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone="UTC"),
+            start_date=DEFAULT_DATE,
+            session=session,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="task", outlets=[asset])
+        session.commit()
+
+        asset_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset.uri))
+
+        response = test_client.post(
+            f"/assets/{asset_id}/materialize",
+            json={"partition_key": "2025-06-01T00:00:00"},
+        )
+        assert response.status_code == 200
+
+        dag_run = session.scalar(select(DagRun).where(DagRun.dag_id == partitioned_dag_id))
+        assert dag_run is not None
+        assert dag_run.partition_key == "2025-06-01T00:00:00"
+        assert dag_run.partition_date == timezone.datetime(2025, 6, 1)
 
 
 class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):


### PR DESCRIPTION
### Why

- The `materialize_asset` route resolved `partition_date` via `validate_context` but never passed it to `create_dagrun`, unlike the sibling `/dags/{dag_id}/dagRuns` trigger route.
- As a result, materialized runs of partitioned Dags were left with `partition_date` NULL.
- That broke two downstream behaviours: backfill dedup created duplicate runs, and partition-date-window clears skipped these runs.

### What

- Pass `partition_date=params["partition_date"]` into `create_dagrun` in `materialize_asset`, matching the trigger route.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
