### PR TITLE
Remove unused ts-sdk label rule from Boring Cyborg config

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -557,9 +557,6 @@ labelPRBasedOnFilePath:
   area:java-sdk:
     - java-sdk/**/*
 
-  area:ts-sdk:
-    - ts-sdk/**/*
-
   "AIP-108: Coordinator":
     - task-sdk/src/airflow/sdk/coordinators/**/*
     - task-sdk/src/airflow/sdk/execution_time/coordinator.py


### PR DESCRIPTION
The `area:ts-sdk` label rule in `.github/boring-cyborg.yml` globs `ts-sdk/**/*`,
but the `ts-sdk/` directory does not exist on `v3-3-test` — it was added to `main`
after 3.3 was cut. The `check-boring-cyborg-configuration` static check flags any
pattern matching zero files, so this stale rule failed the check on every PR
targeting `v3-3-test` (e.g. #69337). Removing the rule restores a green check.

`main` is unaffected — `ts-sdk/` exists there, so the rule is valid.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)