### PR TITLE
[v3-3-test] Fix lang-SDK KubernetesExecutor system test reverting api-server auth manager (#69221)

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/kubernetes_commands.py
@@ -2810,6 +2810,12 @@ def _lang_sdk_deploy_airflow(python: str, kubernetes_version: str, output: Outpu
             get_kubectl_cluster_name(python=python, kubernetes_version=kubernetes_version),
             "--namespace",
             HELM_AIRFLOW_NAMESPACE,
+            # Layer the lang-SDK values on top of the already-deployed release rather than
+            # re-rendering from chart defaults. Without this, helm discards the base deploy's
+            # --set overrides (notably config.core.auth_manager=SimpleAuthManager on Python 3.13),
+            # reverting the api-server to the chart-default FabAuthManager so it never writes
+            # simple_auth_manager_passwords.json.generated and the API-login tests error out.
+            "--reuse-values",
             "--set",
             f"defaultAirflowRepository={image}",
             "--set",


### PR DESCRIPTION

The lang-SDK coordinator system test provisioning helm-upgrades the already-deployed Airflow release with only the lang-SDK values file. Because the upgrade did not reuse the release's existing values, Helm re-rendered from chart defaults and discarded the base deploy's --set overrides -- including config.core.auth_manager, which the base deploy sets to SimpleAuthManager on Python 3.13 (FAB does not support 3.13). The api-server then came back up on the chart-default FabAuthManager and never wrote
simple_auth_manager_passwords.json.generated, so every API-login test in the KubernetesExecutor-3.13 variant errored with FileNotFoundError while fetching the generated admin password.

Reuse the existing release's values on the lang-SDK upgrade so the overrides layer on top and the auth manager (and the rest of the base configuration) stays intact.
(cherry picked from commit bfba4eb)