### PR TITLE
Gate release image and docs publish workflows via release environment

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -101,22 +101,11 @@ jobs:
       default-python-version: "3.10"
       registry-providers: ${{ steps.derive_registry_inputs.outputs.registry-providers }}
       registry-full-build: ${{ steps.derive_registry_inputs.outputs.registry-full-build }}
-    if: contains(fromJSON('[
-      "ashb",
-      "bugraoz93",
-      "eladkal",
-      "ephraimbuddy",
-      "jedcunningham",
-      "jscheffl",
-      "kaxil",
-      "pierrejeambrun",
-      "shahar1",
-      "potiuk",
-      "uranusjr",
-      "utkarsharma2",
-      "vincbeck",
-      "vatsrahul1001",
-      ]'), github.event.sender.login)
+    # Access is gated by the RM-only "release" deployment environment, which
+    # replaces the previous hardcoded release-manager allowlist. The environment
+    # must be configured by ASF INFRA with release managers as required
+    # reviewers - see https://github.com/apache/airflow/issues/69460
+    environment: release
     steps:
       - name: "Checkout for wave provider derivation"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -112,23 +112,11 @@ jobs:
       image-stash-ref: "publish-docs-${{ inputs.ref }}"
       registry-providers: ${{ steps.derive_registry_inputs.outputs.registry-providers }}
       registry-full-build: ${{ steps.derive_registry_inputs.outputs.registry-full-build }}
-    if: contains(fromJSON('[
-      "ashb",
-      "bugraoz93",
-      "eladkal",
-      "ephraimbuddy",
-      "hussein-awala",
-      "jedcunningham",
-      "jscheffl",
-      "kaxil",
-      "o-nikolas",
-      "pierrejeambrun",
-      "shahar1",
-      "potiuk",
-      "uranusjr",
-      "vincbeck",
-      "vatsrahul1001",
-      ]'), github.event.sender.login)
+    # Access is gated by the RM-only "release" deployment environment, which
+    # replaces the previous hardcoded release-manager allowlist. The environment
+    # must be configured by ASF INFRA with release managers as required
+    # reviewers - see https://github.com/apache/airflow/issues/69460
+    environment: release
     steps:
       - name: "Checkout for wave provider derivation"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -57,21 +57,11 @@ jobs:
       AIRFLOW_VERSION: ${{ github.event.inputs.airflowVersion }}
       AMD_ONLY: ${{ github.event.inputs.amdOnly }}
       LIMIT_PYTHON_VERSIONS: ${{ github.event.inputs.limitPythonVersions }}
-    if: contains(fromJSON('[
-      "ashb",
-      "bugraoz93",
-      "eladkal",
-      "ephraimbuddy",
-      "jedcunningham",
-      "jscheffl",
-      "kaxil",
-      "pierrejeambrun",
-      "potiuk",
-      "uranusjr",
-      "utkarsharma2",
-      "vincbeck",
-      "vatsrahul1001",
-      ]'), github.event.sender.login)
+    # Access is gated by the RM-only "release" deployment environment, which
+    # replaces the previous hardcoded release-manager allowlist. The environment
+    # must be configured by ASF INFRA with release managers as required
+    # reviewers - see https://github.com/apache/airflow/issues/69460
+    environment: release
     steps:
       - name: "Input parameters summary"
         shell: bash


### PR DESCRIPTION
Manual, release-process workflows restrict who may trigger them by duplicating a hardcoded release-manager allowlist as an `if: contains(fromJSON('[...]'), github.event.sender.login)` on the first job. The list drifts across files, only gates the *actor* (not the secrets consumed), and is easy to get wrong.

This replaces those allowlists in the **prod image release** (`release_dockerhub_image.yml`) and **docs-to-S3 publish** (`publish-docs-to-s3.yml`) workflows with a dedicated, RM-only `release` **deployment environment** referenced by the entry job. Access control and secret scoping then live in one place.

**Draft** because the `release` environment must first be created by ASF INFRA with release managers as required reviewers. Until it exists with protection rules, a job referencing it runs ungated — so this must not merge before INFRA sets it up (the issue's open question is exactly what `.asf.yaml` can express here).

Deliberately **not** in this PR (tracked in #69460 / the follow-up):
- `update-constraints-on-push.yml` — its manual dispatch is added in #69457; convert once that merges.
- `registry-backfill.yml` / `registry-build.yml` — their entry job is a reusable-workflow call, which can't carry `environment:`; needs a small gating-job restructure.
- `release_single_dockerhub_image.yml` DOCKERHUB secret scoping.
- CI-time secret workflows + re-enabling zizmor `secrets-outside-env`.

Part of #69460.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
