### PR TITLE
Regenerate Anthropic provider docs to remove stale `common.compat` extra

### DIFF
--- a/providers/anthropic/docs/index.rst
+++ b/providers/anthropic/docs/index.rst
@@ -101,25 +101,6 @@ PIP package                                 Version required
 ``anthropic``                               ``>=0.101.0``
 ==========================================  ==================
 
-Optional cross provider package dependencies
---------------------------------------------
-
-Those are dependencies that might be needed in order to use all the features of the package.
-You need to install the specified provider distributions in order to use them.
-
-You can install such cross-provider dependencies when installing from PyPI. For example:
-
-.. code-block:: bash
-
-    pip install apache-airflow-providers-anthropic[common.compat]
-
-
-==================================================================================================================  =================
-Dependent package                                                                                                   Extra
-==================================================================================================================  =================
-`apache-airflow-providers-common-compat <https://airflow.apache.org/docs/apache-airflow-providers-common-compat>`_  ``common.compat``
-==================================================================================================================  =================
-
 Downloading official packages
 -----------------------------
 


### PR DESCRIPTION
Static checks fail on any full-regeneration run (canary builds on main, and PRs that run with `upgrade-to-newer-dependencies`, e.g. [this run](https://github.com/apache/airflow/actions/runs/28676047756/job/85051334218)): the `update-providers-build-files` hook wants to remove the "Optional cross provider package dependencies" section from `providers/anthropic/docs/index.rst`.

The Anthropic provider (#69003) merged with a `docs/index.rst` generated before #68991, which changed doc generation to skip cross-provider deps that are already required dependencies. `apache-airflow-providers-common-compat` is a required dependency of the Anthropic provider (already listed in its Requirements table), so the section advertising `pip install apache-airflow-providers-anthropic[common.compat]` refers to an extra that does not exist in the package.

## Solution

Regenerate the file with the `update-providers-build-files` prek hook. The removed section matches exactly what the hook produces in CI.
