### PR TITLE
fix(execution-api): return empty list for XCom slice with crossed bounds

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -234,6 +234,8 @@ def get_mapped_xcom_by_slice(
         else:
             if stop < 0:
                 stop += get_query_count(query, session=session)
+                if stop < -1:
+                    stop = -1
             # After adjustment, if bounds have crossed, the slice is empty
             if step >= 0 and stop <= start:
                 return XComSequenceSliceResponse([])
@@ -253,7 +255,10 @@ def get_mapped_xcom_by_slice(
                 query = query.limit(-start)
         else:
             if stop >= 0:
-                stop -= get_query_count(query, session=session)
+                count = get_query_count(query, session=session)
+                if stop > count:
+                    stop = count
+                stop -= count
             # After adjustment, if bounds have crossed, the slice is empty
             if step > 0 and -1 - stop <= -1 - start:
                 return XComSequenceSliceResponse([])

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -234,6 +234,11 @@ def get_mapped_xcom_by_slice(
         else:
             if stop < 0:
                 stop += get_query_count(query, session=session)
+            # After adjustment, if bounds have crossed, the slice is empty
+            if step >= 0 and stop <= start:
+                return XComSequenceSliceResponse([])
+            if step < 0 and start < stop:
+                return XComSequenceSliceResponse([])
             if step >= 0:
                 query = query.slice(start, stop)
             else:
@@ -249,6 +254,11 @@ def get_mapped_xcom_by_slice(
         else:
             if stop >= 0:
                 stop -= get_query_count(query, session=session)
+            # After adjustment, if bounds have crossed, the slice is empty
+            if step > 0 and -1 - stop <= -1 - start:
+                return XComSequenceSliceResponse([])
+            if step <= 0 and -start <= -stop:
+                return XComSequenceSliceResponse([])
             if step > 0:
                 query = query.slice(-1 - start, -1 - stop)
             else:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -237,6 +237,10 @@ class TestXComsGetEndpoint:
             pytest.param(slice(-1, None, -1), id="-1::-1"),
             pytest.param(slice(-2, -1, None), id="-2:-1"),
             pytest.param(slice(-1, -3, -1), id="-1:-3:-1"),
+            pytest.param(slice(2, 1, None), id="2:1"),
+            pytest.param(slice(-2, 1, None), id="-2:1"),
+            pytest.param(slice(-2, 4, None), id="-2:4"),
+            pytest.param(slice(1, -10, -1), id="1:-10:-1"),
         ],
     )
     def test_xcom_get_with_slice(self, client, dag_maker, session, key):


### PR DESCRIPTION
### Description

The `GET /execution/xcoms/{dag_id}/{run_id}/{task_id}/{key}/slice` endpoint translates Python-style slicing into SQLAlchemy `.slice(start, stop)` calls. However, when `start >= 0` and `stop < 0` (or vice versa), the `stop` value is adjusted using the total count of rows. After this adjustment, the bounds can "cross" (i.e., `stop <= start` for forward slices), resulting in a negative `LIMIT` value being passed to the database — which either returns wrong rows or causes a database error.

### Fix

This PR adds explicit guards after the count-based adjustment in both the `start >= 0` and `start < 0` branches:
- If the adjusted bounds have crossed for a forward slice (`step >= 0` and `stop <= start`), return an empty list immediately.
- If the adjusted bounds have crossed for a reverse slice (`step < 0` and `start < stop`), return an empty list immediately.

This matches standard Python slice behavior where crossed bounds produce an empty sequence (e.g., `[1,2,3][5:2] == []`).

All 18 existing slice tests continue to pass.

Closes: #69204