### PR TITLE
Fix Microsoft WinRM provider import failure under lowest dependencies

### DIFF
--- a/providers/microsoft/winrm/README.rst
+++ b/providers/microsoft/winrm/README.rst
@@ -56,6 +56,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``pywinrm``                                 ``>=0.5.0``
+``pyspnego``                                ``>=0.4.0``
 ==========================================  ==================
 
 The changelog for the provider package can be found in the

--- a/providers/microsoft/winrm/docs/index.rst
+++ b/providers/microsoft/winrm/docs/index.rst
@@ -102,6 +102,7 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``pywinrm``                                 ``>=0.5.0``
+``pyspnego``                                ``>=0.4.0``
 ==========================================  ==================
 
 Downloading official packages

--- a/providers/microsoft/winrm/pyproject.toml
+++ b/providers/microsoft/winrm/pyproject.toml
@@ -62,6 +62,10 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "pywinrm>=0.5.0",
+    # pywinrm imports ``spnego.ContextProxy``, which pyspnego only exposes from 0.4.0 onwards.
+    # Floor it directly so lowest-dependency resolution does not pick a pre-0.4.0 pyspnego
+    # (which fails at import time with ``module 'spnego' has no attribute 'ContextProxy'``).
+    "pyspnego>=0.4.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -6386,6 +6386,7 @@ source = { editable = "providers/microsoft/winrm" }
 dependencies = [
     { name = "apache-airflow" },
     { name = "apache-airflow-providers-common-compat" },
+    { name = "pyspnego" },
     { name = "pywinrm" },
 ]
 
@@ -6404,6 +6405,7 @@ docs = [
 requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
+    { name = "pyspnego", specifier = ">=0.4.0" },
     { name = "pywinrm", specifier = ">=0.5.0" },
 ]
 


### PR DESCRIPTION
The Microsoft WinRM provider declared only `pywinrm>=0.5.0` and left `pyspnego`
(a transitive dependency of pywinrm) unbounded. `pywinrm` imports
`spnego.ContextProxy`, which `pyspnego` only exposes from version `0.4.0`
onwards, so lowest-dependency resolution selected a pre-`0.4.0` `pyspnego` and
the provider failed at import time with
`module 'spnego' has no attribute 'ContextProxy'` — breaking the `LowestDeps`
providers CI job.

Flooring `pyspnego>=0.4.0` directly in the provider keeps lowest-dependency
resolution on a version that actually provides the attribute `pywinrm` needs.
The gap is pre-existing on `main` (surfaced by the failing `LowestDeps` shard on
PR #64643, which is unrelated to that PR's Samba change).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
