### PR TITLE
fix(fab): decode session serializer bytes to string for cookie-based sessions (fixes #64921)

### DIFF
--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -795,7 +795,7 @@ class AssetManager(LoggingMixin):
         def _queue_dagrun_if_needed(dag: DagModel) -> str | None:
             item = AssetDagRunQueue(target_dag_id=dag.dag_id, asset_id=asset_id)
             # Don't error whole transaction when a single RunQueue item conflicts.
-            # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
+            # https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#using-savepoint
             try:
                 with session.begin_nested():
                     session.merge(item)

--- a/airflow-core/src/airflow/models/base.py
+++ b/airflow-core/src/airflow/models/base.py
@@ -28,7 +28,7 @@ SQL_ALCHEMY_SCHEMA = conf.get("database", "SQL_ALCHEMY_SCHEMA")
 
 # For more information about what the tokens in the naming convention
 # below mean, see:
-# https://docs.sqlalchemy.org/en/14/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention
+# https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention
 naming_convention = {
     "ix": "idx_%(column_0_N_label)s",
     "uq": "%(table_name)s_%(column_0_N_name)s_uq",

--- a/providers/fab/src/airflow/providers/fab/www/session.py
+++ b/providers/fab/src/airflow/providers/fab/www/session.py
@@ -30,19 +30,23 @@ class _LazySafeSerializer:
     Returns bytes (suitable for database BLOB columns).
     """
 
-    def dumps(self, session_dict):
-        encoder = msgspec.msgpack.Encoder(
-            enc_hook=lambda obj: str(obj) if isinstance(obj, LazyString) else obj
-        )
-        return encoder.encode(dict(session_dict))
+	def dumps(self, session_dict):
+		encoder = msgspec.msgpack.Encoder(
+			enc_hook=lambda obj: str(obj) if isinstance(obj, LazyString) else obj
+		)
+		return encoder.encode(dict(session_dict))
 
-    def loads(self, data):
-        decoder = msgspec.msgpack.Decoder()
-        return decoder.decode(data)
+	def loads(self, data):
+		decoder = msgspec.msgpack.Decoder()
+		return decoder.decode(data)
 
-    # optional old API
-    encode = dumps
-    decode = loads
+	def encode(self, session_dict):
+		return self.dumps(session_dict).decode("utf-8")
+
+	def decode(self, data):
+		if isinstance(data, str):
+			data = data.encode("utf-8")
+		return self.loads(data)
 
 
 class SessionExemptMixin:


### PR DESCRIPTION
The _LazySafeSerializer.encode() method returned bytes from msgpack encoding, but cookie-based sessions (via SecureCookieSessionInterface) require a string value. This caused a TypeError when werkzeug's dump_cookie tried to apply a regex pattern on bytes.\n\nFix: implement explicit encode/decode methods that handle the bytes-to-string conversion, instead of aliasing dumps/loads.\n\nFixes #64921

<!-- pr-triage-fold: triaged=2026-07-28T17:13:06Z head=aeeb45c action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @levgiorg** · by `@potiuk` · 2026-07-28 17:13 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
