### PR TITLE
Fix AwaitMessageTriggerFunctionSensor not honoring timeout

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/sensors/kafka.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/sensors/kafka.py
@@ -204,6 +204,10 @@ class AwaitMessageTriggerFunctionSensor(BaseSensorOperator):
             )
 
     def execute(self, context, event=None) -> Any:
+        if isinstance(self.timeout, (int, float)):
+            timeout = timedelta(seconds=self.timeout)
+        else:
+            timeout = self.timeout
         self.defer(
             trigger=AwaitMessageTrigger(
                 topics=self.topics,
@@ -215,6 +219,7 @@ class AwaitMessageTriggerFunctionSensor(BaseSensorOperator):
                 poll_interval=self.poll_interval,
             ),
             method_name="execute_complete",
+            timeout=timeout,
         )
 
         return event
@@ -222,6 +227,10 @@ class AwaitMessageTriggerFunctionSensor(BaseSensorOperator):
     def execute_complete(self, context, event=None):
         self.event_triggered_function(event, **context)
 
+        if isinstance(self.timeout, (int, float)):
+            timeout = timedelta(seconds=self.timeout)
+        else:
+            timeout = self.timeout
         self.defer(
             trigger=AwaitMessageTrigger(
                 topics=self.topics,
@@ -233,4 +242,5 @@ class AwaitMessageTriggerFunctionSensor(BaseSensorOperator):
                 poll_interval=self.poll_interval,
             ),
             method_name="execute_complete",
+            timeout=timeout,
         )

--- a/providers/apache/kafka/tests/unit/apache/kafka/sensors/test_kafka.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/sensors/test_kafka.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import timedelta
 
 import pytest
 
@@ -128,6 +129,27 @@ class TestSensors:
         )
 
         assert sensor.timeout == 600
+
+    def test_await_message_trigger_function_forwards_timeout_to_deferral(self):
+        """The timeout must be forwarded to every deferral, not silently ignored."""
+        sensor = AwaitMessageTriggerFunctionSensor(
+            kafka_config_id="kafka_d",
+            topics=["test"],
+            task_id="test",
+            apply_function=_return_true,
+            event_triggered_function=_return_true,
+            timeout=600,
+        )
+
+        with pytest.raises(TaskDeferred) as exc_info:
+            sensor.execute(context={})
+        assert exc_info.value.timeout == timedelta(seconds=600)
+
+        # The sensor re-defers after every processed event, so the timeout must be
+        # applied to that deferral as well.
+        with pytest.raises(TaskDeferred) as exc_info:
+            sensor.execute_complete(context={})
+        assert exc_info.value.timeout == timedelta(seconds=600)
 
     def test_await_message_trigger_function_with_soft_fail_parameter(self):
         """Test that AwaitMessageTriggerFunctionSensor accepts soft_fail parameter."""


### PR DESCRIPTION
`AwaitMessageTriggerFunctionSensor` accepts a `timeout` parameter and its docstring promises "Time elapsed before the task times out and fails", but neither `defer()` call passed `timeout=`, so the trigger could wait indefinitely and the parameter was silently ignored.

This applies the same fix that was merged for the sibling `AwaitMessageSensor` in #62104 (issue #62097): convert the numeric sensor timeout to a `timedelta` and pass it to `defer()` — here in both `execute` and `execute_complete`, since this sensor re-defers after every processed event.

**Semantics note:** because this sensor re-defers indefinitely by design, the timeout applies to each await cycle rather than to total task runtime — i.e. the task fails (or skips, with `soft_fail=True`) if no matching message arrives within `timeout` seconds of the most recent deferral. Total-elapsed semantics would unconditionally kill a healthy, indefinitely-running sensor, so per-cycle is the useful interpretation; happy to adjust if maintainers prefer otherwise.

On deferral timeout the standard sensor machinery converts `TaskDeferralTimeout` into `AirflowSensorTimeout`, and `soft_fail` is honored.

Adds a regression test asserting the timeout is forwarded on both deferral paths (it was `None` before this fix).
