### PR TITLE
Add anthropic provider maintainers to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,6 +88,7 @@ airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/ @Lee-W @jason810496 @guan
 # Providers
 /providers/akeyless/ @eladkal # + @baraka-akeyless @deanshak
 /providers/amazon/ @o-nikolas
+/providers/anthropic/ @kaxil @gopidesupavan
 /providers/apache/iceberg/ @Fokko
 /providers/celery/ @hussein-awala @dheerajturaga
 /providers/cncf/kubernetes @jedcunningham @hussein-awala @jscheffl


### PR DESCRIPTION
Adds a CODEOWNERS entry for the newly added Anthropic provider (`providers/anthropic/`) so review requests are routed to its maintainers automatically.

```
/providers/anthropic/ @kaxil @gopidesupavan
```

The entry is placed alphabetically between `amazon` and `apache/iceberg`, matching the ordering of the other provider entries. The two owners mirror the existing `/providers/common/ai/` line.