### PR TITLE
Reject inverted date windows in airflow partitions clear

### DIFF
--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -44,7 +44,9 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
     the matching partitions; a date-only value (no time) is treated as local
     midnight.
     """
-    has_range = args.start_date is not None or args.end_date is not None or args.date is not None
+    has_start = args.start_date is not None
+    has_end = args.end_date is not None
+    has_range = has_start or has_end or args.date is not None
     selectors_used = sum([args.run_id is not None, args.partition_key is not None, has_range])
     if selectors_used != 1:
         raise SystemExit(
@@ -53,7 +55,7 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         )
 
     if args.date is not None:
-        if args.start_date is not None or args.end_date is not None:
+        if has_start or has_end:
             raise SystemExit("--date cannot be combined with --start-date / --end-date.")
         raw = args.date
         parts = raw.split("~", 1)
@@ -64,8 +66,12 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             args.end_date = parsedate(parts[1].strip())
         except ValueError:
             raise SystemExit("--date sides must be parseable as a date or datetime.")
+        has_start = has_end = True
 
-    has_date_window = args.start_date is not None or args.end_date is not None
+    if has_start and has_end and args.start_date > args.end_date:
+        raise SystemExit("--start-date must be on or before --end-date.")
+
+    has_date_window = has_start or has_end
     dag = get_db_dag(bundle_names=None, dag_id=args.dag_id) if has_date_window else None
     clear_tis = bool(args.clear_task_instances)
 

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -54,7 +54,9 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             "(--start-date/--end-date or --date)."
         )
 
-    if args.date is not None:
+    from_date_flag = args.date is not None
+
+    if from_date_flag:
         if has_start or has_end:
             raise SystemExit("--date cannot be combined with --start-date / --end-date.")
         raw = args.date
@@ -69,6 +71,11 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
         has_start = has_end = True
 
     if has_start and has_end and args.start_date > args.end_date:
+        if from_date_flag:
+            raise SystemExit(
+                f"--date: the start of the range ({parts[0].strip()!r}) must be on or before "
+                f"the end ({parts[1].strip()!r})."
+            )
         raise SystemExit("--start-date must be on or before --end-date.")
 
     has_date_window = has_start or has_end

--- a/airflow-core/src/airflow/cli/commands/partition_command.py
+++ b/airflow-core/src/airflow/cli/commands/partition_command.py
@@ -70,16 +70,22 @@ def clear(args, *, session: Session = NEW_SESSION) -> None:
             raise SystemExit("--date sides must be parseable as a date or datetime.")
         has_start = has_end = True
 
-    if has_start and has_end and args.start_date > args.end_date:
-        if from_date_flag:
-            raise SystemExit(
-                f"--date: the start of the range ({parts[0].strip()!r}) must be on or before "
-                f"the end ({parts[1].strip()!r})."
-            )
-        raise SystemExit("--start-date must be on or before --end-date.")
-
     has_date_window = has_start or has_end
-    dag = get_db_dag(bundle_names=None, dag_id=args.dag_id) if has_date_window else None
+    if has_date_window:
+        dag = get_db_dag(bundle_names=None, dag_id=args.dag_id)
+        if has_start and has_end:
+            lower = dag.timetable.localize_partition_datetime(args.start_date)
+            upper = dag.timetable.localize_partition_datetime(args.end_date)
+            if lower > upper:
+                if from_date_flag:
+                    raise SystemExit(
+                        f"--date: the start of the range ({parts[0].strip()!r}) must be on or before "
+                        f"the end ({parts[1].strip()!r})."
+                    )
+                raise SystemExit("--start-date must be on or before --end-date.")
+    else:
+        dag = None
+
     clear_tis = bool(args.clear_task_instances)
 
     processed_any = False

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -761,16 +761,22 @@ class TestPartitionsClear:
         assert "--date must be in the form 'a~b'" in str(excinfo.value.code)
 
     @pytest.mark.parametrize(
-        "cli_args",
+        ("cli_args", "expected_message"),
         [
-            ["--start-date", "2026-01-03", "--end-date", "2026-01-01"],
-            ["--date", "2026-01-03~2026-01-01"],
+            (
+                ["--start-date", "2026-01-03", "--end-date", "2026-01-01"],
+                "--start-date must be on or before --end-date.",
+            ),
+            (
+                ["--date", "2026-01-03~2026-01-01"],
+                "--date: the start of the range ('2026-01-03') must be on or before the end ('2026-01-01').",
+            ),
         ],
     )
-    def test_inverted_date_window_is_rejected(self, parser, cli_args):
+    def test_inverted_date_window_is_rejected(self, parser, cli_args, expected_message):
         with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, *cli_args]))
-        assert excinfo.value.code == "--start-date must be on or before --end-date."
+        assert excinfo.value.code == expected_message
 
     def test_equal_start_and_end_date_is_accepted(self, parser, capsys):
         partition_command.clear(

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -800,6 +800,102 @@ class TestPartitionsClear:
             "Cleared partition fields on 1 DagRun(s).\n"
         )
 
+    def test_offset_aware_window_false_rejection_is_accepted(self, parser, dag_maker):
+        """Absolute-instant order disagrees with Asia/Taipei-localized wall-clock order.
+
+        --start-date 2026-01-01T00:00:00+00:00 (instant Jan1 00:00Z) is *after* the
+        instant of --end-date 2026-01-01T01:00:00+10:00 (Dec31 15:00Z), so a raw
+        instant comparison would wrongly flag this as an inverted window. Once each
+        bound's wall-clock reading is localized to the Dag's Asia/Taipei timetable
+        timezone (matching downstream ``apply_partition_date_window``), the window
+        becomes [Dec31 16:00Z, Dec31 17:00Z) -- lower before upper, valid -- and the
+        run seeded inside it must be cleared.
+        """
+        dag_id = "dag_taipei_offset_false_rejection"
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            dag_id,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone="Asia/Taipei"),
+            start_date=datetime(2025, 1, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        dag_maker.create_dagrun(
+            run_id="in_window_run",
+            state=DagRunState.SUCCESS,
+            logical_date=None,
+            partition_date=datetime(2025, 12, 31, 16, 30, 0, tzinfo=pendulum.UTC),
+            partition_key="in-window",
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    dag_id,
+                    "--start-date",
+                    "2026-01-01T00:00:00+00:00",
+                    "--end-date",
+                    "2026-01-01T01:00:00+10:00",
+                ]
+            )
+        )
+
+        run = _get_run("in_window_run")
+        assert run.partition_key is None
+        assert run.partition_date is None
+
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_offset_aware_window_false_acceptance_is_rejected(self, parser, dag_maker):
+        """Absolute-instant order disagrees with Asia/Taipei-localized wall-clock order.
+
+        --start-date 2026-01-01T05:00:00+00:00 (instant Jan1 05:00Z) is *before* the
+        instant of --end-date 2026-01-01T04:00:00-10:00 (Jan1 14:00Z), so a raw
+        instant comparison would wrongly accept this window. Once each bound's
+        wall-clock reading is localized to the Dag's Asia/Taipei timetable timezone,
+        the window is [Dec31 21:00Z, Dec31 20:00Z) -- lower after upper, inverted --
+        and clear() must reject it with the same message as the UTC-only case.
+        """
+        dag_id = "dag_taipei_offset_false_acceptance"
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            dag_id,
+            schedule=CronPartitionTimetable("0 0 * * *", timezone="Asia/Taipei"),
+            start_date=datetime(2025, 1, 1, tzinfo=pendulum.UTC),
+            catchup=True,
+            serialized=True,
+        ):
+            EmptyOperator(task_id="t1")
+        dag_maker.sync_dagbag_to_db()
+
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(
+                parser.parse_args(
+                    [
+                        "partitions",
+                        "clear",
+                        "--dag-id",
+                        dag_id,
+                        "--start-date",
+                        "2026-01-01T05:00:00+00:00",
+                        "--end-date",
+                        "2026-01-01T04:00:00-10:00",
+                    ]
+                )
+            )
+        assert excinfo.value.code == "--start-date must be on or before --end-date."
+
+        clear_db_runs()
+        clear_db_dags()
+
     def test_date_range_syntax_mutually_exclusive_with_start_end(self, parser):
         with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(

--- a/airflow-core/tests/unit/cli/commands/test_partition_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_partition_command.py
@@ -760,6 +760,40 @@ class TestPartitionsClear:
             )
         assert "--date must be in the form 'a~b'" in str(excinfo.value.code)
 
+    @pytest.mark.parametrize(
+        "cli_args",
+        [
+            ["--start-date", "2026-01-03", "--end-date", "2026-01-01"],
+            ["--date", "2026-01-03~2026-01-01"],
+        ],
+    )
+    def test_inverted_date_window_is_rejected(self, parser, cli_args):
+        with pytest.raises(SystemExit) as excinfo:
+            partition_command.clear(parser.parse_args(["partitions", "clear", "--dag-id", DAG_ID, *cli_args]))
+        assert excinfo.value.code == "--start-date must be on or before --end-date."
+
+    def test_equal_start_and_end_date_is_accepted(self, parser, capsys):
+        partition_command.clear(
+            parser.parse_args(
+                [
+                    "partitions",
+                    "clear",
+                    "--dag-id",
+                    DAG_ID,
+                    "--start-date",
+                    "2026-01-02",
+                    "--end-date",
+                    "2026-01-02",
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert captured.out == (
+            "DagRun part_run_2: partition_key='2026-01-02T00:00:00' -> None, "
+            "partition_date=2026-01-02T00:00:00+00:00 -> None\n"
+            "Cleared partition fields on 1 DagRun(s).\n"
+        )
+
     def test_date_range_syntax_mutually_exclusive_with_start_end(self, parser):
         with pytest.raises(SystemExit) as excinfo:
             partition_command.clear(


### PR DESCRIPTION
### Why
`airflow partitions clear` silently reported no matching Dag runs when given an inverted date window — a `--start-date` later than `--end-date`, or a `--date 'a~b'` range where `a` is after `b`. The command treated it as a valid-but-empty window instead of flagging the mistake, so a user who transposed the two dates got a misleading "nothing matched" result rather than an error. This is inconsistent with `dags clear --partition-date-start/--partition-date-end` and the REST `partition_date_start`/`partition_date_end` fields, which already reject inverted
windows with the equivalent message.

### What

- Add an ordering check in `partition_command.clear`: when both bounds are present and `start_date > end_date`, raise `SystemExit` with `--start-date must be on or before --end-date.`
- Apply the check uniformly to both input forms — explicit `--start-date` / `--end-date` flags and the `--date 'a~b'` range shorthand — by normalizing the parsed range into the same `has_start` / `has_end` bounds before validating.
- Equal start and end dates remain valid (a single-day window).

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
