### PR TITLE
Reject invalid partition keys in the create asset events API

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -19,9 +19,18 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
-from pydantic import AliasPath, AwareDatetime, ConfigDict, Field, JsonValue, NonNegativeInt, field_validator
+from pydantic import (
+    AliasPath,
+    AwareDatetime,
+    ConfigDict,
+    Field,
+    JsonValue,
+    NonNegativeInt,
+    StringConstraints,
+    field_validator,
+)
 
 from airflow._shared.secrets_masker import redact
 from airflow._shared.timezones import timezone
@@ -191,18 +200,13 @@ class CreateAssetEventsBody(StrictBaseModel):
     """Create asset events request."""
 
     asset_id: int
-    partition_key: str | None = Field(default=None, max_length=ID_LEN)
+    # pattern (not strip_whitespace) so the value isn't mutated — must stay byte-identical to what
+    # `_validate_outlet_event_partition_keys` in the Execution API accepts for the same raw input.
+    partition_key: Annotated[str, StringConstraints(pattern=r"\S", max_length=ID_LEN)] | None = Field(
+        default=None
+    )
     extra: dict = Field(default_factory=dict)
     access_control: AssetEventAccessControl | None = None
-
-    @field_validator("partition_key")
-    @classmethod
-    def validate_partition_key(cls, v: str | None) -> str | None:
-        if v is None:
-            return v
-        if not v.strip():
-            raise ValueError("partition_key must not be empty or whitespace-only.")
-        return v
 
     @field_validator("extra", mode="after")
     def set_from_rest_api(cls, v: dict) -> dict:

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -202,8 +202,6 @@ class CreateAssetEventsBody(StrictBaseModel):
             return v
         if not v.strip():
             raise ValueError("partition_key must not be empty or whitespace-only.")
-        if len(v) > ID_LEN:
-            raise ValueError(f"partition_key must be at most {ID_LEN} characters; got {len(v)}.")
         return v
 
     @field_validator("extra", mode="after")

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -202,9 +202,7 @@ class CreateAssetEventsBody(StrictBaseModel):
     asset_id: int
     # pattern (not strip_whitespace) so the value isn't mutated — must stay byte-identical to what
     # `_validate_outlet_event_partition_keys` in the Execution API accepts for the same raw input.
-    partition_key: Annotated[str, StringConstraints(pattern=r"\S", max_length=ID_LEN)] | None = Field(
-        default=None
-    )
+    partition_key: Annotated[str, StringConstraints(pattern=r"\S", max_length=ID_LEN)] | None = None
     extra: dict = Field(default_factory=dict)
     access_control: AssetEventAccessControl | None = None
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -27,6 +27,7 @@ from airflow._shared.secrets_masker import redact
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel
 from airflow.api_fastapi.core_api.datamodels.dag_run import TriggerDAGRunPostBody
+from airflow.models.base import ID_LEN
 from airflow.utils.types import DagRunType
 
 if TYPE_CHECKING:
@@ -193,6 +194,17 @@ class CreateAssetEventsBody(StrictBaseModel):
     partition_key: str | None = None
     extra: dict = Field(default_factory=dict)
     access_control: AssetEventAccessControl | None = None
+
+    @field_validator("partition_key")
+    @classmethod
+    def validate_partition_key(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("partition_key must not be empty or whitespace-only.")
+        if len(v) > ID_LEN:
+            raise ValueError(f"partition_key must be at most {ID_LEN} characters; got {len(v)}.")
+        return v
 
     @field_validator("extra", mode="after")
     def set_from_rest_api(cls, v: dict) -> dict:

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/assets.py
@@ -191,7 +191,7 @@ class CreateAssetEventsBody(StrictBaseModel):
     """Create asset events request."""
 
     asset_id: int
-    partition_key: str | None = None
+    partition_key: str | None = Field(default=None, max_length=ID_LEN)
     extra: dict = Field(default_factory=dict)
     access_control: AssetEventAccessControl | None = None
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13265,6 +13265,7 @@ components:
           anyOf:
           - type: string
             maxLength: 250
+            pattern: \S
           - type: 'null'
           title: Partition Key
         extra:

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13264,6 +13264,7 @@ components:
         partition_key:
           anyOf:
           - type: string
+            maxLength: 250
           - type: 'null'
           title: Partition Key
         extra:

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2662,7 +2662,8 @@ export const $CreateAssetEventsBody = {
         partition_key: {
             anyOf: [
                 {
-                    type: 'string'
+                    type: 'string',
+                    maxLength: 250
                 },
                 {
                     type: 'null'

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -2663,7 +2663,8 @@ export const $CreateAssetEventsBody = {
             anyOf: [
                 {
                     type: 'string',
-                    maxLength: 250
+                    maxLength: 250,
+                    pattern: '\\S'
                 },
                 {
                     type: 'null'

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1353,6 +1353,13 @@ class TestPostAssetEvents(TestAssets):
         response = test_client.post("/assets/events", json=event_payload)
         assert response.status_code == expected_status_code
 
+    def test_partition_key_preserves_surrounding_whitespace(self, test_client, session):
+        (asset,) = self.create_assets(num=1, session=session)
+        event_payload = {"asset_id": asset.id, "partition_key": "  2026-03-23  "}
+        response = test_client.post("/assets/events", json=event_payload)
+        assert response.status_code == 200
+        assert response.json()["partition_key"] == "  2026-03-23  "
+
     @pytest.mark.usefixtures("time_freezer")
     @pytest.mark.enable_redact
     def test_should_mask_sensitive_extra(self, test_client, session):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -37,6 +37,7 @@ from airflow.models.asset import (
     DagScheduleAssetReference,
     TaskOutletAssetReference,
 )
+from airflow.models.base import ID_LEN
 from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.trigger import Trigger
@@ -1335,6 +1336,22 @@ class TestPostAssetEvents(TestAssets):
         response = test_client.post("/assets/events", json=event_invalid_payload)
 
         assert response.status_code == 422
+
+    @pytest.mark.parametrize(
+        ("partition_key", "expected_status_code"),
+        [
+            pytest.param("", 422, id="empty"),
+            pytest.param("   ", 422, id="whitespace_only"),
+            pytest.param("a" * (ID_LEN + 1), 422, id="too_long"),
+            pytest.param("2026-03-23", 200, id="valid"),
+            pytest.param(None, 200, id="none"),
+        ],
+    )
+    def test_partition_key_validation(self, test_client, session, partition_key, expected_status_code):
+        (asset,) = self.create_assets(num=1, session=session)
+        event_payload = {"asset_id": asset.id, "partition_key": partition_key}
+        response = test_client.post("/assets/events", json=event_payload)
+        assert response.status_code == expected_status_code
 
     @pytest.mark.usefixtures("time_freezer")
     @pytest.mark.enable_redact

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -432,7 +432,7 @@ class ConnectionTestResponse(BaseModel):
 
 
 class PartitionKey(RootModel[str]):
-    root: Annotated[str, Field(max_length=250, title="Partition Key")]
+    root: Annotated[str, Field(max_length=250, pattern="\\S", title="Partition Key")]
 
 
 class CreateAssetEventsBody(BaseModel):

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -431,6 +431,10 @@ class ConnectionTestResponse(BaseModel):
     message: Annotated[str, Field(title="Message")]
 
 
+class PartitionKey(RootModel[str]):
+    root: Annotated[str, Field(max_length=250, title="Partition Key")]
+
+
 class CreateAssetEventsBody(BaseModel):
     """
     Create asset events request.
@@ -440,7 +444,7 @@ class CreateAssetEventsBody(BaseModel):
         extra="forbid",
     )
     asset_id: Annotated[int, Field(title="Asset Id")]
-    partition_key: Annotated[str | None, Field(title="Partition Key")] = None
+    partition_key: Annotated[PartitionKey | None, Field(title="Partition Key")] = None
     extra: Annotated[dict[str, Any] | None, Field(title="Extra")] = None
     access_control: AssetEventAccessControl | None = None
 


### PR DESCRIPTION
## Why
`POST /assets/events` accepted any `partition_key` without validation. Two bad cases slipped through:

- Empty or whitespace-only keys were silently stored as-is.
- Keys longer than `ID_LEN` (250) chars hit the database column-length limit and surfaced as a `500 Internal Server Error`, leaking an internal failure instead of telling the client the input was invalid.

The Execution API already validates this field; the public API should behave the same way.

## What
- Add a `field_validator` on `CreateAssetEventsBody.partition_key` that rejects empty / whitespace-only values and values exceeding `ID_LEN`, returning `422` instead of storing bad data or raising `500`.
- `None` remains valid (the field stays optional), so non-partitioned events are unaffected.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
