### PR TITLE
escape attachment filename in Content-Disposition header

### DIFF
--- a/airflow-core/src/airflow/utils/email.py
+++ b/airflow-core/src/airflow/utils/email.py
@@ -208,7 +208,7 @@ def build_mime_message(
         basename = os.path.basename(fname)
         with open(fname, "rb") as file:
             part = MIMEApplication(file.read(), Name=basename)
-            part["Content-Disposition"] = f'attachment; filename="{basename}"'
+            part.add_header("Content-Disposition", "attachment", filename=basename)
             part["Content-ID"] = f"<{basename}>"
             msg.attach(part)
 

--- a/airflow-core/tests/unit/utils/test_email.py
+++ b/airflow-core/tests/unit/utils/test_email.py
@@ -146,6 +146,25 @@ class TestEmail:
         assert [mail_to] == recipients
         assert msg["To"] == ",".join(recipients)
 
+    def test_build_mime_message_escapes_attachment_filename(self, tmp_path):
+        # A quote in the filename must not break out of the quoted
+        # Content-Disposition value and inject extra parameters.
+        malicious = 'report.txt"; x-evil="1'
+        attachment = tmp_path / malicious
+        attachment.write_bytes(b"data")
+
+        msg, _ = email.build_mime_message(
+            mail_from="from@example.com",
+            to="to@example.com",
+            subject="subject",
+            html_content="<html></html>",
+            files=[os.fspath(attachment)],
+        )
+
+        part = msg.get_payload()[-1]
+        assert part.get_filename() == malicious
+        assert "x-evil" not in dict(part.get_params(header="Content-Disposition"))
+
 
 @pytest.mark.db_test
 class TestEmailSmtp:

--- a/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
+++ b/providers/smtp/src/airflow/providers/smtp/hooks/smtp.py
@@ -573,7 +573,7 @@ class SmtpHook(BaseHook):
             basename = os.path.basename(fname)
             with open(fname, "rb") as file:
                 part = MIMEApplication(file.read(), Name=basename)
-                part["Content-Disposition"] = f'attachment; filename="{basename}"'
+                part.add_header("Content-Disposition", "attachment", filename=basename)
                 part["Content-ID"] = f"<{basename}>"
                 msg.attach(part)
 

--- a/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
+++ b/providers/smtp/tests/unit/smtp/hooks/test_smtp.py
@@ -236,6 +236,26 @@ class TestSmtpHook:
         assert msg["To"] == ",".join(recipients)
 
     @patch(smtplib_string)
+    def test_build_mime_message_escapes_attachment_filename(self, mock_smtplib, tmp_path):
+        # A quote in the filename must not break out of the quoted
+        # Content-Disposition value and inject extra parameters.
+        malicious = 'report.txt"; x-evil="1'
+        attachment = tmp_path / malicious
+        attachment.write_bytes(b"data")
+        with SmtpHook() as smtp_hook:
+            msg, _ = smtp_hook._build_mime_message(
+                mail_from=FROM_EMAIL,
+                to=TO_EMAIL,
+                subject=TEST_SUBJECT,
+                html_content=TEST_BODY,
+                files=[os.fspath(attachment)],
+            )
+
+        part = msg.get_payload()[-1]
+        assert part.get_filename() == malicious
+        assert "x-evil" not in dict(part.get_params(header="Content-Disposition"))
+
+    @patch(smtplib_string)
     def test_send_smtp(self, mock_smtplib):
         mock_send_mime = mock_smtplib.SMTP_SSL().sendmail
         with SmtpHook() as smtp_hook, tempfile.NamedTemporaryFile() as attachment:


### PR DESCRIPTION
build_mime_message in airflow.utils.email and SmtpHook._build_mime_message build the attachment Content-Disposition with an f-string, so a filename containing a double quote breaks out of the quoted value and injects extra Content-Disposition parameters, letting a crafted attachment name override the filename the recipient's mail client shows or saves. Switch both to Message.add_header with a filename parameter, which lets the stdlib escape the value: ordinary names serialize exactly as before, an ASCII name with a quote is backslash-escaped inside the quoted-string, and non-ASCII names are RFC 2231 encoded. get_filename() round-trips in every case.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)