### PR TITLE
Display latest dagrun state per dag in search result.

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
@@ -62,6 +62,7 @@ export const SearchDags = ({
         queryFn: () =>
           DagService.getDagsUi({
             dagDisplayNamePrefixPattern: inputValue,
+            dagRunsLimit: 1,
             limit: SEARCH_LIMIT,
           }).then((data: DAGWithLatestDagRunsCollectionResponse) => {
             const options = data.dags.map((dag: DAGWithLatestDagRunsResponse) => ({
@@ -87,7 +88,7 @@ export const SearchDags = ({
   const formatOptionLabel = (option: DagSearchOption) => (
     <Flex alignItems="center" gap={2}>
       <StateBadge state={option.state} />
-      <Text>{option.value}</Text>
+      <Text>{option.label}</Text>
     </Flex>
   );
 

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDags.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Field } from "@chakra-ui/react";
+import { Field, Flex, Text } from "@chakra-ui/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AsyncSelect } from "chakra-react-select";
 import type { OptionsOrGroups, GroupBase, SingleValue } from "chakra-react-select";
@@ -25,10 +25,14 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useDebouncedCallback } from "use-debounce";
 
-import { UseDagServiceGetDagsKeyFn } from "openapi/queries";
+import { UseDagServiceGetDagsUiKeyFn } from "openapi/queries";
 import { DagService } from "openapi/requests/services.gen";
-import type { DAGCollectionResponse, DAGResponse } from "openapi/requests/types.gen";
-import type { Option } from "src/utils/option";
+import type {
+  DAGWithLatestDagRunsCollectionResponse,
+  DAGWithLatestDagRunsResponse,
+} from "openapi/requests/types.gen";
+import { StateBadge } from "src/components/StateBadge";
+import type { DagSearchOption } from "src/utils/option";
 
 import { DropdownIndicator } from "./SearchDagsDropdownIndicator";
 
@@ -42,7 +46,7 @@ export const SearchDags = ({
   const navigate = useNavigate();
   const SEARCH_LIMIT = 10;
 
-  const onSelect = (selected: SingleValue<Option>) => {
+  const onSelect = (selected: SingleValue<DagSearchOption>) => {
     if (selected) {
       setIsOpen(false);
       void Promise.resolve(navigate(`/dags/${selected.value}`));
@@ -50,15 +54,19 @@ export const SearchDags = ({
   };
 
   const searchDagDebounced = useDebouncedCallback(
-    (inputValue: string, callback: (options: OptionsOrGroups<Option, GroupBase<Option>>) => void) => {
+    (
+      inputValue: string,
+      callback: (options: OptionsOrGroups<DagSearchOption, GroupBase<DagSearchOption>>) => void,
+    ) => {
       void queryClient.fetchQuery({
         queryFn: () =>
-          DagService.getDags({
+          DagService.getDagsUi({
             dagDisplayNamePrefixPattern: inputValue,
             limit: SEARCH_LIMIT,
-          }).then((data: DAGCollectionResponse) => {
-            const options = data.dags.map((dag: DAGResponse) => ({
+          }).then((data: DAGWithLatestDagRunsCollectionResponse) => {
+            const options = data.dags.map((dag: DAGWithLatestDagRunsResponse) => ({
               label: dag.dag_display_name || dag.dag_id,
+              state: dag.latest_dag_runs[0]?.state ?? null,
               value: dag.dag_id,
             }));
 
@@ -66,13 +74,21 @@ export const SearchDags = ({
 
             return options;
           }),
-        queryKey: UseDagServiceGetDagsKeyFn({
+        queryKey: UseDagServiceGetDagsUiKeyFn({
           dagDisplayNamePrefixPattern: inputValue,
+          dagRunsLimit: 1,
         }),
         staleTime: 0,
       });
     },
     300,
+  );
+
+  const formatOptionLabel = (option: DagSearchOption) => (
+    <Flex alignItems="center" gap={2}>
+      <StateBadge state={option.state} />
+      <Text>{option.value}</Text>
+    </Flex>
   );
 
   return (
@@ -82,6 +98,7 @@ export const SearchDags = ({
         components={{ DropdownIndicator }}
         defaultOptions
         filterOption={undefined}
+        formatOptionLabel={formatOptionLabel}
         loadOptions={searchDagDebounced}
         menuIsOpen
         onChange={onSelect}

--- a/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDagsDropdownIndicator.tsx
+++ b/airflow-core/src/airflow/ui/src/components/SearchDags/SearchDagsDropdownIndicator.tsx
@@ -20,9 +20,9 @@ import { chakraComponents } from "chakra-react-select";
 import type { DropdownIndicatorProps } from "chakra-react-select";
 import { FiSearch } from "react-icons/fi";
 
-import type { Option } from "src/utils/option";
+import type { DagSearchOption } from "src/utils/option";
 
-export const DropdownIndicator: React.FC<DropdownIndicatorProps<Option, false>> = (props) => (
+export const DropdownIndicator: React.FC<DropdownIndicatorProps<DagSearchOption, false>> = (props) => (
   <chakraComponents.DropdownIndicator {...props}>
     <FiSearch />
   </chakraComponents.DropdownIndicator>

--- a/airflow-core/src/airflow/ui/src/utils/option.ts
+++ b/airflow-core/src/airflow/ui/src/utils/option.ts
@@ -16,9 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type { DagRunState } from "openapi/requests/types.gen";
 
 export type Option = {
   readonly disabled?: boolean;
   readonly label: string;
   readonly value: string;
 };
+
+export type DagSearchOption = {
+  readonly state: DagRunState | null;
+} & Option;


### PR DESCRIPTION
Display latest dagrun state per dag in the search result. This helps in knowing the latest dagrun status without going to the dag page.

* closes: #68318
* related: #68318

<img width="1848" height="944" alt="Image" src="https://github.com/user-attachments/assets/3890be8b-f42c-49ef-98c1-8811d33d0807" />

##### Was generative AI tooling used to co-author this PR?

- [x] Yes 

Generated-by: [Claude Code Opus 4.7] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)