### PR TITLE
Fix Sentry before_send and transport dotted-path config resolution in…

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/sentry/configured.py
+++ b/task-sdk/src/airflow/sdk/execution_time/sentry/configured.py
@@ -80,24 +80,28 @@ class ConfiguredSentry(NoopSentry):
                 log.exception("Invalid executor Sentry integration", import_path=executor_integration)
 
         sentry_config_opts: dict[str, Any] = conf.getsection("sentry") or {}
-        if sentry_config_opts:
-            sentry_config_opts.pop("sentry_on")
-            old_way_dsn = sentry_config_opts.pop("sentry_dsn", None)
-            new_way_dsn = sentry_config_opts.pop("dsn", None)
-            # supported backward compatibility with old way dsn option
-            dsn = old_way_dsn or new_way_dsn
+        sentry_config_opts.pop("sentry_on", None)
+        old_way_dsn = sentry_config_opts.pop("sentry_dsn", None)
+        new_way_dsn = sentry_config_opts.pop("dsn", None)
+        # supported backward compatibility with old way dsn option
+        dsn = old_way_dsn or new_way_dsn
 
-            if unsupported_options := self.UNSUPPORTED_SENTRY_OPTIONS.intersection(sentry_config_opts):
-                log.warning(
-                    "There are unsupported options in [sentry] section",
-                    options=unsupported_options,
-                )
+        # Resolve before_send and transport to callables if configured
+        if before_send := conf.getimport("sentry", "before_send", fallback=None):
+            sentry_config_opts["before_send"] = before_send
         else:
-            dsn = None
-            if before_send := conf.getimport("sentry", "before_send", fallback=None):
-                sentry_config_opts["before_send"] = before_send
-            if transport := conf.getimport("sentry", "transport", fallback=None):
-                sentry_config_opts["transport"] = transport
+            sentry_config_opts.pop("before_send", None)
+
+        if transport := conf.getimport("sentry", "transport", fallback=None):
+            sentry_config_opts["transport"] = transport
+        else:
+            sentry_config_opts.pop("transport", None)
+
+        if unsupported_options := self.UNSUPPORTED_SENTRY_OPTIONS.intersection(sentry_config_opts):
+            log.warning(
+                "There are unsupported options in [sentry] section",
+                options=unsupported_options,
+            )
 
         if dsn:
             sentry_sdk.init(dsn=dsn, integrations=integrations, **sentry_config_opts)

--- a/task-sdk/tests/task_sdk/execution_time/test_sentry.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_sentry.py
@@ -202,7 +202,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[],
                 default_integrations=False,
-                before_send="task_sdk.execution_time.test_sentry.before_send",
+                before_send=import_string("task_sdk.execution_time.test_sentry.before_send"),
             ),
         ]
 
@@ -216,7 +216,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[import_string("task_sdk.execution_time.test_sentry.CustomIntegration")()],
                 default_integrations=False,
-                before_send="task_sdk.execution_time.test_sentry.before_send",
+                before_send=import_string("task_sdk.execution_time.test_sentry.before_send"),
             ),
         ]
 
@@ -265,7 +265,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[],
                 default_integrations=False,
-                transport="task_sdk.execution_time.test_sentry.CustomTransport",
+                transport=import_string("task_sdk.execution_time.test_sentry.CustomTransport"),
             ),
         ]
 


### PR DESCRIPTION
close:#69464

A regression in the Task SDK prevented the `[sentry] before_send` and `[sentry] transport` configuration options (when set to dotted-path strings) from being resolved to their actual callables. Instead, they were passed as raw strings to `sentry_sdk.init()`, which led to Sentry silently dropping all events.

This PR ensures that these configuration options are unconditionally resolved using `conf.getimport` to callable objects before initializing the Sentry SDK.
