### PR TITLE
Fix flaky test timeout test_end_drains_result_queue_to_avoid_join_deadlock on Python 3.14

### DIFF
--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -345,7 +345,7 @@ class TestLocalExecutor:
         proc.kill.assert_called_once_with()
         assert proc.join.call_args_list == [mock.call(timeout=0.2), mock.call(timeout=0.2)]
 
-    @pytest.mark.execution_timeout(10)
+    @pytest.mark.execution_timeout(30)
     def test_end_drains_result_queue_to_avoid_join_deadlock(self):
         executor = LocalExecutor(parallelism=1)
         executor.activity_queue = multiprocessing.SimpleQueue()


### PR DESCRIPTION
### Why
- Python 3.14 changed the default multiprocessing start method on Linux from `fork` to `forkserver`.
  - https://docs.python.org/3.14/whatsnew/3.14.html#multiprocessing
- With `fork`, the child is "effectively identical to the parent process" and inherits the already-imported airflow modules. With `forkserver` it is forked from a clean server process instead. The child must import the test module and related airflow import chain.
  - https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
- From [run 28801030578](https://github.com/apache/airflow/actions/runs/28801030578), both Postgres and Sqlite failed on the same test case `test_end_drains_result_queue_to_avoid_join_deadlock` with Python 3.14. Both took around 10 seconds to load modules.
  ```
  2026-07-06T15:37:46.9780300Z 2026-07-06T15:24:31.594329Z [info     ] Shutting down LocalExecutor; waiting for running tasks to finish.  Signal again if you don't want to wait. [airflow.executors.local_executor.LocalExecutor]
  2026-07-06T15:37:46.9782155Z 2026-07-06T15:24:38.789986Z [info     ] Unit test configuration loaded from 'unit_tests.cfg' [airflow.sdk.configuration] loc=configuration.py:247
  2026-07-06T15:37:46.9784010Z 2026-07-06T15:24:41.043595Z [warning  ] FileType is deprecated. Simply open files after parsing arguments. [py.warnings] category=PendingDeprecationWarning filename=/opt/airflow/airflow-core/src/airflow/cli/cli_config.py lineno=646
  2026-07-06T15:37:46.9786186Z 2026-07-06T15:24:41.045115Z [warning  ] FileType is deprecated. Simply open files after parsing arguments. [py.warnings] category=PendingDeprecationWarning filename=/opt/airflow/airflow-core/src/airflow/cli/cli_config.py lineno=868
  ```

  ```
  2026-07-06T16:23:12.8193184Z 2026-07-06T15:24:18.524457Z [info     ] Shutting down LocalExecutor; waiting for running tasks to finish.  Signal again if you don't want to wait. [airflow.executors.local_executor.LocalExecutor]
  2026-07-06T16:23:12.8195400Z 2026-07-06T15:24:26.279040Z [info     ] Unit test configuration loaded from 'unit_tests.cfg' [airflow.sdk.configuration] loc=configuration.py:247
  2026-07-06T16:23:12.8200174Z 2026-07-06T15:24:28.560555Z [warning  ] FileType is deprecated. Simply open files after parsing arguments. [py.warnings] category=PendingDeprecationWarning filename=/opt/airflow/airflow-core/src/airflow/cli/cli_config.py lineno=646
  2026-07-06T16:23:12.8203506Z 2026-07-06T15:24:28.562044Z [warning  ] FileType is deprecated. Simply open files after parsing arguments. [py.warnings] category=PendingDeprecationWarning filename=/opt/airflow/airflow-core/src/airflow/cli/cli_config.py lineno=868
  ```
- Other failed run:
  - https://github.com/apache/airflow/actions/runs/28804860689
  - https://github.com/apache/airflow/actions/runs/28709201804
  - https://github.com/apache/airflow/actions/runs/28667462421
### How

Change the test's `execution_timeout` from 10s to 30s. Align it with `test_clean_stop_on_signal` in the same file, which also spawns a subprocess.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
* related: #67881
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
