### PR TITLE
Fix owners filter on GET /api/v2/dags matching substrings

### DIFF
--- a/airflow-core/newsfragments/42790.bugfix.rst
+++ b/airflow-core/newsfragments/42790.bugfix.rst
@@ -1,0 +1,1 @@
+The ``owners`` filter on ``GET /api/v2/dags`` now matches an owner exactly instead of doing a substring match, so filtering by ``owners=air`` no longer incorrectly returns Dags owned by ``airflow``.

--- a/airflow-core/src/airflow/api_fastapi/common/parameters.py
+++ b/airflow-core/src/airflow/api_fastapi/common/parameters.py
@@ -35,7 +35,17 @@ from typing import (
 from fastapi import Depends, HTTPException, Query, status
 from pendulum.parsing.exceptions import ParserError
 from pydantic import AfterValidator, BaseModel, NonNegativeInt
-from sqlalchemy import Column, String, and_, func, not_, or_, select as sql_select, true as sql_true
+from sqlalchemy import (
+    Column,
+    String,
+    and_,
+    func,
+    literal,
+    not_,
+    or_,
+    select as sql_select,
+    true as sql_true,
+)
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.inspection import inspect
 from sqlalchemy.sql.functions import FunctionElement
@@ -883,8 +893,14 @@ class _OwnersFilter(BaseParam[list[str]]):
         if not self.value:
             return select
 
+        # DagModel.owners stores a comma-joined list of owners (see DAG.owner), normally joined
+        # with ", " but not guaranteed to have the space. Squash the separator and wrap both ends
+        # with "," so a requested owner only matches a whole entry in that list, never a substring
+        # of a neighboring owner's name.
+        squashed_owners = func.replace(DagModel.owners, ", ", ",")
+        wrapped_owners = literal(",").concat(squashed_owners).concat(",")
         conditions = [
-            DagModel.owners.ilike(f"%{_escape_like_pattern(owner)}%", escape=_LIKE_ESCAPE_CHAR)
+            wrapped_owners.ilike(f"%,{_escape_like_pattern(owner.strip())},%", escape=_LIKE_ESCAPE_CHAR)
             for owner in self.value
         ]
         return select.where(or_(*conditions))

--- a/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_parameters.py
@@ -312,7 +312,7 @@ class TestNonSearchFilterEscaping:
         param = _OwnersFilter().set_value(["100%_alice"])
         statement = param.to_orm(select(DagModel))
         sql = _compile(statement)
-        assert r"'%100\%\_alice%'" in sql
+        assert r"'%,100\%\_alice,%'" in sql
         assert "escape" in sql
 
     def test_asset_dependency_filter_escapes_user_wildcards(self):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -56,6 +56,7 @@ DAG5_DISPLAY_NAME = "display5"
 ASSET_SCHEDULED_DAG_ID = "test_asset_scheduled_dag"
 ASSET_DEP_DAG_ID = "test_asset_dep_dag"
 ASSET_DEP_DAG2_ID = "test_asset_dep_dag2"
+MULTI_OWNER_DAG_ID = "test_multi_owner_dag"
 TASK_ID = "op1"
 UTC_JSON_REPR = "UTC" if pendulum.__version__.startswith("3") else "Timezone('UTC')"
 API_PREFIX = "/dags"
@@ -111,6 +112,20 @@ class TestDagEndpoint:
         session.add(dag_model)
         session.add(dagrun_failed)
         session.add(dagrun_success)
+
+    def _create_multi_owner_dag(self, session=None):
+        # Owners as persisted by DAG.owner: a ", "-joined list (see task-sdk DAG.owner property).
+        dag_model = DagModel(
+            dag_id=MULTI_OWNER_DAG_ID,
+            bundle_name="dag_maker",
+            relative_fileloc="multi_owner_dag.py",
+            fileloc="/tmp/multi_owner_dag.py",
+            timetable_summary=None,
+            is_stale=False,
+            is_paused=False,
+            owners="alice, bob",
+        )
+        session.add(dag_model)
 
     def _create_dag_tags(self, session=None):
         session.add(DagTag(dag_id=DAG1_ID, name="tag_2"))
@@ -286,6 +301,22 @@ class TestGetDags(TestDagEndpoint):
                 [DAG1_ID, DAG2_ID],
             ),
             ({"owners": ["test_owner"], "exclude_stale": False}, 1, [DAG3_ID]),
+            # "air" must not match a Dag owned by "airflow" (substring, not exact match).
+            ({"owners": ["air"], "exclude_stale": False}, 0, []),
+            # "owner" must not match "test_owner,another_test_owner" (substring of both entries).
+            ({"owners": ["owner"], "exclude_stale": False}, 0, []),
+            # An owner in the middle/end of a ", "-joined list must match exactly.
+            (
+                {"owners": ["alice"], "exclude_stale": False},
+                1,
+                [MULTI_OWNER_DAG_ID],
+            ),
+            (
+                {"owners": ["bob"], "exclude_stale": False},
+                1,
+                [MULTI_OWNER_DAG_ID],
+            ),
+            ({"owners": ["ali"], "exclude_stale": False}, 0, []),
             ({"last_dag_run_state": "success", "exclude_stale": False}, 1, [DAG3_ID]),
             ({"last_dag_run_state": "failed", "exclude_stale": False}, 1, [DAG1_ID]),
             ({"dag_run_state": "failed"}, 1, [DAG1_ID]),
@@ -445,6 +476,10 @@ class TestGetDags(TestDagEndpoint):
         # Only create asset test data for asset-related tests to avoid affecting other tests
         if any(param in query_params for param in ["has_asset_schedule", "asset_dependency"]):
             self._create_asset_test_data(session)
+        # Only create the multi-owner Dag for owners-related tests to avoid affecting other tests
+        if "owners" in query_params:
+            self._create_multi_owner_dag(session)
+            session.commit()
 
         with assert_queries_count(4):
             response = test_client.get("/dags", params=query_params)


### PR DESCRIPTION
`GET /api/v2/dags?owners=<x>` filtered with a substring `LIKE` against `DagModel.owners`, which stores a comma-joined list of owners. So `owners=air` also returned Dags owned by `airflow`, and `owners=team_a` returned `team_a_legacy` / `team_a_archive`.

This switches the filter to match whole comma-separated entries: the stored list is normalised and comma-wrapped so a requested owner only matches a Dag that actually lists that owner (including owners in the middle/end of a multi-owner list). User-supplied `%`/`_` are still escaped as before.

A previous attempt (#66775) addressed the same report but was closed after CI failures; this PR revives the fix with the escaping preserved, multi-owner coverage, and a newsfragment.

closes: #42790

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)