### PR TITLE
Fix ExternalTaskSensor log timezone

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -23,6 +23,7 @@ import warnings
 from collections.abc import Callable, Collection, Iterable, Sequence
 from typing import TYPE_CHECKING, ClassVar
 
+import pendulum
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models.dag import DagModel
 from airflow.providers.common.compat.sdk import (
@@ -30,6 +31,7 @@ from airflow.providers.common.compat.sdk import (
     BaseOperatorLink,
     BaseSensorOperator,
     conf,
+    timezone,
 )
 from airflow.providers.standard.exceptions import (
     DuplicateStateError,
@@ -311,6 +313,26 @@ class ExternalTaskSensor(BaseSensorOperator):
     def _serialize_dttm_filter(dttm_filter: Sequence[datetime.datetime]) -> str:
         return ",".join(dt.isoformat() for dt in dttm_filter)
 
+    @staticmethod
+    def _get_default_timezone() -> datetime.tzinfo:
+        default_timezone = conf.get_mandatory_value("core", "default_timezone")
+        if default_timezone == "system":
+            return datetime.datetime.now().astimezone().tzinfo or datetime.timezone.utc
+        return pendulum.timezone(default_timezone)
+
+    @classmethod
+    def _serialize_dttm_filter_for_log(cls, dttm_filter: Sequence[datetime.datetime]) -> str:
+        default_timezone = cls._get_default_timezone()
+        formatted_dates = []
+        for dt in dttm_filter:
+            serialized_dt = dt.isoformat()
+            default_timezone_dt = timezone.coerce_datetime(dt).astimezone(default_timezone).isoformat()
+            if serialized_dt == default_timezone_dt:
+                formatted_dates.append(serialized_dt)
+            else:
+                formatted_dates.append(f"{serialized_dt} (default timezone: {default_timezone_dt})")
+        return ",".join(formatted_dates)
+
     def poke(self, context: Context) -> bool:
         # delay check to poke rather than __init__ in case it was supplied as XComArgs
         if self.external_task_ids and len(self.external_task_ids) > len(set(self.external_task_ids)):
@@ -318,6 +340,7 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         dttm_filter = self._get_dttm_filter(context)
         serialized_dttm_filter = self._serialize_dttm_filter(dttm_filter)
+        log_dttm_filter = self._serialize_dttm_filter_for_log(dttm_filter)
         # Save as attribute - to be used by listeners
         self.external_dates_filter = serialized_dttm_filter
 
@@ -326,7 +349,7 @@ class ExternalTaskSensor(BaseSensorOperator):
                 "Poking for tasks %s in dag %s on %s ... ",
                 self.external_task_ids,
                 self.external_dag_id,
-                serialized_dttm_filter,
+                log_dttm_filter,
             )
 
         if self.external_task_group_id:
@@ -334,14 +357,14 @@ class ExternalTaskSensor(BaseSensorOperator):
                 "Poking for task_group '%s' in dag '%s' on %s ... ",
                 self.external_task_group_id,
                 self.external_dag_id,
-                serialized_dttm_filter,
+                log_dttm_filter,
             )
 
         if self.external_dag_id and not self.external_task_group_id and not self.external_task_ids:
             self.log.info(
                 "Poking for DAG '%s' on %s ... ",
                 self.external_dag_id,
-                serialized_dttm_filter,
+                log_dttm_filter,
             )
 
         if AIRFLOW_V_3_0_PLUS:

--- a/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
+++ b/providers/standard/tests/unit/standard/sensors/test_external_task_sensor.py
@@ -23,6 +23,7 @@ import re
 from datetime import time, timedelta
 from unittest import mock
 
+import pendulum
 import pytest
 from sqlalchemy import select
 
@@ -124,6 +125,20 @@ EXTERNAL_IDS_AND_TASK_GROUP_ID_PROVIDE_ERROR = "Only one of `external_task_group
 @pytest.fixture(autouse=True)
 def clean_db():
     clear_db_runs()
+
+
+def test_serialize_dttm_filter_for_log_includes_configured_timezone(monkeypatch):
+    monkeypatch.setattr(
+        "airflow.providers.standard.sensors.external_task.conf.get_mandatory_value",
+        lambda *_: "Asia/Seoul",
+    )
+
+    dttm_filter = [pendulum.datetime(2026, 7, 6, 21, tz="UTC")]
+
+    assert (
+        ExternalTaskSensor._serialize_dttm_filter_for_log(dttm_filter)
+        == "2026-07-06T21:00:00+00:00 (default timezone: 2026-07-07T06:00:00+09:00)"
+    )
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Different test for v3.0+")
@@ -1413,6 +1428,33 @@ class TestExternalTaskSensorV3:
             task_ids=["test_task"],
         )
         assert op.external_dates_filter == expected_date.isoformat()
+
+    @pytest.mark.execution_timeout(10)
+    def test_external_dag_sensor_poke_log_includes_configured_timezone(
+        self, monkeypatch, caplog, dag_maker
+    ):
+        monkeypatch.setattr(
+            "airflow.providers.standard.sensors.external_task.conf.get_mandatory_value",
+            lambda *_: "Asia/Seoul",
+        )
+        logical_date = pendulum.datetime(2026, 7, 6, 21, tz="UTC")
+        self.context["logical_date"] = logical_date
+        self.context["ti"].get_dr_count.return_value = 0
+
+        with dag_maker("test_dag_child"):
+            op = ExternalTaskSensor(
+                task_id="test_external_dag_sensor_check",
+                external_dag_id="other_dag",
+            )
+
+        with caplog.at_level(logging.INFO, logger=op.log.name):
+            caplog.clear()
+            op.poke(context=self.context)
+
+        assert (
+            "Poking for DAG 'other_dag' on "
+            "2026-07-06T21:00:00+00:00 (default timezone: 2026-07-07T06:00:00+09:00) ... "
+        ) in caplog.messages
 
     @pytest.mark.execution_timeout(10)
     def test_external_task_sensor_duplicate_task_ids(self, dag_maker):


### PR DESCRIPTION
## Summary

Make `ExternalTaskSensor` poke logs display external logical dates in Airflow's configured timezone.

## Problem

`ExternalTaskSensor` logs currently serialize the external logical date directly from the stored filter value. This can make poke logs harder to read in deployments where Airflow is configured with a non-UTC timezone.

## Solution

- Add a log-only serializer that converts external logical dates to `settings.TIMEZONE`.
- Use the timezone-adjusted value in poke log messages for DAG, task group, and task checks.
- Keep `external_dates_filter` unchanged so listeners and integrations continue to receive the original serialized logical date.
- Added focused unit coverage for configured-timezone log serialization.

## Validation
- Added focused unit coverage for `ExternalTaskSensor._serialize_dttm_filter_for_log`.

closes: #69657
