### PR TITLE
Warn for bad combination of parameters for RedshiftDataOperator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -125,6 +125,11 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
         self.deferrable = deferrable
         self.session_id = session_id
         self.session_keep_alive_seconds = session_keep_alive_seconds
+        if self.deferrable and not self.wait_for_completion:
+            self.log.warning(
+                "deferrable=True and wait_for_completion=False are set; deferrable will be "
+                "ignored and this task will run non-deferrable."
+            )
 
     def execute(self, context: Context) -> list[GetStatementResultResponseTypeDef] | list[str]:
         """Execute a statement against Amazon Redshift."""

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_data.py
@@ -87,6 +87,21 @@ class TestRedshiftDataOperator:
         assert op.hook._verify is None
         assert op.hook._config is None
 
+    @mock.patch.object(RedshiftDataOperator, "log", new_callable=mock.MagicMock)
+    def test_init_warns_when_deferrable_has_no_effect(self, mock_log):
+        """deferrable=True is a no-op when wait_for_completion=False; the user should be told."""
+        RedshiftDataOperator(
+            task_id=TASK_ID,
+            database=DATABASE,
+            sql=SQL,
+            deferrable=True,
+            wait_for_completion=False,
+        )
+        mock_log.warning.assert_called_once_with(
+            "deferrable=True and wait_for_completion=False are set; deferrable will be "
+            "ignored and this task will run non-deferrable."
+        )
+
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.execute_query")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
     def test_execute(self, mock_conn, mock_exec_query):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### What

`RedshiftDataOperator` has two independent parameters, `deferrable` and `wait_for_completion`. Since #41206, `wait_for_completion=False` intentionally overrides `deferrable=True` and if a task isnt waiting for the statement to finish at all, there is nothing to defer. That is the correct behavior, but it happens silently: a user who sets `deferrable=True` gets no signal that it was ignored.

### Current behaviour

Combining `deferrable=True` with `wait_for_completion=False` submits the statement and returns immediately, exactly as if `deferrable=False` had been set but with no warning, log line, or error indicating that the `deferrable` setting had no effect.

### Proposed change

Added a warning in `RedshiftDataOperator` that fires when this combination is detected, telling the user both whats set and the resulting behavior:

A log.warning rather than a raised exception was a deliberate choice cos this is long standing, already released behavior (not a new feature being gated), so raising would break any existing DAG relying on this combination for zero functional benefit. The goal is discoverability, not enforcement.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
