### PR TITLE
Fix aws_region platform list in Anthropic connection docs

### DIFF
--- a/providers/anthropic/docs/connections.rst
+++ b/providers/anthropic/docs/connections.rst
@@ -49,7 +49,7 @@ Extra (optional)
       ``model`` (e.g. ``hook.create_message(...)``, ``hook.create_agent(...)``). Set it here
       to change the model without editing Dags; falls back to the provider default
       (``claude-opus-4-8``).
-    * ``aws_region`` — AWS region for the ``bedrock`` platform.
+    * ``aws_region`` — AWS region for the ``bedrock`` and ``aws`` platforms.
     * ``project_id`` / ``region`` — GCP project and region for the ``vertex`` platform.
     * ``resource`` — Azure resource name for the ``foundry`` platform.
     * ``anthropic_client_kwargs`` — a nested dictionary forwarded verbatim to the client


### PR DESCRIPTION
The Anthropic connection documentation describes the `aws_region` extra as applying only to the `bedrock` platform, but the hook also passes it to the `aws` platform (Claude Platform on AWS) client — added during review of #69003 ("Pass aws_region to the AnthropicAWS (Claude Platform on AWS) client"). The hook docstring already lists both platforms; this updates `connections.rst` to match, so users configuring `platform="aws"` know the key applies to them.

related: #69003

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Claude Code

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
