### PR TITLE
Fix flaky test_adjust_maintenance_mode_based_on_sysinfo_exit

### DIFF
--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -164,6 +164,18 @@ class TestEdgeWorker:
                 importlib.reload(cli_parser)
                 self.parser = cli_parser.get_parser()
 
+    @pytest.fixture(autouse=True)
+    def reset_maintenance_state(self):
+        # EdgeWorker keeps runtime state in class attributes and some tests set them
+        # on class level. Reset before each test so state does not leak between tests.
+        EdgeWorker.maintenance_mode = False
+        EdgeWorker.maintenance_comments = None
+        try:
+            yield
+        finally:
+            EdgeWorker.maintenance_mode = False
+            EdgeWorker.maintenance_comments = None
+
     @pytest.fixture
     def cli_worker_with_team(self, tmp_path: Path) -> EdgeWorker:
         test_worker = EdgeWorker(str(tmp_path / "mock.pid"), "mock", None, 8, team_name="team_a")


### PR DESCRIPTION
### Why

- `EdgeWorker.maintenance_mode` / `maintenance_comments` are class attributes. The `test_heartbeat` set `EdgeWorker.maintenance_mode = True` on class level and doesn't cleanup.
- CI runs provider unit tests with `pytest -n auto`, so test order is dynamic.
- If `test_heartbeat` runs right before `test_adjust_maintenance_mode_based_on_sysinfo_exit`, the leaked  `True` makes `test_adjust_maintenance_mode_based_on_sysinfo_exit` fail.

### How

- Add an autouse `reset_maintenance_state` fixture to `TestEdgeWorker` that resets `EdgeWorker.maintenance_mode` / `EdgeWorker.maintenance_comments` before each test, and after it.

### Sample Failed Run

- https://github.com/apache/airflow/actions/runs/29023005614/job/86140259202
- https://github.com/apache/airflow/actions/runs/29070727959/job/86293011141

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
