### PR TITLE
Preserve AirflowTaskTimeout when timeout logging fails

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/timeout.py
+++ b/task-sdk/src/airflow/sdk/execution_time/timeout.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import contextlib
 import os
 
 import structlog
@@ -35,7 +36,11 @@ class TimeoutPosix:
 
     def handle_timeout(self, signum, frame):
         """Log information and raises AirflowTaskTimeout."""
-        self.log.error("Process timed out", pid=os.getpid())
+        # Logging must never mask the timeout: task-runner logs go through
+        # a pipe owned by the supervisor, and a broken pipe here would
+        # replace AirflowTaskTimeout with BrokenPipeError. See #64212.
+        with contextlib.suppress(OSError):
+            self.log.error("Process timed out", pid=os.getpid())
         raise AirflowTaskTimeout(self.error_message)
 
     def __enter__(self):

--- a/task-sdk/src/airflow/sdk/execution_time/timeout.py
+++ b/task-sdk/src/airflow/sdk/execution_time/timeout.py
@@ -36,9 +36,7 @@ class TimeoutPosix:
 
     def handle_timeout(self, signum, frame):
         """Log information and raises AirflowTaskTimeout."""
-        # Logging must never mask the timeout: task-runner logs go through
-        # a pipe owned by the supervisor, and a broken pipe here would
-        # replace AirflowTaskTimeout with BrokenPipeError. See #64212.
+        # Ensure the timeout isn't masked by a logging error
         with contextlib.suppress(OSError):
             self.log.error("Process timed out", pid=os.getpid())
         raise AirflowTaskTimeout(self.error_message)

--- a/task-sdk/tests/task_sdk/execution_time/test_timeout.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_timeout.py
@@ -75,3 +75,35 @@ class TestTimeoutPosix:
         tp = TimeoutPosix(seconds=1, error_message="boom")
         with pytest.raises(AirflowTaskTimeout, match="boom"):
             tp.handle_timeout(signal.SIGALRM, None)
+
+    def test_handle_timeout_raises_even_when_log_write_fails(self):
+        # Task-runner logs go through a pipe owned by the supervisor. If that
+        # pipe is broken when SIGALRM fires (e.g. supervisor already died),
+        # self.log.error raises BrokenPipeError inside the signal handler.
+        # Without a guard, that OSError replaces the AirflowTaskTimeout, so
+        # the task exits with the wrong exception class and skips the
+        # timeout-handling path in task_runner. See #64212.
+        if not hasattr(signal, "SIGALRM"):
+            pytest.skip("SIGALRM not supported on this platform")
+
+        tp = TimeoutPosix(seconds=1, error_message="boom")
+        tp.log = mock.MagicMock()
+        tp.log.error.side_effect = BrokenPipeError("supervisor pipe closed")
+
+        with pytest.raises(AirflowTaskTimeout, match="boom"):
+            tp.handle_timeout(signal.SIGALRM, None)
+
+        tp.log.error.assert_called_once_with("Process timed out", pid=mock.ANY)
+
+    def test_handle_timeout_normal_path_logs_and_raises(self):
+        """Regression guard: on the happy path the log is emitted AND AirflowTaskTimeout is raised."""
+        if not hasattr(signal, "SIGALRM"):
+            pytest.skip("SIGALRM not supported on this platform")
+
+        tp = TimeoutPosix(seconds=1, error_message="boom")
+        tp.log = mock.MagicMock()
+
+        with pytest.raises(AirflowTaskTimeout, match="boom"):
+            tp.handle_timeout(signal.SIGALRM, None)
+
+        tp.log.error.assert_called_once_with("Process timed out", pid=mock.ANY)

--- a/task-sdk/tests/task_sdk/execution_time/test_timeout.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_timeout.py
@@ -77,12 +77,6 @@ class TestTimeoutPosix:
             tp.handle_timeout(signal.SIGALRM, None)
 
     def test_handle_timeout_raises_even_when_log_write_fails(self):
-        # Task-runner logs go through a pipe owned by the supervisor. If that
-        # pipe is broken when SIGALRM fires (e.g. supervisor already died),
-        # self.log.error raises BrokenPipeError inside the signal handler.
-        # Without a guard, that OSError replaces the AirflowTaskTimeout, so
-        # the task exits with the wrong exception class and skips the
-        # timeout-handling path in task_runner. See #64212.
         if not hasattr(signal, "SIGALRM"):
             pytest.skip("SIGALRM not supported on this platform")
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Preserve AirflowTaskTimeout when timeout logging fails
---

### Why
`handle_timeout()` logs a timeout message before raising `AirflowTaskTimeout`. The task runtime sends those logs through a pipe handled by the supervisor. If that pipe has been closed (for example, because the supervisor has exited), the logging call can raise `BrokenPipeError` instead.
This masks the original timeout, causing the task to fail with a logging error rather than `AirflowTaskTimeout`. This exact sequence appears in the production traceback in #64212.

### What
Suppress `OSError` raised while logging from `handle_timeout()` so a failed log write cannot mask the timeout. `handle_timeout()` will still raise `AirflowTaskTimeout` after a logging failure. Non-OSError exceptions from the logging stack are deliberately left out of scope.

related: #64212 

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code Opus 4.7 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
