### PR TITLE
 fix(standard-provider): convert all pendulum objects on virtualenv version mismatch

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -752,6 +752,19 @@ def _pendulum_to_native_datetime(obj):
             obj.microsecond,
             tzinfo=tz,
         )
+    if isinstance(obj, pendulum.Date):
+        return dt.date(obj.year, obj.month, obj.day)
+    if isinstance(obj, pendulum.Time):
+        return dt.time(obj.hour, obj.minute, obj.second, obj.microsecond)
+    if isinstance(obj, pendulum.Duration):
+        return dt.timedelta(seconds=obj.total_seconds())
+    if isinstance(obj, pendulum.tz.timezone.PendulumTimezone):
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        try:
+            return ZoneInfo(obj.name)
+        except (ZoneInfoNotFoundError, ValueError, KeyError):
+            return dt.timezone(obj.utcoffset(None))
     if isinstance(obj, dict):
         return {k: _pendulum_to_native_datetime(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv_script.jinja2
@@ -89,8 +89,15 @@ except ImportError:
 
 def _native_datetime_to_pendulum(obj):
     """Convert native datetime to pendulum DateTime (using virtualenv's pendulum version)."""
-    if _pendulum_available and isinstance(obj, _dt.datetime) and not isinstance(obj, _pendulum.DateTime):
-        return _pendulum.instance(obj)
+    if _pendulum_available:
+        if isinstance(obj, _dt.datetime) and not isinstance(obj, _pendulum.DateTime):
+            return _pendulum.instance(obj)
+        if isinstance(obj, _dt.date) and not isinstance(obj, _pendulum.Date):
+            return _pendulum.date(obj.year, obj.month, obj.day)
+        if isinstance(obj, _dt.time) and not isinstance(obj, _pendulum.Time):
+            return _pendulum.time(obj.hour, obj.minute, obj.second, obj.microsecond)
+        if isinstance(obj, _dt.timedelta) and not isinstance(obj, _pendulum.Duration):
+            return _pendulum.duration(seconds=obj.total_seconds())
     if isinstance(obj, dict):
         return {k: _native_datetime_to_pendulum(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):
@@ -99,19 +106,32 @@ def _native_datetime_to_pendulum(obj):
 
 def _pendulum_to_native_datetime(obj):
     """Convert pendulum DateTime to native datetime (using virtualenv's pendulum version)."""
-    if _pendulum_available and isinstance(obj, _pendulum.DateTime):
-        tz = None
-        if obj.timezone_name:
-            from zoneinfo import ZoneInfo
+    if _pendulum_available:
+        if isinstance(obj, _pendulum.DateTime):
+            tz = None
+            if obj.timezone_name:
+                from zoneinfo import ZoneInfo
+                try:
+                    tz = ZoneInfo(obj.timezone_name)
+                except KeyError:
+                    tz = _dt.timezone(obj.utcoffset()) if obj.utcoffset() is not None else None
+            return _dt.datetime(
+                obj.year, obj.month, obj.day,
+                obj.hour, obj.minute, obj.second, obj.microsecond,
+                tzinfo=tz,
+            )
+        if isinstance(obj, _pendulum.Date):
+            return _dt.date(obj.year, obj.month, obj.day)
+        if isinstance(obj, _pendulum.Time):
+            return _dt.time(obj.hour, obj.minute, obj.second, obj.microsecond)
+        if isinstance(obj, _pendulum.Duration):
+            return _dt.timedelta(seconds=obj.total_seconds())
+        if isinstance(obj, _pendulum.tz.timezone.PendulumTimezone):
+            from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
             try:
-                tz = ZoneInfo(obj.timezone_name)
-            except KeyError:
-                tz = _dt.timezone(obj.utcoffset()) if obj.utcoffset() is not None else None
-        return _dt.datetime(
-            obj.year, obj.month, obj.day,
-            obj.hour, obj.minute, obj.second, obj.microsecond,
-            tzinfo=tz,
-        )
+                return ZoneInfo(obj.name)
+            except (ZoneInfoNotFoundError, ValueError, KeyError):
+                return _dt.timezone(obj.utcoffset(None))
     if isinstance(obj, dict):
         return {k: _pendulum_to_native_datetime(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -2492,6 +2492,7 @@ class TestBranchPythonVirtualenvOperator(BaseTestBranchPythonVirtualenvOperator)
 
     @staticmethod
     def default_kwargs(*, python_version=DEFAULT_PYTHON_VERSION, **kwargs):
+        kwargs["python_version"] = python_version
         if "do_not_use_caching" in kwargs:
             kwargs.pop("do_not_use_caching")
         else:

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -2003,6 +2003,32 @@ class TestPythonVirtualenvOperator(_VenvTestBase):
         assert type(result["tuple"][0]) is datetime
         assert result["string"] == "test_value"
 
+    def test_pendulum_to_native_datetime_extended(self):
+        import datetime as dt
+        from zoneinfo import ZoneInfo
+
+        import pendulum
+
+        from airflow.providers.standard.operators.python import _pendulum_to_native_datetime
+
+        pd = pendulum.date(2025, 5, 3)
+        pt = pendulum.time(10, 30, 45, 123456)
+        dur = pendulum.duration(days=1, hours=2)
+        tz1 = pendulum.timezone("America/New_York")
+        tz2 = pendulum.timezone(3600)
+
+        assert type(_pendulum_to_native_datetime(pd)) is dt.date
+        assert not isinstance(_pendulum_to_native_datetime(pd), pendulum.Date)
+
+        assert type(_pendulum_to_native_datetime(pt)) is dt.time
+        assert not isinstance(_pendulum_to_native_datetime(pt), pendulum.Time)
+
+        assert type(_pendulum_to_native_datetime(dur)) is dt.timedelta
+        assert not isinstance(_pendulum_to_native_datetime(dur), pendulum.Duration)
+
+        assert type(_pendulum_to_native_datetime(tz1)) is ZoneInfo
+        assert type(_pendulum_to_native_datetime(tz2)) is dt.timezone
+
     @pytest.mark.parametrize(
         "serializer",
         [


### PR DESCRIPTION
### Description

When using `PythonVirtualenvOperator` with `pendulum<3` in the virtual environment while the host runs Pendulum v3, pickling/unpickling fails because Pendulum's internal representations are incompatible across major versions.

The existing `_pendulum_to_native_datetime` function only converts `pendulum.DateTime` objects to native `datetime.datetime`. However, other Pendulum types (`Date`, `Time`, `Duration`, `Timezone`) can also leak into serialized arguments and return values, causing `AttributeError` exceptions like `type object 'Timezone' has no attribute '_unpickle'`.

This PR extends both the host-side and guest-side conversion functions to handle all Pendulum types:
- `pendulum.Date` → `datetime.date`
- `pendulum.Time` → `datetime.time`
- `pendulum.Duration` → `datetime.timedelta`
- `pendulum.tz.timezone.PendulumTimezone` → `zoneinfo.ZoneInfo` or `datetime.timezone`

The guest-side `_native_datetime_to_pendulum` function in the Jinja2 template is also updated to convert the native types back to their Pendulum equivalents.

A new unit test `test_pendulum_to_native_datetime_extended` verifies all the new type conversions.

Closes: #50752