### PR TITLE
UI: Load Monaco codicon glyph styles via direct CSS import

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
+++ b/airflow-core/src/airflow/ui/src/components/MonacoEditor/configureMonaco.ts
@@ -34,7 +34,11 @@ const loadMonacoModules = async () => {
     import("monaco-editor/esm/vs/editor/editor.api"),
     import("monaco-editor/esm/vs/editor/contrib/folding/browser/folding"),
     import("monaco-editor/esm/vs/editor/contrib/find/browser/findController"),
-    import("monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"),
+    // monaco-editor 0.53 removed the `codiconStyles` side-effect module; import the two codicon
+    // stylesheets it used to pull in directly so folding/find glyphs still render. Both files
+    // ship in 0.52 and 0.55, so this resolves against the current pin and any newer bump.
+    import("monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon.css"),
+    import("monaco-editor/esm/vs/base/browser/ui/codicons/codicon/codicon-modifiers.css"),
   ]).then(([api]) => api);
 
   // Resolve the bundled worker URLs (`?worker&url` runs the worker through Vite's worker


### PR DESCRIPTION
`monaco-editor` 0.53 removed the internal `codiconStyles` side-effect module that the local ESM Monaco setup imported to register the codicon glyph font (folding arrows, find-widget icons). This imports the two stylesheets that module pulled in — `codicon/codicon.css` and `codicon/codicon-modifiers.css` — directly instead, mirroring the existing dynamic-CSS-import pattern already used for Katex (`KatexStyleLoader.ts`).

Both files ship in the currently pinned `0.52.2` and in newer releases, so this is behaviour-neutral today and unblocks the pending `monaco-editor` bump to 0.55.x (dependabot #69354 / the v3-3-test #69355), which otherwise fails the React UI tests with:

```
Failed to resolve import "monaco-editor/esm/vs/base/browser/ui/codicons/codiconStyles"
```

### Verified locally
- monaco 0.52.2 + fix → affected tests pass (no regression)
- monaco 0.55.1 **without** fix → reproduces the exact CI failure above
- monaco 0.55.1 **with** fix → affected tests pass (32/32)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)