### PR TITLE
Fix airflowctl connection create command validation error 

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -444,8 +444,7 @@ class ConnectionsOperations(BaseOperations):
         return super().execute_list(path="connections", data_model=ConnectionCollectionResponse)
 
     def create(
-        self,
-        connection: ConnectionBody,
+        self, connection: ConnectionBody, connection_id: str, conn_type: str
     ) -> ConnectionResponse | ServerResponseError:
         """Create a connection."""
         try:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -679,7 +679,9 @@ class TestConnectionsOperations:
             return httpx.Response(200, json=json.loads(self.connection_response.model_dump_json()))
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))
-        response = client.connections.create(connection=self.connection)
+        response = client.connections.create(
+            connection=self.connection, connection_id=self.connection_id, conn_type=self.conn_type
+        )
         assert response == self.connection_response
 
     def test_create_uses_schema_alias_in_request_body(self):
@@ -701,7 +703,9 @@ class TestConnectionsOperations:
             return httpx.Response(200, json=json.loads(self.connection_response.model_dump_json()))
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))
-        response = client.connections.create(connection=connection)
+        response = client.connections.create(
+            connection=connection, connection_id=connection.connection_id, conn_type=connection.conn_type
+        )
         assert response == self.connection_response
 
     def test_bulk(self):
@@ -1308,15 +1312,6 @@ class TestDagRunOperations:
         assert response == self.dag_run_collection_response
         assert "state" not in captured_params
         assert captured_params["limit"] == "5"
-
-    def test_delete(self):
-        def handle_request(request: httpx.Request) -> httpx.Response:
-            assert request.url.path == f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}"
-            return httpx.Response(204)
-
-        client = make_api_client(transport=httpx.MockTransport(handle_request))
-        response = client.dag_runs.delete(dag_id=self.dag_id, dag_run_id=self.dag_run_id)
-        assert response == self.dag_run_id
 
 
 class TestJobsOperations:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1313,6 +1313,15 @@ class TestDagRunOperations:
         assert "state" not in captured_params
         assert captured_params["limit"] == "5"
 
+    def test_delete(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == f"/api/v2/dags/{self.dag_id}/dagRuns/{self.dag_run_id}"
+            return httpx.Response(204)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.delete(dag_id=self.dag_id, dag_run_id=self.dag_run_id)
+        assert response == self.dag_run_id
+
 
 class TestJobsOperations:
     job_response = JobResponse(


### PR DESCRIPTION
`airflowctl connections create` shows Traceback (most recent call last):
 ```
 airflowctl connections create
Please enter password for encrypted keyring: 
Traceback (most recent call last):
  File "/usr/python/bin/airflowctl", line 10, in <module>
    sys.exit(main())
  File "/opt/airflow/airflow-ctl/src/airflowctl/__main__.py", line 34, in main
    safe_call_command(args.func, args=args)
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 77, in safe_call_command
    function(args)
  File "/opt/airflow/airflow-ctl/src/airflowctl/api/client.py", line 532, in wrapper
    return func(*args, api_client=api_client, **kwargs)
  File "/opt/airflow/airflow-ctl/src/airflowctl/ctl/cli_config.py", line 731, in _get_func
    method_params[datamodel_param_name] = datamodel.model_validate(
  File "/usr/python/lib/python3.10/site-packages/pydantic/main.py", line 732, in model_validate
    return cls.__pydantic_validator__.validate_python(
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ConnectionBody
connection_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type
conn_type
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type

```
Make `connection_id` and `conn_type` as required parameter in connections operations  and update tests 


… tests

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-08T15:38:00Z head=88e6d95 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Prab-27** · by `@potiuk` · 2026-07-08 15:38 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - **Image build** failing (`Additional PROD image tests / Airflow CTL integration tests with PROD image`). See the [contributor guide](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full criteria: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
