### PR TITLE
Fix Java SDK RC2 blockers: source packaging, jar LICENSE/NOTICE, BOM gap

### DIFF
--- a/java-sdk/.gitattributes
+++ b/java-sdk/.gitattributes
@@ -10,6 +10,11 @@
 # Binary files should be left untouched
 *.jar           binary
 
-# Keep the Gradle wrapper jar out of source releases.
-# See: https://issues.apache.org/jira/browse/LEGAL-570
-gradle/wrapper/gradle-wrapper.jar export-ignore
+# Keep the Gradle wrapper out of source releases (the jar is compiled code,
+# see https://issues.apache.org/jira/browse/LEGAL-570; the wrapper scripts and
+# gradle-wrapper.properties are excluded too so the source-release tarball
+# carries no Gradle wrapper at all). The wrapper stays tracked in git; this
+# only affects `git archive` / the `sourceRelease` task output.
+/gradlew export-ignore
+/gradlew.bat export-ignore
+/gradle/wrapper export-ignore

--- a/java-sdk/.gitattributes
+++ b/java-sdk/.gitattributes
@@ -10,11 +10,11 @@
 # Binary files should be left untouched
 *.jar           binary
 
-# Keep the Gradle wrapper out of source releases (the jar is compiled code,
-# see https://issues.apache.org/jira/browse/LEGAL-570; the wrapper scripts and
-# gradle-wrapper.properties are excluded too so the source-release tarball
-# carries no Gradle wrapper at all). The wrapper stays tracked in git; this
-# only affects `git archive` / the `sourceRelease` task output.
+# Keep the Gradle wrapper jar and scripts out of source releases.
+# See: https://issues.apache.org/jira/browse/LEGAL-570
+# This intentionally does not exclude the entire gradle/wrapper directory so
+# gradle-wrapper.properties is kept. This file carries the pinned Gradle version
+# and distribution checksum for a verifier to use when regenerating the wrapper.
 /gradlew export-ignore
 /gradlew.bat export-ignore
-/gradle/wrapper export-ignore
+/gradle/wrapper/gradle-wrapper.jar export-ignore

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -257,11 +257,36 @@ apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.asc
 apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.sha512
 ```
 
-*NOTE:* The source archive deliberately omits `gradle/wrapper/gradle-wrapper.jar`
-since ASF source releases must not contain compiled code (see [LEGAL-570]). To
-build an *extracted* source package, use a locally installed Gradle instead:
-either run `gradle build`, or use `gradle wrapper` once to regenerate the jar
-and then `./gradlew build`.
+*NOTE:* The source archive deliberately omits the **entire Gradle wrapper**, not
+just `gradle/wrapper/gradle-wrapper.jar` (compiled code, see [LEGAL-570]) but
+also `gradlew`, `gradlew.bat`, and `gradle/wrapper/gradle-wrapper.properties`.
+The wrapper remains tracked in git as usual; only the `git archive` output used
+by `sourceRelease` excludes it (see `.gitattributes`). This means an extracted
+source package has no wrapper at all, and no `gradle-wrapper.properties` to pin
+the Gradle version or auto-verify the distribution checksum. There are two ways
+to build from an extracted source package:
+
+* **(a) Build with a locally installed Gradle:**
+
+  ```bash
+  gradle build
+  ```
+
+* **(b) Regenerate the wrapper, then build with it.** Since
+  `gradle-wrapper.properties` is excluded too, pass the version and checksum
+  explicitly instead of relying on a committed properties file:
+
+  ```bash
+  gradle wrapper --gradle-version 8.14.4 \
+    --gradle-distribution-sha256-sum f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
+  ./gradlew build
+  ```
+
+  The version and checksum above are the ones this project currently pins;
+  confirm them against `gradle/wrapper/gradle-wrapper.properties` at the
+  signed git tag being verified (e.g. `java-sdk/1.0.0-beta1-rc1`) — the
+  wrapper is still checked into git and present at any tag, only the
+  *source-release tarball* excludes it.
 
 [LEGAL-570]: https://issues.apache.org/jira/browse/LEGAL-570
 
@@ -291,7 +316,144 @@ is the source-package URL you link in the vote.
 
 Send a `[VOTE]` email to `dev@airflow.apache.org` linking the git tag and
 commit, the source package in `dist/dev`, the closed Nexus staging repository,
-and the `KEYS` file.
+and the `KEYS` file. See "Vote email template" below for the exact fields to
+fill in, and "Verifying a release" for what to ask reviewers to check.
+
+### Vote email template
+
+Past vote emails have shipped with unfilled placeholders or an incomplete
+artifact list, so treat this template as the source of truth and diff your
+draft against it before sending.
+
+```text
+Subject: [VOTE] Release Apache Airflow Java SDK 1.0.0-beta1 based on rc<N>
+
+Hey all,
+
+I have prepared the Apache Airflow Java SDK 1.0.0-beta1 rc<N>.
+
+Changes since rc<N-1>:
+<one-line summary per fix, or "N/A — first RC" if this is rc1>
+
+Consider this a formal vote on whether to release these packages as
+Apache Airflow Java SDK 1.0.0-beta1.
+
+The vote will be open for at least 72 hours (until <YYYY-MM-DD HH:MM UTC>) or
+until the necessary number of votes is reached.
+
+https://www.apache.org/legal/release-policy.html#release-approval
+
+Airflow Java SDK Package:
+https://dist.apache.org/repos/dist/dev/airflow/java-sdk/1.0.0-beta1-rc<N>/
+
+git tag / commit:
+https://github.com/apache/airflow/releases/tag/java-sdk/1.0.0-beta1-rc<N>
+(commit <full-commit-sha>)
+
+KEYS file:
+https://downloads.apache.org/airflow/KEYS
+
+Staging Nexus repository (convenience binaries — 8 artifacts + plugin marker):
+https://repository.apache.org/content/repositories/orgapacheairflow-<NNNN>/org/apache/airflow/
+  - airflow-sdk
+  - airflow-sdk-jul
+  - airflow-sdk-log4j2
+  - airflow-sdk-slf4j
+  - airflow-sdk-jpl
+  - airflow-sdk-processor
+  - airflow-sdk-bom
+  - airflow-sdk-gradle-plugin
+  - org.apache.airflow.sdk.gradle.plugin (Gradle plugin marker artifact)
+
+Please vote accordingly:
+
+[ ] +1 approve
+[ ] +0 no opinion
+[ ] -1 disapprove with the reason
+
+Only PMC members' votes are binding, but everyone is encouraged to test the
+release and vote.
+
+Thanks,
+<your name>
+```
+
+Pre-send checklist:
+
+* Every staged artifact above resolves in the Nexus staging repository — cross
+  check against the *Verify the upload* step, not just this list from memory.
+* `Changes since rc<N-1>` and the vote deadline are filled in (not "N/A" unless
+  this really is rc1, and not left blank).
+* Run `grep '<' email.txt` on the rendered email and confirm **no output** —
+  any match means a template placeholder (`<N>`, `<NNNN>`, `<YYYY-MM-DD ...>`,
+  etc.) was left unfilled.
+
+### Verifying a release
+
+Anyone on `dev@airflow.apache.org` can (and should) independently verify a
+candidate before voting. Below is the checklist a reviewer — or the release
+manager, before sending the vote — should run against the source package in
+`dist/dev`.
+
+1. **Checksum.** Confirm the published SHA-512 matches the downloaded tarball:
+
+   ```bash
+   sha512sum -c apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.sha512
+   ```
+
+2. **Signature.** Import the `KEYS` file and verify the GPG signature:
+
+   ```bash
+   curl -O https://downloads.apache.org/airflow/KEYS
+   gpg --import KEYS
+   gpg --verify apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.asc \
+       apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz
+   ```
+
+3. **Diff against the git tag.** Extract the tarball and compare it with a
+   clean checkout of the tag it claims to be built from — they should be
+   identical apart from the excluded Gradle wrapper files. Note the extracted
+   top-level directory is named after the `--prefix` used by the `sourceRelease`
+   task, `apache-airflow-java-sdk-<version>` — it does **not** carry the `-src`
+   suffix that only appears in the tarball's own filename:
+
+   ```bash
+   tar xzf apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz
+   git clone --branch java-sdk/1.0.0-beta1-rc1 \
+     https://github.com/apache/airflow.git tag-checkout
+   diff -rq apache-airflow-java-sdk-1.0.0-beta1/ tag-checkout/java-sdk/ \
+     | grep -v -E 'gradlew|gradle/wrapper'
+   ```
+
+   Any remaining diff output is unexpected and should block the vote.
+
+4. **No binary files.** ASF source releases must not contain compiled code.
+   Scan for anything that isn't text (the only expected binaries — the
+   wrapper jar — must not appear, since it's excluded):
+
+   ```bash
+   find apache-airflow-java-sdk-1.0.0-beta1/ -type f \
+     -exec sh -c 'file "$1" | grep -qv text && echo "$1"' _ {} \;
+   ```
+
+   This should print nothing.
+
+5. **Build from source.** With a locally installed Gradle (see the *Upload the
+   source package* section above for the two build paths available without
+   the wrapper):
+
+   ```bash
+   cd apache-airflow-java-sdk-1.0.0-beta1/
+   gradle build
+   ```
+
+6. **Staged-binary smoke test.** Resolve the staged Nexus artifacts from a
+   throwaway project to confirm they're actually consumable, following the
+   same pattern as the "Dry-run against a local repository" step: point a
+   `repositories {}` block at the staging repository URL, declare a dependency
+   on `org.apache.airflow:airflow-sdk-bom:1.0.0-beta1`, and confirm the
+   transitive artifacts (including `airflow-sdk-jpl`) resolve and the example
+   bundle builds against them.
 
 ### After a successful vote
 

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -419,7 +419,7 @@ manager, before sending the vote — should run against the source package in
 
    ```bash
    tar xzf apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz
-   git clone --branch java-sdk/1.0.0-beta1-rc1 \
+   git clone --branch java-sdk/1.0.0-beta1-rc<N> \
      https://github.com/apache/airflow.git tag-checkout
    diff -rq apache-airflow-java-sdk-1.0.0-beta1/ tag-checkout/java-sdk/ \
      | grep -v -E 'gradlew|gradle/wrapper'

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -117,22 +117,23 @@ Every release therefore requires a PMC vote before it is published; only
 Edit `gradle.properties` and set the version for this release:
 
 ```properties
-projectVersion=1.0.0
+projectVersion=<VERSION>
 ```
 
 Commit the change and push it to the release branch.
 
 Use a Maven-compatible version string, as defined by the
-[Maven version order specification](https://maven.apache.org/pom.html#Version_Order_Specification).
-For example, version 1 beta 1 is `<VERSION>`, and the eventual
-general-availability release is `1.0.0`.
+[Maven version order specification]. For example, version 1 beta 1 is
+`1.0.0-beta1`, and the eventual version 1 release is `1.0.0`.
+
+[Maven version order specification]: https://maven.apache.org/pom.html#Version_Order_Specification
 
 *NOTE:* Editing `gradle.properties` as above is the standard procedure. You can
 alternatively override the version for a single command without editing the
 file, by passing `-PprojectVersion=<VERSION>` to any Gradle invocation. This
 is handy for one-off or pre-release builds. Either way, `main` should stay on a
 `-SNAPSHOT` version between releases: a snapshot sorts after `<VERSION>` and
-before the `1.0.0` GA, so no extra bump is needed after a beta.
+before the GA, so no extra bump is needed after a beta.
 
 ### Tag the release candidate
 
@@ -142,7 +143,7 @@ suffix). Push the tag before sending the vote so reviewers can check out the
 exact source being voted on.
 
 ```bash
-git tag -s java-sdk/<VERSION>-rc<N> -m "Java SDK <VERSION> RC 1"
+git tag -s java-sdk/<VERSION>-rc<N> -m "Java SDK <VERSION> RC <N>"
 git push upstream java-sdk/<VERSION>-rc<N>
 ```
 
@@ -257,36 +258,12 @@ apache-airflow-java-sdk-<VERSION>-src.tar.gz.asc
 apache-airflow-java-sdk-<VERSION>-src.tar.gz.sha512
 ```
 
-*NOTE:* The source archive omits the Gradle wrapper scripts (`gradlew`,
-`gradlew.bat`) and the compiled `gradle/wrapper/gradle-wrapper.jar` — ASF source
-releases must not contain compiled code (see [LEGAL-570]), and the scripts are
-Gradle's own files, so only project-authored config is shipped. It keeps
-`gradle/wrapper/gradle-wrapper.properties`, so the archive itself pins the Gradle
-version and distribution checksum and there is no need to consult the git tag.
-The wrapper stays tracked in git; only the `git archive` output used by
-`sourceRelease` drops these files (see `.gitattributes`). To build from an
-extracted source package:
-
-* **(a) Build with a locally installed Gradle:**
-
-  ```bash
-  gradle build
-  ```
-
-* **(b) Regenerate the wrapper, then build with it.** The version and checksum
-  are already pinned in the bundled `gradle-wrapper.properties`; pass the same
-  values so the regenerated properties stays identical, then let the wrapper
-  verify the distribution against that checksum:
-
-  ```bash
-  gradle wrapper --gradle-version <GRADLE-VERSION> \
-    --gradle-distribution-sha256-sum <GRADLE-DISTRIBUTION-SHA256>
-  ./gradlew build
-  ```
-
-  `<GRADLE-VERSION>` and `<GRADLE-DISTRIBUTION-SHA256>` are the `distributionUrl`
-  version and `distributionSha256Sum` in the bundled
-  `gradle/wrapper/gradle-wrapper.properties`.
+**NOTE:** The source archive omits the Gradle wrapper scripts (`gradlew`,
+`gradlew.bat`) and `gradle/wrapper/gradle-wrapper.jar` since ASF source releases
+must not contain compiled code (see [LEGAL-570]), and the scripts are not useful
+without the jar. The `gradle/wrapper/gradle-wrapper.properties` file is kept so
+the archive pins the Gradle version and distribution checksum for verification
+when the wrapper is regenerated.
 
 [LEGAL-570]: https://issues.apache.org/jira/browse/LEGAL-570
 
@@ -321,49 +298,46 @@ fill in, and "Verifying a release" for what to ask reviewers to check.
 
 ### Vote email template
 
-Past vote emails have shipped with unfilled placeholders or an incomplete
-artifact list, so treat this template as the source of truth and diff your
-draft against it before sending.
-
 ```text
 Subject: [VOTE] Release Apache Airflow Java SDK <VERSION> based on <VERSION>-rc<N>
 
 Hi,
 
-I would like to call a vote to release Apache Airflow Java SDK <VERSION>, based on release candidate <VERSION>-rc<N>.
+I would like to call a vote to release Apache Airflow Java SDK <VERSION>, based
+on release candidate <VERSION>-rc<N>.
 
-This is a beta release. It is intended for testing and early adoption by users and developers outside the project; APIs may still change before the general-availability release. It is a full, formal ASF release (source package + convenience binaries), not a snapshot or nightly build.
-
-Changes since rc<N-1>: <one-line summary per fix; omit this paragraph for rc1>
+Changes since <the last release>: <a one-line description>
 
 The release candidate contains the following Maven artifacts, all under group id org.apache.airflow:
 
-- airflow-sdk
-- airflow-sdk-jul
-- airflow-sdk-log4j2
-- airflow-sdk-slf4j
-- airflow-sdk-jpl
-- airflow-sdk-processor
-- airflow-sdk-bom
-- airflow-sdk-gradle-plugin
-- org.apache.airflow.sdk.gradle.plugin (Gradle plugin marker artifact)
+- Main SDK API
+    - airflow-sdk
+    - airflow-sdk-processor
+- Logger helpers
+    - airflow-sdk-jpl
+    - airflow-sdk-jul
+    - airflow-sdk-log4j2
+    - airflow-sdk-slf4j
+- Gradle plugin and the marker artifact
+    - airflow-sdk-gradle-plugin
+    - org.apache.airflow.sdk.gradle.plugin
+- BOM
+    - airflow-sdk-bom
 
-Git tag / commit being voted on:
+Git information:
 
 - Tag: java-sdk/<VERSION>-rc<N>
 - Commit: <full-commit-sha>
 - https://github.com/apache/airflow/releases/tag/java-sdk%2F<VERSION>-rc<N>
 
-Source release (the artifact being voted on), signatures and checksums:
+Source release, signatures and checksums:
 https://dist.apache.org/repos/dist/dev/airflow/java-sdk/<VERSION>-rc<N>/
 
-Convenience binaries: staged in the ASF Nexus repository:
+Convenience binaries (staged in the ASF Nexus repository):
 https://repository.apache.org/content/repositories/orgapacheairflow-<NNNN>/
 
-KEYS file (public keys used to sign the release): https://downloads.apache.org/airflow/KEYS
-
-There's no changelogs since this is the first ever release. See the Java SDK's README for a list of features currently provided.
-https://github.com/apache/airflow/tree/java-sdk/<VERSION>-rc<N>/java-sdk
+KEYS file (public keys used to sign the release):
+https://downloads.apache.org/airflow/KEYS
 
 Please review and vote. The vote will remain open for at least 72 hours, until <YYYY-MM-DD HH:MM UTC>, or until the necessary number of binding votes is reached.
 
@@ -373,17 +347,8 @@ Please review and vote. The vote will remain open for at least 72 hours, until <
 
 Only votes from Airflow PMC members are binding, but everyone is welcome and encouraged to test the release and vote.
 
-Here is how you can verify the release before voting:
-
-- Download the source package, its .asc signature and .sha512 checksum from the dist/dev URL above.
-- Verify the checksum: shasum -a 512 -c apache-airflow-java-sdk-<VERSION>-src.tar.gz.sha512
-- Import the KEYS file and verify the signature: gpg --import KEYS && gpg --verify apache-airflow-java-sdk-<VERSION>-src.tar.gz.asc
-- Unpack and build. The source package omits the Gradle wrapper scripts and the compiled gradle-wrapper.jar, but keeps gradle-wrapper.properties, so the pinned Gradle version and distribution checksum travel with the archive. Either build with a locally installed Gradle (gradle build), or regenerate the wrapper with the values already in gradle-wrapper.properties, then build with it:
-    gradle wrapper --gradle-version 8.14.4 --gradle-distribution-sha256-sum f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
-    ./gradlew build
-  Those values are pinned in the bundled gradle-wrapper.properties; you can also confirm the checksum against Gradle's published value at https://services.gradle.org/distributions/gradle-8.14.4-bin.zip.sha256 (or https://gradle.org/release-checksums/).
-- For the full checklist (diff against the signed tag, binary-file scan, staged-binary smoke test), see "Verifying a release" in the Java SDK README:
-  https://github.com/apache/airflow/tree/java-sdk/<VERSION>-rc<N>/java-sdk#verifying-a-release
+The verification process can be found in the main repository:
+https://github.com/apache/airflow/tree/java-sdk/<VERSION>-rc<N>/java-sdk#verifying-a-release
 
 For more details on ASF release verification, see: https://www.apache.org/info/verification.html
 
@@ -393,10 +358,9 @@ Best,
 
 Pre-send checklist:
 
-* Every staged artifact above resolves in the Nexus staging repository — cross
-  check against the *Verify the upload* step, not just this list from memory.
-* `Changes since rc<N-1>` and the vote deadline are filled in (not "N/A" unless
-  this really is rc1, and not left blank).
+* Every staged artifact above resolves in the Nexus staging repository. Cross
+  check against the BOM, not just this list from memory.
+* `Changes since rc<N-1>` and the vote deadline are filled in.
 * Run `grep '<' email.txt` on the rendered email and confirm **no output** —
   any match means a template placeholder (`<N>`, `<NNNN>`, `<YYYY-MM-DD ...>`,
   etc.) was left unfilled.
@@ -424,25 +388,23 @@ manager, before sending the vote — should run against the source package in
    ```
 
 3. **Diff against the git tag.** Extract the tarball and compare it with a
-   clean checkout of the tag it claims to be built from — they should be
-   identical apart from the excluded wrapper scripts and `gradle-wrapper.jar` (`gradle-wrapper.properties` is kept). Note the extracted
-   top-level directory is named after the `--prefix` used by the `sourceRelease`
-   task, `apache-airflow-java-sdk-<version>` — it does **not** carry the `-src`
-   suffix that only appears in the tarball's own filename:
+   clean checkout of the tag it claims to be built from. They should be
+   identical except `gradlew`, `gradlew.bat`, and `gradle-wrapper.jar`. The
+   extracted top-level directory should be `apache-airflow-java-sdk-<version>`
+   without the `-src` suffix that only appears in the tarball's own filename:
 
    ```bash
    tar xzf apache-airflow-java-sdk-<VERSION>-src.tar.gz
    git clone --branch java-sdk/<VERSION>-rc<N> \
      https://github.com/apache/airflow.git tag-checkout
    diff -rq apache-airflow-java-sdk-<VERSION>/ tag-checkout/java-sdk/ \
-     | grep -v -E 'gradlew|gradle-wrapper\.jar'
+     | grep -vE ': (gradlew|gradlew\.bat|gradle-wrapper\.jar)$'
    ```
 
    Any remaining diff output is unexpected and should block the vote.
 
 4. **No binary files.** ASF source releases must not contain compiled code.
-   Scan for anything that isn't text (the only expected binaries — the
-   wrapper jar — must not appear, since it's excluded):
+   Scan for anything that isn't text:
 
    ```bash
    find apache-airflow-java-sdk-<VERSION>/ -type f \
@@ -451,13 +413,20 @@ manager, before sending the vote — should run against the source package in
 
    This should print nothing.
 
-5. **Build from source.** With a locally installed Gradle (see the *Upload the
-   source package* section above for the two build paths):
+5. **Build from source.** Regenerate the Gradle wrapper from a locally installed
+   Gradle (see the *Upload the source package* section above):
 
    ```bash
-   cd apache-airflow-java-sdk-<VERSION>/
-   gradle build
+   cd apache-airflow-java-sdk-<VERSION>
+   gradle wrapper \
+       --gradle-version <GRADLE-VERSION> \
+       --gradle-distribution-sha256-sum <GRADLE-DISTRIBUTION-SHA>
+   ./gradlew build
    ```
+
+   Use the values for `<GRADLE-VERSION>` and `<GRADLE-DISTRIBUTION-SHA>` from
+   `distributionUrl` and `distributionSha256Sum` in the bundled
+   `gradle/wrapper/gradle-wrapper.properties`.
 
 6. **Staged-binary smoke test.** Resolve the staged Nexus artifacts from a
    throwaway project to confirm they're actually consumable, following the

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -124,14 +124,14 @@ Commit the change and push it to the release branch.
 
 Use a Maven-compatible version string, as defined by the
 [Maven version order specification](https://maven.apache.org/pom.html#Version_Order_Specification).
-For example, version 1 beta 1 is `1.0.0-beta1`, and the eventual
+For example, version 1 beta 1 is `<VERSION>`, and the eventual
 general-availability release is `1.0.0`.
 
 *NOTE:* Editing `gradle.properties` as above is the standard procedure. You can
 alternatively override the version for a single command without editing the
-file, by passing `-PprojectVersion=1.0.0-beta1` to any Gradle invocation. This
+file, by passing `-PprojectVersion=<VERSION>` to any Gradle invocation. This
 is handy for one-off or pre-release builds. Either way, `main` should stay on a
-`-SNAPSHOT` version between releases: a snapshot sorts after `1.0.0-beta1` and
+`-SNAPSHOT` version between releases: a snapshot sorts after `<VERSION>` and
 before the `1.0.0` GA, so no extra bump is needed after a beta.
 
 ### Tag the release candidate
@@ -142,8 +142,8 @@ suffix). Push the tag before sending the vote so reviewers can check out the
 exact source being voted on.
 
 ```bash
-git tag -s java-sdk/1.0.0-beta1-rc1 -m "Java SDK 1.0.0-beta1 RC 1"
-git push upstream java-sdk/1.0.0-beta1-rc1
+git tag -s java-sdk/<VERSION>-rc<N> -m "Java SDK <VERSION> RC 1"
+git push upstream java-sdk/<VERSION>-rc<N>
 ```
 
 ### Verify the POM locally
@@ -246,25 +246,26 @@ signature and checksum in one step:
 
 ```bash
 # Signing uses your local gpg keyring, so have your key/passphrase ready.
-./gradlew sourceRelease -PgitRef=java-sdk/1.0.0-beta1-rc1
+./gradlew sourceRelease -PgitRef=java-sdk/<VERSION>-rc<N>
 ```
 
 This writes three files to `build/distributions/`:
 
 ```
-apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz
-apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.asc
-apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.sha512
+apache-airflow-java-sdk-<VERSION>-src.tar.gz
+apache-airflow-java-sdk-<VERSION>-src.tar.gz.asc
+apache-airflow-java-sdk-<VERSION>-src.tar.gz.sha512
 ```
 
-*NOTE:* The source archive deliberately omits the **entire Gradle wrapper**, not
-just `gradle/wrapper/gradle-wrapper.jar` (compiled code, see [LEGAL-570]) but
-also `gradlew`, `gradlew.bat`, and `gradle/wrapper/gradle-wrapper.properties`.
-The wrapper remains tracked in git as usual; only the `git archive` output used
-by `sourceRelease` excludes it (see `.gitattributes`). This means an extracted
-source package has no wrapper at all, and no `gradle-wrapper.properties` to pin
-the Gradle version or auto-verify the distribution checksum. There are two ways
-to build from an extracted source package:
+*NOTE:* The source archive omits the Gradle wrapper scripts (`gradlew`,
+`gradlew.bat`) and the compiled `gradle/wrapper/gradle-wrapper.jar` — ASF source
+releases must not contain compiled code (see [LEGAL-570]), and the scripts are
+Gradle's own files, so only project-authored config is shipped. It keeps
+`gradle/wrapper/gradle-wrapper.properties`, so the archive itself pins the Gradle
+version and distribution checksum and there is no need to consult the git tag.
+The wrapper stays tracked in git; only the `git archive` output used by
+`sourceRelease` drops these files (see `.gitattributes`). To build from an
+extracted source package:
 
 * **(a) Build with a locally installed Gradle:**
 
@@ -272,21 +273,20 @@ to build from an extracted source package:
   gradle build
   ```
 
-* **(b) Regenerate the wrapper, then build with it.** Since
-  `gradle-wrapper.properties` is excluded too, pass the version and checksum
-  explicitly instead of relying on a committed properties file:
+* **(b) Regenerate the wrapper, then build with it.** The version and checksum
+  are already pinned in the bundled `gradle-wrapper.properties`; pass the same
+  values so the regenerated properties stays identical, then let the wrapper
+  verify the distribution against that checksum:
 
   ```bash
-  gradle wrapper --gradle-version 8.14.4 \
-    --gradle-distribution-sha256-sum f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
+  gradle wrapper --gradle-version <GRADLE-VERSION> \
+    --gradle-distribution-sha256-sum <GRADLE-DISTRIBUTION-SHA256>
   ./gradlew build
   ```
 
-  The version and checksum above are the ones this project currently pins;
-  confirm them against `gradle/wrapper/gradle-wrapper.properties` at the
-  signed git tag being verified (e.g. `java-sdk/1.0.0-beta1-rc1`) — the
-  wrapper is still checked into git and present at any tag, only the
-  *source-release tarball* excludes it.
+  `<GRADLE-VERSION>` and `<GRADLE-DISTRIBUTION-SHA256>` are the `distributionUrl`
+  version and `distributionSha256Sum` in the bundled
+  `gradle/wrapper/gradle-wrapper.properties`.
 
 [LEGAL-570]: https://issues.apache.org/jira/browse/LEGAL-570
 
@@ -300,16 +300,16 @@ project's location:
 svn checkout https://dist.apache.org/repos/dist/dev/airflow <dist-dev-checkout>
 
 cd <dist-dev-checkout>
-mkdir -p java-sdk/1.0.0-beta1-rc1
-cp <path-to>/java-sdk/build/distributions/apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz* \
-   java-sdk/1.0.0-beta1-rc1/
+mkdir -p java-sdk/<VERSION>-rc<N>
+cp <path-to>/java-sdk/build/distributions/apache-airflow-java-sdk-<VERSION>-src.tar.gz* \
+   java-sdk/<VERSION>-rc<N>/
 
-svn add --parents java-sdk/1.0.0-beta1-rc1
-svn commit -m "Add Apache Airflow Java SDK 1.0.0-beta1-rc1 source release candidate"
+svn add --parents java-sdk/<VERSION>-rc<N>
+svn commit -m "Add Apache Airflow Java SDK <VERSION>-rc<N> source release candidate"
 ```
 
 The commit publishes them under
-`https://dist.apache.org/repos/dist/dev/airflow/java-sdk/1.0.0-beta1-rc1/`, which
+`https://dist.apache.org/repos/dist/dev/airflow/java-sdk/<VERSION>-rc<N>/`, which
 is the source-package URL you link in the vote.
 
 ### Call the vote
@@ -326,55 +326,68 @@ artifact list, so treat this template as the source of truth and diff your
 draft against it before sending.
 
 ```text
-Subject: [VOTE] Release Apache Airflow Java SDK 1.0.0-beta1 based on rc<N>
+Subject: [VOTE] Release Apache Airflow Java SDK <VERSION> based on <VERSION>-rc<N>
 
-Hey all,
+Hi,
 
-I have prepared the Apache Airflow Java SDK 1.0.0-beta1 rc<N>.
+I would like to call a vote to release Apache Airflow Java SDK <VERSION>, based on release candidate <VERSION>-rc<N>.
 
-Changes since rc<N-1>:
-<one-line summary per fix, or "N/A — first RC" if this is rc1>
+This is a beta release. It is intended for testing and early adoption by users and developers outside the project; APIs may still change before the general-availability release. It is a full, formal ASF release (source package + convenience binaries), not a snapshot or nightly build.
 
-Consider this a formal vote on whether to release these packages as
-Apache Airflow Java SDK 1.0.0-beta1.
+Changes since rc<N-1>: <one-line summary per fix; omit this paragraph for rc1>
 
-The vote will be open for at least 72 hours (until <YYYY-MM-DD HH:MM UTC>) or
-until the necessary number of votes is reached.
+The release candidate contains the following Maven artifacts, all under group id org.apache.airflow:
 
-https://www.apache.org/legal/release-policy.html#release-approval
+- airflow-sdk
+- airflow-sdk-jul
+- airflow-sdk-log4j2
+- airflow-sdk-slf4j
+- airflow-sdk-jpl
+- airflow-sdk-processor
+- airflow-sdk-bom
+- airflow-sdk-gradle-plugin
+- org.apache.airflow.sdk.gradle.plugin (Gradle plugin marker artifact)
 
-Airflow Java SDK Package:
-https://dist.apache.org/repos/dist/dev/airflow/java-sdk/1.0.0-beta1-rc<N>/
+Git tag / commit being voted on:
 
-git tag / commit:
-https://github.com/apache/airflow/releases/tag/java-sdk/1.0.0-beta1-rc<N>
-(commit <full-commit-sha>)
+- Tag: java-sdk/<VERSION>-rc<N>
+- Commit: <full-commit-sha>
+- https://github.com/apache/airflow/releases/tag/java-sdk%2F<VERSION>-rc<N>
 
-KEYS file:
-https://downloads.apache.org/airflow/KEYS
+Source release (the artifact being voted on), signatures and checksums:
+https://dist.apache.org/repos/dist/dev/airflow/java-sdk/<VERSION>-rc<N>/
 
-Staging Nexus repository (convenience binaries — 8 artifacts + plugin marker):
-https://repository.apache.org/content/repositories/orgapacheairflow-<NNNN>/org/apache/airflow/
-  - airflow-sdk
-  - airflow-sdk-jul
-  - airflow-sdk-log4j2
-  - airflow-sdk-slf4j
-  - airflow-sdk-jpl
-  - airflow-sdk-processor
-  - airflow-sdk-bom
-  - airflow-sdk-gradle-plugin
-  - org.apache.airflow.sdk.gradle.plugin (Gradle plugin marker artifact)
+Convenience binaries: staged in the ASF Nexus repository:
+https://repository.apache.org/content/repositories/orgapacheairflow-<NNNN>/
 
-Please vote accordingly:
+KEYS file (public keys used to sign the release): https://downloads.apache.org/airflow/KEYS
 
-[ ] +1 approve
-[ ] +0 no opinion
-[ ] -1 disapprove with the reason
+There's no changelogs since this is the first ever release. See the Java SDK's README for a list of features currently provided.
+https://github.com/apache/airflow/tree/java-sdk/<VERSION>-rc<N>/java-sdk
 
-Only PMC members' votes are binding, but everyone is encouraged to test the
-release and vote.
+Please review and vote. The vote will remain open for at least 72 hours, until <YYYY-MM-DD HH:MM UTC>, or until the necessary number of binding votes is reached.
 
-Thanks,
+[ ] +1 Release this package as Apache Airflow Java SDK <VERSION>
+[ ] +0 No opinion
+[ ] -1 Do not release, because ...
+
+Only votes from Airflow PMC members are binding, but everyone is welcome and encouraged to test the release and vote.
+
+Here is how you can verify the release before voting:
+
+- Download the source package, its .asc signature and .sha512 checksum from the dist/dev URL above.
+- Verify the checksum: shasum -a 512 -c apache-airflow-java-sdk-<VERSION>-src.tar.gz.sha512
+- Import the KEYS file and verify the signature: gpg --import KEYS && gpg --verify apache-airflow-java-sdk-<VERSION>-src.tar.gz.asc
+- Unpack and build. The source package omits the Gradle wrapper scripts and the compiled gradle-wrapper.jar, but keeps gradle-wrapper.properties, so the pinned Gradle version and distribution checksum travel with the archive. Either build with a locally installed Gradle (gradle build), or regenerate the wrapper with the values already in gradle-wrapper.properties, then build with it:
+    gradle wrapper --gradle-version 8.14.4 --gradle-distribution-sha256-sum f1771298a70f6db5a29daf62378c4e18a17fc33c9ba6b14362e0cdf40610380d
+    ./gradlew build
+  Those values are pinned in the bundled gradle-wrapper.properties; you can also confirm the checksum against Gradle's published value at https://services.gradle.org/distributions/gradle-8.14.4-bin.zip.sha256 (or https://gradle.org/release-checksums/).
+- For the full checklist (diff against the signed tag, binary-file scan, staged-binary smoke test), see "Verifying a release" in the Java SDK README:
+  https://github.com/apache/airflow/tree/java-sdk/<VERSION>-rc<N>/java-sdk#verifying-a-release
+
+For more details on ASF release verification, see: https://www.apache.org/info/verification.html
+
+Best,
 <your name>
 ```
 
@@ -398,7 +411,7 @@ manager, before sending the vote — should run against the source package in
 1. **Checksum.** Confirm the published SHA-512 matches the downloaded tarball:
 
    ```bash
-   sha512sum -c apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.sha512
+   sha512sum -c apache-airflow-java-sdk-<VERSION>-src.tar.gz.sha512
    ```
 
 2. **Signature.** Import the `KEYS` file and verify the GPG signature:
@@ -406,23 +419,23 @@ manager, before sending the vote — should run against the source package in
    ```bash
    curl -O https://downloads.apache.org/airflow/KEYS
    gpg --import KEYS
-   gpg --verify apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz.asc \
-       apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz
+   gpg --verify apache-airflow-java-sdk-<VERSION>-src.tar.gz.asc \
+       apache-airflow-java-sdk-<VERSION>-src.tar.gz
    ```
 
 3. **Diff against the git tag.** Extract the tarball and compare it with a
    clean checkout of the tag it claims to be built from — they should be
-   identical apart from the excluded Gradle wrapper files. Note the extracted
+   identical apart from the excluded wrapper scripts and `gradle-wrapper.jar` (`gradle-wrapper.properties` is kept). Note the extracted
    top-level directory is named after the `--prefix` used by the `sourceRelease`
    task, `apache-airflow-java-sdk-<version>` — it does **not** carry the `-src`
    suffix that only appears in the tarball's own filename:
 
    ```bash
-   tar xzf apache-airflow-java-sdk-1.0.0-beta1-src.tar.gz
-   git clone --branch java-sdk/1.0.0-beta1-rc<N> \
+   tar xzf apache-airflow-java-sdk-<VERSION>-src.tar.gz
+   git clone --branch java-sdk/<VERSION>-rc<N> \
      https://github.com/apache/airflow.git tag-checkout
-   diff -rq apache-airflow-java-sdk-1.0.0-beta1/ tag-checkout/java-sdk/ \
-     | grep -v -E 'gradlew|gradle/wrapper'
+   diff -rq apache-airflow-java-sdk-<VERSION>/ tag-checkout/java-sdk/ \
+     | grep -v -E 'gradlew|gradle-wrapper\.jar'
    ```
 
    Any remaining diff output is unexpected and should block the vote.
@@ -432,18 +445,17 @@ manager, before sending the vote — should run against the source package in
    wrapper jar — must not appear, since it's excluded):
 
    ```bash
-   find apache-airflow-java-sdk-1.0.0-beta1/ -type f \
+   find apache-airflow-java-sdk-<VERSION>/ -type f \
      -exec sh -c 'file "$1" | grep -qv text && echo "$1"' _ {} \;
    ```
 
    This should print nothing.
 
 5. **Build from source.** With a locally installed Gradle (see the *Upload the
-   source package* section above for the two build paths available without
-   the wrapper):
+   source package* section above for the two build paths):
 
    ```bash
-   cd apache-airflow-java-sdk-1.0.0-beta1/
+   cd apache-airflow-java-sdk-<VERSION>/
    gradle build
    ```
 
@@ -451,7 +463,7 @@ manager, before sending the vote — should run against the source package in
    throwaway project to confirm they're actually consumable, following the
    same pattern as the "Dry-run against a local repository" step: point a
    `repositories {}` block at the staging repository URL, declare a dependency
-   on `org.apache.airflow:airflow-sdk-bom:1.0.0-beta1`, and confirm the
+   on `org.apache.airflow:airflow-sdk-bom:<VERSION>`, and confirm the
    transitive artifacts (including `airflow-sdk-jpl`) resolve and the example
    bundle builds against them.
 
@@ -471,16 +483,16 @@ Reply with a `[RESULT][VOTE]` tally, then:
 2. **Move** the source package from `dist/dev` to `dist/release`:
 
    ```bash
-   svn mv https://dist.apache.org/repos/dist/dev/airflow/java-sdk/1.0.0-beta1-rc1 \
-          https://dist.apache.org/repos/dist/release/airflow/java-sdk/1.0.0-beta1 \
-          -m "Release Apache Airflow Java SDK 1.0.0-beta1"
+   svn mv https://dist.apache.org/repos/dist/dev/airflow/java-sdk/<VERSION>-rc<N> \
+          https://dist.apache.org/repos/dist/release/airflow/java-sdk/<VERSION> \
+          -m "Release Apache Airflow Java SDK <VERSION>"
    ```
 
 3. **Tag** the final version on the same commit that was voted:
 
    ```bash
-   git tag -s java-sdk/1.0.0-beta1 <voted-commit-hash> -m "Apache Airflow Java SDK 1.0.0-beta1"
-   git push upstream java-sdk/1.0.0-beta1
+   git tag -s java-sdk/<VERSION> <voted-commit-hash> -m "Apache Airflow Java SDK <VERSION>"
+   git push upstream java-sdk/<VERSION>
    ```
 
    Keep the RC tag for traceability.
@@ -492,7 +504,7 @@ Reply with a `[RESULT][VOTE]` tally, then:
 
 Close the vote, **drop** the staging repository in Nexus, remove the `dist/dev`
 candidate, fix the issue, and cut the next RC (`...-rc2`). The released version
-stays the same (e.g. `1.0.0-beta1`); only the RC counter in the tag increments.
+stays the same (e.g. `<VERSION>`); only the RC counter in the tag increments.
 
 ## Contributing
 

--- a/java-sdk/bom/build.gradle.kts
+++ b/java-sdk/bom/build.gradle.kts
@@ -28,6 +28,7 @@ val airflowSupervisorSchemaVersion: String by project
 dependencies {
     constraints {
         api("org.apache.airflow:airflow-sdk:$projectVersion")
+        api("org.apache.airflow:airflow-sdk-jpl:$projectVersion")
         api("org.apache.airflow:airflow-sdk-jul:$projectVersion")
         api("org.apache.airflow:airflow-sdk-log4j2:$projectVersion")
         api("org.apache.airflow:airflow-sdk-processor:${projectVersion}")

--- a/java-sdk/bom/build.gradle.kts
+++ b/java-sdk/bom/build.gradle.kts
@@ -17,7 +17,10 @@
  * under the License.
  */
 
+import org.gradle.api.publish.PublishingExtension
+
 plugins {
+    base
     `java-platform`
     id("airflow-publish")
 }
@@ -50,3 +53,45 @@ publishing {
         }
     }
 }
+
+// What the BOM currently constrains (group org.apache.airflow).
+val bomArtifacts =
+    configurations["api"].dependencyConstraints
+        .filter { it.group == "org.apache.airflow" }
+        .map { it.name }
+        .toSet()
+
+val publishedArtifacts =
+    rootProject.subprojects
+        .filter { it.path != project.path }
+        .flatMap { sub ->
+            evaluationDependsOn(sub.path)
+            sub.extensions.findByType(PublishingExtension::class.java)
+                ?.publications
+                ?.withType(MavenPublication::class.java)
+                ?.filter { it.groupId == "org.apache.airflow" }
+                ?.map { it.artifactId }
+                ?: emptyList()
+        }
+        .toSet()
+
+val verifyBomCoverage by tasks.registering {
+    group = "verification"
+    description = "Fail if airflow-sdk-bom does not constrain the same set of published Java SDK artifacts."
+    doLast {
+        val missing = (publishedArtifacts - bomArtifacts).sorted()
+        val stale = (bomArtifacts - publishedArtifacts).sorted()
+        if (missing.isNotEmpty() || stale.isNotEmpty()) {
+            throw GradleException(
+                buildString {
+                    appendLine("airflow-sdk-bom is out of sync with the published Java SDK artifacts:")
+                    if (missing.isNotEmpty()) appendLine("  published but missing from the BOM: $missing")
+                    if (stale.isNotEmpty()) appendLine("  listed in the BOM but not published: $stale")
+                    append("Update constraints in bom/build.gradle.kts to match.")
+                },
+            )
+        }
+    }
+}
+
+tasks.named("check") { dependsOn(verifyBomCoverage) }

--- a/java-sdk/bom/build.gradle.kts
+++ b/java-sdk/bom/build.gradle.kts
@@ -28,6 +28,7 @@ val airflowSupervisorSchemaVersion: String by project
 dependencies {
     constraints {
         api("org.apache.airflow:airflow-sdk:$projectVersion")
+        api("org.apache.airflow:airflow-sdk-gradle-plugin:$projectVersion")
         api("org.apache.airflow:airflow-sdk-jpl:$projectVersion")
         api("org.apache.airflow:airflow-sdk-jul:$projectVersion")
         api("org.apache.airflow:airflow-sdk-log4j2:$projectVersion")

--- a/java-sdk/buildSrc/src/main/kotlin/airflow-jvm-conventions.gradle.kts
+++ b/java-sdk/buildSrc/src/main/kotlin/airflow-jvm-conventions.gradle.kts
@@ -53,3 +53,25 @@ configure<SpotlessExtension> {
         endWithNewline()
     }
 }
+
+// ASF release policy requires every distributed artifact (including convenience
+// binaries such as the main, sources, javadoc, and test-fixtures jars) to carry
+// LICENSE/NOTICE. `rootProject` is used rather than a bare `rootDir`/`projectDir`
+// because this precompiled script plugin is applied per-subproject: an unqualified
+// reference would resolve relative to whichever subproject applies the plugin,
+// not the multi-project root where LICENSE/NOTICE actually live.
+tasks.withType<Jar>().configureEach {
+    metaInf {
+        from(rootProject.layout.projectDirectory.file("LICENSE"))
+        from(rootProject.layout.projectDirectory.file("NOTICE"))
+    }
+}
+
+// Byte-reproducible archives: strip wall-clock timestamps, fix entry ordering,
+// and pin permission bits so two builds from the same sources are bit-identical.
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+    dirPermissions { unix("755") }
+    filePermissions { unix("644") }
+}

--- a/java-sdk/buildSrc/src/main/kotlin/airflow-jvm-conventions.gradle.kts
+++ b/java-sdk/buildSrc/src/main/kotlin/airflow-jvm-conventions.gradle.kts
@@ -54,12 +54,6 @@ configure<SpotlessExtension> {
     }
 }
 
-// ASF release policy requires every distributed artifact (including convenience
-// binaries such as the main, sources, javadoc, and test-fixtures jars) to carry
-// LICENSE/NOTICE. `rootProject` is used rather than a bare `rootDir`/`projectDir`
-// because this precompiled script plugin is applied per-subproject: an unqualified
-// reference would resolve relative to whichever subproject applies the plugin,
-// not the multi-project root where LICENSE/NOTICE actually live.
 tasks.withType<Jar>().configureEach {
     metaInf {
         from(rootProject.layout.projectDirectory.file("LICENSE"))
@@ -67,8 +61,6 @@ tasks.withType<Jar>().configureEach {
     }
 }
 
-// Byte-reproducible archives: strip wall-clock timestamps, fix entry ordering,
-// and pin permission bits so two builds from the same sources are bit-identical.
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true


### PR DESCRIPTION
- related: [Java SDK 1.0.0-beta1 RC2 vote thread (binding -1 from Jarek; additional release-policy findings from Shahar and RC2 verification)](https://lists.apache.org/thread/qnlsmz1m263nkthwybktsvskg2htgfpj)

## Why

RC2 of the Java SDK 1.0.0-beta1 vote cannot pass: Jarek cast a binding -1 because
the Gradle wrapper still ships in the source-release tarball, and RC2
verification separately found the staged convenience-binary jars are missing
`META-INF/LICENSE`/`NOTICE`, builds aren't byte-reproducible, and the BOM
doesn't manage the `jpl` artifact's version. All three must land before RC3.

## What

- **Source release packaging**: exclude `gradlew`, `gradlew.bat`, and
  `gradle/wrapper` from the `git archive`-based source tarball via
  `.gitattributes` `export-ignore` (the wrapper stays tracked in git — only the
  release tarball omits it). Document both extracted-source build paths, and
  add "Verifying a release" and vote-email template sections to
  `java-sdk/README.md`.
- **Convenience-binary compliance**: inject `META-INF/LICENSE`/`NOTICE` into
  every published jar and make archives byte-reproducible (fixed timestamps,
  file ordering, permissions), centralized once in the `airflow-jvm-conventions`
  convention plugin so it covers every jar-producing module.
- **BOM completeness**: add `airflow-sdk-jpl` to the BOM's dependency
  constraints so consumers can depend on it without pinning a version
  explicitly.

## Verification

Each change was implemented and verified independently (source-archive content
checks, jar inspection plus reproducibility hash diffs, and a BOM resolution
smoke test) and passed its own review pass before being combined here; see
commits 5a03a0260a, 023151182f, and 1f400a8e9d for per-change detail.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
