### PR TITLE
Add Ubuntu Noble system dependencies to INSTALL guide

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -14,11 +14,31 @@ Linux (Debian Bookworm):
     sudo apt install -y --no-install-recommends apt-transport-https apt-utils ca-certificates \
     curl dumb-init freetds-bin krb5-user libgeos-dev \
     ldap-utils libsasl2-2 libsasl2-modules libxmlsec1 locales libffi8 libldap-2.5-0 libssl3 netcat-openbsd \
-    lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc
+    lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc python3-dev \
+    libkrb5-dev gcc libldap2-dev libsasl2-dev
+
+Linux (Ubuntu Noble):
+
+    sudo apt install -y --no-install-recommends apt-transport-https apt-utils ca-certificates \
+    curl dumb-init freetds-bin krb5-user libgeos-dev \
+    ldap-utils libsasl2-2 libsasl2-modules libxmlsec1 locales libffi8 libldap2 libssl3 netcat-openbsd \
+    lsb-release openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc python3-dev \
+    libkrb5-dev gcc libldap2-dev libsasl2-dev
+
 
 You might need to install MariaDB development headers to build some of the dependencies
 
     sudo apt-get install libmariadb-dev libmariadbclient-dev
+
+or
+    sudo apt-get install libmariadb-dev libmariadb-dev-compat
+
+
+On Linux you might also want to install postgres and mysql servers:
+
+
+   sudo apt install postgresql mysql-server
+
 
 MacOS (Mojave/Catalina) you might need to install XCode command line tools and brew and those packages:
 


### PR DESCRIPTION
The `INSTALL` source-install guide only documented Debian Bookworm apt packages. This adds a dedicated **Ubuntu Noble** apt section (package names differ, e.g. `libldap2` vs `libldap-2.5-0`), the build headers needed to compile optional dependencies from source (`python3-dev`, `libkrb5-dev`, `gcc`, `libldap2-dev`, `libsasl2-dev`), a MariaDB compat-package alternative, and a note for installing local postgres/mysql servers.

Docs-only change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)