### PR TITLE
[AIP-94] Mark dags list-jobs as migrated to airflowctl

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -729,6 +729,7 @@ def dag_report(args) -> None:
     )
 
 
+@deprecated_for_airflowctl("airflowctl jobs list")
 @cli_utils.action_cli
 @suppress_logs_and_warning
 @providers_configuration_loaded

--- a/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
+++ b/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
@@ -55,6 +55,7 @@ MIGRATED_CLI_COMMANDS = [
     (dag_command.dag_pause, "airflowctl dags pause"),
     (dag_command.dag_unpause, "airflowctl dags unpause"),
     (dag_command.dag_list_dag_runs, "airflowctl dagrun list"),
+    (dag_command.dag_list_jobs, "airflowctl jobs list"),
     (pool_command.pool_list, "airflowctl pools list"),
     (pool_command.pool_get, "airflowctl pools get"),
     (pool_command.pool_set, "airflowctl pools create"),


### PR DESCRIPTION
related: #68402

Marks `airflow dags list-jobs` as migrated to `airflowctl jobs list` by adding the `deprecated_for_airflowctl` marker. The marker is maintainer/developer-facing only — it records the airflowctl equivalent and freezes the command from further development, without changing behavior or warning users.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)
  - Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
