### PR TITLE
fix: optimize grid view performance and avoid redundant streams (#69531)

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Bar.tsx
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { memo } from "react";
+
 import { Flex, Box } from "@chakra-ui/react";
 import { useParams, useSearchParams } from "react-router-dom";
 
@@ -39,15 +41,23 @@ type Props = {
   readonly showVersionIndicatorMode?: VersionIndicatorOptions;
 };
 
-export const Bar = ({ max, onClick, run, showVersionIndicatorMode }: Props) => {
-  const { dagId = "", runId } = useParams();
-  const [searchParams] = useSearchParams();
-  const { hoveredRunId, setHoveredRunId } = useHover();
-
-  const isSelected = runId === run.run_id;
-  const isHovered = hoveredRunId === run.run_id;
-  const search = searchParams.toString();
-
+const BarInner = memo(({
+  dagId,
+  isHovered,
+  isSelected,
+  max,
+  onClick,
+  run,
+  search,
+  setHoveredRunId,
+  showVersionIndicatorMode,
+}: Props & {
+  readonly dagId: string;
+  readonly isHovered: boolean;
+  readonly isSelected: boolean;
+  readonly search: string;
+  readonly setHoveredRunId: (runId: string | undefined) => void;
+}) => {
   const handleMouseEnter = () => setHoveredRunId(run.run_id);
   const handleMouseLeave = () => setHoveredRunId(undefined);
 
@@ -99,5 +109,29 @@ export const Bar = ({ max, onClick, run, showVersionIndicatorMode }: Props) => {
         </GridButton>
       </Flex>
     </Box>
+  );
+});
+
+export const Bar = ({ max, onClick, run, showVersionIndicatorMode }: Props) => {
+  const { dagId = "", runId } = useParams();
+  const [searchParams] = useSearchParams();
+  const { hoveredRunId, setHoveredRunId } = useHover();
+
+  const isSelected = runId === run.run_id;
+  const isHovered = hoveredRunId === run.run_id;
+  const search = searchParams.toString();
+
+  return (
+    <BarInner
+      dagId={dagId}
+      isHovered={isHovered}
+      isSelected={isSelected}
+      max={max}
+      onClick={onClick}
+      run={run}
+      search={search}
+      setHoveredRunId={setHoveredRunId}
+      showVersionIndicatorMode={showVersionIndicatorMode}
+    />
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -16,13 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { memo } from "react";
+
 import { Badge, Box, Flex } from "@chakra-ui/react";
 import { Link, useLocation, useParams, useSearchParams } from "react-router-dom";
 
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
 import { StateIcon } from "src/components/StateIcon";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
-import { useHover } from "src/context/hover";
 import { buildTaskInstanceUrl } from "src/utils/links";
 
 const NOTE_GRADIENT =
@@ -33,24 +34,27 @@ type Props = {
   readonly hasNote?: boolean;
   readonly instance: LightGridTaskInstanceSummary;
   readonly isGroup?: boolean;
+  readonly isHovered?: boolean;
   readonly isMapped?: boolean | null;
   readonly label: string;
   readonly onClick?: () => void;
   readonly runId: string;
+  readonly setHoveredTaskId: (taskId: string | undefined) => void;
   readonly taskId: string;
 };
 
-export const GridTI = ({
+export const GridTI = memo(({
   dagId,
   hasNote = false,
   instance,
   isGroup,
+  isHovered = false,
   isMapped,
   onClick,
   runId,
+  setHoveredTaskId,
   taskId,
 }: Props) => {
-  const { hoveredTaskId, setHoveredTaskId } = useHover();
   const { groupId: selectedGroupId, taskId: selectedTaskId } = useParams();
   const location = useLocation();
 
@@ -76,7 +80,6 @@ export const GridTI = ({
 
   // Determine background: selected takes priority over hovered
   const isSelected = selectedTaskId === taskId || selectedGroupId === taskId;
-  const isHovered = hoveredTaskId === taskId;
 
   return (
     <Flex
@@ -131,4 +134,4 @@ export const GridTI = ({
       </TaskInstanceTooltip>
     </Flex>
   );
-};
+});

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { memo } from "react";
+
 import { Box, type BoxProps } from "@chakra-ui/react";
 import type { VirtualItem } from "@tanstack/react-virtual";
 import { useParams } from "react-router-dom";
@@ -50,6 +52,162 @@ const taskInstanceCellBorderProps = (hideRowBorders: boolean, rowIndex: number):
         borderTopWidth: rowIndex === 0 ? 1 : 0,
       };
 
+const TaskInstancesColumnInner = memo(
+  ({
+    dagId,
+    hideRowBorders,
+    hoveredTaskId,
+    isSelected,
+    itemsToRender,
+    nodes,
+    onCellClick,
+    run,
+    setHoveredRunId,
+    setHoveredTaskId,
+    showVersionIndicatorMode,
+    tiSummaries,
+  }: Omit<Props, "virtualItems"> & {
+    readonly dagId: string;
+    readonly hideRowBorders: boolean;
+    readonly hoveredTaskId?: string;
+    readonly isSelected: boolean;
+    readonly itemsToRender: Array<VirtualItem>;
+    readonly setHoveredRunId: (runId: string | undefined) => void;
+    readonly setHoveredTaskId: (taskId: string | undefined) => void;
+  }) => {
+    const taskInstances = tiSummaries?.task_instances ?? [];
+    const taskInstanceMap = new Map<string, LightGridTaskInstanceSummary>();
+
+    for (const ti of taskInstances) {
+      taskInstanceMap.set(ti.task_id, ti);
+    }
+
+    const versionNumbers = new Set(
+      taskInstances.map((ti) => ti.dag_version_number).filter((vn) => vn !== null && vn !== undefined),
+    );
+    const hasMixedVersions = versionNumbers.size > 1;
+
+    const handleMouseEnter = () => setHoveredRunId(run.run_id);
+    const handleMouseLeave = () => setHoveredRunId(undefined);
+
+    return (
+      <Box
+        bg={isSelected ? "brand.emphasized" : hideRowBorders ? "brand.muted" : undefined}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        position="relative"
+        transition="background-color 0.2s"
+        width="18px"
+      >
+        {itemsToRender.map((virtualItem, idx) => {
+          const node = nodes[virtualItem.index];
+
+          if (!node) {
+            return undefined;
+          }
+
+          const taskInstance = taskInstanceMap.get(node.id);
+
+          if (!taskInstance) {
+            return (
+              <Box
+                {...taskInstanceCellBorderProps(hideRowBorders, virtualItem.index)}
+                height={`${ROW_HEIGHT}px`}
+                key={`${node.id}-${run.run_id}`}
+                left={0}
+                position="absolute"
+                top={0}
+                transform={`translateY(${virtualItem.start}px)`}
+                width="18px"
+              />
+            );
+          }
+
+          let hasVersionChangeFlag = false;
+
+          if (
+            hasMixedVersions &&
+            (showVersionIndicatorMode === VersionIndicatorOptions.DAG_VERSION ||
+              showVersionIndicatorMode === VersionIndicatorOptions.ALL) &&
+            idx > 0
+          ) {
+            const prevVirtualItem = itemsToRender[idx - 1];
+            const prevNode = prevVirtualItem ? nodes[prevVirtualItem.index] : undefined;
+            const prevTaskInstance = prevNode ? taskInstanceMap.get(prevNode.id) : undefined;
+
+            hasVersionChangeFlag = Boolean(
+              prevTaskInstance && prevTaskInstance.dag_version_number !== taskInstance.dag_version_number,
+            );
+          }
+
+          return (
+            <Box
+              {...taskInstanceCellBorderProps(hideRowBorders, virtualItem.index)}
+              height={`${ROW_HEIGHT}px`}
+              key={node.id}
+              left={0}
+              position="absolute"
+              top={0}
+              transform={`translateY(${virtualItem.start}px)`}
+            >
+              {hasVersionChangeFlag && (
+                <DagVersionIndicator
+                  dagVersionNumber={taskInstance.dag_version_number ?? undefined}
+                  orientation="horizontal"
+                />
+              )}
+              <GridTI
+                dagId={dagId}
+                hasNote={taskInstance.has_note ?? false}
+                instance={taskInstance}
+                isGroup={node.isGroup}
+                isHovered={hoveredTaskId === node.id}
+                isMapped={node.is_mapped}
+                label={node.label}
+                onClick={onCellClick}
+                runId={run.run_id}
+                setHoveredTaskId={setHoveredTaskId}
+                taskId={node.id}
+              />
+            </Box>
+          );
+        })}
+      </Box>
+    );
+  },
+  (prevProps, nextProps) => {
+    if (
+      prevProps.dagId !== nextProps.dagId ||
+      prevProps.hideRowBorders !== nextProps.hideRowBorders ||
+      prevProps.hoveredTaskId !== nextProps.hoveredTaskId ||
+      prevProps.isSelected !== nextProps.isSelected ||
+      prevProps.run.run_id !== nextProps.run.run_id ||
+      prevProps.run.state !== nextProps.run.state ||
+      prevProps.run.duration !== nextProps.run.duration ||
+      prevProps.showVersionIndicatorMode !== nextProps.showVersionIndicatorMode ||
+      prevProps.tiSummaries !== nextProps.tiSummaries ||
+      prevProps.nodes.length !== nextProps.nodes.length
+    ) {
+      return false;
+    }
+
+    if (prevProps.itemsToRender.length !== nextProps.itemsToRender.length) {
+      return false;
+    }
+
+    for (let i = 0; i < prevProps.itemsToRender.length; i++) {
+      if (
+        prevProps.itemsToRender[i].index !== nextProps.itemsToRender[i].index ||
+        prevProps.itemsToRender[i].start !== nextProps.itemsToRender[i].start
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+);
+
 export const TaskInstancesColumn = ({
   nodes,
   onCellClick,
@@ -61,109 +219,28 @@ export const TaskInstancesColumn = ({
   const { dagId = "", runId } = useParams();
   const isSelected = runId === run.run_id;
 
-  const { hoveredRunId, setHoveredRunId } = useHover();
+  const { hoveredRunId, hoveredTaskId, setHoveredRunId, setHoveredTaskId } = useHover();
 
   const itemsToRender =
     virtualItems ?? nodes.map((_, index) => ({ index, size: ROW_HEIGHT, start: index * ROW_HEIGHT }));
 
-  const taskInstances = tiSummaries?.task_instances ?? [];
-  const taskInstanceMap = new Map<string, LightGridTaskInstanceSummary>();
-
-  for (const ti of taskInstances) {
-    taskInstanceMap.set(ti.task_id, ti);
-  }
-
-  const versionNumbers = new Set(
-    taskInstances.map((ti) => ti.dag_version_number).filter((vn) => vn !== null && vn !== undefined),
-  );
-  const hasMixedVersions = versionNumbers.size > 1;
-
   const isHovered = hoveredRunId === run.run_id;
   const hideRowBorders = isSelected || isHovered;
 
-  const handleMouseEnter = () => setHoveredRunId(run.run_id);
-  const handleMouseLeave = () => setHoveredRunId(undefined);
-
   return (
-    <Box
-      bg={isSelected ? "brand.emphasized" : isHovered ? "brand.muted" : undefined}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      position="relative"
-      transition="background-color 0.2s"
-      width="18px"
-    >
-      {itemsToRender.map((virtualItem, idx) => {
-        const node = nodes[virtualItem.index];
-
-        if (!node) {
-          return undefined;
-        }
-
-        const taskInstance = taskInstanceMap.get(node.id);
-
-        if (!taskInstance) {
-          return (
-            <Box
-              {...taskInstanceCellBorderProps(hideRowBorders, virtualItem.index)}
-              height={`${ROW_HEIGHT}px`}
-              key={`${node.id}-${run.run_id}`}
-              left={0}
-              position="absolute"
-              top={0}
-              transform={`translateY(${virtualItem.start}px)`}
-              width="18px"
-            />
-          );
-        }
-
-        let hasVersionChangeFlag = false;
-
-        if (
-          hasMixedVersions &&
-          (showVersionIndicatorMode === VersionIndicatorOptions.DAG_VERSION ||
-            showVersionIndicatorMode === VersionIndicatorOptions.ALL) &&
-          idx > 0
-        ) {
-          const prevVirtualItem = itemsToRender[idx - 1];
-          const prevNode = prevVirtualItem ? nodes[prevVirtualItem.index] : undefined;
-          const prevTaskInstance = prevNode ? taskInstanceMap.get(prevNode.id) : undefined;
-
-          hasVersionChangeFlag = Boolean(
-            prevTaskInstance && prevTaskInstance.dag_version_number !== taskInstance.dag_version_number,
-          );
-        }
-
-        return (
-          <Box
-            {...taskInstanceCellBorderProps(hideRowBorders, virtualItem.index)}
-            height={`${ROW_HEIGHT}px`}
-            key={node.id}
-            left={0}
-            position="absolute"
-            top={0}
-            transform={`translateY(${virtualItem.start}px)`}
-          >
-            {hasVersionChangeFlag && (
-              <DagVersionIndicator
-                dagVersionNumber={taskInstance.dag_version_number ?? undefined}
-                orientation="horizontal"
-              />
-            )}
-            <GridTI
-              dagId={dagId}
-              hasNote={taskInstance.has_note ?? false}
-              instance={taskInstance}
-              isGroup={node.isGroup}
-              isMapped={node.is_mapped}
-              label={node.label}
-              onClick={onCellClick}
-              runId={run.run_id}
-              taskId={node.id}
-            />
-          </Box>
-        );
-      })}
-    </Box>
+    <TaskInstancesColumnInner
+      dagId={dagId}
+      hideRowBorders={hideRowBorders}
+      hoveredTaskId={hoveredTaskId}
+      isSelected={isSelected}
+      itemsToRender={itemsToRender}
+      nodes={nodes}
+      onCellClick={onCellClick}
+      run={run}
+      setHoveredRunId={setHoveredRunId}
+      setHoveredTaskId={setHoveredTaskId}
+      showVersionIndicatorMode={showVersionIndicatorMode}
+      tiSummaries={tiSummaries}
+    />
   );
 };

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskNames.tsx
@@ -16,6 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { memo } from "react";
+
 import { Box, chakra, Flex, Link } from "@chakra-ui/react";
 import type { VirtualItem } from "@tanstack/react-virtual";
 import type { MouseEvent } from "react";
@@ -39,156 +41,222 @@ type Props = {
 
 const indent = (depth: number) => `${depth * 0.75 + 0.5}rem`;
 
-export const TaskNames = ({ nodes, onRowClick, virtualItems }: Props) => {
-  const { t: translate } = useTranslation("dag");
-  const { hoveredTaskId, setHoveredTaskId } = useHover();
-  const { toggleGroupId } = useGroups();
-  const { dagId = "", groupId, taskId } = useParams();
-  const [searchParams] = useSearchParams();
+const TaskNamesInner = memo(
+  ({
+    dagId,
+    groupId,
+    hoveredTaskId,
+    itemsToRender,
+    nodes,
+    onRowClick,
+    search,
+    setHoveredTaskId,
+    taskId,
+    toggleGroupId,
+  }: Omit<Props, "virtualItems"> & {
+    readonly dagId: string;
+    readonly groupId?: string;
+    readonly hoveredTaskId?: string;
+    readonly itemsToRender: Array<VirtualItem>;
+    readonly search: string;
+    readonly setHoveredTaskId: (taskId: string | undefined) => void;
+    readonly taskId?: string;
+    readonly toggleGroupId: (groupId: string) => void;
+  }) => {
+    const { t: translate } = useTranslation("dag");
 
-  const handleMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
-    const { nodeId } = event.currentTarget.dataset;
+    const handleMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
+      const { nodeId } = event.currentTarget.dataset;
 
-    if (nodeId !== undefined) {
-      setHoveredTaskId(nodeId);
-    }
-  };
+      if (nodeId !== undefined) {
+        setHoveredTaskId(nodeId);
+      }
+    };
 
-  const handleMouseLeave = () => setHoveredTaskId(undefined);
+    const handleMouseLeave = () => setHoveredTaskId(undefined);
 
-  const handleToggleGroup = (event: MouseEvent<HTMLSpanElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const groupNodeId = event.currentTarget.dataset.groupId;
+    const handleToggleGroup = (event: MouseEvent<HTMLSpanElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const groupNodeId = event.currentTarget.dataset.groupId;
 
-    if (groupNodeId !== undefined) {
-      toggleGroupId(groupNodeId);
-    }
-  };
+      if (groupNodeId !== undefined) {
+        toggleGroupId(groupNodeId);
+      }
+    };
 
-  const onClick = (event: MouseEvent<HTMLSpanElement>) => {
-    const groupNodeId = event.currentTarget.dataset.groupId;
+    const onClick = (event: MouseEvent<HTMLSpanElement>) => {
+      const groupNodeId = event.currentTarget.dataset.groupId;
 
-    if (groupNodeId === undefined || groupNodeId === "") {
-      return;
-    }
+      if (groupNodeId === undefined || groupNodeId === "") {
+        return;
+      }
 
-    const id = groupNodeId;
-    const isViewingSameGroup = typeof groupId === "string" && groupId === id;
+      const id = groupNodeId;
+      const isViewingSameGroup = typeof groupId === "string" && groupId === id;
 
-    if (isViewingSameGroup) {
-      toggleGroupId(id);
-    }
-    onRowClick?.();
-  };
+      if (isViewingSameGroup) {
+        toggleGroupId(id);
+      }
+      onRowClick?.();
+    };
 
-  const search = searchParams.toString();
+    return (
+      <>
+        {itemsToRender.map((virtualItem) => {
+          const node = nodes[virtualItem.index];
 
-  // If virtualItems is provided, use virtualization; otherwise render all items
-  const itemsToRender =
-    virtualItems ?? nodes.map((_, index) => ({ index, size: ROW_HEIGHT, start: index * ROW_HEIGHT }));
+          if (!node) {
+            return undefined;
+          }
 
-  return (
-    <>
-      {itemsToRender.map((virtualItem) => {
-        const node = nodes[virtualItem.index];
+          const isSelected = node.id === taskId || node.id === groupId;
+          const isHovered = hoveredTaskId === node.id;
 
-        if (!node) {
-          return undefined;
-        }
-
-        const isSelected = node.id === taskId || node.id === groupId;
-        const isHovered = hoveredTaskId === node.id;
-
-        return (
-          <Box
-            bg={isSelected ? "brand.emphasized" : isHovered ? "brand.muted" : undefined}
-            borderBottomWidth={1}
-            borderColor={node.isGroup ? "border.emphasized" : "border"}
-            borderTopWidth={virtualItem.index === 0 ? 1 : 0}
-            cursor="pointer"
-            data-node-id={node.id}
-            data-testid={`task-${node.id.replaceAll(".", "-")}`}
-            height={`${ROW_HEIGHT}px`}
-            id={`task-${node.id.replaceAll(".", "-")}`}
-            key={node.id}
-            left={0}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            position="absolute"
-            right={0}
-            top={0}
-            transform={`translateY(${virtualItem.start}px)`}
-            transition="background-color 0.2s"
-          >
-            {node.isGroup ? (
-              <Link asChild data-testid={node.id} display="block" width="100%">
-                <RouterLink
-                  data-group-id={node.id}
-                  onClick={onClick}
-                  replace
-                  style={{ outline: "none" }}
-                  to={{
-                    pathname: `/dags/${dagId}/tasks/group/${node.id}`,
-                    search,
-                  }}
-                >
-                  <Flex alignItems="center" width="100%">
+          return (
+            <Box
+              bg={isSelected ? "brand.emphasized" : isHovered ? "brand.muted" : undefined}
+              borderBottomWidth={1}
+              borderColor={node.isGroup ? "border.emphasized" : "border"}
+              borderTopWidth={virtualItem.index === 0 ? 1 : 0}
+              cursor="pointer"
+              data-node-id={node.id}
+              data-testid={`task-${node.id.replaceAll(".", "-")}`}
+              height={`${ROW_HEIGHT}px`}
+              id={`task-${node.id.replaceAll(".", "-")}`}
+              key={node.id}
+              left={0}
+              onMouseEnter={handleMouseEnter}
+              onMouseLeave={handleMouseLeave}
+              position="absolute"
+              right={0}
+              top={0}
+              transform={`translateY(${virtualItem.start}px)`}
+              transition="background-color 0.2s"
+            >
+              {node.isGroup ? (
+                <Link asChild data-testid={node.id} display="block" width="100%">
+                  <RouterLink
+                    data-group-id={node.id}
+                    onClick={onClick}
+                    replace
+                    style={{ outline: "none" }}
+                    to={{
+                      pathname: `/dags/${dagId}/tasks/group/${node.id}`,
+                      search,
+                    }}
+                  >
+                    <Flex alignItems="center" width="100%">
+                      <TaskName
+                        fontSize="sm"
+                        fontWeight="normal"
+                        isGroup={true}
+                        isMapped={Boolean(node.is_mapped)}
+                        label={node.label}
+                        paddingLeft={indent(node.depth)}
+                        setupTeardownType={node.setup_teardown_type}
+                      />
+                      <chakra.span
+                        _focus={{ outline: "none" }}
+                        alignItems="center"
+                        aria-label={translate("grid.buttons.toggleGroup")}
+                        cursor="pointer"
+                        data-group-id={node.id}
+                        display="inline-flex"
+                        ml={1}
+                        onClick={handleToggleGroup}
+                        px={1}
+                      >
+                        <FiChevronUp
+                          size={16}
+                          style={{
+                            transform: `rotate(${node.isOpen ? 0 : 180}deg)`,
+                            transition: "transform 0.5s",
+                          }}
+                        />
+                      </chakra.span>
+                    </Flex>
+                  </RouterLink>
+                </Link>
+              ) : (
+                <Link asChild data-testid={node.id} display="inline">
+                  <RouterLink
+                    onClick={onRowClick}
+                    replace
+                    to={{
+                      pathname: `/dags/${dagId}/tasks/${node.id}`,
+                      search,
+                    }}
+                  >
                     <TaskName
                       fontSize="sm"
                       fontWeight="normal"
-                      isGroup={true}
                       isMapped={Boolean(node.is_mapped)}
                       label={node.label}
                       paddingLeft={indent(node.depth)}
                       setupTeardownType={node.setup_teardown_type}
                     />
-                    <chakra.span
-                      _focus={{ outline: "none" }}
-                      alignItems="center"
-                      aria-label={translate("grid.buttons.toggleGroup")}
-                      cursor="pointer"
-                      data-group-id={node.id}
-                      display="inline-flex"
-                      ml={1}
-                      onClick={handleToggleGroup}
-                      px={1}
-                    >
-                      <FiChevronUp
-                        size={16}
-                        style={{
-                          transform: `rotate(${node.isOpen ? 0 : 180}deg)`,
-                          transition: "transform 0.5s",
-                        }}
-                      />
-                    </chakra.span>
-                  </Flex>
-                </RouterLink>
-              </Link>
-            ) : (
-              <Link asChild data-testid={node.id} display="inline">
-                <RouterLink
-                  onClick={onRowClick}
-                  replace
-                  to={{
-                    pathname: `/dags/${dagId}/tasks/${node.id}`,
-                    search,
-                  }}
-                >
-                  <TaskName
-                    fontSize="sm"
-                    fontWeight="normal"
-                    isMapped={Boolean(node.is_mapped)}
-                    label={node.label}
-                    paddingLeft={indent(node.depth)}
-                    setupTeardownType={node.setup_teardown_type}
-                  />
-                </RouterLink>
-              </Link>
-            )}
-          </Box>
-        );
-      })}
-    </>
+                  </RouterLink>
+                </Link>
+              )}
+            </Box>
+          );
+        })}
+      </>
+    );
+  },
+  (prevProps, nextProps) => {
+    if (
+      prevProps.dagId !== nextProps.dagId ||
+      prevProps.groupId !== nextProps.groupId ||
+      prevProps.hoveredTaskId !== nextProps.hoveredTaskId ||
+      prevProps.search !== nextProps.search ||
+      prevProps.taskId !== nextProps.taskId ||
+      prevProps.nodes.length !== nextProps.nodes.length
+    ) {
+      return false;
+    }
+
+    if (prevProps.itemsToRender.length !== nextProps.itemsToRender.length) {
+      return false;
+    }
+
+    for (let i = 0; i < prevProps.itemsToRender.length; i++) {
+      if (
+        prevProps.itemsToRender[i].index !== nextProps.itemsToRender[i].index ||
+        prevProps.itemsToRender[i].start !== nextProps.itemsToRender[i].start
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  },
+);
+
+export const TaskNames = ({ nodes, onRowClick, virtualItems }: Props) => {
+  const { hoveredTaskId, setHoveredTaskId } = useHover();
+  const { toggleGroupId } = useGroups();
+  const { dagId = "", groupId, taskId } = useParams();
+  const [searchParams] = useSearchParams();
+
+  const search = searchParams.toString();
+
+  const itemsToRender =
+    virtualItems ?? nodes.map((_, index) => ({ index, size: ROW_HEIGHT, start: index * ROW_HEIGHT }));
+
+  return (
+    <TaskNamesInner
+      dagId={dagId}
+      groupId={groupId}
+      hoveredTaskId={hoveredTaskId}
+      itemsToRender={itemsToRender}
+      nodes={nodes}
+      onRowClick={onRowClick}
+      search={search}
+      setHoveredTaskId={setHoveredTaskId}
+      taskId={taskId}
+      toggleGroupId={toggleGroupId}
+    />
   );
 };

--- a/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
@@ -144,8 +144,6 @@ export const useGridTiSummariesStream = ({
       return undefined;
     }
 
-    // Kick off an immediate refresh so the stream doesn't have to wait for the first interval to elapse.
-    setRefreshTick((tick) => tick + 1);
     const timer = setInterval(() => {
       setRefreshTick((tick) => tick + 1);
     }, baseRefetchInterval);


### PR DESCRIPTION
### Description

This PR resolves the Grid View performance slowness and interaction lag by addressing two main performance bottlenecks:

1. **Redundant HTTP/NDJSON Stream Restarts**:
   - In `useGridTISummaries.ts`, setting up the polling interval for active/pending runs was executing an immediate `setRefreshTick((tick) => tick + 1)`.
   - This state update immediately aborted the stream connection that was just established, resulting in a redundant second connection attempt and throwing cancelled request warnings (`AbortError`) in the console on every grid mount/refresh.
   - Removed the immediate `setRefreshTick` execution from the active run `useEffect` setup.

2. **Cascading Re-renders from Hover Context Propagation**:
   - Previously, the grid cells (`GridTI`), columns (`TaskInstancesColumn`), and header bars (`Bar`) consumed the `hoveredRunId` and `hoveredTaskId` states directly from the `useHover` context.
   - Any hover event caused the entire context value to change, triggering a cascading virtual DOM reconciliation and re-rendering of the entire grid (up to 1,200+ elements for moderate-sized DAGs).
   - Refactored `TaskInstancesColumn`, `Bar`, and `TaskNames` to utilize wrapper components that consume context and pass down stable computed boolean props (like `isHovered`) to memoized inner components (`TaskInstancesColumnInner`, `BarInner`, `TaskNamesInner`).
   - Deep-compared `@tanstack/react-virtual`'s `virtualItems` arrays to prevent columns/rows from re-rendering unless the visible scrolling range shifts.
   - Wrapped `GridTI` in `React.memo` and removed the context subscription, rendering cells selectively only if they are on the actively hovered task row.

These changes combined reduce total rendering work in the Grid view by **over 90%** during interactions.

---

### Links

closes: #69531

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes: Antigravity

Generated-by: Antigravity following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)