### PR TITLE
Add dataclasses-json floor to common.ai llamaindex extra

### DIFF
--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -210,9 +210,9 @@ Install them when installing from PyPI. For example:
     pip install apache-airflow-providers-common-ai[anthropic]
 
 
-==============  ==========================================================================================================
+==============  =======================================================================================================================================
 Extra           Dependencies
-==============  ==========================================================================================================
+==============  =======================================================================================================================================
 ``anthropic``   ``pydantic-ai-slim[anthropic]``
 ``bedrock``     ``pydantic-ai-slim[bedrock]``
 ``google``      ``pydantic-ai-slim[google]``
@@ -225,11 +225,11 @@ Extra           Dependencies
 ``sql``         ``apache-airflow-providers-common-sql``, ``sqlglot>=30.0.0``
 ``common.sql``  ``apache-airflow-providers-common-sql``
 ``langchain``   ``langchain>=1.0.0``
-``llamaindex``  ``llama-index-core>=0.13.0``, ``llama-index-embeddings-openai>=0.6.0``, ``llama-index-llms-openai>=0.6.0``
+``llamaindex``  ``dataclasses-json>=0.6.7``, ``llama-index-core>=0.13.0``, ``llama-index-embeddings-openai>=0.6.0``, ``llama-index-llms-openai>=0.6.0``
 ``pdf``         ``pypdf>=4.0.0``
 ``docx``        ``python-docx>=1.0.0``
 ``git``         ``apache-airflow-providers-git``
-==============  ==========================================================================================================
+==============  =======================================================================================================================================
 
 Downloading official packages
 -----------------------------

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -113,6 +113,7 @@ dependencies = [
     "langchain>=1.0.0",
 ]
 "llamaindex" = [
+    "dataclasses-json>=0.6.7",
     "llama-index-core>=0.13.0",
     "llama-index-embeddings-openai>=0.6.0",
     "llama-index-llms-openai>=0.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4420,6 +4420,7 @@ langchain = [
     { name = "langchain" },
 ]
 llamaindex = [
+    { name = "dataclasses-json" },
     { name = "llama-index-core" },
     { name = "llama-index-embeddings-openai" },
     { name = "llama-index-llms-openai" },
@@ -4475,6 +4476,7 @@ requires-dist = [
     { name = "apache-airflow-providers-git", marker = "extra == 'git'", editable = "providers/git" },
     { name = "apache-airflow-providers-git", marker = "extra == 'skills'", editable = "providers/git" },
     { name = "apache-airflow-providers-standard", editable = "providers/standard" },
+    { name = "dataclasses-json", marker = "extra == 'llamaindex'", specifier = ">=0.6.7" },
     { name = "fastavro", marker = "python_full_version >= '3.14' and extra == 'avro'", specifier = ">=1.12.1" },
     { name = "fastavro", marker = "python_full_version < '3.14' and extra == 'avro'", specifier = ">=1.10.0" },
     { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.0.0" },


### PR DESCRIPTION
### Why

- The automated CI environment upgrade (https://github.com/apache/airflow/actions/runs/29136631210/job/86502091735) bumped `marshmallow` 3.26.2 → 4.3.0, which broke the Non-DB providers tests.
- `llama-index-core` calls `RefDocInfo.to_dict()` at runtime, so every llama-index code path fails with `AttributeError: 'RefDocInfo' object has no attribute 'to_dict'`. (https://github.com/apache/airflow/actions/runs/29136631210/job/86503145941)
- `llama-index-core` depends on `dataclasses-json` without any version bound. (https://github.com/run-llama/llama_index/blob/67514f63410c6d4c2344e7ca14b3ea7214d0bb84/llama-index-core/pyproject.toml#L59)
- `dataclasses-json` 0.3.1–0.6.7 needs `marshmallow<4.0.0`. (https://github.com/lidatong/dataclasses-json/blob/79631c6ff0525f348bbddb92170d5bb22f511700/setup.py#L20, https://github.com/lidatong/dataclasses-json/blob/dc63902eeb5e1c5ce1ea4e078c50e0eb9bc1a541/pyproject.toml#L14) and 0.2.6-0.3.0 needs `marshmallow==3.0.0rc6` (https://github.com/lidatong/dataclasses-json/blob/baa0fcc5e92a3711b0b88c0fa0a602fc884ce9cb/setup.py#L20).
- To keep marshmallow 4, the resolver fell back to `dataclasses-json` 0.2.5. The newest release without the `<4`. However, this version doesn't have the `to_dict()` API. (https://github.com/lidatong/dataclasses-json/commit/8e37cc34bcc6062ace864107bcba6d66a724b152)

## How

- Add a `dataclasses-json>=0.6.7` floor to the `llamaindex`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
