### PR TITLE
Fix SnowflakeSqlApiOperator polling to avoid needless sleeps

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowflake.py
@@ -491,11 +491,15 @@ class SnowflakeSqlApiOperator(SQLExecuteQueryOperator):
             if statement_status.get("status") == "error":
                 queries_in_progress.remove(query_id)
                 statement_error_status[query_id] = statement_status
-            if statement_status.get("status") == "success":
+            elif statement_status.get("status") == "success":
                 statement_success_status[query_id] = statement_status
                 queries_in_progress.remove(query_id)
-            if statement_status.get("status") == "running":
+            elif statement_status.get("status") == "running":
                 statement_running_status[query_id] = statement_status
+        # Only wait before the next poll cycle if something is still running. Sleeping
+        # unconditionally after every handle would delay returning even when this cycle
+        # already resolved everything (e.g. all statements finished, or one failed).
+        if queries_in_progress:
             time.sleep(self.poll_interval)
         return {
             "success": statement_success_status,

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -359,9 +359,7 @@ class TestSnowflakeSqlApiOperator:
         with pytest.raises(RuntimeError, match="Failed to get status for query uuid1"):
             operator.poll_on_queries()
 
-    def test_poll_on_queries_no_sleep_when_all_resolved(
-        self, mock_execute_query, mock_get_sql_api_query_status
-    ):
+    def test_poll_on_queries_no_sleep_when_all_resolved(self, mock_get_sql_api_query_status):
         operator = SnowflakeSqlApiOperator(
             task_id=TASK_ID,
             snowflake_conn_id="snowflake_default",
@@ -380,7 +378,7 @@ class TestSnowflakeSqlApiOperator:
         assert result["error"] == {"uuid2": {"status": "error"}}
         assert result["running"] == {}
 
-    def test_poll_on_queries_sleeps_once_per_cycle(self, mock_execute_query, mock_get_sql_api_query_status):
+    def test_poll_on_queries_sleeps_once_per_cycle(self, mock_get_sql_api_query_status):
         """One handle is still running, so the cycle sleeps -- but only once, not per handle."""
         operator = SnowflakeSqlApiOperator(
             task_id=TASK_ID,

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowflake.py
@@ -359,6 +359,49 @@ class TestSnowflakeSqlApiOperator:
         with pytest.raises(RuntimeError, match="Failed to get status for query uuid1"):
             operator.poll_on_queries()
 
+    def test_poll_on_queries_no_sleep_when_all_resolved(
+        self, mock_execute_query, mock_get_sql_api_query_status
+    ):
+        operator = SnowflakeSqlApiOperator(
+            task_id=TASK_ID,
+            snowflake_conn_id="snowflake_default",
+            sql=SQL_MULTIPLE_STMTS,
+            statement_count=4,
+            do_xcom_push=False,
+        )
+        operator.query_ids = ["uuid1", "uuid2"]
+        mock_get_sql_api_query_status.side_effect = [{"status": "success"}, {"status": "error"}]
+
+        with mock.patch("time.sleep") as mock_sleep:
+            result = operator.poll_on_queries()
+
+        mock_sleep.assert_not_called()
+        assert result["success"] == {"uuid1": {"status": "success"}}
+        assert result["error"] == {"uuid2": {"status": "error"}}
+        assert result["running"] == {}
+
+    def test_poll_on_queries_sleeps_once_per_cycle(self, mock_execute_query, mock_get_sql_api_query_status):
+        """One handle is still running, so the cycle sleeps -- but only once, not per handle."""
+        operator = SnowflakeSqlApiOperator(
+            task_id=TASK_ID,
+            snowflake_conn_id="snowflake_default",
+            sql=SQL_MULTIPLE_STMTS,
+            statement_count=4,
+            do_xcom_push=False,
+        )
+        operator.query_ids = ["uuid1", "uuid2", "uuid3"]
+        mock_get_sql_api_query_status.side_effect = [
+            {"status": "success"},
+            {"status": "running"},
+            {"status": "success"},
+        ]
+
+        with mock.patch("time.sleep") as mock_sleep:
+            result = operator.poll_on_queries()
+
+        mock_sleep.assert_called_once_with(operator.poll_interval)
+        assert result["running"] == {"uuid2": {"status": "running"}}
+
     @pytest.mark.parametrize(
         ("mock_sql", "statement_count"),
         [pytest.param(SQL_MULTIPLE_STMTS, 4, id="multi"), pytest.param(SINGLE_STMT, 1, id="single")],
@@ -581,18 +624,20 @@ class TestSnowflakeSqlApiOperator:
         mock_get_sql_api_query_status.side_effect = [
             # Initial get_sql_api_query_status check
             {"status": "running"},
-            # 1st poll_on_queries check (poll_interval: 5s)
+            # 1st poll_on_queries check (poll_interval: 5s) -- still running, sleeps
             {"status": "running"},
-            # 2nd poll_on_queries check (poll_interval: 5s)
+            # 2nd poll_on_queries check (poll_interval: 5s) -- still running, sleeps
             {"status": "running"},
-            # 3rd poll_on_queries check (poll_interval: 5s)
+            # 3rd poll_on_queries check -- resolves to success, no sleep needed
             {"status": "success"},
         ]
 
         with mock.patch("time.sleep") as mock_sleep:
             operator.execute(context=None)
             mock_check_query_output.assert_called_once_with(["uuid1"])
-            assert mock_sleep.call_count == 3
+            # Only 2 sleeps: the cycle that resolves the last running query returns
+            # immediately instead of sleeping once more before reporting success.
+            assert mock_sleep.call_count == 2
 
     def test_snowflake_sql_api_execute_operator_polling_failed(
         self, mock_execute_query, mock_get_sql_api_query_status, mock_check_query_output


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What

`SnowflakeSqlApiOperator.poll_on_queries()` polls the status of every submitted SQL API statement handle in a loop and waits `poll_interval` seconds between checks. It exists to avoid hammering the Snowflake SQL API while a query is still running.

### Current behaviour

The `time.sleep(self.poll_interval)` call sits inside the per-handle `for` loop, so it fires after every handle is checked, regardless of whether that handle (or any other) is still running. For a batch of N statement handles, a single call to `poll_on_queries()` can sleep for up to `N * poll_interval` seconds even when every handle already resolved to `success` or `error` on this pass. This adds pointless latency: a batch that just finished still waits before the operator can move on and report the result (or raise on failure).

### Proposed change

Move the sleep out of the per-handle loop to run at most once per call to `poll_on_queries()`, and only when at least one handle is still `running` after checking all of them. A cycle where everything already resolved (all succeeded, or one failed) now returns immediately instead of sleeping first.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
