### PR TITLE
Validate trigger events in Anthropic deferrable tasks

### DIFF
--- a/providers/anthropic/src/airflow/providers/anthropic/exceptions.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/exceptions.py
@@ -29,6 +29,10 @@ class AnthropicBatchTimeout(AnthropicError):
     """Raised when an Anthropic Message Batch does not reach a terminal status in time."""
 
 
+class AnthropicTriggerEventError(AnthropicError):
+    """Raised when a deferred task resumes with a missing or malformed trigger event."""
+
+
 class AnthropicAgentSessionError(AnthropicError):
     """Raised when a Managed Agents session terminates or fails."""
 

--- a/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
@@ -159,10 +159,10 @@ def validate_execute_complete_event(event: dict[str, Any] | None = None) -> dict
     Validate the event a deferred task resumes with, returning it if well-formed.
 
     The event crosses the triggerer/worker boundary through the metadata DB, so a
-    resuming task can receive ``None`` or a status its handlers do not recognise
+    resuming task can receive ``None`` or a status its handlers do not recognize
     (version skew, a custom trigger). Both must fail loudly: the ``execute_complete``
     handlers raise on ``timeout``/``error`` and treat everything else as success, so
-    an unrecognised status would otherwise silently succeed.
+    an unrecognized status would otherwise silently succeed.
     """
     if event is None:
         raise AnthropicTriggerEventError("Trigger error: event is None")

--- a/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
@@ -38,6 +38,7 @@ from airflow.providers.anthropic.exceptions import (
     AnthropicBatchJobError,
     AnthropicBatchTimeout,
     AnthropicError,
+    AnthropicTriggerEventError,
 )
 from airflow.providers.common.compat.sdk import AirflowSkipException, BaseHook
 
@@ -147,6 +148,29 @@ def evaluate_session_state(
             return True, f"Outcome not satisfied for session {session.id}: {evaluation.result}.", False
     # idle but no terminal outcome verdict yet (e.g. the run has not started)
     return False, None, False
+
+
+#: Statuses the provider's triggers emit in their terminal event.
+TRIGGER_EVENT_STATUSES = frozenset({"success", "error", "timeout"})
+
+
+def validate_execute_complete_event(event: dict[str, Any] | None = None) -> dict[str, Any]:
+    """
+    Validate the event a deferred task resumes with, returning it if well-formed.
+
+    The event crosses the triggerer/worker boundary through the metadata DB, so a
+    resuming task can receive ``None`` or a status its handlers do not recognise
+    (version skew, a custom trigger). Both must fail loudly: the ``execute_complete``
+    handlers raise on ``timeout``/``error`` and treat everything else as success, so
+    an unrecognised status would otherwise silently succeed.
+    """
+    if event is None:
+        raise AnthropicTriggerEventError("Trigger error: event is None")
+    if event.get("status") not in TRIGGER_EVENT_STATUSES:
+        raise AnthropicTriggerEventError(
+            f"Unexpected trigger event status {event.get('status')!r}: {event!r}"
+        )
+    return event
 
 
 def evaluate_batch_counts(

--- a/providers/anthropic/src/airflow/providers/anthropic/operators/agent.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/operators/agent.py
@@ -23,7 +23,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.anthropic.exceptions import AnthropicAgentSessionError, AnthropicAgentSessionTimeout
-from airflow.providers.anthropic.hooks.anthropic import AnthropicHook
+from airflow.providers.anthropic.hooks.anthropic import AnthropicHook, validate_execute_complete_event
 from airflow.providers.anthropic.triggers.agent import AnthropicAgentSessionTrigger
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 
@@ -191,8 +191,7 @@ class AnthropicAgentSessionOperator(BaseOperator):
         return session.id
 
     def execute_complete(self, context: Context, event: Any = None) -> str:
-        if not event:
-            raise AnthropicAgentSessionError("Trigger resumed without an event payload.")
+        event = validate_execute_complete_event(event)
         # The deferred task is a fresh instance; restore the session id from the event.
         self.session_id = event["session_id"]
         status = event["status"]

--- a/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/operators/batch.py
@@ -23,7 +23,11 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.anthropic.exceptions import AnthropicBatchJobError, AnthropicBatchTimeout
-from airflow.providers.anthropic.hooks.anthropic import AnthropicHook, evaluate_batch_counts
+from airflow.providers.anthropic.hooks.anthropic import (
+    AnthropicHook,
+    evaluate_batch_counts,
+    validate_execute_complete_event,
+)
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 
@@ -149,6 +153,7 @@ class AnthropicBatchOperator(BaseOperator):
         The deferred task is a fresh instance, so the batch ID is read from the event,
         not ``self.batch_id``.
         """
+        event = validate_execute_complete_event(event)
         self.batch_id = event["batch_id"]
         status = event["status"]
         if status == "timeout":

--- a/providers/anthropic/src/airflow/providers/anthropic/sensors/batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/sensors/batch.py
@@ -23,7 +23,12 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.anthropic.exceptions import AnthropicBatchJobError, AnthropicBatchTimeout
-from airflow.providers.anthropic.hooks.anthropic import AnthropicHook, BatchStatus, evaluate_batch_counts
+from airflow.providers.anthropic.hooks.anthropic import (
+    AnthropicHook,
+    BatchStatus,
+    evaluate_batch_counts,
+    validate_execute_complete_event,
+)
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
 from airflow.providers.common.compat.sdk import BaseSensorOperator, conf
 
@@ -107,6 +112,7 @@ class AnthropicBatchSensor(BaseSensorOperator):
         super().execute(context)
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
+        event = validate_execute_complete_event(event)
         status = event["status"]
         if status == "timeout":
             raise AnthropicBatchTimeout(event["message"])

--- a/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
+++ b/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
@@ -25,6 +25,7 @@ from airflow.providers.anthropic.exceptions import (
     AnthropicAgentSessionTimeout,
     AnthropicBatchTimeout,
     AnthropicError,
+    AnthropicTriggerEventError,
 )
 from airflow.providers.anthropic.hooks.anthropic import (
     DEFAULT_MODEL,
@@ -33,6 +34,7 @@ from airflow.providers.anthropic.hooks.anthropic import (
     BatchStatus,
     SessionStatus,
     evaluate_session_state,
+    validate_execute_complete_event,
 )
 
 pytest.importorskip("anthropic")
@@ -74,6 +76,33 @@ class TestSessionStatus:
     )
     def test_is_terminal(self, status, expected):
         assert SessionStatus.is_terminal(status) is expected
+
+
+class TestValidateTriggerEvent:
+    @pytest.mark.parametrize(
+        ("event", "match"),
+        [
+            pytest.param(None, "event is None", id="none"),
+            pytest.param({}, "Unexpected trigger event status None", id="missing-status"),
+            pytest.param(
+                {"status": "ended", "batch_id": "b"}, "Unexpected trigger event status", id="unknown-status"
+            ),
+        ],
+    )
+    def test_invalid_event_raises(self, event, match):
+        with pytest.raises(AnthropicTriggerEventError, match=match):
+            validate_execute_complete_event(event)
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            pytest.param({"status": "success", "batch_id": "b"}, id="success"),
+            pytest.param({"status": "error", "batch_id": "b", "message": "boom"}, id="error"),
+            pytest.param({"status": "timeout", "batch_id": "b", "message": "slow"}, id="timeout"),
+        ],
+    )
+    def test_valid_event_is_returned(self, event):
+        assert validate_execute_complete_event(event) is event
 
 
 def _session(status, outcome_results=None):

--- a/providers/anthropic/tests/unit/anthropic/operators/test_agent.py
+++ b/providers/anthropic/tests/unit/anthropic/operators/test_agent.py
@@ -21,7 +21,11 @@ from unittest import mock
 import pytest
 
 from airflow.exceptions import TaskDeferred
-from airflow.providers.anthropic.exceptions import AnthropicAgentSessionError, AnthropicAgentSessionTimeout
+from airflow.providers.anthropic.exceptions import (
+    AnthropicAgentSessionError,
+    AnthropicAgentSessionTimeout,
+    AnthropicTriggerEventError,
+)
 from airflow.providers.anthropic.hooks.anthropic import AnthropicHook
 from airflow.providers.anthropic.operators.agent import AnthropicAgentSessionOperator
 from airflow.providers.anthropic.triggers.agent import AnthropicAgentSessionTrigger
@@ -201,10 +205,21 @@ class TestExecuteComplete:
             op.execute_complete({}, {"status": "timeout", "session_id": "s", "message": "slow"})
         hook.archive_session.assert_called_once_with("s")
 
-    def test_none_event_raises(self):
+    @pytest.mark.parametrize(
+        ("event", "match"),
+        [
+            pytest.param(None, "event is None", id="none"),
+            pytest.param(
+                {"status": "rescheduling", "session_id": "s"},
+                "Unexpected trigger event status",
+                id="unknown-status",
+            ),
+        ],
+    )
+    def test_invalid_event_raises(self, event, match):
         op = AnthropicAgentSessionOperator(task_id="a", agent_id="ag", environment_id="env", message="hi")
-        with pytest.raises(AnthropicAgentSessionError, match="without an event"):
-            op.execute_complete({}, None)
+        with pytest.raises(AnthropicTriggerEventError, match=match):
+            op.execute_complete({}, event)
 
 
 class TestOnKill:

--- a/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
+++ b/providers/anthropic/tests/unit/anthropic/operators/test_batch.py
@@ -21,7 +21,11 @@ from unittest import mock
 import pytest
 
 from airflow.exceptions import TaskDeferred
-from airflow.providers.anthropic.exceptions import AnthropicBatchJobError, AnthropicBatchTimeout
+from airflow.providers.anthropic.exceptions import (
+    AnthropicBatchJobError,
+    AnthropicBatchTimeout,
+    AnthropicTriggerEventError,
+)
 from airflow.providers.anthropic.hooks.anthropic import AnthropicHook
 from airflow.providers.anthropic.operators.batch import AnthropicBatchOperator
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
@@ -186,6 +190,18 @@ class TestExecuteComplete:
         op = AnthropicBatchOperator(task_id="t", requests=REQUESTS, fail_on_partial_error=True)
         event = {"status": "success", "batch_id": "b", "request_counts": {"succeeded": 9, "errored": 1}}
         with pytest.raises(AnthropicBatchJobError, match="failed request"):
+            op.execute_complete(_context(), event)
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            pytest.param(None, id="none"),
+            pytest.param({"status": "ended", "batch_id": "b"}, id="unknown-status"),
+        ],
+    )
+    def test_invalid_event_raises_instead_of_succeeding(self, event):
+        op = AnthropicBatchOperator(task_id="t", requests=REQUESTS)
+        with pytest.raises(AnthropicTriggerEventError):
             op.execute_complete(_context(), event)
 
 

--- a/providers/anthropic/tests/unit/anthropic/sensors/test_batch.py
+++ b/providers/anthropic/tests/unit/anthropic/sensors/test_batch.py
@@ -21,7 +21,11 @@ from unittest import mock
 import pytest
 
 from airflow.exceptions import TaskDeferred
-from airflow.providers.anthropic.exceptions import AnthropicBatchJobError, AnthropicBatchTimeout
+from airflow.providers.anthropic.exceptions import (
+    AnthropicBatchJobError,
+    AnthropicBatchTimeout,
+    AnthropicTriggerEventError,
+)
 from airflow.providers.anthropic.hooks.anthropic import AnthropicHook
 from airflow.providers.anthropic.sensors.batch import AnthropicBatchSensor
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
@@ -102,3 +106,15 @@ class TestAnthropicBatchSensorDeferrable:
         sensor = AnthropicBatchSensor(task_id="s", batch_id="b1")
         event = {"status": "success", "batch_id": "b1", "request_counts": {"succeeded": 2}}
         assert sensor.execute_complete({}, event) is None
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            pytest.param(None, id="none"),
+            pytest.param({"status": "ended", "batch_id": "b1"}, id="unknown-status"),
+        ],
+    )
+    def test_execute_complete_invalid_event_raises_instead_of_succeeding(self, event):
+        sensor = AnthropicBatchSensor(task_id="s", batch_id="b1")
+        with pytest.raises(AnthropicTriggerEventError):
+            sensor.execute_complete({}, event)


### PR DESCRIPTION
 The Anthropic provider's three deferrable resume paths — `AnthropicBatchOperator.execute_complete`,  `AnthropicBatchSensor.execute_complete` and `AnthropicAgentSessionOperator.execute_complete` — used the trigger event without validating it:

- **`event=None`**: happens when a deferred task resumes without a payload — a custom or subclassed trigger that yields `TriggerEvent(None)`, or an event payload lost between the triggerer and the worker. Crashed with an opaque
  `TypeError: 'NoneType' object is not subscriptable`.
- **Unrecognised `status`**: happens on triggerer/worker version skew (a task defers under one provider version and resumes under another whose trigger emits a different status vocabulary) or with a custom trigger. These methods branch deny-list style (`timeout`/`error` raise, everything else succeeds), so an unknown status fell through into the success path — the task was marked SUCCESS even though the Anthropic batch/session outcome was unknown.

This adds a `validate_execute_complete_event()` helper applied at the top of all three methods. The `None` check mirrors the amazon provider's helper of the same name (https://github.com/apache/airflow/blob/main/providers/amazon/src/airflow/providers/amazon/aws/utils/__init__.py#L70-L75).
The status check plays the role amazon's call sites cover with their `if validated_event["status"] != "success": raise` allow-list branching (https://github.com/apache/airflow/blob/main/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py#L207-L209)

Note: event validation across other providers is inconsistent — databricks has a required-keys helper (`validate_trigger_event`), while e.g. google and dbt.cloud access the event unvalidated with the same deny-list branching. This PR only fixes the Anthropic provider.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Claude Code

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
