### PR TITLE
Construct default token_endpoint for msgraph filesystem

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/fs/msgraph.py
@@ -105,6 +105,12 @@ def get_fs(conn_id: str | None, storage_options: dict[str, Any] | None = None) -
             if param in options:
                 oauth2_client_params[param] = options[param]
 
+        # Construct default token_endpoint from tenant_id if not explicitly provided
+        if "token_endpoint" not in oauth2_client_params and tenant_id:
+            oauth2_client_params["token_endpoint"] = (
+                f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+            )
+
     # Determine which filesystem to return based on drive_id
     drive_id = options.get("drive_id")
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/fs/test_msgraph.py
@@ -64,7 +64,24 @@ class TestMSGraphFS:
                 "client_id": "test_client_id",
                 "client_secret": "test_client_secret",
                 "tenant_id": "test_tenant_id",
+                "token_endpoint": "https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/token",
             },
+        )
+        assert result == mock_fs_instance
+
+    @patch("airflow.providers.microsoft.azure.fs.msgraph.BaseHook.get_connection")
+    @patch("msgraphfs.MSGDriveFS")
+    def test_get_fs_constructs_token_endpoint(self, mock_msgdrivefs, mock_get_connection, mock_connection):
+        """token_endpoint is auto-constructed from tenant_id when not in extras."""
+        mock_get_connection.return_value = mock_connection
+        mock_fs_instance = MagicMock()
+        mock_msgdrivefs.return_value = mock_fs_instance
+
+        result = get_fs("msgraph_default")
+
+        actual_params = mock_msgdrivefs.call_args[1]["oauth2_client_params"]
+        assert actual_params["token_endpoint"] == (
+            "https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/token"
         )
         assert result == mock_fs_instance
 
@@ -127,6 +144,7 @@ class TestMSGraphFS:
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
             "tenant_id": "test_tenant_id",
+            "token_endpoint": "https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/token",
             "scope": "custom.scope",
         }
         mock_msgdrivefs.assert_called_once_with(


### PR DESCRIPTION
## Summary

When `ObjectStoragePath` is used with `protocol="sharepoint"` (or any msgraph protocol) and a connection that has `client_id`, `client_secret`, `tenant_id` but no explicit `token_endpoint`, `MSGDriveFS` fails because:

1. Airflow's `get_fs` builds a non-None `oauth2_client_params` dict with `client_id`, `client_secret`, `tenant_id`
2. `MSGDriveFS.__init__` only constructs `token_endpoint` from `tenant_id` when `oauth2_client_params` is None
3. `AsyncOAuth2Client.fetch_token()` gets no token endpoint URL → fails

### Fix

When `token_endpoint` is not in `oauth2_client_params` and `tenant_id` is set, construct the default Microsoft identity platform v2.0 token endpoint:
`https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token`

This matches the exact URL `msgraphfs` builds internally when `oauth2_client_params` is absent (line 1470 of msgraphfs/core.py).

### Test plan

- Updated `test_get_fs_with_drive_id` to expect the auto-constructed `token_endpoint`
- Updated `test_get_fs_with_storage_options` to expect the auto-constructed `token_endpoint`
- Added `test_get_fs_constructs_token_endpoint` explicitly verifying the constructed URL
- Existing `test_get_fs_with_extra_oauth_params` still passes — explicit `token_endpoint` in extras is honoured, not overwritten

Fixes #69463
