### PR TITLE
Respect Dag-specific read access in structure endpoint

### DIFF
--- a/airflow-core/newsfragments/69375.bugfix.rst
+++ b/airflow-core/newsfragments/69375.bugfix.rst
@@ -1,0 +1,1 @@
+Allow users with Dag-specific read access to load structure data without task-instance permission.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
@@ -26,7 +26,7 @@ from airflow.api_fastapi.common.parameters import QueryIncludeDownstream, QueryI
 from airflow.api_fastapi.common.router import AirflowRouter
 from airflow.api_fastapi.core_api.datamodels.ui.structure import StructureDataResponse
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
-from airflow.api_fastapi.core_api.security import ReadableDagsFilterDep, requires_access_dag
+from airflow.api_fastapi.core_api.security import GetUserDep, ReadableDagsFilterDep, requires_access_dag
 from airflow.api_fastapi.core_api.services.ui.structure import (
     bind_output_assets_to_tasks,
     get_upstream_assets,
@@ -40,6 +40,16 @@ from airflow.utils.dag_edges import dag_edges
 structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
 
 
+def check_external_dependencies_access(
+    request: Request,
+    user: GetUserDep,
+    external_dependencies: bool = False,
+) -> None:
+    """Require dependencies access only when dependency data is requested."""
+    if external_dependencies:
+        requires_access_dag("GET", DagAccessEntity.DEPENDENCIES)(request, user)
+
+
 @structure_router.get(
     "/structure_data",
     responses=create_openapi_http_exception_doc(
@@ -50,8 +60,7 @@ structure_router = AirflowRouter(tags=["Structure"], prefix="/structure")
     ),
     dependencies=[
         Depends(requires_access_dag("GET")),
-        Depends(requires_access_dag("GET", DagAccessEntity.DEPENDENCIES)),
-        Depends(requires_access_dag("GET", DagAccessEntity.TASK_INSTANCE)),
+        Depends(check_external_dependencies_access),
     ],
 )
 def structure_data(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py
@@ -26,6 +26,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from airflow._shared.timezones import timezone
+from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+from airflow.api_fastapi.auth.managers.simple.simple_auth_manager import SimpleAuthManager
 from airflow.models.asset import AssetAliasModel, AssetEvent, AssetModel
 from airflow.models.dagbag import DBDagBag
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -707,6 +709,77 @@ class TestStructureDataEndpoint:
     def test_delete_dag_should_response_403(self, unauthorized_test_client):
         response = unauthorized_test_client.get("/structure/structure_data", params={"dag_id": DAG_ID})
         assert response.status_code == 403
+
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        return_value={DAG_ID},
+    )
+    @pytest.mark.usefixtures("make_dags")
+    def test_should_return_200_with_dag_specific_read_access(self, _, test_client):
+        def allow_only_dag_read(self, *, method, user, access_entity=None, details=None):
+            return method == "GET" and access_entity is None and details is not None and details.id == DAG_ID
+
+        with mock.patch.object(SimpleAuthManager, "is_authorized_dag", allow_only_dag_read):
+            response = test_client.get("/structure/structure_data", params={"dag_id": DAG_ID})
+
+        assert response.status_code == 200
+        assert {node["id"] for node in response.json()["nodes"]} == {
+            "task_1",
+            "external_task_sensor",
+            "task_2",
+        }
+
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        return_value={DAG_ID},
+    )
+    @pytest.mark.usefixtures("make_dags")
+    def test_should_return_403_for_unreadable_dag_with_dag_specific_read_access(self, _, test_client):
+        def allow_only_dag_read(self, *, method, user, access_entity=None, details=None):
+            return method == "GET" and access_entity is None and details is not None and details.id == DAG_ID
+
+        with mock.patch.object(SimpleAuthManager, "is_authorized_dag", allow_only_dag_read):
+            response = test_client.get(
+                "/structure/structure_data", params={"dag_id": DAG_ID_EXTERNAL_TRIGGER}
+            )
+
+        assert response.status_code == 403
+
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",
+        return_value={DAG_ID_EXTERNAL_TRIGGER, DAG_ID},
+    )
+    @pytest.mark.parametrize(
+        ("external_dependencies", "allow_dependencies", "expected_status"),
+        [
+            pytest.param(False, False, 200, id="dependencies_not_requested"),
+            pytest.param(True, False, 403, id="dependencies_denied"),
+            pytest.param(True, True, 200, id="dependencies_allowed"),
+        ],
+    )
+    @pytest.mark.usefixtures("make_dags")
+    def test_should_require_dependency_access_only_when_external_dependencies_are_requested(
+        self, _, test_client, external_dependencies, allow_dependencies, expected_status
+    ):
+        def authorize_dag(self, *, method, user, access_entity=None, details=None):
+            if access_entity == DagAccessEntity.DEPENDENCIES:
+                return allow_dependencies
+            if access_entity == DagAccessEntity.TASK_INSTANCE:
+                return False
+            return True
+
+        with mock.patch.object(SimpleAuthManager, "is_authorized_dag", authorize_dag):
+            response = test_client.get(
+                "/structure/structure_data",
+                params={
+                    "dag_id": DAG_ID_EXTERNAL_TRIGGER,
+                    "external_dependencies": external_dependencies,
+                },
+            )
+
+        assert response.status_code == expected_status
+        if expected_status == 200:
+            assert "trigger_dag_run_operator" in {node["id"] for node in response.json()["nodes"]}
 
     @mock.patch(
         "airflow.api_fastapi.auth.managers.base_auth_manager.BaseAuthManager.get_authorized_dag_ids",


### PR DESCRIPTION
This updates the UI structure endpoint permissions so users with Dag-specific read access can load the serialized topology used by graph and task-group views.

The task group route `/dags/{dag_id}/tasks/group/{group_id}` uses the UI graph/group context, which calls `/ui/structure/structure_data`. That response contains serialized Dag topology: task/group nodes, edges, and optional dependency nodes. It does not include task-instance runtime state.

Changes:

- Keep the base `requires_access_dag("GET")` dependency on `/structure/structure_data`.
- Require `DagAccessEntity.DEPENDENCIES` only when `external_dependencies=true`.
- Do not require `DagAccessEntity.TASK_INSTANCE` for this topology-only response.
- Add regression tests for Dag-specific read access, unreadable Dags, conditional dependency access, and the intentional absence of task-instance permission.

Validation:

- `ruff format airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py`
- `ruff check --fix airflow-core/src/airflow/api_fastapi/core_api/routes/ui/structure.py airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py`
- `pytest airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_structure.py -q` (`30 passed`)
- `prek` hooks passed except `generate-openapi-spec`, which is blocked locally because Breeze tries to use Docker and `docker` is not installed in this environment.

Manual verification:

- Draft PR pending browser verification on an Airflow dev server. Local process/port checks did not find an Airflow dev server listening on `8080`, `28080`, `5173`, or `8000`.

closes: #62532

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-28T17:14:20Z head=32eb936 action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Vamsi-klu** · by `@potiuk` · 2026-07-28 17:14 UTC
>
> This draft PR has had no activity for several weeks. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **554 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
