### PR TITLE
Migrate exasol provider to pyexasol 2

### DIFF
--- a/providers/exasol/docs/changelog.rst
+++ b/providers/exasol/docs/changelog.rst
@@ -27,6 +27,24 @@
 Changelog
 ---------
 
+5.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+.. warning::
+  Support for ``pyexasol`` 1.x has been dropped; this provider now requires ``pyexasol>=2,<3``.
+  ``pyexasol`` 2 ships a ``py.typed`` marker, so its type hints are now enforced against the hook.
+  The public behaviour of ``ExasolHook`` is unchanged -- ``run``, ``get_records``, ``get_first`` and
+  the pandas export still accept the same ``sql`` and ``parameters`` arguments. Only named
+  (mapping) query parameters are supported, matching what Exasol can bind; passing a positional
+  sequence as ``parameters`` now raises a clear ``TypeError`` instead of failing inside the driver.
+  If you pin ``pyexasol`` in your environment, upgrade it to a ``2.x`` release before upgrading this
+  provider.
+
+* ``Migrate Exasol provider to pyexasol 2 (#69431)``
+
 4.10.4
 ......
 

--- a/providers/exasol/provider.yaml
+++ b/providers/exasol/provider.yaml
@@ -29,6 +29,7 @@ source-date-epoch: 1783356304
 # In such case adding >= NEW_VERSION and bumping to NEW_VERSION in a provider have
 # to be done in the same PR
 versions:
+  - 5.0.0
   - 4.10.4
   - 4.10.3
   - 4.10.2

--- a/providers/exasol/pyproject.toml
+++ b/providers/exasol/pyproject.toml
@@ -62,9 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    # Capped to 1.x: pyexasol 2.x ships stricter types that break the exasol hook.
-    # Remove the cap after migrating; tracked at https://github.com/apache/airflow/issues/69123
-    "pyexasol>=0.26.0,<2",
+    "pyexasol>=2",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"',
     'pandas>=2.3.3; python_version >="3.14"',

--- a/providers/exasol/pyproject.toml
+++ b/providers/exasol/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-airflow-providers-exasol"
-version = "4.10.4"
+version = "5.0.0"
 description = "Provider package apache-airflow-providers-exasol for Apache Airflow"
 readme = "README.rst"
 license = "Apache-2.0"
@@ -62,7 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    "pyexasol>=2",
+    "pyexasol>=2,<3",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"',
     'pandas>=2.3.3; python_version >="3.14"',

--- a/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
+++ b/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import closing
-from typing import TYPE_CHECKING, Any, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
 
 import pyexasol
 from deprecated import deprecated
@@ -145,7 +145,7 @@ class ExasolHook(DbApiHook):
         ``pyexasol.ExaConnection.export_to_pandas``.
         """
         with closing(self.get_conn()) as conn:
-            df = conn.export_to_pandas(sql, query_params=parameters, **kwargs)
+            df = conn.export_to_pandas(sql, query_params=cast("dict | None", parameters), **kwargs)
             return df
 
     @deprecated(
@@ -188,7 +188,10 @@ class ExasolHook(DbApiHook):
             sql statements to execute
         :param parameters: The parameters to render the SQL query with.
         """
-        with closing(self.get_conn()) as conn, closing(conn.execute(sql, parameters)) as cur:
+        with (
+            closing(self.get_conn()) as conn,
+            closing(conn.execute(cast("str", sql), cast("dict | None", parameters))) as cur,
+        ):
             send_sql_hook_lineage(
                 context=self,
                 sql=sql,
@@ -205,7 +208,10 @@ class ExasolHook(DbApiHook):
             sql statements to execute
         :param parameters: The parameters to render the SQL query with.
         """
-        with closing(self.get_conn()) as conn, closing(conn.execute(sql, parameters)) as cur:
+        with (
+            closing(self.get_conn()) as conn,
+            closing(conn.execute(cast("str", sql), cast("dict | None", parameters))) as cur,
+        ):
             send_sql_hook_lineage(
                 context=self,
                 sql=sql,
@@ -334,7 +340,7 @@ class ExasolHook(DbApiHook):
             results = []
             for sql_statement in sql_list:
                 self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
-                with closing(conn.execute(sql_statement, parameters)) as exa_statement:
+                with closing(conn.execute(sql_statement, cast("dict | None", parameters))) as exa_statement:
                     if handler is not None:
                         result = self._make_common_data_structure(handler(exa_statement))
 

--- a/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
+++ b/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import closing
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import pyexasol
 from deprecated import deprecated
@@ -131,6 +131,54 @@ class ExasolHook(DbApiHook):
             )
         return self.sqlalchemy_url.render_as_string(hide_password=False)
 
+    @staticmethod
+    def _serialize_query_params(
+        parameters: Iterable | Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        """
+        Coerce hook-level parameters to the mapping pyexasol accepts.
+
+        pyexasol 2 ships type hints where ``query_params`` is ``dict | None`` (Exasol
+        binds named parameters only). ``DbApiHook`` allows a broader
+        ``Iterable | Mapping | None`` type, so convert mappings to a plain ``dict`` and
+        reject positional sequences -- which Exasol cannot bind -- with a clear error
+        instead of forwarding an unsupported value.
+        """
+        if parameters is None:
+            return None
+        if isinstance(parameters, Mapping):
+            return dict(parameters)
+        raise TypeError(
+            "Exasol only supports named query parameters passed as a mapping; "
+            f"got {type(parameters).__name__}. Positional parameters are not supported."
+        )
+
+    def _execute_statements(
+        self,
+        conn: ExaConnection,
+        sql: str | list[str],
+        query_params: dict[str, Any] | None,
+    ) -> ExaStatement:
+        """
+        Execute ``sql`` and return the last statement's open cursor.
+
+        Mirrors :meth:`run`: a string is executed as a single statement, and a list is
+        executed sequentially with the final statement's cursor returned so the caller
+        can fetch from it. Intermediate cursors are closed as we go.
+        """
+        if isinstance(sql, str):
+            statements = [sql] if sql.strip() else []
+        else:
+            statements = list(sql)
+        cur: ExaStatement | None = None
+        for statement in statements:
+            if cur is not None:
+                cur.close()
+            cur = conn.execute(statement, query_params)
+        if cur is None:
+            raise ValueError("List of SQL statements is empty")
+        return cur
+
     def _get_pandas_df(
         self, sql, parameters: Iterable | Mapping[str, Any] | None = None, **kwargs
     ) -> pd.DataFrame:
@@ -145,7 +193,7 @@ class ExasolHook(DbApiHook):
         ``pyexasol.ExaConnection.export_to_pandas``.
         """
         with closing(self.get_conn()) as conn:
-            df = conn.export_to_pandas(sql, query_params=cast("dict | None", parameters), **kwargs)
+            df = conn.export_to_pandas(sql, query_params=self._serialize_query_params(parameters), **kwargs)
             return df
 
     @deprecated(
@@ -188,9 +236,10 @@ class ExasolHook(DbApiHook):
             sql statements to execute
         :param parameters: The parameters to render the SQL query with.
         """
+        query_params = self._serialize_query_params(parameters)
         with (
             closing(self.get_conn()) as conn,
-            closing(conn.execute(cast("str", sql), cast("dict | None", parameters))) as cur,
+            closing(self._execute_statements(conn, sql, query_params)) as cur,
         ):
             send_sql_hook_lineage(
                 context=self,
@@ -208,9 +257,10 @@ class ExasolHook(DbApiHook):
             sql statements to execute
         :param parameters: The parameters to render the SQL query with.
         """
+        query_params = self._serialize_query_params(parameters)
         with (
             closing(self.get_conn()) as conn,
-            closing(conn.execute(cast("str", sql), cast("dict | None", parameters))) as cur,
+            closing(self._execute_statements(conn, sql, query_params)) as cur,
         ):
             send_sql_hook_lineage(
                 context=self,
@@ -335,12 +385,13 @@ class ExasolHook(DbApiHook):
         else:
             raise ValueError("List of SQL statements is empty")
         _last_result = None
+        query_params = self._serialize_query_params(parameters)
         with closing(self.get_conn()) as conn:
             self.set_autocommit(conn, autocommit)
             results = []
             for sql_statement in sql_list:
                 self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
-                with closing(conn.execute(sql_statement, cast("dict | None", parameters))) as exa_statement:
+                with closing(conn.execute(sql_statement, query_params)) as exa_statement:
                     if handler is not None:
                         result = self._make_common_data_structure(handler(exa_statement))
 

--- a/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
@@ -194,11 +194,20 @@ class TestExasolHook:
 
     def test_run_with_parameters(self):
         sql = "SQL"
-        parameters = ("param1", "param2")
+        parameters = {"param1": "value1", "param2": "value2"}
         self.db_hook.run(sql, autocommit=True, parameters=parameters)
         self.conn.set_autocommit.assert_called_once_with(True)
+        # pyexasol 2 binds named parameters only; the mapping is forwarded as a plain dict.
         self.conn.execute.assert_called_once_with(sql, parameters)
         self.conn.commit.assert_not_called()
+
+    @pytest.mark.parametrize("parameters", [("param1", "param2"), ["param1", "param2"]])
+    def test_run_rejects_positional_parameters(self, parameters):
+        # Exasol binds named parameters only; a positional sequence cannot be bound, so the
+        # hook rejects it at the boundary instead of forwarding an unsupported value to pyexasol.
+        with pytest.raises(TypeError, match="named query parameters"):
+            self.db_hook.run("SQL", parameters=parameters)
+        self.conn.execute.assert_not_called()
 
     def test_run_multi_queries(self):
         sql = ["SQL1", "SQL2"]
@@ -250,6 +259,36 @@ class TestExasolHook:
         assert call_kw["sql"] == sql
         assert call_kw["sql_parameters"] is None
         assert call_kw["cur"] is self.cur
+
+    def test_get_records_with_mapping_parameters(self):
+        sql = "SELECT * FROM t WHERE id = :id"
+        parameters = {"id": 1}
+        self.db_hook.get_records(sql, parameters=parameters)
+        # The mapping is forwarded to pyexasol as ``query_params`` (a plain dict), not a cast.
+        self.conn.execute.assert_called_once_with(sql, parameters)
+        self.cur.fetchall.assert_called_once()
+
+    def test_get_records_multi_queries(self):
+        # A list of statements is executed sequentially (mirroring ``run``); records are fetched
+        # from the last statement's cursor.
+        sql = ["SQL1", "SQL2"]
+        self.db_hook.get_records(sql)
+        assert self.conn.execute.call_count == 2
+        self.conn.execute.assert_any_call("SQL1", None)
+        self.conn.execute.assert_called_with("SQL2", None)
+        self.cur.fetchall.assert_called_once()
+
+    def test_get_records_rejects_positional_parameters(self):
+        with pytest.raises(TypeError, match="named query parameters"):
+            self.db_hook.get_records("SELECT 1", parameters=("a", "b"))
+        self.conn.execute.assert_not_called()
+
+    def test_get_first_with_mapping_parameters(self):
+        sql = "SELECT * FROM t WHERE id = :id"
+        parameters = {"id": 1}
+        self.db_hook.get_first(sql, parameters=parameters)
+        self.conn.execute.assert_called_once_with(sql, parameters)
+        self.cur.fetchone.assert_called_once()
 
     @mock.patch("airflow.providers.common.sql.hooks.sql.send_sql_hook_lineage")
     def test_get_df_hook_lineage(self, mock_send_lineage):


### PR DESCRIPTION
Closes #69123.

Migrates the Exasol provider to `pyexasol` 2 and addresses @potiuk's review.

**Dependency**
- `providers/exasol/pyproject.toml`: `pyexasol>=0.26.0,<2` → `pyexasol>=2,<3` (keep an upper bound).

**Honest type handling (no more `cast`)**
pyexasol 2 ships a `py.typed` marker, so `ExaConnection.execute` / `export_to_pandas` are now typed as `(query: str, query_params: dict | None)`. Instead of casting the hook's broader `sql` / `parameters` to the driver types (which lies to mypy), the hook now handles the mismatch at runtime:

- `_serialize_query_params`: converts a `Mapping` to a plain `dict` and raises a clear `TypeError` for a positional sequence. Exasol binds named parameters only, so a positional sequence could never have worked — it now fails at the boundary with a helpful message instead of deep inside the driver.
- `_execute_statements`: resolves `sql` the way `run()` does — a `str` is one statement, a `list[str]` is executed sequentially and records are fetched from the last cursor. This keeps the base `get_records` / `get_first` `str | list[str]` contract (a list has been valid input since #23812) without casting `sql` to `str`.
- `run()` and `_get_pandas_df` route `parameters` through the same helper.

**Breaking change + version**
- Bumped the provider to **5.0.0** (major) and added a `Breaking changes` note under the `Changelog` header: `pyexasol` 1.x support is dropped, and a positional `parameters` sequence now raises. `ExasolHook`'s public API (`run` / `get_records` / `get_first` / pandas export arguments) is otherwise unchanged.

**Tests**
- Added coverage in `providers/exasol/tests/unit/exasol/hooks/test_exasol.py` for the parameter-passing paths (mapping forwarded as a `dict`; positional sequence rejected) and the list-`sql` handling. `test_run_with_parameters` now uses a mapping, since its previous positional tuple is rejected by design.

**Verification**
- `ruff format --check` is clean and there are no new `ruff check` findings on the changed files; the boundary helpers were unit-checked in isolation. I could not stand up the full Airflow toolchain in my environment this round, so the integrated mypy and provider unit tests run in CI here — I am watching them.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Claude Code (Opus 4.8) (no human review before posting)

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=b134946 action=comment -->

---

> [!IMPORTANT]
> **Maintainer triage note for @youdie006** - by `@potiuk` - 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - Other failing CI checks. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - Pre-commit / static checks. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - Provider tests. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
