### PR TITLE
Fix flaky LocalExecutor drain test under Python 3.14 forkserver

### DIFF
--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -347,12 +347,18 @@ class TestLocalExecutor:
 
     @pytest.mark.execution_timeout(10)
     def test_end_drains_result_queue_to_avoid_join_deadlock(self):
+        # Pin the worker to "fork": the drain logic under test is start-method-agnostic, but under the
+        # "forkserver" default (Python 3.14+ on Linux) each spawned worker re-imports the whole airflow
+        # stack before it can write a result, which intermittently exceeds the execution_timeout and
+        # makes this test flaky. Forking inherits the already-imported parent, so the worker writes
+        # immediately and reliably reproduces the full-result_queue scenario this test guards.
+        ctx = multiprocessing.get_context("fork")
         executor = LocalExecutor(parallelism=1)
-        executor.activity_queue = multiprocessing.SimpleQueue()
-        executor.result_queue = multiprocessing.SimpleQueue()
+        executor.activity_queue = ctx.SimpleQueue()
+        executor.result_queue = ctx.SimpleQueue()
         result_count = 8
         payload_size = 128 * 1024
-        proc = multiprocessing.Process(
+        proc = ctx.Process(
             target=_write_large_results_to_queue,
             args=(executor.result_queue, result_count, payload_size),
         )


### PR DESCRIPTION
`test_end_drains_result_queue_to_avoid_join_deadlock` intermittently timed out on the Python 3.14 CI jobs (always the `3.14 Core...Serialization` group, all DB backends). Root cause: Python 3.14 changes the default multiprocessing start method on Linux from `fork` to `forkserver`. The drain logic under test is start-method-agnostic, but a `forkserver` worker is forked from a near-empty server and re-imports the entire airflow stack on every spawn. The throwaway worker this test starts therefore spends seconds in `import airflow` before it writes a single result, and `end()` waits through it — occasionally exceeding the test's `@execution_timeout(10)`.

Pinning the worker to the `fork` start method makes it inherit the already-imported parent, write immediately, and reliably reproduce the full-`result_queue` scenario the test guards — as it did before 3.14 changed the default. The production `LocalExecutor.end()` drain path is unchanged (it is correct).

Verified on the `main/ci/python3.14` image: the unpatched test reproducibly hangs (~1/50 iterations, 7–12 s each), while the patched test passes 300/300 under the `forkserver` default with every iteration under 0.3 s.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)