### PR TITLE
Fix DatabricksSqlHook sqlalchemy_url missing http_path from connection extra

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -186,7 +186,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
     def _resolve_http_path(self, allow_endpoint_lookup: bool = True) -> str | None:
         """
-        Resolve http_path from explicit arg, connection extra, or endpoint name.
+        Resolve http_path from explicit arg, endpoint name, or connection extra.
 
         :param allow_endpoint_lookup: If True, may call API to resolve sql_endpoint_name.
             Set False for offline-safe paths like sqlalchemy_url.
@@ -194,14 +194,10 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         """
         if self._http_path:
             return self._http_path
-        if "http_path" in self.databricks_conn.extra_dejson:
-            self._http_path = self.databricks_conn.extra_dejson["http_path"]
-            return self._http_path
         if allow_endpoint_lookup and self._sql_endpoint_name:
             endpoint = self._get_sql_endpoint_by_name(self._sql_endpoint_name)
-            self._http_path = endpoint["odbc_params"]["path"]
-            return self._http_path
-        return self._http_path
+            return endpoint["odbc_params"]["path"]
+        return self.databricks_conn.extra_dejson.get("http_path")
 
     def get_conn(self) -> AirflowConnection:
         """Return a Databricks SQL connection object."""

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -191,6 +191,13 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         :param allow_endpoint_lookup: If True, may call API to resolve sql_endpoint_name.
             Set False for offline-safe paths like sqlalchemy_url.
         :return: resolved http_path or None if not found.
+
+        When allow_endpoint_lookup=False (used by sqlalchemy_url etc.),
+        sql_endpoint_name is ignored and we fall back to http_path from the
+        connection extra. This keeps the property fully offline. If both
+        sql_endpoint_name and an extra http_path are set, sqlalchemy_url may
+        therefore point at a different warehouse than the one get_conn() will
+        actually connect to. This asymmetry is intentional.
         """
         if self._http_path:
             return self._http_path
@@ -203,12 +210,12 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         """Return a Databricks SQL connection object."""
         if not self._http_path:
             self._http_path = self._resolve_http_path(allow_endpoint_lookup=True)
-            if not self._http_path:
-                raise AirflowException(
-                    "http_path should be provided either explicitly, "
-                    "or in extra parameter of Databricks connection, "
-                    "or sql_endpoint_name should be specified"
-                )
+        if not self._http_path:
+            raise AirflowException(
+                "http_path should be provided either explicitly, "
+                "or in extra parameter of Databricks connection, "
+                "or sql_endpoint_name should be specified"
+            )
 
         prev_token = self._token
         new_token = self._get_token(raise_error=True)

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py
@@ -184,15 +184,30 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         else:
             return endpoint
 
+    def _resolve_http_path(self, allow_endpoint_lookup: bool = True) -> str | None:
+        """
+        Resolve http_path from explicit arg, connection extra, or endpoint name.
+
+        :param allow_endpoint_lookup: If True, may call API to resolve sql_endpoint_name.
+            Set False for offline-safe paths like sqlalchemy_url.
+        :return: resolved http_path or None if not found.
+        """
+        if self._http_path:
+            return self._http_path
+        if "http_path" in self.databricks_conn.extra_dejson:
+            self._http_path = self.databricks_conn.extra_dejson["http_path"]
+            return self._http_path
+        if allow_endpoint_lookup and self._sql_endpoint_name:
+            endpoint = self._get_sql_endpoint_by_name(self._sql_endpoint_name)
+            self._http_path = endpoint["odbc_params"]["path"]
+            return self._http_path
+        return self._http_path
+
     def get_conn(self) -> AirflowConnection:
         """Return a Databricks SQL connection object."""
         if not self._http_path:
-            if self._sql_endpoint_name:
-                endpoint = self._get_sql_endpoint_by_name(self._sql_endpoint_name)
-                self._http_path = endpoint["odbc_params"]["path"]
-            elif "http_path" in self.databricks_conn.extra_dejson:
-                self._http_path = self.databricks_conn.extra_dejson["http_path"]
-            else:
+            self._http_path = self._resolve_http_path(allow_endpoint_lookup=True)
+            if not self._http_path:
                 raise AirflowException(
                     "http_path should be provided either explicitly, "
                     "or in extra parameter of Databricks connection, "
@@ -254,8 +269,10 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
                 "Install it with: pip install 'apache-airflow-providers-databricks[sqlalchemy]'"
             )
 
+        http_path = self._resolve_http_path(allow_endpoint_lookup=False)
+
         url_query = {
-            "http_path": self._http_path,
+            "http_path": http_path,
             "catalog": self.catalog,
             "schema": self.schema,
         }

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py
@@ -45,6 +45,7 @@ HOST = "xx.cloud.databricks.com"
 HOST_WITH_SCHEME = "https://xx.cloud.databricks.com"
 TOKEN = "token"
 HTTP_PATH = "sql/protocolv1/o/1234567890123456/0123-456789-abcd123"
+ENDPOINT_HTTP_PATH = "/sql/1.0/endpoints/1264e5078741679a"
 SCHEMA = "test_schema"
 CATALOG = "test_catalog"
 
@@ -94,7 +95,7 @@ def mock_get_requests():
                 "name": "Test",
                 "odbc_params": {
                     "hostname": "xx.cloud.databricks.com",
-                    "path": "/sql/1.0/endpoints/1264e5078741679a",
+                    "path": ENDPOINT_HTTP_PATH,
                 },
             }
         ]
@@ -148,6 +149,41 @@ def test_get_uri():
         f"catalog={CATALOG}&http_path={quote_plus(HTTP_PATH)}&schema={SCHEMA}"
     )
     assert uri == expected_uri
+
+
+@mock.patch("airflow.providers.databricks.hooks.databricks_sql.sql.connect")
+def test_get_conn_prefers_sql_endpoint_name_over_connection_extra_http_path(mock_connect, mock_get_requests):
+    hook = DatabricksSqlHook(databricks_conn_id=DEFAULT_CONN_ID, sql_endpoint_name="Test")
+    hook.databricks_conn = Connection(
+        conn_id=DEFAULT_CONN_ID,
+        conn_type="databricks",
+        host=HOST,
+        password=TOKEN,
+        extra={"http_path": "sql/protocolv1/o/extra/path"},
+    )
+
+    hook.get_conn()
+
+    mock_connect.assert_called_once()
+    assert mock_connect.call_args.args[1] == ENDPOINT_HTTP_PATH
+
+
+def test_sqlalchemy_url_uses_connection_extra_http_path_without_endpoint_lookup():
+    hook = DatabricksSqlHook(databricks_conn_id=DEFAULT_CONN_ID, sql_endpoint_name="Test")
+    hook.databricks_conn = Connection(
+        conn_id=DEFAULT_CONN_ID,
+        conn_type="databricks",
+        host=HOST,
+        password=TOKEN,
+        extra={"http_path": "sql/protocolv1/o/extra/path"},
+    )
+
+    with mock.patch.object(DatabricksSqlHook, "_get_sql_endpoint_by_name", autospec=True) as mock_endpoint:
+        url = hook.sqlalchemy_url.render_as_string(hide_password=False)
+
+    assert "http_path=sql%2Fprotocolv1%2Fo%2Fextra%2Fpath" in url
+    assert hook._http_path is None
+    mock_endpoint.assert_not_called()
 
 
 def get_cursor_descriptions(fields: list[str]) -> list[tuple[str]]:


### PR DESCRIPTION
## Problem
`DatabricksSqlHook.sqlalchemy_url` and `get_uri()` did not include `http_path` when that path was configured through the Databricks connection extra JSON. That is a common UI configuration path, and it made SQLAlchemy usage fail even though `get_conn()` could connect.

## What Changed
- Added shared `http_path` resolution for SQLAlchemy URL generation.
- Kept `sqlalchemy_url` offline-safe by allowing explicit `http_path` and connection-extra `http_path`, but not making a REST API call for `sql_endpoint_name`.
- Added a follow-up commit that preserves the existing `get_conn()` precedence: explicit `http_path`, then `sql_endpoint_name`, then connection extra.
- Added tests for endpoint precedence and offline SQLAlchemy URL behavior.

## Why The Follow-Up Commit Exists
The feedback was correct: the first helper implementation resolved connection extras before named SQL endpoints, which would have changed `get_conn()` behavior. The follow-up keeps the SQLAlchemy fix while preserving the established connection precedence.

## Impact
- SQLAlchemy URL and URI generation now work when `http_path` lives in the Databricks connection extra.
- `get_conn()` continues to prefer a named SQL endpoint over connection-extra `http_path` when both are provided.
- `sqlalchemy_url` does not perform a network/API lookup.

Fixes: #69031

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache-69747-databricks uv run --python 3.11 --project providers/databricks ruff format providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py`
- `UV_CACHE_DIR=/tmp/uv-cache-69747-databricks uv run --python 3.11 --project providers/databricks ruff check --fix providers/databricks/src/airflow/providers/databricks/hooks/databricks_sql.py providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py`
- `AIRFLOW_HOME=/tmp/airflow-home-69747 UV_CACHE_DIR=/tmp/uv-cache-69747-databricks uv run --python 3.11 --project providers/databricks pytest providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py::test_sqlachemy_url_property providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py::test_get_conn_prefers_sql_endpoint_name_over_connection_extra_http_path providers/databricks/tests/unit/databricks/hooks/test_databricks_sql.py::test_sqlalchemy_url_uses_connection_extra_http_path_without_endpoint_lookup -xvs`
- Result: `3 passed, 1 warning`
- Commit hooks passed for the follow-up commit.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-5); reviewed by @Vamsi-klu before posting
