### PR TITLE
Link the published Java SDK API reference from the Java SDK docs

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
@@ -30,6 +30,12 @@ scheduling remain in Python; individual tasks delegate to a JVM subprocess that 
    :local:
    :depth: 2
 
+API reference
+-------------
+
+The generated API reference (Javadoc) for the Java SDK is published with the Airflow documentation at
+`Java SDK API Reference <https://airflow.apache.org/docs/java-sdk/stable/>`__.
+
 Prerequisites
 -------------
 
@@ -226,9 +232,7 @@ Register tasks manually in a ``BundleBuilder``:
       }
     }
 
-See the Java SDK's published JavaDoc for more details.
-
-.. TODO: (AIP-108) Put a link here once we publish the JavaDoc.
+See the `Java SDK API Reference <https://airflow.apache.org/docs/java-sdk/stable/>`__ for more details.
 
 .. _java-sdk/logging:
 

--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
@@ -33,7 +33,7 @@ scheduling remain in Python; individual tasks delegate to a JVM subprocess that 
 API reference
 -------------
 
-The generated API reference (Javadoc) for the Java SDK is published with the Airflow documentation at
+The generated API reference for the Java SDK is published with the Airflow documentation at
 `Java SDK API Reference <https://airflow.apache.org/docs/java-sdk/stable/>`__.
 
 Prerequisites


### PR DESCRIPTION
## Why

The Java SDK guide left an AIP-108 TODO in place of a Javadoc link. The docs pipeline now targets https://airflow.apache.org/docs/java-sdk/stable/, so the placeholder can become a real link.

## What

- Add an `API reference` section to `language-sdks/java.rst`, mirroring the Go SDK one from #69429.
- Replace the TODO with an inline `Java SDK API Reference` link.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)