### PR TITLE
Fix @asset reserved keys with default value

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
+++ b/task-sdk/src/airflow/sdk/definitions/asset/decorators.py
@@ -87,14 +87,15 @@ class _AssetMainOperator(PythonOperator):
 
         value: Any
         for key, param in inspect.signature(self.python_callable).parameters.items():
-            if param.default is not inspect.Parameter.empty:
-                value = param.default
-            elif key == "self":
+            # ``self``/``context``/``outlet_events`` are reserved keys.
+            if key == "self":
                 value = _fetch_asset(self._definition_name)
             elif key == "context":
                 value = context
             elif key == "outlet_events":
                 value = context["outlet_events"]
+            elif param.default is not inspect.Parameter.empty:
+                value = param.default
             else:
                 value = _fetch_asset(key)
             yield key, value

--- a/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
+++ b/task-sdk/tests/task_sdk/definitions/test_asset_decorators.py
@@ -449,6 +449,44 @@ class Test_AssetMainOperator:
             mock.call.send(GetAssetByName(name="inlet_asset_1")),
         ]
 
+    @pytest.mark.parametrize(
+        ("python_callable", "reserved_key"),
+        [
+            pytest.param(lambda self=None: None, "self", id="self"),
+            pytest.param(lambda context=None: None, "context", id="context"),
+            pytest.param(lambda outlet_events=None: None, "outlet_events", id="outlet_events"),
+        ],
+    )
+    def test_determine_kwargs_injects_reserved_key_with_default(
+        self, mock_supervisor_comms, func_fixer, python_callable, reserved_key
+    ):
+        """A default on a reserved arg (self/context/outlet_events) must not shadow the injected value."""
+        mock_supervisor_comms.send.side_effect = [
+            AssetResult(name="example_asset_func", uri="example_asset_func", group="asset"),
+        ]
+        fixed_callable = func_fixer(python_callable)
+        definition = asset(schedule=None)(fixed_callable)
+        outlet_events = OutletEventAccessors()
+        context = {"outlet_events": outlet_events}
+
+        op = _AssetMainOperator(
+            task_id="example_asset_func",
+            inlets=[],
+            outlets=[definition],
+            python_callable=fixed_callable,
+            definition_name="example_asset_func",
+        )
+
+        injected = op.determine_kwargs(context=context)[reserved_key]
+
+        assert injected is not None
+        if reserved_key == "self":
+            assert isinstance(injected, Asset)
+        elif reserved_key == "context":
+            assert injected is context
+        else:
+            assert injected is outlet_events
+
     def test_from_definition_custom_name(self, mock_supervisor_comms, func_fixer):
         @func_fixer
         def example_asset_func(self):


### PR DESCRIPTION
User values should not overwrite invalid inlet asset names. This PR ignores default value for reserved keys `self` / `context` / `outlet_events`. 

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
