### PR TITLE
Fix Hive metastore partition sensor initialization

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
@@ -70,13 +70,20 @@ class MetastorePartitionSensor(SqlSensor):
         self.partition_name = partition_name
         self.table = table
         self.schema = schema
-        super().__init__(conn_id=mysql_conn_id, sql=_METASTORE_PARTITION_SQL, **kwargs)
+        _kwargs: dict[str, Any] = {"conn_id": mysql_conn_id, "sql": _METASTORE_PARTITION_SQL}
+        if kwargs:
+            _kwargs |= kwargs
+        super().__init__(**_kwargs)
 
     def poke(self, context: Context) -> Any:
-        schema = self.schema
-        table = self.table
-        if "." in table:
-            schema, table = table.split(".", maxsplit=1)
+        if "." in self.table:
+            parts = self.table.split(".")
+            if len(parts) != 2:
+                raise ValueError(f"Expected 'schema.table' format, got: {self.table!r}")
+            schema, table = parts
+        else:
+            schema, table = self.schema, self.table
+
         self.parameters = {
             "table": table,
             "schema": schema,

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py
@@ -26,6 +26,18 @@ if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
 
 
+_METASTORE_PARTITION_SQL = """
+SELECT 'X'
+FROM PARTITIONS A0
+LEFT OUTER JOIN TBLS B0 ON A0.TBL_ID = B0.TBL_ID
+LEFT OUTER JOIN DBS C0 ON B0.DB_ID = C0.DB_ID
+WHERE
+    B0.TBL_NAME = %(table)s AND
+    C0.NAME = %(schema)s AND
+    A0.PART_NAME = %(partition_name)s;
+"""
+
+
 class MetastorePartitionSensor(SqlSensor):
     """
     An alternative to the HivePartitionSensor that talk directly to the MySQL db.
@@ -43,7 +55,7 @@ class MetastorePartitionSensor(SqlSensor):
     :param mysql_conn_id: a reference to the MySQL conn_id for the metastore
     """
 
-    template_fields: Sequence[str] = ("partition_name", "table", "schema")
+    template_fields: Sequence[str] = (*SqlSensor.template_fields, "partition_name", "table", "schema")
     ui_color = "#8da7be"
 
     def __init__(
@@ -58,28 +70,16 @@ class MetastorePartitionSensor(SqlSensor):
         self.partition_name = partition_name
         self.table = table
         self.schema = schema
-        self.first_poke = True
-        self.conn_id = mysql_conn_id
-        # TODO(aoen): We shouldn't be using SqlSensor here but MetastorePartitionSensor.
-        # The problem is the way apply_defaults works isn't compatible with inheritance.
-        # The inheritance model needs to be reworked in order to support overriding args/
-        # kwargs with arguments here, then 'conn_id' and 'sql' can be passed into the
-        # constructor below and apply_defaults will no longer throw an exception.
-        super().__init__(**kwargs)
+        super().__init__(conn_id=mysql_conn_id, sql=_METASTORE_PARTITION_SQL, **kwargs)
 
     def poke(self, context: Context) -> Any:
-        if self.first_poke:
-            self.first_poke = False
-            if "." in self.table:
-                self.schema, self.table = self.table.split(".")
-            self.sql = f"""
-            SELECT 'X'
-            FROM PARTITIONS A0
-            LEFT OUTER JOIN TBLS B0 ON A0.TBL_ID = B0.TBL_ID
-            LEFT OUTER JOIN DBS C0 ON B0.DB_ID = C0.DB_ID
-            WHERE
-                B0.TBL_NAME = '{self.table}' AND
-                C0.NAME = '{self.schema}' AND
-                A0.PART_NAME = '{self.partition_name}';
-            """
+        schema = self.schema
+        table = self.table
+        if "." in table:
+            schema, table = table.split(".", maxsplit=1)
+        self.parameters = {
+            "table": table,
+            "schema": schema,
+            "partition_name": self.partition_name,
+        }
         return super().poke(context)

--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_metastore_partition.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_metastore_partition.py
@@ -27,6 +27,54 @@ from airflow.providers.apache.hive.sensors.metastore_partition import MetastoreP
 from unit.apache.hive import DEFAULT_DATE, DEFAULT_DATE_DS, MockDBConnection, TestHiveEnvironment
 
 
+@pytest.mark.parametrize(
+    ("table", "schema", "expected_parameters"),
+    [
+        (
+            "airflow.static_babynames_partitioned",
+            "default",
+            {
+                "table": "static_babynames_partitioned",
+                "schema": "airflow",
+                "partition_name": f"ds={DEFAULT_DATE_DS}",
+            },
+        ),
+        (
+            "static_babynames_partitioned",
+            "airflow",
+            {
+                "table": "static_babynames_partitioned",
+                "schema": "airflow",
+                "partition_name": f"ds={DEFAULT_DATE_DS}",
+            },
+        ),
+    ],
+)
+def test_metastore_partition_sensor_uses_documented_constructor_and_parameters(
+    table, schema, expected_parameters
+):
+    op = MetastorePartitionSensor(
+        task_id="hive_partition_check",
+        mysql_conn_id="test_connection_id",
+        table=table,
+        schema=schema,
+        partition_name=f"ds={DEFAULT_DATE_DS}",
+    )
+    hook = mock.MagicMock()
+    hook.get_records.return_value = [["test_record"]]
+    op._get_hook = mock.MagicMock(return_value=hook)
+
+    assert op.conn_id == "test_connection_id"
+    assert op.poke({}) is True
+
+    hook.get_records.assert_called_once()
+    sql, parameters = hook.get_records.call_args.args
+    assert "B0.TBL_NAME = %(table)s" in sql
+    assert "C0.NAME = %(schema)s" in sql
+    assert "A0.PART_NAME = %(partition_name)s" in sql
+    assert parameters == expected_parameters
+
+
 @pytest.mark.skipif(
     "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
 )
@@ -34,8 +82,7 @@ class TestHivePartitionSensor(TestHiveEnvironment):
     def test_hive_metastore_sql_sensor(self):
         op = MetastorePartitionSensor(
             task_id="hive_partition_check",
-            conn_id="test_connection_id",
-            sql="test_sql",
+            mysql_conn_id="test_connection_id",
             table="airflow.static_babynames_partitioned",
             partition_name=f"ds={DEFAULT_DATE_DS}",
             dag=self.dag,


### PR DESCRIPTION
## Why

`MetastorePartitionSensor` documents `mysql_conn_id` as the connection argument and is intended to generate the Hive metastore partition query internally. After inheriting from `SqlSensor`, the documented constructor path still required callers to pass the parent `conn_id` and `sql` arguments manually, so normal usage did not match the public API.

The sensor also interpolated templated table, schema, and partition values directly into the SQL string. Passing those values through SQL parameters keeps the query construction aligned with `SqlSensor` behavior.

## What

- Updated `providers/apache/hive/src/airflow/providers/apache/hive/sensors/metastore_partition.py` so `MetastorePartitionSensor` passes `mysql_conn_id` to `SqlSensor` as `conn_id` and owns the metastore partition SQL.
- Changed `poke()` to split `schema.table` input at runtime and pass `table`, `schema`, and `partition_name` through `SqlSensor.parameters`.
- Expanded `SqlSensor` template fields while preserving `partition_name`, `table`, and `schema` templating.
- Updated `providers/apache/hive/tests/unit/apache/hive/sensors/test_metastore_partition.py` to cover the documented constructor, schema/table splitting, and parameterized SQL call.
- Updated the existing Hive metastore sensor test setup to use `mysql_conn_id`.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Codex 5-5

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
