### PR TITLE
fix(providers/standard): support poke_interval as poll_interval in deferrable ExternalTaskSensor

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -191,10 +191,20 @@ class ExternalTaskSensor(BaseSensorOperator):
         execution_delta: datetime.timedelta | None = None,
         execution_date_fn: Callable | None = None,
         check_existence: bool = False,
-        poll_interval: float = 2.0,
+        poll_interval: float | None = None,
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ):
+        if poll_interval is None:
+            if "poke_interval" in kwargs:
+                poke_interval = kwargs["poke_interval"]
+                if isinstance(poke_interval, datetime.timedelta):
+                    poll_interval = poke_interval.total_seconds()
+                else:
+                    poll_interval = float(poke_interval)
+            else:
+                poll_interval = 2.0
+
         super().__init__(**kwargs)
 
         self.allowed_states: list[str] = (

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -1068,6 +1068,29 @@ exit 0
         assert exc.value.trigger.execution_dates == [DEFAULT_DATE]
 
     @pytest.mark.execution_timeout(10)
+    def test_external_task_sensor_deferrable_respects_poke_interval(self, dag_maker):
+        context = {"execution_date": DEFAULT_DATE}
+        with dag_maker() as dag:
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="test_dag_parent",
+                external_task_id="test_task",
+                deferrable=True,
+                poke_interval=15.0,
+            )
+            dr = dag.create_dagrun(
+                run_id="abcrhroceuh",
+                run_type=DagRunType.MANUAL,
+                state=None,
+            )
+            context.update(dag_run=dr, logical_date=DEFAULT_DATE)
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(context=context)
+        assert isinstance(exc.value.trigger, WorkflowTrigger)
+        assert exc.value.trigger.poke_interval == 15.0
+
+    @pytest.mark.execution_timeout(10)
     def test_external_task_sensor_deferrable_timeout_only(self, dag_maker):
         """Test that deferrable mode uses timeout parameter when only timeout is set."""
         context = {"execution_date": DEFAULT_DATE}
@@ -1444,6 +1467,23 @@ class TestExternalTaskSensorV3:
         assert exc.value.trigger.external_dag_id == "test_dag_parent"
         assert exc.value.trigger.external_task_ids == ["test_task"]
         assert exc.value.trigger.logical_dates == [DEFAULT_DATE]
+
+    @pytest.mark.execution_timeout(10)
+    def test_external_task_sensor_deferrable_respects_poke_interval(self, dag_maker):
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_task_sensor_check",
+                external_dag_id="test_dag_parent",
+                external_task_id="test_task",
+                deferrable=True,
+                poke_interval=15.0,
+            )
+
+        with pytest.raises(TaskDeferred) as exc:
+            op.execute(context=self.context)
+
+        assert isinstance(exc.value.trigger, WorkflowTrigger)
+        assert exc.value.trigger.poke_interval == 15.0
 
     @pytest.mark.execution_timeout(10)
     def test_external_task_sensor_only_dag_id(self, dag_maker):


### PR DESCRIPTION
### Description

When using `ExternalTaskSensor` in deferrable mode (`deferrable=True`), the `poke_interval` parameter was being ignored. The trigger would default to polling every 2 seconds, which resulted in excessive logging and API server polling load.

This PR addresses the issue by setting the default value of `poll_interval` to `None`. 
- If `poll_interval` is not explicitly provided but `poke_interval` is set by the user, the trigger will use the user-specified `poke_interval` value.
- Otherwise, it falls back to the historical default value of `2.0` seconds.

### Verification

Added a new unit test `test_external_task_sensor_deferrable_respects_poke_interval` in `test_external_task_sensor.py` to verify that `poke_interval` is correctly resolved and set on the `WorkflowTrigger`.

Closes: #68990