### PR TITLE
fix(providers/google): fallback to fetch Dataflow job ID by name prefix when Beam regex matches none

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -460,6 +460,15 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
         )
 
         location = self.dataflow_config.location or DEFAULT_DATAFLOW_LOCATION
+        if not self.dataflow_job_id and self.dataflow_hook and self.dataflow_job_name:
+            fetched_job_id = self.dataflow_hook.fetch_job_id_by_name(
+                job_name=self.dataflow_job_name,
+                project_id=self.dataflow_config.project_id,
+                location=location,
+            )
+            if fetched_job_id and isinstance(fetched_job_id, str):
+                self.dataflow_job_id = fetched_job_id
+
         DataflowJobLink.persist(
             context=context,
             region=self.dataflow_config.location,
@@ -655,6 +664,14 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
                 is_dataflow_job_id_exist_callback=self.is_dataflow_job_id_exist_callback,
             )
             if self.dataflow_job_name and self.dataflow_config.location:
+                if not self.dataflow_job_id and self.dataflow_hook:
+                    fetched_job_id = self.dataflow_hook.fetch_job_id_by_name(
+                        job_name=self.dataflow_job_name,
+                        project_id=self.dataflow_config.project_id,
+                        location=self.dataflow_config.location,
+                    )
+                    if fetched_job_id and isinstance(fetched_job_id, str):
+                        self.dataflow_job_id = fetched_job_id
                 DataflowJobLink.persist(
                     context=context,
                     region=self.dataflow_config.location,
@@ -823,6 +840,14 @@ class BeamRunGoPipelineOperator(BeamBasePipelineOperator):
                     variables=snake_case_pipeline_options,
                     process_line_callback=process_line_callback,
                 )
+                if not self.dataflow_job_id and dataflow_job_name and self.dataflow_config.location:
+                    fetched_job_id = self.dataflow_hook.fetch_job_id_by_name(
+                        job_name=dataflow_job_name,
+                        project_id=self.dataflow_config.project_id,
+                        location=self.dataflow_config.location,
+                    )
+                    if fetched_job_id and isinstance(fetched_job_id, str):
+                        self.dataflow_job_id = fetched_job_id
                 DataflowJobLink.persist(context=context)
                 if dataflow_job_name and self.dataflow_config.location:
                     self.dataflow_hook.wait_for_done(

--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataflow.py
@@ -1174,6 +1174,38 @@ class DataflowHook(GoogleBaseHook):
         return jobs_controller.fetch_job_by_id(job_id)
 
     @GoogleBaseHook.fallback_to_default_project_id
+    def fetch_job_id_by_name(
+        self,
+        job_name: str,
+        project_id: str = PROVIDE_PROJECT_ID,
+        location: str = DEFAULT_DATAFLOW_LOCATION,
+    ) -> str | None:
+        """
+        Fetch the job ID of the job with the specified name prefix.
+
+        :param job_name: Job name prefix to search for.
+        :param project_id: Optional, the Google Cloud project ID.
+        :param location: The location of the Dataflow job.
+        :return: the Job ID if exactly one job is found, otherwise None.
+        """
+        try:
+            jobs_controller = _DataflowJobsController(
+                dataflow=self.get_conn(),
+                project_number=project_id,
+                location=location,
+            )
+            jobs = jobs_controller._fetch_jobs_by_prefix_name(job_name)
+            if len(jobs) == 1:
+                return jobs[0]["id"]
+            if len(jobs) > 1:
+                self.log.warning("Multiple Dataflow jobs found matching prefix %s: %s", job_name, [j["name"] for j in jobs])
+            else:
+                self.log.info("No Dataflow jobs found matching prefix %s", job_name)
+        except Exception as e:
+            self.log.warning("Failed to fetch Dataflow job ID by name prefix %s: %s", job_name, e)
+        return None
+
+    @GoogleBaseHook.fallback_to_default_project_id
     def fetch_job_metrics_by_id(
         self,
         job_id: str,

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataflow.py
@@ -342,6 +342,42 @@ class TestDataflowHook:
         )
         method_wait_for_done.assert_called_once_with()
 
+    @mock.patch(DATAFLOW_STRING.format("_DataflowJobsController"))
+    @mock.patch(DATAFLOW_STRING.format("DataflowHook.get_conn"))
+    def test_fetch_job_id_by_name(self, mock_conn, mock_dataflowjob):
+        controller = mock_dataflowjob.return_value
+        controller._fetch_jobs_by_prefix_name.return_value = [{"id": "TEST_JOB_ID_123"}]
+
+        res = self.dataflow_hook.fetch_job_id_by_name(
+            job_name="JOB_NAME",
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+        )
+        mock_conn.assert_called_once()
+        mock_dataflowjob.assert_called_once_with(
+            dataflow=mock_conn.return_value,
+            project_number=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+        )
+        controller._fetch_jobs_by_prefix_name.assert_called_once_with("JOB_NAME")
+        assert res == "TEST_JOB_ID_123"
+
+    @mock.patch(DATAFLOW_STRING.format("_DataflowJobsController"))
+    @mock.patch(DATAFLOW_STRING.format("DataflowHook.get_conn"))
+    def test_fetch_job_id_by_name_multiple_jobs(self, mock_conn, mock_dataflowjob):
+        controller = mock_dataflowjob.return_value
+        controller._fetch_jobs_by_prefix_name.return_value = [
+            {"id": "TEST_JOB_ID_123", "name": "JOB_NAME_1"},
+            {"id": "TEST_JOB_ID_456", "name": "JOB_NAME_2"},
+        ]
+
+        res = self.dataflow_hook.fetch_job_id_by_name(
+            job_name="JOB_NAME",
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+        )
+        assert res is None
+
 
 @pytest.mark.db_test
 class TestDataflowTemplateHook:


### PR DESCRIPTION
### Description

When using `BeamRunPythonPipelineOperator`, `BeamRunJavaPipelineOperator`, or `BeamRunGoPipelineOperator` with the `DataflowRunner`, the operator relies on scraping the launcher's stdout log lines to extract the Dataflow Job ID (using `JOB_ID_PATTERN`). 

If logging is not configured to include INFO level (e.g., the root logger is left at the default WARNING), the SDK's INFO line indicating the created job ID is never printed to stdout. This causes the job ID extraction to fail silently, leaving `self.dataflow_job_id` as `None`.
- In non-deferrable mode, `DataflowHook.wait_for_done` falls back to prefix-based lookup and the task succeeds.
- In deferrable mode, the operator defers with `job_id=None` and fails on resume with a `400 Request must contain a job and project id` error.

This PR fixes the issue by:
1. Adding a new `fetch_job_id_by_name` method to `DataflowHook`.
2. Implementing a fallback in the Python, Java, and Go operators to resolve the `dataflow_job_id` using the hook method before calling `DataflowJobLink.persist(...)` or deferring.

### Verification

- Added unit tests `test_fetch_job_id_by_name` and `test_fetch_job_id_by_name_multiple_jobs` in `test_dataflow.py`.
- Verified that all existing unit tests in `test_beam.py` pass successfully (ensuring mock objects in tests are not assigned to the job ID by checking `isinstance(..., str)`).

Closes: #68279