### PR TITLE
Clarify db downgrade rollback limits

### DIFF
--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -323,6 +323,13 @@ Downgrading Airflow
 
 You can downgrade to a particular Airflow version with the ``db downgrade`` command.  Alternatively you may provide an Alembic revision id to downgrade to.
 
+.. warning::
+
+    ``db downgrade`` only reverts schema changes tracked by Alembic. It does not rewrite metadata rows
+    that were already written by the newer Airflow version into an older serialization format. If the
+    newer version has already run against the database, restoring a metadata DB backup taken before the
+    upgrade is the only clean rollback path.
+
 If you want to preview the commands but not execute them, use option ``--show-sql-only``.
 
 Options ``--from-revision`` and ``--from-version`` may only be used in conjunction with the ``--show-sql-only`` option, because when actually *running* migrations we should always downgrade from current revision.

--- a/airflow-core/docs/installation/upgrading.rst
+++ b/airflow-core/docs/installation/upgrading.rst
@@ -42,6 +42,11 @@ migration might be the only easy way out. This can for example be caused by a br
 network connection between your CLI and the database while the migration happens, so taking
 a backup is an important precaution to avoid problems like this.
 
+Backups are also the only clean rollback path when a newer Airflow version has already written
+metadata rows in a format that an older version cannot read. ``airflow db downgrade`` only
+reverts Alembic schema migrations; it does not rewrite existing metadata row content back to an
+older serialization format.
+
 When you need to upgrade
 ========================
 


### PR DESCRIPTION
## Summary
- add a rollback warning to the upgrade guide explaining that backups are the only clean rollback path once a newer Airflow version has written incompatible metadata rows
- add a matching warning to the db downgrade CLI docs explaining that the command only reverts Alembic schema changes

## Testing
- git diff --check
- python -m docutils --report=5 --exit-status=4 airflow-core/docs/howto/usage-cli.rst NUL
- python -m docutils --report=5 --exit-status=4 airflow-core/docs/installation/upgrading.rst NUL

Closes #68317
