### PR TITLE
Reduce K8s test resource usage with single-node Kind clusters

### DIFF
--- a/.github/workflows/kustomize-overlays-tests.yml
+++ b/.github/workflows/kustomize-overlays-tests.yml
@@ -102,13 +102,13 @@ jobs:
       #                          convention (sources come from the base
       #                          image, not the workspace).
       #   5. upload-k8s-image  -> loads the now-built kubernetes-variant
-      #                           image into every kind node, so kubelet
+      #                           image into the kind node, so kubelet
       #                           can resolve the chart's image reference
       #                           without hitting ghcr (which is private).
       #   6. deploy-airflow
       #   7. smoke-test-overlay  -> renders the overlay, auto-preloads the
       #                             overlay's own images into the kind
-      #                             nodes (no per-overlay images list
+      #                             node (no per-overlay images list
       #                             needed - discovery walks the rendered
       #                             manifest), applies, walks the
       #                             STATUS.yaml verify: block with
@@ -124,7 +124,7 @@ jobs:
         run: breeze k8s configure-cluster
       - name: "Build kubernetes-variant image on top of the restored PROD image"
         run: breeze k8s build-k8s-image --no-copy-local-sources
-      - name: "Upload kubernetes-variant image to kind nodes"
+      - name: "Upload kubernetes-variant image to the kind node"
         run: breeze k8s upload-k8s-image
       - name: "Deploy Airflow chart"
         run: breeze k8s deploy-airflow --executor CeleryExecutor

--- a/contributing-docs/testing/k8s_tests.rst
+++ b/contributing-docs/testing/k8s_tests.rst
@@ -282,7 +282,6 @@ Should result in KinD creating the K8S cluster.
       apiServerPort: 48366
     nodes:
       - role: control-plane
-      - role: worker
         extraPortMappings:
           - containerPort: 30007
             hostPort: 18150
@@ -291,12 +290,11 @@ Should result in KinD creating the K8S cluster.
 
     Creating cluster "airflow-python-3.10-v1.24.2" ...
      ✓ Ensuring node image (kindest/node:v1.24.2) 🖼
-     ✓ Preparing nodes 📦 📦
+     ✓ Preparing nodes 📦
      ✓ Writing configuration 📜
      ✓ Starting control-plane 🕹️
      ✓ Installing CNI 🔌
      ✓ Installing StorageClass 💾
-     ✓ Joining worker nodes 🚜
     Set kubectl context to "kind-airflow-python-3.10-v1.24.2"
     You can now use your cluster with:
 
@@ -379,11 +377,9 @@ Should show the status of current KinD cluster.
     coredns-6d4b75cb6d-rwp9d                                           1/1     Running   0          71s
     coredns-6d4b75cb6d-vqnrc                                           1/1     Running   0          71s
     etcd-airflow-python-3.10-v1.24.2-control-plane                     1/1     Running   0          84s
-    kindnet-ckc8l                                                      1/1     Running   0          69s
     kindnet-qqt8k                                                      1/1     Running   0          71s
     kube-apiserver-airflow-python-3.10-v1.24.2-control-plane           1/1     Running   0          84s
     kube-controller-manager-airflow-python-3.10-v1.24.2-control-plane  1/1     Running   0          84s
-    kube-proxy-6g7hn                                                   1/1     Running   0          69s
     kube-proxy-dwfvp                                                   1/1     Running   0          71s
     kube-scheduler-airflow-python-3.10-v1.24.2-control-plane            1/1     Running   0          84s
 
@@ -449,7 +445,6 @@ Should show the status of current KinD cluster.
     Good version of helm installed: 3.9.2 in /Users/jarek/IdeaProjects/airflow/kubernetes-tests/.venv/bin
     Stable repo is already added
     Uploading Airflow image ghcr.io/apache/airflow/main/prod/python3.10-kubernetes to cluster airflow-python-3.10-v1.24.2
-    Image: "ghcr.io/apache/airflow/main/prod/python3.10-kubernetes" with ID "sha256:fb6195f7c2c2ad97788a563a3fe9420bf3576c85575378d642cd7985aff97412" not yet present on node "airflow-python-3.10-v1.24.2-worker", loading...
     Image: "ghcr.io/apache/airflow/main/prod/python3.10-kubernetes" with ID "sha256:fb6195f7c2c2ad97788a563a3fe9420bf3576c85575378d642cd7985aff97412" not yet present on node "airflow-python-3.10-v1.24.2-control-plane", loading...
 
     NEXT STEP: You might now deploy Airflow by:

--- a/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/kubernetes_utils.py
@@ -402,12 +402,28 @@ def set_random_cluster_ports(python: str, kubernetes_version: str, output: Outpu
     get_console(output=output).print("\n")
 
 
+# Must match containerPort in scripts/ci/kubernetes/kind-cluster-conf.yaml and
+# nodePort in scripts/ci/kubernetes/nodeport.yaml.
+FORWARDED_NODE_PORT = 30007
+
+
+def _extract_forwarded_host_port(conf: dict[str, Any]) -> int:
+    for node in conf["nodes"]:
+        for port_mapping in node.get("extraPortMappings", []):
+            if port_mapping["containerPort"] == FORWARDED_NODE_PORT:
+                return port_mapping["hostPort"]
+    raise ValueError(
+        f"No node in the kind cluster config has an extraPortMappings entry for "
+        f"containerPort {FORWARDED_NODE_PORT}. Delete and recreate the cluster."
+    )
+
+
 def get_kubernetes_port_numbers(python: str, kubernetes_version: str) -> tuple[int, int]:
     conf = _get_kind_cluster_config_content(python=python, kubernetes_version=kubernetes_version)
     if not conf:
         return 0, 0
     k8s_api_server_port = conf["networking"]["apiServerPort"]
-    api_server_port = conf["nodes"][1]["extraPortMappings"][0]["hostPort"]
+    api_server_port = _extract_forwarded_host_port(conf)
     return k8s_api_server_port, api_server_port
 
 

--- a/dev/breeze/tests/test_kubernetes_utils.py
+++ b/dev/breeze/tests/test_kubernetes_utils.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from airflow_breeze.utils.kubernetes_utils import get_kubernetes_port_numbers
+
+SINGLE_NODE_CONFIG = """\
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ipv4
+  apiServerAddress: "127.0.0.1"
+  apiServerPort: 48366
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30007
+        hostPort: 18150
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+"""
+
+# Rendered config of a cluster created before the switch to single-node clusters —
+# port extraction must keep working for clusters that already exist on disk.
+LEGACY_TWO_NODE_CONFIG = """\
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ipv4
+  apiServerAddress: "127.0.0.1"
+  apiServerPort: 48366
+nodes:
+  - role: control-plane
+  - role: worker
+    extraPortMappings:
+      - containerPort: 30007
+        hostPort: 18150
+        listenAddress: "127.0.0.1"
+        protocol: TCP
+"""
+
+NO_FORWARDED_PORT_CONFIG = """\
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: ipv4
+  apiServerAddress: "127.0.0.1"
+  apiServerPort: 48366
+nodes:
+  - role: control-plane
+"""
+
+
+@pytest.mark.parametrize(
+    "config", [SINGLE_NODE_CONFIG, LEGACY_TWO_NODE_CONFIG], ids=["single-node", "legacy-two-node"]
+)
+@patch("airflow_breeze.utils.kubernetes_utils._get_kind_cluster_config_content", autospec=True)
+def test_get_kubernetes_port_numbers_extracts_ports_from_any_node(mock_get_content, config):
+    mock_get_content.return_value = yaml.safe_load(config)
+    assert get_kubernetes_port_numbers(python="3.10", kubernetes_version="v1.30.13") == (48366, 18150)
+
+
+@patch("airflow_breeze.utils.kubernetes_utils._get_kind_cluster_config_content", autospec=True)
+def test_get_kubernetes_port_numbers_raises_when_forwarded_port_mapping_is_missing(mock_get_content):
+    mock_get_content.return_value = yaml.safe_load(NO_FORWARDED_PORT_CONFIG)
+    with pytest.raises(ValueError, match="extraPortMappings"):
+        get_kubernetes_port_numbers(python="3.10", kubernetes_version="v1.30.13")

--- a/scripts/ci/kubernetes/kind-cluster-conf.yaml
+++ b/scripts/ci/kubernetes/kind-cluster-conf.yaml
@@ -23,7 +23,6 @@ networking:
   apiServerPort: {{API_SERVER_PORT}}
 nodes:
   - role: control-plane
-  - role: worker
     extraPortMappings:
       - containerPort: 30007
         hostPort: {{FORWARDED_PORT_NUMBER}}


### PR DESCRIPTION
The K8s test Kind clusters have used a control-plane + worker topology since the original Kind migration in 2019 (#5837), and it was never revisited. Nothing uses the second node: workload pods can never schedule on the control-plane (`NoSchedule` taint), yet `kind load` copies the ~1.8GB Airflow image and the pinned test images into **every** node — the control-plane copy is pure overhead. No test depends on the topology.

This switches the cluster to a single control-plane node (Kind's own default), which runs the workloads too — Kind removes the taint on single-node clusters.

## Changes

- `kind-cluster-conf.yaml`: drop the worker node, move `extraPortMappings` to the control-plane
- `get_kubernetes_port_numbers()`: the forwarded port was read from the hard-coded `nodes[1]`, which raises `IndexError` on the new config; it now looks the mapping up by `containerPort`, so rendered configs of clusters created **before** this change keep working too
- unit tests for the port extraction (single-node / legacy two-node / missing mapping)
- doc sample outputs and workflow comments updated to match

## Local benchmark

Single run, Apple-silicon macOS + Docker Desktop, same image on both sides, KubernetesExecutor, python 3.10 / K8s v1.30.13:

| metric | two-node (main) | single-node (this PR) | delta |
|---|---|---|---|
| `upload-k8s-image` | 114.1s | 66.4s | **−42%** |
| containerd disk, all nodes | 15.1 GB | 7.8 GB | **−48%** |
| memory after deploy, all nodes | ~3.39 GiB | ~2.65 GiB | **−22%** |
| `kind create cluster` ¹ | 50.5s | 16.8s | **−67%** |
| `deploy-airflow` | 97.0s | 83.9s | −14% |
| test results | 57 passed / 3 skipped | 57 passed / 3 skipped | identical |

¹ measured with plain `kind create cluster` and the node image cached on both sides, isolating the topology effect — the worker join is the expensive part.

## Verification

- KubernetesExecutor suite on the single-node cluster: 57 passed / 3 skipped — identical to the two-node baseline
- CeleryExecutor (largest pod count: redis + celery workers): 53 passed / 7 skipped, including the two Celery-specific tests that are skipped under KubernetesExecutor

Every job in the CI K8s matrix (36 `K8S System` jobs per canary run, ~500 job-minutes) pays the double image load today. I'll post a per-job duration comparison against recent canary runs once CI has run on this PR.

## Validation

- `uv run --project dev/breeze pytest dev/breeze/tests/test_kubernetes_utils.py -xvs`
- `prek run --from-ref main --stage pre-commit`
- full manual `breeze k8s` flow (create / configure / upload / deploy / tests / delete) for both executors above

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-28T17:14:26Z head=721f60f action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @aaron-y-chen** · by `@potiuk` · 2026-07-28 17:14 UTC
>
> This draft PR has had no activity for several weeks. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **430 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
