### PR TITLE
[v3-3-test] Remove redundant session.commit() calls in FastAPI route handlers

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -136,7 +136,6 @@ def pause_backfill(backfill_id: NonNegativeInt, session: SessionDep) -> Backfill
         raise HTTPException(status.HTTP_409_CONFLICT, "Backfill is already completed.")
     if b.is_paused is False:
         b.is_paused = True
-    session.commit()
     return b
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -243,8 +243,6 @@ def update_hitl_detail(
             task_instance=locked_ti,
             session=session,
         )
-
-    session.commit()
     return HITLDetailResponse.model_validate(hitl_detail_model)
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/hitl.py
@@ -131,7 +131,6 @@ def update_hitl_detail(
     hitl_detail_model.chosen_options = payload.chosen_options
     hitl_detail_model.params_input = payload.params_input
     session.add(hitl_detail_model)
-    session.commit()
     return HITLDetailResponse.from_hitl_detail_orm(hitl_detail_model)
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -481,5 +481,4 @@ def delete_xcom(
         XComModel.map_index == map_index,
     )
     session.execute(query)
-    session.commit()
     return {"message": f"XCom with key: {key} successfully deleted."}


### PR DESCRIPTION
Backport of #69495 to `v3-3-test`.

Cherry-picked from 5e23c6a0cc8d5d3ca9d329b7b3e4c3c87deee2e1.

Clean cherry-pick, no conflicts.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)