### PR TITLE
Guard code_mode example DAG on SQLToolset import

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_agent.py
@@ -230,23 +230,24 @@ example_agent_operator_hitl_review()
 
 
 # [START howto_operator_agent_code_mode]
-@dag(tags=["example"])
-def example_agent_operator_code_mode():
-    AgentOperator(
-        task_id="code_mode_analyst",
-        prompt="For the top 3 customers by order count, what was each one's total spend?",
-        llm_conn_id="pydanticai_default",
-        system_prompt="You are a SQL analyst. Write Python that calls the tools to answer.",
-        toolsets=[SQLToolset(db_conn_id="postgres_default", allowed_tables=["customers", "orders"])],
-        # Requires the `code-mode` extra:
-        #   pip install "apache-airflow-providers-common-ai[code-mode]"
-        code_mode=True,
-    )
+if SQLToolset is not None:
 
+    @dag(tags=["example"])
+    def example_agent_operator_code_mode():
+        AgentOperator(
+            task_id="code_mode_analyst",
+            prompt="For the top 3 customers by order count, what was each one's total spend?",
+            llm_conn_id="pydanticai_default",
+            system_prompt="You are a SQL analyst. Write Python that calls the tools to answer.",
+            toolsets=[SQLToolset(db_conn_id="postgres_default", allowed_tables=["customers", "orders"])],
+            # Requires the `code-mode` extra:
+            #   pip install "apache-airflow-providers-common-ai[code-mode]"
+            code_mode=True,
+        )
 
-# [END howto_operator_agent_code_mode]
+    # [END howto_operator_agent_code_mode]
 
-example_agent_operator_code_mode()
+    example_agent_operator_code_mode()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

The `example_agent_operator_code_mode` DAG in `providers/common/ai` fails to parse when the optional `[sql]` extra (`sqlglot`) is not installed. It references `SQLToolset` at the module level without the `if SQLToolset is not None:` guard, so on a fresh environment `SQLToolset` is `None` and DAG parsing raises `TypeError: 'NoneType' object is not callable`.

This is a regression of the same class of bug fixed in #68497, which wrapped every SQL-dependent example DAG in this provider with the `if X is not None:` guard. The code-mode example was added afterward in #68407 and reintroduced the problem by omitting the guard.

This restores the established pattern: the DAG definition, its howto markers, and its registration call are all wrapped in `if SQLToolset is not None:`, so the DAG loads only when the optional dependency is present and no longer errors on a fresh dev environment.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
