### PR TITLE
Bump flask-appbuilder to 5.2.2

### DIFF
--- a/providers/fab/README.rst
+++ b/providers/fab/README.rst
@@ -57,7 +57,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1``
-``flask-appbuilder``                        ``==5.2.1``
+``flask-appbuilder``                        ``==5.2.2``
 ``pyjwt``                                   ``>=2.11.0``
 ``flask-login``                             ``>=0.6.2; python_version < "3.14"``
 ``flask-login``                             ``>=0.6.3; python_version >= "3.14"``

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -111,7 +111,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1``
-``flask-appbuilder``                        ``==5.2.1``
+``flask-appbuilder``                        ``==5.2.2``
 ``pyjwt``                                   ``>=2.11.0``
 ``flask-login``                             ``>=0.6.2; python_version < "3.14"``
 ``flask-login``                             ``>=0.6.3; python_version >= "3.14"``

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/providers/fab/auth_manager/security_manager/override.py` with their upstream counterparts.
     # In particular, make sure any breaking changes, for example any new methods, are accounted for.
-    "flask-appbuilder==5.2.1",  # Whenever updating the version, run test_fab_alignment.py to verify.
+    "flask-appbuilder==5.2.2",  # Whenever updating the version, run test_fab_alignment.py to verify.
     # Transitive via flask-appbuilder -> flask-jwt-extended; pinned here so the FAB
     # provider keeps installing cleanly when paired with older airflow-core releases
     # (the compat-3.0.6 matrix job) whose own pyjwt floor predates `jwt.types.Options`

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py
@@ -40,7 +40,7 @@ from airflow.providers.fab.auth_manager.models import Role
 from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 # The FAB version that override.py was last aligned with.
-EXPECTED_FAB_VERSION = "5.2.1"
+EXPECTED_FAB_VERSION = "5.2.2"
 
 # FAB public methods that override.py intentionally does NOT implement.
 # Every entry must have a comment explaining why it's excluded.

--- a/uv.lock
+++ b/uv.lock
@@ -5298,7 +5298,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.6.2" },
     { name = "cachetools", specifier = ">=6.0" },
     { name = "flask", specifier = ">=2.2.1" },
-    { name = "flask-appbuilder", specifier = "==5.2.1" },
+    { name = "flask-appbuilder", specifier = "==5.2.2" },
     { name = "flask-limiter", specifier = ">3" },
     { name = "flask-login", marker = "python_full_version < '3.14'", specifier = ">=0.6.2" },
     { name = "flask-login", marker = "python_full_version >= '3.14'", specifier = ">=0.6.3" },
@@ -12022,7 +12022,7 @@ wheels = [
 
 [[package]]
 name = "flask-appbuilder"
-version = "5.2.1"
+version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apispec", extra = ["yaml"] },
@@ -12047,9 +12047,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "wtforms" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b2/ad1784b3393cda84fd68b90689b1d6db037c13a62a9726ef639068bf8a75/flask_appbuilder-5.2.1.tar.gz", hash = "sha256:a5f6f34aa4ae0092a9eeb5051dc210869d9360429a429b0be88416c2616e1281", size = 7077970, upload-time = "2026-04-09T11:06:35.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f1/6aa168038f829eb76f056caa72d8381d64520b3444c185f5121e96e3828c/flask_appbuilder-5.2.2.tar.gz", hash = "sha256:0527623394b40b859ff47056e3621a61eefaaa16ccf188f272c64294307587ca", size = 7078906, upload-time = "2026-06-23T12:21:39.139Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/af/bdfd96170b1159ddc0e8424dfebbbac93d7270a1a749b0857fdaf384f027/flask_appbuilder-5.2.1-py3-none-any.whl", hash = "sha256:c5a134870fc0b780ac8d9de15fea8c470613ebe44feeddf01a2c18d2c066e144", size = 2217302, upload-time = "2026-04-09T11:06:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/2c3cb04fac8ef455746d7ab536bf58bf66d39785dc2612d24af514be5b98/flask_appbuilder-5.2.2-py3-none-any.whl", hash = "sha256:9dcae59cd15e5a284175d65c682529a6a73b7ba9d53d408e4796ec062d05472a", size = 2217171, upload-time = "2026-06-23T12:21:34.926Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrades Flask-AppBuilder from `5.2.1` to `5.2.2` (latest on PyPI, released 2026-06-23). Follows the same shape as #66841.

## What 5.2.2 changes and how it maps to Airflow

FAB 5.2.2 carries four security-relevant fixes to the security manager (parts of which Airflow vendors in `override.py`) plus a dependency-cap change:

| FAB 5.2.2 change | Airflow impact |
|---|---|
| **#2465** — raise Flask-Limiter upper bound `<4` → `<5` | Unblocks Flask-Limiter 4.x. Airflow's own pin stays `>3`; `uv lock` keeps the resolved version at **3.12** (minimal resolution), so this PR does not actually move Flask-Limiter. See compatibility note below. |
| **#2469** — escape LDAP filter metacharacters in `_search_ldap` | **Already present** in `override.py` (Airflow was ahead — it also validates balanced parentheses). No change. |
| **#2435** — `add_register_user` uses `uuid4` instead of `uuid1` | **Already present** in `override.py`. No change. |
| **#2470** — anchor OAuth email-whitelist regex to end of string | Lives in FAB's `AuthOAuthView.oauth_authorized`, which Airflow's `CustomAuthOAuthView` calls via `super()`. **Inherited automatically.** No change. |
| **#2468** — warn when Azure OAuth JWT signature verification is disabled | See follow-up below. |

No new **public** FAB security-manager methods were added, so `test_fab_alignment.py` passes with only the `EXPECTED_FAB_VERSION` bump.

## Flask-Limiter compatibility note

FAB lifting its cap merely *unblocks* Flask-Limiter 4.x; `uv lock` keeps 3.12. To be safe I verified Airflow's vendored Flask-Limiter usage in `providers/fab/src/airflow/providers/fab/www/security_manager.py` against Flask-Limiter **4.1.1**:

- `from flask_limiter import Limiter` and `from flask_limiter.util import get_remote_address` — both still valid (4.0 prefixed *internal* submodules with `_`, but `util` remains public).
- `Limiter(key_func=...)`, `limiter.init_app(...)`, and `limiter.limit(...)` with all the kwargs Airflow passes (`per_method`, `methods`, `error_message`, `exempt_when`, `override_defaults`, `deduct_when`, `on_breach`, `cost`) — all present in 4.1.1.

So even if a future resolution picks Flask-Limiter 4.x, no vendored-code change is required.

## Changes

- `providers/fab/pyproject.toml` — `flask-appbuilder==5.2.1` → `==5.2.2`
- `providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py` — `EXPECTED_FAB_VERSION` → `"5.2.2"`
- `uv.lock` — re-resolved (flask-appbuilder only; Flask-Limiter stays 3.12)
- `generated/provider_dependencies.json` (+ `.sha256sum`), `providers/fab/README.rst`, `providers/fab/docs/index.rst` — regenerated by prek (the docs-index regeneration also dropped a stale release-time-only tail block that had drifted on `main`)

## Validation

- `test_fab_alignment.py` — all 7 alignment tests pass with `flask-appbuilder==5.2.2` installed.
- `providers/fab/tests/unit/fab/auth_manager/security_manager/` — all 40 unit tests pass.
- `override.py` and the vendored `www` security manager import cleanly under FAB 5.2.2.
- Full `pre-commit` prek stage green.

## Follow-up (not in this PR)

FAB #2468 adds a `log.warning` when Azure OAuth JWT signature verification is disabled. Airflow's `_decode_and_validate_azure_jwt` deliberately deviates from FAB (manual base64 payload decode; `verify_signature` defaults to `False`), and FAB's warning text references FAB's own roadmap ("a future major release will change the default to `True`"), which doesn't fit Airflow's deviation. Whether Airflow should emit its own equivalent warning — arguably more important here since verification is off by default — is a behavioral security change that belongs in a focused change, not this dependency bump.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)