### PR TITLE
Convert exception dict back to pretty stack trace in supervisor

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2311,6 +2311,45 @@ def length_prefixed_frame_reader(
     return cb, on_close
 
 
+def _format_exception_dict(exc_dict: list[dict[str, Any]] | Any) -> str | Any:
+    """
+    Format a structlog exception dictionary back into a pretty stack trace.
+    If the input is not a list of dicts, it is returned as-is.
+    """
+    if not isinstance(exc_dict, list):
+        return exc_dict
+
+    formatted_exceptions = []
+
+    for i, exc in enumerate(exc_dict):
+        if not isinstance(exc, dict):
+            return exc_dict  # Fallback if structure isn't what we expect
+
+        exc_type = exc.get("exc_type", "Exception")
+        exc_value = exc.get("exc_value", "")
+        frames = exc.get("frames", [])
+
+        lines = []
+        if i > 0:
+            if exc.get("is_cause"):
+                lines.append("\nThe above exception was the direct cause of the following exception:\n")
+            elif exc.get("is_context"):
+                lines.append("\nDuring handling of the above exception, another exception occurred:\n")
+
+        lines.append("Traceback (most recent call last):")
+        for frame in frames:
+            lines.append(
+                f'  File "{frame.get("filename", "")}", line {frame.get("lineno", "")}, in {frame.get("name", "")}'
+            )
+            if "line" in frame and frame["line"]:
+                lines.append(f'    {frame["line"]}')
+
+        lines.append(f"{exc_type}: {exc_value}")
+        formatted_exceptions.append("\n".join(lines))
+
+    return "\n".join(formatted_exceptions)
+
+
 def process_log_messages_from_subprocess(
     loggers: tuple[FilteringBoundLogger, ...],
 ) -> Generator[None, bytes | bytearray, None]:
@@ -2344,8 +2383,7 @@ def process_log_messages_from_subprocess(
             event["timestamp"] = msgspec.json.decode(f'"{ts}"', type=datetime)
 
         if exc := event.pop("exception", None):
-            # TODO: convert the dict back to a pretty stack trace
-            event["error_detail"] = exc
+            event["error_detail"] = _format_exception_dict(exc)
 
         if level := NAME_TO_LEVEL.get(event.pop("level")):
             msg = event.pop("event", None)


### PR DESCRIPTION
### Description
In `task-sdk/src/airflow/sdk/execution_time/supervisor.py`, exception details from the task runner subprocess were being passed as a dictionary via the log event from `structlog`. An existing `TODO` comment indicated that this dictionary should be converted back into a pretty stack trace before being assigned to the `error_detail` field. Because it was left as a raw dictionary, it prevented operators from natively viewing readable stack traces in the logs.

This PR resolves the `TODO` by adding a private formatting utility function (`_format_exception_dict`) that correctly handles the `structlog` exception dictionary format (similar to what was recently done for the Triggerer). It safely iterates over the parsed exception dictionaries and reconstructs standard Python stack traces (including nested `__cause__` and `__context__` chains). The raw dictionary is now seamlessly parsed back into a human-readable traceback string before being logged.

<!-- Note: If you opened an issue for this, you can add "closes: #ISSUE" here -->

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Antigravity

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=b8f0cc7 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @KushagraB424** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
