### PR TITLE
Keep asyncpg installed by default in the Postgres provider

### DIFF
--- a/providers/postgres/README.rst
+++ b/providers/postgres/README.rst
@@ -60,6 +60,7 @@ PIP package                                 Version required
 ``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``psycopg[binary]``                         ``>=3.2.9; python_version < "3.14"``
 ``psycopg[binary]``                         ``>=3.3.3; python_version >= "3.14"``
+``asyncpg``                                 ``>=0.30.0``
 ==========================================  ======================================
 
 Optional cross provider package dependencies

--- a/providers/postgres/docs/changelog.rst
+++ b/providers/postgres/docs/changelog.rst
@@ -34,14 +34,19 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 .. note::
-    The default async metadata-database driver is now ``psycopg`` (psycopg3),
-    which is installed by default in place of ``asyncpg``. As a result, the
-    ``[psycopg]`` optional extra was removed and ``[asyncpg]`` was added.
-
-    Starting with Airflow 3.4.0, the default derived async connection URL changes from
+    On Airflow 3.4.0 and later, the default async metadata-database driver becomes
+    ``psycopg`` (psycopg3): the derived async connection URL changes from
     ``postgresql+asyncpg://`` to ``postgresql+psycopg_async://``, which is safe behind
-    transaction-mode PgBouncer with no extra configuration. To keep using asyncpg, install
-    ``apache-airflow-providers-postgres[asyncpg]`` and set
+    transaction-mode PgBouncer with no extra configuration. ``psycopg[binary]`` is now
+    installed by default to serve it.
+
+    ``asyncpg`` remains installed by default as well. This provider still supports Airflow
+    cores older than 3.4.0, which derive the async URL as ``postgresql+asyncpg://``
+    unconditionally and have no psycopg fallback — so asyncpg must stay present for them to
+    work. It will become opt-in-only (via the existing ``[asyncpg]`` extra) in a future
+    release once the minimum supported Airflow is 3.4.0.
+
+    To keep using asyncpg on Airflow 3.4.0+, set
     ``[database] sql_alchemy_conn_async = postgresql+asyncpg://...`` explicitly.
 
 * ``Switch the default async Postgres driver from asyncpg to psycopg3 (#69089)``

--- a/providers/postgres/docs/index.rst
+++ b/providers/postgres/docs/index.rst
@@ -108,6 +108,7 @@ PIP package                                 Version required
 ``psycopg2-binary``                         ``>=2.9.10; python_version >= "3.13"``
 ``psycopg[binary]``                         ``>=3.2.9; python_version < "3.14"``
 ``psycopg[binary]``                         ``>=3.3.3; python_version >= "3.14"``
+``asyncpg``                                 ``>=0.30.0``
 ==========================================  ======================================
 
 Optional cross provider package dependencies

--- a/providers/postgres/pyproject.toml
+++ b/providers/postgres/pyproject.toml
@@ -68,6 +68,13 @@ dependencies = [
     "psycopg2-binary>=2.9.10; python_version >= '3.13'",
     "psycopg[binary]>=3.2.9; python_version < '3.14'",
     "psycopg[binary]>=3.3.3; python_version >= '3.14'",
+    # asyncpg must stay a default dependency while this provider still supports Airflow
+    # cores older than 3.4.0: those cores derive the async metadata-DB URL as
+    # ``postgresql+asyncpg://`` unconditionally and have no psycopg_async fallback, so
+    # dropping asyncpg breaks their async engine. Make it opt-in-only (via the ``[asyncpg]``
+    # extra) only once the minimum supported Airflow is >= 3.4.0; tracked at
+    # https://github.com/apache/airflow/issues/68453
+    "asyncpg>=0.30.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/uv.lock
+++ b/uv.lock
@@ -7172,6 +7172,7 @@ dependencies = [
     { name = "apache-airflow" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-sql" },
+    { name = "asyncpg" },
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg2-binary" },
 ]
@@ -7223,6 +7224,7 @@ requires-dist = [
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
     { name = "apache-airflow-providers-microsoft-azure", marker = "extra == 'microsoft-azure'", editable = "providers/microsoft/azure" },
     { name = "apache-airflow-providers-openlineage", marker = "extra == 'openlineage'", editable = "providers/openlineage" },
+    { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "asyncpg", marker = "extra == 'asyncpg'", specifier = ">=0.30.0" },
     { name = "pandas", marker = "python_full_version == '3.13.*' and extra == 'pandas'", specifier = ">=2.2.3" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'pandas'", specifier = ">=2.1.2" },


### PR DESCRIPTION
### Problem

Postgres provider `7.0.0` (currently in RC as `7.0.0rc1`, #69526 / merged #69089) made **psycopg3 the default async metadata-DB driver** and, as part of that, **moved `asyncpg` from a default dependency to the opt-in `[asyncpg]` extra**.

The psycopg-async default and its `postgresql+asyncpg://` fallback only exist on **Airflow 3.4.0+** (`airflow-core` `settings.py::_get_async_conn_uri_from_sync`). Every **currently released** 3.x core (3.0–3.3), which this provider still supports (`apache-airflow>=2.11.0`), derives the async metadata-DB URL as `postgresql+asyncpg://` **unconditionally** and has **no psycopg fallback**.

So upgrading the Postgres provider to `7.0.0` on any released 3.x core (or a 3.4.0 deployment that pinned an older core) leaves the async metadata-DB engine unable to load its driver:

```
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgresql.asyncpg
```

This is a regression against cores the provider claims to support, and a reason to hold `postgres 7.0.0rc1`.

### Fix

Keep `asyncpg` as a **default** dependency of the Postgres provider until its minimum supported Airflow is `3.4.0` (i.e. until every supported core knows the `psycopg_async` fallback). psycopg3 remains the default *async* driver on 3.4.0+; asyncpg is simply still present so older supported cores keep working. The removal is gated on the floor bump and noted at the workaround site.

- `pyproject.toml`: add `asyncpg>=0.30.0` back to default `dependencies` (comment explains the constraint + tracking issue).
- `changelog.rst`: correct the 7.0.0 note — asyncpg stays installed by default; the psycopg_async switch is 3.4.0+ behavior only.
- `README.rst` / `docs/index.rst` / `uv.lock`: regenerated by prek hooks.

The eventual removal (converge on psycopg3-only) is tracked at #68453.

related: #69526
related: #68453

### Test plan

Dependency/packaging + changelog change; no Python behavior to unit-test (the affected async-URL derivation lives in `airflow-core`, unchanged here). Verified: prek `Update dependencies for providers`, `Sync provider README.rst Requirements table with pyproject.toml`, `Update uv.lock`, and changelog-format hooks all pass.

> Note: two related **core** hardening items remain as separate follow-ups (not required to unblock the RC): core `_USE_PSYCOPG3` gates on `find_spec("psycopg")` only, missing the SQLAlchemy-2 guard the provider hook has; and the derived async URL is not validated against installed drivers, so failures surface as an opaque `NoSuchModuleError`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)