### PR TITLE
Fix AwaitMessageTrigger crash on tombstone messages when apply_function is unset

### DIFF
--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py
@@ -132,11 +132,14 @@ class AwaitMessageTrigger(BaseEventTrigger):
             elif message.error():
                 raise AirflowException(f"Error: {message.error()}")
             else:
-                event = (
-                    await async_message_process(message)
-                    if async_message_process
-                    else message.value().decode("utf-8")
-                )
+                if async_message_process:
+                    event = await async_message_process(message)
+                else:
+                    value = message.value()
+                    # A tombstone (null value, e.g. from a log-compacted topic) carries no
+                    # payload to emit, so treat it like a non-matching message and keep polling
+                    # instead of raising AttributeError on ``None.decode()``.
+                    event = value.decode("utf-8") if value is not None else None
                 if event:
                     if self.commit_offset:
                         await async_commit(message=message, asynchronous=False)

--- a/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/triggers/test_await_message.py
@@ -50,6 +50,22 @@ class MockedMessage:
     def error(*args, **kwargs):
         return False
 
+    def value(*args, **kwargs):
+        return b"test_message"
+
+
+class MockedTombstoneMessage:
+    """A message with a null payload, e.g. a deletion marker from a log-compacted topic."""
+
+    def __init__(*args, **kwargs):
+        pass
+
+    def error(*args, **kwargs):
+        return False
+
+    def value(*args, **kwargs):
+        return None
+
 
 class MockedConsumer:
     def __init__(*args, **kwargs) -> None:
@@ -161,6 +177,62 @@ class TestTrigger:
         await asyncio.sleep(1.0)
         assert task.done() is False
         asyncio.get_event_loop().stop()
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_tombstone_message_keeps_polling(self, mocker):
+        """
+        A tombstone (null-value) message must not crash the trigger when no apply_function is set.
+
+        Regression test: the trigger previously raised
+        ``AttributeError: 'NoneType' object has no attribute 'decode'`` on ``message.value()``
+        returning ``None``. A tombstone carries no payload to emit, so the trigger should
+        commit the offset (when ``commit_offset`` is enabled) and keep polling.
+        """
+        message = MockedTombstoneMessage()
+        consumer = MockedConsumer()
+        mocker.patch.object(consumer, "poll", return_value=message)
+        commit_mock = mocker.patch.object(consumer, "commit")
+        mocker.patch.object(KafkaConsumerHook, "get_consumer", return_value=consumer)
+
+        trigger = AwaitMessageTrigger(
+            kafka_config_id="kafka_d",
+            apply_function=None,
+            topics=["noop"],
+            poll_timeout=0.0001,
+            poll_interval=5,
+        )
+
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(1.0)
+        try:
+            # The task must neither raise nor yield an event: the tombstone is skipped
+            # and the trigger sleeps through poll_interval waiting for the next message.
+            assert task.done() is False
+            # The tombstone offset is still committed, like any other non-matching message.
+            assert commit_mock.mock_calls == [call(message=message, asynchronous=False)]
+        finally:
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_trigger_run_without_apply_function_yields_message_value(self, mocker):
+        """A regular message with no apply_function yields the decoded message value."""
+        consumer = MockedConsumer()
+        mocker.patch.object(consumer, "poll", return_value=MockedMessage())
+        mocker.patch.object(consumer, "commit")
+        mocker.patch.object(KafkaConsumerHook, "get_consumer", return_value=consumer)
+
+        trigger = AwaitMessageTrigger(
+            kafka_config_id="kafka_d",
+            apply_function=None,
+            topics=["noop"],
+            poll_timeout=0.0001,
+            poll_interval=5,
+        )
+
+        task = asyncio.create_task(trigger.run().__anext__())
+        await asyncio.sleep(1.0)
+        assert task.done() is True
+        assert task.result().payload == "test_message"
 
     @pytest.mark.asyncio
     async def test_cleanup_closes_consumer(self, mocker):


### PR DESCRIPTION
When `AwaitMessageTrigger` is used without an `apply_function` (supported since #55437), the trigger calls `message.value().decode("utf-8")` on every polled message. For a tombstone message — `value()` is `None`, a routine occurrence on log-compacted topics where a null value is the deletion marker — this raises `AttributeError: 'NoneType' object has no attribute 'decode'`, crashing the trigger and failing the deferred task.

This PR treats a tombstone the same way as any other non-matching message: no event is emitted, the offset is committed (when `commit_offset=True`, matching the existing non-matching path so the tombstone is not re-read forever after a restart), and the trigger keeps polling.

Why skip rather than emit: the trigger's contract is already truthiness-based (`if event:`), so a `None` payload cannot be yielded on this path today, and a `TriggerEvent(None)` would carry no usable payload downstream. Users who need to react to tombstones can already do so via `apply_function`, which receives the raw message (including `value() is None`) and can map it to any truthy payload. Surfacing tombstones from the no-`apply_function` convenience path would be a separate opt-in feature; crashing on them is a bug.

Tests:
* `test_trigger_run_tombstone_message_keeps_polling` — regression test: `poll()` returns a null-value message; asserts the trigger neither raises nor yields and commits the tombstone offset. Fails on `main` with the exact `AttributeError` above.
* `test_trigger_run_without_apply_function_yields_message_value` — asserts the happy path still yields the decoded payload.
* `MockedMessage` now has a `value()` method: the `apply_function=None` case of `test_trigger_run_good` previously passed for the wrong reason — the mock lacked `value()`, so the task finished via this same `AttributeError`, satisfying `task.done() is True`.

No behavior change for non-null messages or when `apply_function` is set. Empty (`b""`) payloads were already treated as non-events by the `if event:` check — unchanged.
