### PR TITLE
Add validate trigger events in dbt cloud deferrable tasks

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -190,7 +190,6 @@ providers/databricks/tests/unit/databricks/hooks/test_databricks_base.py::1
 providers/datadog/src/airflow/providers/datadog/hooks/datadog.py::2
 providers/datadog/src/airflow/providers/datadog/sensors/datadog.py::1
 providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py::3
-providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py::1
 providers/dingding/src/airflow/providers/dingding/hooks/dingding.py::2
 providers/discord/src/airflow/providers/discord/operators/discord_webhook.py::1
 providers/docker/src/airflow/providers/docker/decorators/docker.py::1
@@ -415,7 +414,7 @@ providers/trino/src/airflow/providers/trino/hooks/trino.py::1
 providers/vespa/src/airflow/providers/vespa/operators/vespa_ingest.py::1
 providers/ydb/src/airflow/providers/ydb/hooks/ydb.py::1
 providers/ydb/src/airflow/providers/ydb/operators/ydb.py::1
-scripts/ci/prek/check_new_airflow_exception_usage.py::5
+scripts/ci/prek/check_new_airflow_exception_usage.py::4
 task-sdk/src/airflow/sdk/bases/sensor.py::1
 task-sdk/src/airflow/sdk/bases/skipmixin.py::3
 task-sdk/src/airflow/sdk/crypto.py::1

--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -414,7 +414,7 @@ providers/trino/src/airflow/providers/trino/hooks/trino.py::1
 providers/vespa/src/airflow/providers/vespa/operators/vespa_ingest.py::1
 providers/ydb/src/airflow/providers/ydb/hooks/ydb.py::1
 providers/ydb/src/airflow/providers/ydb/operators/ydb.py::1
-scripts/ci/prek/check_new_airflow_exception_usage.py::4
+scripts/ci/prek/check_new_airflow_exception_usage.py::5
 task-sdk/src/airflow/sdk/bases/sensor.py::1
 task-sdk/src/airflow/sdk/bases/skipmixin.py::3
 task-sdk/src/airflow/sdk/crypto.py::1

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -138,6 +138,32 @@ class DbtCloudResourceLookupError(AirflowException):
     """Exception raised when a dbt Cloud resource cannot be uniquely identified."""
 
 
+class DbtCloudTriggerEventException(AirflowException):
+    """Raised when a deferred task resumes with a missing or malformed trigger event."""
+
+
+#: Statuses the provider's trigger emits in its terminal event.
+TRIGGER_EVENT_STATUSES = frozenset({"success", "cancelled", "error", "timeout"})
+
+
+def validate_execute_complete_event(event: dict[str, Any] | None = None) -> dict[str, Any]:
+    """
+    Validate the event a deferred task resumes with, returning it if well-formed.
+
+    The event crosses the triggerer/worker boundary through the metadata DB, so a
+    resuming task can receive ``None`` (e.g. a lost payload) or a status its handlers
+    do not recognize (triggerer/worker version skew, a custom trigger). Both must fail
+    loudly rather than silently falling through to the success path.
+    """
+    if event is None:
+        raise DbtCloudTriggerEventException("Trigger error: event is None")
+    if event.get("status") not in TRIGGER_EVENT_STATUSES:
+        raise DbtCloudTriggerEventException(
+            f"Unexpected trigger event status {event.get('status')!r}: {event!r}"
+        )
+    return event
+
+
 T = TypeVar("T", bound=Any)
 
 

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -29,6 +29,7 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudJobRunException,
     DbtCloudJobRunStatus,
     JobRunInfo,
+    validate_execute_complete_event,
 )
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_events_from_dbt_cloud_run
@@ -283,8 +284,9 @@ class DbtCloudRunJobOperator(BaseOperator):
                 )
             return self.run_id
 
-    def execute_complete(self, context: Context, event: dict[str, Any]) -> int:
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> int:
         """Execute when the trigger fires - returns immediately."""
+        event = validate_execute_complete_event(event)
         self.run_id = event["run_id"]
         if event["status"] == "cancelled":
             raise DbtCloudJobRunException(f"Job run {self.run_id} has been cancelled.")

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -20,8 +20,13 @@ import time
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.common.compat.sdk import AirflowException, BaseSensorOperator, conf
-from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
+from airflow.providers.common.compat.sdk import BaseSensorOperator, conf
+from airflow.providers.dbt.cloud.hooks.dbt import (
+    DbtCloudHook,
+    DbtCloudJobRunException,
+    DbtCloudJobRunStatus,
+    validate_execute_complete_event,
+)
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 from airflow.providers.dbt.cloud.utils.openlineage import generate_openlineage_events_from_dbt_cloud_run
 
@@ -114,15 +119,16 @@ class DbtCloudJobRunSensor(BaseSensorOperator):
                     method_name="execute_complete",
                 )
 
-    def execute_complete(self, context: Context, event: dict[str, Any]) -> int:
+    def execute_complete(self, context: Context, event: dict[str, Any] | None = None) -> int:
         """
         Execute when the trigger fires - returns immediately.
 
         This relies on trigger to throw an exception, otherwise it assumes
         execution was successful.
         """
-        if event["status"] in ["error", "cancelled"]:
-            raise AirflowException()
+        event = validate_execute_complete_event(event)
+        if event["status"] != "success":
+            raise DbtCloudJobRunException(event["message"])
         self.log.info(event["message"])
         return int(event["run_id"])
 

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -35,8 +35,10 @@ from airflow.providers.dbt.cloud.hooks.dbt import (
     DbtCloudJobRunException,
     DbtCloudJobRunStatus,
     DbtCloudResourceLookupError,
+    DbtCloudTriggerEventException,
     TokenAuth,
     fallback_to_default_account,
+    validate_execute_complete_event,
 )
 
 from tests_common.test_utils.compat import timezone
@@ -156,6 +158,34 @@ class TestDbtCloudJobRunStatus:
     def test_invalid_terminal_job_run_status(self, statuses):
         with pytest.raises(ValueError, match=NOT_VAILD_DBT_STATUS):
             DbtCloudJobRunStatus.check_is_valid(statuses)
+
+
+class TestValidateExecuteCompleteEvent:
+    @pytest.mark.parametrize(
+        ("event", "match"),
+        [
+            pytest.param(None, "event is None", id="none"),
+            pytest.param({}, "Unexpected trigger event status None", id="missing-status"),
+            pytest.param(
+                {"status": "ended", "run_id": 1234}, "Unexpected trigger event status", id="unknown-status"
+            ),
+        ],
+    )
+    def test_invalid_event_raises(self, event, match):
+        with pytest.raises(DbtCloudTriggerEventException, match=match):
+            validate_execute_complete_event(event)
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            pytest.param({"status": "success", "run_id": 1234, "message": "ok"}, id="success"),
+            pytest.param({"status": "cancelled", "run_id": 1234, "message": "cancelled"}, id="cancelled"),
+            pytest.param({"status": "error", "run_id": 1234, "message": "failed"}, id="error"),
+            pytest.param({"status": "timeout", "run_id": 1234, "message": "timed out"}, id="timeout"),
+        ],
+    )
+    def test_valid_event_is_returned(self, event):
+        assert validate_execute_complete_event(event) is event
 
 
 class TestDbtCloudHook:

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -24,7 +24,12 @@ import pytest
 
 from airflow.models import DAG, Connection
 from airflow.providers.common.compat.sdk import TaskDeferred, timezone
-from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
+from airflow.providers.dbt.cloud.hooks.dbt import (
+    DbtCloudHook,
+    DbtCloudJobRunException,
+    DbtCloudJobRunStatus,
+    DbtCloudTriggerEventException,
+)
 from airflow.providers.dbt.cloud.operators.dbt import (
     DbtCloudGetJobRunArtifactOperator,
     DbtCloudListJobRunsOperator,
@@ -374,6 +379,26 @@ class TestDbtCloudRunJobOperator:
             account_id=operator.account_id,
             run_id=RUN_ID,
         )
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            pytest.param(None, id="none"),
+            pytest.param({"status": "ended", "run_id": RUN_ID, "message": "m"}, id="unknown-status"),
+        ],
+    )
+    def test_execute_complete_invalid_event_raises_instead_of_succeeding(self, event):
+        """Verify a missing or unrecognized trigger event fails loudly instead of succeeding."""
+        operator = DbtCloudRunJobOperator(
+            task_id=TASK_ID,
+            dbt_cloud_conn_id=ACCOUNT_ID_CONN,
+            job_id=JOB_ID,
+            dag=self.dag,
+            deferrable=True,
+        )
+
+        with pytest.raises(DbtCloudTriggerEventException):
+            operator.execute_complete(context=self.mock_context, event=event)
 
     @patch(
         "airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_by_name",

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/sensors/test_dbt.py
@@ -22,8 +22,13 @@ from unittest.mock import patch
 import pytest
 
 from airflow.models.connection import Connection
-from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
-from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
+from airflow.providers.common.compat.sdk import TaskDeferred
+from airflow.providers.dbt.cloud.hooks.dbt import (
+    DbtCloudHook,
+    DbtCloudJobRunException,
+    DbtCloudJobRunStatus,
+    DbtCloudTriggerEventException,
+)
 from airflow.providers.dbt.cloud.sensors.dbt import DbtCloudJobRunSensor
 from airflow.providers.dbt.cloud.triggers.dbt import DbtCloudRunJobTrigger
 
@@ -151,10 +156,11 @@ class TestDbtCloudJobRunSensor:
         [
             ("cancelled", "Job run 1234 has been cancelled."),
             ("error", "Job run 1234 has failed."),
+            ("timeout", "Job run 1234 has timed out."),
         ],
     )
     def test_execute_complete_failure(self, mock_status, mock_message):
-        """Assert execute_complete method to raise exception on the cancelled and error status"""
+        """Assert execute_complete method to raise exception on the cancelled, error, and timeout status"""
         task = DbtCloudJobRunSensor(
             dbt_cloud_conn_id=self.CONN_ID,
             task_id=self.TASK_ID,
@@ -162,7 +168,30 @@ class TestDbtCloudJobRunSensor:
             timeout=self.TIMEOUT,
             deferrable=True,
         )
-        with pytest.raises(AirflowException):
+        with pytest.raises(DbtCloudJobRunException, match=mock_message):
             task.execute_complete(
                 context={}, event={"status": mock_status, "message": mock_message, "run_id": self.DBT_RUN_ID}
             )
+
+    @pytest.mark.parametrize(
+        ("event", "match"),
+        [
+            pytest.param(None, "event is None", id="none"),
+            pytest.param(
+                {"status": "rescheduling", "message": "m", "run_id": 1234},
+                "Unexpected trigger event status",
+                id="unknown-status",
+            ),
+        ],
+    )
+    def test_execute_complete_invalid_event_raises(self, event, match):
+        """Assert execute_complete raises instead of silently succeeding on a malformed event"""
+        task = DbtCloudJobRunSensor(
+            dbt_cloud_conn_id=self.CONN_ID,
+            task_id=self.TASK_ID,
+            run_id=self.DBT_RUN_ID,
+            timeout=self.TIMEOUT,
+            deferrable=True,
+        )
+        with pytest.raises(DbtCloudTriggerEventException, match=match):
+            task.execute_complete(context={}, event=event)


### PR DESCRIPTION
`DbtCloudRunJobOperator.execute_complete` and `DbtCloudJobRunSensor.execute_complete` used the trigger event without validating it:

- **`event=None`**: happens when a deferred task resumes without a payload — a custom or subclassed trigger that yields `TriggerEvent(None)`, or an event payload lost between the triggerer and the worker. Both methods crashed with an opaque `TypeError: 'NoneType' object is not subscriptable`.
- **Unrecognised `status`**: happens on triggerer/worker version skew (a task defers under one provider version and resumes under another whose trigger emits a different status vocabulary) or with a custom trigger. `DbtCloudRunJobTrigger` emits `success`/`cancelled`/`error`/`timeout`, but both `execute_complete` methods branch deny-list style (only specific failure statuses raise, everything else succeeds), so an unknown status fell through into the success path — the task was marked SUCCESS even though the dbt Cloud job outcome was unknown.
- **The sensor additionally never checked `timeout` at all** — it only raised on `error`/`cancelled`, so a job run that timed out while deferred was silently marked SUCCESS.

This adds a `validate_execute_complete_event()` helper (with a dedicated `DbtCloudTriggerEventException`), applied at the top of both `execute_complete` methods. Same fix shape as the anthropic (#69379) and OpenAI (#69506) providers: the `None` check mirrors the amazon provider's helper of the same name, and the status check plays the role amazon's call sites cover with their `if validated_event["status"] != "success": raise` allow-list branching.

The sensor's fix also replaces a bare `raise AirflowException()` (no message) with `DbtCloudJobRunException(event["message"])`, which both fixes the missing `timeout` handling and surfaces the trigger's actual message instead of an empty exception.

The operator keeps its existing per-status branching (`cancelled`/`error`/`timeout` each have distinct messages, and `timeout` additionally attempts job cancellation) since `validate_execute_complete_event()` already closes the status set to the four values above.

* related: #69379

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Claude code

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
