### PR TITLE
Reject invalid Amazon Bedrock model IDs in the Anthropic provider

### DIFF
--- a/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/hooks/anthropic.py
@@ -297,6 +297,20 @@ class AnthropicHook(BaseHook):
             kwargs["scope"] = wif["scope"]
         return WorkloadIdentityCredentials(**kwargs)
 
+    def _resolve_model(self, model: str | None) -> str:
+        """Resolve the effective model id; Bedrock rejects a bare id, so require its prefix."""
+        resolved = model or self.default_model
+        # Valid Bedrock ids either start with the ``anthropic.`` provider prefix or carry a
+        # region/profile prefix as a dotted component (e.g. ``us.anthropic.``, ``global.anthropic.``).
+        is_bedrock_model_id = resolved.startswith("anthropic.") or ".anthropic." in resolved
+        if self.platform == "bedrock" and not is_bedrock_model_id:
+            raise AnthropicError(
+                f"Model {resolved!r} is not a valid Amazon Bedrock model id. Bedrock ids carry a "
+                "provider/region prefix (e.g. 'global.anthropic.claude-opus-4-6-v1'); set one via "
+                "the 'model' argument or the connection's extra['model']."
+            )
+        return resolved
+
     def _require_first_party(self, feature: str) -> None:
         if self.platform not in FIRST_PARTY_PLATFORMS:
             raise AnthropicError(
@@ -348,7 +362,7 @@ class AnthropicHook(BaseHook):
         :param system: Optional system prompt.
         """
         params: dict[str, Any] = {
-            "model": model or self.default_model,
+            "model": self._resolve_model(model),
             "max_tokens": max_tokens,
             "messages": messages,
             **kwargs,

--- a/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
+++ b/providers/anthropic/tests/unit/anthropic/hooks/test_anthropic.py
@@ -185,6 +185,40 @@ class TestDefaultModel:
         hook.create_agent(name="a")
         assert client.beta.agents.create.call_args.kwargs["model"] == "claude-sonnet-4-6"
 
+    @pytest.mark.parametrize(
+        "model",
+        [None, "my-anthropic.model"],  # bare default id and a substring that is not a real prefix
+    )
+    def test_bedrock_rejects_invalid_model_id(self, model):
+        extra = {"platform": "bedrock", **({"model": model} if model else {})}
+        hook, client = _make_hook(extra=extra)
+        with pytest.raises(AnthropicError, match="not a valid Amazon Bedrock model id"):
+            hook.create_message([{"role": "user", "content": "hi"}])
+        client.messages.create.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("platform", "model", "expected"),
+        [
+            (
+                "bedrock",
+                "anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            ),
+            ("bedrock", "global.anthropic.claude-opus-4-6-v1", "global.anthropic.claude-opus-4-6-v1"),
+            (
+                "bedrock",
+                "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            ),
+            ("vertex", None, DEFAULT_MODEL),  # non-Bedrock platforms skip the guard
+        ],
+    )
+    def test_accepts_valid_model_id(self, platform, model, expected):
+        extra = {"platform": platform, **({"model": model} if model else {})}
+        hook, client = _make_hook(extra=extra)
+        hook.create_message([{"role": "user", "content": "hi"}])
+        assert client.messages.create.call_args.kwargs["model"] == expected
+
 
 class TestManagedAgentsHook:
     def _hook_with_client(self, extra=None):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why

The default model `claude-opus-4-8` is a bare first-party ID that Amazon Bedrock rejects, so a Bedrock connection without an overridden model failed with an opaque 400.

Reference: https://platform.claude.com/docs/en/build-with-claude/claude-on-amazon-bedrock-legacy

## How

- Add `_resolve_model` to validate the resolved model on the bedrock platform, raising `AnthropicError` with the correct prefixed-ID guidance.
- Route `create_message` through the validator; leave Vertex, Foundry, and first-party unchanged.
- Cover with tests for Bedrock rejection, prefixed-ID acceptance, and Vertex passthrough.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Code with opus 4.8

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
