### PR TITLE
Align dynamic chain example with preceding static example

### DIFF
--- a/airflow-core/docs/core-concepts/dags.rst
+++ b/airflow-core/docs/core-concepts/dags.rst
@@ -130,7 +130,7 @@ And if you want to chain together dependencies, you can use ``chain``::
     chain(op1, op2, op3, op4)
 
     # You can also do it dynamically
-    chain(*[EmptyOperator(task_id=f"op{i}") for i in range(1, 6)])
+    chain(*[EmptyOperator(task_id=f"op{i}") for i in range(1, 5)])
 
 Chain can also do *pairwise* dependencies for lists the same size (this is different from the *cross dependencies* created by ``cross_downstream``!)::
 


### PR DESCRIPTION
This PR fixes a small inconsistency in the `chain()` documentation example.

The preceding example demonstrates:

```python
chain(op1, op2, op3, op4)
```

which chains four tasks.

However, the equivalent dynamic example immediately below creates five tasks:

```python
chain(*[EmptyOperator(task_id=f"op{i}") for i in range(1, 6)])
```

This change updates the range to create four operators instead, making both examples equivalent and easier to compare.

This is a documentation-only change and does not affect Airflow behavior.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (ChatGPT)

<!--
Generated-by: ChatGPT following the guidelines:
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
-->

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=3e6eed7 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @jonathankibg** · by `@potiuk` · 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
