### PR TITLE
Reduce Dag processor log noise from per-Dag run lookups

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -194,20 +194,20 @@ class _RunInfo(NamedTuple):
             return cls(None, 0)
 
         if dag.timetable.partitioned:
-            log.info("Getting latest run for partitioned Dag", dag_id=dag.dag_id)
+            log.debug("Getting latest run for partitioned Dag", dag_id=dag.dag_id)
             latest_run = session.scalar(_get_latest_runs_stmt_partitioned(dag_id=dag.dag_id))
         else:
-            log.info("Getting latest run for non-partitioned Dag", dag_id=dag.dag_id)
+            log.debug("Getting latest run for non-partitioned Dag", dag_id=dag.dag_id)
             latest_run = session.scalar(_get_latest_runs_stmt(dag_id=dag.dag_id))
         if latest_run:
-            log.info(
+            log.debug(
                 "got latest run",
                 dag_id=dag.dag_id,
                 logical_date=str(latest_run.logical_date),
                 partition_key=latest_run.partition_key,
             )
         else:
-            log.info("no latest run found", dag_id=dag.dag_id)
+            log.debug("no latest run found", dag_id=dag.dag_id)
         active_run_counts = DagRun.active_runs_of_dags(
             dag_ids=[dag.dag_id],
             exclude_backfill=True,


### PR DESCRIPTION
**Why**

- `_RunInfo.calculate` emitted four `INFO`-level log lines for every Dag on every parse round.
- In deployments with hundreds of Dags this floods the Dag processor logs with messages that carry no operator-actionable signal.

**What**

- Downgrade the four per-Dag lookup log lines in `_RunInfo.calculate` (`airflow-core/src/airflow/dag_processing/collection.py`) from `log.info` to `log.debug`:
  - "Getting latest run for partitioned Dag"
  - "Getting latest run for non-partitioned Dag"
  - "got latest run"
  - "no latest run found"
- No behavioural change beyond log verbosity; the diagnostics remain available at `DEBUG`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?


If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
