### PR TITLE
Handle IMAP attachment filename collisions

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -193,6 +193,7 @@ class ImapHook(BaseHook):
         mail_folder: str = "INBOX",
         mail_filter: str = "All",
         not_found_mode: str = "raise",
+        overwrite_file: bool = True,
     ) -> None:
         """
         Download mail's attachments in the mail folder by its name to the local directory.
@@ -211,6 +212,10 @@ class ImapHook(BaseHook):
             If it is set to 'raise' it will raise an exception,
             if set to 'warn' it will only print a warning and
             if set to 'ignore' it won't notify you at all.
+        :param overwrite_file: Specify what should happen when a downloaded attachment
+            has the same filename as an existing file. If set to True, the existing file
+            is overwritten. If set to False, a numeric suffix is appended before the
+            final extension, for example ``report_1.csv`` or ``archive.tar_1.gz``.
         """
         mail_attachments = self._retrieve_mails_attachments_by_name(
             name, check_regex, latest_only, max_mails, mail_folder, mail_filter
@@ -219,7 +224,7 @@ class ImapHook(BaseHook):
         if not mail_attachments:
             self._handle_not_found_mode(not_found_mode)
 
-        self._create_files(mail_attachments, local_output_directory)
+        self._create_files(mail_attachments, local_output_directory, overwrite_file)
 
     def _handle_not_found_mode(self, not_found_mode: str) -> None:
         if not_found_mode not in ("raise", "warn", "ignore"):
@@ -287,14 +292,16 @@ class ImapHook(BaseHook):
             return mail.get_attachments_by_name(name, check_regex, find_first=latest_only)
         return []
 
-    def _create_files(self, mail_attachments: list, local_output_directory: str) -> None:
+    def _create_files(
+        self, mail_attachments: list, local_output_directory: str, overwrite_file: bool = True
+    ) -> None:
         for name, payload in mail_attachments:
             if self._is_symlink(name):
                 self.log.error("Can not create file because it is a symlink!")
             elif self._is_escaping_current_directory(name):
                 self.log.error("Can not create file because it is escaping the current directory!")
             else:
-                self._create_file(name, payload, local_output_directory)
+                self._create_file(name, payload, local_output_directory, overwrite_file)
 
     def _is_symlink(self, name: str) -> bool:
         # IMPORTANT NOTE: os.path.islink is not working for windows symlinks
@@ -311,11 +318,26 @@ class ImapHook(BaseHook):
             else local_output_directory + os.sep + name
         )
 
-    def _create_file(self, name: str, payload: Any, local_output_directory: str) -> None:
+    def _create_file(
+        self, name: str, payload: Any, local_output_directory: str, overwrite_file: bool = True
+    ) -> None:
         file_path = self._correct_path(name, local_output_directory)
 
-        with open(file_path, "wb") as file:
-            file.write(payload)
+        if overwrite_file:
+            with open(file_path, "wb") as file:
+                file.write(payload)
+            return
+
+        filename, extension = os.path.splitext(name)
+        counter = 1
+        while True:
+            try:
+                with open(file_path, "xb") as file:
+                    file.write(payload)
+                return
+            except FileExistsError:
+                file_path = self._correct_path(f"{filename}_{counter}{extension}", local_output_directory)
+                counter += 1
 
 
 class Mail(LoggingMixin):

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -408,6 +408,45 @@ class TestImapHook:
         mock_imaplib.IMAP4_SSL.return_value.search.assert_called_once_with(None, mail_filter)
         assert mock_open_method.call_count == 1
 
+    @pytest.mark.parametrize(
+        ("attachment_name", "expected_filenames"),
+        [
+            ("test1.csv", ["test1.csv", "test1_1.csv", "test1_2.csv"]),
+            ("README", ["README", "README_1", "README_2"]),
+            ("archive.tar.gz", ["archive.tar.gz", "archive.tar_1.gz", "archive.tar_2.gz"]),
+        ],
+    )
+    def test_create_file_without_overwrite_preserves_existing_files(
+        self, tmp_path, attachment_name, expected_filenames
+    ):
+        imap_hook = ImapHook()
+
+        for payload in (b"first", b"second", b"third"):
+            imap_hook._create_file(
+                name=attachment_name,
+                payload=payload,
+                local_output_directory=str(tmp_path),
+                overwrite_file=False,
+            )
+
+        assert sorted(path.name for path in tmp_path.iterdir()) == sorted(expected_filenames)
+        assert [path.read_bytes() for path in sorted(tmp_path.iterdir())] == [b"first", b"second", b"third"]
+
+    @pytest.mark.parametrize("attachment_name", ["test1.csv", "README", "archive.tar.gz"])
+    def test_create_file_with_overwrite_replaces_existing_file(self, tmp_path, attachment_name):
+        imap_hook = ImapHook()
+
+        for payload in (b"first", b"second", b"third"):
+            imap_hook._create_file(
+                name=attachment_name,
+                payload=payload,
+                local_output_directory=str(tmp_path),
+                overwrite_file=True,
+            )
+
+        assert [path.name for path in tmp_path.iterdir()] == [attachment_name]
+        assert (tmp_path / attachment_name).read_bytes() == b"third"
+
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_with_max_mails(self, mock_imaplib):
         mock_conn = _create_fake_imap(mock_imaplib, with_mail=True)
@@ -481,7 +520,6 @@ class TestImapHook:
 
     @patch(imaplib_string)
     def test_retrieve_mail_attachments_with_plaintext_rfc2047_encoded_filename(self, mock_imaplib):
-
         # Filename contains a mix of plain text and RFC 2047 encoded text.
         # Example: 'bar =?utf-8?B?ZsOzbw==?=' decodes to 'bar fóo'
         encoded_name = "bar =?utf-8?B?ZsOzbw==?="


### PR DESCRIPTION
## Summary

- add an `overwrite_file` option to `ImapHook.download_mail_attachments`, defaulting to the existing overwrite behavior
- preserve duplicate attachment filenames when `overwrite_file=False` by writing numeric suffixed copies such as `report_1.csv`
- add focused regression coverage for overwrite and non-overwrite behavior, including filenames without extensions and filenames with multiple extensions

Fixes #65870

## Tests

- `python -m ruff check providers\imap\src\airflow\providers\imap\hooks\imap.py providers\imap\tests\unit\imap\hooks\test_imap.py`
- `python -m ruff format --check providers\imap\src\airflow\providers\imap\hooks\imap.py providers\imap\tests\unit\imap\hooks\test_imap.py`
- `git diff --check`
- standalone collision regression script for `_create_file` preserving duplicate filenames and overwriting existing files

I also attempted the focused pytest target with Airflow's managed environment:

- `uv run python -m pytest providers\imap\tests\unit\imap\hooks\test_imap.py -q`

That environment setup failed on Windows before running tests because `apache-airflow[all]` pulls `apache-airflow-core[memray]`, and `memray==1.19.3` reports `memray does not support this platform (win32)`.

