### PR TITLE
Add raise_on_delivery_failure option to ProduceToTopicOperator

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
@@ -40,6 +40,10 @@ def acked(err, msg):
         )
 
 
+class KafkaMessageDeliveryError(AirflowException):
+    """Raised when one or more messages could not be delivered to Kafka."""
+
+
 class ProduceToTopicOperator(BaseOperator):
     """
     An operator that produces messages to a Kafka topic.
@@ -58,7 +62,14 @@ class ProduceToTopicOperator(BaseOperator):
     :param synchronous: If writes to kafka should be fully synchronous, defaults to True
     :param poll_timeout: How long of a delay should be applied when calling poll after production to kafka,
         defaults to 0
-    :raises AirflowException: _description_
+    :param raise_on_delivery_failure: Kafka reports delivery outcomes asynchronously through the
+        delivery callback, so a message that is rejected by the broker (e.g. too large, unknown
+        topic, insufficient permissions) does not make the task fail by default - the error is only
+        passed to the delivery callback. Set to True to fail the task with an ``AirflowException``
+        when at least one message could not be delivered. Defaults to False to keep backwards
+        compatibility.
+    :raises AirflowException: If ``raise_on_delivery_failure`` is True and at least one message
+        could not be delivered.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -82,6 +93,7 @@ class ProduceToTopicOperator(BaseOperator):
         delivery_callback: str | None = None,
         synchronous: bool = True,
         poll_timeout: float = 0,
+        raise_on_delivery_failure: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -99,6 +111,7 @@ class ProduceToTopicOperator(BaseOperator):
         self.delivery_callback = dc
         self.synchronous = synchronous
         self.poll_timeout = poll_timeout
+        self.raise_on_delivery_failure = raise_on_delivery_failure
 
         if not (self.topic and self.producer_function):
             raise AirflowException(
@@ -126,11 +139,27 @@ class ProduceToTopicOperator(BaseOperator):
             **self.producer_function_kwargs,
         )
 
+        # Delivery outcomes are reported asynchronously via the delivery callback, so collect the
+        # failures reported by the broker (e.g. message too large, unknown topic, ACL denied) to be
+        # able to fail the task once all outstanding deliveries have been resolved.
+        delivery_errors: list[Any] = []
+
+        def on_delivery(err, msg):
+            if err is not None:
+                delivery_errors.append(err)
+            self.delivery_callback(err, msg)
+
         # For each returned k/v in the callable : publish and flush if needed.
         for k, v in producer_callable():
-            producer.produce(self.topic, key=k, value=v, on_delivery=self.delivery_callback)
+            producer.produce(self.topic, key=k, value=v, on_delivery=on_delivery)
             producer.poll(self.poll_timeout)
             if self.synchronous:
                 producer.flush()
 
         producer.flush()
+
+        if self.raise_on_delivery_failure and delivery_errors:
+            raise KafkaMessageDeliveryError(
+                f"Failed to deliver {len(delivery_errors)} message(s) to topic {self.topic!r}. "
+                f"First error: {delivery_errors[0]}"
+            )

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
@@ -40,6 +40,10 @@ def acked(err, msg):
         )
 
 
+class KafkaMessageDeliveryError(AirflowException):
+    """Raised when one or more messages could not be delivered to Kafka."""
+
+
 class ProduceToTopicOperator(BaseOperator):
     """
     An operator that produces messages to a Kafka topic.
@@ -58,7 +62,16 @@ class ProduceToTopicOperator(BaseOperator):
     :param synchronous: If writes to kafka should be fully synchronous, defaults to True
     :param poll_timeout: How long of a delay should be applied when calling poll after production to kafka,
         defaults to 0
-    :raises AirflowException: _description_
+    :param raise_on_delivery_failure: Kafka reports delivery outcomes asynchronously through the
+        delivery callback, so a message that is rejected by the broker (e.g. too large, unknown
+        topic, insufficient permissions) does not make the task fail by default - the error is only
+        passed to the delivery callback. Set to True to fail the task with an ``AirflowException``
+        when at least one message could not be delivered. Because the task fails after the batch has
+        already been partially produced, a retry re-produces the whole batch, so messages that were
+        delivered successfully the first time will be produced again. Defaults to False to keep
+        backwards compatibility.
+    :raises AirflowException: If ``raise_on_delivery_failure`` is True and at least one message
+        could not be delivered.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -82,6 +95,7 @@ class ProduceToTopicOperator(BaseOperator):
         delivery_callback: str | None = None,
         synchronous: bool = True,
         poll_timeout: float = 0,
+        raise_on_delivery_failure: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -99,6 +113,7 @@ class ProduceToTopicOperator(BaseOperator):
         self.delivery_callback = dc
         self.synchronous = synchronous
         self.poll_timeout = poll_timeout
+        self.raise_on_delivery_failure = raise_on_delivery_failure
 
     def execute(self, context) -> None:
         if not (self.topic and self.producer_function):
@@ -124,11 +139,28 @@ class ProduceToTopicOperator(BaseOperator):
             **self.producer_function_kwargs,
         )
 
+        # Delivery outcomes are reported asynchronously via the delivery callback, so collect the
+        # failures reported by the broker (e.g. message too large, unknown topic, ACL denied) to be
+        # able to fail the task once all outstanding deliveries have been resolved. Only collect when
+        # raise_on_delivery_failure is set, since that is the only path that consumes them.
+        delivery_errors: list[Any] = []
+
+        def on_delivery(err, msg):
+            if err is not None and self.raise_on_delivery_failure:
+                delivery_errors.append(err)
+            self.delivery_callback(err, msg)
+
         # For each returned k/v in the callable : publish and flush if needed.
         for k, v in producer_callable():
-            producer.produce(self.topic, key=k, value=v, on_delivery=self.delivery_callback)
+            producer.produce(self.topic, key=k, value=v, on_delivery=on_delivery)
             producer.poll(self.poll_timeout)
             if self.synchronous:
                 producer.flush()
 
         producer.flush()
+
+        if self.raise_on_delivery_failure and delivery_errors:
+            raise KafkaMessageDeliveryError(
+                f"Failed to deliver {len(delivery_errors)} message(s) to topic {self.topic!r}. "
+                f"First error: {delivery_errors[0]}"
+            )

--- a/providers/apache/kafka/tests/unit/apache/kafka/operators/test_produce.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/operators/test_produce.py
@@ -19,13 +19,20 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+from unittest import mock
 
 import pytest
+from confluent_kafka import KafkaError
 
 from airflow.models import Connection
-from airflow.providers.apache.kafka.operators.produce import ProduceToTopicOperator
+from airflow.providers.apache.kafka.operators.produce import (
+    KafkaMessageDeliveryError,
+    ProduceToTopicOperator,
+)
 
 log = logging.getLogger(__name__)
+
+GET_PRODUCER_PATH = "airflow.providers.apache.kafka.hooks.produce.KafkaProducerHook.get_producer"
 
 
 def _simple_producer(key, value) -> list[tuple[Any, Any]]:
@@ -38,6 +45,14 @@ def _simple_producer(key, value) -> list[tuple[Any, Any]]:
     :rtype: list[tuple[Any, Any]]
     """
     return [(key, value)]
+
+
+_custom_delivery_callback_calls: list[Any] = []
+
+
+def _custom_delivery_callback(err, msg) -> None:
+    """A delivery callback recording the errors it was invoked with."""
+    _custom_delivery_callback_calls.append(err)
 
 
 class TestProduceToTopic:
@@ -85,3 +100,81 @@ class TestProduceToTopic:
         )
 
         operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_raise_on_delivery_failure(self, mock_get_producer):
+        mock_producer = mock_get_producer.return_value
+        error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(error, None)
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+            raise_on_delivery_failure=True,
+        )
+
+        with pytest.raises(KafkaMessageDeliveryError, match="Failed to deliver 1 message"):
+            operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_raise_on_delivery_failure_successful_delivery(self, mock_get_producer):
+        mock_producer = mock_get_producer.return_value
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(
+            None, mock.MagicMock()
+        )
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+            raise_on_delivery_failure=True,
+        )
+
+        operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_delivery_failure_ignored_by_default(self, mock_get_producer):
+        mock_producer = mock_get_producer.return_value
+        error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(error, None)
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+        )
+
+        operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_raise_on_delivery_failure_custom_callback(self, mock_get_producer):
+        _custom_delivery_callback_calls.clear()
+        mock_producer = mock_get_producer.return_value
+        error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(error, None)
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+            delivery_callback="unit.apache.kafka.operators.test_produce._custom_delivery_callback",
+            raise_on_delivery_failure=True,
+        )
+
+        with pytest.raises(KafkaMessageDeliveryError, match="Failed to deliver 1 message"):
+            operator.execute(context={})
+
+        assert _custom_delivery_callback_calls == [error]

--- a/providers/apache/kafka/tests/unit/apache/kafka/operators/test_produce.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/operators/test_produce.py
@@ -19,16 +19,23 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+from unittest import mock
 
 import pendulum
 import pytest
+from confluent_kafka import KafkaError
 
 from airflow.models import Connection
 from airflow.models.dag import DAG
-from airflow.providers.apache.kafka.operators.produce import ProduceToTopicOperator
+from airflow.providers.apache.kafka.operators.produce import (
+    KafkaMessageDeliveryError,
+    ProduceToTopicOperator,
+)
 from airflow.providers.common.compat.sdk import AirflowException
 
 log = logging.getLogger(__name__)
+
+GET_PRODUCER_PATH = "airflow.providers.apache.kafka.hooks.produce.KafkaProducerHook.get_producer"
 
 
 def _simple_producer(key, value) -> list[tuple[Any, Any]]:
@@ -41,6 +48,14 @@ def _simple_producer(key, value) -> list[tuple[Any, Any]]:
     :rtype: list[tuple[Any, Any]]
     """
     return [(key, value)]
+
+
+_custom_delivery_callback_calls: list[Any] = []
+
+
+def _custom_delivery_callback(err, msg) -> None:
+    """A delivery callback recording the errors it was invoked with."""
+    _custom_delivery_callback_calls.append(err)
 
 
 class TestProduceToTopic:
@@ -103,3 +118,81 @@ class TestProduceToTopic:
         assert operator.topic == ""
         with pytest.raises(AirflowException, match="topic and producer_function must be provided"):
             operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_raise_on_delivery_failure(self, mock_get_producer):
+        mock_producer = mock_get_producer.return_value
+        error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(error, None)
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+            raise_on_delivery_failure=True,
+        )
+
+        with pytest.raises(KafkaMessageDeliveryError, match="Failed to deliver 1 message"):
+            operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_raise_on_delivery_failure_successful_delivery(self, mock_get_producer):
+        mock_producer = mock_get_producer.return_value
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(
+            None, mock.MagicMock()
+        )
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+            raise_on_delivery_failure=True,
+        )
+
+        operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_delivery_failure_ignored_by_default(self, mock_get_producer):
+        mock_producer = mock_get_producer.return_value
+        error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(error, None)
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+        )
+
+        operator.execute(context={})
+
+    @mock.patch(GET_PRODUCER_PATH)
+    def test_operator_raise_on_delivery_failure_custom_callback(self, mock_get_producer):
+        _custom_delivery_callback_calls.clear()
+        mock_producer = mock_get_producer.return_value
+        error = KafkaError(KafkaError.MSG_SIZE_TOO_LARGE)
+        mock_producer.produce.side_effect = lambda topic, key, value, on_delivery: on_delivery(error, None)
+
+        operator = ProduceToTopicOperator(
+            kafka_config_id="kafka_d",
+            topic="test_1",
+            producer_function=_simple_producer,
+            producer_function_args=(b"test", b"test"),
+            task_id="test",
+            synchronous=False,
+            delivery_callback="unit.apache.kafka.operators.test_produce._custom_delivery_callback",
+            raise_on_delivery_failure=True,
+        )
+
+        with pytest.raises(KafkaMessageDeliveryError, match="Failed to deliver 1 message"):
+            operator.execute(context={})
+
+        assert _custom_delivery_callback_calls == [error]


### PR DESCRIPTION
Kafka reports delivery outcomes asynchronously through the producer's delivery callback. Today `ProduceToTopicOperator`'s default callback only *logs* delivery errors, so a message rejected by the broker (e.g. `MSG_SIZE_TOO_LARGE`, unknown topic, ACL denied) is silently lost while the task is still marked successful.

This PR adds an opt-in `raise_on_delivery_failure` parameter (default `False`, fully backwards compatible). When enabled, the operator collects errors passed to the delivery callback and, after the final `flush()` has resolved all outstanding deliveries, fails the task with an `AirflowException` reporting the number of failed messages and the first error. The configured `delivery_callback` is still invoked for every delivery report, so existing custom callbacks keep working unchanged.

New unit tests cover: task failure on delivery error, success path with the flag enabled, unchanged default behaviour, and interaction with a custom `delivery_callback` (all with a mocked producer, no broker required). Existing tests are untouched.
