### PR TITLE
Add feature-comparison table and toolset links to common.ai provider docs

### DIFF
--- a/providers/anthropic/docs/index.rst
+++ b/providers/anthropic/docs/index.rst
@@ -19,12 +19,14 @@
 ``apache-airflow-providers-anthropic``
 ======================================
 
+The ``anthropic`` provider gives Dags direct access to Anthropic's own APIs — this page
+compares that choice against ``common.ai``.
+
 When to use this provider
 --------------------------
 
-The ``anthropic`` provider gives Dags direct access to Anthropic's own APIs. This page
-compares that choice against ``common.ai``. Use ``anthropic`` when a Dag needs Anthropic's
-native API surface — services Anthropic runs for you, which no vendor-neutral operator wraps:
+Use ``anthropic`` when a Dag needs Anthropic's native API surface — services Anthropic runs
+for you, which no vendor-neutral operator wraps:
 
 * ``AnthropicBatchOperator`` and ``AnthropicBatchSensor`` — submit a Claude
   `Message Batches <https://docs.claude.com/en/docs/build-with-claude/batch-processing>`__

--- a/providers/anthropic/docs/index.rst
+++ b/providers/anthropic/docs/index.rst
@@ -22,12 +22,14 @@
 When to use this provider
 --------------------------
 
-Use ``anthropic`` when a Dag needs Anthropic's native API surface — services Anthropic runs
-for you, which no vendor-neutral operator wraps:
+The ``anthropic`` provider gives Dags direct access to Anthropic's own APIs. This page
+compares that choice against ``common.ai``. Use ``anthropic`` when a Dag needs Anthropic's
+native API surface — services Anthropic runs for you, which no vendor-neutral operator wraps:
 
 * ``AnthropicBatchOperator`` and ``AnthropicBatchSensor`` — submit a Claude
   `Message Batches <https://docs.claude.com/en/docs/build-with-claude/batch-processing>`__
-  job for asynchronous bulk processing and wait for it to complete.
+  job for asynchronous bulk processing and wait for it to complete; Message Batches run at
+  50% of standard cost, with most completing within an hour and a 24-hour SLA.
 * ``AnthropicAgentSessionOperator`` — start a Managed Agents session in which the agent loop
   runs server-side on Anthropic's infrastructure; the Airflow task only kicks off the session
   and waits for its outcome.

--- a/providers/cohere/docs/index.rst
+++ b/providers/cohere/docs/index.rst
@@ -19,12 +19,13 @@
 ``apache-airflow-providers-cohere``
 ======================================
 
+The ``cohere`` provider gives Dags direct access to Cohere's own Embed API — this page
+compares that choice against ``common.ai``.
+
 When to use this provider
 --------------------------
 
-The ``cohere`` provider gives Dags direct access to Cohere's own Embed API. This page
-compares that choice against ``common.ai``. Use ``cohere`` when a Dag needs Cohere's
-native embedding models specifically:
+Use ``cohere`` when a Dag needs Cohere's native embedding models specifically:
 
 * ``CohereEmbeddingOperator`` — call Cohere's
   `Embed API <https://docs.cohere.com/docs/embeddings>`__ directly via ``CohereHook``.

--- a/providers/cohere/docs/index.rst
+++ b/providers/cohere/docs/index.rst
@@ -19,6 +19,22 @@
 ``apache-airflow-providers-cohere``
 ======================================
 
+When to use this provider
+--------------------------
+
+The ``cohere`` provider gives Dags direct access to Cohere's own Embed API. This page
+compares that choice against ``common.ai``. Use ``cohere`` when a Dag needs Cohere's
+native embedding models specifically:
+
+* ``CohereEmbeddingOperator`` — call Cohere's
+  `Embed API <https://docs.cohere.com/docs/embeddings>`__ directly via ``CohereHook``.
+
+Use :doc:`apache-airflow-providers-common-ai:index` instead when the embedding step should
+stay vendor-neutral:
+
+* Document-to-vector-store pipelines with its document loader, embedding, and retrieval
+  operators (see :doc:`apache-airflow-providers-common-ai:operators/index`), which are not
+  tied to Cohere's embedding models.
 
 .. toctree::
     :hidden:

--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -26,7 +26,7 @@ When to use this provider
    :header-rows: 1
    :widths: 40 30 30
 
-   * - You need
+   * - Use case
      - Use
      - Package
    * - Portable generation, classification, extraction, branching, or a

--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -19,6 +19,8 @@
 ``apache-airflow-providers-common-ai``
 ##################################################
 
+The ``common.ai`` provider is the vendor-neutral way to put LLM and agent steps in a Dag.
+
 When to use this provider
 --------------------------
 
@@ -42,14 +44,14 @@ When to use this provider
      - The vendor's own provider
      - e.g. :doc:`apache-airflow-providers-anthropic:index`
 
-``common.ai`` is the vendor-neutral way to put LLM and agent steps in a Dag. It is built on
-`pydantic-ai <https://ai.pydantic.dev/>`__, so the model vendor (OpenAI, Anthropic, Google,
-Bedrock, …) is picked by the connection ``llm_conn_id`` points at — switching providers later
-is a connection change, not a Dag rewrite. Existing LangChain tools aren't locked out either:
-with the ``langchain`` extra installed, they can be wrapped in ``LangChainToolset`` and
-dropped straight into a common.ai agent (see :doc:`toolsets`). The AI step is orchestrated
-by Airflow: the model calls, the agent loop, and any tools all run in the Airflow worker,
-where they get retries, logging, and observability like any other task.
+``common.ai`` is built on `pydantic-ai <https://ai.pydantic.dev/>`__, so the model vendor
+(OpenAI, Anthropic, Google, Bedrock, …) is picked by the connection ``llm_conn_id`` points
+at — switching providers later is a connection change, not a Dag rewrite. Existing LangChain
+tools aren't locked out either: with the ``langchain`` extra installed, they can be wrapped
+in ``LangChainToolset`` and dropped straight into a common.ai agent (see :doc:`toolsets`).
+The AI step is orchestrated by Airflow: the model calls, the agent loop, and any tools all
+run in the Airflow worker, where they get retries, logging, and observability like any other
+task.
 
 Use it when a Dag needs:
 

--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -22,12 +22,33 @@
 When to use this provider
 --------------------------
 
+.. list-table::
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - You need
+     - Use
+     - Package
+   * - Portable generation, classification, extraction, branching, or a
+       worker-run agent with toolsets
+     - ``common.ai``
+     - ``apache-airflow-providers-common-ai``
+   * - A vendor's native Embeddings, Responses, or Batch API
+     - The vendor's own provider
+     - e.g. :doc:`apache-airflow-providers-openai:index`,
+       :doc:`apache-airflow-providers-anthropic:index`
+   * - A vendor-managed, server-side agent session (e.g. Anthropic Managed Agents)
+     - The vendor's own provider
+     - e.g. :doc:`apache-airflow-providers-anthropic:index`
+
 ``common.ai`` is the vendor-neutral way to put LLM and agent steps in a Dag. It is built on
 `pydantic-ai <https://ai.pydantic.dev/>`__, so the model vendor (OpenAI, Anthropic, Google,
 Bedrock, …) is picked by the connection ``llm_conn_id`` points at — switching providers later
-is a connection change, not a Dag rewrite. The AI step is orchestrated by Airflow: the model
-calls, the agent loop, and any tools all run in the Airflow worker, where they get retries,
-logging, and observability like any other task.
+is a connection change, not a Dag rewrite. Existing LangChain tools aren't locked out either:
+with the ``langchain`` extra installed, they can be wrapped in ``LangChainToolset`` and
+dropped straight into a common.ai agent (see :doc:`toolsets`). The AI step is orchestrated
+by Airflow: the model calls, the agent loop, and any tools all run in the Airflow worker,
+where they get retries, logging, and observability like any other task.
 
 Use it when a Dag needs:
 
@@ -35,8 +56,9 @@ Use it when a Dag needs:
   :doc:`LLMOperator and @task.llm <operators/llm>`, with Pydantic-typed output pushed to XCom.
 * **Branching on a model's decision** — :doc:`LLMBranchOperator <operators/llm_branch>`.
 * **Agents with tools** — :doc:`AgentOperator <operators/agent>` runs a multi-turn agent loop
-  in the worker, calling Airflow-defined toolsets (SQL, hooks, MCP servers), with optional
-  human-in-the-loop review and durable step replay.
+  in the worker, calling Airflow-defined :doc:`toolsets <toolsets>` (SQL, hooks, MCP servers),
+  with optional human-in-the-loop review and durable step replay — if the task retries after
+  a failure, completed steps are replayed from cache instead of re-executing.
 * **Document pipelines** — loading, file analysis, embeddings, and retrieval for RAG
   (see :doc:`operators/index`).
 

--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -36,7 +36,8 @@ When to use this provider
    * - A vendor's native Embeddings, Responses, or Batch API
      - The vendor's own provider
      - e.g. :doc:`apache-airflow-providers-openai:index`,
-       :doc:`apache-airflow-providers-anthropic:index`
+       :doc:`apache-airflow-providers-anthropic:index`,
+       :doc:`apache-airflow-providers-cohere:index`
    * - A vendor-managed, server-side agent session (e.g. Anthropic Managed Agents)
      - The vendor's own provider
      - e.g. :doc:`apache-airflow-providers-anthropic:index`
@@ -69,6 +70,7 @@ a service the vendor runs for you, which no vendor-neutral operator wraps:
 * :doc:`apache-airflow-providers-anthropic:index` — the Claude Message Batches API, and
   Managed Agents sessions where the agent loop runs on Anthropic's infrastructure rather
   than in the Airflow worker.
+* :doc:`apache-airflow-providers-cohere:index` — Cohere's own Embed API.
 
 As a rule of thumb: if Airflow should *run* the AI step (and the model should stay
 swappable), use ``common.ai``; if the Dag *submits work to* a vendor-managed service and

--- a/providers/openai/docs/index.rst
+++ b/providers/openai/docs/index.rst
@@ -19,13 +19,15 @@
 ``apache-airflow-providers-openai``
 ======================================
 
+The ``openai`` provider gives Dags direct access to OpenAI's own APIs — this page compares
+that choice against ``common.ai``.
+
 When to use this provider
 --------------------------
 
-The ``openai`` provider gives Dags direct access to OpenAI's own APIs. This page compares
-that choice against ``common.ai``. Use ``openai`` when a Dag needs OpenAI's
-native API surface — thin wrappers over OpenAI-specific endpoints and options, built on
-``OpenAIHook``, the underlying client the operators below share:
+Use ``openai`` when a Dag needs OpenAI's native API surface — thin wrappers over
+OpenAI-specific endpoints and options, built on ``OpenAIHook``, the underlying client the
+operators below share:
 
 * ``OpenAIEmbeddingOperator`` — call the Embeddings API directly, e.g. to feed a vector
   store.

--- a/providers/openai/docs/index.rst
+++ b/providers/openai/docs/index.rst
@@ -22,17 +22,20 @@
 When to use this provider
 --------------------------
 
-Use ``openai`` when a Dag needs OpenAI's native API surface — thin wrappers over
-OpenAI-specific endpoints and options:
+The ``openai`` provider gives Dags direct access to OpenAI's own APIs. This page compares
+that choice against ``common.ai``. Use ``openai`` when a Dag needs OpenAI's
+native API surface — thin wrappers over OpenAI-specific endpoints and options, built on
+``OpenAIHook``, the underlying client the operators below share:
 
 * ``OpenAIEmbeddingOperator`` — call the Embeddings API directly, e.g. to feed a vector
   store.
 * ``OpenAIResponseOperator`` — call the
   `Responses API <https://platform.openai.com/docs/api-reference/responses>`__ with
   OpenAI-specific parameters.
-* ``OpenAITriggerBatchOperator`` and ``OpenAIHook`` — submit a
+* ``OpenAITriggerBatchOperator`` — submit a
   `Batch API <https://platform.openai.com/docs/guides/batch>`__ job for asynchronous bulk
-  processing and wait for it to complete.
+  processing and wait for it to complete; OpenAI prices Batch API calls at roughly half the
+  cost of the equivalent synchronous call, in exchange for a turnaround of up to ~24 hours.
 
 Use :doc:`apache-airflow-providers-common-ai:index` instead when the AI step should be run by
 Airflow itself and stay vendor-neutral:


### PR DESCRIPTION
## What
Addressing feedback on #69551 (merged)


- **openai / anthropic / common.ai**: moved the short definition sentence above the "When to use this provider" heading, so readers meet the provider before the comparison.
- **openai**: clarified that `OpenAIHook` is the shared underlying client (not batch-specific); added the Batch API cost/turnaround rationale (~half cost, up to ~24h turnaround).
- **anthropic**: added the Message Batches cost/turnaround rationale (50% of standard cost, most within an hour, 24-hour SLA), reusing figures already in `operators/anthropic.rst`.
- **common.ai**:
    - added a use-case → package comparison table linking to the vendor provider pages
    - noted LangChain tools work via `LangChainToolset` with the `langchain` extra
    - linked the toolsets doc from the agent bullet and noted durable step replay on retry; added cohere to the vendor-provider bullet list.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
