### PR TITLE
Run slow XCom request handlers off the supervisor event loop

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -34,6 +34,7 @@ import time
 import weakref
 from collections import deque
 from collections.abc import Callable, Generator
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
 from http import HTTPStatus
@@ -664,6 +665,21 @@ class WatchedSubprocess:
         factory=weakref.WeakKeyDictionary, init=False
     )
 
+    _request_executor: ThreadPoolExecutor | None = attrs.field(default=None, init=False)
+    """
+    Lazily created executor running slow request handlers off the event-loop thread.
+
+    A single worker preserves the order in which requests were received.
+    """
+
+    _pending_requests: deque[tuple[Future[tuple[BaseModel | None, dict[str, bool]]], int]] = attrs.field(
+        factory=deque, init=False
+    )
+    """Handlers running on ``_request_executor``, each with the request id to respond to."""
+
+    _request_wakeup: tuple[socket, socket] | None = attrs.field(default=None, init=False)
+    """Socketpair used by ``_request_executor`` workers to wake up the selector loop."""
+
     selector: selectors.BaseSelector = attrs.field(factory=selectors.DefaultSelector, repr=False)
 
     _frame_encoder: msgspec.msgpack.Encoder = attrs.field(factory=comms._new_encoder, repr=False)
@@ -980,6 +996,126 @@ class WatchedSubprocess:
     def _handle_request(self, msg, log: FilteringBoundLogger, req_id: int) -> None:
         raise NotImplementedError()
 
+    def _submit_request_to_thread(
+        self,
+        handler: Callable[[], tuple[BaseModel | None, dict[str, bool]]],
+        req_id: int,
+    ) -> None:
+        """
+        Run a request handler on a worker thread and respond once it completes.
+
+        Handlers that upload large payloads (e.g. ``SetXCom`` with a big value) can block for
+        longer than the task-instance heartbeat timeout; running them inline would stall the
+        single-threaded event loop and starve :meth:`ActivitySubprocess._send_heartbeat_if_needed`,
+        getting the task killed as a zombie. The single worker preserves request ordering, and
+        since the child blocks on each request until it gets a response, at most one request per
+        child socket is in flight at a time.
+
+        The response is written back to the child by :meth:`_drain_pending_requests` so that all
+        socket writes stay on the event-loop thread.
+        """
+        if self._request_executor is None:
+            self._request_executor = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="supervisor-request"
+            )
+            # Self-pipe so a completing worker wakes up the selector loop instead of the
+            # response waiting for the loop's select() timeout to expire.
+            wakeup_read, wakeup_write = socketpair()
+            wakeup_read.setblocking(False)
+            self._request_wakeup = (wakeup_read, wakeup_write)
+            self.selector.register(
+                wakeup_read, selectors.EVENT_READ, (self._on_request_wakeup, lambda sock: None)
+            )
+
+        # Capture the current trace context (attached in handle_requests) so outbound HTTP
+        # calls made on the worker thread are still linked to the correct task span.
+        ctx = otel_context.get_current()
+
+        def run_handler() -> tuple[BaseModel | None, dict[str, bool]]:
+            token = otel_context.attach(ctx)
+            try:
+                return handler()
+            finally:
+                otel_context.detach(token)
+
+        def wake_up_selector(_: Future) -> None:
+            # Runs on the worker thread once the future is done; a 1-byte write is enough to
+            # interrupt the selector's select() so the response is sent without delay.
+            if self._request_wakeup is not None:
+                with suppress(OSError):
+                    self._request_wakeup[1].send(b"\x01")
+
+        future = self._request_executor.submit(run_handler)
+        self._pending_requests.append((future, req_id))
+        future.add_done_callback(wake_up_selector)
+
+    def _on_request_wakeup(self, sock: socket) -> bool:
+        """Discard wake-up bytes sent by ``_request_executor`` workers; the selector loop drains the completed requests."""
+        with suppress(BlockingIOError):
+            while sock.recv(4096):
+                pass
+        return True
+
+    def _drain_pending_requests(self) -> None:
+        """
+        Respond to any background request handlers that have finished.
+
+        Only the head of the queue is checked so responses are always sent in the order the
+        requests were received. Errors are mapped to the same ``ErrorResponse`` shapes as the
+        inline error handling in :meth:`handle_requests`, so the child is never left waiting.
+        """
+        while self._pending_requests and self._pending_requests[0][0].done():
+            future, req_id = self._pending_requests.popleft()
+            try:
+                resp, dump_opts = future.result()
+            except ServerResponseError as e:
+                status_code = e.response.status_code if e.response is not None else None
+                error_details = None
+                if e.response is not None:
+                    with suppress(Exception):
+                        error_details = e.response.json()
+                log.error(
+                    "API server error",
+                    status_code=status_code,
+                    detail=error_details,
+                    message=str(e),
+                )
+                with suppress(Exception):
+                    self.send_msg(
+                        msg=None,
+                        error=ErrorResponse(
+                            error=ErrorType.API_SERVER_ERROR,
+                            detail={
+                                "status_code": status_code,
+                                "message": str(e),
+                                "detail": error_details,
+                            },
+                        ),
+                        request_id=req_id,
+                    )
+            except Exception as e:
+                log.exception(
+                    "Unhandled exception while handling task request in background",
+                    request_id=req_id,
+                    exc_info=e,
+                )
+                with suppress(Exception):
+                    self.send_msg(
+                        msg=None,
+                        error=ErrorResponse(
+                            error=ErrorType.API_SERVER_ERROR,
+                            detail={
+                                "status_code": None,
+                                "message": str(e),
+                                "exception_type": type(e).__name__,
+                            },
+                        ),
+                        request_id=req_id,
+                    )
+            else:
+                with suppress(BrokenPipeError, ConnectionResetError):
+                    self.send_msg(resp, request_id=req_id, error=None, **dump_opts)
+
     @staticmethod
     def _close_unused_sockets(*sockets):
         """Close unused ends of sockets after fork."""
@@ -1002,6 +1138,14 @@ class WatchedSubprocess:
 
         if stuck_sockets:
             log.warning("Force-closed stuck sockets", pid=self.pid, sockets=stuck_sockets)
+
+        if self._request_executor is not None:
+            self._request_executor.shutdown(wait=False)
+        if self._request_wakeup is not None:
+            for sock in self._request_wakeup:
+                with suppress(Exception):
+                    sock.close()
+            self._request_wakeup = None
 
         self._open_sockets.clear()
         self.selector.close()
@@ -1124,6 +1268,10 @@ class WatchedSubprocess:
                 sock: socket = key.fileobj  # type: ignore[assignment]
                 on_close(sock)
                 sock.close()
+
+        # Respond to any request handlers that finished on the worker thread. This runs on the
+        # event-loop thread so all writes to the child sockets stay on this thread.
+        self._drain_pending_requests()
 
         # Check if the subprocess has exited
         return self._check_subprocess_exit(raise_on_timeout=raise_on_timeout, expect_signal=expect_signal)
@@ -1731,9 +1879,15 @@ class ActivitySubprocess(WatchedSubprocess):
         elif isinstance(msg, SkipDownstreamTasks):
             self.client.task_instances.skip_downstream_tasks(self.id, msg)
         elif isinstance(msg, SetXCom):
-            resp, dump_opts = handle_set_xcom(self.client, msg)
+            # Uploading a large XCom value can outlast the heartbeat timeout, so run the handler
+            # on a worker thread to keep the event loop (and thus heartbeats) going. The response
+            # is sent from `_drain_pending_requests` once the API call finishes, so return here.
+            self._submit_request_to_thread(functools.partial(handle_set_xcom, self.client, msg), req_id)
+            return
         elif isinstance(msg, DeleteXCom):
-            resp, dump_opts = handle_delete_xcom(self.client, msg)
+            # Same as SetXCom: deleting mapped XComs can be slow on the API server side.
+            self._submit_request_to_thread(functools.partial(handle_delete_xcom, self.client, msg), req_id)
+            return
         elif isinstance(msg, PutVariable):
             resp, dump_opts = handle_put_variable(self.client, msg)
         elif isinstance(msg, SetRenderedFields):
@@ -1988,6 +2142,17 @@ class InProcessTestSupervisor(ActivitySubprocess):
         # InProcessSupervisor has no subprocess, so we don't need to poll anything. This is called from
         # _handle_socket_comms, so we need to override it
         return None
+
+    def _submit_request_to_thread(
+        self,
+        handler: Callable[[], tuple[BaseModel | None, dict[str, bool]]],
+        req_id: int,
+    ) -> None:
+        # Run the handler inline: requests are made synchronously via `InProcessSupervisorComms`
+        # and there is no event loop to starve, so keep dag.test()'s synchronous semantics
+        # (including exceptions propagating to the caller).
+        resp, dump_opts = handler()
+        self.send_msg(resp, request_id=req_id, error=None, **dump_opts)
 
     def _handle_socket_comms(self):
         while self._open_sockets:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -27,6 +27,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -167,6 +168,7 @@ from airflow.sdk.execution_time.supervisor import (
     _make_process_nondumpable,
     _remote_logging_conn,
     in_process_api_server,
+    length_prefixed_frame_reader,
     make_buffered_socket_reader,
     process_log_messages_from_subprocess,
     set_supervisor_comms,
@@ -2984,6 +2986,12 @@ class TestHandleRequest:
         req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body=message.model_dump())
         generator.send(req_frame)
 
+        # Some handlers (e.g. SetXCom) run on a worker thread and only reply once the supervisor
+        # event loop drains them; wait for them so the response is on the socket before reading it.
+        while watched_subprocess._pending_requests:
+            watched_subprocess._pending_requests[0][0].exception()  # Block until done, don't raise
+            watched_subprocess._drain_pending_requests()
+
         if mask_secret_args is not None:
             mock_mask_secret.assert_called_with(*mask_secret_args)
 
@@ -3131,6 +3139,78 @@ class TestHandleRequest:
         req2 = _RequestFrame(id=randint(1, 2**32 - 1), body=msg2.model_dump())
         # Should not raise StopIteration (which would mean the loop crashed).
         generator.send(req2)
+
+    def test_slow_set_xcom_does_not_block_heartbeats(self, watched_subprocess, mocker):
+        """A slow XCom upload must not starve the supervisor event loop of heartbeats.
+
+        Uploading a large XCom payload used to run inline on the event-loop
+        thread, so `_send_heartbeat_if_needed` could not run until the upload
+        finished and the scheduler killed the task as a zombie once
+        `task_instance_heartbeat_timeout` passed (#64628). The upload now runs
+        on a worker thread: simulate a slow `client.xcoms.set` that only
+        returns once a heartbeat has been observed, and verify the supervisor
+        keeps heartbeating while the upload is in flight and still sends the
+        response back to the task afterwards.
+        """
+        watched_subprocess, read_socket = watched_subprocess
+
+        # Heartbeat on every loop iteration, and make `_check_subprocess_exit` a no-op.
+        mocker.patch("airflow.sdk.execution_time.supervisor.MIN_HEARTBEAT_INTERVAL", 0.0)
+        watched_subprocess._process.TimeoutExpired = psutil.TimeoutExpired
+        watched_subprocess._process.wait.side_effect = psutil.TimeoutExpired(0)
+
+        heartbeat_seen = threading.Event()
+        heartbeat_arrived_during_upload = False
+
+        def slow_xcom_set(*args, **kwargs):
+            # Block until the supervisor manages to heartbeat. If the event loop is blocked by
+            # this very call, no heartbeat can happen and this times out with the flag False.
+            nonlocal heartbeat_arrived_during_upload
+            heartbeat_arrived_during_upload = heartbeat_seen.wait(timeout=5.0)
+
+        watched_subprocess.client.xcoms.set = mocker.Mock(side_effect=slow_xcom_set)
+        watched_subprocess.client.task_instances.heartbeat = mocker.Mock(
+            side_effect=lambda *args, **kwargs: heartbeat_seen.set()
+        )
+
+        # Register the requests socket with the selector, as `_register_pipe_readers` does.
+        watched_subprocess.selector.register(
+            watched_subprocess.stdin,
+            selectors.EVENT_READ,
+            length_prefixed_frame_reader(
+                watched_subprocess.handle_requests(log=mocker.Mock()),
+                on_close=watched_subprocess._on_socket_closed,
+            ),
+        )
+
+        msg = SetXCom(
+            dag_id="test_dag", run_id="test_run", task_id="test_task", key="key", value="a-large-value"
+        )
+        req_frame = _RequestFrame(id=randint(1, 2**32 - 1), body=msg.model_dump())
+        read_socket.sendall(req_frame.as_bytes())
+
+        # Drive the supervisor event loop like `_monitor_subprocess` does, until the response for
+        # the XCom request arrives (or we give up).
+        read_socket.setblocking(False)
+        response_frame = None
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            watched_subprocess._service_subprocess(max_wait_time=0.1)
+            watched_subprocess._send_heartbeat_if_needed()
+            try:
+                frame_len = int.from_bytes(read_socket.recv(4), "big")
+            except BlockingIOError:
+                continue
+            response_frame = msgspec.msgpack.Decoder(_ResponseFrame).decode(read_socket.recv(frame_len))
+            break
+
+        watched_subprocess.client.xcoms.set.assert_called_once()
+        assert heartbeat_arrived_during_upload, (
+            "No heartbeat while the XCom upload was in flight: the upload blocked the event loop"
+        )
+        assert response_frame is not None, "Task never got a response for the SetXCom request"
+        assert response_frame.id == req_frame.id
+        assert response_frame.error is None
 
     @pytest.mark.parametrize(
         ("msg", "api_method", "expected_state"),


### PR DESCRIPTION
The task-supervisor is a single-threaded `selectors` event loop, and the `SetXCom` branch of `_handle_request` ran `client.xcoms.set(...)` — a synchronous httpx POST that serializes and uploads the entire payload — inline on that loop. For a large XCom value the POST outlasts `task_instance_heartbeat_timeout` (default 300s), `_send_heartbeat_if_needed` never gets a turn, and the scheduler purges the still-running task as a zombie. That's #64628 (18-minute upload for a ~300MB payload in the report).

**Fix**

- `SetXCom`/`DeleteXCom` handlers now run on a lazily-created single-worker `ThreadPoolExecutor`; the event loop keeps servicing sockets and heartbeats while the upload is in flight.
- Responses are drained back on the event-loop thread (`_drain_pending_requests`, called from `_service_subprocess`), so all socket writes stay single-threaded. Errors map to the same `ErrorResponse` shapes as the existing inline handling, so the child is never left waiting.
- A self-pipe wakes the selector when a worker finishes, so responses aren't delayed by the `select()` timeout.
- Ordering is preserved: single worker + head-of-queue draining, and the task-runner protocol blocks on each request per child socket, so at most one offloaded request per child is in flight anyway.
- The current OTel context is attached on the worker thread so the outbound HTTP call stays linked to the task span.
- `InProcessTestSupervisor` (`dag.test()`) overrides the submission to stay fully synchronous — no behavior change there.

This follows the approach from #64743 (closed as a stale draft, not on technical grounds), rebased onto the `request_handlers.py` refactor, with the review findings from that PR baked in (guarded `exc.response`, guarded `.json()`, non-blocking executor shutdown in `_cleanup_open_sockets`).

**Testing**

New regression test `test_slow_set_xcom_does_not_block_heartbeats`: the mocked `xcoms.set` blocks until a heartbeat is observed, so on `main` it deadlocks into failure (verified: fails on `main`, passes here). Full `TestHandleRequest` passes; existing `set_xcom`/`delete_xcom` cases were adapted to wait for the drained response.

Known limitation, stated for the record: JSON serialization inside httpx holds the GIL, so a multi-second stall during serialization is still possible — but it's bounded and far below the heartbeat timeout, and the dominant cost (the network upload) now fully overlaps heartbeats.

closes: #64628
