### PR TITLE
Simplify airflowctl query parameter handling

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -88,6 +88,16 @@ log = structlog.get_logger(logger_name=__name__)
 T = TypeVar("T", bound=BaseModel)
 
 
+def _serialize_query_param(value: Any) -> Any:
+    if isinstance(value, datetime.datetime):
+        return value.isoformat()
+    return value
+
+
+def _build_query_params(**values: Any) -> dict[str, Any]:
+    return {name: _serialize_query_param(value) for name, value in values.items() if value is not None}
+
+
 # Generic Server Response Error
 class ServerResponseError(httpx.HTTPStatusError):
     """Server response error (Generic)."""
@@ -642,19 +652,15 @@ class DagRunOperations(BaseOperations):
         if not dag_id:
             dag_id = "~"
 
-        params: dict[str, Any] = {"limit": limit}
-        if state is not None:
-            params["state"] = str(state)
-        if start_date is not None:
-            params["start_date"] = start_date.isoformat()
-        if end_date is not None:
-            params["end_date"] = end_date.isoformat()
-        if logical_date_gte is not None:
-            params["logical_date_gte"] = logical_date_gte.isoformat()
-        if logical_date_lte is not None:
-            params["logical_date_lte"] = logical_date_lte.isoformat()
-        if order_by is not None:
-            params["order_by"] = order_by
+        params = _build_query_params(
+            limit=limit,
+            state=str(state) if state is not None else None,
+            start_date=start_date,
+            end_date=end_date,
+            logical_date_gte=logical_date_gte,
+            logical_date_lte=logical_date_lte,
+            order_by=order_by,
+        )
 
         try:
             self.response = self.client.get(f"/dags/{dag_id}/dagRuns", params=params)
@@ -673,13 +679,7 @@ class JobsOperations(BaseOperations):
         is_alive: bool | None = None,
     ) -> JobCollectionResponse | ServerResponseError:
         """List all jobs."""
-        params: dict[str, Any] = {}
-        if job_type:
-            params["job_type"] = job_type
-        if hostname:
-            params["hostname"] = hostname
-        if is_alive is not None:
-            params["is_alive"] = is_alive
+        params = _build_query_params(job_type=job_type or None, hostname=hostname or None, is_alive=is_alive)
 
         return super().execute_list(path="jobs", data_model=JobCollectionResponse, params=params)
 

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -100,7 +100,7 @@ from airflowctl.api.datamodels.generated import (
     XComResponse,
     XComResponseNative,
 )
-from airflowctl.api.operations import BaseOperations
+from airflowctl.api.operations import BaseOperations, _build_query_params
 from airflowctl.exceptions import AirflowCtlConnectionException
 
 if TYPE_CHECKING:
@@ -127,6 +127,20 @@ class HelloCollectionResponse(BaseModel):
 
 
 class TestBaseOperations:
+    def test_build_query_params_skips_none_and_serializes_datetime(self):
+        logical_date = datetime.datetime(2025, 1, 1, 12, 30, tzinfo=datetime.timezone.utc)
+
+        assert _build_query_params(
+            logical_date=logical_date,
+            state=None,
+            limit=10,
+            order_by="-id",
+        ) == {
+            "logical_date": logical_date.isoformat(),
+            "limit": 10,
+            "order_by": "-id",
+        }
+
     def test_server_connection_refused(self):
         client = make_api_client(base_url="http://localhost")
         with pytest.raises(


### PR DESCRIPTION
## Why

`airflowctl` API operations need to build query parameters consistently when optional filters are added. The Dag run list operation already had several repeated checks for skipping unset values and serializing datetimes, and similar optional parameter handling exists in other operations. Centralizing that logic makes future filters easier to add without duplicating the same query parameter handling.

suggested by @bugraoz93 in https://github.com/apache/airflow/pull/68564#discussion_r3508011496

## What

- Added helper functions in `airflow-ctl/src/airflowctl/api/operations.py` to build query parameters and serialize `datetime` values with `isoformat()`.
- Updated `DagRunOperations.list()` to use the shared helper for state, date, logical date, ordering, and limit query parameters.
- Updated `JobsOperations.list()` to use the same helper while preserving the existing behavior for empty `job_type` and `hostname` values.
- Added a unit test in `airflow-ctl/tests/airflow_ctl/api/test_operations.py` covering skipped `None` values and datetime serialization.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
