### PR TITLE
Make Google deprecation date parsing locale independent

### DIFF
--- a/providers/google/src/airflow/providers/google/common/deprecated.py
+++ b/providers/google/src/airflow/providers/google/common/deprecated.py
@@ -25,6 +25,26 @@ from typing import Any
 from deprecated import deprecated as standard_deprecated
 from deprecated.classic import ClassicAdapter
 
+# English month names used by the `Month DD, YYYY` date format. Hardcoded rather than
+# derived from `calendar`/`strftime` because the `%B` directive is locale-dependent:
+# under a non-English LC_TIME it fails to parse the English month at decoration time and
+# emits a localized month name in the deprecation message.
+_MONTH_NAMES = (
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+)
+_MONTH_NUMBERS = {name.lower(): number for number, name in enumerate(_MONTH_NAMES, start=1)}
+
 
 class AirflowDeprecationAdapter(ClassicAdapter):
     """
@@ -86,7 +106,11 @@ class AirflowDeprecationAdapter(ClassicAdapter):
     def _validate_date(value: str | None) -> date | None:
         if value:
             try:
-                return datetime.strptime(value, "%B %d, %Y").date()
+                month_name, separator, day_and_year = value.partition(" ")
+                month_number = _MONTH_NUMBERS.get(month_name.lower())
+                if not separator or month_number is None:
+                    raise ValueError(f"Unknown month name in {value!r}.")
+                return datetime.strptime(f"{month_number} {day_and_year}", "%m %d, %Y").date()
             except ValueError as ex:
                 error_message = (
                     f"Invalid date '{value}'. "
@@ -126,7 +150,8 @@ class AirflowDeprecationAdapter(ClassicAdapter):
 
     def sunset_message(self) -> str:
         if self.planned_removal_date:
-            return f"after {self.planned_removal_date.strftime('%B %d, %Y')}"
+            month_name = _MONTH_NAMES[self.planned_removal_date.month - 1]
+            return f"after {month_name} {self.planned_removal_date.strftime('%d, %Y')}"
         if self.planned_removal_release:
             return f"since version {self.planned_removal_release}"
         return "in the future"

--- a/providers/google/tests/unit/google/common/test_deprecated.py
+++ b/providers/google/tests/unit/google/common/test_deprecated.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
+import locale
 from datetime import date
 from unittest import mock
 
@@ -25,6 +27,20 @@ from airflow.providers.google.common.deprecated import AirflowDeprecationAdapter
 
 ADAPTER_PATH = "airflow.providers.google.common.deprecated"
 ADAPTER_CLASS_PATH = f"{ADAPTER_PATH}.AirflowDeprecationAdapter"
+
+
+@contextlib.contextmanager
+def _time_locale(name: str):
+    """Temporarily set LC_TIME, skipping the test if the locale is unavailable."""
+    saved = locale.setlocale(locale.LC_TIME)
+    try:
+        locale.setlocale(locale.LC_TIME, name)
+    except locale.Error:
+        pytest.skip(f"locale {name!r} is not available on this system")
+    try:
+        yield
+    finally:
+        locale.setlocale(locale.LC_TIME, saved)
 
 
 class TestAirflowDeprecationAdapter:
@@ -45,25 +61,22 @@ class TestAirflowDeprecationAdapter:
         assert adapter.planned_removal_date == mock_date
         assert adapter.planned_removal_release == mock_release
 
-    @mock.patch(f"{ADAPTER_PATH}.datetime")
-    def test_validate_date(self, mock_datetime):
-        value = "August 22, 2024"
-        expected_date = date(2024, 8, 22)
-        mock_datetime.strptime.return_value.date.return_value = expected_date
+    @pytest.mark.parametrize(
+        ("value", "expected_date"),
+        [
+            ("August 22, 2024", date(2024, 8, 22)),
+            ("June 30, 2026", date(2026, 6, 30)),
+            ("January 1, 2020", date(2020, 1, 1)),
+            # Month names are matched case-insensitively, as the previous `%B` parsing did.
+            ("august 22, 2024", date(2024, 8, 22)),
+            ("AUGUST 22, 2024", date(2024, 8, 22)),
+        ],
+    )
+    def test_validate_date(self, value, expected_date):
+        assert AirflowDeprecationAdapter._validate_date(value) == expected_date
 
-        actual_date = AirflowDeprecationAdapter._validate_date(value)
-
-        assert actual_date == expected_date
-        mock_datetime.strptime.assert_called_once_with(value, "%B %d, %Y")
-
-    @mock.patch(f"{ADAPTER_PATH}.datetime")
-    def test_validate_date_none(self, mock_datetime):
-        value = None
-
-        actual_date = AirflowDeprecationAdapter._validate_date(value)
-
-        assert actual_date is None
-        assert not mock_datetime.strptime.called
+    def test_validate_date_none(self):
+        assert AirflowDeprecationAdapter._validate_date(None) is None
 
     @pytest.mark.parametrize(
         "invalid_date",
@@ -81,6 +94,17 @@ class TestAirflowDeprecationAdapter:
         )
         with pytest.raises(ValueError, match=expected_error_message):
             AirflowDeprecationAdapter(planned_removal_date=invalid_date)
+
+    @pytest.mark.parametrize("locale_name", ["de_DE.UTF-8", "fr_FR.UTF-8"])
+    def test_validate_date_is_locale_independent(self, locale_name):
+        with _time_locale(locale_name):
+            assert AirflowDeprecationAdapter._validate_date("June 30, 2026") == date(2026, 6, 30)
+
+    @pytest.mark.parametrize("locale_name", ["de_DE.UTF-8", "fr_FR.UTF-8"])
+    def test_sunset_message_uses_english_month_regardless_of_locale(self, locale_name):
+        with _time_locale(locale_name):
+            adapter = AirflowDeprecationAdapter(planned_removal_date="June 30, 2026")
+            assert adapter.sunset_message() == "after June 30, 2026"
 
     @pytest.mark.parametrize(
         "release_string",


### PR DESCRIPTION
The `@deprecated` decorator in the Google provider parses and formats the
`planned_removal_date` using `strptime`/`strftime` with the `%B` directive.
`%B` resolves the full month name against the process `LC_TIME` locale, so it
only recognizes the English month names ("June 30, 2026") when the process runs
under an English (or C) locale.

Under a non-English `LC_TIME`/`LC_ALL` (for example `de_DE`, `fr_FR`, `es_ES`),
`datetime.strptime("June 30, 2026", "%B %d, %Y")` raises `ValueError`, which
`AirflowDeprecationAdapter._validate_date` re-wraps as
`ValueError: Invalid date 'June 30, 2026'`. This happens at decoration time,
which is import time: the BigQuery operators decorate a class member with
`@deprecated(planned_removal_date="June 30, 2026", ...)` at class-body level, so
importing `airflow.providers.google.cloud.operators.bigquery` under a non-English
process locale fails outright. Any module that uses this decorator with a
`planned_removal_date` is affected the same way.

The formatting side has the same root cause: `sunset_message()` used
`strftime('%B %d, %Y')`, which renders a localized month name (for example
`Juni`/`juin`) in the deprecation warning under a non-English locale, even though
the developer wrote an English date.

This makes the month handling locale independent while keeping the accepted input
format, the error message, and the rendered output identical:

- Parsing translates the English month name to its number through a fixed
  mapping, then parses the numeric parts with the locale-independent `%m %d, %Y`.
  The mapping is case-insensitive, matching the previous `%B` behavior (which
  accepted `"june 30, 2026"` / `"JUNE 30, 2026"` too).
- `sunset_message()` formats the month from the same fixed English names and the
  day/year with digit-only directives.

The month names are hardcoded on purpose: `calendar.month_name` and `strftime`
are themselves locale-dependent, so they cannot be used to make this
locale-independent.

### Reproduction (before this change)

```python
import locale
locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")

from deprecated import deprecated  # airflow's Google-provider AirflowDeprecationAdapter

@deprecated(planned_removal_date="June 30, 2026")
def f(): ...
# ValueError: Invalid date 'June 30, 2026'. Expected format: 'Month DD, YYYY', ...
```

or simply, under such a locale:

```python
from airflow.providers.google.cloud.operators.bigquery import BigQueryGetDataOperator
# ValueError: Invalid date 'June 30, 2026'. ...
```

### Tests

- Reworked `test_validate_date` from mock-based assertions on the internal
  `strptime(value, "%B %d, %Y")` call (which this change replaces) to behavioral,
  parametrized parsing assertions, including case-insensitive month spellings.
- Added `test_validate_date_is_locale_independent` (parses `June 30, 2026` under
  `de_DE.UTF-8`/`fr_FR.UTF-8`) and
  `test_sunset_message_uses_english_month_regardless_of_locale` (message stays
  `after June 30, 2026`). Both skip cleanly if the locale is not installed on the
  runner.

Both new locale tests fail against `main` with the exact
`Invalid date 'June 30, 2026'` crash and pass with this change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, OpenCode (GPT-5.6)

Generated-by: OpenCode (GPT-5.6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)