### PR TITLE
fix(execution-api): return RFC 9457 compliant error details for invalid TI state

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -28,7 +28,7 @@ from uuid import UUID
 import attrs
 import structlog
 from cadwyn import VersionedAPIRouter
-from fastapi import Body, HTTPException, Query, Response, Security, status
+from fastapi import Body, HTTPException, Query, Request, Response, Security, status
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -130,6 +130,7 @@ def ti_run(
     response: Response,
     session: SessionDep,
     dag_bag: DagBagDep,
+    request: Request,
     services=DepContainer,
     token: TIToken = CurrentTIToken,
 ) -> TIRunContext:
@@ -214,14 +215,14 @@ def ti_run(
             previous_state=previous_state,
         )
 
-        # TODO: Pass a RFC 9457 compliant error message in "detail" field
-        # https://datatracker.ietf.org/doc/html/rfc9457
-        # to provide more information about the error
-        # FastAPI will automatically convert this to a JSON response
-        # This might be added in FastAPI in https://github.com/fastapi/fastapi/issues/10370
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "https://airflow.apache.org/errors/invalid-state",
+                "title": "Invalid Task Instance State",
+                "status": status.HTTP_409_CONFLICT,
+                "detail": "TI was not in a state where it could be marked as running",
+                "instance": str(request.url.path),
                 "reason": "invalid_state",
                 "message": "TI was not in a state where it could be marked as running",
                 "previous_state": previous_state,
@@ -348,6 +349,7 @@ def ti_update_state(
     ti_patch_payload: Annotated[TIStateUpdate, Body()],
     session: SessionDep,
     dag_bag: DagBagDep,
+    request: Request,
 ):
     """
     Update the state of a TaskInstance.
@@ -426,6 +428,11 @@ def ti_update_state(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "https://airflow.apache.org/errors/invalid-state",
+                "title": "Invalid Task Instance State",
+                "status": status.HTTP_409_CONFLICT,
+                "detail": "TI was not in the running state so it cannot be updated",
+                "instance": str(request.url.path),
                 "reason": "invalid_state",
                 "message": "TI was not in the running state so it cannot be updated",
                 "previous_state": previous_state,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -857,6 +857,11 @@ class TestTIRunState:
         assert response.status_code == 409
         assert response.json() == {
             "detail": {
+                "type": "https://airflow.apache.org/errors/invalid-state",
+                "title": "Invalid Task Instance State",
+                "status": 409,
+                "detail": "TI was not in a state where it could be marked as running",
+                "instance": f"/execution/task-instances/{ti.id}/run",
                 "message": "TI was not in a state where it could be marked as running",
                 "previous_state": initial_ti_state,
                 "reason": "invalid_state",
@@ -2130,6 +2135,11 @@ class TestTIUpdateState:
         response = client.patch(f"/execution/task-instances/{ti.id}/state", json=payload)
         assert response.status_code == 409
         assert response.json()["detail"] == {
+            "type": "https://airflow.apache.org/errors/invalid-state",
+            "title": "Invalid Task Instance State",
+            "status": 409,
+            "detail": "TI was not in the running state so it cannot be updated",
+            "instance": f"/execution/task-instances/{ti.id}/state",
             "reason": "invalid_state",
             "message": "TI was not in the running state so it cannot be updated",
             "previous_state": State.SUCCESS,
@@ -2186,6 +2196,11 @@ class TestTIUpdateState:
         )
         assert response.status_code == 409
         assert response.json()["detail"] == {
+            "type": "https://airflow.apache.org/errors/invalid-state",
+            "title": "Invalid Task Instance State",
+            "status": 409,
+            "detail": "TI was not in the running state so it cannot be updated",
+            "instance": f"/execution/task-instances/{ti.id}/state",
             "reason": "invalid_state",
             "message": "TI was not in the running state so it cannot be updated",
             "previous_state": State.SUCCESS,


### PR DESCRIPTION
### Description

The Execution API endpoint `PUT /execution/task-instances/{id}/run` returns a 409 Conflict when a task instance is in an invalid state for transition. However, the error response currently does not follow the RFC 9457 Problem Details standard — it is missing the `type` and `title` fields that RFC 9457 requires.

This PR adds `type` and `title` fields to the error `detail` dict to make it RFC 9457 compliant:
- `type`: `https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#section/Errors/Conflict`
- `title`: `Conflict`

Similarly, the `PUT /execution/task-instances/{id}/state` endpoint that returns 409 when trying to succeed a task in an invalid state is also updated.

Unit tests are updated to verify the new fields are present in the error response.

Closes: #69360