### PR TITLE
fix(execution-api): support connection IDs with slashes in get_connection route

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
 
 
 @router.get(
-    "/{connection_id}",
+    "/{connection_id:path}",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the connection"},

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
@@ -86,6 +86,28 @@ class TestGetConnection:
         session.delete(connection)
         session.commit()
 
+    def test_connection_get_with_slash(self, client, session):
+        # Clear any dirty state
+        session.query(Connection).filter(Connection.conn_id == "test/conn/with/slash").delete()
+        session.commit()
+
+        connection = Connection(
+            conn_id="test/conn/with/slash",
+            conn_type="http",
+            host="localhost",
+        )
+
+        session.add(connection)
+        session.commit()
+
+        try:
+            response = client.get("/execution/connections/test/conn/with/slash")
+            assert response.status_code == 200
+            assert response.json()["conn_id"] == "test/conn/with/slash"
+        finally:
+            session.delete(connection)
+            session.commit()
+
     @mock.patch.dict(
         "os.environ",
         {"AIRFLOW_CONN_TEST_CONN2": '{"uri": "http://root:admin@localhost:8080/https?headers=header"}'},


### PR DESCRIPTION
### Description

The Execution API endpoint `GET /execution/connections/{connection_id}` uses a standard path parameter `{connection_id}`, which causes FastAPI to treat slashes in connection IDs as path separators. This means connection IDs containing slashes (e.g. `my/slashed/conn`) return a 404 Not Found instead of resolving correctly.

This is inconsistent with the Variables endpoint which already uses `{variable_key:path}` to support keys with slashes.

This PR fixes the issue by changing the route definition from `/{connection_id}` to `/{connection_id:path}`, allowing connection IDs with slashes to be properly resolved.

A new unit test `test_connection_get_with_slash` is added to verify that connections with slashed IDs can be fetched successfully.

Closes: #57864