### PR TITLE
Google: Guard bigquery_to_postgres's psycopg2-specific adapter registration

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py
@@ -22,13 +22,13 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from psycopg2.extensions import register_adapter
-from psycopg2.extras import Json
-
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.transfers.bigquery_to_sql import BigQueryToSqlBaseOperator
 from airflow.providers.google.cloud.utils.bigquery_get_data import bigquery_get_data
-from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+# This module only imports cleanly without psycopg2 installed once apache-airflow-providers-postgres
+# itself guards its own psycopg2 imports (apache/airflow#68453); requires that provider release.
+from airflow.providers.postgres.hooks.postgres import USE_PSYCOPG3, PostgresHook
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -81,8 +81,12 @@ class BigQueryToPostgresOperator(BigQueryToSqlBaseOperator):
 
     @cached_property
     def postgres_hook(self) -> PostgresHook:
-        register_adapter(list, Json)
-        register_adapter(dict, Json)
+        if not USE_PSYCOPG3:
+            from psycopg2.extensions import register_adapter
+            from psycopg2.extras import Json
+
+            register_adapter(list, Json)
+            register_adapter(dict, Json)
         return PostgresHook(database=self.database, postgres_conn_id=self.postgres_conn_id)
 
     def get_sql_hook(self) -> PostgresHook:

--- a/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -148,8 +150,13 @@ class TestBigQueryToPostgresOperator:
     @mock.patch(
         "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials_and_project_id"
     )
-    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_postgres.register_adapter")
-    def test_adapters_to_json_registered(self, mock_register_adapter, mock_get_creds, mock_get_client):
+    @mock.patch("psycopg2.extensions.register_adapter")
+    def test_adapters_to_json_registered_on_psycopg2_path(
+        self, mock_register_adapter, mock_get_creds, mock_get_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "airflow.providers.google.cloud.transfers.bigquery_to_postgres.USE_PSYCOPG3", False
+        )
         mock_get_creds.return_value = (None, TEST_PROJECT)
         client = MagicMock()
         client.list_rows.return_value = []
@@ -165,6 +172,32 @@ class TestBigQueryToPostgresOperator:
 
         mock_register_adapter.assert_any_call(list, Json)
         mock_register_adapter.assert_any_call(dict, Json)
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
+    @mock.patch(
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials_and_project_id"
+    )
+    @mock.patch("psycopg2.extensions.register_adapter")
+    def test_adapters_not_registered_on_psycopg3_path(
+        self, mock_register_adapter, mock_get_creds, mock_get_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "airflow.providers.google.cloud.transfers.bigquery_to_postgres.USE_PSYCOPG3", True
+        )
+        mock_get_creds.return_value = (None, TEST_PROJECT)
+        client = MagicMock()
+        client.list_rows.return_value = []
+        mock_get_client.return_value = client
+
+        operator = BigQueryToPostgresOperator(
+            task_id=TASK_ID,
+            dataset_table=f"{TEST_DATASET}.{TEST_TABLE_ID}",
+            target_table_name=TEST_DESTINATION_TABLE,
+            replace=False,
+        )
+        operator.postgres_hook
+
+        mock_register_adapter.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_postgres.PostgresHook")
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_sql.BigQueryHook")
@@ -254,3 +287,17 @@ class TestBigQueryToPostgresOperator:
         assert "columnLineage" in output_ds.facets
         col_lineage = output_ds.facets["columnLineage"]
         assert set(col_lineage.fields.keys()) == {"id", "name"}
+
+
+def test_bigquery_to_postgres_module_imports_without_psycopg2(monkeypatch):
+    """The module must import cleanly even when psycopg2 isn't installed."""
+    monkeypatch.setitem(sys.modules, "psycopg2", None)
+    monkeypatch.setitem(sys.modules, "psycopg2.extensions", None)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", None)
+    module_name = "airflow.providers.google.cloud.transfers.bigquery_to_postgres"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    try:
+        module = importlib.import_module(module_name)
+        assert module.BigQueryToPostgresOperator is not None
+    finally:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

related:
- #68453

depends on:
- https://github.com/apache/airflow/pull/69474


`register_adapter(list/dict, Json)` in `BigQueryToPostgresOperator` is psycopg2-specific and previously ran unconditionally, forcing psycopg2 to be importable even when the resolved `PostgresHook` connection is actually on psycopg3 (where it's a no-op). Only import and call it when `PostgresHook` is actually on the psycopg2 path.

> **Note:** this module only imports cleanly without psycopg2 installed once `apache-airflow-providers-postgres` itself stops hard-requiring psycopg2 — that's the companion change in **psycopg3-sync-postgres**. This PR should be merged after (or at least released alongside) that one; see the code comment at the import site in `bigquery_to_postgres.py`.

### What changed

- `providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py`: the `from psycopg2.extensions import register_adapter` / `from psycopg2.extras import Json` imports and the `register_adapter(...)` calls are now conditional on `not PostgresHook.USE_PSYCOPG3`, guarded inside `postgres_hook`, with a comment documenting the dependency on the postgres provider's own guard fix.

### Test plan

- Existing `bigquery_to_postgres` test suite passes.
- New tests: `test_adapters_to_json_registered_on_psycopg2_path`, `test_adapters_not_registered_on_psycopg3_path`, `test_bigquery_to_postgres_module_imports_without_psycopg2` (simulates psycopg2 absent via `sys.modules` patching, confirms clean import).

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
