### PR TITLE
Scheduler: extend HA advisory lock coordination to CockroachDB

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -563,10 +563,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         executable_tis: list[TI] = []
 
-        if get_dialect_name(session) == "postgresql":
-            # Optimization: to avoid littering the DB errors of "ERROR: canceling statement due to lock
-            # timeout", try to take out a transactional advisory lock (unlocks automatically on
-            # COMMIT/ROLLBACK)
+        if get_dialect_name(session) in ("postgresql", "cockroachdb"):
+            # Transaction-level advisory lock optimization, available on PostgreSQL and
+            # CockroachDB 26.3+. Taking a transactional advisory lock (which unlocks
+            # automatically on COMMIT/ROLLBACK) avoids littering the DB with
+            # "ERROR: canceling statement due to lock timeout" errors.
             lock_acquired = session.execute(
                 text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
                     id=DBLocks.SCHEDULER_CRITICAL_SECTION.value

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -38,6 +38,7 @@ import pytest
 import time_machine
 from sqlalchemy import delete, func, inspect, select, update
 from sqlalchemy.dialects import mysql
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload
 
 from airflow import settings
@@ -2287,6 +2288,33 @@ class TestSchedulerJob:
 
         session.flush()
         session.rollback()
+
+    @pytest.mark.parametrize("dialect", ["postgresql", "cockroachdb"])
+    def test_executable_tis_uses_advisory_lock_for_postgres_family(self, dialect):
+        """Both PostgreSQL and CockroachDB (26.3+) coordinate HA schedulers via xact advisory locks."""
+        job_runner = SchedulerJobRunner(job=Job())
+        session = mock.MagicMock()
+        session.execute.return_value.scalar.return_value = False
+
+        with mock.patch("airflow.jobs.scheduler_job_runner.get_dialect_name", return_value=dialect):
+            with pytest.raises(OperationalError, match="Failed to acquire advisory lock"):
+                job_runner._executable_task_instances_to_queued(max_tis=32, session=session)
+
+        executed_sql = str(session.execute.call_args[0][0])
+        assert "pg_try_advisory_xact_lock" in executed_sql
+
+    def test_executable_tis_skips_advisory_lock_for_other_dialects(self):
+        job_runner = SchedulerJobRunner(job=Job())
+        session = mock.MagicMock()
+
+        with (
+            mock.patch("airflow.jobs.scheduler_job_runner.get_dialect_name", return_value="mysql"),
+            mock.patch("airflow.models.pool.Pool.slots_stats", return_value={}),
+        ):
+            assert job_runner._executable_task_instances_to_queued(max_tis=32, session=session) == []
+
+        executed_sql = " ".join(str(call.args[0]) for call in session.execute.call_args_list if call.args)
+        assert "pg_try_advisory_xact_lock" not in executed_sql
 
     def test_find_executable_task_instances_none(self, dag_maker):
         dag_id = "SchedulerJobTest.test_find_executable_task_instances_none"


### PR DESCRIPTION
The scheduler's critical section takes a transaction-scoped advisory lock (`pg_try_advisory_xact_lock`) so HA schedulers coordinate instead of colliding on the pool row locks. The guard in `executable_task_instances_to_queued` currently limits this to the postgresql dialect. CockroachDB v26.3 implements the same transaction-level advisory lock functions with PostgreSQL semantics, so this extends the guard to the cockroachdb dialect. Other dialects are unaffected.

Why the advisory lock rather than relying on the existing pool row locks: the row-lock path discovers scheduler contention by starting the critical section and failing partway through. On PostgreSQL that produces avoidable lock-timeout errors in the server log, which is the original motivation for this fast path. On engines that detect conflicts
under `SERIALIZABLE` at commit time, the losing scheduler instead pays for a full critical-section attempt that then rolls back as a serialization conflict. The advisory lock turns both into one cheap function call, and the losing scheduler simply skips the critical section for that loop and does other useful work.

Minimum version for the new path: CockroachDB v26.3. Verified in an HA deployment (two schedulers) where lock acquisition and single-holder behavior were observed via `pg_locks` during a concurrent stress run.

Discussed on the devlist:
https://lists.apache.org/thread/t6jo4th3sn23jmr34m6gcxzw4k8mo4pc

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=3a34ad0 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @viragtripathi** · by `@potiuk` · 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
