### PR TITLE
Fix remote task log pollution leaking out of S3 log handler test

### DIFF
--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -665,7 +665,7 @@ class TestFileTaskLogHandler:
         assert actual == os.fspath(tmp_path / expected)
 
     @skip_if_force_lowest_dependencies_marker
-    def test_read_remote_logs_with_real_s3_remote_log_io(self, create_task_instance, session):
+    def test_read_remote_logs_with_real_s3_remote_log_io(self, monkeypatch, create_task_instance, session):
         """Test _read_remote_logs method using real S3RemoteLogIO with mock AWS"""
         import tempfile
 
@@ -721,7 +721,9 @@ class TestFileTaskLogHandler:
 
                     import airflow.logging_config
 
-                    airflow.logging_config._ActiveLoggingConfig.remote_task_log = s3_remote_log_io
+                    monkeypatch.setattr(
+                        airflow.logging_config._ActiveLoggingConfig, "remote_task_log", s3_remote_log_io
+                    )
 
                     sources, logs = fth._read_remote_logs(ti, try_number=1)
 


### PR DESCRIPTION
- related: #69520

## Why

`test_read_remote_logs_with_real_s3_remote_log_io` assigns `_ActiveLoggingConfig.remote_task_log` directly and never restores it, so any log-reading test collected afterwards (e.g. `test_log_reader.py` when run after `test_log_handlers.py`) tries to fetch logs from the long-gone mocked S3 bucket and fails with `InvalidAccessKeyId`.

## What

- Set `_ActiveLoggingConfig.remote_task_log` via `monkeypatch.setattr` so it is restored after the test.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
