### PR TITLE
docs: update SQLAlchemy pooling documentation link

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -683,7 +683,7 @@ database:
         Check connection at the start of each connection pool checkout.
         Typically, this is a simple statement like "SELECT 1".
         See `SQLAlchemy Pooling: Disconnect Handling - Pessimistic
-        <https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic>`__
+        <https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic>`__
         for more details.
       version_added: 2.3.0
       type: boolean


### PR DESCRIPTION
## What

Updates the remaining SQLAlchemy documentation reference in:

airflow-core/src/airflow/config_templates/config.yml

from SQLAlchemy 1.4 documentation (en/14) to SQLAlchemy 2.0 documentation (en/20).

## Why

Airflow now uses SQLAlchemy 2.x and the referenced page exists in SQLAlchemy 2.0 documentation.

## Changes

Updated:

https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic

to:

https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic