### PR TITLE
Fix CloudComposerDAGRunSensor returning success when no runs in window

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -217,16 +217,16 @@ class CloudComposerDAGRunSensor(BaseSensorOperator):
         start_date: datetime,
         end_date: datetime,
     ) -> bool:
+        found_runs_in_window = False
         for dag_run in dag_runs:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    dag_run["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and dag_run["state"] not in self.allowed_states:
-                return False
-        return True
+            execution_date = parser.parse(
+                dag_run["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
+            )
+            if start_date.timestamp() < execution_date.timestamp() < end_date.timestamp():
+                found_runs_in_window = True
+                if dag_run["state"] not in self.allowed_states:
+                    return False
+        return found_runs_in_window
 
     def _get_composer_airflow_version(self) -> int:
         """Return Composer Airflow version."""
@@ -562,16 +562,16 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
         end_date: datetime,
         states: Iterable[str],
     ) -> bool:
+        found_task_instances_in_window = False
         for task_instance in task_instances:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    task_instance["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and task_instance["state"] not in states:
-                return False
-        return True
+            execution_date = parser.parse(
+                task_instance["execution_date" if self._composer_airflow_version < 3 else "logical_date"]
+            )
+            if start_date.timestamp() < execution_date.timestamp() < end_date.timestamp():
+                found_task_instances_in_window = True
+                if task_instance["state"] not in states:
+                    return False
+        return found_task_instances_in_window
 
     def _get_composer_airflow_version(self) -> int:
         """Return Composer Airflow version."""

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -267,16 +267,16 @@ class CloudComposerDAGRunTrigger(BaseTrigger):
         start_date: datetime,
         end_date: datetime,
     ) -> bool:
+        found_runs_in_window = False
         for dag_run in dag_runs:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    dag_run["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and dag_run["state"] not in self.allowed_states:
-                return False
-        return True
+            execution_date = parser.parse(
+                dag_run["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
+            )
+            if start_date.timestamp() < execution_date.timestamp() < end_date.timestamp():
+                found_runs_in_window = True
+                if dag_run["state"] not in self.allowed_states:
+                    return False
+        return found_runs_in_window
 
     def _get_async_hook(self) -> CloudComposerAsyncHook:
         return CloudComposerAsyncHook(
@@ -444,16 +444,16 @@ class CloudComposerExternalTaskTrigger(BaseTrigger):
         end_date: datetime,
         states: Iterable[str],
     ) -> bool:
+        found_task_instances_in_window = False
         for task_instance in task_instances:
-            if (
-                start_date.timestamp()
-                < parser.parse(
-                    task_instance["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
-                ).timestamp()
-                < end_date.timestamp()
-            ) and task_instance["state"] not in states:
-                return False
-        return True
+            execution_date = parser.parse(
+                task_instance["execution_date" if self.composer_airflow_version < 3 else "logical_date"]
+            )
+            if start_date.timestamp() < execution_date.timestamp() < end_date.timestamp():
+                found_task_instances_in_window = True
+                if task_instance["state"] not in states:
+                    return False
+        return found_task_instances_in_window
 
     def _get_async_hook(self) -> CloudComposerAsyncHook:
         return CloudComposerAsyncHook(


### PR DESCRIPTION
## Problem

CloudComposerDAGRunSensor and CloudComposerExternalTaskSensor (plus their deferrable triggers) returned True even when zero runs existed inside execution_range.

Repro:
- API returns [run_from_last_week]
- Window is yesterday (execution_range=[2024-05-22 17:00, 2024-05-22 20:00])
- len(dag_runs) != 0 passes
- Loop finds no run inside window, for loop exits, returns True (bug)

Result: downstream tasks run with missing data — silent data loss, highest severity.

Same bug existed in 4 duplicated methods:
- CloudComposerDAGRunSensor._check_dag_runs_states
- CloudComposerExternalTaskSensor._check_task_instances_states
- CloudComposerDAGRunTrigger._check_dag_runs_states
- CloudComposerExternalTaskTrigger._check_task_instances_states

This is a re-attempt of #61046 which was reverted in #61346 due to system test regression. Previous fix covered only 1 sensor; this covers all 4.

## What I did

Introduced found_runs_in_window / found_task_instances_in_window flag:

- If no run inside window → returns False (wait), not True
- If run inside window with bad state → False
- If run inside window all good → True
- Keeps strict < boundary semantics, no breaking change to interval interpretation

Fix applied to 4 locations in sensors and triggers.

## Impact

- Fixes data loss: Sensor now correctly waits when no runs in window instead of silently succeeding
- Consistent behavior: All 4 sensor/trigger variants fixed
- No API change: Same method signatures, same return type
- System test note: Previous revert (#61346) reported infinite waiting loop for airflow_monitoring dag. Correct behavior is to wait; if monitoring dag isn't running, sensor should wait, not succeed with missing data.

## Testing

Existing tests:
```
uv run --project providers-google pytest providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py -k TestCloudComposerDAGRunSensor -xvs → 20 passed
uv run --project providers-google pytest providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py -xvs → 34 passed
```

Manual reproduction (watch-it-fail):
- Outside window 2024-05-10 run with window 2024-05-22 to 2024-05-23 → False (was incorrectly True)
- Inside window success → True
- Inside window failed → False
- Mixed inside/outside: only inside counts

Edge cases:
- Empty list [] → False
- All outside window → False
- Boundary exclusive (< not <=) preserved
- Version <3 vs >=3 handled

Static checks: ruff format/check passed, prek pre-commit passed, no new AirflowException.

Closes: #57512
Related: #61046, #61346

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Muse Spark 1.1

Generated-by: Muse Spark 1.1 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)