### PR TITLE
Bump flask-appbuilder to 5.2.2 in FAB provider

### DIFF
--- a/providers/fab/README.rst
+++ b/providers/fab/README.rst
@@ -57,7 +57,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1``
-``flask-appbuilder``                        ``==5.2.1``
+``flask-appbuilder``                        ``==5.2.2``
 ``pyjwt``                                   ``>=2.11.0``
 ``flask-login``                             ``>=0.6.2; python_version < "3.14"``
 ``flask-login``                             ``>=0.6.3; python_version >= "3.14"``

--- a/providers/fab/docs/index.rst
+++ b/providers/fab/docs/index.rst
@@ -111,7 +111,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.12.0``
 ``blinker``                                 ``>=1.6.2``
 ``flask``                                   ``>=2.2.1``
-``flask-appbuilder``                        ``==5.2.1``
+``flask-appbuilder``                        ``==5.2.2``
 ``pyjwt``                                   ``>=2.11.0``
 ``flask-login``                             ``>=0.6.2; python_version < "3.14"``
 ``flask-login``                             ``>=0.6.3; python_version >= "3.14"``

--- a/providers/fab/pyproject.toml
+++ b/providers/fab/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/providers/fab/auth_manager/security_manager/override.py` with their upstream counterparts.
     # In particular, make sure any breaking changes, for example any new methods, are accounted for.
-    "flask-appbuilder==5.2.1",  # Whenever updating the version, run test_fab_alignment.py to verify.
+    "flask-appbuilder==5.2.2",  # Whenever updating the version, run test_fab_alignment.py to verify.
     # Transitive via flask-appbuilder -> flask-jwt-extended; pinned here so the FAB
     # provider keeps installing cleanly when paired with older airflow-core releases
     # (the compat-3.0.6 matrix job) whose own pyjwt floor predates `jwt.types.Options`

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_fab_alignment.py
@@ -40,7 +40,7 @@ from airflow.providers.fab.auth_manager.models import Role
 from airflow.providers.fab.auth_manager.security_manager.override import FabAirflowSecurityManagerOverride
 
 # The FAB version that override.py was last aligned with.
-EXPECTED_FAB_VERSION = "5.2.1"
+EXPECTED_FAB_VERSION = "5.2.2"
 
 # FAB public methods that override.py intentionally does NOT implement.
 # Every entry must have a comment explaining why it's excluded.

--- a/uv.lock
+++ b/uv.lock
@@ -5298,7 +5298,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.6.2" },
     { name = "cachetools", specifier = ">=6.0" },
     { name = "flask", specifier = ">=2.2.1" },
-    { name = "flask-appbuilder", specifier = "==5.2.1" },
+    { name = "flask-appbuilder", specifier = "==5.2.2" },
     { name = "flask-limiter", specifier = ">3" },
     { name = "flask-login", marker = "python_full_version < '3.14'", specifier = ">=0.6.2" },
     { name = "flask-login", marker = "python_full_version >= '3.14'", specifier = ">=0.6.3" },
@@ -12022,7 +12022,7 @@ wheels = [
 
 [[package]]
 name = "flask-appbuilder"
-version = "5.2.1"
+version = "5.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apispec", extra = ["yaml"] },
@@ -12047,9 +12047,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "wtforms" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/b2/ad1784b3393cda84fd68b90689b1d6db037c13a62a9726ef639068bf8a75/flask_appbuilder-5.2.1.tar.gz", hash = "sha256:a5f6f34aa4ae0092a9eeb5051dc210869d9360429a429b0be88416c2616e1281", size = 7077970, upload-time = "2026-04-09T11:06:35.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f1/6aa168038f829eb76f056caa72d8381d64520b3444c185f5121e96e3828c/flask_appbuilder-5.2.2.tar.gz", hash = "sha256:0527623394b40b859ff47056e3621a61eefaaa16ccf188f272c64294307587ca", size = 7078906, upload-time = "2026-06-23T12:21:39.139Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/af/bdfd96170b1159ddc0e8424dfebbbac93d7270a1a749b0857fdaf384f027/flask_appbuilder-5.2.1-py3-none-any.whl", hash = "sha256:c5a134870fc0b780ac8d9de15fea8c470613ebe44feeddf01a2c18d2c066e144", size = 2217302, upload-time = "2026-04-09T11:06:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/2c3cb04fac8ef455746d7ab536bf58bf66d39785dc2612d24af514be5b98/flask_appbuilder-5.2.2-py3-none-any.whl", hash = "sha256:9dcae59cd15e5a284175d65c682529a6a73b7ba9d53d408e4796ec062d05472a", size = 2217171, upload-time = "2026-06-23T12:21:34.926Z" },
 ]
 
 [[package]]
@@ -14295,6 +14295,7 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/6b/e8e38a3e1b828c029e4b0aa39ecdd940319ffe725273a0f8be6efae88a7c/ibmmq-2.1.0.tar.gz", hash = "sha256:63ac906290700b55e88cc7c32232579e4419aba209830b6009d6d89cbb089555", size = 436005, upload-time = "2026-06-17T11:48:41.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/e6/d17301d1171dea40b6ed642557174c0de78fea46568756106d143e98cc88/ibmmq-2.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9dbb2b509ec1e86a8111480e35c5b346fa21bae7266c35634d76dd377da80fdb", size = 395482, upload-time = "2026-06-17T11:48:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/2e/f8b4f8088ca697d9d5978fba6e5d9a1adf83421346c51800b3700b179f52/ibmmq-2.1.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:81c65da995be055d4fe02eb65ab05b8c5465324d3c320d5def63bbea32c08087", size = 435602, upload-time = "2026-07-06T08:02:24.283Z" },
     { url = "https://files.pythonhosted.org/packages/20/09/e833b4e18115c94df8b3e6c293755a1cdb5bbd30b935ecc71b89e0206874/ibmmq-2.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:5d68c837f216721b2d6d7495cf91c717670a5cec383b28aa584616a9c48c1c30", size = 400532, upload-time = "2026-06-17T11:48:38.923Z" },
 ]
 


### PR DESCRIPTION
Bumps the vendored Flask-AppBuilder dependency in the FAB provider from 5.2.1 to 5.2.2.

FAB 5.2.2 hardens the security manager (LDAP search-filter escaping, OAuth email-allowlist regex anchoring, API-login provider validation). Airflow's vendored security manager already escapes LDAP filters (and validates the search filter), and it inherits the OAuth allowlist matching from FAB's OAuth view via `super().oauth_authorized()`, so `override.py` needs no change; `test_fab_alignment.py` confirms the vendored code stays structurally in sync with 5.2.2.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
