### PR TITLE
Convert exception dict back to pretty stack trace in triggerer

### DIFF
--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -179,6 +179,53 @@ def _make_trigger_span(
     return tracer.start_as_current_span(span_name, attributes=attributes, context=parent_context)
 
 
+def _format_exception_dict(exc: list[dict] | dict | str | Any) -> str | Any:
+    """Format a structlog exception dict (or list of dicts) into a traceback string."""
+    if isinstance(exc, str):
+        return exc
+
+    if isinstance(exc, dict):
+        exc = [exc]
+
+    if not isinstance(exc, list):
+        return exc
+
+    lines = []
+    for i, e in enumerate(exc):
+        if not isinstance(e, dict):
+            continue
+
+        if i > 0:
+            if e.get("is_cause"):
+                lines.append("\nThe above exception was the direct cause of the following exception:\n")
+            elif e.get("is_context"):
+                lines.append("\nDuring handling of the above exception, another exception occurred:\n")
+            else:
+                lines.append("\n")
+
+        lines.append("Traceback (most recent call last):")
+        for frame in e.get("frames", []):
+            filename = frame.get("filename", "")
+            lineno = frame.get("lineno", "")
+            name = frame.get("name", "")
+            line = frame.get("line", "")
+            lines.append(f'  File "{filename}", line {lineno}, in {name}')
+            if line:
+                lines.append(f"    {line}")
+
+        exc_type = e.get("exc_type", "")
+        exc_value = e.get("exc_value", "")
+        if exc_type and exc_value:
+            lines.append(f"{exc_type}: {exc_value}")
+        elif exc_type:
+            lines.append(exc_type)
+
+    if not lines:
+        return exc
+
+    return "\n".join(lines)
+
+
 __all__ = [
     "TriggerRunner",
     "TriggerRunnerSupervisor",
@@ -1041,8 +1088,7 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 log = fallback_log
 
             if exc := event.pop("exception", None):
-                # TODO: convert the dict back to a pretty stack trace
-                event["error_detail"] = exc
+                event["error_detail"] = _format_exception_dict(exc)
             if lvl_name := NAME_TO_LEVEL.get(event.pop("level")):
                 log.log(lvl_name, event.pop("event", None), **event)
 

--- a/providers/apache/kafka/docs/index.rst
+++ b/providers/apache/kafka/docs/index.rst
@@ -145,12 +145,13 @@ Install them when installing from PyPI. For example:
     pip install apache-airflow-providers-apache-kafka[google]
 
 
-====================  ====================================================
-Extra                 Dependencies
-====================  ====================================================
-``google``            ``apache-airflow-providers-google``
-``common.messaging``  ``apache-airflow-providers-common-messaging>=2.0.0``
-====================  ====================================================
+========================  =============================================================
+Extra                     Dependencies
+========================  =============================================================
+``google``                ``apache-airflow-providers-google``
+``aws``                   ``apache-airflow-providers-amazon>=8.11.0``
+``common.messaging``      ``apache-airflow-providers-common-messaging>=2.0.0``
+========================  =============================================================
 
 Downloading official packages
 -----------------------------

--- a/ts-sdk/src/generated/supervisor.ts
+++ b/ts-sdk/src/generated/supervisor.ts
@@ -363,13 +363,17 @@ export type After = string | null;
 export type Before = string | null;
 export type Limit = number | null;
 export type Ascending = boolean;
-export type Type29 = "GetAssetEventByAsset";
+export type Extra7 = {
+  [k: string]: string;
+} | null;
 export type AliasName = string;
 export type After1 = string | null;
 export type Before1 = string | null;
 export type Limit1 = number | null;
 export type Ascending1 = boolean;
-export type Type30 = "GetAssetEventByAssetAlias";
+export type Extra8 = {
+  [k: string]: string;
+} | null;
 export type Name11 = string;
 export type Key6 = string;
 export type Type31 = "GetAssetStateStoreByName";
@@ -1205,7 +1209,7 @@ export interface GetAssetEventByAsset {
   before?: Before;
   limit?: Limit;
   ascending?: Ascending;
-  type?: Type29;
+  extra?: Extra7;
 }
 /**
  * This interface was referenced by `SupervisorWireSchema`'s JSON-Schema
@@ -1217,7 +1221,7 @@ export interface GetAssetEventByAssetAlias {
   before?: Before1;
   limit?: Limit1;
   ascending?: Ascending1;
-  type?: Type30;
+  extra?: Extra8;
 }
 /**
  * This interface was referenced by `SupervisorWireSchema`'s JSON-Schema


### PR DESCRIPTION
Currently, when the triggerer subprocess logs an exception, it is popped as a raw dictionary and assigned to `error_detail`, which prevents it from rendering natively as a readable stack trace in logs.

This converts the structlog exception dictionary back into a standard formatted traceback string so operators can easily read triggerer errors natively.

closes #69572

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the `Generated-by:`.
-->

- [x] Yes

Generated-by: Antigravity IDE (Gemini 3.1 Pro) following the guidelines (https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `[pr_number].significant.rst`, in `airflow-core/newsfragments` (https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-28T17:12:55Z head=ca73f6b action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @KushagraB424** · by `@potiuk` · 2026-07-28 17:12 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
