### PR TITLE
Avoid deactivating configured Dag bundles on transient get bundle errors

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -314,13 +314,18 @@ class DagBundlesManager(LoggingMixin):
                 if not team:
                     raise _bundle_item_exc(f"Team '{config.team_name}' does not exist")
 
+            # Pop configured bundles out of ``stored`` before ``_extract_and_sign_template``.
+            # A transient connection error from that call must not deactivate the bundle,
+            # which would make all Dags in it non-schedulable.
+            bundle = stored.pop(name, None)
+
             try:
                 new_template, new_params = _extract_and_sign_template(name)
             except Exception as e:
                 self.log.exception("Error creating bundle '%s': %s", name, e)
                 continue
 
-            if bundle := stored.pop(name, None):
+            if bundle:
                 bundle.active = True
                 if new_template != bundle.signed_url_template:
                     bundle.signed_url_template = new_template

--- a/airflow-core/src/airflow/dag_processing/bundles/manager.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/manager.py
@@ -355,13 +355,18 @@ class DagBundlesManager(LoggingMixin):
                 if not team:
                     raise _bundle_item_exc(f"Team '{config.team_name}' does not exist")
 
+            # Pop configured bundles out of ``stored`` before ``_extract_and_sign_template``.
+            # A transient connection error from that call must not deactivate the bundle,
+            # which would make all Dags in it non-schedulable.
+            bundle = stored.pop(name, None)
+
             try:
                 new_template, new_params = _extract_and_sign_template(name)
             except Exception as e:
                 self.log.exception("Error creating bundle '%s': %s", name, e)
                 continue
 
-            if bundle := stored.pop(name, None):
+            if bundle:
                 bundle.active = True
                 if new_template != bundle.signed_url_template:
                     bundle.signed_url_template = new_template

--- a/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
@@ -201,6 +201,36 @@ def test_sync_bundles_to_db(clear_db, session):
 
 @pytest.mark.db_test
 @conf_vars({("core", "LOAD_EXAMPLES"): "False"})
+def test_sync_bundles_to_db_keeps_configured_bundle_on_transient_creation_error(clear_db, session):
+    """A configured bundle failing to instantiate with transient error must not be deactivated."""
+    with patch.dict(
+        os.environ, {"AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(BASIC_BUNDLE_CONFIG)}
+    ):
+        manager = DagBundlesManager()
+        manager.sync_bundles_to_db()
+
+        session.add(
+            ParseImportError(
+                bundle_name="my-test-bundle",
+                filename="some_file.py",
+                stacktrace="some error",
+            )
+        )
+        session.flush()
+
+        manager = DagBundlesManager()
+        with patch.object(
+            DagBundlesManager, "get_bundle", autospec=True, side_effect=RuntimeError("transient error")
+        ):
+            manager.sync_bundles_to_db()
+
+    bundle = session.scalar(select(DagBundleModel).where(DagBundleModel.name == "my-test-bundle"))
+    assert bundle.active is True
+    assert session.scalar(select(func.count(ParseImportError.id))) == 1
+
+
+@pytest.mark.db_test
+@conf_vars({("core", "LOAD_EXAMPLES"): "False"})
 def test_sync_bundles_to_db_does_not_log_removing_none_team(clear_db, caplog):
     with patch.dict(
         os.environ, {"AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(BASIC_BUNDLE_CONFIG)}

--- a/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_dag_bundle_manager.py
@@ -223,6 +223,36 @@ def test_sync_bundles_to_db(clear_db, session):
 
 @pytest.mark.db_test
 @conf_vars({("core", "LOAD_EXAMPLES"): "False"})
+def test_sync_bundles_to_db_keeps_configured_bundle_on_transient_creation_error(clear_db, session):
+    """A configured bundle failing to instantiate with transient error must not be deactivated."""
+    with patch.dict(
+        os.environ, {"AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(BASIC_BUNDLE_CONFIG)}
+    ):
+        manager = DagBundlesManager()
+        manager.sync_bundles_to_db()
+
+        session.add(
+            ParseImportError(
+                bundle_name="my-test-bundle",
+                filename="some_file.py",
+                stacktrace="some error",
+            )
+        )
+        session.flush()
+
+        manager = DagBundlesManager()
+        with patch.object(
+            DagBundlesManager, "get_bundle", autospec=True, side_effect=RuntimeError("transient error")
+        ):
+            manager.sync_bundles_to_db()
+
+    bundle = session.scalar(select(DagBundleModel).where(DagBundleModel.name == "my-test-bundle"))
+    assert bundle.active is True
+    assert session.scalar(select(func.count(ParseImportError.id))) == 1
+
+
+@pytest.mark.db_test
+@conf_vars({("core", "LOAD_EXAMPLES"): "False"})
 def test_sync_bundles_to_db_does_not_log_removing_none_team(clear_db, caplog):
     with patch.dict(
         os.environ, {"AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST": json.dumps(BASIC_BUNDLE_CONFIG)}

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -45,6 +45,7 @@ from uuid6 import uuid7
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.dag_processing.bundles.base import BaseDagBundle
+from airflow.dag_processing.bundles.local import LocalDagBundle
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.dagbag import DagBag
 from airflow.dag_processing.manager import (
@@ -83,6 +84,18 @@ pytestmark = pytest.mark.db_test
 
 logger = logging.getLogger(__name__)
 TEST_DAG_FOLDER = Path(__file__).parents[1].resolve() / "dags"
+
+
+class _HealthControlledDagBundle(LocalDagBundle):
+    """LocalDagBundle that fails to instantiate unless its health file contains "ok"."""
+
+    def __init__(self, *, health_file: str, **kwargs) -> None:
+        state = Path(health_file).read_text().strip()
+        if state != "ok":
+            raise RuntimeError(f"simulated {state}")
+        super().__init__(**kwargs)
+
+
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 
@@ -1071,6 +1084,77 @@ class TestDagFileProcessorManager:
             ).all()
         )
         assert is_stale_by_dag == {"dag_in_inactive_bundle": True, "dag_in_active_bundle": False}
+
+    def test_transient_bundle_creation_error_keeps_bundle_active_and_dags_fresh(self, tmp_path):
+        """A bundle failing to instantiate with transient error must not be deactivated."""
+        dags_dir = tmp_path / "dags"
+        dags_dir.mkdir()
+        (dags_dir / "good_dag.py").write_text(
+            textwrap.dedent(
+                """
+                from airflow.providers.standard.operators.empty import EmptyOperator
+                from airflow.sdk import DAG
+
+                with DAG(dag_id="dag_in_flaky_bundle", schedule=None):
+                    EmptyOperator(task_id="noop")
+                """
+            )
+        )
+        (dags_dir / "broken_dag.py").write_text("an invalid airflow DAG")
+        health_file = tmp_path / "health.txt"
+
+        bundle_config = [
+            {
+                "name": "flaky-bundle",
+                "classpath": f"{__name__}._HealthControlledDagBundle",
+                "kwargs": {
+                    "path": str(dags_dir),
+                    "health_file": str(health_file),
+                    "refresh_interval": 0,
+                },
+            }
+        ]
+
+        def get_db_state():
+            with create_session() as session:
+                active = session.scalar(
+                    select(DagBundleModel.active).where(DagBundleModel.name == "flaky-bundle")
+                )
+                fresh_dags = session.scalar(
+                    select(func.count())
+                    .select_from(DagModel)
+                    .where(DagModel.bundle_name == "flaky-bundle", ~DagModel.is_stale)
+                )
+                import_errors = session.scalar(select(func.count()).select_from(ParseImportError))
+            return active, fresh_dags, import_errors
+
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(bundle_config)}):
+            # Phase 1: misconfigured from day one — sync never succeeds, so no bundle row exists at all
+            health_file.write_text("misconfiguration")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (None, 0, 0)
+
+            # Phase 2: healthy restart — the bundle row appears and Dags get parsed
+            health_file.write_text("ok")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (True, 1, 1)
+
+            # Phase 3: restart with transient connection error — must not deactivate the bundle
+            health_file.write_text("transient connection error")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (True, 1, 1)
+
+            # Phase 4: healthy again
+            health_file.write_text("ok")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (True, 1, 1)
+
+        # Phase 5: removing the (again failing) bundle from config must follow the removal
+        # path: deactivate it, mark its Dags stale, and drop its import errors.
+        health_file.write_text("transient connection error")
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps([])}):
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (False, 0, 0)
 
     @mock.patch("airflow.dag_processing.manager.is_lock_not_available_error")
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -45,6 +45,7 @@ from uuid6 import uuid7
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.dag_processing.bundles.base import BaseDagBundle
+from airflow.dag_processing.bundles.local import LocalDagBundle
 from airflow.dag_processing.bundles.manager import DagBundlesManager
 from airflow.dag_processing.dagbag import DagBag
 from airflow.dag_processing.manager import (
@@ -83,6 +84,18 @@ pytestmark = pytest.mark.db_test
 
 logger = logging.getLogger(__name__)
 TEST_DAG_FOLDER = Path(__file__).parents[1].resolve() / "dags"
+
+
+class _HealthControlledDagBundle(LocalDagBundle):
+    """LocalDagBundle that fails to instantiate unless its health file contains "ok"."""
+
+    def __init__(self, *, health_file: str, **kwargs) -> None:
+        state = Path(health_file).read_text().strip()
+        if state != "ok":
+            raise RuntimeError(f"simulated {state}")
+        super().__init__(**kwargs)
+
+
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 
@@ -1252,6 +1265,77 @@ class TestDagFileProcessorManager:
         ]
         assert len(legacy_log_calls) == 1
         assert legacy_log_calls[0].args[1] == 3
+
+    def test_transient_bundle_creation_error_keeps_bundle_active_and_dags_fresh(self, tmp_path):
+        """A bundle failing to instantiate with transient error must not be deactivated."""
+        dags_dir = tmp_path / "dags"
+        dags_dir.mkdir()
+        (dags_dir / "good_dag.py").write_text(
+            textwrap.dedent(
+                """
+                from airflow.providers.standard.operators.empty import EmptyOperator
+                from airflow.sdk import DAG
+
+                with DAG(dag_id="dag_in_flaky_bundle", schedule=None):
+                    EmptyOperator(task_id="noop")
+                """
+            )
+        )
+        (dags_dir / "broken_dag.py").write_text("an invalid airflow DAG")
+        health_file = tmp_path / "health.txt"
+
+        bundle_config = [
+            {
+                "name": "flaky-bundle",
+                "classpath": f"{__name__}._HealthControlledDagBundle",
+                "kwargs": {
+                    "path": str(dags_dir),
+                    "health_file": str(health_file),
+                    "refresh_interval": 0,
+                },
+            }
+        ]
+
+        def get_db_state():
+            with create_session() as session:
+                active = session.scalar(
+                    select(DagBundleModel.active).where(DagBundleModel.name == "flaky-bundle")
+                )
+                fresh_dags = session.scalar(
+                    select(func.count())
+                    .select_from(DagModel)
+                    .where(DagModel.bundle_name == "flaky-bundle", ~DagModel.is_stale)
+                )
+                import_errors = session.scalar(select(func.count()).select_from(ParseImportError))
+            return active, fresh_dags, import_errors
+
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps(bundle_config)}):
+            # Phase 1: misconfigured from day one — sync never succeeds, so no bundle row exists at all
+            health_file.write_text("misconfiguration")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (None, 0, 0)
+
+            # Phase 2: healthy restart — the bundle row appears and Dags get parsed
+            health_file.write_text("ok")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (True, 1, 1)
+
+            # Phase 3: restart with transient connection error — must not deactivate the bundle
+            health_file.write_text("transient connection error")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (True, 1, 1)
+
+            # Phase 4: healthy again
+            health_file.write_text("ok")
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (True, 1, 1)
+
+        # Phase 5: removing the (again failing) bundle from config must follow the removal
+        # path: deactivate it, mark its Dags stale, and drop its import errors.
+        health_file.write_text("transient connection error")
+        with conf_vars({("dag_processor", "dag_bundle_config_list"): json.dumps([])}):
+            DagFileProcessorManager(max_runs=1, processor_timeout=365 * 86_400).run()
+            assert get_db_state() == (False, 0, 0)
 
     @mock.patch("airflow.dag_processing.manager.is_lock_not_available_error")
     @pytest.mark.usefixtures("testing_dag_bundle")


### PR DESCRIPTION
### Why

- `sync_bundles_to_db()` deactivates every bundle left in `stored` as "no longer found in config", and also deletes its `ParseImportError` rows.
- When `_extract_and_sign_template()` raises a transient error while instantiating the bundle at dag-processor startup, the `continue` skipped `stored.pop(name)`. A bundle still present in the config fell into that removal path.
- The wrong deactivation cascades. The `deactivate_stale_dags()` marks every Dag of the bundle `is_stale=True`.

### How

- Pop configured bundles out of `stored` before calling `_extract_and_sign_template()`, so a creation failure only skips that sync's metadata update instead of misclassifying the bundle as removed from config.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=7d50191 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @FrankYang0529** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
