### PR TITLE
Add log socket reconnections

### DIFF
--- a/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
+++ b/task-sdk/src/airflow/sdk/coordinators/_subprocess.py
@@ -43,7 +43,13 @@ import structlog
 
 from airflow.sdk.configuration import conf
 from airflow.sdk.execution_time.coordinator import BaseCoordinator
-from airflow.sdk.execution_time.supervisor import ActivitySubprocess, NeverRaised, ProcessTracker
+from airflow.sdk.execution_time.supervisor import (
+    ActivitySubprocess,
+    NeverRaised,
+    ProcessTracker,
+    make_buffered_socket_reader,
+    process_log_messages_from_subprocess,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -352,6 +358,7 @@ class _PopenActivitySubprocess(ActivitySubprocess):
                 *tracker.untrack(stdout_r, stderr_r, socks[comm_server], socks[logs_server]),
                 data=drained,
             )
+            self._register_logs_reaccepter(logs_server, proc)
             self._on_child_started(
                 ti=what,
                 dag_rel_path=dag_rel_path,
@@ -364,6 +371,45 @@ class _PopenActivitySubprocess(ActivitySubprocess):
             tracker.untrack(comm_server, logs_server, proc)
 
         return self
+
+    def _register_logs_reaccepter(self, logs_server: socket.socket, proc: subprocess.Popen) -> None:
+        """Keep accepting on the logs server so runtimes can reconnect and flush buffered logs."""
+
+        def accept(sock: socket.socket) -> bool:
+            try:
+                conn, _ = sock.accept()
+            except BlockingIOError:
+                return True
+            except OSError:
+                return False
+            try:
+                if not _is_connection_from_process(conn, proc):
+                    log.warning(
+                        "Rejected log reconnection not owned by child process",
+                        pid=proc.pid,
+                        peer=conn.getpeername(),
+                    )
+                    conn.close()
+                    return True
+            except OSError:
+                log.warning("Rejected log reconnection after socket error", pid=proc.pid)
+                conn.close()
+                return True
+            log.debug("Accepted log socket reconnection", pid=proc.pid)
+            self._open_sockets[conn] = "logs"
+            self.selector.register(
+                conn,
+                selectors.EVENT_READ,
+                make_buffered_socket_reader(
+                    process_log_messages_from_subprocess(self._get_target_loggers()),
+                    on_close=self._on_socket_closed,
+                ),
+            )
+            return True
+
+        # Not in _open_sockets: a listener has no EOF, so the monitor loop must not wait on it.
+        logs_server.setblocking(False)
+        self.selector.register(logs_server, selectors.EVENT_READ, (accept, self._on_socket_closed))
 
     def wait(self) -> int:
         code = super().wait()

--- a/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
+++ b/task-sdk/tests/task_sdk/coordinators/test_subprocess.py
@@ -844,3 +844,85 @@ class TestPopenActivitySubprocessStart:
                 subprocess_logs_to_stdout=False,
             )
         assert mock_register.mock_calls == [call(ANY, ANY, ANY, ANY, data=ANY)]
+
+
+class TestLogsReaccepter:
+    @pytest.fixture(autouse=True)
+    def mock_child_connection_check(self):
+        with patch(
+            "airflow.sdk.coordinators._subprocess._is_connection_from_process",
+            return_value=True,
+        ):
+            yield
+
+    @pytest.fixture
+    def proc(self, mock_client):
+        with (
+            patch("airflow.sdk.coordinators._subprocess.subprocess.Popen") as popen_mock,
+            patch(
+                "airflow.sdk.coordinators._subprocess._accept_connections",
+                side_effect=lambda servers, drains, proc, **kw: (
+                    {soc: MagicMock(spec=socket.socket) for soc in servers.values()},
+                    {soc: b"" for soc in drains.values()},
+                ),
+            ),
+            patch.object(ActivitySubprocess, "_register_pipe_readers"),
+            patch.object(ActivitySubprocess, "_on_child_started"),
+        ):
+            popen_mock.return_value.pid = 12345
+            proc = _PopenActivitySubprocess.start(
+                what=_make_ti(),
+                dag_rel_path="bundle",
+                bundle_info=MagicMock(),
+                client=mock_client,
+                command=["/bin/true"],
+                subprocess_logs_to_stdout=False,
+            )
+        yield proc
+        proc.selector.close()
+        proc._close_unused_sockets(proc._comm_server, proc._logs_server)
+
+    def test_reconnected_log_records_are_forwarded(self, proc):
+        """A runtime reconnecting to the logs server gets its flushed records read, not black-holed."""
+        received: list[bytes] = []
+
+        def recording_processor(loggers):
+            while True:
+                received.append(bytes((yield)))
+
+        with patch(
+            "airflow.sdk.coordinators._subprocess.process_log_messages_from_subprocess",
+            side_effect=recording_processor,
+        ):
+            client = socket.create_connection(proc._logs_server.getsockname())
+            try:
+                # First service accepts the reconnection, second reads the flushed line.
+                proc._service_subprocess(max_wait_time=1.0)
+                assert "logs" in proc._open_sockets.values()
+                client.sendall(b'{"event": "buffered while down"}\n')
+                proc._service_subprocess(max_wait_time=1.0)
+            finally:
+                client.close()
+        assert received == [b'{"event": "buffered while down"}\n']
+
+    @pytest.mark.parametrize("check", [False, OSError("gone")], ids=["not_owned", "socket_error"])
+    def test_rejected_reconnection_keeps_listening(self, proc, check):
+        with patch(
+            "airflow.sdk.coordinators._subprocess._is_connection_from_process",
+            **({"side_effect": check} if isinstance(check, OSError) else {"return_value": check}),
+        ):
+            rejected = socket.create_connection(proc._logs_server.getsockname())
+            proc._service_subprocess(max_wait_time=1.0)
+            rejected.close()
+        assert "logs" not in proc._open_sockets.values()
+
+        accepted = socket.create_connection(proc._logs_server.getsockname())
+        try:
+            proc._service_subprocess(max_wait_time=1.0)
+            assert "logs" in proc._open_sockets.values()
+        finally:
+            accepted.close()
+
+    def test_spurious_wakeup_does_not_close_listener(self, proc):
+        handler, _ = proc.selector.get_key(proc._logs_server).data
+        assert handler(proc._logs_server) is True


### PR DESCRIPTION
## Why

A task runtime that dropped its logs connection could never reconnect, so logs buffered during the outage were silently lost.

## How

- Register a non-blocking reaccepter on the logs server so runtimes can reconnect and flush buffered logs
- Reject reconnections not owned by the child process tree; transient socket errors no longer stall the supervisor loop
- Test reconnection forwarding, rejection paths, and spurious wakeups

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)