### PR TITLE
Let area:kubernetes-tests label force the Kubernetes tests job

### DIFF
--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -627,6 +627,7 @@ This table summarizes the labels you can use on PRs to control the selective che
 |----------------------------------|----------------------------------|-------------------------------------------------------------------------------------------|
 | all versions                     | all-versions, *-versions-*       | Run tests for all python and k8s versions.                                                |
 | allow suspended provider changes | allow-suspended-provider-changes | Allow changes to suspended providers.                                                     |
+| area:kubernetes-tests            | run-kubernetes-tests             | If set, the Kubernetes tests job is run regardless of changed files (does not force the full test matrix). |
 | canary                           | is-canary-run                    | If set, the PR run from apache/airflow repo behaves as `canary` run.                      |
 | debug ci resources               | debug-ci-resources               | If set, then debugging resources is enabled during parallel tests and you can see them.   |
 | default versions only            | all-versions, *-versions-*       | If set, the number of Python and Kubernetes, DB versions are limited to the default ones. |

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -92,6 +92,7 @@ UPGRADE_TO_NEWER_DEPENDENCIES_LABEL = "upgrade to newer dependencies"
 USE_PUBLIC_RUNNERS_LABEL = "use public runners"
 ALLOW_PROVIDER_DEPENDENCY_BUMP_LABEL = "allow provider dependency bump"
 SKIP_COMMON_COMPAT_CHECK_LABEL = "skip common compat check"
+AREA_KUBERNETES_TESTS_LABEL = "area:kubernetes-tests"
 ALL_CI_SELECTIVE_TEST_TYPES = "API Always CLI Core Other Serialization"
 
 ALL_PROVIDERS_SELECTIVE_TEST_TYPES = (
@@ -1079,6 +1080,12 @@ class SelectiveChecks:
 
     @cached_property
     def run_kubernetes_tests(self) -> bool:
+        if AREA_KUBERNETES_TESTS_LABEL in self._pr_labels:
+            console_print(
+                "[warning]Running Kubernetes tests because "
+                f"label '{AREA_KUBERNETES_TESTS_LABEL}' is in {self._pr_labels}[/]"
+            )
+            return True
         return self._should_be_run(FileGroupForCi.KUBERNETES_FILES)
 
     @cached_property

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3570,6 +3570,19 @@ def test_run_kubernetes_tests_forced_by_label():
     assert checks.full_tests_needed is False
 
 
+def test_run_kubernetes_tests_forced_by_label_with_no_changed_files():
+    """The label still forces the Kubernetes tests job even when no files changed."""
+    checks = SelectiveChecks(
+        files=(),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+        default_branch="main",
+        pr_labels=("area:kubernetes-tests",),
+    )
+    assert checks.run_kubernetes_tests is True
+    assert checks.full_tests_needed is False
+
+
 def test_filter_platform_excluded_test_types_handles_all_shapes():
     """Direct unit check of the in-place filter for the three Providers[...] shapes."""
     checks = SelectiveChecks(

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3556,6 +3556,20 @@ def test_individual_providers_excludes_platform_excluded_on_arm():
         assert "Providers[ibm.mq]" in amd_output
 
 
+def test_run_kubernetes_tests_forced_by_label():
+    """`area:kubernetes-tests` forces the Kubernetes tests job without pulling in
+    the full test matrix, unlike `full tests needed`."""
+    checks = SelectiveChecks(
+        files=("INTHEWILD.md",),
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+        default_branch="main",
+        pr_labels=("area:kubernetes-tests",),
+    )
+    assert checks.run_kubernetes_tests is True
+    assert checks.full_tests_needed is False
+
+
 def test_filter_platform_excluded_test_types_handles_all_shapes():
     """Direct unit check of the in-place filter for the three Providers[...] shapes."""
     checks = SelectiveChecks(


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/68709

## Why

Today the only label that can force the Kubernetes tests job is `full tests needed`, which also pulls in the entire test matrix. Respecting the existing `area:kubernetes-tests` label lets maintainers re-run just the Kubernetes tests when selective-checks' file-path heuristics don't catch a change's impact.

## What

- `run_kubernetes_tests` returns `true` when the `area:kubernetes-tests` label is set on the PR, independent of `full_tests_needed` (the `tests-kubernetes` job and prod image build already cascade from this output — no workflow changes needed).
- Document the label in the labels table of `04_selective_checks.md`.
- Add a test asserting the label forces `run_kubernetes_tests` without tripping `full_tests_needed`.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)