### PR TITLE
Fix execution API 404 for connection IDs containing a slash

### DIFF
--- a/airflow-core/newsfragments/69585.bugfix.rst
+++ b/airflow-core/newsfragments/69585.bugfix.rst
@@ -1,5 +1,1 @@
-Fix tasks failing with a 404 when fetching a connection whose ID contains a slash
-
-The execution API route for connections now matches connection IDs that contain ``/``
-(for example ``dev-env/project-name``), so tasks resolve them instead of failing with a
-"connection not found" error.
+Fix tasks failing with a 404 when fetching a connection whose ID contains a slash (for example ``dev-env/project-name``).

--- a/airflow-core/newsfragments/69585.bugfix.rst
+++ b/airflow-core/newsfragments/69585.bugfix.rst
@@ -1,0 +1,5 @@
+Fix tasks failing with a 404 when fetching a connection whose ID contains a slash
+
+The execution API route for connections now matches connection IDs that contain ``/``
+(for example ``dev-env/project-name``), so tasks resolve them instead of failing with a
+"connection not found" error.

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/connections.py
@@ -57,7 +57,9 @@ log = logging.getLogger(__name__)
 
 
 @router.get(
-    "/{connection_id}",
+    # ``:path`` so connection IDs containing ``/`` (e.g. ``dev-env/project-name``)
+    # match instead of being split into separate segments, mirroring the variables route.
+    "/{connection_id:path}",
     responses={
         status.HTTP_401_UNAUTHORIZED: {"description": "Unauthorized"},
         status.HTTP_403_FORBIDDEN: {"description": "Task does not have access to the connection"},

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_connections.py
@@ -86,6 +86,20 @@ class TestGetConnection:
         session.delete(connection)
         session.commit()
 
+    def test_connection_get_with_slash_in_id(self, client, session):
+        connection = Connection(conn_id="dev-env/project-name", conn_type="http", host="localhost")
+
+        session.add(connection)
+        session.commit()
+
+        response = client.get("/execution/connections/dev-env/project-name")
+
+        assert response.status_code == 200
+        assert response.json()["conn_id"] == "dev-env/project-name"
+
+        session.delete(connection)
+        session.commit()
+
     @mock.patch.dict(
         "os.environ",
         {"AIRFLOW_CONN_TEST_CONN2": '{"uri": "http://root:admin@localhost:8080/https?headers=header"}'},


### PR DESCRIPTION
Tasks fetch connections from the API server through `GET /execution/connections/{conn_id}`. The route used the default string path converter, so a `conn_id` that contains `/` (for example `dev-env/project-name`) was split into separate path segments and never matched, and the task failed with a 404 even though the connection existed. `airflow connections get` reads connections directly and was unaffected, so the CLI and Task SDK disagreed for the same connection.

This switches the route to the `:path` converter so slashed connection IDs route to the handler, mirroring how the variables route (`/{variable_key:path}`) already handles slashed keys. Added a regression test for a connection whose ID contains a slash.

closes: #57864

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

<!-- pr-triage-fold: triaged=2026-07-11T14:59:47Z head=4434c65 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Samin061** · by `@potiuk` · 2026-07-11 14:59 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed (see our [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria)):
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
