### PR TITLE
Document each provider's optional extras in its docs index

### DIFF
--- a/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
+++ b/dev/breeze/src/airflow_breeze/templates/PROVIDER_INDEX_TEMPLATE.rst.jinja2
@@ -89,6 +89,22 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 {{ CROSS_PROVIDERS_DEPENDENCIES_TABLE_RST | safe }}
 {%- endif %}
 
+{%- if OPTIONAL_DEPENDENCIES %}
+
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install {{ PACKAGE_PIP_NAME }}[{{ (OPTIONAL_DEPENDENCIES | list)[0] }}]
+
+
+{{ OPTIONAL_DEPENDENCIES_TABLE_RST | safe }}
+{%- endif %}
+
 Downloading official packages
 -----------------------------
 

--- a/dev/breeze/tests/test_packages.py
+++ b/dev/breeze/tests/test_packages.py
@@ -27,6 +27,7 @@ from airflow_breeze.utils.packages import (
     apply_version_suffix_to_non_provider_pyproject_tomls,
     apply_version_suffix_to_provider_pyproject_toml,
     convert_cross_package_dependencies_to_table,
+    convert_optional_dependencies_to_table,
     convert_pip_requirements_to_table,
     expand_all_provider_distributions,
     find_matching_long_package_names,
@@ -39,11 +40,13 @@ from airflow_breeze.utils.packages import (
     get_pip_package_name,
     get_provider_details,
     get_provider_info_dict,
+    get_provider_jinja_context,
     get_provider_requirements,
     get_removed_provider_ids,
     get_short_package_name,
     get_suspended_provider_folders,
     get_suspended_provider_ids,
+    render_template,
     validate_provider_info_with_runtime_schema,
 )
 from airflow_breeze.utils.path_utils import AIRFLOW_ROOT_PATH
@@ -315,6 +318,43 @@ def test_convert_cross_package_dependencies_to_table():
         convert_cross_package_dependencies_to_table(get_cross_provider_dependent_packages("trino")).strip()
         == EXPECTED.strip()
     )
+
+
+@pytest.mark.parametrize("markdown", [True, False])
+def test_convert_optional_dependencies_to_table(markdown: bool):
+    optional_dependencies = {
+        "aiobotocore": ["aiobotocore>=3.0.0"],
+        "s3fs": ["s3fs>=2023.10.0", "boto3>=1.0"],
+    }
+    table = convert_optional_dependencies_to_table(optional_dependencies, markdown=markdown)
+    quote = "`" if markdown else "``"
+    assert "Extra" in table
+    assert "Dependencies" in table
+    assert f"{quote}aiobotocore{quote}" in table
+    assert f"{quote}aiobotocore>=3.0.0{quote}" in table
+    # Multiple dependencies for a single extra are comma-joined in one cell.
+    assert f"{quote}s3fs>=2023.10.0{quote}, {quote}boto3>=1.0{quote}" in table
+
+
+def test_provider_index_template_renders_optional_dependencies():
+    # Amazon carries plain-PyPI extras (e.g. ``aiobotocore``) that are not cross-provider
+    # dependencies, so their only rendering path is the "Optional dependencies" section.
+    context = get_provider_jinja_context("amazon", current_release_version="1.0.0", version_suffix="")
+    rendered = render_template(
+        template_name="PROVIDER_INDEX", context=context, extension=".rst", keep_trailing_newline=True
+    )
+    assert "Optional dependencies\n---------------------" in rendered
+    assert "``aiobotocore``" in rendered
+
+
+def test_provider_index_template_omits_optional_dependencies_when_none():
+    context = get_provider_jinja_context("amazon", current_release_version="1.0.0", version_suffix="")
+    context["OPTIONAL_DEPENDENCIES"] = {}
+    context["OPTIONAL_DEPENDENCIES_TABLE_RST"] = ""
+    rendered = render_template(
+        template_name="PROVIDER_INDEX", context=context, extension=".rst", keep_trailing_newline=True
+    )
+    assert "Optional dependencies\n---------------------" not in rendered
 
 
 def test_get_provider_info_dict():

--- a/providers/akeyless/docs/index.rst
+++ b/providers/akeyless/docs/index.rst
@@ -106,6 +106,23 @@ PIP package                                 Version required
 ``akeyless``                                ``>=5.0.0``
 ==========================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-akeyless[cloud_id]
+
+
+============  =====================
+Extra         Dependencies
+============  =====================
+``cloud_id``  ``akeyless_cloud_id``
+============  =====================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/amazon/docs/index.rst
+++ b/providers/amazon/docs/index.rst
@@ -160,6 +160,41 @@ Dependent package                                                               
 `apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                            ``ssh``
 ========================================================================================================================  ====================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-amazon[aiobotocore]
+
+
+====================  ============================================================================================================================================================
+Extra                 Dependencies
+====================  ============================================================================================================================================================
+``aiobotocore``       ``aiobotocore>=3.0.0``
+``cncf.kubernetes``   ``apache-airflow-providers-cncf-kubernetes>=7.2.0``
+``s3fs``              ``s3fs>=2023.10.0``
+``python3-saml``      ``python3-saml>=1.16.0; python_version < '3.13'``, ``xmlsec>=1.3.14; python_version < '3.13'``, ``lxml>=6.0.0; python_version < '3.13'``
+``apache.hive``       ``apache-airflow-providers-apache-hive``
+``exasol``            ``apache-airflow-providers-exasol``
+``fab``               ``apache-airflow-providers-fab>=2.2.0``
+``ftp``               ``apache-airflow-providers-ftp``
+``google``            ``apache-airflow-providers-google``
+``imap``              ``apache-airflow-providers-imap``
+``microsoft.azure``   ``apache-airflow-providers-microsoft-azure``
+``mongo``             ``apache-airflow-providers-mongo``
+``pandas``            ``pandas>=2.1.2; python_version <"3.13"``, ``pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"``, ``pandas>=2.3.3; python_version >="3.14"``
+``openlineage``       ``apache-airflow-providers-openlineage>=2.3.0``
+``salesforce``        ``apache-airflow-providers-salesforce``
+``ssh``               ``apache-airflow-providers-ssh``
+``standard``          ``apache-airflow-providers-standard``
+``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+``sqlalchemy``        ``sqlalchemy>=1.4.54``
+====================  ============================================================================================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/anthropic/docs/index.rst
+++ b/providers/anthropic/docs/index.rst
@@ -101,6 +101,25 @@ PIP package                                 Version required
 ``anthropic``                               ``>=0.101.0``
 ==========================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-anthropic[bedrock]
+
+
+===========  ===============================
+Extra        Dependencies
+===========  ===============================
+``bedrock``  ``anthropic[bedrock]>=0.101.0``
+``vertex``   ``anthropic[vertex]>=0.101.0``
+``aws``      ``anthropic[aws]>=0.101.0``
+===========  ===============================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/apache/druid/docs/index.rst
+++ b/providers/apache/druid/docs/index.rst
@@ -124,6 +124,23 @@ Dependent package                                                               
 `apache-airflow-providers-apache-hive <https://airflow.apache.org/docs/apache-airflow-providers-apache-hive>`_  ``apache.hive``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-apache-druid[apache.hive]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``apache.hive``  ``apache-airflow-providers-apache-hive``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/apache/hive/docs/index.rst
+++ b/providers/apache/hive/docs/index.rst
@@ -137,6 +137,30 @@ Dependent package                                                               
 `apache-airflow-providers-vertica <https://airflow.apache.org/docs/apache-airflow-providers-vertica>`_                  ``vertica``
 ======================================================================================================================  ===================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-apache-hive[amazon]
+
+
+===================  =============================================================================================
+Extra                Dependencies
+===================  =============================================================================================
+``amazon``           ``apache-airflow-providers-amazon``
+``microsoft.mssql``  ``apache-airflow-providers-microsoft-mssql``
+``mysql``            ``apache-airflow-providers-mysql``
+``presto``           ``apache-airflow-providers-presto``
+``samba``            ``apache-airflow-providers-samba``
+``sqlalchemy``       ``sqlalchemy>=1.4.54``
+``vertica``          ``apache-airflow-providers-vertica``
+``GSSAPI``           ``winkerberos>=0.7.0; sys_platform == "win32"``, ``kerberos>=1.3.0; sys_platform != "win32"``
+===================  =============================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/apache/impala/docs/index.rst
+++ b/providers/apache/impala/docs/index.rst
@@ -113,6 +113,24 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ==========================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-apache-impala[kerberos]
+
+
+==============  ======================
+Extra           Dependencies
+==============  ======================
+``kerberos``    ``kerberos>=1.3.0``
+``sqlalchemy``  ``sqlalchemy>=1.4.54``
+==============  ======================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/apache/kafka/docs/index.rst
+++ b/providers/apache/kafka/docs/index.rst
@@ -134,6 +134,24 @@ Dependent package                                                               
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_                      ``google``
 ========================================================================================================================  ====================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-apache-kafka[google]
+
+
+====================  ====================================================
+Extra                 Dependencies
+====================  ====================================================
+``google``            ``apache-airflow-providers-google``
+``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+====================  ====================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/apache/spark/docs/index.rst
+++ b/providers/apache/spark/docs/index.rst
@@ -127,6 +127,25 @@ Dependent package                                                               
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
 ======================================================================================================================  ===================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-apache-spark[cncf.kubernetes]
+
+
+===================  ===================================================
+Extra                Dependencies
+===================  ===================================================
+``cncf.kubernetes``  ``apache-airflow-providers-cncf-kubernetes>=7.4.0``
+``openlineage``      ``apache-airflow-providers-openlineage``
+``pyspark``          ``pyspark>=4.0.0``
+===================  ===================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/celery/docs/index.rst
+++ b/providers/celery/docs/index.rst
@@ -115,6 +115,23 @@ Dependent package                                                               
 `apache-airflow-providers-cncf-kubernetes <https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes>`_  ``cncf.kubernetes``
 ======================================================================================================================  ===================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-celery[cncf.kubernetes]
+
+
+===================  ===================================================
+Extra                Dependencies
+===================  ===================================================
+``cncf.kubernetes``  ``apache-airflow-providers-cncf-kubernetes>=7.4.0``
+===================  ===================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -132,6 +132,38 @@ Dependent package                                                               
 `apache-airflow-providers-git <https://airflow.apache.org/docs/apache-airflow-providers-git>`_                ``git``
 ============================================================================================================  ==============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-common-ai[anthropic]
+
+
+==============  ==========================================================================================================
+Extra           Dependencies
+==============  ==========================================================================================================
+``anthropic``   ``pydantic-ai-slim[anthropic]``
+``bedrock``     ``pydantic-ai-slim[bedrock]``
+``google``      ``pydantic-ai-slim[google]``
+``openai``      ``pydantic-ai-slim[openai]``
+``mcp``         ``pydantic-ai-slim[mcp]``
+``code-mode``   ``pydantic-ai-harness[codemode]>=0.3.0``
+``skills``      ``apache-airflow-providers-git>=0.4.0``, ``pydantic-ai-skills>=0.11.0``
+``avro``        ``fastavro>=1.10.0; python_version < "3.14"``, ``fastavro>=1.12.1; python_version >= "3.14"``
+``parquet``     ``pyarrow>=18.0.0; python_version < '3.14'``, ``pyarrow>=22.0.0; python_version >= '3.14'``
+``sql``         ``apache-airflow-providers-common-sql``, ``sqlglot>=30.0.0``
+``common.sql``  ``apache-airflow-providers-common-sql``
+``langchain``   ``langchain>=1.0.0``
+``llamaindex``  ``llama-index-core>=0.13.0``, ``llama-index-embeddings-openai>=0.6.0``, ``llama-index-llms-openai>=0.6.0``
+``pdf``         ``pypdf>=4.0.0``
+``docx``        ``python-docx>=1.0.0``
+``git``         ``apache-airflow-providers-git``
+==============  ==========================================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/common/compat/docs/index.rst
+++ b/providers/common/compat/docs/index.rst
@@ -109,6 +109,24 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-common-compat[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+``standard``     ``apache-airflow-providers-standard``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/common/io/docs/index.rst
+++ b/providers/common/io/docs/index.rst
@@ -126,6 +126,23 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-common-io[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/common/messaging/docs/index.rst
+++ b/providers/common/messaging/docs/index.rst
@@ -103,6 +103,24 @@ PIP package         Version required
 ``apache-airflow``  ``>=3.0.1``
 ==================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-common-messaging[amazon]
+
+
+================  ================================================
+Extra             Dependencies
+================  ================================================
+``amazon``        ``apache-airflow-providers-amazon>=9.7.0``
+``apache.kafka``  ``apache-airflow-providers-apache-kafka>=1.9.0``
+================  ================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/common/sql/docs/index.rst
+++ b/providers/common/sql/docs/index.rst
@@ -130,6 +130,30 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_        ``openlineage``
 ====================================================================================================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-common-sql[pandas]
+
+
+==================  =======================================================================================================================================================================
+Extra               Dependencies
+==================  =======================================================================================================================================================================
+``pandas``          ``pandas[sql-other]>=2.1.2; python_version <"3.13"``, ``pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"``, ``pandas>=2.3.3; python_version >="3.14"``
+``openlineage``     ``apache-airflow-providers-openlineage``
+``polars``          ``polars>=1.26.0``
+``sqlalchemy``      ``sqlalchemy>=1.4.54``
+``amazon``          ``apache-airflow-providers-amazon``
+``datafusion``      ``datafusion>=50.0.0,<52.0.0``
+``pyiceberg-core``  ``pyiceberg-core>=0.8.0``
+``apache.iceberg``  ``apache-airflow-providers-apache-iceberg``
+==================  =======================================================================================================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/databricks/docs/index.rst
+++ b/providers/databricks/docs/index.rst
@@ -136,6 +136,30 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-databricks[avro]
+
+
+==================  ================================================================================================================================================================
+Extra               Dependencies
+==================  ================================================================================================================================================================
+``avro``            ``fastavro>=1.9.0; python_version<"3.14"``, ``fastavro>=1.10.0; python_version>="3.12" and python_version<"3.14"``, ``fastavro>=1.12.1; python_version>="3.14"``
+``azure-identity``  ``azure-identity>=1.3.1``
+``fab``             ``apache-airflow-providers-fab>=2.2.0``
+``google``          ``apache-airflow-providers-google>=10.24.0``
+``sdk``             ``databricks-sdk==0.10.0``
+``standard``        ``apache-airflow-providers-standard``
+``openlineage``     ``apache-airflow-providers-openlineage>=2.3.0``
+``sqlalchemy``      ``databricks-sqlalchemy>=1.0.2``
+==================  ================================================================================================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/dbt/cloud/docs/index.rst
+++ b/providers/dbt/cloud/docs/index.rst
@@ -132,6 +132,23 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-dbt-cloud[openlineage]
+
+
+===============  ===============================================
+Extra            Dependencies
+===============  ===============================================
+``openlineage``  ``apache-airflow-providers-openlineage>=2.3.0``
+===============  ===============================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/elasticsearch/docs/index.rst
+++ b/providers/elasticsearch/docs/index.rst
@@ -108,6 +108,23 @@ PIP package                                 Version required
 ``elasticsearch``                           ``<10,>=8.10``
 ==========================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-elasticsearch[polars]
+
+
+==========  ==================
+Extra       Dependencies
+==========  ==================
+``polars``  ``polars>=1.26.0``
+==========  ==================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/exasol/docs/index.rst
+++ b/providers/exasol/docs/index.rst
@@ -107,6 +107,23 @@ PIP package                                 Version required
 ``pandas``                                  ``>=2.3.3; python_version >= "3.14"``
 ==========================================  =================================================================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-exasol[sqlalchemy]
+
+
+==============  ======================
+Extra           Dependencies
+==============  ======================
+``sqlalchemy``  ``sqlalchemy>=1.4.54``
+==============  ======================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -129,6 +129,24 @@ PIP package                                 Version required
 ``flask_limiter``                           ``>3``
 ==========================================  =====================================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-fab[kerberos]
+
+
+============  ===================
+Extra         Dependencies
+============  ===================
+``kerberos``  ``kerberos>=1.3.0``
+``oauth``     ``authlib>=1.0.0``
+============  ===================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/ftp/docs/index.rst
+++ b/providers/ftp/docs/index.rst
@@ -130,6 +130,23 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-ftp[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -229,6 +229,43 @@ Dependent package                                                               
 `apache-airflow-providers-trino <https://airflow.apache.org/docs/apache-airflow-providers-trino>`_                        ``trino``
 ========================================================================================================================  ====================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-google[cncf.kubernetes]
+
+
+====================  ====================================================
+Extra                 Dependencies
+====================  ====================================================
+``cncf.kubernetes``   ``apache-airflow-providers-cncf-kubernetes>=10.1.0``
+``fab``               ``apache-airflow-providers-fab>=2.0.0``
+``leveldb``           ``plyvel>=1.5.1; python_version < '3.13'``
+``oracle``            ``apache-airflow-providers-oracle>=3.1.0``
+``facebook``          ``apache-airflow-providers-facebook>=2.2.0``
+``amazon``            ``apache-airflow-providers-amazon>=2.6.0``
+``apache.cassandra``  ``apache-airflow-providers-apache-cassandra``
+``microsoft.azure``   ``apache-airflow-providers-microsoft-azure>=13.0.0``
+``microsoft.mssql``   ``apache-airflow-providers-microsoft-mssql``
+``mongo``             ``apache-airflow-providers-mongo``
+``mysql``             ``apache-airflow-providers-mysql``
+``openlineage``       ``apache-airflow-providers-openlineage``
+``postgres``          ``apache-airflow-providers-postgres``
+``presto``            ``apache-airflow-providers-presto``
+``salesforce``        ``apache-airflow-providers-salesforce``
+``sftp``              ``apache-airflow-providers-sftp``
+``ssh``               ``apache-airflow-providers-ssh``
+``trino``             ``apache-airflow-providers-trino``
+``http``              ``apache-airflow-providers-http``
+``standard``          ``apache-airflow-providers-standard``
+``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+====================  ====================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/hashicorp/docs/index.rst
+++ b/providers/hashicorp/docs/index.rst
@@ -116,6 +116,24 @@ Dependent package                                                               
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
 ====================================================================================================  ==========
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-hashicorp[boto3]
+
+
+==========  ===================================
+Extra       Dependencies
+==========  ===================================
+``boto3``   ``boto3>=1.37.2``
+``google``  ``apache-airflow-providers-google``
+==========  ===================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/ibm/mq/docs/index.rst
+++ b/providers/ibm/mq/docs/index.rst
@@ -125,6 +125,24 @@ Dependent package                                                               
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 ========================================================================================================================  ====================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-ibm-mq[ibmmq]
+
+
+====================  ===============================================================================
+Extra                 Dependencies
+====================  ===============================================================================
+``ibmmq``             ``ibmmq>=2.0.6; platform_machine != "aarch64" and platform_machine != "arm64"``
+``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+====================  ===============================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/informatica/docs/index.rst
+++ b/providers/informatica/docs/index.rst
@@ -162,6 +162,24 @@ Dependent package                                                               
 `apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
 ============================================================================================================  ==============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-informatica[common.compat]
+
+
+=================  ==========================================
+Extra              Dependencies
+=================  ==========================================
+``common.compat``  ``apache-airflow-providers-common-compat``
+``common.sql``     ``apache-airflow-providers-common-sql``
+=================  ==========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/jdbc/docs/index.rst
+++ b/providers/jdbc/docs/index.rst
@@ -135,6 +135,23 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-jdbc[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/microsoft/azure/docs/index.rst
+++ b/providers/microsoft/azure/docs/index.rst
@@ -164,6 +164,28 @@ Dependent package                                                               
 `apache-airflow-providers-sftp <https://airflow.apache.org/docs/apache-airflow-providers-sftp>`_                          ``sftp``
 ========================================================================================================================  ====================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-microsoft-azure[amazon]
+
+
+====================  ====================================================
+Extra                 Dependencies
+====================  ====================================================
+``amazon``            ``apache-airflow-providers-amazon``
+``oracle``            ``apache-airflow-providers-oracle``
+``sftp``              ``apache-airflow-providers-sftp``
+``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+``google``            ``apache-airflow-providers-google``
+``openlineage``       ``apache-airflow-providers-openlineage>=2.3.0``
+====================  ====================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/microsoft/mssql/docs/index.rst
+++ b/providers/microsoft/mssql/docs/index.rst
@@ -128,6 +128,23 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-microsoft-mssql[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/mysql/docs/index.rst
+++ b/providers/mysql/docs/index.rst
@@ -133,6 +133,28 @@ Dependent package                                                               
 `apache-airflow-providers-vertica <https://airflow.apache.org/docs/apache-airflow-providers-vertica>`_          ``vertica``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-mysql[mysql-connector-python]
+
+
+==========================  ========================================
+Extra                       Dependencies
+==========================  ========================================
+``mysql-connector-python``
+``amazon``                  ``apache-airflow-providers-amazon``
+``openlineage``             ``apache-airflow-providers-openlineage``
+``presto``                  ``apache-airflow-providers-presto``
+``trino``                   ``apache-airflow-providers-trino``
+``vertica``                 ``apache-airflow-providers-vertica``
+==========================  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/openlineage/docs/index.rst
+++ b/providers/openlineage/docs/index.rst
@@ -115,6 +115,23 @@ PIP package                                 Version required
 ``openlineage-python``                      ``>=1.47.0``
 ==========================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-openlineage[sqlalchemy]
+
+
+==============  ======================
+Extra           Dependencies
+==============  ======================
+``sqlalchemy``  ``sqlalchemy>=1.4.54``
+==============  ======================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/oracle/docs/index.rst
+++ b/providers/oracle/docs/index.rst
@@ -125,6 +125,24 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-oracle[numpy]
+
+
+===============  ============================================================================================================================================================================================================================================
+Extra            Dependencies
+===============  ============================================================================================================================================================================================================================================
+``numpy``        ``numpy>=1.22.4; python_version<'3.11'``, ``numpy>=1.23.2; python_version=='3.11'``, ``numpy>=1.26.0; python_version=='3.12'``, ``numpy>=2.1.0; python_version>='3.13' and python_version<'3.14'``, ``numpy>=2.4.3; python_version>='3.14'``
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ============================================================================================================================================================================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/pgvector/docs/index.rst
+++ b/providers/pgvector/docs/index.rst
@@ -127,6 +127,23 @@ Dependent package                                                               
 `apache-airflow-providers-common-sql <https://airflow.apache.org/docs/apache-airflow-providers-common-sql>`_  ``common.sql``
 ============================================================================================================  ==============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-pgvector[common.sql]
+
+
+==============  =======================================
+Extra           Dependencies
+==============  =======================================
+``common.sql``  ``apache-airflow-providers-common-sql``
+==============  =======================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -131,6 +131,29 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
 ======================================================================================================================  ===================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-postgres[amazon]
+
+
+===================  ============================================================================================================================================================
+Extra                Dependencies
+===================  ============================================================================================================================================================
+``amazon``           ``apache-airflow-providers-amazon>=2.6.0``
+``asyncpg``          ``asyncpg>=0.30.0``
+``microsoft.azure``  ``apache-airflow-providers-microsoft-azure>=12.8.0``
+``openlineage``      ``apache-airflow-providers-openlineage``
+``pandas``           ``pandas>=2.1.2; python_version <"3.13"``, ``pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"``, ``pandas>=2.3.3; python_version >="3.14"``
+``polars``           ``polars>=1.26.0``
+``sqlalchemy``       ``sqlalchemy>=1.4.54``
+===================  ============================================================================================================================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/presto/docs/index.rst
+++ b/providers/presto/docs/index.rst
@@ -131,6 +131,24 @@ Dependent package                                                               
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
 ====================================================================================================  ==========
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-presto[google]
+
+
+==============  ===================================
+Extra           Dependencies
+==============  ===================================
+``google``      ``apache-airflow-providers-google``
+``sqlalchemy``  ``sqlalchemy>=1.4.54``
+==============  ===================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/redis/docs/index.rst
+++ b/providers/redis/docs/index.rst
@@ -126,6 +126,23 @@ Dependent package                                                               
 `apache-airflow-providers-common-messaging <https://airflow.apache.org/docs/apache-airflow-providers-common-messaging>`_  ``common.messaging``
 ========================================================================================================================  ====================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-redis[common.messaging]
+
+
+====================  ====================================================
+Extra                 Dependencies
+====================  ====================================================
+``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
+====================  ====================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/samba/docs/index.rst
+++ b/providers/samba/docs/index.rst
@@ -123,6 +123,23 @@ Dependent package                                                               
 `apache-airflow-providers-google <https://airflow.apache.org/docs/apache-airflow-providers-google>`_  ``google``
 ====================================================================================================  ==========
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-samba[google]
+
+
+==========  ===================================
+Extra       Dependencies
+==========  ===================================
+``google``  ``apache-airflow-providers-google``
+==========  ===================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/sftp/docs/index.rst
+++ b/providers/sftp/docs/index.rst
@@ -128,6 +128,24 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-sftp[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+``sshfs``        ``sshfs>=2023.1.0``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/snowflake/docs/index.rst
+++ b/providers/snowflake/docs/index.rst
@@ -138,6 +138,24 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_          ``openlineage``
 ======================================================================================================================  ===================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-snowflake[microsoft.azure]
+
+
+===================  ====================================================
+Extra                Dependencies
+===================  ====================================================
+``microsoft.azure``  ``apache-airflow-providers-microsoft-azure>=12.8.0``
+``openlineage``      ``apache-airflow-providers-openlineage>=2.3.0``
+===================  ====================================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/standard/docs/index.rst
+++ b/providers/standard/docs/index.rst
@@ -112,6 +112,23 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-standard[openlineage]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/teradata/docs/index.rst
+++ b/providers/teradata/docs/index.rst
@@ -128,6 +128,26 @@ Dependent package                                                               
 `apache-airflow-providers-ssh <https://airflow.apache.org/docs/apache-airflow-providers-ssh>`_                          ``ssh``
 ======================================================================================================================  ===================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-teradata[microsoft.azure]
+
+
+===================  ============================================
+Extra                Dependencies
+===================  ============================================
+``microsoft.azure``  ``apache-airflow-providers-microsoft-azure``
+``amazon``           ``apache-airflow-providers-amazon``
+``sqlalchemy``       ``sqlalchemy>=1.4.54``
+``ssh``              ``apache-airflow-providers-ssh``
+===================  ============================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/trino/docs/index.rst
+++ b/providers/trino/docs/index.rst
@@ -130,6 +130,24 @@ Dependent package                                                               
 `apache-airflow-providers-openlineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage>`_  ``openlineage``
 ==============================================================================================================  ===============
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-trino[google]
+
+
+===============  ========================================
+Extra            Dependencies
+===============  ========================================
+``google``       ``apache-airflow-providers-google``
+``openlineage``  ``apache-airflow-providers-openlineage``
+===============  ========================================
+
 Downloading official packages
 -----------------------------
 

--- a/providers/vertica/docs/index.rst
+++ b/providers/vertica/docs/index.rst
@@ -107,6 +107,23 @@ PIP package                                 Version required
 ``vertica-python``                          ``>=1.3.0``
 ==========================================  ==================
 
+Optional dependencies
+---------------------
+
+These extras install optional third-party libraries that enable additional features of the provider.
+Install them when installing from PyPI. For example:
+
+.. code-block:: bash
+
+    pip install apache-airflow-providers-vertica[sqlalchemy]
+
+
+==============  ======================
+Extra           Dependencies
+==============  ======================
+``sqlalchemy``  ``sqlalchemy>=1.4.54``
+==============  ======================
+
 Downloading official packages
 -----------------------------
 


### PR DESCRIPTION
## Summary

A provider's docs index page listed only *cross-provider* extras -- extras that install another Airflow provider -- under "Optional cross provider package dependencies". A provider's plain-PyPI optional extras had no rendering path in the docs at all.

For `common-ai` that left `anthropic`, `bedrock`, `openai`, `mcp`, `code-mode`, `langchain`, `llamaindex`, `pdf`, `docx` (and more) undocumented; for `amazon`, extras like `aiobotocore`, `s3fs`, and `pandas`.

This adds an "Optional dependencies" section to the provider index template that renders the full extras table, so every extra a provider declares in `[project.optional-dependencies]` is documented alongside its dependencies and a `pip install pkg[extra]` example.

## Why this shape

The optional-dependencies table and its Jinja context (`OPTIONAL_DEPENDENCIES`, `OPTIONAL_DEPENDENCIES_TABLE_RST`) already existed and are already rendered by the PyPI **README** template (added in #55280). The docs-site **index** template was simply never given the section, so this reuses the exact same computed context -- no new data plumbing.

It sits alongside the existing "Optional cross provider package dependencies" table, which stays because it links out to the other providers' docs. This mirrors how the README already renders both tables.

## Scope of the diff

The index template is shared, and the `update-providers-build-files` static check regenerates every provider's `index.rst` from it. So the section can't be scoped to one provider -- all `index.rst` files that gain a section have to be regenerated in the same PR to keep the check green. The 40 providers touched here are exactly those that declare optional extras; providers with none are unchanged. The change is purely additive (a new section), verified idempotent against the generator.
