### PR TITLE
Convert ValueError to HTTPException for missing DagRun in ti_run

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -267,10 +267,15 @@ def ti_run(
             .unique()
             .one_or_none()
         )
-
         if not dr:
             log.error("DagRun not found", dag_id=ti.dag_id, run_id=ti.run_id)
-            raise ValueError(f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={
+                    "reason": "not_found",
+                    "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.",
+                },
+            )
 
         # Send the keys to the SDK so that the client requests to clear those XComs from the server.
         # The reason we cannot do this here in the server is because we need to issue a purge on custom XCom backends

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -203,6 +203,35 @@ class TestTIRunState:
         events = response.json()["dag_run"]["consumed_asset_events"]
         assert [e["partition_key"] for e in events] == ["2024-01-15"]
 
+    @mock.patch("sqlalchemy.orm.Session.scalars")
+    def test_ti_run_missing_dagrun(self, mock_scalars, client, session, create_task_instance):
+        ti = create_task_instance(
+            task_id="test_ti_run_missing_dagrun",
+            state=State.QUEUED,
+            session=session,
+        )
+        session.commit()
+
+        # Mock the scalars call so that the DagRun lookup returns None
+        mock_scalars.return_value.unique.return_value.one_or_none.return_value = None
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/run",
+            json={
+                "state": "running",
+                "hostname": "random-hostname",
+                "unixname": "random-unixname",
+                "pid": 100,
+                "start_date": "2024-10-31T12:00:00Z",
+            },
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == {
+            "reason": "not_found",
+            "message": f"DagRun with dag_id={ti.dag_id} and run_id={ti.run_id} not found.",
+        }
+
     @pytest.mark.parametrize(
         ("max_tries", "should_retry"),
         [


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

Fixes an issue where a `ValueError` is raised internally if a `DagRun` is not found during the `ti_run` endpoint execution. This resulted in an unhandled 500 Internal Server Error being returned to the client instead of a clean error payload.

This PR replaces the `ValueError` with an `HTTPException(status_code=404)`, which complies with the execution API error translation rules.

closes: #69392

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (Gemini AI Assistant)

<!--
Generated-by: Gemini AI following the guidelines
-->

---
