### PR TITLE
SnowflakeCortexAgentHook: Set stream=False for Cortex Agent requests

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_cortex_agent.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_cortex_agent.py
@@ -130,7 +130,10 @@ class SnowflakeCortexAgentHook(SnowflakeHook):
         if thread_id is not None and parent_message_id is None:
             raise ValueError("parent_message_id must be provided when thread_id is specified.")
 
-        payload: dict[str, Any] = {"messages": messages}
+        payload: dict[str, Any] = {
+            "messages": messages,
+            "stream": False,
+        }
 
         if thread_id is not None:
             payload["thread_id"] = thread_id

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_cortex_agent.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_cortex_agent.py
@@ -125,6 +125,7 @@ class TestSnowflakeCortexAgentHook:
                         ],
                     }
                 ],
+                "stream": False,
             },
             timeout=REQUEST_TIMEOUT,
         )
@@ -175,6 +176,7 @@ class TestSnowflakeCortexAgentHook:
 
         assert payload["thread_id"] == 123
         assert payload["parent_message_id"] == 456
+        assert payload["stream"] is False
 
     @mock.patch(f"{MODULE_PATH}.requests.request")
     @mock.patch(f"{HOOK_PATH}._get_conn_params")
@@ -215,6 +217,7 @@ class TestSnowflakeCortexAgentHook:
         assert payload["orchestration"] == {"max_tokens": 1000}
         assert payload["tools"] == [{"name": "search_tool"}]
         assert payload["tool_resources"] == {"search_tool": {"config": "value"}}
+        assert payload["stream"] is False
 
     @mock.patch(f"{MODULE_PATH}.requests.request")
     @mock.patch(f"{HOOK_PATH}._get_conn_params")


### PR DESCRIPTION
**Description**

This change fixes the `SnowflakeCortexAgentHook` by explicitly setting `stream=False` when invoking the Cortex Agent API, ensuring the hook receives a JSON response.

**Rationale**

The Cortex Agent API returns a Server-Sent Events (SSE) stream by default. Since the hook expects a JSON response, explicitly disabling streaming restores the expected behaviour.

**Tests**

Updated the unit tests to verify that `stream=False` is included in all Cortex Agent requests.