### PR TITLE
Enforce execution_timeout during task deferrals

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -138,6 +138,7 @@ class TIDeferredStatePayload(StrictBaseModel):
     """
 
     trigger_timeout: timedelta | None = None
+    execution_timeout: timedelta | None = None
     queue: str | None = None
     next_method: str
     """The name of the method on the operator to call in the worker after the trigger has fired."""

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -693,8 +693,14 @@ def _create_ti_state_update_query_and_update_state(
         session.add(trigger_row)
         session.flush()
 
-        # TODO: HANDLE execution timeout later as it requires a call to the DB
-        # either get it from the serialised DAG or get it from the API
+        if ti_patch_payload.execution_timeout is not None:
+            ti = session.get(TI, task_instance_id)
+            if ti and ti.start_date:
+                execution_timeout_date = ti.start_date + ti_patch_payload.execution_timeout
+                if timeout:
+                    timeout = min(timeout, execution_timeout_date)
+                else:
+                    timeout = execution_timeout_date
 
         query = update(TI).where(TI.id == task_instance_id)
 

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1512,6 +1512,8 @@ class TestTIUpdateState:
                 state=State.RUNNING,
                 session=session,
             )
+            # simulate a task that started 1 hour ago
+            ti.start_date = timezone.datetime(2024, 11, 22) - timedelta(hours=1)
             session.commit()
 
             instant = timezone.datetime(2024, 11, 22)
@@ -1536,6 +1538,7 @@ class TestTIUpdateState:
                     },
                 },
                 "trigger_timeout": "P1D",  # 1 day
+                "execution_timeout": "PT2H", # 2 hours
                 "queue": "default" if queues_enabled else None,
                 "classpath": "my-classpath",
                 "next_method": "execute_callback",
@@ -1585,8 +1588,11 @@ class TestTIUpdateState:
                 },
                 "bar": "abc",
             }
+            # execution_timeout_date = start_date + 2 hours = 2024-11-22 - 1hr + 2hrs = 2024-11-22 01:00:00
+            # trigger_timeout = instant + 1 day = 2024-11-23 00:00:00
+            # min is execution_timeout_date
             assert tis[0].trigger_timeout == timezone.make_aware(
-                datetime(2024, 11, 23), timezone=timezone.utc
+                datetime(2024, 11, 22, 1, 0, 0), timezone=timezone.utc
             )
 
             t = session.scalars(select(Trigger)).all()

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest import mock
 from uuid import UUID, uuid4
@@ -1513,10 +1513,10 @@ class TestTIUpdateState:
                 session=session,
             )
             # simulate a task that started 1 hour ago
-            ti.start_date = timezone.datetime(2024, 11, 22) - timedelta(hours=1)
+            ti.start_date = datetime(2024, 11, 22, tzinfo=timezone.utc) - timedelta(hours=1)
             session.commit()
 
-            instant = timezone.datetime(2024, 11, 22)
+            instant = datetime(2024, 11, 22, tzinfo=timezone.utc)
             time_machine.move_to(instant, tick=False)
 
             payload = {

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -273,6 +273,7 @@ class TIDeferredStatePayload(BaseModel):
     classpath: Annotated[str, Field(title="Classpath")]
     trigger_kwargs: Annotated[dict[str, JsonValue] | str | None, Field(title="Trigger Kwargs")] = None
     trigger_timeout: Annotated[timedelta | None, Field(title="Trigger Timeout")] = None
+    execution_timeout: Annotated[timedelta | None, Field(title="Execution Timeout")] = None
     queue: Annotated[str | None, Field(title="Queue")] = None
     next_method: Annotated[str, Field(title="Next Method")]
     next_kwargs: Annotated[dict[str, JsonValue] | None, Field(title="Next Kwargs")] = None

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1476,6 +1476,7 @@ def _defer_task(
         classpath=classpath,
         trigger_kwargs=trigger_kwargs,
         trigger_timeout=defer.timeout,
+        execution_timeout=ti.task.execution_timeout,
         queue=queue,
         next_method=defer.method_name,
         next_kwargs=next_kwargs,
@@ -2070,6 +2071,7 @@ def _run_execute_callable(
     context: Context,
     execute: Callable[..., Any] | functools.partial[Any],
     task: BaseOperator,
+    ti: RuntimeTaskInstance,
 ) -> Any:
     """
     Run the task's execute callable, applying the execution timeout if one is set.
@@ -2084,9 +2086,15 @@ def _run_execute_callable(
     ctx.run(ExecutorSafeguard.tracker.set, task)
     if task.execution_timeout:
         from airflow.sdk.execution_time.timeout import timeout
+        from airflow.utils.timezone import utcnow
 
-        # TODO: handle timeout in case of deferral
         timeout_seconds = task.execution_timeout.total_seconds()
+        
+        # If the task resumes from deferral, subtract the time already spent
+        if ti.start_date:
+            time_passed = (utcnow() - ti.start_date).total_seconds()
+            timeout_seconds -= time_passed
+
         try:
             # It's possible we're already timed out, so fast-fail if true
             if timeout_seconds <= 0:
@@ -2140,7 +2148,7 @@ def _execute_task(context: Context, ti: RuntimeTaskInstance, log: Logger):
 
     log.info("::endgroup::")
 
-    result = _run_execute_callable(context, execute, task)
+    result = _run_execute_callable(context, execute, task, ti)
 
     if (post_execute_hook := task._post_execute_hook) is not None:
         create_executable_runner(post_execute_hook, outlet_events, logger=log).run(context, result)

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -2086,13 +2086,12 @@ def _run_execute_callable(
     ctx.run(ExecutorSafeguard.tracker.set, task)
     if task.execution_timeout:
         from airflow.sdk.execution_time.timeout import timeout
-        from airflow.utils.timezone import utcnow
 
         timeout_seconds = task.execution_timeout.total_seconds()
         
         # If the task resumes from deferral, subtract the time already spent
         if ti.start_date:
-            time_passed = (utcnow() - ti.start_date).total_seconds()
+            time_passed = (datetime.now(tz=timezone.utc) - ti.start_date).total_seconds()
             timeout_seconds -= time_passed
 
         try:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5712,7 +5712,7 @@ class TestRunExecuteCallable:
             seen["tracker"] = ExecutorSafeguard.tracker.get(None)
             return context["value"] * 2
 
-        result = _run_execute_callable(context={"value": 21}, execute=execute, task=task)
+        result = _run_execute_callable(context={"value": 21}, execute=execute, task=task, ti=mock.MagicMock(start_date=None))
 
         assert result == 42
         # The safeguard tracker is set to the task inside the copy used to run execute.
@@ -5731,7 +5731,7 @@ class TestRunExecuteCallable:
             time.sleep(0.2)
 
         with pytest.raises(AirflowTaskTimeout):
-            _run_execute_callable(context={}, execute=execute, task=task)
+            _run_execute_callable(context={}, execute=execute, task=task, ti=mock.MagicMock(start_date=None))
 
         task.on_kill.assert_called_once()
 
@@ -5741,7 +5741,7 @@ class TestRunExecuteCallable:
         execute = mock.MagicMock()
 
         with pytest.raises(AirflowTaskTimeout):
-            _run_execute_callable(context={}, execute=execute, task=task)
+            _run_execute_callable(context={}, execute=execute, task=task, ti=mock.MagicMock(start_date=None))
 
         execute.assert_not_called()
         task.on_kill.assert_called_once()
@@ -5759,7 +5759,7 @@ class TestRunExecuteCallable:
 
         with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
             with t.start_as_current_span("parent", context=parent_ctx):
-                result = _run_execute_callable(context={}, execute=lambda context: "ok", task=task)
+                result = _run_execute_callable(context={}, execute=lambda context: "ok", task=task, ti=mock.MagicMock(start_date=None))
 
         assert result == "ok"
         names = [s.name for s in exporter.get_finished_spans()]
@@ -5787,7 +5787,7 @@ class TestRunExecuteCallable:
 
         with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
             with t.start_as_current_span("parent", context=parent_ctx):
-                result = _run_execute_callable(context={}, execute=execute, task=task)
+                result = _run_execute_callable(context={}, execute=execute, task=task, ti=mock.MagicMock(start_date=None))
 
         assert result == "ok"
         spans = {s.name: s for s in exporter.get_finished_spans()}
@@ -5806,7 +5806,7 @@ class TestRunExecuteCallable:
 
         with mock.patch("airflow.sdk.execution_time.task_runner.tracer", t):
             with t.start_as_current_span("parent", context=parent_ctx):
-                result = _run_execute_callable(context={}, execute=lambda context: "ok", task=task)
+                result = _run_execute_callable(context={}, execute=lambda context: "ok", task=task, ti=mock.MagicMock(start_date=None))
 
         assert result == "ok"
         names = [s.name for s in exporter.get_finished_spans()]


### PR DESCRIPTION
When a task instance updates its state to `DEFERRED` via the Execution API, the system only recorded the `trigger_timeout`, but failed to enforce the task's overall `execution_timeout`.

This PR fixes this by:
1. Adding `execution_timeout` to the `TIDeferredStatePayload` schema.
2. Updating the Task SDK to compute and pass the `ti.task.execution_timeout` in the `DeferTask` payload.
3. Updating the Execution API `ti_update_state` route to compute the absolute execution timeout ceiling limit (`ti.start_date + execution_timeout`) and store the minimum of the `trigger_timeout` and `execution_timeout`.
4. Updating `task_runner.py` to also deduct time already spent when local execution resumes, ensuring that time limits apply properly across deferral gaps.

closes: #69678

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.
-->

---
###### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Google DeepMind Antigravity IDE following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=4d4c362 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @KushagraB424** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
