### PR TITLE
Add uranusjr to the release manager allowlist in workflows

### DIFF
--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -112,6 +112,7 @@ jobs:
       "pierrejeambrun",
       "shahar1",
       "potiuk",
+      "uranusjr",
       "utkarsharma2",
       "vincbeck",
       "vatsrahul1001",

--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -60,6 +60,7 @@ jobs:
         "pierrejeambrun",
         "shahar1",
         "potiuk",
+        "uranusjr",
         "utkarsharma2",
         "vincbeck"
         ]'), github.event.sender.login)

--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -75,6 +75,7 @@ jobs:
         "pierrejeambrun",
         "shahar1",
         "potiuk",
+        "uranusjr",
         "utkarsharma2",
         "vincbeck"
         ]'), github.event.sender.login)

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -67,6 +67,7 @@ jobs:
       "kaxil",
       "pierrejeambrun",
       "potiuk",
+      "uranusjr",
       "utkarsharma2",
       "vincbeck",
       "vatsrahul1001",


### PR DESCRIPTION
Adds @uranusjr to the sender allowlist that gates the manually triggered
release-related workflows: registry build, registry backfill, docs
publishing to S3, and the DockerHub image release.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)