### PR TITLE
Fix false positive in verification step

### DIFF
--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -408,7 +408,7 @@ manager, before sending the vote — should run against the source package in
 
    ```bash
    find apache-airflow-java-sdk-<VERSION>/ -type f \
-     -exec sh -c 'file "$1" | grep -qv text && echo "$1"' _ {} \;
+     -exec sh -c 'file -b "$1" | grep -qviE "text|json|xml|empty" && echo "$1"' _ {} \;
    ```
 
    This should print nothing.


### PR DESCRIPTION
Grep may not treat a JSON file as text. Be more relaxed about this. All we want to do is to ensure there are no binaries...