### PR TITLE
Add regression tests for _cli_safe_flash escaping in FAB auth manager

### DIFF
--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -248,32 +248,6 @@ class TestFabAirflowSecurityManagerOverride:
         sm._get_authentik_token_info = Mock(return_value=resp)
         assert sm.get_oauth_user_info(provider, {"id_token": None}) == user_info
 
-    def test_get_oauth_user_info_azure_with_groups_config(self):
-        from flask import Flask
-
-        app = Flask(__name__)
-        app.config["AUTH_OAUTH_ROLE_KEYS"] = {"azure": "groups"}
-
-        azure_response = {
-            "oid": "user-123",
-            "given_name": "Jane",
-            "family_name": "Smith",
-            "email": "jane.smith@example.com",
-            "groups": ["admin-group", "viewer-group"],
-        }
-
-        with app.app_context():
-            sm = EmptySecurityManager()
-            sm.appbuilder = Mock(sm=sm)
-            sm.oauth_remotes = {}
-            sm._decode_and_validate_azure_jwt = Mock(return_value=azure_response)
-
-            user_info = sm.get_oauth_user_info("azure", {"id_token": "test-token"})
-
-            assert user_info["username"] == "user-123"
-            assert user_info["email"] == "jane.smith@example.com"
-            assert user_info["role_keys"] == ["admin-group", "viewer-group"]
-
     @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.flash")
     @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.has_request_context")
     def test_cli_safe_flash_passes_preescaped_html_to_flash(

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -247,3 +247,76 @@ class TestFabAirflowSecurityManagerOverride:
         sm._decode_and_validate_azure_jwt = Mock(return_value=resp)
         sm._get_authentik_token_info = Mock(return_value=resp)
         assert sm.get_oauth_user_info(provider, {"id_token": None}) == user_info
+
+    def test_get_oauth_user_info_azure_with_groups_config(self):
+        from flask import Flask
+
+        app = Flask(__name__)
+        app.config["AUTH_OAUTH_ROLE_KEYS"] = {"azure": "groups"}
+
+        azure_response = {
+            "oid": "user-123",
+            "given_name": "Jane",
+            "family_name": "Smith",
+            "email": "jane.smith@example.com",
+            "groups": ["admin-group", "viewer-group"],
+        }
+
+        with app.app_context():
+            sm = EmptySecurityManager()
+            sm.appbuilder = Mock(sm=sm)
+            sm.oauth_remotes = {}
+            sm._decode_and_validate_azure_jwt = Mock(return_value=azure_response)
+
+            user_info = sm.get_oauth_user_info("azure", {"id_token": "test-token"})
+
+            assert user_info["username"] == "user-123"
+            assert user_info["email"] == "jane.smith@example.com"
+            assert user_info["role_keys"] == ["admin-group", "viewer-group"]
+
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.flash")
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.has_request_context")
+    def test_cli_safe_flash_passes_preescaped_html_to_flash(
+        self,
+        mock_has_request_context,
+        mock_flash,
+    ):
+        """_cli_safe_flash does not escape; callers must escape user input before calling it.
+
+        Callers use escape(user.username) before embedding in the message string.
+        This test verifies that pre-escaped content reaches flash() intact as Markup.
+        """
+        mock_has_request_context.return_value = True
+
+        raw_username = "<script>alert('xss')</script>"
+        # Simulate what call sites do: escape(user.username) before calling _cli_safe_flash
+        safe_username = "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"
+
+        EmptySecurityManager._cli_safe_flash(
+            f"User {safe_username} already exists",
+            "warning",
+        )
+
+        flash_arg = mock_flash.call_args[0][0]
+
+        # The raw, unescaped tag must not appear - escaping at call site prevents XSS
+        assert raw_username not in str(flash_arg)
+        # The pre-escaped content is preserved intact by the Markup wrapping
+        assert safe_username in str(flash_arg)
+
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.log")
+    @mock.patch("airflow.providers.fab.auth_manager.security_manager.override.has_request_context")
+    def test_cli_safe_flash_formats_cli_output(
+        self,
+        mock_has_request_context,
+        mock_log,
+    ):
+        """Outside a web context, _cli_safe_flash converts HTML tags to terminal-safe text."""
+        mock_has_request_context.return_value = False
+
+        EmptySecurityManager._cli_safe_flash(
+            "Hello<br><b>World</b>",
+            "warning",
+        )
+
+        mock_log.warning.assert_called_once_with("Hello\n*World*")


### PR DESCRIPTION
## Summary

Adds regression coverage for `_cli_safe_flash` in the FAB auth manager security manager override:

* pre-escaped HTML reaches `flash()` intact as `Markup` — raw user input never renders unescaped (call sites escape with `escape()` before calling)
* outside a request context, HTML tags are converted to terminal-safe text (`<br>` → newline, `<b>`/`</b>` → `*`) and routed to the logger at the requested level

## Why

Prevents accidental unsafe rendering of user-controlled content in FAB auth manager flash messages, and pins the CLI formatting behavior.

## Supersedes #66648

That PR was stale-closed as a draft and the branch has moved since, so it can no longer be reopened. Change since then:

* Removed `test_get_oauth_user_info_azure_with_groups_config`, which asserted `role_keys` is populated from a `groups` claim via an `AUTH_OAUTH_ROLE_KEYS` config key. That key does not exist in the codebase — `get_oauth_user_info()` reads the `roles` claim only — so the test failed deterministically (`AssertionError: assert [] == ['admin-group', 'viewer-group']`). It was also out of scope for this PR.

## Local verification (branch is on top of current `v3-1-test` tip a9eb88d)

* `pytest providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py` → **22 passed** (venv with `apache-airflow==3.1.8` and `flask-appbuilder==4.6.3` per the provider pins)
* Static checks run on the changed file: `ruff`, `ruff-format`, `codespell`, `end-of-file-fixer`, `trailing-whitespace`, `check-merge-conflict`, `debug-statements`, `check-builtin-literals`, `flynt`, `check-lazy-logging` — all pass
* Diff is exactly one test file, +47 lines

Note on the previously flagged `Integration and System Tests / Integration core redis` failure on #66648: this change only adds provider unit tests, so that failure looks unrelated to the diff — happy to investigate if it reappears on a fresh CI run.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes: Claude (Anthropic) — used to diagnose the failing test, remove it, and run the local verification described above; output reviewed by the author.