### PR TITLE
Add back explicit dependencies to ktlint

### DIFF
--- a/java-sdk/sdk/build.gradle.kts
+++ b/java-sdk/sdk/build.gradle.kts
@@ -287,6 +287,10 @@ tasks.named("compileKotlin") {
     dependsOn("generateJsonSchema2Pojo")
 }
 
+tasks.named("runKtlintCheckOverMainSourceSet") {
+    dependsOn("generateJsonSchema2Pojo", "generateDiscriminator")
+}
+
 tasks.matching { it.name.startsWith("dokkaGenerate") }.configureEach {
     dependsOn("generateJsonSchema2Pojo", "generateDiscriminator")
 }


### PR DESCRIPTION
ktlint greps files directly without using outputs from other tasks, so it may fail to trigger dependencies in certain cases.

This reverts the removal of the rule in #69628.