### PR TITLE
pgvector: Guard the psycopg2-specific `register_vector` import

### DIFF
--- a/providers/pgvector/src/airflow/providers/pgvector/operators/pgvector.py
+++ b/providers/pgvector/src/airflow/providers/pgvector/operators/pgvector.py
@@ -17,8 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from pgvector.psycopg2 import register_vector
-
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -41,6 +40,16 @@ class PgVectorIngestOperator(SQLExecuteQueryOperator):
 
     def _register_vector(self) -> None:
         """Register the vector type with your connection."""
+        # This always uses the psycopg2-specific registration helper, regardless of whether the
+        # underlying connection is actually psycopg2 or psycopg3; tracked separately at
+        # https://github.com/apache/airflow/issues/69443
+        try:
+            from pgvector.psycopg2 import register_vector
+        except (ImportError, ModuleNotFoundError) as err:
+            raise AirflowOptionalProviderFeatureException(
+                "psycopg2 is not installed. Please install it with "
+                "`pip install apache-airflow-providers-postgres[psycopg2]`."
+            ) from err
         conn = self.get_db_hook().get_conn()
         register_vector(conn)
 

--- a/providers/pgvector/tests/unit/pgvector/operators/test_pgvector.py
+++ b/providers/pgvector/tests/unit/pgvector/operators/test_pgvector.py
@@ -16,10 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
 
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 from airflow.providers.pgvector.operators.pgvector import PgVectorIngestOperator
 
 
@@ -32,7 +35,12 @@ def pg_vector_ingest_operator():
     )
 
 
-@patch("airflow.providers.pgvector.operators.pgvector.register_vector")
+# These two tests patch pgvector.psycopg2.register_vector, which requires psycopg2 to be
+# installed. Once apache-airflow-providers-postgres stops hard-requiring psycopg2 (a separate,
+# independently-branched fix for the same migration, apache/airflow#68453), this provider's own
+# dev environment could lose psycopg2 unless its dependency on that provider requests the
+# [psycopg2] extra explicitly -- currently not declared because that extra doesn't exist yet.
+@patch("pgvector.psycopg2.register_vector")
 @patch("airflow.providers.pgvector.operators.pgvector.PgVectorIngestOperator.get_db_hook")
 def test_register_vector(mock_get_db_hook, mock_register_vector, pg_vector_ingest_operator):
     # Create a mock database connection
@@ -43,7 +51,7 @@ def test_register_vector(mock_get_db_hook, mock_register_vector, pg_vector_inges
     mock_register_vector.assert_called_with(mock_db_hook.get_conn())
 
 
-@patch("airflow.providers.pgvector.operators.pgvector.register_vector")
+@patch("pgvector.psycopg2.register_vector")
 @patch("airflow.providers.pgvector.operators.pgvector.SQLExecuteQueryOperator.execute")
 @patch("airflow.providers.pgvector.operators.pgvector.PgVectorIngestOperator.get_db_hook")
 def test_execute(
@@ -54,3 +62,22 @@ def test_execute(
 
     pg_vector_ingest_operator.execute(None)
     mock_execute_query_operator_execute.assert_called_once()
+
+
+def test_register_vector_raises_clear_error_without_psycopg2(monkeypatch, pg_vector_ingest_operator):
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", None)
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        pg_vector_ingest_operator._register_vector()
+
+
+def test_pgvector_module_imports_without_psycopg2(monkeypatch):
+    """The module must import cleanly even when psycopg2/pgvector.psycopg2 isn't installed."""
+    monkeypatch.setitem(sys.modules, "psycopg2", None)
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", None)
+    module_name = "airflow.providers.pgvector.operators.pgvector"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    try:
+        module = importlib.import_module(module_name)
+        assert module.PgVectorIngestOperator is not None
+    finally:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related:
- #68453
- https://github.com/apache/airflow/issues/69443

depends on:
- #69474  

`from pgvector.psycopg2 import register_vector` ran unconditionally at module level in `PgVectorIngestOperator`, forcing psycopg2 to be importable regardless of which driver the underlying `PostgresHook` connection actually uses. Make the import lazy and raise a clear, actionable error if it's genuinely needed but missing.

> **Note:** this module only imports cleanly without psycopg2 installed once `apache-airflow-providers-postgres` itself stops hard-requiring psycopg2 — that's the companion change in **psycopg3-sync-postgres**. This PR should be merged after (or at least released alongside) that one; see the code comment at the import site and in the test file.

This does **not** fix a separate, pre-existing bug where `register_vector` is always called with the psycopg2-specific helper regardless of whether the connection is actually psycopg2 or psycopg3 — that's tracked separately at apache/airflow#69443, referenced in a code comment at the guard site so it isn't lost.

### What changed

- `providers/pgvector/src/airflow/providers/pgvector/operators/pgvector.py`: `from pgvector.psycopg2 import register_vector` moved inside `_register_vector()`, guarded with `AirflowOptionalProviderFeatureException` if `pgvector.psycopg2`/psycopg2 is unavailable.

### Test plan

- New tests: `test_register_vector_raises_clear_error_without_psycopg2`, `test_pgvector_module_imports_without_psycopg2` (simulates psycopg2 absent via `sys.modules` patching, confirms clean import and a clear error on actual use).
- Existing `register_vector`-mocking tests still pass; a code comment documents that they currently rely on psycopg2 staying installed in this provider's dev environment until the postgres provider's `[psycopg2]` extra exists to depend on explicitly.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 