### PR TITLE
Fix before_send/transport dotted-path resolution in Task SDK Sentry c…

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/sentry/configured.py
+++ b/task-sdk/src/airflow/sdk/execution_time/sentry/configured.py
@@ -80,24 +80,26 @@ class ConfiguredSentry(NoopSentry):
                 log.exception("Invalid executor Sentry integration", import_path=executor_integration)
 
         sentry_config_opts: dict[str, Any] = conf.getsection("sentry") or {}
-        if sentry_config_opts:
-            sentry_config_opts.pop("sentry_on")
-            old_way_dsn = sentry_config_opts.pop("sentry_dsn", None)
-            new_way_dsn = sentry_config_opts.pop("dsn", None)
-            # supported backward compatibility with old way dsn option
-            dsn = old_way_dsn or new_way_dsn
+        sentry_config_opts.pop("sentry_on", None)
+        old_way_dsn = sentry_config_opts.pop("sentry_dsn", None)
+        new_way_dsn = sentry_config_opts.pop("dsn", None)
+        # supported backward compatibility with old way dsn option
+        dsn = old_way_dsn or new_way_dsn
 
-            if unsupported_options := self.UNSUPPORTED_SENTRY_OPTIONS.intersection(sentry_config_opts):
-                log.warning(
-                    "There are unsupported options in [sentry] section",
-                    options=unsupported_options,
-                )
-        else:
-            dsn = None
-            if before_send := conf.getimport("sentry", "before_send", fallback=None):
-                sentry_config_opts["before_send"] = before_send
-            if transport := conf.getimport("sentry", "transport", fallback=None):
-                sentry_config_opts["transport"] = transport
+        if unsupported_options := self.UNSUPPORTED_SENTRY_OPTIONS.intersection(sentry_config_opts):
+            log.warning(
+                "There are unsupported options in [sentry] section",
+                options=unsupported_options,
+            )
+
+        # before_send/transport are dotted-path strings and must be resolved to callables here.
+        # This must run unconditionally: conf.getsection("sentry") always returns a non-empty
+        # dict (schema defaults), so gating this behind "sentry_config_opts is empty" made it
+        # unreachable and left before_send/transport as raw strings (GH#69464).
+        if before_send := conf.getimport("sentry", "before_send", fallback=None):
+            sentry_config_opts["before_send"] = before_send
+        if transport := conf.getimport("sentry", "transport", fallback=None):
+            sentry_config_opts["transport"] = transport
 
         if dsn:
             sentry_sdk.init(dsn=dsn, integrations=integrations, **sentry_config_opts)

--- a/task-sdk/tests/task_sdk/execution_time/test_sentry.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_sentry.py
@@ -202,7 +202,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[],
                 default_integrations=False,
-                before_send="task_sdk.execution_time.test_sentry.before_send",
+                before_send=before_send,
             ),
         ]
 
@@ -216,7 +216,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[import_string("task_sdk.execution_time.test_sentry.CustomIntegration")()],
                 default_integrations=False,
-                before_send="task_sdk.execution_time.test_sentry.before_send",
+                before_send=before_send,
             ),
         ]
 
@@ -265,7 +265,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[],
                 default_integrations=False,
-                transport="task_sdk.execution_time.test_sentry.CustomTransport",
+                transport=CustomTransport,
             ),
         ]
 

--- a/task-sdk/tests/task_sdk/execution_time/test_sentry.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_sentry.py
@@ -202,7 +202,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[],
                 default_integrations=False,
-                before_send=before_send,
+                before_send=import_string("task_sdk.execution_time.test_sentry.before_send"),
             ),
         ]
 
@@ -216,7 +216,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[import_string("task_sdk.execution_time.test_sentry.CustomIntegration")()],
                 default_integrations=False,
-                before_send=before_send,
+                before_send=import_string("task_sdk.execution_time.test_sentry.before_send"),
             ),
         ]
 
@@ -265,7 +265,7 @@ class TestSentryHook:
             mock.call(
                 integrations=[],
                 default_integrations=False,
-                transport=CustomTransport,
+                transport=import_string("task_sdk.execution_time.test_sentry.CustomTransport"),
             ),
         ]
 


### PR DESCRIPTION
Fix `[sentry] before_send`/`transport` dotted-path config never resolved to a callable in Task SDK

## Problem

`ConfiguredSentry.prepare_to_enrich_errors()` in
`task-sdk/src/airflow/sdk/execution_time/sentry/configured.py` resolves the
`before_send`/`transport` dotted-path config options into real callables only
inside an `else` branch guarded by `if sentry_config_opts:`.

`conf.getsection("sentry")` always returns a non-empty dict (schema defaults
such as `sentry_on` are always present), so that `if` is always true and the
`else` branch — the only place `before_send`/`transport` are ever resolved via
`conf.getimport()` — is unreachable dead code.

As a result, a configured `before_send`/`transport` dotted path is passed to
`sentry_sdk.init()` as a raw string instead of a callable. `sentry_sdk` then
raises `TypeError: 'str' object is not callable` internally when trying to
invoke it, which it swallows via `capture_internal_exceptions()` — so every
Sentry event is silently dropped with no error surfaced to the user.

This is a regression from Airflow 2.x's `airflow/sentry.py`, where the
equivalent `conf.getimport(...)` calls ran unconditionally. The branching
structure changed when this was ported to the Task SDK in #57032, making the
resolution path unreachable.

## Fix

Make `before_send`/`transport` resolution unconditional, matching 2.x
behavior, while preserving the existing DSN handling and the
`UNSUPPORTED_SENTRY_OPTIONS` warning.

## Testing

- Updated the three existing tests (`test_prepare_to_enrich_errors`,
  `test_prepare_to_enrich_errors_with_executor_integration`,
  `test_custom_transport`) that were asserting the *unresolved dotted-path
  string* was passed to `sentry_sdk.init()` — they now assert the *resolved
  callable*, which is effectively the regression test for this bug.
- No behavior change when `before_send`/`transport` aren't configured
  (`test_minimum_config` still passes unchanged).

closes: #69464

## AI Disclosure

- [x] This contribution used AI assistance.

**Model(s) used:** Codex (GPT-5.5) Following by [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


**AI was used for:**
- Drafting the PR description.
- Verifying test cases locally.
- Reviewing the implementation from a performance perspective.

The implementation and code changes were developed and validated by me.