### PR TITLE
Avoid scheduler crash when periodic maintenance actions fail

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1842,7 +1842,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         timers.call_regular_interval(
             conf.getfloat("scheduler", "parsing_cleanup_interval"),
             self._remove_unreferenced_triggers,
-            catch_exceptions=True,
+            non_fatal=True,
         )
 
         if any(x.is_local for x in self.executors):
@@ -1860,7 +1860,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         timers.call_regular_interval(
             delay=conf.getfloat("connection_test", "reaper_interval", fallback=30.0),
             action=self._reap_stale_connection_tests,
-            catch_exceptions=True,
+            non_fatal=True,
         )
 
         idle_count = 0

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1842,6 +1842,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         timers.call_regular_interval(
             conf.getfloat("scheduler", "parsing_cleanup_interval"),
             self._remove_unreferenced_triggers,
+            catch_exceptions=True,
         )
 
         if any(x.is_local for x in self.executors):
@@ -1859,6 +1860,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         timers.call_regular_interval(
             delay=conf.getfloat("connection_test", "reaper_interval", fallback=30.0),
             action=self._reap_stale_connection_tests,
+            catch_exceptions=True,
         )
 
         idle_count = 0

--- a/airflow-core/src/airflow/utils/event_scheduler.py
+++ b/airflow-core/src/airflow/utils/event_scheduler.py
@@ -51,8 +51,7 @@ class EventScheduler(scheduler, LoggingMixin):
                     action(*args, **kwargs)
                 except Exception as e:
                     self.log.exception(
-                        "Failed to run periodic action %s due to %s. "
-                        "Please investigate if this is persistent.",
+                        "Failed to run periodic action %s due to %s; will retry on the next cycle",
                         getattr(action, "__name__", action),
                         e,
                     )

--- a/airflow-core/src/airflow/utils/event_scheduler.py
+++ b/airflow-core/src/airflow/utils/event_scheduler.py
@@ -49,8 +49,13 @@ class EventScheduler(scheduler, LoggingMixin):
             if non_fatal:
                 try:
                     action(*args, **kwargs)
-                except Exception:
-                    self.log.exception("Exception raised in periodic action %s", action)
+                except Exception as e:
+                    self.log.exception(
+                        "Failed to run periodic action %s due to %s. "
+                        "Please investigate if this is persistent.",
+                        getattr(action, "__name__", action),
+                        e,
+                    )
             else:
                 action(*args, **kwargs)
             # This is not perfect. If we want a timer every 60s, but action

--- a/airflow-core/src/airflow/utils/event_scheduler.py
+++ b/airflow-core/src/airflow/utils/event_scheduler.py
@@ -32,13 +32,13 @@ class EventScheduler(scheduler, LoggingMixin):
         action: Callable,
         arguments=(),
         kwargs=None,
-        catch_exceptions: bool = False,
+        non_fatal: bool = False,
     ):
         """
         Call a function at (roughly) a given interval.
 
-        :param catch_exceptions: If True, an exception raised by ``action`` is logged
-            and swallowed instead of propagating, so a single bad cycle can't kill
+        :param non_fatal: If True, an exception raised by ``action`` is logged and
+            swallowed instead of propagating, so a single bad cycle can't kill
             whatever is driving this scheduler. The next cycle is still scheduled either
             way. Defaults to False (propagate), preserving prior behavior for callers
             that rely on the exception surfacing.
@@ -46,7 +46,7 @@ class EventScheduler(scheduler, LoggingMixin):
 
         def repeat(*args, **kwargs):
             self.log.debug("Calling %s", action)
-            if catch_exceptions:
+            if non_fatal:
                 try:
                     action(*args, **kwargs)
                 except Exception:

--- a/airflow-core/src/airflow/utils/event_scheduler.py
+++ b/airflow-core/src/airflow/utils/event_scheduler.py
@@ -50,10 +50,11 @@ class EventScheduler(scheduler, LoggingMixin):
                 try:
                     action(*args, **kwargs)
                 except Exception as e:
-                    self.log.exception(
+                    self.log.warning(
                         "Failed to run periodic action %s due to %s; will retry on the next cycle",
                         getattr(action, "__name__", action),
                         e,
+                        exc_info=True,
                     )
             else:
                 action(*args, **kwargs)

--- a/airflow-core/src/airflow/utils/event_scheduler.py
+++ b/airflow-core/src/airflow/utils/event_scheduler.py
@@ -32,12 +32,27 @@ class EventScheduler(scheduler, LoggingMixin):
         action: Callable,
         arguments=(),
         kwargs=None,
+        catch_exceptions: bool = False,
     ):
-        """Call a function at (roughly) a given interval."""
+        """
+        Call a function at (roughly) a given interval.
+
+        :param catch_exceptions: If True, an exception raised by ``action`` is logged
+            and swallowed instead of propagating, so a single bad cycle can't kill
+            whatever is driving this scheduler. The next cycle is still scheduled either
+            way. Defaults to False (propagate), preserving prior behavior for callers
+            that rely on the exception surfacing.
+        """
 
         def repeat(*args, **kwargs):
             self.log.debug("Calling %s", action)
-            action(*args, **kwargs)
+            if catch_exceptions:
+                try:
+                    action(*args, **kwargs)
+                except Exception:
+                    self.log.exception("Exception raised in periodic action %s", action)
+            else:
+                action(*args, **kwargs)
             # This is not perfect. If we want a timer every 60s, but action
             # takes 10s to run, this will run it every 70s.
             # Good enough for now

--- a/airflow-core/tests/unit/utils/test_event_scheduler.py
+++ b/airflow-core/tests/unit/utils/test_event_scheduler.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.utils.event_scheduler import EventScheduler
 
 
@@ -37,4 +39,35 @@ class TestEventScheduler:
         # Make sure it added another event to the queue
         assert len(timers.queue) == 2
         somefunction.assert_called_once()
+        assert timers.queue[0].time < timers.queue[1].time
+
+    def test_call_regular_interval_propagates_exception_by_default(self):
+        """Without opting in, an action's exception still propagates (unchanged default behavior)."""
+        failing_action = mock.MagicMock(side_effect=RuntimeError("boom"))
+
+        timers = EventScheduler()
+        timers.call_regular_interval(30, failing_action)
+        assert len(timers.queue) == 1
+
+        with pytest.raises(RuntimeError, match="boom"):
+            timers.queue[0].action()
+
+        failing_action.assert_called_once()
+        # The next cycle was never scheduled because the exception propagated.
+        assert len(timers.queue) == 1
+
+    def test_call_regular_interval_catch_exceptions_swallows_action_exception(self):
+        """With catch_exceptions=True, a raising action is swallowed and the next cycle is still scheduled."""
+        failing_action = mock.MagicMock(side_effect=RuntimeError("boom"))
+
+        timers = EventScheduler()
+        timers.call_regular_interval(30, failing_action, catch_exceptions=True)
+        assert len(timers.queue) == 1
+
+        # Should not raise, even though the action does.
+        timers.queue[0].action()
+
+        failing_action.assert_called_once()
+        # The next cycle was still scheduled despite the exception.
+        assert len(timers.queue) == 2
         assert timers.queue[0].time < timers.queue[1].time

--- a/airflow-core/tests/unit/utils/test_event_scheduler.py
+++ b/airflow-core/tests/unit/utils/test_event_scheduler.py
@@ -56,12 +56,12 @@ class TestEventScheduler:
         # The next cycle was never scheduled because the exception propagated.
         assert len(timers.queue) == 1
 
-    def test_call_regular_interval_catch_exceptions_swallows_action_exception(self):
-        """With catch_exceptions=True, a raising action is swallowed and the next cycle is still scheduled."""
+    def test_call_regular_interval_non_fatal_swallows_action_exception(self):
+        """With non_fatal=True, a raising action is swallowed and the next cycle is still scheduled."""
         failing_action = mock.MagicMock(side_effect=RuntimeError("boom"))
 
         timers = EventScheduler()
-        timers.call_regular_interval(30, failing_action, catch_exceptions=True)
+        timers.call_regular_interval(30, failing_action, non_fatal=True)
         assert len(timers.queue) == 1
 
         # Should not raise, even though the action does.


### PR DESCRIPTION
**What does this PR do?**
- Adds an opt-in `non_fatal: bool = False` parameter to `EventScheduler.call_regular_interval`. When `True`, an exception raised by the periodic `action` is logged (`self.log.warning(..., exc_info=True)`) and swallowed instead of propagating; the next cycle is still scheduled either way. Default is `False`, preserving current behavior for existing callers.
- Enables `non_fatal=True` for the two `SchedulerJobRunner` periodic maintenance callbacks registered via `call_regular_interval` that had no exception handling at all: `_remove_unreferenced_triggers` and `_reap_stale_connection_tests`.
- Logs `Failed to run periodic action <name> due to <exception>; will retry on the next cycle` on the caught-exception path — matches the existing `Failed to <thing> due to %s` house style already used by `_update_dag_run_state_for_paused_dags`, and states why a single occurrence is safe to ignore. Logged at `WARNING` (with `exc_info=True` to still capture the full traceback) rather than `ERROR`, so a persistent (rather than transient) failure repeating every cycle doesn't generate steady-state ERROR-level noise.

**Motivation:**
`EventScheduler.call_regular_interval`'s inner `repeat()` closure calls the registered `action` with no exception handling, so a single transient failure (e.g. a DB `statement_timeout` during `_remove_unreferenced_triggers`'s DELETE) propagates all the way up and crashes the whole `SchedulerJob`. In practice this means: the scheduler process dies with a critical-level log, and every task instance it was tracking gets swept into the orphaned-task-adoption path on the next scheduler startup — a heavyweight, disruptive recovery flow triggered by what should have been a harmless, skippable cycle of a periodic cleanup job. This is inconsistent with the existing pattern elsewhere in `SchedulerJobRunner` — `_update_dag_run_state_for_paused_dags` already wraps its own body in `except Exception as e:  # should not fail the scheduler`, and the same crash-avoidance philosophy has precedent in merged PRs like #62893 (isolating per-DagRun failures so one bad DagRun can't crash the scheduler). `EventScheduler` is documented as a "general purpose" utility, so rather than making it always swallow exceptions (which would silently change behavior for any future caller that wants failures to propagate), the fix is an explicit opt-in.

**Testing:**
- Unit tests: 2 new tests in `test_event_scheduler.py` — one confirms the default (no flag) still propagates the action's exception, one confirms `non_fatal=True` swallows it and still schedules the next cycle.

**Notes:**
- Named `non_fatal` rather than `catch_exceptions` to be outcome-focused (this failure isn't fatal to the scheduler) rather than mechanism-focused, matching existing "non-fatal" terminology already used elsewhere in the codebase (`dag_processing/importers/base.py`).
- Log level was changed from `ERROR` (`self.log.exception`) to `WARNING` (`self.log.warning(..., exc_info=True)`) in response to review feedback — addresses steady-state log noise for a persistent failure while keeping the traceback for debuggability.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

<!-- Generated-by: Claude Code following the guidelines at contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions -->
