### PR TITLE
Celery: Make psycopg (v3) the default synchronous Postgres driver

### DIFF
--- a/providers/celery/docs/changelog.rst
+++ b/providers/celery/docs/changelog.rst
@@ -27,6 +27,13 @@
 Changelog
 ---------
 
+.. note::
+    When ``[celery] result_backend`` is not set and Airflow derives it from ``sql_alchemy_conn``, a
+    driverless ``postgresql://`` connection string now produces ``db+postgresql+psycopg://...`` instead
+    of ``db+postgresql+psycopg2://...``, matching the sync Postgres driver default change in
+    ``apache-airflow`` and ``apache-airflow-providers-postgres``. An explicit ``[celery] result_backend``
+    or an explicit driver in ``sql_alchemy_conn`` is unaffected.
+
 3.21.0
 ......
 

--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -247,7 +247,7 @@ config:
         version_added: ~
         type: string
         sensitive: true
-        example: "db+postgresql+psycopg2://postgres:airflow@postgres/airflow"
+        example: "db+postgresql+psycopg://postgres:airflow@postgres/airflow"
         default: ~
       result_backend_sqlalchemy_engine_options:
         description: |

--- a/providers/celery/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/celery/src/airflow/providers/celery/executors/default_celery.py
@@ -79,9 +79,9 @@ def get_default_celery_config(team_conf) -> dict[str, Any]:
     else:
         log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
         sql_alchemy_conn = team_conf.get("database", "SQL_ALCHEMY_CONN")
-        # In SQLAlchemy 2.1 the default PostgreSQL driver changed from psycopg2 to psycopg (v3).
-        # To maintain existing behavior, we explicitly specify psycopg2 for driverless PostgreSQL URLs.
-        sql_alchemy_conn = sql_alchemy_conn.replace("postgresql://", "postgresql+psycopg2://", 1)
+        # Airflow's sync metadata-database driver default is psycopg (v3); mirror that explicitly
+        # for driverless PostgreSQL URLs instead of relying on SQLAlchemy's own default.
+        sql_alchemy_conn = sql_alchemy_conn.replace("postgresql://", "postgresql+psycopg://", 1)
         result_backend = f"db+{sql_alchemy_conn}"
 
     # Handle result backend transport options (for Redis Sentinel support)

--- a/providers/celery/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/celery/src/airflow/providers/celery/executors/default_celery.py
@@ -31,6 +31,23 @@ from airflow.providers.common.compat.sdk import AirflowException, conf
 
 log = logging.getLogger(__name__)
 
+_USE_PSYCOPG3: bool
+try:
+    from importlib.util import find_spec
+
+    import sqlalchemy
+    from packaging.version import Version
+
+    _sqlalchemy_version = Version(sqlalchemy.__version__)
+    _is_sqla2 = (_sqlalchemy_version.major, _sqlalchemy_version.minor, _sqlalchemy_version.micro) >= (
+        2,
+        0,
+        0,
+    )
+    _USE_PSYCOPG3 = find_spec("psycopg") is not None and _is_sqla2
+except (ImportError, ModuleNotFoundError):
+    _USE_PSYCOPG3 = False
+
 
 def _broker_supports_visibility_timeout(url):
     return url.startswith(("redis://", "rediss://", "sqs://", "sentinel://"))
@@ -80,8 +97,11 @@ def get_default_celery_config(team_conf) -> dict[str, Any]:
         log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
         sql_alchemy_conn = team_conf.get("database", "SQL_ALCHEMY_CONN")
         # Airflow's sync metadata-database driver default is psycopg (v3); mirror that explicitly
-        # for driverless PostgreSQL URLs instead of relying on SQLAlchemy's own default.
-        sql_alchemy_conn = sql_alchemy_conn.replace("postgresql://", "postgresql+psycopg://", 1)
+        # for driverless PostgreSQL URLs instead of relying on SQLAlchemy's own default. Fall back to
+        # psycopg2 when psycopg/SQLAlchemy 2.0 aren't both available, matching PostgresHook's own
+        # USE_PSYCOPG3 gating so this doesn't break environments still on the older combination.
+        target_scheme = "postgresql+psycopg://" if _USE_PSYCOPG3 else "postgresql+psycopg2://"
+        sql_alchemy_conn = sql_alchemy_conn.replace("postgresql://", target_scheme, 1)
         result_backend = f"db+{sql_alchemy_conn}"
 
     # Handle result backend transport options (for Redis Sentinel support)

--- a/providers/celery/src/airflow/providers/celery/get_provider_info.py
+++ b/providers/celery/src/airflow/providers/celery/get_provider_info.py
@@ -130,7 +130,7 @@ def get_provider_info():
                         "version_added": None,
                         "type": "string",
                         "sensitive": True,
-                        "example": "db+postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                        "example": "db+postgresql+psycopg://postgres:airflow@postgres/airflow",
                         "default": None,
                     },
                     "result_backend_sqlalchemy_engine_options": {

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -795,14 +795,11 @@ def test_result_backend_transport_options_with_multiple_options():
         ("database", "sql_alchemy_conn"): "postgresql://user:pass@host/db",
     }
 )
-def test_result_backend_derived_from_sql_alchemy_conn_uses_psycopg():
+def test_result_backend_derived_from_sql_alchemy_conn_uses_psycopg(monkeypatch):
     """A driverless sql_alchemy_conn must derive a psycopg (v3) result_backend, not psycopg2."""
-    import importlib
-
-    importlib.reload(default_celery)
-    assert (
-        default_celery.DEFAULT_CELERY_CONFIG["result_backend"] == "db+postgresql+psycopg://user:pass@host/db"
-    )
+    monkeypatch.setattr(default_celery, "_USE_PSYCOPG3", True)
+    config = default_celery.get_default_celery_config(conf)
+    assert config["result_backend"] == "db+postgresql+psycopg://user:pass@host/db"
 
 
 @conf_vars(

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -789,6 +789,22 @@ def test_result_backend_transport_options_with_multiple_options():
     assert result_backend_opts["master_name"] == "mymaster"
 
 
+@conf_vars(
+    {
+        ("celery", "result_backend"): None,
+        ("database", "sql_alchemy_conn"): "postgresql://user:pass@host/db",
+    }
+)
+def test_result_backend_derived_from_sql_alchemy_conn_uses_psycopg():
+    """A driverless sql_alchemy_conn must derive a psycopg (v3) result_backend, not psycopg2."""
+    import importlib
+
+    importlib.reload(default_celery)
+    assert (
+        default_celery.DEFAULT_CELERY_CONFIG["result_backend"] == "db+postgresql+psycopg://user:pass@host/db"
+    )
+
+
 @conf_vars({("celery_result_backend_transport_options", "sentinel_kwargs"): "invalid_json"})
 def test_result_backend_sentinel_kwargs_invalid_json():
     """Test that invalid JSON in sentinel_kwargs raises an error."""

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -805,6 +805,19 @@ def test_result_backend_derived_from_sql_alchemy_conn_uses_psycopg():
     )
 
 
+@conf_vars(
+    {
+        ("celery", "result_backend"): None,
+        ("database", "sql_alchemy_conn"): "postgresql://user:pass@host/db",
+    }
+)
+def test_result_backend_falls_back_to_psycopg2_without_psycopg3(monkeypatch):
+    """Without psycopg/SQLAlchemy 2.0 available, the derivation must fall back to psycopg2."""
+    monkeypatch.setattr(default_celery, "_USE_PSYCOPG3", False)
+    config = default_celery.get_default_celery_config(conf)
+    assert config["result_backend"] == "db+postgresql+psycopg2://user:pass@host/db"
+
+
 @conf_vars({("celery_result_backend_transport_options", "sentinel_kwargs"): "invalid_json"})
 def test_result_backend_sentinel_kwargs_invalid_json():
     """Test that invalid JSON in sentinel_kwargs raises an error."""


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related:
- #68453

depends on:
- #69469
- #69474 

The hardcoded fallback that derives `[celery] result_backend` from `sql_alchemy_conn` when a driverless `postgresql://` URL is configured targeted `postgresql+psycopg2://` explicitly. Update it to match the new sync Postgres driver default.

### What changed

- `providers/celery/src/airflow/providers/celery/executors/default_celery.py`: the result-backend URL derivation now targets `postgresql+psycopg://` when psycopg (v3) is actually usable, falling back to `postgresql+psycopg2://` otherwise. A new `_USE_PSYCOPG3` check (`psycopg` importable AND SQLAlchemy ≥ 2.0.0) gates this — `providers/celery` declares no dependency on psycopg or SQLAlchemy 2.0, so an unconditional switch would have silently broken the derivation under Airflow's lowest-dependency-resolution CI job.
- `providers/celery/src/airflow/providers/celery/get_provider_info.py`: example connection string updated to `db+postgresql+psycopg://...`.
- `providers/celery/docs/changelog.rst`: note describing the result-backend URL default change as user-facing.

### Test plan

- `providers/celery/tests/unit/celery/executors/test_celery_executor.py`: `test_result_backend_derived_from_sql_alchemy_conn_uses_psycopg` asserts the new `postgresql+psycopg` scheme (via `monkeypatch.setattr(default_celery, "_USE_PSYCOPG3", True)`, not `importlib.reload`, to stay deterministic regardless of what's actually installed in the test environment). New `test_result_backend_falls_back_to_psycopg2_without_psycopg3` covers the opposite path.
- Both tests run and pass; deterministic under lowest-dependency-resolution conditions since neither depends on ambient package availability.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
