### PR TITLE
Fix KafkaBaseHook.test_connection missing oauth_cb for managed Kafka

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/base.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/hooks/base.py
@@ -97,9 +97,15 @@ class KafkaBaseHook(BaseHook):
             if isinstance(value, str):
                 config[key] = import_string(value)
 
-    @cached_property
-    def get_conn(self) -> Any:
-        """Get the configuration object."""
+    def _build_config(self) -> dict[str, Any]:
+        """
+        Build the confluent-kafka configuration for this connection.
+
+        Resolves callback options provided as dotted-path strings and injects the
+        managed OAuth token callback (Google Managed Kafka or Amazon MSK IAM) when
+        applicable, so that establishing a connection and testing it always use an
+        identical configuration.
+        """
         config = self.get_connection(self.kafka_config_id).extra_dejson
         self._resolve_callbacks(config)
 
@@ -127,7 +133,12 @@ class KafkaBaseHook(BaseHook):
             config.update({"oauth_cb": token})
         else:
             self._maybe_add_msk_iam_oauth(config, bootstrap_servers)
-        return self._get_client(config)
+        return config
+
+    @cached_property
+    def get_conn(self) -> Any:
+        """Get the configuration object."""
+        return self._get_client(self._build_config())
 
     def _maybe_add_msk_iam_oauth(self, config: dict[str, Any], bootstrap_servers: str | None) -> None:
         """
@@ -172,10 +183,10 @@ class KafkaBaseHook(BaseHook):
     def test_connection(self) -> tuple[bool, str]:
         """Test Connectivity from the UI."""
         try:
-            config = self.get_connection(self.kafka_config_id).extra_dejson
-            # Resolve callbacks so that configured dotted-path strings
-            # (e.g. oauth_cb) are exercised by the test as well.
-            self._resolve_callbacks(config)
+            # Build the config exactly as a real connection would, so resolved
+            # dotted-path callbacks and the managed OAuth token callback (Google
+            # Managed Kafka or Amazon MSK IAM) are exercised by the UI test too.
+            config = self._build_config()
             t = AdminClient(config).list_topics(timeout=10)
             if t:
                 return True, "Connection successful."

--- a/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_base.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/hooks/test_base.py
@@ -85,7 +85,7 @@ class TestKafkaBaseHook:
     @mock.patch("airflow.providers.apache.kafka.hooks.base.AdminClient")
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
     def test_test_connection(self, mock_get_connection, admin_client, hook):
-        config = {"bootstrap.servers": MagicMock()}
+        config = {"bootstrap.servers": "localhost:9092"}
         mock_get_connection.return_value.extra_dejson = config
         connection = hook.test_connection()
         admin_client.assert_called_once_with(config)
@@ -99,7 +99,7 @@ class TestKafkaBaseHook:
     )
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
     def test_test_connection_no_topics(self, mock_get_connection, admin_client, hook):
-        config = {"bootstrap.servers": MagicMock()}
+        config = {"bootstrap.servers": "localhost:9092"}
         mock_get_connection.return_value.extra_dejson = config
         connection = hook.test_connection()
         admin_client.assert_called_once_with(config)
@@ -122,11 +122,30 @@ class TestKafkaBaseHook:
     @mock.patch("airflow.providers.apache.kafka.hooks.base.AdminClient")
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
     def test_test_connection_exception(self, mock_get_connection, admin_client, hook):
-        config = {"bootstrap.servers": MagicMock()}
+        config = {"bootstrap.servers": "localhost:9092"}
         mock_get_connection.return_value.extra_dejson = config
         admin_client.return_value.list_topics.side_effect = [ValueError("some error")]
         connection = hook.test_connection()
         assert connection == (False, "some error")
+
+    @mock.patch("airflow.providers.google.cloud.hooks.managed_kafka.ManagedKafkaHook")
+    @mock.patch("airflow.providers.apache.kafka.hooks.base.AdminClient")
+    @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
+    def test_test_connection_injects_managed_kafka_oauth(
+        self, mock_get_connection, admin_client, managed_kafka_hook, hook
+    ):
+        # A managed Kafka cluster needs an oauth_cb token callback. test_connection must apply
+        # the same injection as get_conn, otherwise "Test Connection" fails in the UI even though
+        # the hook itself authenticates correctly.
+        config = {
+            "bootstrap.servers": "bootstrap.my-cluster.us-central1.managedkafka.my-project.cloud.goog:9092"
+        }
+        mock_get_connection.return_value.extra_dejson = config
+        connection = hook.test_connection()
+        admin_client.assert_called_once()
+        passed_config = admin_client.call_args.args[0]
+        assert passed_config["oauth_cb"] is managed_kafka_hook.return_value.get_confluent_token
+        assert connection == (True, "Connection successful.")
 
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
     def test_get_conn_msk_iam_provisioned(self, mock_get_connection, hook):


### PR DESCRIPTION
### Problem

`KafkaBaseHook.test_connection()` builds its `AdminClient` from the raw connection
configuration and (since the recent callback-resolution change) resolves dotted-path
callbacks — but it never injects the **managed OAuth token callback** that `get_conn` adds
for Google Managed Service for Apache Kafka and Amazon MSK IAM connections. As a result,
**"Test Connection" in the UI fails for those managed connections** even though the hook
itself authenticates and connects correctly — the test path never gets the `oauth_cb`
token callback.

```python
def test_connection(self) -> tuple[bool, str]:
    try:
        config = self.get_connection(self.kafka_config_id).extra_dejson
        self._resolve_callbacks(config)          # no managed oauth_cb injection
        t = AdminClient(config).list_topics(timeout=10)
```

### Fix

The configuration-building logic shared with `get_conn` (bootstrap validation, dotted-path
callback resolution, and the managed OAuth token injection for Google Managed Kafka /
Amazon MSK IAM) is extracted into a `_build_config()` helper that **both** `get_conn` and
`test_connection` use. The UI test now exercises exactly the same configuration as a real
connection, so managed connections test successfully. `get_conn` behaviour is unchanged (a
pure extraction).

### Tests

- New `test_test_connection_injects_managed_kafka_oauth` asserts the managed `oauth_cb` is
  present in the config passed to `AdminClient` from `test_connection`.
- The existing `test_connection` unit tests now use a concrete non-managed broker address
  (`localhost:9092`) instead of a `MagicMock`, since `test_connection` now builds the full
  runtime config and a mock host would spuriously match the managed-Kafka path.
- Full `providers/apache/kafka/tests/unit/apache/kafka/hooks/test_base.py` suite passes
  (23/23); `ruff check` and `ruff format --check` are clean.

> Rebased onto `main` after the dotted-path callback-resolution change landed; the diff was
> reworked to route both `get_conn` and `test_connection` through the shared `_build_config`
> helper (the earlier revision predated that refactor).
