### PR TITLE
Chart: Default airflow version to 3.3.0

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: airflow
 version: 2.0.0
-appVersion: 3.2.2
+appVersion: 3.3.0
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
 home: https://airflow.apache.org/
@@ -47,21 +47,21 @@ annotations:
       url: https://airflow.apache.org/docs/helm-chart/1.21.0/
   artifacthub.io/screenshots: |
     - title: Home Page
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/home_dark.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/home_dark.png
     - title: Dag Overview Dashboard
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_dashboard.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/dag_overview_dashboard.png
     - title: Dags View
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dags.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/dags.png
     - title: Assets View
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/asset_view.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/asset_view.png
     - title: Grid View
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_grid.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/dag_overview_grid.png
     - title: Graph View
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_graph.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/dag_overview_graph.png
     - title: Variable View
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/variable_hidden.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/variable_hidden.png
     - title: Code View
-      url: https://airflow.apache.org/docs/apache-airflow/3.2.2/_images/dag_overview_code.png
+      url: https://airflow.apache.org/docs/apache-airflow/3.3.0/_images/dag_overview_code.png
   artifacthub.io/changes: |
     - description: >
         Workers config options have been moved under workers.celery.* and workers.kubernetes.*:
@@ -116,7 +116,7 @@ annotations:
         url: https://github.com/apache/airflow/pull/65056
       - name: '#65059'
         url: https://github.com/apache/airflow/pull/65059
-    - description: Default Airflow image updated to 3.2.2
+    - description: Default Airflow image updated to 3.3.0
       kind: changed
       links:
       - name: '#64841'

--- a/chart/newsfragments/69481.significant.rst
+++ b/chart/newsfragments/69481.significant.rst
@@ -1,0 +1,3 @@
+Default Airflow image is updated to ``3.3.0``
+
+The default Airflow image that is used with the Chart is now ``3.3.0``, previously it was ``3.2.2``.

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -78,7 +78,7 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "3.2.2",
+            "default": "3.3.0",
             "x-docsSection": "Common"
         },
         "defaultAirflowDigest": {
@@ -93,7 +93,7 @@
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed). Version 3.1.0 and above is supported.",
             "type": "string",
-            "default": "3.2.2",
+            "default": "3.3.0",
             "x-docsSection": "Common"
         },
         "securityContexts": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,14 +59,14 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default Airflow tag to deploy
-defaultAirflowTag: "3.2.2"
+defaultAirflowTag: "3.3.0"
 
 # Default Airflow digest. If specified, it takes precedence over tag
 defaultAirflowDigest: ~
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
 # Version 3.1.0 and above is supported.
-airflowVersion: "3.2.2"
+airflowVersion: "3.3.0"
 
 images:
   airflow:


### PR DESCRIPTION
Update the Helm chart default Airflow version to `3.3.0` now that it has been released:

- `appVersion`, `defaultAirflowTag`, and `airflowVersion` bumped `3.2.2` → `3.3.0`.
- Screenshot doc URLs and the artifacthub changelog entry updated to `3.3.0`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)