### PR TITLE
Scheduler: survive serialization conflicts in the critical section

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -124,6 +124,7 @@ from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.sqlalchemy import (
     get_dialect_name,
     is_lock_not_available_error,
+    is_serialization_error,
     prohibit_commit,
     random_db_uuid,
     with_row_locks,
@@ -2002,7 +2003,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # We know we can't do anything here, so don't even try!
                 self.log.debug("All executors are full, skipping critical section")
                 num_queued_tis = 0
+                guard.commit()
             else:
+                # Snapshot the executors' in-memory queues so a failed commit can discard
+                # exactly the workloads buffered in this round. They must not be dispatched
+                # if their QUEUED state never reached the database.
+                queued_keys_before = {executor: set(executor.queued_tasks) for executor in self.executors}
                 try:
                     timer = stats.timer("scheduler.critical_section_duration")
                     timer.start()
@@ -2013,6 +2019,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
                     # metric, way down
                     timer.stop(send=True)
+
+                    # Serialization failures can surface at commit time as well, so the commit
+                    # must happen inside this handler.
+                    guard.commit()
                 except OperationalError as e:
                     timer.stop(send=False)
 
@@ -2021,9 +2031,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         stats.incr("scheduler.critical_section_busy")
                         session.rollback()
                         return 0
+                    if is_serialization_error(error=e):
+                        self.log.debug(
+                            "Critical section hit a database serialization conflict, "
+                            "will retry on the next scheduler loop"
+                        )
+                        stats.incr("scheduler.critical_section_conflict")
+                        session.rollback()
+                        for executor, keys_before in queued_keys_before.items():
+                            for key in set(executor.queued_tasks) - keys_before:
+                                del executor.queued_tasks[key]
+                        return 0
                     raise
-
-            guard.commit()
 
         return num_queued_tis
 

--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -702,6 +702,19 @@ def is_lock_not_available_error(error: OperationalError):
     return False
 
 
+def is_serialization_error(error: OperationalError) -> bool:
+    """
+    Check if the error is a transaction serialization failure or deadlock.
+
+    PostgreSQL-compatible databases report these as SQLSTATE 40001
+    (serialization_failure) and 40P01 (deadlock_detected). Both are transient:
+    the transaction is safe to retry.
+    """
+    # psycopg2 exposes the SQLSTATE as pgcode, psycopg 3 as sqlstate
+    db_err_code = getattr(error.orig, "pgcode", None) or getattr(error.orig, "sqlstate", None)
+    return db_err_code in ("40001", "40P01")
+
+
 def make_dialect_kwarg(dialect: str) -> dict[str, str | Iterable[str]]:
     """Create an SQLAlchemy-version-aware dialect keyword argument."""
     return {"dialect_names": (dialect,)}

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -38,6 +38,7 @@ import pytest
 import time_machine
 from sqlalchemy import delete, func, inspect, select, update
 from sqlalchemy.dialects import mysql
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload
 
 from airflow import settings
@@ -10315,6 +10316,67 @@ def test_schedule_dag_run_with_upstream_skip(dag_maker, session):
             .where(DagRun.dag_id == dag.dag_id, DagRun.state == DagRunState.RUNNING)
         )
         assert running_count == 2
+
+
+class FakeDbError(Exception):
+    """Minimal stand-in for a database driver error carrying a pgcode attribute."""
+
+    def __init__(self, code):
+        super().__init__(code)
+        self.pgcode = code
+
+
+@pytest.mark.parametrize(
+    ("pgcode", "metric"),
+    [
+        ("40001", "scheduler.critical_section_conflict"),
+        ("40P01", "scheduler.critical_section_conflict"),
+        ("55P03", "scheduler.critical_section_busy"),
+    ],
+)
+def test_do_scheduling_survives_critical_section_conflicts(session, pgcode, metric):
+    """A serialization failure or busy lock in the critical section must not crash the scheduler."""
+    scheduler_job = Job()
+    job_runner = SchedulerJobRunner(job=scheduler_job)
+    job_runner.processor_agent = mock.MagicMock()
+
+    error = OperationalError("stmt", None, FakeDbError(pgcode))
+    with (
+        mock.patch.object(SchedulerJobRunner, "_critical_section_enqueue_task_instances", side_effect=error),
+        mock.patch("airflow._shared.observability.metrics.stats.incr") as mock_stats_incr,
+    ):
+        assert job_runner._do_scheduling(session) == 0
+
+    mock_stats_incr.assert_any_call(metric)
+
+
+def test_do_scheduling_serialization_conflict_discards_buffered_workloads(session):
+    """A commit-time serialization failure must remove buffered workloads from executor queues."""
+    mock_executor = mock.MagicMock(name="TestExecutor")
+    mock_executor.slots_available = 10
+    mock_executor.queued_tasks = {"old_key": "old_workload"}
+
+    scheduler_job = Job()
+    job_runner = SchedulerJobRunner(job=scheduler_job, executors=[mock_executor])
+    job_runner.processor_agent = mock.MagicMock()
+
+    def simulate_buffering_then_failure(session):
+        mock_executor.queued_tasks["new_key"] = "new_workload"
+        raise OperationalError("stmt", None, FakeDbError("40001"))
+
+    with (
+        mock.patch.object(
+            SchedulerJobRunner,
+            "_critical_section_enqueue_task_instances",
+            side_effect=simulate_buffering_then_failure,
+        ),
+        mock.patch("airflow._shared.observability.metrics.stats.incr") as mock_stats_incr,
+    ):
+        assert job_runner._do_scheduling(session) == 0
+
+    assert "old_key" in mock_executor.queued_tasks
+    assert "new_key" not in mock_executor.queued_tasks
+    mock_stats_incr.assert_any_call("scheduler.critical_section_conflict")
 
 
 class TestSchedulerJobQueriesCount:

--- a/airflow-core/tests/unit/utils/test_sqlalchemy.py
+++ b/airflow-core/tests/unit/utils/test_sqlalchemy.py
@@ -25,7 +25,7 @@ from unittest import mock
 import pytest
 from kubernetes.client import Configuration, models as k8s
 from sqlalchemy import text
-from sqlalchemy.exc import StatementError
+from sqlalchemy.exc import OperationalError, StatementError
 
 from airflow import settings
 from airflow.sdk import DAG
@@ -38,6 +38,7 @@ from airflow.utils.sqlalchemy import (
     apply_regex_query_timeout,
     ensure_pod_is_valid_after_unpickling,
     get_dialect_name,
+    is_serialization_error,
     prohibit_commit,
     with_row_locks,
 )
@@ -443,3 +444,32 @@ class TestApplyRegexQueryTimeout:
             with apply_regex_query_timeout(session):
                 pass
         session.execute.assert_not_called()
+
+
+class _FakePsycopg2Error(Exception):
+    def __init__(self, pgcode=None):
+        super().__init__(pgcode)
+        self.pgcode = pgcode
+
+
+class _FakePsycopg3Error(Exception):
+    def __init__(self, sqlstate=None):
+        super().__init__(sqlstate)
+        self.sqlstate = sqlstate
+
+
+class TestIsSerializationError:
+    @pytest.mark.parametrize("code", ["40001", "40P01"])
+    def test_detects_psycopg2_codes(self, code):
+        error = OperationalError("stmt", None, _FakePsycopg2Error(code))
+        assert is_serialization_error(error) is True
+
+    @pytest.mark.parametrize("code", ["40001", "40P01"])
+    def test_detects_psycopg3_codes(self, code):
+        error = OperationalError("stmt", None, _FakePsycopg3Error(code))
+        assert is_serialization_error(error) is True
+
+    @pytest.mark.parametrize("code", ["55P03", "23505", None])
+    def test_ignores_other_codes(self, code):
+        error = OperationalError("stmt", None, _FakePsycopg2Error(code))
+        assert is_serialization_error(error) is False

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -206,6 +206,13 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
+  - name: "scheduler.critical_section_conflict"
+    description: "Count of times a scheduler process hit a database serialization conflict (SQLSTATE 40001
+    or 40P01) in the critical section and deferred to the next loop iteration."
+    type: "counter"
+    legacy_name: "-"
+    name_variables: []
+
   - name: "ti.start"
     description: "Number of started task in a given Dag. Similar to {job_name}_start but for task.
     Metric with dag_id and task_id tagging."


### PR DESCRIPTION
Under SERIALIZABLE isolation PostgreSQL can abort a transaction with SQLSTATE 40001 (serialization_failure), and deadlocks surface as 40P01. In the scheduler's critical section either can be raised while queuing task instances or at COMMIT time. Today that exception escapes _do_scheduling and crashes the scheduler job even though the transaction
is safe to retry, while the sibling case of a busy advisory lock (55P03) is already handled gracefully.

This handles serialization failures the same way: roll back, increment a new scheduler.critical_section_conflict metric, and let the next scheduler loop retry. Two details worth reviewer attention:

- The critical section buffers workloads into the executors' in-memory queued_tasks dict
  before the commit, so the handler discards exactly the workloads buffered in the failed
  round. Dispatching them after rollback would trip the execution API's requirement that a
  task instance be in QUEUED state before it can start.
- guard.commit() moves inside the handled scope, because serialization failures frequently
  surface at commit time rather than at statement time.

Behavior change for PostgreSQL deployments running SERIALIZABLE: a serialization failure or deadlock in the critical section no longer crashes the scheduler; it is counted and retried on the next loop, mirroring the existing 55P03 handling. MySQL deadlock codes (errno 1213) are out of scope here and could be a follow-up if there is interest.

Note that lowering the isolation level is not a workaround: even under READ COMMITTED, PostgreSQL-compatible engines can surface 40001 to the client once their automatic per-statement retries are exhausted or a partial result set has already been streamed, so the scheduler needs to handle it regardless of the configured isolation level. In HA
testing this change handled serialization conflicts observed under both SERIALIZABLE and READ COMMITTED.

Verified in an HA deployment (two schedulers, 240 concurrent task instances, on a PostgreSQL-compatible database running SERIALIZABLE): serialization conflicts were observed and survived, and both schedulers completed with zero restarts. Unit tests cover the new helper for psycopg2 and psycopg3 error shapes, the 40001 and 40P01 handler paths,
a 55P03 regression case, and the buffered-workload purge.

Discussed on the devlist:
https://lists.apache.org/thread/t6jo4th3sn23jmr34m6gcxzw4k8mo4pc

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=153f6ad action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @viragtripathi** · by `@potiuk` · 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
