### PR TITLE
validate log server hostname before building the log fetch url

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -23,6 +23,7 @@ import heapq
 import io
 import logging
 import os
+import re
 from collections.abc import Generator, Iterator
 from contextlib import suppress
 from datetime import datetime
@@ -147,6 +148,14 @@ class LogType(str, Enum):
     WORKER = "worker"
 
 
+# The log server host is reported by the worker/triggerer over the Execution API and stored on the
+# task instance, so the api-server must treat it as untrusted when it later builds the log-fetch URL.
+# A bare hostname or IP only ever needs these characters; rejecting anything else stops a value
+# carrying URL syntax (a userinfo "@", a path, a scheme) from pointing the authenticated fetch, which
+# sends a signed task-instance-logs token, at an unintended host.
+_SAFE_LOG_SERVER_HOST = re.compile(r"\A[A-Za-z0-9._-]+\Z")
+
+
 def _set_task_deferred_context_var():
     """
     Tell task log handler that task exited with deferral.
@@ -189,6 +198,9 @@ def _fetch_logs_from_service(url: str, log_relative_path: str) -> Response:
         timeout=timeout,
         headers={"Authorization": generator.generate({"filename": log_relative_path})},
         stream=True,
+        # A log server returns content directly and never redirects. Not following redirects keeps
+        # the signed token from being replayed to whatever host a redirect would point at.
+        allow_redirects=False,
     )
     response.encoding = "utf-8"
     return response
@@ -738,7 +750,7 @@ class FileTaskHandler(logging.Handler):
             config_key = "worker_log_server_port"
             config_default = 8793
 
-        if not hostname:
+        if not hostname or not _SAFE_LOG_SERVER_HOST.match(hostname):
             return None, None
 
         return (

--- a/airflow-core/tests/unit/utils/log/test_file_task_handler.py
+++ b/airflow-core/tests/unit/utils/log/test_file_task_handler.py
@@ -20,7 +20,13 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from airflow.utils.log.file_task_handler import FileTaskHandler
+import pytest
+
+from airflow.utils.log.file_task_handler import (
+    FileTaskHandler,
+    LogType,
+    _fetch_logs_from_service,
+)
 from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.file_task_handler import convert_list_to_stream, extract_events
@@ -124,6 +130,50 @@ class TestFileTaskHandlerLogServer:
         assert "trigger" in sources[0]
         assert streams == []
         mock_fetch.assert_not_called()
+
+
+class TestLogRetrievalUrlHostname:
+    """The log server hostname comes from the worker over the Execution API and must not carry URL syntax."""
+
+    def setup_method(self):
+        self.handler = FileTaskHandler(base_log_folder="/tmp/test_logs")
+        self.ti = MagicMock()
+        self.ti.triggerer_job = None
+
+    @pytest.mark.parametrize(
+        "hostname",
+        [
+            "worker-1@evil.example",
+            "evil.example/log",
+            "http://evil.example",
+            "worker-1:9/../",
+            "worker-1?x=1",
+            "worker-1#frag",
+            "worker-1 evil.example",
+            "worker-1\nevil.example",
+        ],
+    )
+    def test_get_log_retrieval_url_rejects_unsafe_hostname(self, hostname):
+        self.ti.hostname = hostname
+        assert self.handler._get_log_retrieval_url(
+            self.ti, "dag/run/task/1.log", log_type=LogType.WORKER
+        ) == (None, None)
+
+    @pytest.mark.parametrize("hostname", ["worker-1", "worker-1.example.com", "10.0.0.5"])
+    def test_get_log_retrieval_url_allows_valid_hostname(self, hostname):
+        self.ti.hostname = hostname
+        url, rel_path = self.handler._get_log_retrieval_url(
+            self.ti, "dag/run/task/1.log", log_type=LogType.WORKER
+        )
+        assert url is not None
+        assert url.startswith(f"http://{hostname}:")
+        assert url.endswith("/log/dag/run/task/1.log")
+        assert rel_path == "dag/run/task/1.log"
+
+    @patch("requests.get")
+    def test_fetch_logs_from_service_does_not_follow_redirects(self, mock_get):
+        _fetch_logs_from_service("http://worker-1:8793/log/dag/run/task/1.log", "dag/run/task/1.log")
+        assert mock_get.call_args.kwargs["allow_redirects"] is False
 
 
 class TestFileTaskHandlerReadFromLocal:


### PR DESCRIPTION
When the api-server serves a task's logs it fetches them from the worker's log server at `http://{hostname}:{port}/log/...`, where `hostname` is whatever the worker reported for that task instance over the Execution API and was stored on the row unchanged. Nothing checks that value is a bare host before it is interpolated into the URL, so a hostname that carries URL syntax (for example `real-worker@attacker.host`, or a value with a path or scheme) breaks out of the host component and the request lands on a different host than intended. That request is not anonymous: `_fetch_logs_from_service` attaches a freshly signed `task-instance-logs` token and, by default, follows redirects, so the token can be delivered to an attacker-chosen host and a log-server redirect can bounce it further. I hit this while tracing where `ti.hostname` is written against where it is later trusted, and the two ends disagree on the value being a safe host. The fix validates the hostname against a bare-host pattern inside `_get_log_retrieval_url` so an unexpected value yields no fetch URL at all, which covers both the worker and triggerer paths, and sets `allow_redirects=False` on the fetch so a signed request cannot be redirected off-host. Valid hostnames and IPs are unaffected.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)