### PR TITLE
Remove redundant session.commit() calls in FastAPI route handlers

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -136,7 +136,6 @@ def pause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> Backfill
         raise HTTPException(status.HTTP_409_CONFLICT, "Backfill is already completed.")
     if b.is_paused is False:
         b.is_paused = True
-    session.commit()
     return b
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -243,8 +243,6 @@ def update_hitl_detail(
             task_instance=locked_ti,
             session=session,
         )
-
-    session.commit()
     return HITLDetailResponse.model_validate(hitl_detail_model)
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -131,7 +131,6 @@ def update_hitl_detail(
     hitl_detail_model.chosen_options = payload.chosen_options
     hitl_detail_model.params_input = payload.params_input
     session.add(hitl_detail_model)
-    session.commit()
     return HITLDetailResponse.from_hitl_detail_orm(hitl_detail_model)
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -481,5 +481,4 @@ def delete_xcom(
         XComModel.map_index == map_index,
     )
     session.execute(query)
-    session.commit()
     return {"message": f"XCom with key: {key} successfully deleted."}


### PR DESCRIPTION
### Description

The database session in the FastAPI layer is injected via the `SessionDep` dependency, which is backed by the `create_session` context manager. This context manager automatically commits the transaction when a request completes successfully. 

Explicitly calling `session.commit()` inside the route handler is redundant and circumvents the dependency's intended transaction lifecycle management. This brings these specific route handlers in line with the codebase guideline that prohibits functions accepting a `session` parameter from calling `commit`.

### Impacted Files
- `airflow/api_fastapi/execution_api/routes/xcoms.py`
- `airflow/api_fastapi/execution_api/routes/hitl.py`
- `airflow/api_fastapi/core_api/routes/public/hitl.py`
- `airflow/api_fastapi/core_api/routes/public/backfills.py`

Closes: #69492

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (Antigravity)

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
