### PR TITLE
Fix CeleryKubernetesExecutor starting Kubernetes watcher client-side

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -285,8 +285,12 @@ class KubernetesExecutor(BaseExecutor):
     def start(self) -> None:
         """Start the executor."""
         self.log.info("Start Kubernetes executor")
-        self.scheduler_job_id = str(self.job_id)
+        self.scheduler_job_id = str(self.job_id) if self.job_id else None
         self.log.debug("Start with scheduler_job_id: %s", self.scheduler_job_id)
+        if not self.scheduler_job_id:
+            self.log.debug("Skipping scheduler and client initialization as no job_id is set.")
+            return
+
         from airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils import (
             AirflowKubernetesScheduler,
         )
@@ -346,6 +350,8 @@ class KubernetesExecutor(BaseExecutor):
 
     def sync(self) -> None:
         """Synchronize task state."""
+        if not self.kube_scheduler:
+            return
         if TYPE_CHECKING:
             assert self.scheduler_job_id
             assert self.kube_scheduler

--- a/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/tests/providers/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -1198,8 +1198,8 @@ class TestKubernetesExecutor:
     def test_cleanup_stuck_queued_tasks(self, mock_delete_pod, mock_kube_client, dag_maker, session):
         """Delete any pods associated with a task stuck in queued."""
         executor = KubernetesExecutor()
+        executor.job_id = "123"
         executor.start()
-        executor.scheduler_job_id = "123"
         with dag_maker(dag_id="test_cleanup_stuck_queued_tasks"):
             op = BashOperator(task_id="bash", bash_command=["echo 0", "echo 1"])
         dag_run = dag_maker.create_dagrun()
@@ -1494,6 +1494,16 @@ class TestKubernetesExecutor:
 
     def test_cli_commands_vended(self):
         assert KubernetesExecutor.get_cli_commands()
+
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    def test_start_without_job_id(self, mock_get_kube_client):
+        executor = KubernetesExecutor()
+        executor.job_id = None
+        executor.start()
+        assert executor.scheduler_job_id is None
+        assert executor.kube_client is None
+        assert executor.kube_scheduler is None
+        mock_get_kube_client.assert_not_called()
 
     def test_annotations_for_logging_task_metadata(self):
         annotations_test = {


### PR DESCRIPTION
When using CeleryKubernetesExecutor, starting the executor client-side (e.g., during task execution via airflow tasks run) unconditionally initialized the Kubernetes client and spawned pod watchers. This resulted in authorization failures (403 Forbidden) or config errors (ConfigException) on worker pods that lack Kubernetes API access. This change conditionally initializes the Kubernetes client and watchers only if a valid scheduler_job_id is set (indicating a scheduler/backfill job). Closes #49074


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
### Root Cause
When executing airflow tasks run client-side (e.g. on Celery workers), the CLI loads the configured executor. For CeleryKubernetesExecutor, this starts both the celery and kubernetes executors.
However, KubernetesExecutor.start() unconditionally:

Calls get_kube_client() to load config/session.
Instantiates AirflowKubernetesScheduler and immediately spawns KubernetesJobWatcher threads.
This client-side process only queues/runs the task and doesn't need to watch pod status. On workers lacking RBAC permissions (or running out-of-cluster), this leads to immediate crashes.

### Proposed Fix
We can make the initialization of the Kubernetes client and watchers conditional. If self.job_id is not present (indicating a client-side execution path, not a scheduler daemon/backfill job), we can return early from KubernetesExecutor.start() and skip sync() actions.

I have implemented this fix and verified that:

The client-side task run command now succeeds.
All existing KubernetesExecutor and CeleryKubernetesExecutor unit tests pass.
Added a new unit test validating this conditional startup behavior.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ X ] Yes (please specify the tool below)
-  Generated-by: Google Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
