### PR TITLE
Make Vertex AI evaluation stack an opt-in provider extra

### DIFF
--- a/airflow-core/tests/unit/always/test_example_dags.py
+++ b/airflow-core/tests/unit/always/test_example_dags.py
@@ -48,6 +48,10 @@ OPTIONAL_PROVIDERS_DEPENDENCIES: dict[str, dict[str, str | None]] = {
     # value: a dictionary containing package distributions with an optional version specifier, e.g., >=2.3.4
     # yandexcloud is automatically removed in case botocore is upgraded to latest
     r".*example_yandexcloud.*\.py": {"yandexcloud": None},
+    # example_gen_ai_generative_model builds a RunEvaluationOperator at parse time, which
+    # imports vertexai.preview.evaluation -> scikit-learn from the optional google[vertex-eval]
+    # extra. Skip the import check when that extra is not installed.
+    r".*example_gen_ai_generative_model\.py": {"scikit-learn": None},
 }
 IGNORE_AIRFLOW_PROVIDER_DEPRECATION_WARNING: tuple[str, ...] = (
     # Certain examples or system tests may trigger AirflowProviderDeprecationWarnings.

--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -77,7 +77,7 @@ PIP package                                 Version required
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-genai``                            ``>=2.8.0``
-``google-cloud-aiplatform[evaluation]``     ``>=1.155.0``
+``google-cloud-aiplatform``                 ``>=1.155.0``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
 ``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``ray[default]``                            ``>=2.55.0; python_version >= "3.14" and python_version < "3.15"``
@@ -204,6 +204,7 @@ Extra                 Dependencies
 ``http``              ``apache-airflow-providers-http``
 ``standard``          ``apache-airflow-providers-standard``
 ``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+``vertex-eval``       ``google-cloud-aiplatform[evaluation]>=1.155.0``
 ====================  ====================================================
 
 The changelog for the provider package can be found in the

--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -77,7 +77,7 @@ PIP package                                 Version required
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-genai``                            ``>=2.8.0``
-``google-cloud-aiplatform[evaluation]``     ``>=1.164.0``
+``google-cloud-aiplatform``                 ``>=1.164.0``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
 ``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``ray[default]``                            ``>=2.55.0; python_version >= "3.14" and python_version < "3.15"``
@@ -204,6 +204,7 @@ Extra                 Dependencies
 ``http``              ``apache-airflow-providers-http``
 ``standard``          ``apache-airflow-providers-standard``
 ``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+``vertex-eval``       ``google-cloud-aiplatform[evaluation]>=1.164.0``
 ====================  ====================================================
 
 The changelog for the provider package can be found in the

--- a/providers/google/docs/changelog.rst
+++ b/providers/google/docs/changelog.rst
@@ -27,6 +27,23 @@
 Changelog
 ---------
 
+.. Breaking change
+
+The ``google-cloud-aiplatform[evaluation]`` stack (``litellm``,
+``scikit-learn``, ``ruamel-yaml``) is no longer part of the base install of
+``apache-airflow-providers-google``. Users who exercise Vertex AI
+generative-model evaluation via ``GenerativeModelHook.get_eval_task`` /
+``run_evaluation`` (or ``RunEvaluationOperator``) must install the new
+``vertex-eval`` extra:
+
+.. code-block:: bash
+
+    pip install 'apache-airflow-providers-google[vertex-eval]'
+
+Users who do not touch those Vertex AI evaluation APIs are unaffected and
+will no longer pull in ``litellm``, ``scikit-learn``, and ``ruamel-yaml``
+transitively.
+
 22.3.0
 ......
 

--- a/providers/google/docs/changelog.rst
+++ b/providers/google/docs/changelog.rst
@@ -27,6 +27,22 @@
 Changelog
 ---------
 
+.. Breaking change
+
+The Vertex AI generative-model evaluation stack (``jsonschema``, ``litellm``,
+``pyyaml``, ``ruamel.yaml``, ``scikit-learn``, and ``tqdm``) is no longer part
+of the base install of ``apache-airflow-providers-google``. Users who exercise
+Vertex AI generative-model evaluation via ``GenerativeModelHook.get_eval_task``
+/ ``run_evaluation`` (or ``RunEvaluationOperator``) must install the new
+``vertex-eval`` extra:
+
+.. code-block:: bash
+
+    pip install 'apache-airflow-providers-google[vertex-eval]'
+
+Users who do not touch those Vertex AI evaluation APIs are unaffected and will
+no longer pull in these evaluation-only dependencies transitively.
+
 22.3.0
 ......
 

--- a/providers/google/docs/changelog.rst
+++ b/providers/google/docs/changelog.rst
@@ -27,6 +27,21 @@
 Changelog
 ---------
 
+.. Breaking change
+
+The optional dependency stack for Vertex AI generative-model evaluation is no
+longer enabled by the base install of ``apache-airflow-providers-google``. Users
+who exercise Vertex AI generative-model evaluation via
+``GenerativeModelHook.get_eval_task`` / ``run_evaluation`` (or
+``RunEvaluationOperator``) must install the new ``vertex-eval`` extra:
+
+.. code-block:: bash
+
+    pip install 'apache-airflow-providers-google[vertex-eval]'
+
+Users who do not touch those Vertex AI evaluation APIs are unaffected and will
+no longer pull in these evaluation-only dependencies transitively.
+
 22.4.0
 ......
 
@@ -52,11 +67,10 @@ Misc
 * ``Add type annotations to sql hooks (#70815)``
 
 .. Below changes are excluded from the changelog. Move them to
-   appropriate section above if needed. Do not delete the lines(!):
-   * ``Replace the ACL calls with IAM roles for the system tests + add new (#70978)``
-   * ``Adopt flit 4 as the provider distribution build backend (#71186)``
-   * ``Fix Java Beam SDK example to target Java 11 (#71218)``
-
+  appropriate section above if needed. Do not delete the lines(!):
+  * ``Replace the ACL calls with IAM roles for the system tests + add new (#70978)``
+  * ``Adopt flit 4 as the provider distribution build backend (#71186)``
+  * ``Fix Java Beam SDK example to target Java 11 (#71218)``
 
 22.3.0
 ......

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -130,7 +130,7 @@ PIP package                                 Version required
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-genai``                            ``>=2.8.0``
-``google-cloud-aiplatform[evaluation]``     ``>=1.155.0``
+``google-cloud-aiplatform``                 ``>=1.155.0``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
 ``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``ray[default]``                            ``>=2.55.0; python_version >= "3.14" and python_version < "3.15"``
@@ -265,6 +265,7 @@ Extra                 Dependencies
 ``http``              ``apache-airflow-providers-http``
 ``standard``          ``apache-airflow-providers-standard``
 ``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+``vertex-eval``       ``google-cloud-aiplatform[evaluation]>=1.155.0``
 ====================  ====================================================
 
 Downloading official packages

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -130,7 +130,7 @@ PIP package                                 Version required
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-genai``                            ``>=2.8.0``
-``google-cloud-aiplatform[evaluation]``     ``>=1.164.0``
+``google-cloud-aiplatform``                 ``>=1.164.0``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
 ``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``ray[default]``                            ``>=2.55.0; python_version >= "3.14" and python_version < "3.15"``
@@ -265,6 +265,7 @@ Extra                 Dependencies
 ``http``              ``apache-airflow-providers-http``
 ``standard``          ``apache-airflow-providers-standard``
 ``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+``vertex-eval``       ``google-cloud-aiplatform[evaluation]>=1.164.0``
 ====================  ====================================================
 
 Downloading official packages

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -84,7 +84,12 @@ dependencies = [
     # google-cloud-aiplatform doesn't install ray for python 3.12 (issue: https://github.com/googleapis/python-aiplatform/issues/5252).
     # Temporarily lock in ray 2.42.0 which is compatible with python 3.12 until linked issue is solved.
     # Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed
-    "google-cloud-aiplatform[evaluation]>=1.155.0",
+    # The [evaluation] extra pulls in litellm/scikit-learn/ruamel-yaml and is only needed
+    # by Vertex AI generative-model evaluation (EvalTask). It is exposed as the
+    # ``vertex-eval`` provider extra so users who don't run LLM evaluation are not
+    # forced to install those packages. See:
+    # https://github.com/apache/airflow/issues/69323
+    "google-cloud-aiplatform>=1.155.0",
     "ray[default]>=2.42.0;python_version<'3.13'",
     "ray[default]>=2.49.0;python_version>='3.13' and python_version <'3.14'",
     "ray[default]>=2.55.0;python_version>='3.14' and python_version <'3.15'",
@@ -218,6 +223,13 @@ dependencies = [
 ]
 "common.messaging" = [
     "apache-airflow-providers-common-messaging>=2.0.0"
+]
+# Vertex AI generative-model evaluation stack (EvalTask). Pulls in litellm and
+# scikit-learn via google-cloud-aiplatform[evaluation]. Kept as an opt-in extra
+# so the base provider install stays lean. See:
+# https://github.com/apache/airflow/issues/69323
+"vertex-eval" = [
+    "google-cloud-aiplatform[evaluation]>=1.155.0",
 ]
 
 [dependency-groups]

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -84,10 +84,9 @@ dependencies = [
     # google-cloud-aiplatform doesn't install ray for python 3.12 (issue: https://github.com/googleapis/python-aiplatform/issues/5252).
     # Temporarily lock in ray 2.42.0 which is compatible with python 3.12 until linked issue is solved.
     # Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed
-    # Floor raised to 1.164.0: earlier "evaluation" extras cap litellm below the version that
-    # carries the fixes for CVE-2026-35030 and its follow-on advisories on Python 3.14.
-    # - https://github.com/googleapis/python-aiplatform/issues/7057
-    "google-cloud-aiplatform[evaluation]>=1.164.0",
+    # Vertex AI evaluation dependencies ship in the ``vertex-eval`` extra so base installs stay lean.
+    # - https://github.com/apache/airflow/issues/69323
+    "google-cloud-aiplatform>=1.164.0",
     "ray[default]>=2.42.0;python_version<'3.13'",
     "ray[default]>=2.49.0;python_version>='3.13' and python_version <'3.14'",
     "ray[default]>=2.55.0;python_version>='3.14' and python_version <'3.15'",
@@ -221,6 +220,12 @@ dependencies = [
 ]
 "common.messaging" = [
     "apache-airflow-providers-common-messaging>=2.0.0"
+]
+# Floor 1.164.0: earlier "evaluation" extras cap litellm below the version that carries
+# the fixes for CVE-2026-35030 and its follow-on advisories on Python 3.14.
+# - https://github.com/googleapis/python-aiplatform/issues/7057
+"vertex-eval" = [
+    "google-cloud-aiplatform[evaluation]>=1.164.0",
 ]
 
 [dependency-groups]

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
@@ -19,16 +19,41 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import vertexai
 from vertexai.generative_models import GenerativeModel
 from vertexai.language_models import TextEmbeddingModel
 from vertexai.preview import generative_models as preview_generative_model
 from vertexai.preview.caching import CachedContent
-from vertexai.preview.evaluation import EvalResult, EvalTask
 
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
+
+if TYPE_CHECKING:
+    # ``vertexai.preview.evaluation`` is only available when the ``[evaluation]``
+    # extra of ``google-cloud-aiplatform`` is installed (Airflow exposes this via
+    # the ``apache-airflow-providers-google[vertex-eval]`` extra). Keep the import
+    # under TYPE_CHECKING so the module loads for users who never touch EvalTask.
+    from vertexai.preview.evaluation import EvalResult, EvalTask
+
+
+def _import_vertex_evaluation():
+    """
+    Import the optional ``vertexai.preview.evaluation`` module lazily.
+
+    Raise a clear ``ImportError`` pointing at the ``[vertex-eval]`` provider extra
+    when the underlying ``google-cloud-aiplatform[evaluation]`` extra is missing.
+    """
+    try:
+        from vertexai.preview import evaluation as vertex_evaluation
+    except ImportError as e:
+        raise ImportError(
+            "Vertex AI generative-model evaluation requires the optional "
+            "'google-cloud-aiplatform[evaluation]' dependency. Install the "
+            "provider extra with:\n\n"
+            "    pip install 'apache-airflow-providers-google[vertex-eval]'\n"
+        ) from e
+    return vertex_evaluation
 
 
 class GenerativeModelHook(GoogleBaseHook):
@@ -64,7 +89,8 @@ class GenerativeModelHook(GoogleBaseHook):
         experiment: str,
     ) -> EvalTask:
         """Return an EvalTask object."""
-        eval_task = EvalTask(
+        vertex_evaluation = _import_vertex_evaluation()
+        eval_task = vertex_evaluation.EvalTask(
             dataset=dataset,
             metrics=metrics,
             experiment=experiment,

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
@@ -19,16 +19,37 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import vertexai
 from vertexai.generative_models import GenerativeModel
 from vertexai.language_models import TextEmbeddingModel
 from vertexai.preview import generative_models as preview_generative_model
 from vertexai.preview.caching import CachedContent
-from vertexai.preview.evaluation import EvalResult, EvalTask
 
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
+
+if TYPE_CHECKING:
+    # Keep the optional evaluation import from breaking users who never touch EvalTask.
+    from vertexai.preview.evaluation import EvalResult, EvalTask
+
+
+def _import_vertex_evaluation():
+    """
+    Import the optional ``vertexai.preview.evaluation`` module lazily.
+
+    Raise a clear ``ImportError`` pointing at the ``[vertex-eval]`` provider extra
+    when the Vertex AI evaluation dependencies are missing.
+    """
+    try:
+        from vertexai.preview import evaluation as vertex_evaluation
+    except ImportError as e:
+        raise ImportError(
+            "Vertex AI generative-model evaluation requires optional dependencies. "
+            "Install the provider extra with:\n\n"
+            "    pip install 'apache-airflow-providers-google[vertex-eval]'\n"
+        ) from e
+    return vertex_evaluation
 
 
 class GenerativeModelHook(GoogleBaseHook):
@@ -64,7 +85,8 @@ class GenerativeModelHook(GoogleBaseHook):
         experiment: str,
     ) -> EvalTask:
         """Return an EvalTask object."""
-        eval_task = EvalTask(
+        vertex_evaluation = _import_vertex_evaluation()
+        eval_task = vertex_evaluation.EvalTask(
             dataset=dataset,
             metrics=metrics,
             experiment=experiment,

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model.py
@@ -23,6 +23,10 @@ import pytest
 
 # For no Pydantic environment, we need to skip the tests
 pytest.importorskip("google.cloud.aiplatform_v1")
+# The evaluation stack (litellm, scikit-learn, ...) ships via the optional
+# ``google-cloud-aiplatform[evaluation]`` extra (exposed as the ``vertex-eval``
+# provider extra), so it is not installed in the lean base test environment.
+pytest.importorskip("vertexai.preview.evaluation")
 
 from vertexai.generative_models import HarmBlockThreshold, HarmCategory, Part, Tool, grounding
 from vertexai.preview.evaluation import MetricPromptTemplateExamples

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model.py
@@ -23,6 +23,9 @@ import pytest
 
 # For no Pydantic environment, we need to skip the tests
 pytest.importorskip("google.cloud.aiplatform_v1")
+# The evaluation stack ships via the ``vertex-eval`` provider extra and is not
+# installed in the lean base test environment.
+pytest.importorskip("vertexai.preview.evaluation")
 
 from vertexai.generative_models import HarmBlockThreshold, HarmCategory, Part, Tool, grounding
 from vertexai.preview.evaluation import MetricPromptTemplateExamples

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model_optional_extra.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model_optional_extra.py
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import builtins
+from unittest import mock
+
+import pytest
+
+# Only the base ``google-cloud-aiplatform`` (``vertexai``) is required to import
+# the hook module; the optional ``[evaluation]`` extra is deliberately absent so
+# this test can prove the lazy-import guard's behavior.
+pytest.importorskip("google.cloud.aiplatform_v1")
+
+from airflow.providers.google.cloud.hooks.vertex_ai import generative_model
+
+
+class TestVertexEvaluationImport:
+    """Tests for the lazy-import helper that guards the optional evaluation stack.
+
+    This file intentionally does not import ``vertexai.preview.evaluation`` at module
+    level so it runs even in the lean environment where the ``vertex-eval`` extra is
+    not installed -- which is exactly the situation the guard exists to handle.
+    """
+
+    def test_missing_evaluation_extra_raises_actionable_error(self):
+        """Users without ``[vertex-eval]`` get a pip-install hint, not a bare ModuleNotFoundError."""
+        real_import = builtins.__import__
+
+        def _blocked_import(name, import_globals=None, import_locals=None, fromlist=(), level=0):
+            # Simulate the ``[evaluation]`` extra being absent regardless of what is
+            # actually installed, so the guard's behavior is asserted deterministically
+            # (patching ``sys.modules`` is not reliable across vertexai versions).
+            if name == "vertexai.preview" and "evaluation" in (fromlist or ()):
+                raise ImportError("No module named 'vertexai.preview.evaluation'")
+            return real_import(name, import_globals, import_locals, fromlist, level)
+
+        with mock.patch("builtins.__import__", side_effect=_blocked_import):
+            with pytest.raises(ImportError, match=r"apache-airflow-providers-google\[vertex-eval\]"):
+                generative_model._import_vertex_evaluation()

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model_optional_extra.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model_optional_extra.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import builtins
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+# Only the base ``google-cloud-aiplatform`` package is required to import the hook.
+pytest.importorskip("google.cloud.aiplatform_v1")
+
+from airflow.providers.google.cloud.hooks.vertex_ai import generative_model
+
+
+class TestVertexEvaluationImport:
+    def test_missing_evaluation_dependencies_raises_actionable_error(self):
+        real_import = builtins.__import__
+
+        def _blocked_import(name, import_globals=None, import_locals=None, fromlist=(), level=0):
+            # Patching ``sys.modules`` is not reliable across vertexai versions.
+            if name == "vertexai.preview" and "evaluation" in (fromlist or ()):
+                raise ImportError("No module named 'vertexai.preview.evaluation'")
+            return real_import(name, import_globals, import_locals, fromlist, level)
+
+        with mock.patch("builtins.__import__", side_effect=_blocked_import):
+            with pytest.raises(ImportError, match=r"apache-airflow-providers-google\[vertex-eval\]"):
+                generative_model._import_vertex_evaluation()
+
+    @mock.patch.object(generative_model, "_import_vertex_evaluation", autospec=True)
+    def test_get_eval_task_uses_lazy_evaluation_import(self, mock_import):
+        def create_eval_task(*, dataset, metrics, experiment):
+            return None
+
+        eval_task_constructor = mock.create_autospec(
+            create_eval_task,
+            return_value=mock.sentinel.eval_task,
+        )
+        mock_import.return_value = SimpleNamespace(EvalTask=eval_task_constructor)
+        hook = object.__new__(generative_model.GenerativeModelHook)
+
+        result = hook.get_eval_task(
+            dataset=mock.sentinel.dataset,
+            metrics=mock.sentinel.metrics,
+            experiment=mock.sentinel.experiment,
+        )
+
+        mock_import.assert_called_once_with()
+        eval_task_constructor.assert_called_once_with(
+            dataset=mock.sentinel.dataset,
+            metrics=mock.sentinel.metrics,
+            experiment=mock.sentinel.experiment,
+        )
+        assert result is mock.sentinel.eval_task

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model_optional_extra.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_generative_model_optional_extra.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import builtins
+import runpy
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+# Only the base ``google-cloud-aiplatform`` package is required to import the hook.
+pytest.importorskip("google.cloud.aiplatform_v1")
+
+from airflow.providers.google.cloud.hooks.vertex_ai import generative_model
+
+_REAL_IMPORT = builtins.__import__
+
+
+def _import_except_vertex_evaluation(name, import_globals=None, import_locals=None, fromlist=(), level=0):
+    if name.startswith("vertexai.preview.evaluation") or (
+        name == "vertexai.preview" and "evaluation" in (fromlist or ())
+    ):
+        raise ImportError("No module named 'vertexai.preview.evaluation'")
+    return _REAL_IMPORT(name, import_globals, import_locals, fromlist, level)
+
+
+class TestVertexEvaluationImport:
+    def test_hook_module_imports_without_evaluation_dependencies(self):
+        with mock.patch("builtins.__import__", side_effect=_import_except_vertex_evaluation):
+            runpy.run_path(generative_model.__file__)
+
+    def test_missing_evaluation_dependencies_raises_actionable_error(self):
+        with mock.patch("builtins.__import__", side_effect=_import_except_vertex_evaluation):
+            with pytest.raises(ImportError, match=r"apache-airflow-providers-google\[vertex-eval\]"):
+                generative_model._import_vertex_evaluation()
+
+    @mock.patch.object(generative_model, "_import_vertex_evaluation", autospec=True)
+    def test_get_eval_task_uses_lazy_evaluation_import(self, mock_import):
+        def create_eval_task(*, dataset, metrics, experiment):
+            return None
+
+        eval_task_constructor = mock.create_autospec(
+            create_eval_task,
+            return_value=mock.sentinel.eval_task,
+        )
+        mock_import.return_value = SimpleNamespace(EvalTask=eval_task_constructor)
+        hook = object.__new__(generative_model.GenerativeModelHook)
+
+        result = hook.get_eval_task(
+            dataset=mock.sentinel.dataset,
+            metrics=mock.sentinel.metrics,
+            experiment=mock.sentinel.experiment,
+        )
+
+        mock_import.assert_called_once_with()
+        eval_task_constructor.assert_called_once_with(
+            dataset=mock.sentinel.dataset,
+            metrics=mock.sentinel.metrics,
+            experiment=mock.sentinel.experiment,
+        )
+        assert result is mock.sentinel.eval_task

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_generative_model.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_generative_model.py
@@ -24,6 +24,10 @@ import pytest
 pytest.importorskip("google.cloud.aiplatform_v1")
 pytest.importorskip("google.cloud.aiplatform_v1beta1")
 vertexai = pytest.importorskip("vertexai.generative_models")
+# The evaluation stack ships via the optional ``google-cloud-aiplatform[evaluation]``
+# extra (exposed as the ``vertex-eval`` provider extra) and is not installed in the
+# lean base test environment.
+pytest.importorskip("vertexai.preview.evaluation")
 from vertexai.generative_models import HarmBlockThreshold, HarmCategory, Tool, grounding
 from vertexai.preview.evaluation import MetricPromptTemplateExamples
 

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_generative_model.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_generative_model.py
@@ -24,6 +24,9 @@ import pytest
 pytest.importorskip("google.cloud.aiplatform_v1")
 pytest.importorskip("google.cloud.aiplatform_v1beta1")
 vertexai = pytest.importorskip("vertexai.generative_models")
+# The evaluation stack ships via the ``vertex-eval`` provider extra and is not
+# installed in the lean base test environment.
+pytest.importorskip("vertexai.preview.evaluation")
 from vertexai.generative_models import HarmBlockThreshold, HarmCategory, Tool, grounding
 from vertexai.preview.evaluation import MetricPromptTemplateExamples
 

--- a/providers/google/tests/unit/google/test_provider_dependencies.py
+++ b/providers/google/tests/unit/google/test_provider_dependencies.py
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def test_vertex_evaluation_dependencies_are_opt_in():
+    provider_root = Path(__file__).parents[3]
+    with (provider_root / "pyproject.toml").open("rb") as pyproject_file:
+        project = tomllib.load(pyproject_file)["project"]
+
+    aiplatform_dependencies = [
+        dependency
+        for dependency in project["dependencies"]
+        if dependency.startswith("google-cloud-aiplatform")
+    ]
+
+    assert aiplatform_dependencies == ["google-cloud-aiplatform>=1.164.0"]
+    assert project["optional-dependencies"]["vertex-eval"] == ["google-cloud-aiplatform[evaluation]>=1.164.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -5541,7 +5541,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
-    { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+    { name = "google-cloud-aiplatform" },
     { name = "google-cloud-alloydb" },
     { name = "google-cloud-automl" },
     { name = "google-cloud-batch" },
@@ -5664,6 +5664,9 @@ standard = [
 trino = [
     { name = "apache-airflow-providers-trino" },
 ]
+vertex-eval = [
+    { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -5735,7 +5738,8 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0.2" },
     { name = "google-auth", specifier = ">=2.29.0" },
     { name = "google-auth-httplib2", specifier = ">=0.0.1" },
-    { name = "google-cloud-aiplatform", extras = ["evaluation"], specifier = ">=1.164.0" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.164.0" },
+    { name = "google-cloud-aiplatform", extras = ["evaluation"], marker = "extra == 'vertex-eval'", specifier = ">=1.164.0" },
     { name = "google-cloud-alloydb", specifier = ">=0.4.0" },
     { name = "google-cloud-automl", specifier = ">=2.12.0" },
     { name = "google-cloud-batch", specifier = ">=0.13.0" },
@@ -5799,7 +5803,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.3.0" },
     { name = "types-protobuf", specifier = ">=5.27.0,!=5.29.1.20250402" },
 ]
-provides-extras = ["cncf-kubernetes", "fab", "leveldb", "oracle", "facebook", "amazon", "apache-cassandra", "microsoft-azure", "microsoft-mssql", "mongo", "mysql", "openlineage", "postgres", "presto", "salesforce", "sftp", "ssh", "trino", "http", "standard", "common-messaging"]
+provides-extras = ["cncf-kubernetes", "fab", "leveldb", "oracle", "facebook", "amazon", "apache-cassandra", "microsoft-azure", "microsoft-mssql", "mongo", "mysql", "openlineage", "postgres", "presto", "salesforce", "sftp", "ssh", "trino", "http", "standard", "common-messaging", "vertex-eval"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -64,9 +64,9 @@ apache-airflow-providers-apache-cassandra = false
 apache-airflow-providers-asana = false
 apache-airflow-providers-oracle = false
 apache-airflow-providers-mysql = false
-apache-airflow-providers-teradata = false
 apache-airflow-providers-alibaba = false
 apache-airflow-providers-microsoft-mssql = false
+apache-airflow-providers-teradata = false
 apache-airflow-providers-jdbc = false
 apache-airflow-helm-chart = false
 apache-airflow-providers-anthropic = false
@@ -5509,7 +5509,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
-    { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+    { name = "google-cloud-aiplatform" },
     { name = "google-cloud-alloydb" },
     { name = "google-cloud-automl" },
     { name = "google-cloud-batch" },
@@ -5631,6 +5631,9 @@ standard = [
 trino = [
     { name = "apache-airflow-providers-trino" },
 ]
+vertex-eval = [
+    { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -5702,7 +5705,8 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0.2" },
     { name = "google-auth", specifier = ">=2.29.0" },
     { name = "google-auth-httplib2", specifier = ">=0.0.1" },
-    { name = "google-cloud-aiplatform", extras = ["evaluation"], specifier = ">=1.164.0" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.164.0" },
+    { name = "google-cloud-aiplatform", extras = ["evaluation"], marker = "extra == 'vertex-eval'", specifier = ">=1.164.0" },
     { name = "google-cloud-alloydb", specifier = ">=0.4.0" },
     { name = "google-cloud-automl", specifier = ">=2.12.0" },
     { name = "google-cloud-batch", specifier = ">=0.13.0" },
@@ -5766,7 +5770,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=8.3.0" },
     { name = "types-protobuf", specifier = ">=5.27.0,!=5.29.1.20250402" },
 ]
-provides-extras = ["cncf-kubernetes", "fab", "leveldb", "oracle", "facebook", "amazon", "apache-cassandra", "microsoft-azure", "microsoft-mssql", "mongo", "mysql", "openlineage", "postgres", "presto", "salesforce", "sftp", "ssh", "trino", "http", "standard", "common-messaging"]
+provides-extras = ["cncf-kubernetes", "fab", "leveldb", "oracle", "facebook", "amazon", "apache-cassandra", "microsoft-azure", "microsoft-mssql", "mongo", "mysql", "openlineage", "postgres", "presto", "salesforce", "sftp", "ssh", "trino", "http", "standard", "common-messaging", "vertex-eval"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Why

The Google provider enabled `google-cloud-aiplatform[evaluation]` for every installation, even though its evaluation dependency stack is only needed by Vertex AI generative-model evaluation APIs. Users of unrelated Google hooks and operators therefore received unnecessary ML and evaluation dependencies.

## What changed

- Keep `google-cloud-aiplatform>=1.164.0` in the base provider dependencies without enabling `evaluation`.
- Add a `vertex-eval` provider extra that installs `google-cloud-aiplatform[evaluation]>=1.164.0`.
- Load `vertexai.preview.evaluation` only when an evaluation API is called and provide an actionable installation error when it is unavailable.
- Update generated dependency tables and add a breaking-change migration note.
- Add regressions for the dependency metadata split and lazy evaluation import.

## Migration

Users of `GenerativeModelHook.get_eval_task`, `GenerativeModelHook.run_evaluation`, or `RunEvaluationOperator` must install:

```bash
pip install 'apache-airflow-providers-google[vertex-eval]'
```

## Validation

- Dependency metadata regression: 1 passed; the same assertions fail against `upstream/main`.
- `uv lock --check`: passed, resolving 965 packages.
- `ruff format` and `ruff check`: passed.
- `git diff --check`: passed.
- GitHub mergeability check: passed after rebasing onto current `main`.

Full provider tests were not run locally because Airflow does not support native Windows; CI provides the Linux test result.

related: #69323

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - GitHub Copilot

Generated-by: GitHub Copilot following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: GitHub Copilot (no human review before posting)