### PR TITLE
Log SQL query on its own line in BigQueryInsertJobOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -2474,7 +2474,9 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
         )
 
         try:
-            self.log.info("Executing: %s'", self.configuration)
+            self.log.info("Executing: %s", self.configuration)
+            if self.sql:
+                self.log.info("SQL query:\n%s", self.sql)
             # Create a job
             if self.job_id is None:
                 raise ValueError("job_id cannot be None")


### PR DESCRIPTION
When `BigQueryInsertJobOperator` starts, it logs the whole job `configuration` dict in a single line. For query jobs this makes the SQL essentially unreadable in the task log — the query shows up embedded in the dict repr with escaped `\n` sequences:

```
Executing: {'query': {'query': 'select *\nfrom table\nwhere condition', 'useLegacySql': False}}'
```

This change logs the SQL on its own log line (reusing the operator's existing `sql` property) so newlines render naturally and the query can be read — and copy-pasted into the BigQuery console — directly from the log:

```
Executing: {'query': {'query': 'select *\nfrom table\nwhere condition', 'useLegacySql': False}}
SQL query:
select *
from table
where condition
```

This restores a behaviour Airflow used to have rather than adding something new: `BigQueryExecuteQueryOperator` logged the plain SQL string directly — [`self.log.info("Executing: %s", self.sql)`](https://github.com/apache/airflow/blob/79bb80b4b6cbb39998a2c4435ac5df279d3fb3b1/providers/src/airflow/providers/google/cloud/operators/bigquery.py#L1364) — until the deprecated operator was removed in #43953, leaving the configuration-dict dump as the only trace of the query in the logs. This also matches how sibling operators log SQL today (e.g. `BigQueryCheckOperator`'s `Executing SQL check: %s`). The stray trailing quote in the current log line is fixed along the way.

Readable SQL in the log matters most after a failure or when logs are consumed remotely (CloudWatch/Stackdriver/grep), where the UI's rendered-template view isn't available. For non-query job types (load/copy/extract) the behaviour is unchanged.

No test added: the change is log-output-only, and the project testing standards discourage asserting on log output.

**Verification performed:**

- All 37 `BigQueryInsertJobOperator` unit tests pass in Breeze; mypy and static checks clean.
- Ran the `example_bigquery_value_check.py` system test end-to-end against a real GCP project: the Dag passed (`1 passed in 188s`), and the task log shows the new `SQL query:` line rendered as plain text.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)