### PR TITLE
Make psycopg (v3) the default synchronous Postgres driver in providers

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -524,6 +524,7 @@ downstreams
 dp
 dq
 Drillbit
+driverless
 dropdown
 druidHook
 ds

--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -26,6 +26,13 @@
 Changelog
 ---------
 
+.. note::
+    ``RedshiftSQLHook.get_sqlalchemy_engine()``, used for the SQLAlchemy engine backing
+    lineage/reflection, now resolves an explicit Postgres DB-API driver for a bare
+    ``postgresql://`` URL, preferring ``psycopg`` (v3) when importable and falling back to
+    ``psycopg2``. Where both drivers are installed, this engine now uses ``psycopg`` (v3),
+    matching the sync Postgres driver default change in ``apache-airflow-providers-postgres``.
+
 9.32.0
 ......
 

--- a/providers/amazon/docs/executors/batch-executor.rst
+++ b/providers/amazon/docs/executors/batch-executor.rst
@@ -298,7 +298,7 @@ Create a Job Definition
 
 .. code-block:: bash
 
-   postgresql+psycopg2://<username>:<password>@<endpoint>/<database_name>
+   postgresql+psycopg://<username>:<password>@<endpoint>/<database_name>
 
 7. Add other configuration as necessary for Airflow generally (see `here <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html>`__), the Batch executor (see :ref:`here <config-options>`) or for remote logging (see :ref:`here <logging>`). Note that any configuration changes should be made across the entire Airflow environment to keep configuration consistent.
 

--- a/providers/amazon/docs/executors/ecs-executor.rst
+++ b/providers/amazon/docs/executors/ecs-executor.rst
@@ -332,7 +332,7 @@ Create Task Definition
 
 .. code-block:: bash
 
-   postgresql+psycopg2://<username>:<password>@<endpoint>/<database_name>
+   postgresql+psycopg://<username>:<password>@<endpoint>/<database_name>
 
 
 - ``AIRFLOW__ECS_EXECUTOR__SECURITY_GROUPS``, with the value being a comma separated list of security group IDs associated with the VPC used for the RDS instance.

--- a/providers/amazon/docs/executors/lambda-executor.rst
+++ b/providers/amazon/docs/executors/lambda-executor.rst
@@ -334,7 +334,7 @@ Finally create the function:
 
 .. code-block:: bash
 
-   postgresql+psycopg2://<username>:<password>@<endpoint>/<database_name>
+   postgresql+psycopg://<username>:<password>@<endpoint>/<database_name>
 
 
 - ``AIRFLOW__LAMBDA_EXECUTOR__QUEUE_URL``, with the value being the URL of the SQS queue created above.

--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from functools import cached_property
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 import redshift_connector
@@ -25,9 +26,9 @@ from redshift_connector import Connection as RedshiftConnection, InterfaceError,
 
 try:
     from sqlalchemy import create_engine
-    from sqlalchemy.engine.url import URL
+    from sqlalchemy.engine.url import URL, make_url
 except ImportError:
-    URL = create_engine = None  # type: ignore[assignment,misc]
+    URL = create_engine = make_url = None  # type: ignore[assignment,misc]
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
@@ -36,6 +37,35 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook
 if TYPE_CHECKING:
     from airflow.models.connection import Connection
     from airflow.providers.openlineage.sqlparser import DatabaseInfo
+
+
+def _is_sqlalchemy_2() -> bool:
+    """Whether the installed SQLAlchemy has the native psycopg (v3) dialect (added in 2.0)."""
+    from packaging.version import Version
+    from sqlalchemy import __version__ as sqlalchemy_version
+
+    return Version(sqlalchemy_version) >= Version("2.0.0")
+
+
+def _resolve_postgres_drivername() -> str:
+    """
+    Pick a Postgres DB-API driver for the SQLAlchemy engine used by lineage/reflection.
+
+    Redshift is wire-compatible with Postgres, but Airflow's own connection to Redshift
+    uses ``redshift_connector`` directly (see ``get_conn``) — this only picks the driver
+    for the separate SQLAlchemy engine used e.g. for OpenLineage extraction.
+    """
+    # The psycopg (v3) package may be importable even where SQLAlchemy is pinned below 2.0
+    # (e.g. compat tests against older released Airflow versions), which doesn't register
+    # SQLAlchemy's native "postgresql+psycopg" dialect and would raise NoSuchModuleError.
+    if find_spec("psycopg") is not None and _is_sqlalchemy_2():
+        return "postgresql+psycopg"
+    if find_spec("psycopg2") is not None:
+        return "postgresql+psycopg2"
+    raise AirflowOptionalProviderFeatureException(
+        "A Postgres DB-API driver is required for the SQLAlchemy engine. Install one with: "
+        "pip install 'apache-airflow-providers-amazon[sqlalchemy]' psycopg2-binary (or psycopg[binary])"
+    )
 
 
 class RedshiftSQLHook(DbApiHook):
@@ -201,7 +231,8 @@ class RedshiftSQLHook(DbApiHook):
         else:
             engine_kwargs["connect_args"] = conn_kwargs
 
-        return create_engine(self.get_uri(), **engine_kwargs)
+        engine_url = make_url(self.get_uri()).set(drivername=_resolve_postgres_drivername())
+        return create_engine(engine_url, **engine_kwargs)
 
     def get_table_primary_key(self, table: str, schema: str | None = "public") -> list[str] | None:
         """

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_redshift_sql.py
@@ -24,7 +24,7 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 from airflow.providers.amazon.version_compat import NOTSET
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
 
 LOGIN_USER = "login"
 LOGIN_PASSWORD = "password"
@@ -53,6 +53,47 @@ class TestRedshiftSQLHookConn:
         db_uri = self.db_hook.get_uri()
         expected = "postgresql://login:password@host:5439/dev"
         assert db_uri == expected
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.create_engine")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql._is_sqlalchemy_2", return_value=True)
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.find_spec")
+    def test_get_sqlalchemy_engine_prefers_psycopg3(self, mock_find_spec, mock_is_sqla2, mock_create_engine):
+        # Mock create_engine so this doesn't depend on psycopg actually being importable, or on
+        # the ambient SQLAlchemy major version matching what _is_sqlalchemy_2 is mocked to return.
+        mock_find_spec.return_value = object()
+        self.db_hook.get_sqlalchemy_engine()
+        engine_url = mock_create_engine.call_args[0][0]
+        assert engine_url.drivername == "postgresql+psycopg"
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.create_engine")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.find_spec")
+    def test_get_sqlalchemy_engine_falls_back_to_psycopg2(self, mock_find_spec, mock_create_engine):
+        # psycopg2 is optional (see providers/postgres's [psycopg2] extra) and may not be
+        # installed here, so mock create_engine instead of letting it actually import the driver.
+        mock_find_spec.side_effect = lambda name: None if name == "psycopg" else object()
+        self.db_hook.get_sqlalchemy_engine()
+        engine_url = mock_create_engine.call_args[0][0]
+        assert engine_url.drivername == "postgresql+psycopg2"
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.create_engine")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql._is_sqlalchemy_2", return_value=False)
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.find_spec")
+    def test_get_sqlalchemy_engine_falls_back_to_psycopg2_on_sqlalchemy_1(
+        self, mock_find_spec, mock_is_sqla2, mock_create_engine
+    ):
+        # psycopg (v3) can be importable even when SQLAlchemy is pinned below 2.0 (e.g. compat
+        # tests against older released Airflow versions) — SQLAlchemy's native "postgresql+psycopg"
+        # dialect only exists from 2.0 onwards, so this must still fall back to psycopg2 rather
+        # than let create_engine raise NoSuchModuleError.
+        mock_find_spec.return_value = object()
+        self.db_hook.get_sqlalchemy_engine()
+        engine_url = mock_create_engine.call_args[0][0]
+        assert engine_url.drivername == "postgresql+psycopg2"
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.find_spec", return_value=None)
+    def test_get_sqlalchemy_engine_raises_clear_error_without_a_driver(self, mock_find_spec):
+        with pytest.raises(AirflowOptionalProviderFeatureException, match="Postgres DB-API driver"):
+            self.db_hook.get_sqlalchemy_engine()
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.redshift_connector.connect")
     def test_get_conn(self, mock_connect):

--- a/providers/celery/docs/changelog.rst
+++ b/providers/celery/docs/changelog.rst
@@ -27,6 +27,13 @@
 Changelog
 ---------
 
+.. note::
+    When ``[celery] result_backend`` is not set and Airflow derives it from ``sql_alchemy_conn``, a
+    driverless ``postgresql://`` connection string now produces ``db+postgresql+psycopg://...`` instead
+    of ``db+postgresql+psycopg2://...``, matching the sync Postgres driver default change in
+    ``apache-airflow`` and ``apache-airflow-providers-postgres``. An explicit ``[celery] result_backend``
+    or an explicit driver in ``sql_alchemy_conn`` is unaffected.
+
 3.22.0
 ......
 

--- a/providers/celery/provider.yaml
+++ b/providers/celery/provider.yaml
@@ -248,7 +248,7 @@ config:
         version_added: ~
         type: string
         sensitive: true
-        example: "db+postgresql+psycopg2://postgres:airflow@postgres/airflow"
+        example: "db+postgresql+psycopg://postgres:airflow@postgres/airflow"
         default: ~
       result_backend_sqlalchemy_engine_options:
         description: |

--- a/providers/celery/src/airflow/providers/celery/executors/default_celery.py
+++ b/providers/celery/src/airflow/providers/celery/executors/default_celery.py
@@ -31,6 +31,18 @@ from airflow.providers.common.compat.sdk import AirflowException, conf
 
 log = logging.getLogger(__name__)
 
+_USE_PSYCOPG3: bool
+try:
+    from importlib.metadata import version
+    from importlib.util import find_spec
+
+    from packaging.version import Version
+
+    _is_sqla2 = Version(version("sqlalchemy")) >= Version("2.0.0")
+    _USE_PSYCOPG3 = _is_sqla2 and find_spec("psycopg") is not None
+except (ImportError, ModuleNotFoundError):
+    _USE_PSYCOPG3 = False
+
 
 def _broker_supports_visibility_timeout(url):
     return url.startswith(("redis://", "rediss://", "sqs://", "sentinel://"))
@@ -79,9 +91,12 @@ def get_default_celery_config(team_conf) -> dict[str, Any]:
     else:
         log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
         sql_alchemy_conn = team_conf.get("database", "SQL_ALCHEMY_CONN")
-        # In SQLAlchemy 2.1 the default PostgreSQL driver changed from psycopg2 to psycopg (v3).
-        # To maintain existing behavior, we explicitly specify psycopg2 for driverless PostgreSQL URLs.
-        sql_alchemy_conn = sql_alchemy_conn.replace("postgresql://", "postgresql+psycopg2://", 1)
+        # Airflow's sync metadata-database driver default is psycopg (v3); mirror that explicitly
+        # for driverless PostgreSQL URLs instead of relying on SQLAlchemy's own default. Fall back to
+        # psycopg2 when psycopg/SQLAlchemy 2.0 aren't both available, matching PostgresHook's own
+        # USE_PSYCOPG3 gating so this doesn't break environments still on the older combination.
+        target_scheme = "postgresql+psycopg://" if _USE_PSYCOPG3 else "postgresql+psycopg2://"
+        sql_alchemy_conn = sql_alchemy_conn.replace("postgresql://", target_scheme, 1)
         result_backend = f"db+{sql_alchemy_conn}"
 
     # Handle result backend transport options (for Redis Sentinel support)

--- a/providers/celery/src/airflow/providers/celery/get_provider_info.py
+++ b/providers/celery/src/airflow/providers/celery/get_provider_info.py
@@ -130,7 +130,7 @@ def get_provider_info():
                         "version_added": None,
                         "type": "string",
                         "sensitive": True,
-                        "example": "db+postgresql+psycopg2://postgres:airflow@postgres/airflow",
+                        "example": "db+postgresql+psycopg://postgres:airflow@postgres/airflow",
                         "default": None,
                     },
                     "result_backend_sqlalchemy_engine_options": {

--- a/providers/celery/tests/unit/celery/executors/test_celery_executor.py
+++ b/providers/celery/tests/unit/celery/executors/test_celery_executor.py
@@ -847,6 +847,32 @@ def test_result_backend_transport_options_with_multiple_options():
     assert result_backend_opts["master_name"] == "mymaster"
 
 
+@conf_vars(
+    {
+        ("celery", "result_backend"): None,
+        ("database", "sql_alchemy_conn"): "postgresql://user:pass@host/db",
+    }
+)
+def test_result_backend_derived_from_sql_alchemy_conn_uses_psycopg(monkeypatch):
+    """A driverless sql_alchemy_conn must derive a psycopg (v3) result_backend, not psycopg2."""
+    monkeypatch.setattr(default_celery, "_USE_PSYCOPG3", True)
+    config = default_celery.get_default_celery_config(conf)
+    assert config["result_backend"] == "db+postgresql+psycopg://user:pass@host/db"
+
+
+@conf_vars(
+    {
+        ("celery", "result_backend"): None,
+        ("database", "sql_alchemy_conn"): "postgresql://user:pass@host/db",
+    }
+)
+def test_result_backend_falls_back_to_psycopg2_without_psycopg3(monkeypatch):
+    """Without psycopg/SQLAlchemy 2.0 available, the derivation must fall back to psycopg2."""
+    monkeypatch.setattr(default_celery, "_USE_PSYCOPG3", False)
+    config = default_celery.get_default_celery_config(conf)
+    assert config["result_backend"] == "db+postgresql+psycopg2://user:pass@host/db"
+
+
 @conf_vars({("celery_result_backend_transport_options", "sentinel_kwargs"): "invalid_json"})
 def test_result_backend_sentinel_kwargs_invalid_json():
     """Test that invalid JSON in sentinel_kwargs raises an error."""

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -22,6 +22,7 @@ from collections.abc import Callable, Generator, Iterable, Mapping, MutableMappi
 from contextlib import closing, contextmanager, suppress
 from datetime import datetime
 from functools import cached_property
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast, overload
 from urllib.parse import urlparse
 
@@ -66,6 +67,16 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 SQL_PLACEHOLDERS = frozenset({"%s", "?"})
+
+
+def _is_sqlalchemy_2() -> bool:
+    """Whether the installed SQLAlchemy has the native psycopg (v3) dialect (added in 2.0)."""
+    from packaging.version import Version
+    from sqlalchemy import __version__ as sqlalchemy_version
+
+    return Version(sqlalchemy_version) >= Version("2.0.0")
+
+
 WARNING_MESSAGE = """Import of {} from the 'airflow.providers.common.sql.hooks' module is deprecated and will
 be removed in the future. Please import it from 'airflow.providers.common.sql.hooks.handlers'."""
 
@@ -334,7 +345,23 @@ class DbApiHook(BaseHook):
 
         self.log.debug("url: %s", url)
         self.log.debug("engine_kwargs: %s", engine_kwargs)
-        return create_engine(url=url, **engine_kwargs)
+        try:
+            return create_engine(url=url, **engine_kwargs)
+        except (ImportError, ModuleNotFoundError):
+            # SQLAlchemy resolves a bare "postgresql" scheme to the psycopg2 DB-API by default.
+            # Retry with a driver this hook can actually resolve, since psycopg2 may not be
+            # installed now that it's an optional extra of apache-airflow-providers-postgres.
+            parsed_url = make_url(url) if make_url is not None else None
+            if parsed_url is None or parsed_url.drivername != "postgresql":
+                raise
+            # psycopg (v3) may be importable where SQLAlchemy is pinned below 2.0, which has no
+            # native "postgresql+psycopg" dialect and would raise NoSuchModuleError — so only
+            # prefer it on SQLAlchemy 2.0+; otherwise fall back to psycopg2.
+            if find_spec("psycopg") is not None and _is_sqlalchemy_2():
+                return create_engine(url=parsed_url.set(drivername="postgresql+psycopg"), **engine_kwargs)
+            if find_spec("psycopg2") is not None:
+                return create_engine(url=parsed_url.set(drivername="postgresql+psycopg2"), **engine_kwargs)
+            raise
 
     @cached_property
     def inspector(self) -> Inspector:

--- a/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
+++ b/providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py
@@ -358,8 +358,16 @@ class DbApiHook(BaseHook):
             # native "postgresql+psycopg" dialect and would raise NoSuchModuleError — so only
             # prefer it on SQLAlchemy 2.0+; otherwise fall back to psycopg2.
             if find_spec("psycopg") is not None and _is_sqlalchemy_2():
+                self.log.info(
+                    "SQLAlchemy could not load a DB-API driver for the bare 'postgresql://' URL; "
+                    "retrying with psycopg (v3) ('postgresql+psycopg')."
+                )
                 return create_engine(url=parsed_url.set(drivername="postgresql+psycopg"), **engine_kwargs)
             if find_spec("psycopg2") is not None:
+                self.log.info(
+                    "SQLAlchemy could not load a DB-API driver for the bare 'postgresql://' URL; "
+                    "retrying with 'postgresql+psycopg2'."
+                )
                 return create_engine(url=parsed_url.set(drivername="postgresql+psycopg2"), **engine_kwargs)
             raise
 

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -343,7 +343,7 @@ class TestDbApiHookGetSqlalchemyEngine:
     @patch("airflow.providers.common.sql.hooks.sql.find_spec")
     @patch("airflow.providers.common.sql.hooks.sql.create_engine")
     def test_falls_back_to_psycopg_when_psycopg2_import_fails(
-        self, mock_create_engine, mock_find_spec, mock_is_sqlalchemy_2
+        self, mock_create_engine, mock_find_spec, mock_is_sqlalchemy_2, caplog
     ):
         mock_find_spec.return_value = object()
         mock_create_engine.side_effect = [ModuleNotFoundError("No module named 'psycopg2'"), MagicMock()]
@@ -354,13 +354,17 @@ class TestDbApiHookGetSqlalchemyEngine:
         assert mock_create_engine.call_count == 2
         retried_url = mock_create_engine.call_args.kwargs["url"]
         assert retried_url.drivername == "postgresql+psycopg"
+        assert (
+            "SQLAlchemy could not load a DB-API driver for the bare 'postgresql://' URL; "
+            "retrying with psycopg (v3) ('postgresql+psycopg')."
+        ) in caplog.text
 
     @pytest.mark.db_test
     @patch("airflow.providers.common.sql.hooks.sql._is_sqlalchemy_2", return_value=False)
     @patch("airflow.providers.common.sql.hooks.sql.find_spec")
     @patch("airflow.providers.common.sql.hooks.sql.create_engine")
     def test_falls_back_to_psycopg2_when_sqlalchemy_below_2(
-        self, mock_create_engine, mock_find_spec, mock_is_sqlalchemy_2
+        self, mock_create_engine, mock_find_spec, mock_is_sqlalchemy_2, caplog
     ):
         # SQLAlchemy 1.4 (shipped with Airflow 2.11) has no native "postgresql+psycopg" dialect,
         # so even when psycopg (v3) is importable the retry must use psycopg2, not psycopg.
@@ -373,11 +377,17 @@ class TestDbApiHookGetSqlalchemyEngine:
         assert mock_create_engine.call_count == 2
         retried_url = mock_create_engine.call_args.kwargs["url"]
         assert retried_url.drivername == "postgresql+psycopg2"
+        assert (
+            "SQLAlchemy could not load a DB-API driver for the bare 'postgresql://' URL; "
+            "retrying with 'postgresql+psycopg2'."
+        ) in caplog.text
 
     @pytest.mark.db_test
     @patch("airflow.providers.common.sql.hooks.sql.find_spec")
     @patch("airflow.providers.common.sql.hooks.sql.create_engine")
-    def test_falls_back_to_psycopg2_when_psycopg_unavailable(self, mock_create_engine, mock_find_spec):
+    def test_falls_back_to_psycopg2_when_psycopg_unavailable(
+        self, mock_create_engine, mock_find_spec, caplog
+    ):
         mock_find_spec.side_effect = lambda name: None if name == "psycopg" else object()
         mock_create_engine.side_effect = [ModuleNotFoundError("No module named 'psycopg2'"), MagicMock()]
         dbapi_hook = mock_db_hook(DbApiHook, conn_params={"conn_type": "postgresql"})
@@ -387,6 +397,10 @@ class TestDbApiHookGetSqlalchemyEngine:
         assert mock_create_engine.call_count == 2
         retried_url = mock_create_engine.call_args.kwargs["url"]
         assert retried_url.drivername == "postgresql+psycopg2"
+        assert (
+            "SQLAlchemy could not load a DB-API driver for the bare 'postgresql://' URL; "
+            "retrying with 'postgresql+psycopg2'."
+        ) in caplog.text
 
     @pytest.mark.db_test
     @patch("airflow.providers.common.sql.hooks.sql.find_spec", return_value=None)

--- a/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
+++ b/providers/common/sql/tests/unit/common/sql/hooks/test_sql.py
@@ -334,6 +334,84 @@ class TestDbApiHook:
             assert isinstance(df, expected_type)
 
 
+class TestDbApiHookGetSqlalchemyEngine:
+    """SQLAlchemy resolves a bare ``postgresql`` scheme to the psycopg2 DB-API by default, which
+    may not be installed now that it's an optional extra of apache-airflow-providers-postgres."""
+
+    @pytest.mark.db_test
+    @patch("airflow.providers.common.sql.hooks.sql._is_sqlalchemy_2", return_value=True)
+    @patch("airflow.providers.common.sql.hooks.sql.find_spec")
+    @patch("airflow.providers.common.sql.hooks.sql.create_engine")
+    def test_falls_back_to_psycopg_when_psycopg2_import_fails(
+        self, mock_create_engine, mock_find_spec, mock_is_sqlalchemy_2
+    ):
+        mock_find_spec.return_value = object()
+        mock_create_engine.side_effect = [ModuleNotFoundError("No module named 'psycopg2'"), MagicMock()]
+        dbapi_hook = mock_db_hook(DbApiHook, conn_params={"conn_type": "postgresql"})
+
+        dbapi_hook.get_sqlalchemy_engine()
+
+        assert mock_create_engine.call_count == 2
+        retried_url = mock_create_engine.call_args.kwargs["url"]
+        assert retried_url.drivername == "postgresql+psycopg"
+
+    @pytest.mark.db_test
+    @patch("airflow.providers.common.sql.hooks.sql._is_sqlalchemy_2", return_value=False)
+    @patch("airflow.providers.common.sql.hooks.sql.find_spec")
+    @patch("airflow.providers.common.sql.hooks.sql.create_engine")
+    def test_falls_back_to_psycopg2_when_sqlalchemy_below_2(
+        self, mock_create_engine, mock_find_spec, mock_is_sqlalchemy_2
+    ):
+        # SQLAlchemy 1.4 (shipped with Airflow 2.11) has no native "postgresql+psycopg" dialect,
+        # so even when psycopg (v3) is importable the retry must use psycopg2, not psycopg.
+        mock_find_spec.return_value = object()
+        mock_create_engine.side_effect = [ModuleNotFoundError("No module named 'psycopg2'"), MagicMock()]
+        dbapi_hook = mock_db_hook(DbApiHook, conn_params={"conn_type": "postgresql"})
+
+        dbapi_hook.get_sqlalchemy_engine()
+
+        assert mock_create_engine.call_count == 2
+        retried_url = mock_create_engine.call_args.kwargs["url"]
+        assert retried_url.drivername == "postgresql+psycopg2"
+
+    @pytest.mark.db_test
+    @patch("airflow.providers.common.sql.hooks.sql.find_spec")
+    @patch("airflow.providers.common.sql.hooks.sql.create_engine")
+    def test_falls_back_to_psycopg2_when_psycopg_unavailable(self, mock_create_engine, mock_find_spec):
+        mock_find_spec.side_effect = lambda name: None if name == "psycopg" else object()
+        mock_create_engine.side_effect = [ModuleNotFoundError("No module named 'psycopg2'"), MagicMock()]
+        dbapi_hook = mock_db_hook(DbApiHook, conn_params={"conn_type": "postgresql"})
+
+        dbapi_hook.get_sqlalchemy_engine()
+
+        assert mock_create_engine.call_count == 2
+        retried_url = mock_create_engine.call_args.kwargs["url"]
+        assert retried_url.drivername == "postgresql+psycopg2"
+
+    @pytest.mark.db_test
+    @patch("airflow.providers.common.sql.hooks.sql.find_spec", return_value=None)
+    @patch("airflow.providers.common.sql.hooks.sql.create_engine")
+    def test_reraises_when_no_postgres_driver_is_available(self, mock_create_engine, mock_find_spec):
+        original_error = ModuleNotFoundError("No module named 'psycopg2'")
+        mock_create_engine.side_effect = original_error
+        dbapi_hook = mock_db_hook(DbApiHook, conn_params={"conn_type": "postgresql"})
+
+        with pytest.raises(ModuleNotFoundError, match="psycopg2"):
+            dbapi_hook.get_sqlalchemy_engine()
+        mock_create_engine.assert_called_once()
+
+    @pytest.mark.db_test
+    @patch("airflow.providers.common.sql.hooks.sql.create_engine")
+    def test_does_not_retry_for_non_postgres_schemes(self, mock_create_engine):
+        original_error = ModuleNotFoundError("No module named 'some_other_driver'")
+        mock_create_engine.side_effect = original_error
+        dbapi_hook = mock_db_hook(DbApiHook, conn_params={"conn_type": "mysql"})
+
+        with pytest.raises(ModuleNotFoundError, match="some_other_driver"):
+            dbapi_hook.get_sqlalchemy_engine()
+        mock_create_engine.assert_called_once()
+
+
 class TestDbApiHookGetTableSchema:
     @pytest.mark.db_test
     def test_get_table_schema(self):

--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py
@@ -22,13 +22,10 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from psycopg2.extensions import register_adapter
-from psycopg2.extras import Json
-
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.transfers.bigquery_to_sql import BigQueryToSqlBaseOperator
 from airflow.providers.google.cloud.utils.bigquery_get_data import bigquery_get_data
-from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.providers.postgres.hooks.postgres import USE_PSYCOPG3, PostgresHook
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -81,8 +78,12 @@ class BigQueryToPostgresOperator(BigQueryToSqlBaseOperator):
 
     @cached_property
     def postgres_hook(self) -> PostgresHook:
-        register_adapter(list, Json)
-        register_adapter(dict, Json)
+        if not USE_PSYCOPG3:
+            from psycopg2.extensions import register_adapter
+            from psycopg2.extras import Json
+
+            register_adapter(list, Json)
+            register_adapter(dict, Json)
         return PostgresHook(database=self.database, postgres_conn_id=self.postgres_conn_id)
 
     def get_sql_hook(self) -> PostgresHook:

--- a/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_postgres.py
@@ -17,6 +17,8 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -148,8 +150,13 @@ class TestBigQueryToPostgresOperator:
     @mock.patch(
         "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials_and_project_id"
     )
-    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_postgres.register_adapter")
-    def test_adapters_to_json_registered(self, mock_register_adapter, mock_get_creds, mock_get_client):
+    @mock.patch("psycopg2.extensions.register_adapter")
+    def test_adapters_to_json_registered_on_psycopg2_path(
+        self, mock_register_adapter, mock_get_creds, mock_get_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "airflow.providers.google.cloud.transfers.bigquery_to_postgres.USE_PSYCOPG3", False
+        )
         mock_get_creds.return_value = (None, TEST_PROJECT)
         client = MagicMock()
         client.list_rows.return_value = []
@@ -165,6 +172,32 @@ class TestBigQueryToPostgresOperator:
 
         mock_register_adapter.assert_any_call(list, Json)
         mock_register_adapter.assert_any_call(dict, Json)
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
+    @mock.patch(
+        "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials_and_project_id"
+    )
+    @mock.patch("psycopg2.extensions.register_adapter")
+    def test_adapters_not_registered_on_psycopg3_path(
+        self, mock_register_adapter, mock_get_creds, mock_get_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "airflow.providers.google.cloud.transfers.bigquery_to_postgres.USE_PSYCOPG3", True
+        )
+        mock_get_creds.return_value = (None, TEST_PROJECT)
+        client = MagicMock()
+        client.list_rows.return_value = []
+        mock_get_client.return_value = client
+
+        operator = BigQueryToPostgresOperator(
+            task_id=TASK_ID,
+            dataset_table=f"{TEST_DATASET}.{TEST_TABLE_ID}",
+            target_table_name=TEST_DESTINATION_TABLE,
+            replace=False,
+        )
+        operator.postgres_hook
+
+        mock_register_adapter.assert_not_called()
 
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_postgres.PostgresHook")
     @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_sql.BigQueryHook")
@@ -254,3 +287,17 @@ class TestBigQueryToPostgresOperator:
         assert "columnLineage" in output_ds.facets
         col_lineage = output_ds.facets["columnLineage"]
         assert set(col_lineage.fields.keys()) == {"id", "name"}
+
+
+def test_bigquery_to_postgres_module_imports_without_psycopg2(monkeypatch):
+    """The module must import cleanly even when psycopg2 isn't installed."""
+    monkeypatch.setitem(sys.modules, "psycopg2", None)
+    monkeypatch.setitem(sys.modules, "psycopg2.extensions", None)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", None)
+    module_name = "airflow.providers.google.cloud.transfers.bigquery_to_postgres"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    try:
+        module = importlib.import_module(module_name)
+        assert module.BigQueryToPostgresOperator is not None
+    finally:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)

--- a/providers/pgvector/pyproject.toml
+++ b/providers/pgvector/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "apache-airflow",
     "apache-airflow-task-sdk",
     "apache-airflow-devel-common",
+    "apache-airflow-providers-common-compat",
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-postgres",
     # Additional devel dependencies (do not remove this line and add extra development dependencies)

--- a/providers/pgvector/src/airflow/providers/pgvector/operators/pgvector.py
+++ b/providers/pgvector/src/airflow/providers/pgvector/operators/pgvector.py
@@ -17,8 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from pgvector.psycopg2 import register_vector
-
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 
 
@@ -41,6 +40,24 @@ class PgVectorIngestOperator(SQLExecuteQueryOperator):
 
     def _register_vector(self) -> None:
         """Register the vector type with your connection."""
+        from airflow.providers.postgres.hooks.postgres import USE_PSYCOPG3
+
+        if USE_PSYCOPG3:
+            try:
+                from pgvector.psycopg import register_vector
+            except (ImportError, ModuleNotFoundError) as err:
+                raise AirflowOptionalProviderFeatureException(
+                    "pgvector's psycopg (v3) integration is not installed. Please install it with "
+                    "`pip install --upgrade pgvector`."
+                ) from err
+        else:
+            try:
+                from pgvector.psycopg2 import register_vector
+            except (ImportError, ModuleNotFoundError) as err:
+                raise AirflowOptionalProviderFeatureException(
+                    "psycopg2 is not installed. Please install it with "
+                    "`pip install apache-airflow-providers-postgres[psycopg2]`."
+                ) from err
         conn = self.get_db_hook().get_conn()
         register_vector(conn)
 

--- a/providers/pgvector/tests/unit/pgvector/operators/test_pgvector.py
+++ b/providers/pgvector/tests/unit/pgvector/operators/test_pgvector.py
@@ -16,10 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
 from unittest.mock import Mock, patch
 
 import pytest
 
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 from airflow.providers.pgvector.operators.pgvector import PgVectorIngestOperator
 
 
@@ -32,10 +35,24 @@ def pg_vector_ingest_operator():
     )
 
 
-@patch("airflow.providers.pgvector.operators.pgvector.register_vector")
+@patch("airflow.providers.postgres.hooks.postgres.USE_PSYCOPG3", False)
 @patch("airflow.providers.pgvector.operators.pgvector.PgVectorIngestOperator.get_db_hook")
-def test_register_vector(mock_get_db_hook, mock_register_vector, pg_vector_ingest_operator):
-    # Create a mock database connection
+def test_register_vector_psycopg2(mock_get_db_hook, monkeypatch, pg_vector_ingest_operator):
+    # psycopg2 is optional (see providers/postgres's [psycopg2] extra), so patch the module
+    # via sys.modules instead of `@patch("pgvector.psycopg2...")`, which would import it for real.
+    mock_psycopg2 = Mock()
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", mock_psycopg2)
+    mock_db_hook = Mock()
+    mock_get_db_hook.return_value = mock_db_hook
+
+    pg_vector_ingest_operator._register_vector()
+    mock_psycopg2.register_vector.assert_called_with(mock_db_hook.get_conn())
+
+
+@patch("airflow.providers.postgres.hooks.postgres.USE_PSYCOPG3", True)
+@patch("pgvector.psycopg.register_vector")
+@patch("airflow.providers.pgvector.operators.pgvector.PgVectorIngestOperator.get_db_hook")
+def test_register_vector_psycopg3(mock_get_db_hook, mock_register_vector, pg_vector_ingest_operator):
     mock_db_hook = Mock()
     mock_get_db_hook.return_value = mock_db_hook
 
@@ -43,14 +60,44 @@ def test_register_vector(mock_get_db_hook, mock_register_vector, pg_vector_inges
     mock_register_vector.assert_called_with(mock_db_hook.get_conn())
 
 
-@patch("airflow.providers.pgvector.operators.pgvector.register_vector")
+@patch("airflow.providers.postgres.hooks.postgres.USE_PSYCOPG3", False)
 @patch("airflow.providers.pgvector.operators.pgvector.SQLExecuteQueryOperator.execute")
 @patch("airflow.providers.pgvector.operators.pgvector.PgVectorIngestOperator.get_db_hook")
 def test_execute(
-    mock_get_db_hook, mock_execute_query_operator_execute, mock_register_vector, pg_vector_ingest_operator
+    mock_get_db_hook, mock_execute_query_operator_execute, monkeypatch, pg_vector_ingest_operator
 ):
+    # psycopg2 is optional (see providers/postgres's [psycopg2] extra), so patch the module
+    # via sys.modules instead of `@patch("pgvector.psycopg2...")`, which would import it for real.
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", Mock())
     mock_db_hook = Mock()
     mock_get_db_hook.return_value = mock_db_hook
 
     pg_vector_ingest_operator.execute(None)
     mock_execute_query_operator_execute.assert_called_once()
+
+
+@patch("airflow.providers.postgres.hooks.postgres.USE_PSYCOPG3", False)
+def test_register_vector_raises_clear_error_without_psycopg2(monkeypatch, pg_vector_ingest_operator):
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", None)
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        pg_vector_ingest_operator._register_vector()
+
+
+@patch("airflow.providers.postgres.hooks.postgres.USE_PSYCOPG3", True)
+def test_register_vector_raises_clear_error_without_psycopg3(monkeypatch, pg_vector_ingest_operator):
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg", None)
+    with pytest.raises(AirflowOptionalProviderFeatureException, match=r"psycopg \(v3\) integration"):
+        pg_vector_ingest_operator._register_vector()
+
+
+def test_pgvector_module_imports_without_psycopg2(monkeypatch):
+    """The module must import cleanly even when psycopg2/pgvector.psycopg2 isn't installed."""
+    monkeypatch.setitem(sys.modules, "psycopg2", None)
+    monkeypatch.setitem(sys.modules, "pgvector.psycopg2", None)
+    module_name = "airflow.providers.pgvector.operators.pgvector"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    try:
+        module = importlib.import_module(module_name)
+        assert module.PgVectorIngestOperator is not None
+    finally:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)

--- a/providers/postgres/README.rst
+++ b/providers/postgres/README.rst
@@ -56,10 +56,10 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``psycopg2-binary``                         ``>=2.9.9; python_version < "3.13"``
-``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``psycopg[binary]``                         ``>=3.2.9; python_version < "3.14"``
 ``psycopg[binary]``                         ``>=3.3.3; python_version >= "3.14"``
+``psycopg2-binary``                         ``>=2.9.9; python_version < "3.13"``
+``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``asyncpg``                                 ``>=0.30.0``
 ==========================================  ======================================
 
@@ -96,6 +96,7 @@ Extra                Dependencies
 ``openlineage``      ``apache-airflow-providers-openlineage``
 ``pandas``           ``pandas>=2.1.2; python_version <"3.13"``, ``pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"``, ``pandas>=2.3.3; python_version >="3.14"``
 ``polars``           ``polars>=1.26.0``
+``psycopg2``         ``psycopg2-binary>=2.9.9; python_version < "3.13"``, ``psycopg2-binary>=2.9.10; python_version >= "3.13"``
 ``sqlalchemy``       ``sqlalchemy>=1.4.54``
 ===================  ============================================================================================================================================================
 

--- a/providers/postgres/docs/changelog.rst
+++ b/providers/postgres/docs/changelog.rst
@@ -49,6 +49,20 @@ Breaking changes
     To keep using asyncpg on Airflow 3.4.0+, set
     ``[database] sql_alchemy_conn_async = postgresql+asyncpg://...`` explicitly.
 
+.. note::
+    On Airflow 3.4.0 and later, ``psycopg`` (psycopg3) becomes the default synchronous Postgres
+    driver, mirroring the async default above. ``psycopg[binary]`` is installed by default to serve it.
+
+    ``psycopg2-binary`` remains installed by default as well. This provider still supports Airflow
+    cores older than 3.4.0, which normalize the synchronous metadata-database connection to
+    ``postgresql+psycopg2://`` and have no psycopg fallback; Airflow 2.11 additionally ships
+    SQLAlchemy 1.4, which has no native ``psycopg`` (v3) dialect at all — so psycopg2 must stay
+    present for those cores to work. It will become opt-in-only (via the existing ``[psycopg2]``
+    extra) in a future release once the minimum supported Airflow is 3.4.0.
+
+    To keep using psycopg2 on Airflow 3.4.0+, set
+    ``[database] sql_alchemy_conn = postgresql+psycopg2://...`` explicitly.
+
 * ``Switch the default async Postgres driver from asyncpg to psycopg3 (#69089)``
 
 .. Below changes are excluded from the changelog. Move them to

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -104,10 +104,10 @@ PIP package                                 Version required
 ``apache-airflow``                          ``>=2.11.0``
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``apache-airflow-providers-common-sql``     ``>=1.32.0``
-``psycopg2-binary``                         ``>=2.9.9; python_version < "3.13"``
-``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``psycopg[binary]``                         ``>=3.2.9; python_version < "3.14"``
 ``psycopg[binary]``                         ``>=3.3.3; python_version >= "3.14"``
+``psycopg2-binary``                         ``>=2.9.9; python_version < "3.13"``
+``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``asyncpg``                                 ``>=0.30.0``
 ==========================================  ======================================
 
@@ -152,6 +152,7 @@ Extra                Dependencies
 ``openlineage``      ``apache-airflow-providers-openlineage``
 ``pandas``           ``pandas>=2.1.2; python_version <"3.13"``, ``pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"``, ``pandas>=2.3.3; python_version >="3.14"``
 ``polars``           ``polars>=1.26.0``
+``psycopg2``         ``psycopg2-binary>=2.9.9; python_version < '3.13'``, ``psycopg2-binary>=2.9.10; python_version >= '3.13'``
 ``sqlalchemy``       ``sqlalchemy>=1.4.54``
 ===================  ============================================================================================================================================================
 

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -62,18 +62,18 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    # psycopg2 remains the sync driver for now; its removal and the sync migration to
-    # psycopg3 are tracked at https://github.com/apache/airflow/issues/68453
-    "psycopg2-binary>=2.9.9; python_version < '3.13'",
-    "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "psycopg[binary]>=3.2.9; python_version < '3.14'",
     "psycopg[binary]>=3.3.3; python_version >= '3.14'",
-    # asyncpg must stay a default dependency while this provider still supports Airflow
-    # cores older than 3.4.0: those cores derive the async metadata-DB URL as
-    # ``postgresql+asyncpg://`` unconditionally and have no psycopg_async fallback, so
-    # dropping asyncpg breaks their async engine. Make it opt-in-only (via the ``[asyncpg]``
-    # extra) only once the minimum supported Airflow is >= 3.4.0; tracked at
-    # https://github.com/apache/airflow/issues/68453
+    # psycopg2-binary and asyncpg must stay default dependencies while this provider still
+    # supports Airflow cores older than 3.4.0. Those cores normalize the sync metadata-DB conn
+    # to ``postgresql+psycopg2://`` (see core ``_upgrade_postgres_metastore_conn``) and derive
+    # the async URL as ``postgresql+asyncpg://`` unconditionally, with no psycopg fallback;
+    # Airflow 2.11 additionally ships SQLAlchemy 1.4, which has no native ``psycopg`` (v3)
+    # dialect at all. The psycopg3 defaults only take effect on 3.4.0+, so both drivers become
+    # opt-in-only (via the ``[psycopg2]`` / ``[asyncpg]`` extras) together once the minimum
+    # supported Airflow is >= 3.4.0; tracked at https://github.com/apache/airflow/issues/68453
+    "psycopg2-binary>=2.9.9; python_version < '3.13'",
+    "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "asyncpg>=0.30.0",
 ]
 
@@ -99,6 +99,10 @@ dependencies = [
 ]
 "polars" = [
     "polars>=1.26.0"
+]
+"psycopg2" = [
+    "psycopg2-binary>=2.9.9; python_version < '3.13'",
+    "psycopg2-binary>=2.9.10; python_version >= '3.13'",
 ]
 "sqlalchemy" = [
     "sqlalchemy>=1.4.54"

--- a/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
@@ -18,14 +18,12 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from contextlib import closing
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeAlias, cast, overload
 
 from more_itertools import chunked
-from psycopg2 import connect as ppg2_connect
-from psycopg2.extras import DictCursor, NamedTupleCursor, RealDictCursor, execute_values
 
 from airflow.providers.common.compat.sdk import (
     AirflowException,
@@ -54,9 +52,35 @@ if USE_PSYCOPG3:
     from psycopg.rows import dict_row, namedtuple_row
     from psycopg.types.json import register_default_adapters
 
+try:
+    import psycopg2 as _psycopg2
+    import psycopg2.extras as _psycopg2_extras
+except (ImportError, ModuleNotFoundError):
+    _psycopg2 = None
+    _psycopg2_extras = None
+
+ppg2_connect: Callable[..., Any] | None = _psycopg2.connect if _psycopg2 else None
+DictCursor: type | None = _psycopg2_extras.DictCursor if _psycopg2_extras else None
+NamedTupleCursor: type | None = _psycopg2_extras.NamedTupleCursor if _psycopg2_extras else None
+RealDictCursor: type | None = _psycopg2_extras.RealDictCursor if _psycopg2_extras else None
+execute_values: Callable[..., Any] | None = _psycopg2_extras.execute_values if _psycopg2_extras else None
+
+
+def _require_psycopg2() -> NoReturn:
+    raise AirflowOptionalProviderFeatureException(
+        "psycopg2 is not installed. Please install it with "
+        "`pip install apache-airflow-providers-postgres[psycopg2]`."
+    )
+
+
 if TYPE_CHECKING:
     from pandas import DataFrame as PandasDataFrame
     from polars import DataFrame as PolarsDataFrame
+    from psycopg2.extras import (
+        DictCursor as _DictCursorType,
+        NamedTupleCursor as _NamedTupleCursorType,
+        RealDictCursor as _RealDictCursorType,
+    )
     from sqlalchemy.engine import URL
 
     from airflow.providers.common.sql.dialects.dialect import Dialect
@@ -65,7 +89,7 @@ if TYPE_CHECKING:
     if USE_PSYCOPG3:
         from psycopg.errors import Diagnostic
 
-    CursorType: TypeAlias = DictCursor | RealDictCursor | NamedTupleCursor
+    CursorType: TypeAlias = _DictCursorType | _RealDictCursorType | _NamedTupleCursorType
     CursorRow: TypeAlias = dict[str, Any] | tuple[Any, ...]
 
 
@@ -204,6 +228,9 @@ class PostgresHook(DbApiHook):
             valid_cursors = "dictcursor, namedtuplecursor"
             raise ValueError(f"Invalid cursor passed {_cursor}. Valid options are: {valid_cursors}")
 
+        if DictCursor is None:
+            _require_psycopg2()
+
         cursor_types = {
             "dictcursor": DictCursor,
             "realdictcursor": RealDictCursor,
@@ -234,6 +261,9 @@ class PostgresHook(DbApiHook):
                 connection.add_notice_handler(self._notice_handler)
 
             return connection
+
+        if ppg2_connect is None:
+            _require_psycopg2()
 
         return ppg2_connect(**conn_args)
 
@@ -691,6 +721,8 @@ class PostgresHook(DbApiHook):
             )
 
         # if fast_executemany is enabled with psycopg2, use optimized execute_values from psycopg
+        if execute_values is None:
+            _require_psycopg2()
         self._insert_statement_format = "INSERT INTO {} {} VALUES %s"
 
         nb_rows = 0

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -58,6 +58,27 @@ else:
     import psycopg2.extras
 
 
+def test_hooks_postgres_raises_clear_error_without_psycopg2(monkeypatch):
+    """PostgresHook must fail loudly (not with a bare ImportError or a real connection attempt)
+    when psycopg2-specific functionality is used but psycopg2 isn't installed."""
+    import airflow.providers.postgres.hooks.postgres as postgres_module
+
+    monkeypatch.setattr(postgres_module, "USE_PSYCOPG3", False)
+    monkeypatch.setattr(postgres_module, "ppg2_connect", None)
+    monkeypatch.setattr(postgres_module, "DictCursor", None)
+    monkeypatch.setattr(postgres_module, "RealDictCursor", None)
+    monkeypatch.setattr(postgres_module, "NamedTupleCursor", None)
+    monkeypatch.setattr(postgres_module, "execute_values", None)
+
+    hook = postgres_module.PostgresHook.__new__(postgres_module.PostgresHook)
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        hook._get_cursor("dictcursor")
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        hook._create_connection({})
+    with pytest.raises(AirflowOptionalProviderFeatureException, match="psycopg2 is not installed"):
+        hook.insert_rows(table="t", rows=[(1,)], fast_executemany=True)
+
+
 @pytest.fixture
 def mock_connect(mocker):
     """Mock the connection object according to the correct psycopg version."""

--- a/providers/postgres/tests/unit/postgres/test_provider_dependencies.py
+++ b/providers/postgres/tests/unit/postgres/test_provider_dependencies.py
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from importlib import metadata
+
+import pytest
+
+DISTRIBUTION = "apache-airflow-providers-postgres"
+
+
+def _default_requirements() -> list[str]:
+    """Requirement strings the provider installs by default (i.e. not gated behind an extra)."""
+    return [req for req in (metadata.requires(DISTRIBUTION) or []) if "extra ==" not in req]
+
+
+@pytest.mark.parametrize("package", ["psycopg2-binary", "asyncpg"])
+def test_backcompat_driver_stays_a_default_dependency(package):
+    """
+    ``psycopg2-binary`` (sync) and ``asyncpg`` (async) must remain default dependencies, not
+    optional extras, while the provider supports Airflow cores older than 3.4.0. Those cores
+    normalize the sync metadata-DB conn to ``postgresql+psycopg2://`` and derive the async URL as
+    ``postgresql+asyncpg://`` with no psycopg fallback (and Airflow 2.11 ships SQLAlchemy 1.4,
+    which has no ``psycopg`` v3 dialect), so demoting either driver to an extra silently breaks
+    them. Removal is gated on bumping the floor to 3.4.0; see
+    https://github.com/apache/airflow/issues/68453
+    """
+    defaults = _default_requirements()
+    assert any(req.startswith(package) for req in defaults), (
+        f"{package} must stay a default dependency of {DISTRIBUTION} until the minimum supported "
+        f"Airflow is >= 3.4.0. Default dependencies were: {defaults}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ name = "adbc-driver-manager"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/5e/50aab18cb501e42d3aca3cd2cc26c6637094fcaf5b6576e350c444188f1f/adbc_driver_manager-1.11.0.tar.gz", hash = "sha256:c64aaabeb5810109ab3d2961008f1b014e9f2d87b3df4416c2a080a40237af50", size = 233059, upload-time = "2026-04-07T00:17:28.263Z" }
 wheels = [
@@ -375,8 +375,8 @@ name = "adbc-driver-postgresql"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "adbc-driver-manager", marker = "python_full_version < '3.13'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.13'" },
+    { name = "adbc-driver-manager" },
+    { name = "importlib-resources" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/10/2962c25035887cd03af3b348eac3302493936f45048c220021a802d07f12/adbc_driver_postgresql-1.11.0.tar.gz", hash = "sha256:f5688b8648ac7a86d8b89340231bb3686ac5df56ee95d1ca0b875dad5d52b48a", size = 32328, upload-time = "2026-04-07T00:17:29.232Z" }
 wheels = [
@@ -392,8 +392,8 @@ name = "adbc-driver-sqlite"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "adbc-driver-manager", marker = "python_full_version < '3.13'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.13'" },
+    { name = "adbc-driver-manager" },
+    { name = "importlib-resources" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/dd/8a5f4908aa4bdec64dcd672734fa314d692517458ce169591639d0123fe1/adbc_driver_sqlite-1.11.0.tar.gz", hash = "sha256:a4c6b4962610f7cd67cd754c42dd74e18a2c11fabeec9488c5501d73ae62dc62", size = 28885, upload-time = "2026-04-07T00:17:31.325Z" }
 wheels = [
@@ -456,7 +456,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -480,7 +480,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -7218,6 +7218,9 @@ pandas = [
 polars = [
     { name = "polars" },
 ]
+psycopg2 = [
+    { name = "psycopg2-binary" },
+]
 sqlalchemy = [
     { name = "sqlalchemy" },
 ]
@@ -7256,9 +7259,11 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], marker = "python_full_version >= '3.14'", specifier = ">=3.3.3" },
     { name = "psycopg2-binary", marker = "python_full_version < '3.13'", specifier = ">=2.9.9" },
     { name = "psycopg2-binary", marker = "python_full_version >= '3.13'", specifier = ">=2.9.10" },
+    { name = "psycopg2-binary", marker = "python_full_version >= '3.13' and extra == 'psycopg2'", specifier = ">=2.9.10" },
+    { name = "psycopg2-binary", marker = "python_full_version < '3.13' and extra == 'psycopg2'", specifier = ">=2.9.9" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4.54" },
 ]
-provides-extras = ["amazon", "asyncpg", "microsoft-azure", "openlineage", "pandas", "polars", "sqlalchemy"]
+provides-extras = ["amazon", "asyncpg", "microsoft-azure", "openlineage", "psycopg2", "pandas", "polars", "sqlalchemy"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -10429,8 +10434,8 @@ name = "cassandra-driver"
 version = "3.30.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecated", marker = "python_full_version < '3.14'" },
-    { name = "geomet", marker = "python_full_version < '3.14'" },
+    { name = "deprecated" },
+    { name = "geomet" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/ed/4e16210e194660f107929ee494f1cf18557252655067d9b39029c241be2d/cassandra_driver-3.30.1.tar.gz", hash = "sha256:0c6a3e1428f7c6a9aa6c944b9c47a37cd2cdbeb5b5a82d42c33afdd56f14e398", size = 289233, upload-time = "2026-07-06T20:14:31.37Z" }
 wheels = [
@@ -12472,7 +12477,7 @@ name = "geomet"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "click" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/8c/dde022aa6747b114f6b14a7392871275dea8867e2bd26cddb80cc6d66620/geomet-1.1.0.tar.gz", hash = "sha256:51e92231a0ef6aaa63ac20c443377ba78a303fd2ecd179dc3567de79f3c11605", size = 28732, upload-time = "2023-11-14T15:43:36.764Z" }
 wheels = [
@@ -13905,7 +13910,7 @@ name = "gssapi"
 version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "decorator", marker = "python_full_version < '3.15' or sys_platform != 'win32'" },
+    { name = "decorator" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/52/c1e90623c259a42ab0587078bb04f959867b970add46ff66750ead8fc7c5/gssapi-1.11.1.tar.gz", hash = "sha256:2049ee4b1d0c363163a1344b7282a363f9f4094e51d2c36de0cf01d4735e0ae2", size = 95233, upload-time = "2026-01-26T21:01:39.463Z" }
 wheels = [
@@ -14690,17 +14695,17 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -14724,18 +14729,18 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -14747,7 +14752,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -18075,9 +18080,9 @@ wheels = [
 
 [package.optional-dependencies]
 sql-other = [
-    { name = "adbc-driver-postgresql", marker = "python_full_version < '3.13'" },
-    { name = "adbc-driver-sqlite", marker = "python_full_version < '3.13'" },
-    { name = "sqlalchemy", marker = "python_full_version < '3.13'" },
+    { name = "adbc-driver-postgresql" },
+    { name = "adbc-driver-sqlite" },
+    { name = "sqlalchemy" },
 ]
 
 [[package]]
@@ -20485,9 +20490,9 @@ name = "python3-saml"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "isodate", marker = "python_full_version < '3.13'" },
-    { name = "lxml", marker = "python_full_version < '3.13'" },
-    { name = "xmlsec", marker = "python_full_version < '3.13'" },
+    { name = "isodate" },
+    { name = "lxml" },
+    { name = "xmlsec" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/98/6e0268c3a9893af3d4c5cf670183e0314cd6b5cb034a612d6a7cc5060df8/python3-saml-1.16.0.tar.gz", hash = "sha256:97c9669aecabc283c6e5fb4eb264f446b6e006f5267d01c9734f9d8bffdac133", size = 83468, upload-time = "2023-10-09T10:37:43.128Z" }
 wheels = [
@@ -21620,10 +21625,10 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/59/44985a2bdc95c74e34fef3d10cb5d93ce13b0e2a7baefffe1b53853b502d/scikit_learn-1.5.2.tar.gz", hash = "sha256:b4237ed7b3fdd0a4882792e68ef2545d5baa50aca3bb45aa7df468138ad8f94d", size = 7001680, upload-time = "2024-09-11T15:50:10.957Z" }
 wheels = [
@@ -21666,13 +21671,13 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "narwhals", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -21717,7 +21722,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -21777,7 +21782,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -21858,7 +21863,7 @@ resolution-markers = [
     "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -22302,23 +22307,23 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -22334,23 +22339,23 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -22372,23 +22377,23 @@ resolution-markers = [
     "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -22454,12 +22459,12 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "starlette", marker = "python_full_version < '3.11'" },
-    { name = "uvicorn", marker = "python_full_version < '3.11'" },
-    { name = "watchfiles", marker = "python_full_version < '3.11'" },
-    { name = "websockets", marker = "python_full_version < '3.11'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/2c/155e1de2c1ba96a72e5dba152c509a8b41e047ee5c2def9e9f0d812f8be7/sphinx_autobuild-2024.10.3.tar.gz", hash = "sha256:248150f8f333e825107b6d4b86113ab28fa51750e5f9ae63b59dc339be951fb1", size = 14023, upload-time = "2024-10-02T23:15:30.172Z" }
 wheels = [
@@ -22483,13 +22488,13 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "colorama" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "starlette", marker = "python_full_version >= '3.11'" },
-    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
-    { name = "watchfiles", marker = "python_full_version >= '3.11'" },
-    { name = "websockets", marker = "python_full_version >= '3.11'" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
@@ -22519,7 +22524,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -22543,7 +22548,7 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
@@ -24499,7 +24504,7 @@ name = "xmlsec"
 version = "1.3.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml", marker = "python_full_version < '3.13'" },
+    { name = "lxml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/14/538b75379e6ab8f688f14d8663e2ab138d9c778bac4999d155b5f33c71c1/xmlsec-1.3.17.tar.gz", hash = "sha256:f3fac9ae679f66585925cc00c5f6839ae36c1d03157619571dee18acc05b9c01", size = 115637, upload-time = "2025-11-11T16:20:46.019Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -7121,6 +7121,7 @@ common-sql = [
 dev = [
     { name = "apache-airflow" },
     { name = "apache-airflow-devel-common" },
+    { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-sql" },
     { name = "apache-airflow-providers-postgres" },
     { name = "apache-airflow-task-sdk" },
@@ -7143,6 +7144,7 @@ provides-extras = ["common-sql"]
 dev = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-devel-common", editable = "devel-common" },
+    { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
     { name = "apache-airflow-providers-postgres", editable = "providers/postgres" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
@@ -7263,7 +7265,7 @@ requires-dist = [
     { name = "psycopg2-binary", marker = "python_full_version < '3.13' and extra == 'psycopg2'", specifier = ">=2.9.9" },
     { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4.54" },
 ]
-provides-extras = ["amazon", "asyncpg", "microsoft-azure", "openlineage", "psycopg2", "pandas", "polars", "sqlalchemy"]
+provides-extras = ["amazon", "asyncpg", "microsoft-azure", "openlineage", "pandas", "polars", "psycopg2", "sqlalchemy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes:
- #69443

related:
- #68453
- #69469

---

Makes `psycopg` (v3) the default **synchronous** Postgres driver across the providers, mirroring the async default switch (#69089). psycopg3 is used wherever it actually works (SQLAlchemy 2.0+); `psycopg2-binary` **stays installed by default** as a fallback so nothing regresses on the Airflow versions this provider still supports.

### Why psycopg2 stays a default dependency (not demoted to an extra)

An earlier revision of this PR moved `psycopg2-binary` to an opt-in `[psycopg2]` extra. That regresses every core older than 3.4.0, so it now stays a default dependency — gated to become opt-in only once the minimum supported Airflow is 3.4.0. The reasons mirror #69690 (which kept `asyncpg` installed by default for the same class of reason on the async side):

- **Core normalizes the sync metadata-DB conn to `postgresql+psycopg2://`.** On every currently released core, `configuration.py::_upgrade_postgres_metastore_conn` rewrites a bare `postgresql://` / legacy `postgres://` / `postgres+psycopg2://` `sql_alchemy_conn` to explicit `postgresql+psycopg2://`, and `settings.py` builds the metadata engine from that string with no psycopg fallback. Dropping psycopg2 breaks the metadata DB.
- **Airflow 2.11 ships SQLAlchemy 1.4**, which has no native `postgresql+psycopg` (v3) dialect at all. Since this provider still supports `apache-airflow>=2.11.0`, psycopg2 is the only viable sync driver there.

So `psycopg[binary]`, `psycopg2-binary`, and `asyncpg` are all default dependencies. The removal of the psycopg2/asyncpg defaults is deferred, gated on the floor bump to 3.4.0, and noted at the workaround site (tracked at #68453).

### Relationship to #69469 (the core half)

The sync switch for Airflow's own metadata DB lives in **core #69469**: it flips `_upgrade_postgres_metastore_conn` to derive `postgresql+psycopg://` when psycopg (v3) is importable (gated to land in 3.4.0), mirroring the async `_USE_PSYCOPG3` guard.

Because this PR keeps **both** sync drivers installed by default, it is robust to #69469's presence and to merge order: whether core normalizes the conn to `+psycopg2://` (pre-#69469) or `+psycopg://` (post-#69469), the driver behind that scheme is always present. The two PRs can merge in either order and release independently without a broken window. The eventual removal of the psycopg2 default is what's coupled to #69469 shipping in every supported core — deferred to the 3.4.0 floor bump.

### What changed (6 commits, one per package)

1. **`providers/postgres`** — `PostgresHook` no longer requires psycopg2 at import time: the psycopg2-specific connection / cursor / `execute_values` imports are lazy/guarded and raise a clear `AirflowOptionalProviderFeatureException` if psycopg2 is genuinely needed but missing. A new `[psycopg2]` extra is added for the eventual opt-in. `psycopg2-binary` **remains a default dependency** for the backward-compat reasons above; a regression test asserts both `psycopg2-binary` and `asyncpg` stay default (non-extra) dependencies.
2. **`providers/celery`** — the `[celery] result_backend` derivation from a driverless `sql_alchemy_conn` now targets `postgresql+psycopg://` (matching the new sync default) when psycopg (v3) is importable, falling back to `postgresql+psycopg2://` otherwise — mirroring the same guard `PostgresHook` uses.
3. **`providers/google`** — `BigQueryToPostgresOperator`'s psycopg2-specific `register_adapter(list/dict, Json)` now only runs when the resolved `PostgresHook` connection is actually on psycopg2 (a no-op on psycopg3), so the module imports cleanly without psycopg2 installed.
4. **`providers/pgvector`** — `PgVectorIngestOperator._register_vector` now calls the registration helper matching the connection's actual driver (`pgvector.psycopg2.register_vector` vs. `pgvector.psycopg.register_vector`) instead of always assuming psycopg2, fixing a pre-existing bug. Its "psycopg (v3) integration missing" error now points at `pip install --upgrade pgvector`.
5. **`providers/amazon`** — `RedshiftSQLHook.get_sqlalchemy_engine()` resolves an explicit driver (prefers psycopg **on SQLAlchemy 2.0+**, falls back to psycopg2, clear error if neither) instead of relying on SQLAlchemy's implicit psycopg2 default for a bare `postgresql://` URI. `get_uri()`'s own bare-scheme contract is untouched. Also updates the Batch/ECS/Lambda executor docs' example connection strings to `postgresql+psycopg://`.
6. **`providers/common/sql`** — `DbApiHook.get_sqlalchemy_engine()` retries with an explicit driver only for the specific "bare `postgresql` scheme, driver import failed" case; any other scheme's failure still propagates unchanged, keeping the class DB-agnostic. The retry prefers psycopg **only on SQLAlchemy 2.0+** (which has the native `postgresql+psycopg` dialect) and falls back to psycopg2 otherwise, so it stays correct on Airflow 2.11's SQLAlchemy 1.4. This is the general
   safety net: any current or future `DbApiHook` subclass with a postgres-compatible `conn_type` that doesn't override `sqlalchemy_url` is covered by this fix, not just the two concrete cases (amazon, google) found so far.

### Test plan

- New/updated tests per commit cover: the lazy-psycopg2 fallback itself; both `USE_PSYCOPG3` branches in celery/google/pgvector; `PgVectorIngestOperator` registering against **both** a psycopg2-backed and a psycopg3-backed connection; and `get_sqlalchemy_engine`'s driver-resolution / retry / re-raise / no-retry-for-other-schemes behavior in both amazon and common.sql — including the new SQLAlchemy-1.4 case that must fall back to psycopg2 rather than psycopg (v3).
- A packaging regression test asserts `psycopg2-binary` and `asyncpg` remain default (non-extra) dependencies of `apache-airflow-providers-postgres`, so a future change can't silently demote either driver back to an extra and reintroduce the `<3.4.0` regression.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
