### PR TITLE
Fix BaseSerialization double-wrapping args for builtin exceptions

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -555,7 +555,7 @@ class BaseSerialization:
                 cls.serialize(
                     {
                         "exc_cls_name": var.__class__.__name__,
-                        "args": [var.args],
+                        "args": list(var.args),
                         "kwargs": {},
                     },
                     strict=strict,

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -581,6 +581,27 @@ def test_roundtrip_exceptions():
 
 
 @pytest.mark.parametrize(
+    "exc",
+    [
+        KeyError("boom"),
+        AttributeError("attr missing"),
+        KeyError("a", "b"),
+        KeyError(),
+    ],
+)
+def test_roundtrip_builtin_exceptions(exc):
+    """BaseSerialization should preserve ``args`` when round-tripping built-in exceptions.
+
+    Regression test for https://github.com/apache/airflow/issues/69743 where
+    a KeyError("boom") would deserialize with args == (("boom",),) instead of ("boom",).
+    """
+    ser = BaseSerialization.serialize(exc)
+    deser = BaseSerialization.deserialize(ser)
+    assert isinstance(deser, type(exc))
+    assert deser.args == exc.args
+
+
+@pytest.mark.parametrize(
     "concurrency_parameter",
     [
         "max_active_tis_per_dag",


### PR DESCRIPTION
Ran into this from #69743 — `BaseSerialization` was mangling `args` for
built-in exceptions like `KeyError` on the round trip.

Turns out the exception-serialization branch for `KeyError`/`AttributeError`
was storing `args` as `[var.args]`. Since `var.args` is already a tuple
(e.g. `("boom",)`), that wraps it in an extra layer. When deserializing,
`exc_cls(*args)` unpacks that as a single positional arg — so you get
`KeyError(("boom",))` instead of `KeyError("boom")`, and `.args` comes back
as `(("boom",),)` instead of `("boom",)`.

Fix is a one-liner: store `list(var.args)` instead of `[var.args]` so it
stays flat.

Added a parametrized test covering single-arg, multi-arg, and no-arg
`KeyError`/`AttributeError` round-trips so this doesn't regress.

closes: #69743

## AI Disclosure

- [x] This contribution used AI assistance.

**Model(s) used:** Codex (GPT-5.5) Following by [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

**AI was used for:**
- Drafting the PR description.
- Verifying test cases locally.
- Reviewing the implementation from a performance perspective.

The implementation and code changes were developed and validated by me.