### PR TITLE
i18n(ko): add missing translations(Jul 8)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/admin.json
@@ -177,6 +177,7 @@
           "title": "건너뛰기"
         }
       },
+      "parsingFile": "파일 구문 분석 중...",
       "title": "변수 가져오기",
       "upload": "JSON 파일 업로드",
       "uploadPlaceholder": "변수를 포함한 JSON 파일 업로드 (e.g., {\"key\": \"value\", ...})"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -195,6 +195,23 @@
   },
   "pendingDagRun_one": "대기 중인 Dag 실행 {{count}}개",
   "pendingDagRun_other": "대기 중인 Dag 실행 {{count}}개",
+  "presetFilters": {
+    "deleteTitle": "프리셋 필터 삭제",
+    "deleteWarning": "프리셋 필터는 이 브라우저에만 저장됩니다.",
+    "duplicate": "프리셋 필터 \"{{name}}\"에 이미 동일한 설정이 저장되어 있습니다.",
+    "empty": "아직 프리셋 필터가 없습니다",
+    "info": {
+      "default": "프리셋 필터를 기본값으로 고정하면, 필터가 적용되지 않은 상태로 이 페이지에 들어올 때 자동으로 적용됩니다.",
+      "save": "현재 필터와 정렬을 이름 붙인 프리셋 필터로 저장하고, 언제든 다시 전환할 수 있습니다.",
+      "storage": "프리셋 필터는 이 브라우저에 저장됩니다."
+    },
+    "namePlaceholder": "프리셋 필터 이름",
+    "nothingToSave": "저장할 내용이 없습니다. 필터나 정렬을 적용하면 프리셋 필터로 저장할 수 있습니다.",
+    "save": "저장",
+    "setDefault": "기본값으로 설정",
+    "title": "프리셋 필터",
+    "unsetDefault": "기본값 해제"
+  },
   "reset": "초기화",
   "runId": "실행 ID",
   "runTypes": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/dags.json
@@ -76,6 +76,11 @@
       "upstream": "업스트림"
     }
   },
+  "runStateCounts": {
+    "label": "실행 상태",
+    "loading": "실행 상태 개수 로드 중...",
+    "tooltip": "{{state}}: {{formattedCount}} — 클릭하여 실행 필터링"
+  },
   "search": {
     "advanced": "고급 검색",
     "clear": "검색 지우기",


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Fills in the missing Korean (`ko`) translations so the locale is back in sync with `en`.

- **Dags list run state counts** (`dags.json`) — added now that #67242, the feature that introduced these strings, has merged.
- **Preset filters** (`common.json`) and **variable import** (`admin.json`) — the remaining `ko` gaps.

`preset` appears in the `ko` locale for the first time here. Following the locale's existing convention, it is kept as a transliteration (프리셋) rather than translated to a native phrase — the same way other UI terms are handled (trigger → 트리거, pool → 풀, connection → 커넥션, filter → 필터).

<img width="884" height="494" alt="image" src="https://github.com/user-attachments/assets/f03db2a1-c01d-4c66-a797-bbc377a89a2f" />


@choo121600 @onestn @noeunkim 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
