### PR TITLE
Link pkg.go.dev API reference from the Go SDK docs

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/go.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/go.rst
@@ -37,6 +37,12 @@ the bundle: one runnable file to ship, with no separate manifest or archive. The
    :local:
    :depth: 2
 
+API reference
+-------------
+
+The generated API reference for the Go SDK module, and the list of its released versions, is available on
+`pkg.go.dev <https://pkg.go.dev/github.com/apache/airflow/go-sdk>`__.
+
 Prerequisites
 -------------
 


### PR DESCRIPTION
## Why

The Go SDK guide describes the `sdk.Client` interfaces but never points readers at the full generated API reference, even though pkg.go.dev already indexes the module at https://pkg.go.dev/github.com/apache/airflow/go-sdk.

## What

- Add an "API reference" section at the top of `airflow-core/docs/authoring-and-scheduling/language-sdks/go.rst` linking to the module on pkg.go.dev.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
