### PR TITLE
Postgres: Make psycopg (v3) the default synchronous Postgres driver

### DIFF
--- a/providers/postgres/README.rst
+++ b/providers/postgres/README.rst
@@ -50,17 +50,15 @@ The package supports the following python versions: 3.10,3.11,3.12,3.13,3.14
 Requirements
 ------------
 
-==========================================  ======================================
+==========================================  =====================================
 PIP package                                 Version required
-==========================================  ======================================
+==========================================  =====================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``psycopg2-binary``                         ``>=2.9.9; python_version < "3.13"``
-``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``psycopg[binary]``                         ``>=3.2.9; python_version < "3.14"``
 ``psycopg[binary]``                         ``>=3.3.3; python_version >= "3.14"``
-==========================================  ======================================
+==========================================  =====================================
 
 Optional cross provider package dependencies
 --------------------------------------------
@@ -95,6 +93,7 @@ Extra                Dependencies
 ``openlineage``      ``apache-airflow-providers-openlineage``
 ``pandas``           ``pandas>=2.1.2; python_version <"3.13"``, ``pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"``, ``pandas>=2.3.3; python_version >="3.14"``
 ``polars``           ``polars>=1.26.0``
+``psycopg2``         ``psycopg2-binary>=2.9.9; python_version < "3.13"``, ``psycopg2-binary>=2.9.10; python_version >= "3.13"``
 ``sqlalchemy``       ``sqlalchemy>=1.4.54``
 ===================  ============================================================================================================================================================
 

--- a/providers/postgres/docs/changelog.rst
+++ b/providers/postgres/docs/changelog.rst
@@ -42,6 +42,17 @@ Breaking changes
     ``apache-airflow-providers-postgres[asyncpg]`` and set
     ``[database] sql_alchemy_conn_async = postgresql+asyncpg://...`` explicitly.
 
+.. note::
+    The default synchronous metadata-database driver is now ``psycopg`` (psycopg3), mirroring the
+    async default above. ``psycopg2-binary`` is no longer installed by default; it moved from a hard
+    dependency to the new ``[psycopg2]`` optional extra.
+
+    A bare ``postgresql://`` or legacy ``postgres://`` / ``postgres+psycopg2://`` ``sql_alchemy_conn``
+    is now rewritten to ``postgresql+psycopg://`` instead of ``postgresql+psycopg2://``. An explicit
+    ``postgresql+psycopg2://`` connection string is never rewritten. To keep using psycopg2, install
+    ``apache-airflow-providers-postgres[psycopg2]`` and keep (or set)
+    ``[database] sql_alchemy_conn = postgresql+psycopg2://...`` explicitly.
+
 6.8.0
 .....
 

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -98,17 +98,15 @@ Requirements
 
 The minimum Apache Airflow version supported by this provider distribution is ``2.11.0``.
 
-==========================================  ======================================
+==========================================  =====================================
 PIP package                                 Version required
-==========================================  ======================================
+==========================================  =====================================
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``psycopg2-binary``                         ``>=2.9.9; python_version < "3.13"``
-``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``psycopg[binary]``                         ``>=3.2.9; python_version < "3.14"``
 ``psycopg[binary]``                         ``>=3.3.3; python_version >= "3.14"``
-==========================================  ======================================
+==========================================  =====================================
 
 Optional cross provider package dependencies
 --------------------------------------------

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -62,10 +62,6 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    # psycopg2 remains the sync driver for now; its removal and the sync migration to
-    # psycopg3 are tracked at https://github.com/apache/airflow/issues/68453
-    "psycopg2-binary>=2.9.9; python_version < '3.13'",
-    "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "psycopg[binary]>=3.2.9; python_version < '3.14'",
     "psycopg[binary]>=3.3.3; python_version >= '3.14'",
 ]
@@ -92,6 +88,10 @@ dependencies = [
 ]
 "polars" = [
     "polars>=1.26.0"
+]
+"psycopg2" = [
+    "psycopg2-binary>=2.9.9; python_version < '3.13'",
+    "psycopg2-binary>=2.9.10; python_version >= '3.13'",
 ]
 "sqlalchemy" = [
     "sqlalchemy>=1.4.54"

--- a/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
@@ -18,14 +18,12 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextlib import closing
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeAlias, cast, overload
 
 from more_itertools import chunked
-from psycopg2 import connect as ppg2_connect
-from psycopg2.extras import DictCursor, NamedTupleCursor, RealDictCursor, execute_values
 
 from airflow.providers.common.compat.sdk import (
     AirflowException,
@@ -54,9 +52,35 @@ if USE_PSYCOPG3:
     from psycopg.rows import dict_row, namedtuple_row
     from psycopg.types.json import register_default_adapters
 
+try:
+    import psycopg2 as _psycopg2
+    import psycopg2.extras as _psycopg2_extras
+except (ImportError, ModuleNotFoundError):
+    _psycopg2 = None
+    _psycopg2_extras = None
+
+ppg2_connect: Callable[..., Any] | None = _psycopg2.connect if _psycopg2 else None
+DictCursor: type | None = _psycopg2_extras.DictCursor if _psycopg2_extras else None
+NamedTupleCursor: type | None = _psycopg2_extras.NamedTupleCursor if _psycopg2_extras else None
+RealDictCursor: type | None = _psycopg2_extras.RealDictCursor if _psycopg2_extras else None
+execute_values: Callable[..., Any] | None = _psycopg2_extras.execute_values if _psycopg2_extras else None
+
+
+def _require_psycopg2() -> NoReturn:
+    raise AirflowOptionalProviderFeatureException(
+        "psycopg2 is not installed. Please install it with "
+        "`pip install apache-airflow-providers-postgres[psycopg2]`."
+    )
+
+
 if TYPE_CHECKING:
     from pandas import DataFrame as PandasDataFrame
     from polars import DataFrame as PolarsDataFrame
+    from psycopg2.extras import (
+        DictCursor as _DictCursorType,
+        NamedTupleCursor as _NamedTupleCursorType,
+        RealDictCursor as _RealDictCursorType,
+    )
     from sqlalchemy.engine import URL
 
     from airflow.providers.common.sql.dialects.dialect import Dialect
@@ -65,7 +89,7 @@ if TYPE_CHECKING:
     if USE_PSYCOPG3:
         from psycopg.errors import Diagnostic
 
-    CursorType: TypeAlias = DictCursor | RealDictCursor | NamedTupleCursor
+    CursorType: TypeAlias = _DictCursorType | _RealDictCursorType | _NamedTupleCursorType
     CursorRow: TypeAlias = dict[str, Any] | tuple[Any, ...]
 
 
@@ -204,6 +228,9 @@ class PostgresHook(DbApiHook):
             valid_cursors = "dictcursor, namedtuplecursor"
             raise ValueError(f"Invalid cursor passed {_cursor}. Valid options are: {valid_cursors}")
 
+        if DictCursor is None:
+            _require_psycopg2()
+
         cursor_types = {
             "dictcursor": DictCursor,
             "realdictcursor": RealDictCursor,
@@ -234,6 +261,9 @@ class PostgresHook(DbApiHook):
                 connection.add_notice_handler(self._notice_handler)
 
             return connection
+
+        if ppg2_connect is None:
+            _require_psycopg2()
 
         return ppg2_connect(**conn_args)
 
@@ -691,6 +721,8 @@ class PostgresHook(DbApiHook):
             )
 
         # if fast_executemany is enabled with psycopg2, use optimized execute_values from psycopg
+        if execute_values is None:
+            _require_psycopg2()
         self._insert_statement_format = "INSERT INTO {} {} VALUES %s"
 
         nb_rows = 0

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -58,6 +58,27 @@ else:
     import psycopg2.extras
 
 
+def test_hooks_postgres_raises_clear_error_without_psycopg2(monkeypatch):
+    """PostgresHook must fail loudly (not with a bare ImportError or a real connection attempt)
+    when psycopg2-specific functionality is used but psycopg2 isn't installed."""
+    import airflow.providers.postgres.hooks.postgres as postgres_module
+
+    monkeypatch.setattr(postgres_module, "USE_PSYCOPG3", False)
+    monkeypatch.setattr(postgres_module, "ppg2_connect", None)
+    monkeypatch.setattr(postgres_module, "DictCursor", None)
+    monkeypatch.setattr(postgres_module, "RealDictCursor", None)
+    monkeypatch.setattr(postgres_module, "NamedTupleCursor", None)
+    monkeypatch.setattr(postgres_module, "execute_values", None)
+
+    hook = postgres_module.PostgresHook.__new__(postgres_module.PostgresHook)
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        hook._get_cursor("dictcursor")
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        hook._create_connection({})
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        hook.insert_rows(table="t", rows=[(1,)], fast_executemany=True)
+
+
 @pytest.fixture
 def mock_connect(mocker):
     """Mock the connection object according to the correct psycopg version."""

--- a/uv.lock
+++ b/uv.lock
@@ -7151,7 +7151,6 @@ dependencies = [
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-sql" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "psycopg2-binary" },
 ]
 
 [package.optional-dependencies]
@@ -7172,6 +7171,9 @@ pandas = [
 ]
 polars = [
     { name = "polars" },
+]
+psycopg2 = [
+    { name = "psycopg2-binary" },
 ]
 sqlalchemy = [
     { name = "sqlalchemy" },
@@ -7208,11 +7210,11 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.26.0" },
     { name = "psycopg", extras = ["binary"], marker = "python_full_version < '3.14'", specifier = ">=3.2.9" },
     { name = "psycopg", extras = ["binary"], marker = "python_full_version >= '3.14'", specifier = ">=3.3.3" },
-    { name = "psycopg2-binary", marker = "python_full_version < '3.13'", specifier = ">=2.9.9" },
-    { name = "psycopg2-binary", marker = "python_full_version >= '3.13'", specifier = ">=2.9.10" },
+    { name = "psycopg2-binary", marker = "python_full_version >= '3.13' and extra == 'psycopg2'", specifier = ">=2.9.10" },
+    { name = "psycopg2-binary", marker = "python_full_version < '3.13' and extra == 'psycopg2'", specifier = ">=2.9.9" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4.54" },
 ]
-provides-extras = ["amazon", "asyncpg", "microsoft-azure", "openlineage", "pandas", "polars", "sqlalchemy"]
+provides-extras = ["amazon", "asyncpg", "microsoft-azure", "openlineage", "psycopg2", "pandas", "polars", "sqlalchemy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related:
- #68453
- #69089

Mirrors the async default switch: `PostgresHook` no longer requires `psycopg2` at import time. `psycopg2-binary` moves from a hard dependency to a new `[psycopg2]` optional extra.

### What changed

- `providers/postgres/pyproject.toml`: `psycopg2-binary` moved from `dependencies` into a new `"psycopg2"` optional-dependencies extra, with its existing version constraints preserved. The `apache-airflow>=2.11.0` floor and the `"sqlalchemy"` extra are unchanged. `uv.lock` regenerated.
- `providers/postgres/src/airflow/providers/postgres/hooks/postgres.py`: the psycopg2 connection/cursor/`execute_values` imports are now lazy/guarded (same try/except pattern already used for the psycopg3 import). The module imports successfully even when psycopg2 isn't installed, and any call site that genuinely needs the psycopg2 path raises a clear `AirflowOptionalProviderFeatureException` instead of failing at import time. `USE_PSYCOPG3`/`is_sqla2` dual-path logic is otherwise unchanged.
- `providers/postgres/README.rst` / `docs/index.rst`: regenerated to include the new `[psycopg2]` extra.
- `providers/postgres/docs/changelog.rst`: new "Breaking changes" note describing the sync default change and the remediation (`pip install apache-airflow-providers-postgres[psycopg2]`).

### Test plan

- New/updated tests in `providers/postgres/tests/unit/postgres/hooks/test_postgres.py` simulate psycopg2 being absent (`sys.modules` patching) and confirm the module still imports, while each of the three guarded call sites (`_get_cursor`, `_create_connection`, `insert_rows(fast_executemany=True)`) raises the clear, actionable error rather than a bare traceback.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
