### PR TITLE
Fix more Java SDK build edge cases

### DIFF
--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -419,14 +419,14 @@ manager, before sending the vote — should run against the source package in
    ```bash
    cd apache-airflow-java-sdk-<VERSION>
    gradle wrapper \
-       --gradle-version <GRADLE-VERSION> \
+       --gradle-distribution-url <GRADLE-DISTRIBUTION-URL> \
        --gradle-distribution-sha256-sum <GRADLE-DISTRIBUTION-SHA>
    ./gradlew build
    ```
 
-   Use the values for `<GRADLE-VERSION>` and `<GRADLE-DISTRIBUTION-SHA>` from
-   `distributionUrl` and `distributionSha256Sum` in the bundled
-   `gradle/wrapper/gradle-wrapper.properties`.
+   Use values from `distributionUrl` and `distributionSha256Sum` in the bundled
+   `gradle/wrapper/gradle-wrapper.properties` to fill in
+   `<GRADLE-DISTRIBUTION-URL>` and `<GRADLE-DISTRIBUTION-SHA>`.
 
 6. **Staged-binary smoke test.** Resolve the staged Nexus artifacts from a
    throwaway project to confirm they're actually consumable, following the

--- a/java-sdk/bom/build.gradle.kts
+++ b/java-sdk/bom/build.gradle.kts
@@ -78,9 +78,13 @@ val publishedArtifacts =
 val verifyBomCoverage by tasks.registering {
     group = "verification"
     description = "Fail if airflow-sdk-bom does not constrain the same set of published Java SDK artifacts."
+
+    // Capture early to keep compatibility to the Gradle configuration cache.
+    val published = publishedArtifacts
+    val bom = bomArtifacts
     doLast {
-        val missing = (publishedArtifacts - bomArtifacts).sorted()
-        val stale = (bomArtifacts - publishedArtifacts).sorted()
+        val missing = (published - bom).sorted()
+        val stale = (bom - published).sorted()
         if (missing.isNotEmpty() || stale.isNotEmpty()) {
             throw GradleException(
                 buildString {

--- a/java-sdk/buildSrc/build.gradle.kts
+++ b/java-sdk/buildSrc/build.gradle.kts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     `kotlin-dsl`
 }
@@ -25,6 +27,15 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+// Pin Java and Kotlin bytecode targets so they stay aligned to avoid warning on
+// misaligned Java and Kotlin target versions. (This is for the build logic and
+// unrelated to the Java 11 target set in the SDK modules.)
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0")

--- a/java-sdk/sdk/build.gradle.kts
+++ b/java-sdk/sdk/build.gradle.kts
@@ -39,6 +39,7 @@ val schemaBaseUrl = "https://airflow.staged.apache.org/schemas/supervisor-schema
 val schemaInput = layout.projectDirectory.file("schema/schema.json")
 val pointersDir = layout.buildDirectory.dir("schema-pointers/main")
 val jsonSchemaPackage = "org.apache.airflow.sdk.execution.comm"
+val schemaModelsDir = layout.buildDirectory.dir("generate-resources/main/src/main/java")
 val discriminatorDir = layout.buildDirectory.dir("generated-resources/main/src/main/kotlin")
 
 dependencies {
@@ -241,11 +242,7 @@ val javadocJar by tasks.registering(Jar::class) {
 jsonSchema2Pojo {
     setSource(listOf(pointersDir.get().asFile))
     targetPackage = jsonSchemaPackage
-    targetDirectory =
-        layout.buildDirectory
-            .dir("generate-resources/main/src/main/java")
-            .get()
-            .asFile
+    targetDirectory = schemaModelsDir.get().asFile
     setAnnotationStyle("jackson")
     dateTimeType = "java.time.OffsetDateTime"
     generateBuilders = false
@@ -261,8 +258,8 @@ jsonSchema2Pojo {
 
 sourceSets {
     main {
-        java.srcDir(layout.buildDirectory.dir("generate-resources/main/src/main/java"))
-        kotlin.srcDir(discriminatorDir)
+        java.srcDir(tasks.named("generateJsonSchema2Pojo").map { schemaModelsDir })
+        kotlin.srcDir(tasks.named("generateDiscriminator").map { discriminatorDir })
     }
 }
 
@@ -286,16 +283,8 @@ tasks.named("generateJsonSchema2Pojo") {
     dependsOn("generatePointers")
 }
 
-tasks.named("compileJava") {
-    dependsOn("generateJsonSchema2Pojo")
-}
-
 tasks.named("compileKotlin") {
-    dependsOn("generateJsonSchema2Pojo", "generateDiscriminator")
-}
-
-tasks.named("runKtlintCheckOverMainSourceSet") {
-    dependsOn("generateJsonSchema2Pojo", "generateDiscriminator")
+    dependsOn("generateJsonSchema2Pojo")
 }
 
 tasks.matching { it.name.startsWith("dokkaGenerate") }.configureEach {


### PR DESCRIPTION
See individual commit messages for reasons of each change. Identified issues:

1. The verifyBomCoverage task was not compatible with Gradle configuration cache.
2. When doing incremental builds, subprojects depending on sdk (log handlers) may fail due to incorrect Gradle task dependency setup.
3. Warnings on JVM version mismatch when regenerating the Gradle wrapper on a clean machine without Internet (so foojay does not kick in automatically).

None of them are critical, although arguably the first is blocking since it changes the verification commands, and in turn change the source artifact's hash because those commands are included in the README file. Anyway, let’s get them fixed for RC3.

I also slightly edited the Gradle wrapper generation instruction to make it easier to use (you can now just copy the URL directly instead of extracting the version from it.)