### PR TITLE
Tune prepare-providers-documentation skill classification and changelog rules

### DIFF
--- a/.agents/skills/prepare-providers-documentation/SKILL.md
+++ b/.agents/skills/prepare-providers-documentation/SKILL.md
@@ -245,6 +245,16 @@ ever need the min-Airflow-bump case (`v`), that one is still a `needs_llm`
 judgement: a sub-agent should flag it when a PR bumps the provider's minimum
 Airflow version.
 
+> [!NOTE]
+> A `needs_llm` commit can still be classified as `skip` by the LLM. The
+> deterministic classifier only catches test/example-only changes by looking
+> at which files were modified in the commit. PRs that change build tooling,
+> packaging infrastructure, or breeze templates (files under `dev/breeze/`,
+> `scripts/`, etc.) and only regenerate template-generated files in the
+> provider slice (e.g. `README.rst`, `index.rst`, `pyproject.toml`) are NOT
+> caught by the deterministic rules but should still be classified as `skip`
+> — they have zero user-facing impact on the provider package itself.
+
 #### Classify the `needs_llm` commits — batched per provider, not one agent per PR
 
 Only the commits the classifier returned as `needs_llm` still need a sub-agent.
@@ -292,9 +302,18 @@ For EACH commit above:
    - feature:       adds new capability, parameter, operator, sensor, hook,
                     or extends an existing one in a backwards-compatible way
    - breaking:      see "Breaking-change checklist" below
-   - misc:          dependency bumps, internal refactors, packaging-only
-                    changes, type-hint cleanups, no user-visible behavior
-   - skip:          only tests/examples/CI for this provider's slice
+   - misc:          dependency bumps, internal refactors, type-hint
+                    cleanups, no user-visible behavior
+   - skip:          only tests/examples/CI for this provider's slice,
+                    OR changes that only touch build tooling, packaging
+                    infrastructure, or template-generated files (e.g.
+                    README.rst, index.rst, pyproject.toml regeneration,
+                    flit/sdist config, breeze templates) — even when
+                    those files live under the provider path. If the
+                    PR's actual code changes are entirely in dev/breeze/
+                    or similar tooling and the provider-scoped diff is
+                    limited to regenerated docs/metadata, classify as
+                    skip.
    - min_airflow_bump: explicitly bumps the minimum Airflow version pin
 4. Set BREAKING_RISK to "maybe" whenever the diff has any signal from the
    breaking-change checklist below, even if you think the author intended
@@ -477,6 +496,14 @@ Rules:
   indent, double backticks).
 - Subjects must be the original commit subject with backticks replaced by
   single quotes (matches `message_without_backticks`). Don't paraphrase.
+- **Strip Conventional Commit prefixes** before writing to the changelog.
+  If the subject starts with a prefix like `feat:`, `fix:`, `chore:`,
+  `docs:`, `refactor:`, `ci:`, `test:`, `perf:`, `build:`, or `style:`
+  (with or without a scope in parentheses, e.g. `fix(amazon):`), remove
+  the prefix and capitalize the first letter of the remaining text.
+  Example: `refactor: Fix _is_http_client_closed ...` →
+  `Fix _is_http_client_closed ...`. Airflow does not use Conventional
+  Commits and these prefixes should not appear in changelogs.
 - Always keep the `(#NNNN)` PR suffix.
 
 #### 4c. Regenerate templates with breeze
@@ -544,6 +571,14 @@ provider-by-provider:
 
 - Confirm the version in `provider.yaml` matches the bump rule.
 - Confirm `changelog.rst` has the right sections populated.
+- **Check for misplaced top-level note blocks.** Each provider's
+  `changelog.rst` has a standing `.. NOTE TO CONTRIBUTORS:` RST comment
+  near the top (above all version sections). If you detect any `.. note::`
+  directive that is NOT nested under a specific version section (i.e. it
+  appears before the first version header, or between the `Changelog`
+  heading and the first version), notify the release manager immediately —
+  it likely means a breaking-change or min-version note was accidentally
+  written at the wrong indentation level or position.
 - Confirm Phase 4d ran: no `# use next version` comment remains where the
   referenced provider was bumped in this wave.
 - Flag anything where Phase 3.5 had to escalate, so the RM can double-check.


### PR DESCRIPTION
Improve the AI-driven provider documentation skill based on lessons learned from the last release wave (#69486).

Two issues observed during that run:

1. PRs that only touch build tooling or breeze templates — with the provider-scoped diff limited to regenerated files like README.rst or index.rst — were classified as `misc` instead of `skip`. Examples: #68991 (fix provider docs vs pyproject.toml inconsistency) and #65861 (add flit sdist sections). The deterministic classifier doesn't catch these because it only looks at file paths within the provider, not whether those files are template-generated output. Added explicit guidance in both the sub-agent prompt and the Phase 3 notes so the LLM correctly classifies these as `skip`.

2. Some PR titles use Conventional Commit prefixes (`feat:`, `refactor:`, etc.) which should not appear in changelogs. Added a rule in Phase 4b to strip these prefixes before writing changelog entries.

---

##### Was generative AI tooling used to co-author this PR?

  - [X] Yes — Claude Code (Opus 4.6)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
