### PR TITLE
[v3-3-test] Reduce noise in the daily CI duration trend alert (#69113)

### DIFF
--- a/.github/workflows/ci-duration-monitor.yml
+++ b/.github/workflows/ci-duration-monitor.yml
@@ -49,7 +49,20 @@ jobs:
           # main coverage comes from the scheduled canary runs of the AMD workflow.
           WORKFLOW_NAME: "ci-amd.yml"
           BRANCH: "main"
+          # Only successful (green) canary runs feed the baseline — a failed or cancelled
+          # canary stops partway, so its truncated wall-clock and per-job durations would
+          # skew the trend downwards and mask real regressions. Set explicitly so the
+          # green-only guarantee is visible at the call site and can't be silently changed.
+          ONLY_SUCCESSFUL: "true"
           MAX_RUNS: "25"
+          # Compare the median of the last few nightly runs (not a single run) against the
+          # baseline so one unlucky run — slow PyPI, runner queue pressure, cold cache — does
+          # not trip the alert. With LATEST_RUNS=1 both sides were asymmetric (raw point vs
+          # median) and the alert fired most nights on whichever jobs happened to be slow.
+          LATEST_RUNS: "3"
+          # Network-bound jobs (constraint resolution, provider installs) legitimately swing
+          # tens of minutes run-to-run; require a larger sustained jump before flagging them.
+          JOB_MIN_ABS_INCREASE_MINUTES: "6"
           OUTPUT_FILE: "slack-message.json"
 
       - name: "Post duration alert to Slack"


### PR DESCRIPTION
Backport of #69113 to `v3-3-test`.

The duration monitor flagged jobs by comparing a single nightly canary run against
the median of the preceding runs, so any one slow run tripped the alert. This pins
the monitor to green canary runs, compares the median of the last few runs against
the baseline, and requires a larger absolute jump before flagging individual jobs.

Cherry-picked cleanly from e99daee1. The `v3-3-test` copy of
`scripts/ci/analyze_ci_job_durations.py` already supports `ONLY_SUCCESSFUL`,
`LATEST_RUNS`, and `JOB_MIN_ABS_INCREASE_MINUTES` with matching defaults, so the
workflow-only change is self-contained.

closes: #69332

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)