### PR TITLE
Add option to expose git-sync metrics port

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -317,12 +317,23 @@ If release name contains chart name it will be used as a full name.
       value: ":{{ .Values.dags.gitSync.httpPort }}"
     - name: GITSYNC_HTTP_BIND
       value: ":{{ .Values.dags.gitSync.httpPort }}"
+    {{- if .Values.dags.gitSync.metrics.enabled }}
+    - name: GIT_SYNC_HTTP_METRICS
+      value: "true"
+    - name: GITSYNC_HTTP_METRICS
+      value: "true"
+    {{- end }}
     {{- end }}
     {{- with .Values.dags.gitSync.env }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   resources: {{ toYaml .Values.dags.gitSync.resources | nindent 4 }}
   {{- if not .is_init }}
+  {{- if .Values.dags.gitSync.metrics.enabled }}
+  ports:
+    - name: gitsync-metrics
+      containerPort: {{ .Values.dags.gitSync.httpPort }}
+  {{- end }}
   {{- if .Values.dags.gitSync.startupProbe.enabled }}
   startupProbe:
     httpGet:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -12099,6 +12099,18 @@
                             "type": "integer",
                             "default": 1234
                         },
+                        "metrics": {
+                            "description": "Expose the git-sync metrics endpoint by adding a named container port and enabling metrics on the git-sync http server.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable the git-sync metrics port.",
+                                    "type": "boolean",
+                                    "default": false
+                                }
+                            }
+                        },
                         "recommendedProbeSetting": {
                             "description": "Setting this to true, will remove readiness probe usage and configure liveness probe to use a dedicated Git-Sync liveness service.",
                             "type": "boolean",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4494,6 +4494,11 @@ dags:
     # default one and old one will be removed
     recommendedProbeSetting: false
 
+    # Expose git-sync metrics by adding a named container port.
+    # Requires the git-sync http server, which is bound on httpPort.
+    metrics:
+      enabled: false
+
     startupProbe:
       enabled: true
       timeoutSeconds: 1

--- a/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
+++ b/helm-tests/tests/helm_tests/other/test_git_sync_scheduler.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import jmespath
+import pytest
 from chart_utils.helm_template_generator import render_chart
 
 
@@ -121,6 +122,56 @@ class TestGitSyncSchedulerTest:
                 "timeoutSeconds": 1,
             },
         }
+
+    @pytest.mark.parametrize(
+        ("executor", "show_only", "extra_values"),
+        [
+            ("LocalExecutor", "templates/scheduler/scheduler-deployment.yaml", {}),
+            ("CeleryExecutor", "templates/workers/worker-deployment.yaml", {}),
+            ("CeleryExecutor", "templates/triggerer/triggerer-deployment.yaml", {}),
+            (
+                "KubernetesExecutor",
+                "templates/dag-processor/dag-processor-deployment.yaml",
+                {"dagProcessor": {"enabled": True}},
+            ),
+        ],
+    )
+    def test_metrics_port_added_when_metrics_enabled(self, executor, show_only, extra_values):
+        values = {
+            "executor": executor,
+            "dags": {"gitSync": {"enabled": True, "metrics": {"enabled": True}}},
+            **extra_values,
+        }
+        docs = render_chart(values=values, show_only=[show_only])
+
+        container = jmespath.search("spec.template.spec.containers[?name=='git-sync']", docs[0])[0]
+        assert container["ports"] == [{"name": "gitsync-metrics", "containerPort": 1234}]
+        assert {"name": "GITSYNC_HTTP_METRICS", "value": "true"} in container["env"]
+        assert {"name": "GIT_SYNC_HTTP_METRICS", "value": "true"} in container["env"]
+
+    def test_metrics_port_follows_http_port(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "dags": {"gitSync": {"enabled": True, "httpPort": 8080, "metrics": {"enabled": True}}},
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        container = jmespath.search("spec.template.spec.containers[?name=='git-sync']", docs[0])[0]
+        assert container["ports"] == [{"name": "gitsync-metrics", "containerPort": 8080}]
+
+    def test_no_metrics_port_by_default(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "dags": {"gitSync": {"enabled": True}},
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        container = jmespath.search("spec.template.spec.containers[?name=='git-sync']", docs[0])[0]
+        assert "ports" not in container
 
     def test_validate_the_git_sync_container_spec_if_wait_specified(self):
         docs = render_chart(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
The git-sync sidecar can serve Prometheus metrics via its built-in HTTP server
(`GITSYNC_HTTP_METRICS`), but the chart provides no way to declare that port on
the container, so the metrics endpoint cannot be discovered or scraped.

This PR adds a `dags.gitSync.metrics.enabled` option (default `false`). When
enabled, the git-sync sidecar container gets:

- `GIT_SYNC_HTTP_METRICS` / `GITSYNC_HTTP_METRICS` env vars set to `"true"`
- a named container port `gitsync-metrics` bound to the existing
  `dags.gitSync.httpPort` value, so the declared port can never drift from the
  bind address

The init container is unaffected (it runs no HTTP server). With the option
disabled (default), rendered manifests are identical to `main`.

Rendered output with `dags.gitSync.metrics.enabled=true`:

```yaml
            - name: GIT_SYNC_HTTP_METRICS
              value: "true"
            - name: GITSYNC_HTTP_METRICS
              value: "true"
          ports:
            - name: gitsync-metrics
              containerPort: 1234
```

With default values, no ports section or metrics env vars are rendered
(verified via `helm template` before/after comparison).

Exposing the metrics via a dedicated Service or scrape annotations is
intentionally left out of scope, per the open design question on the issue —
happy to add it here or in a follow-up based on maintainer preference.

Unit tests added in `test_git_sync_scheduler.py` covering: port + env rendering
when enabled, port following a custom `httpPort`, and no rendering by default.

closes: #62592
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Fable 5

Generated-by: [Claude Fable 5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
