### PR TITLE
Fix RFC 9457 error response in task instances API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -222,8 +222,12 @@ def ti_run(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "https://datatracker.ietf.org/doc/html/rfc9457#section-3.1",
+                "title": "Invalid Task Instance State",
+                "status": status.HTTP_409_CONFLICT,
+                "detail": "TI was not in a state where it could be marked as running",
+                "instance": f"/execution/task-instances/{task_instance_id}/run",
                 "reason": "invalid_state",
-                "message": "TI was not in a state where it could be marked as running",
                 "previous_state": previous_state,
             },
         )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -857,9 +857,13 @@ class TestTIRunState:
         assert response.status_code == 409
         assert response.json() == {
             "detail": {
-                "message": "TI was not in a state where it could be marked as running",
-                "previous_state": initial_ti_state,
+                "type": "https://datatracker.ietf.org/doc/html/rfc9457#section-3.1",
+                "title": "Invalid Task Instance State",
+                "status": 409,
+                "detail": "TI was not in a state where it could be marked as running",
+                "instance": f"/execution/task-instances/{ti.id}/run",
                 "reason": "invalid_state",
+                "previous_state": initial_ti_state,
             }
         }
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

### Description

This PR resolves an existing `TODO` in `airflow/api_fastapi/execution_api/routes/task_instances.py` by ensuring that when an `HTTPException` is raised due to an invalid Task Instance state (409 Conflict), the `detail` object complies with the RFC 9457 format for problem details. It adds the standard `type`, `title`, `status`, `detail`, and `instance` fields to the response.

closes: #69360

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
Generated-by: Google DeepMind Antigravity IDE following the guidelines.
