### PR TITLE
Mention min Java version in Java SDK README

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/java.rst
@@ -39,7 +39,7 @@ The generated API reference for the Java SDK is published with the Airflow docum
 Prerequisites
 -------------
 
-* JRE 17 or later must be available on the Airflow worker nodes.
+* JRE 11 or later must be available on the Airflow worker nodes.
 * The compiled task JAR(s) and JVM dependencies must be accessible from the worker.
 * The ``apache-airflow-task-sdk`` package (installed with Airflow) provides the coordinator;
   no additional Python packages are needed.

--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -25,6 +25,12 @@ write workflow bundles, and have Airflow consume the result.
 The SDK and execution-time logic is implemented in Kotlin.
 An example is bundled showing how the SDK can be used in Java.
 
+See also Airflow documentation on Java SDK under *Authoring and Scheduling* for
+more details on using the Java SDK.
+
+The SDK requires Java 11 or later at runtime. Optional components and
+development tools may have further requirements.
+
 ## Building the SDK
 
 ```bash


### PR DESCRIPTION
The Airflow side documentation incorrectly said the minimum requirement is 17. It is corrected. (17 is required if you want to use the Spark integration, as specified in the Spark example.)