### PR TITLE
Fix HTTP_422_UNPROCESSABLE_ENTITY deprecation warnings.

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/exceptions.py
+++ b/airflow-core/src/airflow/api_fastapi/common/exceptions.py
@@ -26,6 +26,7 @@ from typing import Generic, TypeVar
 from fastapi import HTTPException, Request, status
 from sqlalchemy.exc import DatabaseError, DataError, IntegrityError
 
+from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.configuration import conf
 from airflow.exceptions import DeserializationError
 from airflow.utils.strings import get_random_string
@@ -137,7 +138,7 @@ class DataErrorHandler(_DatabaseErrorHandler[DataError]):
     range, or the wrong type for its column), so it is a client error, not a 500.
     """
 
-    status_code = status.HTTP_422_UNPROCESSABLE_ENTITY
+    status_code = HTTP_422_UNPROCESSABLE_CONTENT
     reason = "Value rejected by database"
 
     def __init__(self):

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -36,6 +36,7 @@ from airflow.api_fastapi.common.parameters import (
     SortParam,
 )
 from airflow.api_fastapi.common.router import AirflowRouter
+from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.core_api.datamodels.common import (
     BulkBody,
     BulkResponse,
@@ -97,7 +98,7 @@ def _ensure_executor_is_configured(executor: str | None) -> None:
         executor in (name.alias, name.module_path, name.module_path.split(".")[-1]) for name in configured
     ):
         raise HTTPException(
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            HTTP_422_UNPROCESSABLE_CONTENT,
             f"Executor '{executor}' is not configured. "
             f"Configured executors: {[name.alias or name.module_path for name in configured]}",
         )
@@ -371,7 +372,7 @@ def test_connection(
         [
             status.HTTP_403_FORBIDDEN,
             status.HTTP_409_CONFLICT,
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            HTTP_422_UNPROCESSABLE_CONTENT,
         ]
     ),
     dependencies=[Depends(action_logging())],

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -27,6 +27,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Session
 
+from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.common.exceptions import (
     ERROR_HANDLERS,
     DagErrorHandler,
@@ -453,7 +454,7 @@ class TestDataErrorHandler:
         exc = self._make_data_error(orig_msg)
         with pytest.raises(HTTPException) as exc_info:
             self.handler.exception_handler(Mock(), exc)
-        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert exc_info.value.status_code == HTTP_422_UNPROCESSABLE_CONTENT
         assert exc_info.value.detail == {
             "reason": "Value rejected by database",
             "statement": "hidden",
@@ -472,7 +473,7 @@ class TestDataErrorHandler:
         exc = self._make_data_error(orig_msg)
         with pytest.raises(HTTPException) as exc_info:
             self.handler.exception_handler(Mock(), exc)
-        assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert exc_info.value.status_code == HTTP_422_UNPROCESSABLE_CONTENT
         detail = exc_info.value.detail
         assert isinstance(detail, dict)
         assert detail["reason"] == "Value rejected by database"
@@ -491,7 +492,7 @@ class TestDataErrorHandler:
             raise self._make_data_error("(1406, \"Data too long for column 'conf' at row 1\")")
 
         response = TestClient(app, raise_server_exceptions=False).post("/test")
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == HTTP_422_UNPROCESSABLE_CONTENT
         detail = response.json()["detail"]
         assert detail["reason"] == "Value rejected by database"
         assert detail["statement"] == "hidden"

--- a/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
+++ b/airflow-core/tests/unit/api_fastapi/common/test_exceptions.py
@@ -27,7 +27,6 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import DataError, IntegrityError
 from sqlalchemy.orm import Session
 
-from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.common.exceptions import (
     ERROR_HANDLERS,
     DagErrorHandler,
@@ -35,6 +34,7 @@ from airflow.api_fastapi.common.exceptions import (
     _DatabaseDialect,
     _UniqueConstraintErrorHandler,
 )
+from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.configuration import conf
 from airflow.exceptions import DeserializationError
 from airflow.models import DagRun, Pool, Variable


### PR DESCRIPTION
Use `HTTP_422_UNPROCESSABLE_ENTITY` from compat module to fix deprecation warnings during api server startup and tests.

```
[2026-07-05T15:29:17.939314Z] {/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/api_fastapi/common/exceptions.py:132} WARNING - 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead. category=DeprecationWarning
[2026-07-05T15:29:19.200948Z] {/home/karthikeyan/stuff/python/airflow/airflow-core/src/airflow/api_fastapi/core_api/routes/public/__init__.py:29} WARNING - 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead. category=DeprecationWarning
```

Similar to https://github.com/apache/airflow/pull/58828 and https://github.com/apache/airflow/pull/56564