### PR TITLE
Fixed KiotaRequestAdapterHook _is_http_client_closed method wrongly returning True when transport was not opened yet

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -419,7 +419,7 @@ class KiotaRequestAdapterHook(BaseHook):
         transport = cast("AioHttpTransport", credential._client._pipeline._transport)
 
         if not transport._has_been_opened and transport.session is None:
-            return True
+            return False
         if transport.session is not None:
             return transport.session.closed
         return False

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -76,6 +76,21 @@ class TestKiotaRequestAdapterHook:
             assert actual.base_url == "https://graph.microsoft.com/v1.0/"
 
     @classmethod
+    def mock_authentication_provider_never_opened(self) -> AuthenticationProvider:
+        """Return an auth provider whose transport has never been opened (session is None)."""
+        transport = Mock(spec=AioHttpTransport, _has_been_opened=False)
+        transport.session = None
+        pipeline = Mock(spec=AsyncPipelineClient)
+        pipeline._transport = transport
+        client = Mock(spec=AadClient)
+        client._pipeline = pipeline
+        credentials = Mock(spec=AsyncTokenCredential)
+        credentials._client = client
+        access_token_provider = Mock(spec=AzureIdentityAccessTokenProvider)
+        access_token_provider._credentials = credentials
+        return BaseBearerTokenAuthenticationProvider(access_token_provider=access_token_provider)
+
+    @classmethod
     def mock_authentication_provider(self, closed: bool) -> AuthenticationProvider:
         transport = Mock(spec=AioHttpTransport, _has_been_opened=not closed)
         transport.session = Mock(spec=ClientSession, closed=closed)
@@ -592,6 +607,20 @@ class TestKiotaRequestAdapterHook:
 
             assert result is fresh_adapter
             assert hook.cached_request_adapters[hook.conn_id] == ("v1.0", fresh_adapter)
+
+    @pytest.mark.asyncio
+    async def test_get_async_conn_does_not_rebuild_adapter_when_transport_never_opened(self):
+        """get_async_conn must keep the cached adapter when transport has never been opened (session is None)."""
+        with patch_hook():
+            hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
+            adapter = Mock(spec=HttpxRequestAdapter)
+            adapter._http_client = Mock(spec=AsyncClient, is_closed=False)
+            adapter._authentication_provider = self.mock_authentication_provider_never_opened()
+            hook.cached_request_adapters[hook.conn_id] = (hook.api_version, adapter)
+
+            result = await hook.get_async_conn()
+
+            assert result is adapter
 
     @pytest.mark.asyncio
     async def test_send_request_invalidates_cache_and_raises_on_any_error(self):


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: [#69128](https://github.com/apache/airflow/pull/69128)
-->

## Fix `_is_http_client_closed` incorrectly treating a never-opened transport as closed

### Problem

`KiotaRequestAdapterHook._is_http_client_closed` contained a logic error:

```python
# Before
if not transport._has_been_opened and transport.session is None:
    return True  # ← wrong: this means "never used", not "closed"
```

When the underlying Azure credential AioHttpTransport had never been opened (has_been_opened=False, session=None), the method returned True, signalling that the HTTP client was closed. As a result, get_async_conn discarded and rebuilt the cached RequestAdapter on every invocation even though it was perfectly healthy.

### Fix

Return False for this branch — a transport that was never opened is not closed:

```python
# After
if not transport._has_been_opened and transport.session is None:
    return False
```

This is a follow-up PR on [#69128](https://github.com/apache/airflow/pull/69128).

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes (please specify the tool below)

Claude Opus 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
