### PR TITLE
Making ResumableJobMixin a abstract class and its methods abstractmethods

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
+++ b/task-sdk/src/airflow/sdk/bases/resumablejobmixin.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
 tracer = trace.get_tracer(__name__)
 
 
-class ResumableJobMixin:
+class ResumableJobMixin(ABC):
     """
     Mixin for operators that submit one long-running job to an external system and poll for completion.
 
@@ -52,7 +53,7 @@ class ResumableJobMixin:
     Usage: call ``execute_resumable(context)`` from the operator's ``execute()`` when reconnection
     is supported.
 
-    Subclasses must implement the methods specific to their external system. The mixin owns
+    Subclasses must implement all the methods specific to their external system. The mixin owns
     only ``execute_resumable()`` and the task_state_store read/write logic.
 
     Example::
@@ -209,6 +210,7 @@ class ResumableJobMixin:
         self.poll_until_complete(external_id, context)
         return self.get_job_result(external_id, context)
 
+    @abstractmethod
     def submit_job(self, context: Context) -> JsonValue:
         """
         Submit the job to the external system. Return its external ID.
@@ -218,6 +220,7 @@ class ResumableJobMixin:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def get_job_status(self, external_id: JsonValue, context: Context) -> str:
         """
         Query the external system for the current job status.
@@ -229,6 +232,7 @@ class ResumableJobMixin:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def is_job_active(self, status: str) -> bool:
         """
         Return True if the job is still running and can be reconnected to.
@@ -238,6 +242,7 @@ class ResumableJobMixin:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def is_job_succeeded(self, status: str) -> bool:
         """
         Return True if the job completed successfully.
@@ -247,10 +252,12 @@ class ResumableJobMixin:
         """
         raise NotImplementedError
 
+    @abstractmethod
     def poll_until_complete(self, external_id: JsonValue, context: Context) -> None:
         """Block until the job reaches a terminal state. Raise on failure."""
         raise NotImplementedError
 
+    @abstractmethod
     def get_job_result(self, external_id: JsonValue, context: Context) -> Any:
         """Return the job result after completion. Return None if not applicable."""
         raise NotImplementedError

--- a/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
@@ -402,3 +402,155 @@ class TestLogging:
         assert entry["external_id"] == "job-001"
         for key, val in extra_fields.items():
             assert entry[key] == val
+
+
+class _MissingSubmitJob(ResumableJobMixin, BaseOperator):
+    def get_job_status(self, external_id, context) -> str:
+        return "RUNNING"
+
+    def is_job_active(self, status: str) -> bool:
+        return True
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return False
+
+    def poll_until_complete(self, external_id, context) -> None:
+        return None
+
+    def get_job_result(self, external_id, context):
+        return None
+
+
+class _MissingGetJobStatus(ResumableJobMixin, BaseOperator):
+    def submit_job(self, context):
+        return "id"
+
+    def is_job_active(self, status: str) -> bool:
+        return True
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return False
+
+    def poll_until_complete(self, external_id, context) -> None:
+        return None
+
+    def get_job_result(self, external_id, context):
+        return None
+
+
+class _MissingIsJobActive(ResumableJobMixin, BaseOperator):
+    def submit_job(self, context):
+        return "id"
+
+    def get_job_status(self, external_id, context) -> str:
+        return "RUNNING"
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return False
+
+    def poll_until_complete(self, external_id, context) -> None:
+        return None
+
+    def get_job_result(self, external_id, context):
+        return None
+
+
+class _MissingIsJobSucceeded(ResumableJobMixin, BaseOperator):
+    def submit_job(self, context):
+        return "id"
+
+    def get_job_status(self, external_id, context) -> str:
+        return "RUNNING"
+
+    def is_job_active(self, status: str) -> bool:
+        return True
+
+    def poll_until_complete(self, external_id, context) -> None:
+        return None
+
+    def get_job_result(self, external_id, context):
+        return None
+
+
+class _MissingPollUntilComplete(ResumableJobMixin, BaseOperator):
+    def submit_job(self, context):
+        return "id"
+
+    def get_job_status(self, external_id, context) -> str:
+        return "RUNNING"
+
+    def is_job_active(self, status: str) -> bool:
+        return True
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return False
+
+    def get_job_result(self, external_id, context):
+        return None
+
+
+class _MissingGetJobResult(ResumableJobMixin, BaseOperator):
+    def submit_job(self, context):
+        return "id"
+
+    def get_job_status(self, external_id, context) -> str:
+        return "RUNNING"
+
+    def is_job_active(self, status: str) -> bool:
+        return True
+
+    def is_job_succeeded(self, status: str) -> bool:
+        return False
+
+    def poll_until_complete(self, external_id, context) -> None:
+        return None
+
+
+class _MissingEverything(ResumableJobMixin, BaseOperator):
+    pass
+
+
+class TestAbstractMethodEnforcement:
+    def test_mixin_itself_cannot_be_instantiated(self):
+        with pytest.raises(TypeError, match="Can't instantiate abstract class ResumableJobMixin"):
+            ResumableJobMixin()
+
+    def test_fully_implemented_subclass_has_no_abstract_methods(self):
+        assert ConcreteResumableOperator.__abstractmethods__ == frozenset()
+
+    def test_fully_implemented_subclass_instantiates_and_behaves_normally(self):
+        op = ConcreteResumableOperator(task_id="test_task")
+        assert isinstance(op, ResumableJobMixin)
+
+        op.execute_resumable(make_context(FakeTaskState()))
+        assert op.submitted_ids == ["job-001"]
+
+    def test_missing_all_methods_reports_every_one(self):
+        assert _MissingEverything.__abstractmethods__ == frozenset(
+            {
+                "submit_job",
+                "get_job_status",
+                "is_job_active",
+                "is_job_succeeded",
+                "poll_until_complete",
+                "get_job_result",
+            }
+        )
+        with pytest.raises(TypeError, match="Can't instantiate abstract class _MissingEverything"):
+            _MissingEverything(task_id="test_task")
+
+    @pytest.mark.parametrize(
+        ("partial_cls", "missing_method"),
+        [
+            pytest.param(_MissingSubmitJob, "submit_job", id="submit_job"),
+            pytest.param(_MissingGetJobStatus, "get_job_status", id="get_job_status"),
+            pytest.param(_MissingIsJobActive, "is_job_active", id="is_job_active"),
+            pytest.param(_MissingIsJobSucceeded, "is_job_succeeded", id="is_job_succeeded"),
+            pytest.param(_MissingPollUntilComplete, "poll_until_complete", id="poll_until_complete"),
+            pytest.param(_MissingGetJobResult, "get_job_result", id="get_job_result"),
+        ],
+    )
+    def test_missing_single_method_fails_at_construction(self, partial_cls, missing_method):
+        assert partial_cls.__abstractmethods__ == frozenset({missing_method})
+        with pytest.raises(TypeError, match=f"abstract method '{missing_method}'"):
+            partial_cls(task_id="test_task")

--- a/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
+++ b/task-sdk/tests/task_sdk/bases/test_resumablejobmixin.py
@@ -552,5 +552,5 @@ class TestAbstractMethodEnforcement:
     )
     def test_missing_single_method_fails_at_construction(self, partial_cls, missing_method):
         assert partial_cls.__abstractmethods__ == frozenset({missing_method})
-        with pytest.raises(TypeError, match=f"abstract method '{missing_method}'"):
+        with pytest.raises(TypeError):
             partial_cls(task_id="test_task")


### PR DESCRIPTION
…hods

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - claude sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

### What

`ResumableJobMixin`'s six subclass-facing methods (`submit_job`, `get_job_status`, `is_job_active`, `is_job_succeeded`, `poll_until_complete`, `get_job_result`) are the entire contract a subclass must fulfill to get crash-safe execution. Today, if an implementer forgets to override one, the class still constructs fine and the mistake only surfaces as a `NotImplementedError` the first time that specific method is actually called, which can be much later than when the operator was defined.

### Current behaviour

A subclass missing, say, `get_job_result` instantiates without complaint. The gap is invisible until a task actually reaches that code path, which for methods like `poll_until_complete`'s reconnect branch might only happen after a real worker crash in production, long after the operator shipped.

### Proposed change

`ResumableJobMixin` now inherits from `ABC` and decorates all six methods with `@abstractmethod`. `BaseOperatorMeta` (the metaclass every `BaseOperator` subclass already uses) already inherits from `ABCMeta`, so this composes with `(ResumableJobMixin, BaseOperator)` with zero metaclass conflict.

### Why all six must be overridden

- The mixin has no reasonable default for any of them and each one is where the subclass's specific external system (Databricks, Snowflake, etc.) actually gets talked to, and `execute_resumable()`'s control flow calls all six depending on which branch it takes (fresh submit, reconnect, already-succeeded, terminal failure). 

- A subclass that's missing even one of them isn't "mostly correct", it has a hole in the exact contract this mixin exists to provide, and today that hole is silent until runtime. Marking them abstract moves the failure from "the first time this specific code path executes, maybe in production during an actual crash" to "the moment the class is defined," which is a strictly better place to catch it, a missing override bug should fail at parse/import time, not lie dormant until an operator's least-tested branch (e.g. reconnect-on-crash) finally runs for real.

### User implications / backcompat

- No behavior change for any correctly-implemented subclass such as `DatabricksSubmitRunOperator`, `DatabricksRunNowOperator`, and `SparkSubmitOperator` (all currently shipped) already override every one of the six methods, so nothing changes for them; overriding an abstract method works identically to overriding a regular one. 

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
