### PR TITLE
Cancel the Redshift statement when a user kills the deferred task

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/redshift_data.py
@@ -61,6 +61,9 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
     :param session_id: the session identifier of the query
     :param session_keep_alive_seconds: duration in seconds to keep the session alive after the query
         finishes. The maximum time a session can keep alive is 24 hours
+    :param cancel_on_kill: If True (default), cancel the running Redshift statement when the task is
+        killed. This applies both while the operator is running and, for a deferred task, while it
+        waits in the triggerer.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         If this is ``None`` or empty then the default boto3 behaviour is used. If
         running Airflow in a distributed manner and aws_conn_id is None or
@@ -104,6 +107,7 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         session_id: str | None = None,
         session_keep_alive_seconds: int | None = None,
+        cancel_on_kill: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -125,6 +129,7 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
         self.deferrable = deferrable
         self.session_id = session_id
         self.session_keep_alive_seconds = session_keep_alive_seconds
+        self.cancel_on_kill = cancel_on_kill
 
     def execute(self, context: Context) -> list[GetStatementResultResponseTypeDef] | list[str]:
         """Execute a statement against Amazon Redshift."""
@@ -170,6 +175,7 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
                         region_name=self.region_name,
                         verify=self.verify,
                         botocore_config=self.botocore_config,
+                        cancel_on_kill=self.cancel_on_kill,
                     ),
                     method_name="execute_complete",
                 )
@@ -224,6 +230,8 @@ class RedshiftDataOperator(AwsBaseOperator[RedshiftDataHook]):
 
     def on_kill(self) -> None:
         """Cancel the submitted redshift query."""
+        if not self.cancel_on_kill:
+            return
         if hasattr(self, "statement_id"):
             self.log.info("Received a kill signal.")
             self.log.info("Stopping Query with statementId - %s", self.statement_id)

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/redshift_data.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/redshift_data.py
@@ -41,6 +41,9 @@ class RedshiftDataTrigger(BaseTrigger):
     :param poll_interval:  polling period in seconds to check for the status
     :param aws_conn_id: AWS connection ID for redshift
     :param region_name: aws region to use
+    :param cancel_on_kill: If True (default), cancel the running Redshift statement when the user
+        kills the deferred task (mark failed, clear, or mark success). Requires a version of
+        ``apache-airflow`` with ``BaseTrigger.on_kill()`` support; on older versions it is inert.
     """
 
     def __init__(
@@ -52,6 +55,7 @@ class RedshiftDataTrigger(BaseTrigger):
         region_name: str | None = None,
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
+        cancel_on_kill: bool = True,
     ):
         super().__init__()
         self.statement_id = statement_id
@@ -62,6 +66,7 @@ class RedshiftDataTrigger(BaseTrigger):
         self.region_name = region_name
         self.verify = verify
         self.botocore_config = botocore_config
+        self.cancel_on_kill = cancel_on_kill
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         """Serialize RedshiftDataTrigger arguments and classpath."""
@@ -75,6 +80,7 @@ class RedshiftDataTrigger(BaseTrigger):
                 "region_name": self.region_name,
                 "verify": self.verify,
                 "botocore_config": self.botocore_config,
+                "cancel_on_kill": self.cancel_on_kill,
             },
         )
 
@@ -86,6 +92,21 @@ class RedshiftDataTrigger(BaseTrigger):
             verify=self.verify,
             config=self.botocore_config,
         )
+
+    async def on_kill(self) -> None:
+        """Cancel the running Redshift statement when the user kills the deferred task."""
+        if not self.cancel_on_kill or not self.statement_id:
+            return
+        self.log.info("Cancelling Redshift statement %s.", self.statement_id)
+        try:
+            async with await self.hook.get_async_conn() as client:
+                await client.cancel_statement(Id=self.statement_id)
+            self.log.info("Redshift statement %s cancelled.", self.statement_id)
+        except Exception:
+            self.log.exception(
+                "Failed to cancel Redshift statement %s. The query may still be running.",
+                self.statement_id,
+            )
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
         try:

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_redshift_data.py
@@ -278,6 +278,23 @@ class TestRedshiftDataOperator:
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
+    def test_on_kill_respects_cancel_on_kill_false(self, mock_conn):
+        mock_conn.execute_statement.return_value = {"Id": STATEMENT_ID, "SessionId": SESSION_ID}
+        operator = RedshiftDataOperator(
+            aws_conn_id=CONN_ID,
+            task_id=TASK_ID,
+            cluster_identifier="cluster_identifier",
+            sql=SQL,
+            database=DATABASE,
+            wait_for_completion=False,
+            cancel_on_kill=False,
+        )
+        mock_ti = mock.MagicMock(name="MockedTaskInstance")
+        operator.execute({"ti": mock_ti})
+        operator.on_kill()
+        mock_conn.cancel_statement.assert_not_called()
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
     def test_return_sql_result(self, mock_conn):
         expected_result = [{"Result": True}]
         cluster_identifier = "cluster_identifier"
@@ -382,6 +399,7 @@ class TestRedshiftDataOperator:
             deferrable_operator.execute({"ti": mock_ti})
 
         assert isinstance(exc.value.trigger, RedshiftDataTrigger)
+        assert exc.value.trigger.cancel_on_kill is True
 
     def test_execute_complete_failure(self, deferrable_operator):
         """Tests that an AirflowException is raised in case of error event"""

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_redshift_data.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_redshift_data.py
@@ -24,6 +24,7 @@ import pytest
 from airflow.providers.amazon.aws.hooks.redshift_data import (
     ABORTED_STATE,
     FAILED_STATE,
+    RedshiftDataHook,
     RedshiftDataQueryAbortedError,
     RedshiftDataQueryFailedError,
 )
@@ -57,7 +58,20 @@ class TestRedshiftDataTrigger:
             "region_name": None,
             "botocore_config": None,
             "verify": None,
+            "cancel_on_kill": True,
         }
+
+    def test_redshift_data_trigger_serialization_cancel_on_kill_false(self):
+        """cancel_on_kill=False round-trips through serialization."""
+        trigger = RedshiftDataTrigger(
+            statement_id="uuid",
+            task_id=TEST_TASK_ID,
+            aws_conn_id=TEST_CONN_ID,
+            poll_interval=POLL_INTERVAL,
+            cancel_on_kill=False,
+        )
+        _, kwargs = trigger.serialize()
+        assert kwargs["cancel_on_kill"] is False
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -151,3 +165,64 @@ class TestRedshiftDataTrigger:
         task = [i async for i in trigger.run()]
         assert len(task) == 1
         assert TriggerEvent(expected_response) in task
+
+    @pytest.mark.asyncio
+    @mock.patch.object(RedshiftDataHook, "get_async_conn")
+    async def test_on_kill_cancels_the_statement(self, mock_get_async_conn):
+        """on_kill() cancels the running statement when enabled and a statement_id is set."""
+        mock_client = mock.AsyncMock()
+        mock_cm = mock.AsyncMock()
+        mock_cm.__aenter__.return_value = mock_client
+        mock_get_async_conn.return_value = mock_cm
+
+        trigger = RedshiftDataTrigger(
+            statement_id="uuid",
+            task_id=TEST_TASK_ID,
+            poll_interval=POLL_INTERVAL,
+            aws_conn_id=TEST_CONN_ID,
+        )
+        await trigger.on_kill()
+
+        mock_client.cancel_statement.assert_awaited_once_with(Id="uuid")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("cancel_on_kill", "statement_id"),
+        [
+            pytest.param(False, "uuid", id="disabled"),
+            pytest.param(True, "", id="no-statement-id"),
+        ],
+    )
+    @mock.patch.object(RedshiftDataHook, "get_async_conn")
+    async def test_on_kill_does_not_cancel(self, mock_get_async_conn, cancel_on_kill, statement_id):
+        """on_kill() is a no-op (no connection opened) when disabled or without a statement_id."""
+        trigger = RedshiftDataTrigger(
+            statement_id=statement_id,
+            task_id=TEST_TASK_ID,
+            poll_interval=POLL_INTERVAL,
+            aws_conn_id=TEST_CONN_ID,
+            cancel_on_kill=cancel_on_kill,
+        )
+        await trigger.on_kill()
+
+        mock_get_async_conn.assert_not_called()
+
+    @pytest.mark.asyncio
+    @mock.patch.object(RedshiftDataHook, "get_async_conn")
+    async def test_on_kill_swallows_cancel_errors(self, mock_get_async_conn):
+        """on_kill() logs and swallows exceptions raised while cancelling."""
+        mock_client = mock.AsyncMock()
+        mock_client.cancel_statement.side_effect = Exception("AWS API error")
+        mock_cm = mock.AsyncMock()
+        mock_cm.__aenter__.return_value = mock_client
+        mock_get_async_conn.return_value = mock_cm
+
+        trigger = RedshiftDataTrigger(
+            statement_id="uuid",
+            task_id=TEST_TASK_ID,
+            poll_interval=POLL_INTERVAL,
+            aws_conn_id=TEST_CONN_ID,
+        )
+        await trigger.on_kill()
+
+        mock_client.cancel_statement.assert_awaited_once_with(Id="uuid")


### PR DESCRIPTION
### Problem

A deferred `RedshiftDataOperator` parks its query in the triggerer, so the operator's own `on_kill` no longer runs once the task is deferred. When a user marks that task failed, clears it, or marks it success, `RedshiftDataTrigger` had no `on_kill` hook, so the Redshift statement kept running against the cluster or workgroup even though the operator already cancels the statement on kill in the non-deferred path.

On Redshift Serverless a runaway statement keeps billing RPU hours, and on a provisioned cluster it holds a WLM slot, until it finishes on its own.

### Change

`RedshiftDataTrigger` gains an `on_kill` that cancels the running statement when the user acts on the deferred task, using the hook's async connection (`cancel_statement`). This matches the behaviour already shipped for the EMR, Dataproc, BigQuery, and Dataflow triggers, and closes the last common AWS gap from the deferrable `on_kill` work tracked in #36090.

A `cancel_on_kill` flag (default `True`) is added to both `RedshiftDataOperator` and `RedshiftDataTrigger` so users can opt out, and the operator threads it into the trigger at the defer site. Cancellation is best effort: failures while cancelling are logged and swallowed so the trigger teardown is not blocked.

### Precedent

* #65740 `EmrServerlessStartJobTrigger`
* #65742 `DataprocSubmitTrigger` / `DataprocSubmitJobDirectTrigger`
* #66704 `BigQueryInsertJobTrigger`

### Tests

Trigger tests cover cancel on kill, the disabled and missing statement id no ops, best effort error swallowing, and serialization of the new flag. Operator tests cover the `cancel_on_kill=False` guard and that the flag is threaded into the trigger on defer. Every new assertion fails without the source change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)