### PR TITLE
Document commit SHA support for GitDagBundle tracking_ref

### DIFF
--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -64,8 +64,3 @@ without a restart. Tags and commit SHAs are static (assuming tags aren't moved),
 to known-good code — but promoting or rolling back a SHA means changing ``tracking_ref`` in
 ``dag_bundle_config_list`` itself, which requires restarting the Dag processor and workers to take
 effect.
-
-This is different from Dag bundle versioning: each Dag run already records the commit its bundle
-resolved to and can be rerun with that code regardless of the current ``tracking_ref`` (see
-:ref:`rerun_with_latest_version <config:core__rerun_with_latest_version>`). That only affects
-individual reruns, not which commit future runs use.

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -70,3 +70,9 @@ dag_bundle_config_list`` config change like any other: it takes effect only afte
 and workers are restarted to reload the configuration. This is unlike moving a branch/tag ref, where
 the config is unchanged and the existing ``refresh_interval`` polling picks up the new commit with no
 restart required.
+
+This is also distinct from Dag bundle versioning. Each Dag run already records the commit its bundle
+resolved to, so it can be rerun with that exact code regardless of the bundle's current
+``tracking_ref`` (see :ref:`rerun_with_latest_version <config:core__rerun_with_latest_version>`).
+That only affects individual reruns; it does not change which commit new Dag parses and runs use.
+Promoting or rolling back the active environment still requires changing ``tracking_ref`` itself.

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -59,20 +59,13 @@ bundle to that exact commit:
      }
     ]'
 
-Branches move as new commits are pushed, which is useful when combined with ``refresh_interval`` to
-pick up new changes automatically without any restart. Tags and commit SHAs point to a fixed commit
-(assuming tags are not moved), so they're useful for pinning a bundle to known-good code.
+Branches move as new commits are pushed, so combined with ``refresh_interval`` they pick up new code
+without a restart. Tags and commit SHAs are static (assuming tags aren't moved), pinning the bundle
+to known-good code — but promoting or rolling back a SHA means changing ``tracking_ref`` in
+``dag_bundle_config_list`` itself, which requires restarting the Dag processor and workers to take
+effect.
 
-When ``tracking_ref`` is a commit SHA, new commits pushed to the repository are not picked up by
-``refresh_interval``, since a SHA always refers to the same commit. Promoting or rolling back to a
-different SHA means changing the ``tracking_ref`` value itself, which is an ``[dag_processor]
-dag_bundle_config_list`` config change like any other: it takes effect only after the Dag processor
-and workers are restarted to reload the configuration. This is unlike moving a branch/tag ref, where
-the config is unchanged and the existing ``refresh_interval`` polling picks up the new commit with no
-restart required.
-
-This is also distinct from Dag bundle versioning. Each Dag run already records the commit its bundle
-resolved to, so it can be rerun with that exact code regardless of the bundle's current
-``tracking_ref`` (see :ref:`rerun_with_latest_version <config:core__rerun_with_latest_version>`).
-That only affects individual reruns; it does not change which commit new Dag parses and runs use.
-Promoting or rolling back the active environment still requires changing ``tracking_ref`` itself.
+This is different from Dag bundle versioning: each Dag run already records the commit its bundle
+resolved to and can be rerun with that code regardless of the current ``tracking_ref`` (see
+:ref:`rerun_with_latest_version <config:core__rerun_with_latest_version>`). That only affects
+individual reruns, not which commit future runs use.

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -62,5 +62,4 @@ bundle to that exact commit:
 Branches move as new commits are pushed, so combined with ``refresh_interval`` they pick up new code
 without a restart. Tags and commit SHAs are static (assuming tags aren't moved), pinning the bundle
 to known-good code — but promoting or rolling back a SHA means changing ``tracking_ref`` in
-``dag_bundle_config_list`` itself, which requires restarting the Dag processor and workers to take
-effect.
+``dag_bundle_config_list`` itself, which requires restarting the Dag processor to take effect.

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -41,3 +41,28 @@ Example of using the GitDagBundle:
          }
      }
     ]'
+
+``tracking_ref`` accepts a branch, tag, or full commit SHA. Setting it to a commit SHA pins the
+bundle to that exact commit:
+
+.. code-block:: bash
+
+    export AIRFLOW__DAG_PROCESSOR__DAG_BUNDLE_CONFIG_LIST='[
+     {
+         "name": "my-git-repo",
+         "classpath": "airflow.providers.git.bundles.git.GitDagBundle",
+         "kwargs": {
+             "repo_url": "https://github.com/org/repo.git",
+             "tracking_ref": "a3d1850dd1aa1919a61620aa39f202185c9321c0",
+             "subdir": "dags"
+         }
+     }
+    ]'
+
+Branches move as new commits are pushed, which is useful when combined with ``refresh_interval`` to
+pick up new changes automatically. Tags and commit SHAs point to a fixed commit (assuming tags are
+not moved), so they're useful for pinning a bundle to known-good code.
+
+When ``tracking_ref`` is a commit SHA, new commits pushed to the repository are not picked up by
+``refresh_interval``, since a SHA always refers to the same commit. To promote or roll back to a
+different SHA, update the bundle configuration's ``tracking_ref`` to the desired SHA.

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -60,9 +60,13 @@ bundle to that exact commit:
     ]'
 
 Branches move as new commits are pushed, which is useful when combined with ``refresh_interval`` to
-pick up new changes automatically. Tags and commit SHAs point to a fixed commit (assuming tags are
-not moved), so they're useful for pinning a bundle to known-good code.
+pick up new changes automatically without any restart. Tags and commit SHAs point to a fixed commit
+(assuming tags are not moved), so they're useful for pinning a bundle to known-good code.
 
 When ``tracking_ref`` is a commit SHA, new commits pushed to the repository are not picked up by
-``refresh_interval``, since a SHA always refers to the same commit. To promote or roll back to a
-different SHA, update the bundle configuration's ``tracking_ref`` to the desired SHA.
+``refresh_interval``, since a SHA always refers to the same commit. Promoting or rolling back to a
+different SHA means changing the ``tracking_ref`` value itself, which is an ``[dag_processor]
+dag_bundle_config_list`` config change like any other: it takes effect only after the Dag processor
+and workers are restarted to reload the configuration. This is unlike moving a branch/tag ref, where
+the config is unchanged and the existing ``refresh_interval`` polling picks up the new commit with no
+restart required.

--- a/providers/git/docs/bundles/index.rst
+++ b/providers/git/docs/bundles/index.rst
@@ -61,5 +61,16 @@ bundle to that exact commit:
 
 Branches move as new commits are pushed, so combined with ``refresh_interval`` they pick up new code
 without a restart. Tags and commit SHAs are static (assuming tags aren't moved), pinning the bundle
-to known-good code — but promoting or rolling back a SHA means changing ``tracking_ref`` in
-``dag_bundle_config_list`` itself, which requires restarting the Dag processor to take effect.
+to known-good code — but changing a SHA-pinned ``tracking_ref`` is a ``dag_bundle_config_list``
+config change, not a ref move, so it only takes effect once the Dag processor is restarted and
+reloads the configuration. If ``[dag_processor] disable_bundle_versioning`` (or the
+``disable_bundle_versioning`` Dag parameter) is set, workers also resolve code from their own
+``tracking_ref`` rather than a recorded bundle version, so they need the updated configuration too.
+
+.. note::
+
+    Rolling back a SHA-pinned ``tracking_ref`` after a restart is reliable, since the commit's
+    objects are already present in the bundle's local storage. Promoting to a *new* SHA can fail
+    to check out that commit unless the bundle's local storage is cleared first (for example, a
+    fresh pod, or manually deleting the bundle's directory) — see
+    `GH-71388 <https://github.com/apache/airflow/issues/71388>`_ for the underlying limitation.

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -45,7 +45,7 @@ class GitDagBundle(BaseDagBundle):
     Instead of cloning the repository every time, we clone the repository once into a bare repo from the source
     and then do a clone for each version from there.
 
-    :param tracking_ref: Branch or tag for this DAG bundle
+    :param tracking_ref: Branch, tag, or commit SHA for this DAG bundle
     :param subdir: Subdirectory within the repository where the DAGs are stored (Optional)
     :param git_conn_id: Connection ID for SSH/token based connection to the repository (Optional)
     :param repo_url: Explicit Git repository URL to override the connection's host. (Optional)

--- a/providers/git/src/airflow/providers/git/bundles/git.py
+++ b/providers/git/src/airflow/providers/git/bundles/git.py
@@ -212,6 +212,9 @@ class GitDagBundle(BaseDagBundle):
                 raise RuntimeError("Error cloning repository") from e
             except InvalidGitRepositoryError as e:
                 raise RuntimeError(f"Invalid git repository at {self.repo_path}") from e
+            # If tracking_ref was just repointed to a SHA that predates this working clone's
+            # last fetch, this checkout fails until the clone is fetched or storage is cleared;
+            # tracked at https://github.com/apache/airflow/issues/71388
             self.repo.git.checkout(self.tracking_ref)
             self._log.debug("bundle initialize", version=self.version)
             if self.version:

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -702,6 +702,66 @@ class TestGitDagBundle:
         assert {"test_dag.py"} == files_in_repo
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_tracking_ref_supports_commit_sha(self, mock_githook, git_repo):
+        """Ensure that tracking_ref accepts a full commit SHA and checks out that commit."""
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        first_commit = repo.head.commit
+
+        # Add a second commit so the SHA-pinned bundle can be verified against it
+        file_path = repo_path / "new_test.py"
+        with open(file_path, "w") as f:
+            f.write("hello world")
+        repo.index.add([file_path])
+        repo.index.commit("Another commit")
+
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
+        bundle.initialize()
+
+        assert _version_str(bundle.get_current_version()) == first_commit.hexsha
+
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py"} == files_in_repo
+
+        assert_repo_is_closed(bundle)
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_tracking_ref_commit_sha_promote_and_rollback(self, mock_githook, git_repo):
+        """Ensure a SHA-pinned tracking_ref can be promoted to a new SHA and rolled back.
+
+        This mirrors how a bundle config change is applied in practice: a new bundle
+        object is created with the updated ``tracking_ref``.
+        """
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        first_commit = repo.head.commit
+
+        file_path = repo_path / "new_test.py"
+        with open(file_path, "w") as f:
+            f.write("hello world")
+        repo.index.add([file_path])
+        second_commit = repo.index.commit("Another commit")
+
+        # Initial deploy pinned to the first commit's SHA
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == first_commit.hexsha
+
+        # Promote: config change re-creates the bundle pointed at the second commit's SHA
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == second_commit.hexsha
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py", "new_test.py"} == files_in_repo
+
+        # Rollback: config change re-creates the bundle pointed back at the first commit's SHA
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == first_commit.hexsha
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py"} == files_in_repo
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_refresh_after_force_push_does_not_reclone(self, mock_githook, git_repo):
         """Refresh after force-push must fetch+reset, never clone."""
         repo_path, repo = git_repo

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -702,35 +702,12 @@ class TestGitDagBundle:
         assert {"test_dag.py"} == files_in_repo
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
-    def test_tracking_ref_supports_commit_sha(self, mock_githook, git_repo):
-        """Ensure that tracking_ref accepts a full commit SHA and checks out that commit."""
-        repo_path, repo = git_repo
-        mock_githook.return_value.repo_url = repo_path
-        first_commit = repo.head.commit
-
-        # Add a second commit so the SHA-pinned bundle can be verified against it
-        file_path = repo_path / "new_test.py"
-        with open(file_path, "w") as f:
-            f.write("hello world")
-        repo.index.add([file_path])
-        repo.index.commit("Another commit")
-
-        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
-        bundle.initialize()
-
-        assert _version_str(bundle.get_current_version()) == first_commit.hexsha
-
-        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
-        assert {"test_dag.py"} == files_in_repo
-
-        assert_repo_is_closed(bundle)
-
-    @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_tracking_ref_commit_sha_promote_and_rollback(self, mock_githook, git_repo):
-        """Ensure a SHA-pinned tracking_ref can be promoted to a new SHA and rolled back.
+        """Ensure tracking_ref accepts a full commit SHA, and a SHA-pinned bundle can be
+        promoted to a new SHA and rolled back.
 
-        This mirrors how a bundle config change is applied in practice: a new bundle
-        object is created with the updated ``tracking_ref``.
+        Promotion/rollback is simulated by creating a new bundle object with the updated
+        tracking_ref, mirroring how a bundle config change is applied in practice.
         """
         repo_path, repo = git_repo
         mock_githook.return_value.repo_url = repo_path
@@ -746,6 +723,9 @@ class TestGitDagBundle:
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
         bundle.initialize()
         assert _version_str(bundle.get_current_version()) == first_commit.hexsha
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py"} == files_in_repo
+        assert_repo_is_closed(bundle)
 
         # Promote: config change re-creates the bundle pointed at the second commit's SHA
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)

--- a/providers/git/tests/unit/git/bundles/test_git.py
+++ b/providers/git/tests/unit/git/bundles/test_git.py
@@ -702,12 +702,9 @@ class TestGitDagBundle:
         assert {"test_dag.py"} == files_in_repo
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
-    def test_tracking_ref_commit_sha_promote_and_rollback(self, mock_githook, git_repo):
-        """Ensure tracking_ref accepts a full commit SHA, and a SHA-pinned bundle can be
-        promoted to a new SHA and rolled back.
-
-        Promotion/rollback is simulated by creating a new bundle object with the updated
-        tracking_ref, mirroring how a bundle config change is applied in practice.
+    def test_tracking_ref_commit_sha_rollback(self, mock_githook, git_repo):
+        """Ensure tracking_ref accepts a full commit SHA, and rolling back to an
+        already-local SHA succeeds after a config-driven bundle re-creation.
         """
         repo_path, repo = git_repo
         mock_githook.return_value.repo_url = repo_path
@@ -719,27 +716,79 @@ class TestGitDagBundle:
         repo.index.add([file_path])
         second_commit = repo.index.commit("Another commit")
 
-        # Initial deploy pinned to the first commit's SHA
-        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
-        bundle.initialize()
-        assert _version_str(bundle.get_current_version()) == first_commit.hexsha
-        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
-        assert {"test_dag.py"} == files_in_repo
-        assert_repo_is_closed(bundle)
-
-        # Promote: config change re-creates the bundle pointed at the second commit's SHA
+        # Initial deploy pinned to the second commit's SHA; both commits are already
+        # fetched into local storage since the origin repo had them at clone time.
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)
         bundle.initialize()
         assert _version_str(bundle.get_current_version()) == second_commit.hexsha
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py", "new_test.py"} == files_in_repo
+        assert_repo_is_closed(bundle)
 
-        # Rollback: config change re-creates the bundle pointed back at the first commit's SHA
+        # Rollback: config change re-creates the bundle pointed back at the first commit's
+        # SHA. That commit's objects are already in local storage, so it succeeds.
         bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
         bundle.initialize()
         assert _version_str(bundle.get_current_version()) == first_commit.hexsha
         files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
         assert {"test_dag.py"} == files_in_repo
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_tracking_ref_commit_sha_promote_fails_without_clearing_storage(self, mock_githook, git_repo):
+        """A SHA created after the bundle's local storage was first populated can't be
+        promoted to in-place: the working clone never fetches it before checkout.
+
+        This documents a known limitation rather than desired behavior -- it should start
+        passing once the fix tracked at https://github.com/apache/airflow/issues/71388 lands,
+        at which point this test should be updated to assert success instead.
+        """
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        first_commit = repo.head.commit
+
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == first_commit.hexsha
+        assert_repo_is_closed(bundle)
+
+        # Created after the bundle's local storage already exists.
+        file_path = repo_path / "new_test.py"
+        with open(file_path, "w") as f:
+            f.write("hello world")
+        repo.index.add([file_path])
+        second_commit = repo.index.commit("Another commit")
+
+        # Promote in-place: config change re-creates the bundle against the same local
+        # storage. The new commit's objects were never fetched into the working clone.
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)
+        with pytest.raises(GitCommandError, match="reference is not a tree|unable to read tree"):
+            bundle.initialize()
+
+    @mock.patch("airflow.providers.git.bundles.git.GitHook")
+    def test_tracking_ref_commit_sha_promote_succeeds_with_fresh_storage(self, mock_githook, git_repo):
+        """Promoting a SHA-pinned tracking_ref to a new commit succeeds once local storage
+        is cleared (e.g. a fresh pod), since that re-clones from the updated bare mirror.
+        """
+        repo_path, repo = git_repo
+        mock_githook.return_value.repo_url = repo_path
+        first_commit = repo.head.commit
+
+        bundle = GitDagBundle(name="test", git_conn_id=CONN_HTTPS, tracking_ref=first_commit.hexsha)
+        bundle.initialize()
+        assert_repo_is_closed(bundle)
+
+        file_path = repo_path / "new_test.py"
+        with open(file_path, "w") as f:
+            f.write("hello world")
+        repo.index.add([file_path])
+        second_commit = repo.index.commit("Another commit")
+
+        # Different bundle name -> fresh local storage, simulating a freshly started pod.
+        bundle = GitDagBundle(name="test-fresh", git_conn_id=CONN_HTTPS, tracking_ref=second_commit.hexsha)
+        bundle.initialize()
+        assert _version_str(bundle.get_current_version()) == second_commit.hexsha
+        files_in_repo = {f.name for f in bundle.path.iterdir() if f.is_file()}
+        assert {"test_dag.py", "new_test.py"} == files_in_repo
 
     @mock.patch("airflow.providers.git.bundles.git.GitHook")
     def test_refresh_after_force_push_does_not_reclone(self, mock_githook, git_repo):


### PR DESCRIPTION
Clarifies that `GitDagBundle.tracking_ref` supports a branch, tag, or full commit SHA — it already works with a SHA in practice, but the provider docs only described branch/tag. Adds a commit-SHA example to the bundle docs, a note on static-ref refresh behavior (a SHA-pinned bundle doesn't pick up new commits via `refresh_interval`; promoting/rolling back requires updating `tracking_ref` in the bundle config), and test coverage for SHA checkout, promotion, and rollback.

Verified manually against a live repository, and confirmed during review: rolling back a SHA-pinned `tracking_ref` to an already-local commit works reliably after a Dag processor restart. Promoting to a genuinely new SHA can fail on restart if the bundle's local storage survives it (the default) — `_initialize()` checks out the new ref before the working clone has fetched it, so the checkout fails until that storage is cleared (fresh pod, or deleted bundle directory). That limitation is tracked at #71388; the docs and tests here describe the current behavior accordingly rather than promising promotion just works with a restart. Also scoped the restart note to mention that with `disable_bundle_versioning`, workers resolve code from their own `tracking_ref` and need the updated config too, not just the Dag processor.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Otto (Astronomer AI assistant, built on pi)

Generated-by: Otto following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated by [Otto](https://astronomer.io/otto)

<!-- pr-triage-fold: triaged=2026-07-28T16:10:18Z head=eefc965 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @coleheflin** · by `@potiuk` · 2026-07-28 16:10 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Other failing CI checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **345 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
