### PR TITLE
Fix task execution upsert failing on cockroachdb connections

### DIFF
--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -136,7 +136,7 @@ def build_upsert_stmt(
     :raises ValueError: if the dialect does not support a known upsert syntax
     """
     stmt: MySQLInsert | PostgreSQLInsert | SQLiteInsert
-    if dialect == "postgresql":
+    if dialect in ("postgresql", "cockroachdb"):
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
         stmt = pg_insert(model).values(**values)
@@ -154,7 +154,7 @@ def build_upsert_stmt(
     else:
         raise ValueError(
             f"Unsupported database dialect '{dialect}' for upsert. "
-            "Supported dialects are: postgresql, mysql, sqlite."
+            "Supported dialects are: postgresql, cockroachdb, mysql, sqlite."
         )
     return stmt
 

--- a/airflow-core/tests/unit/utils/test_sqlalchemy.py
+++ b/airflow-core/tests/unit/utils/test_sqlalchemy.py
@@ -36,6 +36,7 @@ from airflow.settings import Session
 from airflow.utils.sqlalchemy import (
     ExecutorConfigType,
     apply_regex_query_timeout,
+    build_upsert_stmt,
     ensure_pod_is_valid_after_unpickling,
     get_dialect_name,
     prohibit_commit,
@@ -443,3 +444,32 @@ class TestApplyRegexQueryTimeout:
             with apply_regex_query_timeout(session):
                 pass
         session.execute.assert_not_called()
+
+
+class TestBuildUpsertStmt:
+    @pytest.mark.parametrize("dialect", ["postgresql", "cockroachdb"])
+    def test_postgres_family_uses_on_conflict_do_update(self, dialect):
+        from sqlalchemy.dialects.postgresql.dml import Insert as PgInsert
+
+        from airflow.models.pool import Pool
+
+        stmt = build_upsert_stmt(
+            dialect=dialect,
+            model=Pool,
+            conflict_cols=["pool"],
+            values={"pool": "test_pool", "slots": 1},
+            update_fields={"slots": 1},
+        )
+        assert isinstance(stmt, PgInsert)
+
+    def test_unsupported_dialect_raises(self):
+        from airflow.models.pool import Pool
+
+        with pytest.raises(ValueError, match="Unsupported database dialect 'mssql'"):
+            build_upsert_stmt(
+                dialect="mssql",
+                model=Pool,
+                conflict_cols=["pool"],
+                values={"pool": "test_pool"},
+                update_fields={},
+            )


### PR DESCRIPTION
Airflow 3.3.0 introduced build_upsert_stmt (utils/sqlalchemy.py) for atomic INSERT ... ON CONFLICT writes, used by the execution API when tasks start (rendered task instance fields, variables, metastore state). The helper dispatches on the dialect name and raises ValueError for anything outside postgresql/mysql/sqlite, so on a cockroachdb connection every task start fails with a 500 from the execution API:

    `ValueError: Unsupported database dialect 'cockroachdb' for upsert.`

The cockroachdb SQLAlchemy dialect subclasses the postgresql one and supports the same INSERT ... ON CONFLICT DO UPDATE construct, so this adds it to the postgresql arm of the dispatch. Other dialects are unaffected. Includes unit tests for the postgres-family dispatch and the unsupported-dialect error.

Verified end to end against CockroachDB v26.3: without this change, task runs fail at startup on Airflow 3.3.0; with it, a two-scheduler stress run completes normally.

Related PRs from the same devlist proposal: #69260, #69555, #69556, #69557.
Discussed on the devlist:
https://lists.apache.org/thread/t6jo4th3sn23jmr34m6gcxzw4k8mo4pc

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)