### PR TITLE
UI: Preserve raw connection extra JSON

### DIFF
--- a/airflow-core/newsfragments/69741.bugfix.rst
+++ b/airflow-core/newsfragments/69741.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve raw connection extra JSON when editing provider-specific connection fields in the UI.

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FlexibleForm.tsx
@@ -77,6 +77,7 @@ export type FlexibleFormProps = {
   readonly key?: string;
   readonly namespace?: string;
   readonly noAccordion?: boolean;
+  readonly preserveRawConf?: boolean;
   readonly setError: (error: boolean) => void;
   readonly subHeader?: string;
 };
@@ -89,31 +90,55 @@ export const FlexibleForm = ({
   isHITL,
   namespace = "default",
   noAccordion,
+  preserveRawConf = false,
   setError,
   subHeader,
 }: FlexibleFormProps) => {
-  const { paramsDict: params, setDisabled, setInitialParamDict, setParamsDict } = useParamStore(namespace);
+  const {
+    initParamsDictFromConf,
+    paramsDict: params,
+    setDisabled,
+    setInitialParamDict,
+    setMergeParamUpdatesIntoConf,
+    setParamsDict,
+  } = useParamStore(namespace);
   const processedSections = new Map();
   const [sectionError, setSectionError] = useState<Map<string, boolean>>(new Map());
   const [hasValidationError, setHasValidationError] = useState(false);
+
+  useEffect(() => {
+    setMergeParamUpdatesIntoConf(preserveRawConf);
+  }, [preserveRawConf, setMergeParamUpdatesIntoConf]);
 
   useEffect(() => {
     // Initialize paramsDict and initialParamDict when modal opens
     if (Object.keys(initialParamsDict.paramsDict).length > 0 && Object.keys(params).length === 0) {
       const paramsCopy = structuredClone(initialParamsDict.paramsDict);
 
-      setParamsDict(paramsCopy);
-      setInitialParamDict(initialParamsDict.paramsDict);
+      if (preserveRawConf) {
+        initParamsDictFromConf(paramsCopy);
+      } else {
+        setParamsDict(paramsCopy);
+        setInitialParamDict(initialParamsDict.paramsDict);
+      }
     }
-  }, [initialParamsDict, params, setParamsDict, setInitialParamDict]);
+  }, [
+    initParamsDictFromConf,
+    initialParamsDict,
+    params,
+    preserveRawConf,
+    setParamsDict,
+    setInitialParamDict,
+  ]);
 
   useEffect(
     () => () => {
       // Clear paramsDict and initialParamDict when the component is unmounted or modal closes
       setParamsDict({});
       setInitialParamDict({});
+      setMergeParamUpdatesIntoConf(false);
     },
-    [setParamsDict, setInitialParamDict],
+    [setParamsDict, setInitialParamDict, setMergeParamUpdatesIntoConf],
   );
 
   useEffect(() => {

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.test.tsx
@@ -1,0 +1,145 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ParamsSpec } from "src/queries/useDagParams";
+import { Wrapper } from "src/utils/Wrapper";
+
+import ConnectionForm from "./ConnectionForm";
+import type { ConnectionBody } from "./Connections";
+
+const { snowflakeExtraFields } = vi.hoisted(() => ({
+  snowflakeExtraFields: {
+    account: {
+      description: null,
+      schema: {
+        const: undefined,
+        description_md: undefined,
+        enum: undefined,
+        examples: undefined,
+        format: undefined,
+        items: undefined,
+        maximum: undefined,
+        maxLength: undefined,
+        minimum: undefined,
+        minLength: undefined,
+        section: undefined,
+        title: "Account",
+        type: ["string", "null"],
+        values_display: undefined,
+      },
+      value: undefined,
+    },
+    insecure_mode: {
+      description: "Turns off OCSP certificate checks",
+      schema: {
+        const: undefined,
+        description_md: undefined,
+        enum: undefined,
+        examples: undefined,
+        format: undefined,
+        items: undefined,
+        maximum: undefined,
+        maxLength: undefined,
+        minimum: undefined,
+        minLength: undefined,
+        section: undefined,
+        title: "Insecure Mode",
+        type: ["boolean", "null"],
+        values_display: undefined,
+      },
+      value: false,
+    },
+  } satisfies ParamsSpec,
+}));
+
+vi.mock("src/components/JsonEditor", () => ({
+  JsonEditor: ({
+    onBlur,
+    onChange,
+    value,
+  }: {
+    readonly onBlur?: () => void;
+    readonly onChange?: (value: string) => void;
+    readonly value?: string;
+  }) => (
+    <textarea
+      aria-label="extra-json"
+      onBlur={onBlur}
+      onChange={(event) => onChange?.(event.target.value)}
+      value={value ?? ""}
+    />
+  ),
+}));
+
+vi.mock("src/queries/useConfig.tsx", () => ({
+  useConfig: () => false,
+}));
+
+vi.mock("src/queries/useConnectionTypeMeta", () => ({
+  useConnectionTypeMeta: () => ({
+    formattedData: {
+      snowflake: {
+        connection_type: "snowflake",
+        default_conn_name: undefined,
+        extra_fields: snowflakeExtraFields,
+        hook_class_name: "airflow.providers.snowflake.hooks.snowflake.SnowflakeHook",
+        hook_name: "Snowflake",
+        standard_fields: {},
+      },
+    },
+    hookNames: { snowflake: "Snowflake" },
+    isPending: false,
+    keysList: ["snowflake"],
+  }),
+}));
+
+const initialConnection: ConnectionBody = {
+  conn_type: "snowflake",
+  connection_id: "snowflake_default",
+  description: "",
+  extra: '{"account":"1234"}',
+  host: "",
+  login: "",
+  password: "",
+  port: "",
+  schema: "",
+  team_name: "",
+};
+
+describe("ConnectionForm", () => {
+  it("does not rewrite raw Snowflake extras with untouched provider defaults", async () => {
+    render(
+      <ConnectionForm
+        error={undefined}
+        initialConnection={initialConnection}
+        isEditMode
+        isPending={false}
+        mutateConnection={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const extraJson = await screen.findByLabelText("extra-json");
+
+    await waitFor(() => expect((extraJson as HTMLTextAreaElement).value).toBe('{\n  "account": "1234"\n}'));
+    expect((extraJson as HTMLTextAreaElement).value).not.toContain("insecure_mode");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionForm.tsx
@@ -35,6 +35,8 @@ import { useParamStore } from "src/queries/useParamStore";
 import StandardFields from "./ConnectionStandardFields";
 import type { ConnectionBody } from "./Connections";
 
+const CONNECTION_EXTRA_NAMESPACE = "connection-extra";
+
 type AddConnectionFormProps = {
   readonly error: unknown;
   readonly initialConnection: ConnectionBody;
@@ -57,7 +59,7 @@ const ConnectionForm = ({
     isPending: isMetaPending,
     keysList: connectionTypes,
   } = useConnectionTypeMeta();
-  const { conf: extra, setConf } = useParamStore();
+  const { conf: extra, setConf } = useParamStore(CONNECTION_EXTRA_NAMESPACE);
   const {
     control,
     formState: { isDirty, isValid },
@@ -223,6 +225,8 @@ const ConnectionForm = ({
               flexibleFormDefaultSection={translate("connections.form.extraFields")}
               initialParamsDict={paramsDic}
               key={selectedConnType}
+              namespace={CONNECTION_EXTRA_NAMESPACE}
+              preserveRawConf
               setError={setFormErrors}
               subHeader={isEditMode ? translate("connections.form.helperTextForRedactedFields") : undefined}
             />

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.test.ts
@@ -1,0 +1,155 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ParamsSpec, ParamSpec } from "src/queries/useDagParams";
+
+import { useParamStore } from "./useParamStore";
+
+const baseSchema = {
+  const: undefined,
+  description_md: undefined,
+  enum: undefined,
+  examples: undefined,
+  format: undefined,
+  items: undefined,
+  maximum: undefined,
+  maxLength: undefined,
+  minimum: undefined,
+  minLength: undefined,
+  section: undefined,
+  values_display: undefined,
+};
+
+let namespaceId = 0;
+
+const getStore = () => {
+  const namespace = `use-param-store-test-${namespaceId}`;
+
+  namespaceId += 1;
+
+  return renderHook(() => useParamStore(namespace));
+};
+
+const createParam = (title: string, value: unknown, type: ParamSpec["schema"]["type"]): ParamSpec => ({
+  description: null,
+  schema: {
+    ...baseSchema,
+    title,
+    type,
+  },
+  value,
+});
+
+const createSnowflakeParams = (): ParamsSpec => ({
+  account: createParam("Account", undefined, ["string", "null"]),
+  insecure_mode: createParam("Insecure Mode", false, ["boolean", "null"]),
+  warehouse: createParam("Warehouse", undefined, ["string", "null"]),
+});
+
+const setParamValue = (params: ParamsSpec, key: string, value: unknown) => {
+  const param = params[key];
+
+  if (param === undefined) {
+    throw new Error(`Missing test param: ${key}`);
+  }
+
+  param.value = value;
+};
+
+describe("useParamStore", () => {
+  it("keeps the default params-to-conf serialization behavior", () => {
+    const { result } = getStore();
+    const params = createSnowflakeParams();
+
+    setParamValue(params, "account", "1234");
+
+    act(() => result.current.setParamsDict(params));
+
+    expect(JSON.parse(result.current.conf) as Record<string, unknown>).toEqual({
+      account: "1234",
+      insecure_mode: false,
+    });
+  });
+
+  it("initializes provider params from raw conf without injecting provider defaults", () => {
+    const { result } = getStore();
+
+    act(() => {
+      result.current.setMergeParamUpdatesIntoConf(true);
+      result.current.setConf('{"account":"1234","unknown":"keep"}');
+      result.current.initParamsDictFromConf(createSnowflakeParams());
+    });
+
+    expect(result.current.paramsDict.account?.value).toBe("1234");
+    expect(result.current.paramsDict.insecure_mode?.value).toBeUndefined();
+    expect(result.current.paramsDict.unknown).toBeUndefined();
+    expect(JSON.parse(result.current.conf) as Record<string, unknown>).toEqual({
+      account: "1234",
+      unknown: "keep",
+    });
+  });
+
+  it("merges changed provider fields into raw conf while preserving unknown keys", () => {
+    const { result } = getStore();
+
+    act(() => {
+      result.current.setMergeParamUpdatesIntoConf(true);
+      result.current.setConf('{"account":"1234","unknown":"keep"}');
+      result.current.initParamsDictFromConf(createSnowflakeParams());
+    });
+
+    const nextParams = structuredClone(result.current.paramsDict);
+
+    setParamValue(nextParams, "warehouse", "test_warehouse");
+
+    act(() => result.current.setParamsDict(nextParams));
+
+    const parsedConf = JSON.parse(result.current.conf) as Record<string, unknown>;
+
+    expect(parsedConf).toEqual({
+      account: "1234",
+      unknown: "keep",
+      warehouse: "test_warehouse",
+    });
+    expect(parsedConf).not.toHaveProperty("insecure_mode");
+  });
+
+  it("removes cleared provider fields from raw conf without dropping unrelated keys", () => {
+    const { result } = getStore();
+
+    act(() => {
+      result.current.setMergeParamUpdatesIntoConf(true);
+      result.current.setConf('{"account":"1234","unknown":"keep","warehouse":"test_warehouse"}');
+      result.current.initParamsDictFromConf(createSnowflakeParams());
+    });
+
+    const nextParams = structuredClone(result.current.paramsDict);
+
+    setParamValue(nextParams, "account", null);
+
+    act(() => result.current.setParamsDict(nextParams));
+
+    expect(JSON.parse(result.current.conf) as Record<string, unknown>).toEqual({
+      unknown: "keep",
+      warehouse: "test_warehouse",
+    });
+  });
+});

--- a/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useParamStore.ts
@@ -45,11 +45,85 @@ type FormStore = {
   conf: string;
   disabled: boolean;
   initialParamDict: ParamsSpec;
+  initParamsDictFromConf: (newParamsDict: ParamsSpec) => void;
+  mergeParamUpdatesIntoConf: boolean;
   paramsDict: ParamsSpec;
+  paramsDictSnapshot: ParamsSpec;
   setConf: (confString: string) => void;
   setDisabled: (disabled: boolean) => void;
   setInitialParamDict: (newParamsDict: ParamsSpec) => void;
+  setMergeParamUpdatesIntoConf: (mergeParamUpdatesIntoConf: boolean) => void;
   setParamsDict: (newParamsDict: ParamsSpec) => void;
+};
+
+const valuesAreEqual = (left: unknown, right: unknown) => JSON.stringify(left) === JSON.stringify(right);
+
+const hasValue = (value: unknown) => value !== "" && value !== null && value !== undefined;
+
+const parseConfObject = (confString: string) => {
+  if (confString.trim() === "") {
+    return {};
+  }
+
+  const parsedConf = JSON.parse(confString) as unknown;
+
+  return typeof parsedConf === "object" && parsedConf !== null && !Array.isArray(parsedConf)
+    ? (parsedConf as Record<string, unknown>)
+    : {};
+};
+
+const buildParamsDictFromConf = ({
+  baseDict,
+  confString,
+  includeMissingParams,
+  includeUnknownParams,
+  paramsDict,
+}: {
+  readonly baseDict: ParamsSpec;
+  readonly confString: string;
+  readonly includeMissingParams: boolean;
+  readonly includeUnknownParams: boolean;
+  readonly paramsDict: ParamsSpec;
+}) => {
+  const parsedConf = parseConfObject(confString);
+
+  // Preserve a stable ordering of parameters (and thus sections in the trigger form)
+  // by following the order from the initial param dict when available.
+  const updatedParamsDictEntries: Array<[string, ParamSpec]> = [];
+  const inBase = new Set<string>(Object.keys(baseDict));
+
+  for (const [key, baseParam] of Object.entries(baseDict)) {
+    if (Object.hasOwn(parsedConf, key) || includeMissingParams) {
+      updatedParamsDictEntries.push([
+        key,
+        {
+          description: baseParam.description ?? null,
+          schema: baseParam.schema,
+          value: Object.hasOwn(parsedConf, key) ? parsedConf[key] : undefined,
+        },
+      ]);
+    }
+  }
+
+  if (includeUnknownParams) {
+    // Append any extra keys that exist in the JSON but not in the base dict.
+    for (const [key, value] of Object.entries(parsedConf)) {
+      if (!inBase.has(key)) {
+        const existingParam = paramsDict[key] ?? baseDict[key];
+
+        updatedParamsDictEntries.push([
+          key,
+          {
+            description: existingParam?.description ?? null,
+            schema: existingParam?.schema ?? paramPlaceholder.schema,
+            value,
+          },
+        ]);
+      }
+    }
+  }
+
+  return Object.fromEntries(updatedParamsDictEntries);
 };
 
 const createParamStore = () =>
@@ -57,7 +131,25 @@ const createParamStore = () =>
     conf: "{}",
     disabled: false,
     initialParamDict: {},
+    initParamsDictFromConf: (newParamsDict: ParamsSpec) =>
+      set((state) => {
+        const paramsDict = buildParamsDictFromConf({
+          baseDict: newParamsDict,
+          confString: state.conf,
+          includeMissingParams: true,
+          includeUnknownParams: false,
+          paramsDict: state.paramsDict,
+        });
+
+        return {
+          initialParamDict: newParamsDict,
+          paramsDict,
+          paramsDictSnapshot: structuredClone(paramsDict),
+        };
+      }),
+    mergeParamUpdatesIntoConf: false,
     paramsDict: {},
+    paramsDictSnapshot: {},
 
     setConf: (confString: string) =>
       set((state) => {
@@ -65,55 +157,68 @@ const createParamStore = () =>
           return {};
         }
 
-        const parsedConf = JSON.parse(confString) as Record<string, unknown>;
         const baseDict =
           Object.keys(state.initialParamDict).length > 0 ? state.initialParamDict : state.paramsDict;
+        const paramsDict = buildParamsDictFromConf({
+          baseDict,
+          confString,
+          includeMissingParams: state.mergeParamUpdatesIntoConf,
+          includeUnknownParams: !state.mergeParamUpdatesIntoConf,
+          paramsDict: state.paramsDict,
+        });
 
-        // Preserve a stable ordering of parameters (and thus sections in the trigger form)
-        // by following the order from the initial param dict when available.
-        const updatedParamsDictEntries: Array<[string, ParamSpec]> = [];
-        const inBase = new Set<string>(Object.keys(baseDict));
-
-        for (const [key, baseParam] of Object.entries(baseDict)) {
-          if (Object.hasOwn(parsedConf, key)) {
-            updatedParamsDictEntries.push([
-              key,
-              {
-                description: baseParam.description ?? null,
-                schema: baseParam.schema,
-                value: parsedConf[key],
-              },
-            ]);
-          }
-        }
-
-        // Append any extra keys that exist in the JSON but not in the base dict.
-        for (const [key, value] of Object.entries(parsedConf)) {
-          if (!inBase.has(key)) {
-            const existingParam = state.paramsDict[key] ?? state.initialParamDict[key];
-
-            updatedParamsDictEntries.push([
-              key,
-              {
-                description: existingParam?.description ?? null,
-                schema: existingParam?.schema ?? paramPlaceholder.schema,
-                value,
-              },
-            ]);
-          }
-        }
-
-        const updatedParamsDict: ParamsSpec = Object.fromEntries(updatedParamsDictEntries);
-
-        return { conf: confString, paramsDict: updatedParamsDict };
+        return {
+          conf: confString,
+          paramsDict,
+          paramsDictSnapshot: state.mergeParamUpdatesIntoConf ? structuredClone(paramsDict) : {},
+        };
       }),
 
     setDisabled: (disabled: boolean) => set(() => ({ disabled })),
 
     setInitialParamDict: (newParamsDict: ParamsSpec) => set(() => ({ initialParamDict: newParamsDict })),
 
+    setMergeParamUpdatesIntoConf: (mergeParamUpdatesIntoConf: boolean) =>
+      set(() => ({ mergeParamUpdatesIntoConf })),
+
     setParamsDict: (newParamsDict: ParamsSpec) =>
       set((state) => {
+        if (state.mergeParamUpdatesIntoConf) {
+          const changedKeys = Object.entries(newParamsDict)
+            .filter(([key, param]) => !valuesAreEqual(param.value, state.paramsDictSnapshot[key]?.value))
+            .map(([key]) => key);
+
+          if (changedKeys.length === 0) {
+            return { paramsDict: newParamsDict, paramsDictSnapshot: structuredClone(newParamsDict) };
+          }
+
+          let parsedConf: Record<string, unknown>;
+
+          try {
+            parsedConf = parseConfObject(state.conf);
+          } catch {
+            return { paramsDict: newParamsDict, paramsDictSnapshot: structuredClone(newParamsDict) };
+          }
+
+          for (const key of changedKeys) {
+            const value = newParamsDict[key]?.value;
+
+            if (hasValue(value)) {
+              parsedConf[key] = value;
+            } else {
+              parsedConf = Object.fromEntries(
+                Object.entries(parsedConf).filter(([existingKey]) => existingKey !== key),
+              );
+            }
+          }
+
+          return {
+            conf: JSON.stringify(parsedConf, undefined, 2),
+            paramsDict: newParamsDict,
+            paramsDictSnapshot: structuredClone(newParamsDict),
+          };
+        }
+
         const newConf = JSON.stringify(
           Object.fromEntries(Object.entries(newParamsDict).map(([key, { value }]) => [key, value])),
           undefined,


### PR DESCRIPTION
## Problem

Editing a Snowflake connection in the UI could silently rewrite the raw `extra` JSON. If the connection had manually entered extras such as `{"account":"1234"}`, opening and saving the form could replace that JSON with provider-field defaults like `{"insecure_mode":false}`.

closes: #57984

## What Changed

The connection form now preserves the raw `extra` JSON as the source of truth for keys that the user did not change through provider-specific fields.

Provider extra fields are initialized from matching keys in the raw JSON, but untouched provider defaults are not serialized back into the JSON. When a user edits a provider field, only that changed key is merged into the existing JSON. Clearing a provider field removes that key while preserving unrelated keys.

## Impact

Users can safely edit Snowflake connections without losing manually configured extras. Existing raw JSON keys are preserved, and defaults such as `insecure_mode: false` are not injected unless the user explicitly changes the field.

## Testing

- `pnpm exec vitest run src/queries/useParamStore.test.ts src/pages/Connections/ConnectionForm.test.tsx`
- `pnpm lint`
- Commit hook: `Compile / format / lint UI`
- `git diff --check`

The tests cover the problem statement expectations: preserving `account`, avoiding untouched `insecure_mode`, preserving unknown keys, merging changed provider fields, and removing cleared provider fields.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
