### PR TITLE
Update SQLAlchemy doc link to 2.0 in config.yml

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -683,7 +683,7 @@ database:
         Check connection at the start of each connection pool checkout.
         Typically, this is a simple statement like "SELECT 1".
         See `SQLAlchemy Pooling: Disconnect Handling - Pessimistic
-        <https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic>`__
+        <https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic>`__
         for more details.
       version_added: 2.3.0
       type: boolean


### PR DESCRIPTION
### Description

Updates the remaining SQLAlchemy documentation link in `config.yml` from SQLAlchemy 1.4 (`en/14`) to SQLAlchemy 2.0 (`en/20`), matching the fact that `airflow-core` now requires SQLAlchemy 2.x.

Closes: #69164