### PR TITLE
Clarify Task Instance terminal state reporting

### DIFF
--- a/task-sdk-integration-tests/tests/task_sdk_tests/test_task_instance_operations.py
+++ b/task-sdk-integration-tests/tests/task_sdk_tests/test_task_instance_operations.py
@@ -177,7 +177,7 @@ def test_ti_state_transitions(sdk_client, task_instance_id):
     Test task instance state transition to terminal state.
     """
     console.print("[yellow]Testing state transition: RUNNING → FAILED...")
-    sdk_client.task_instances.finish(
+    sdk_client.task_instances.set_terminal_state(
         id=task_instance_id, state=TerminalStateNonSuccess.FAILED, when=utcnow(), rendered_map_index="-1"
     )
 

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -265,11 +265,12 @@ class TaskInstanceOperations:
             raise
         return TIRunContext.model_validate_json(resp.read())
 
-    def finish(self, id: uuid.UUID, state: TerminalStateNonSuccess, when: datetime, rendered_map_index):
-        """Tell the API server that this TI has reached a terminal state."""
+    def set_terminal_state(
+        self, id: uuid.UUID, state: TerminalStateNonSuccess, when: datetime, rendered_map_index
+    ):
+        """Tell the API server that this TI has reached a non-success terminal state."""
         if state == TaskInstanceState.SUCCESS:
             raise ValueError("Logic error. SUCCESS state should call the `succeed` function instead")
-        # TODO: handle the naming better. finish sounds wrong as "even" deferred is essentially finishing.
         body = TITerminalStatePayload(
             end_date=when, state=TerminalStateNonSuccess(state), rendered_map_index=rendered_map_index
         )

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -271,11 +271,12 @@ class TaskInstanceOperations:
             raise
         return TIRunContext.model_validate_json(resp.read())
 
-    def finish(self, id: uuid.UUID, state: TerminalStateNonSuccess, when: datetime, rendered_map_index):
-        """Tell the API server that this TI has reached a terminal state."""
+    def set_terminal_state(
+        self, id: uuid.UUID, state: TerminalStateNonSuccess, when: datetime, rendered_map_index
+    ):
+        """Tell the API server that this TI has reached a non-success terminal state."""
         if state == TaskInstanceState.SUCCESS:
             raise ValueError("Logic error. SUCCESS state should call the `succeed` function instead")
-        # TODO: handle the naming better. finish sounds wrong as "even" deferred is essentially finishing.
         body = TITerminalStatePayload(
             end_date=when, state=TerminalStateNonSuccess(state), rendered_map_index=rendered_map_index
         )

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1316,9 +1316,9 @@ class ActivitySubprocess(WatchedSubprocess):
     # this attribute stays set and the dispatcher in
     # `update_task_state_if_needed` re-issues the matching API call on
     # subprocess exit — re-attempting the original transition rather than
-    # falling back to `finish()`, which doesn't accept SUCCESS / DEFERRED /
-    # SERVER_TERMINATED on the server side. Cleared (and `_terminal_state`
-    # set) only after the API call returns successfully.
+    # falling back to the generic non-success terminal-state update, which
+    # does not accept SUCCESS / DEFERRED / SERVER_TERMINATED. Cleared
+    # (and `_terminal_state` set) only after the API call returns successfully.
     _pending_terminal_state_msg: (
         SucceedTask | RetryTask | DeferTask | RescheduleTask | AwaitInputTask | None
     ) = attrs.field(default=None, init=False)
@@ -1446,20 +1446,19 @@ class ActivitySubprocess(WatchedSubprocess):
         # the original request. Re-issue the matching dedicated API call so
         # the server learns the terminal state we couldn't deliver earlier.
         # Without this recovery, a transient API failure during the direct
-        # call would leave the TI stuck RUNNING on the server — `finish()`
-        # cannot substitute because the server-side `finish` endpoint does
-        # not accept SUCCESS / DEFERRED / SERVER_TERMINATED transitions.
+        # call would leave the TI stuck RUNNING on the server. The generic
+        # non-success terminal-state update cannot substitute because its
+        # payload does not accept SUCCESS / DEFERRED / SERVER_TERMINATED.
         if self._pending_terminal_state_msg is not None:
             self._replay_pending_terminal_state_msg()
             return
 
-        # If the process has finished a non-directly-patched state (e.g.
-        # FAILED, UP_FOR_RETRY without RetryTask), `finish()` is the
-        # dedicated endpoint for those transitions. For states already in
-        # STATES_SENT_DIRECTLY whose direct API call succeeded, no further
-        # action is needed.
+        # If the process has finished in a non-success terminal state that was
+        # not sent directly, report it with `set_terminal_state()`. For states
+        # already in STATES_SENT_DIRECTLY whose direct API call succeeded, no
+        # further action is needed.
         if self.final_state not in STATES_SENT_DIRECTLY:
-            self.client.task_instances.finish(
+            self.client.task_instances.set_terminal_state(
                 id=self.id,
                 state=self.final_state,
                 when=datetime.now(tz=timezone.utc),
@@ -1695,7 +1694,7 @@ class ActivitySubprocess(WatchedSubprocess):
         dump_opts: dict[str, bool] = {}
         if isinstance(msg, TaskState):
             # No direct API call here — the recovery path in
-            # `update_task_state_if_needed` will call `finish()` for
+            # `update_task_state_if_needed` will call `set_terminal_state()` for
             # non-direct states (FAILED, etc.) once the subprocess exits.
             self._terminal_state = msg.state
             self._task_end_time_monotonic = time.monotonic()

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1373,9 +1373,9 @@ class ActivitySubprocess(WatchedSubprocess):
     # this attribute stays set and the dispatcher in
     # `update_task_state_if_needed` re-issues the matching API call on
     # subprocess exit — re-attempting the original transition rather than
-    # falling back to `finish()`, which doesn't accept SUCCESS / DEFERRED /
-    # SERVER_TERMINATED on the server side. Cleared (and `_terminal_state`
-    # set) only after the API call returns successfully.
+    # falling back to the generic non-success terminal-state update, which
+    # does not accept SUCCESS / DEFERRED / SERVER_TERMINATED. Cleared
+    # (and `_terminal_state` set) only after the API call returns successfully.
     _pending_terminal_state_msg: (
         SucceedTask | RetryTask | DeferTask | RescheduleTask | AwaitInputTask | None
     ) = attrs.field(default=None, init=False)
@@ -1509,20 +1509,20 @@ class ActivitySubprocess(WatchedSubprocess):
         # the original request. Re-issue the matching dedicated API call so
         # the server learns the terminal state we couldn't deliver earlier.
         # Without this recovery, a transient API failure during the direct
-        # call would leave the TI stuck RUNNING on the server — `finish()`
-        # cannot substitute because the server-side `finish` endpoint does
-        # not accept SUCCESS / DEFERRED / SERVER_TERMINATED transitions.
+        # call would leave the TI stuck RUNNING on the server. The generic
+        # non-success terminal-state update cannot substitute because its
+        # payload does not accept SUCCESS / DEFERRED / SERVER_TERMINATED.
         if self._pending_terminal_state_msg is not None:
             self._replay_pending_terminal_state_msg()
             return
 
         # If the process has finished in a non-directly-patched state (e.g.
-        # FAILED, or SKIPPED reported via a TaskState message), `finish()` is
-        # the dedicated endpoint for those transitions. For states already in
-        # STATES_SENT_DIRECTLY whose direct API call succeeded, no further
-        # action is needed.
+        # FAILED, or SKIPPED reported via a TaskState message),
+        # `set_terminal_state()` is the dedicated endpoint for those
+        # transitions. For states already in STATES_SENT_DIRECTLY whose direct
+        # API call succeeded, no further action is needed.
         if self.final_state not in STATES_SENT_DIRECTLY:
-            self.client.task_instances.finish(
+            self.client.task_instances.set_terminal_state(
                 id=self.id,
                 state=self.final_state,
                 when=datetime.now(tz=timezone.utc),
@@ -1758,7 +1758,7 @@ class ActivitySubprocess(WatchedSubprocess):
         dump_opts: dict[str, bool] = {}
         if isinstance(msg, TaskState):
             # No direct API call here — the recovery path in
-            # `update_task_state_if_needed` will call `finish()` for
+            # `update_task_state_if_needed` will call `set_terminal_state()` for
             # non-direct states (FAILED, etc.) once the subprocess exits.
             self._terminal_state = msg.state
             self._task_end_time_monotonic = time.monotonic()

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -405,8 +405,8 @@ class TestTaskInstanceOperations:
     @pytest.mark.parametrize(
         "state", [state for state in TerminalTIState if state != TerminalTIState.SUCCESS]
     )
-    def test_task_instance_finish(self, state):
-        # Simulate a successful response from the server that finishes (moved to terminal state) a task
+    def test_task_instance_set_terminal_state(self, state):
+        # Simulate a successful response from the server that sets a non-success terminal state for a task
         ti_id = uuid6.uuid7()
 
         def handle_request(request: httpx.Request) -> httpx.Response:
@@ -421,7 +421,7 @@ class TestTaskInstanceOperations:
             return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
         client = make_client(transport=httpx.MockTransport(handle_request))
-        client.task_instances.finish(
+        client.task_instances.set_terminal_state(
             ti_id, state=state, when="2024-10-31T12:00:00Z", rendered_map_index="test"
         )
 

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -422,8 +422,8 @@ class TestTaskInstanceOperations:
     @pytest.mark.parametrize(
         "state", [state for state in TerminalTIState if state != TerminalTIState.SUCCESS]
     )
-    def test_task_instance_finish(self, state):
-        # Simulate a successful response from the server that finishes (moved to terminal state) a task
+    def test_task_instance_set_terminal_state(self, state):
+        # Simulate a successful response from the server that sets a non-success terminal state for a task
         ti_id = uuid6.uuid7()
 
         def handle_request(request: httpx.Request) -> httpx.Response:
@@ -438,7 +438,7 @@ class TestTaskInstanceOperations:
             return httpx.Response(status_code=400, json={"detail": "Bad Request"})
 
         client = make_client(transport=httpx.MockTransport(handle_request))
-        client.task_instances.finish(
+        client.task_instances.set_terminal_state(
             ti_id, state=state, when="2024-10-31T12:00:00Z", rendered_map_index="test"
         )
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3233,9 +3233,9 @@ class TestHandleRequest:
         self, watched_subprocess, mocker, msg, api_method, expected_state
     ):
         """If a direct terminal-state API call was attempted and raised, the
-        recovery dispatcher must re-issue the dedicated endpoint (not
-        `finish()`, which the server-side endpoint refuses for SUCCESS /
-        DEFERRED / SERVER_TERMINATED). Covers all four message types.
+        recovery dispatcher must re-issue the dedicated method, not the
+        generic non-success terminal-state update, which refuses SUCCESS /
+        DEFERRED / SERVER_TERMINATED. Covers all four message types.
         """
         watched_subprocess, _ = watched_subprocess
         watched_subprocess._exit_code = 0
@@ -3244,9 +3244,9 @@ class TestHandleRequest:
 
         watched_subprocess.update_task_state_if_needed()
 
-        # Recovery re-issues the dedicated endpoint, NOT finish().
+        # Recovery re-issues the dedicated method, not the generic terminal-state update.
         getattr(watched_subprocess.client.task_instances, api_method).assert_called_once()
-        watched_subprocess.client.task_instances.finish.assert_not_called()
+        watched_subprocess.client.task_instances.set_terminal_state.assert_not_called()
         assert watched_subprocess._terminal_state == expected_state
         assert watched_subprocess._pending_terminal_state_msg is None
 
@@ -3260,7 +3260,7 @@ class TestHandleRequest:
 
         watched_subprocess.update_task_state_if_needed()
 
-        watched_subprocess.client.task_instances.finish.assert_not_called()
+        watched_subprocess.client.task_instances.set_terminal_state.assert_not_called()
         watched_subprocess.client.task_instances.succeed.assert_not_called()
 
 
@@ -3378,7 +3378,7 @@ class TestInProcessTestSupervisor:
         )
 
         # Patch the API client used by InProcessTestSupervisor to return a predictable TI context
-        fake_task_instances = mock.MagicMock(spec_set=["start", "finish"])
+        fake_task_instances = mock.MagicMock(spec_set=["start", "set_terminal_state"])
         fake_task_instances.start.return_value = make_ti_context()
         fake_client = mock.MagicMock(spec_set=["task_instances"])
         fake_client.task_instances = fake_task_instances

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -3673,9 +3673,9 @@ class TestHandleRequest:
         self, watched_subprocess, mocker, msg, api_method, expected_state
     ):
         """If a direct terminal-state API call was attempted and raised, the
-        recovery dispatcher must re-issue the dedicated endpoint (not
-        `finish()`, which the server-side endpoint refuses for SUCCESS /
-        DEFERRED / SERVER_TERMINATED). Covers all four message types.
+        recovery dispatcher must re-issue the dedicated method, not the
+        generic non-success terminal-state update, which refuses SUCCESS /
+        DEFERRED / SERVER_TERMINATED. Covers all four message types.
         """
         watched_subprocess, _ = watched_subprocess
         watched_subprocess._exit_code = 0
@@ -3684,9 +3684,9 @@ class TestHandleRequest:
 
         watched_subprocess.update_task_state_if_needed()
 
-        # Recovery re-issues the dedicated endpoint, NOT finish().
+        # Recovery re-issues the dedicated method, not the generic terminal-state update.
         getattr(watched_subprocess.client.task_instances, api_method).assert_called_once()
-        watched_subprocess.client.task_instances.finish.assert_not_called()
+        watched_subprocess.client.task_instances.set_terminal_state.assert_not_called()
         assert watched_subprocess._terminal_state == expected_state
         assert watched_subprocess._pending_terminal_state_msg is None
 
@@ -3700,7 +3700,7 @@ class TestHandleRequest:
 
         watched_subprocess.update_task_state_if_needed()
 
-        watched_subprocess.client.task_instances.finish.assert_not_called()
+        watched_subprocess.client.task_instances.set_terminal_state.assert_not_called()
         watched_subprocess.client.task_instances.succeed.assert_not_called()
 
 
@@ -3818,7 +3818,7 @@ class TestInProcessTestSupervisor:
         )
 
         # Patch the API client used by InProcessTestSupervisor to return a predictable TI context
-        fake_task_instances = mock.MagicMock(spec_set=["start", "finish"])
+        fake_task_instances = mock.MagicMock(spec_set=["start", "set_terminal_state"])
         fake_task_instances.start.return_value = make_ti_context()
         fake_client = mock.MagicMock(spec_set=["task_instances"])
         fake_client.task_instances = fake_task_instances


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Why
The Task SDK client previously exposed this operation as `finish()`, but that name made it sound like the generic path for any task that stops executing. In practice, this method only reports non-success terminal Task Instance states; success, retry, defer, reschedule, and awaiting-input transitions use dedicated methods and payloads.

## Change
Rename the Task SDK client method used for non-success terminal Task Instance state updates from `finish()` to `set_terminal_state()`.

This better reflects that success, retry, defer, reschedule, and awaiting-input states each use dedicated API payloads and should not fall back to this generic non-success terminal-state update.

Updated the supervisor call sites, comments, unit tests, and Task SDK integration test usage.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
