### PR TITLE
Use time.monotonic() for duration checks in databricks provider

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks_base.py
@@ -1085,7 +1085,7 @@ class BaseDatabricksHook(BaseHook):
 
         https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service
         """
-        if self._metadata_cache and time.time() < self._metadata_expiry:
+        if self._metadata_cache and time.monotonic() < self._metadata_expiry:
             return
         try:
             for attempt in self._get_retry_object():
@@ -1101,7 +1101,7 @@ class BaseDatabricksHook(BaseHook):
 
                     self._validate_azure_metadata_service(response_json)
                     self._metadata_cache = response_json
-                    self._metadata_expiry = time.time() + self._metadata_ttl
+                    self._metadata_expiry = time.monotonic() + self._metadata_ttl
                     break
         except RetryError:
             raise ConnectionError(f"Failed to reach Azure Metadata Service after {self.retry_limit} retries.")
@@ -1110,7 +1110,7 @@ class BaseDatabricksHook(BaseHook):
 
     async def _a_check_azure_metadata_service(self):
         """Async version of `_check_azure_metadata_service()`."""
-        if self._metadata_cache and time.time() < self._metadata_expiry:
+        if self._metadata_cache and time.monotonic() < self._metadata_expiry:
             return
         try:
             async for attempt in self._a_get_retry_object():
@@ -1125,7 +1125,7 @@ class BaseDatabricksHook(BaseHook):
                         response_json = await resp.json()
                     self._validate_azure_metadata_service(response_json)
                     self._metadata_cache = response_json
-                    self._metadata_expiry = time.time() + self._metadata_ttl
+                    self._metadata_expiry = time.monotonic() + self._metadata_ttl
                     break
         except RetryError:
             raise ConnectionError(f"Failed to reach Azure Metadata Service after {self.retry_limit} retries.")

--- a/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/triggers/databricks.py
@@ -199,7 +199,7 @@ class DatabricksSQLStatementExecutionTrigger(BaseTrigger):
 
     async def run(self):
         async with self.hook:
-            while self.end_time > time.time():
+            while self.end_time > time.monotonic():
                 statement_state = await self.hook.a_get_sql_statement_state(self.statement_id)
                 if not statement_state.is_terminal:
                     self.log.info(

--- a/providers/databricks/src/airflow/providers/databricks/utils/mixins.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/mixins.py
@@ -97,9 +97,9 @@ class DatabricksSQLStatementsMixin:
         """Execute a SQL statement in non-deferrable mode."""
         # Determine the time at which the Task will timeout. The statement_state is defined here in the event
         # the while-loop is never entered
-        end_time = time.time() + self.timeout
+        end_time = time.monotonic() + self.timeout
 
-        while end_time > time.time():
+        while end_time > time.monotonic():
             statement_state: SQLStatementState = self._hook.get_sql_statement_state(self.statement_id)
 
             if statement_state.is_terminal:
@@ -118,8 +118,8 @@ class DatabricksSQLStatementsMixin:
             self.log.info("Sleeping for %s seconds.", self.polling_period_seconds)
             time.sleep(self.polling_period_seconds)
 
-        # Once the timeout is exceeded, the query is cancelled. This is an important steps; if a query takes
-        # to log, it needs to be killed. Otherwise, it may be the case that there are "zombie" queries running
+        # Once the timeout is exceeded, the query is cancelled. This is an important step; if a query takes
+        # too long, it needs to be killed. Otherwise, it may be the case that there are "zombie" queries running
         # that are no longer being orchestrated
         self._hook.cancel_sql_statement(self.statement_id)
         raise AirflowException(
@@ -131,7 +131,7 @@ class DatabricksSQLStatementsMixin:
     ) -> None:
         """Execute a SQL statement in deferrable mode."""
         statement_state: SQLStatementState = self._hook.get_sql_statement_state(self.statement_id)
-        end_time: float = time.time() + self.timeout
+        end_time: float = time.monotonic() + self.timeout
 
         if not statement_state.is_terminal:
             # If the query is still running and there is no statement_id, this is somewhat of a "zombie"


### PR DESCRIPTION
Duration and timeout comparisons should use `time.monotonic()` instead of `time.time()` to be immune to system clock adjustments (NTP, DST, etc.). This aligns with the project coding standard documented in AGENTS.md.

Changes:
- `databricks_base.py`: Replace `time.time()` with `time.monotonic()` in Azure metadata cache TTL checks (both sync and async versions)
- `databricks.py` trigger: Replace `time.time()` with `time.monotonic()` in the polling loop timeout check
- `mixins.py`: Replace `time.time()` with `time.monotonic()` in SQL statement execution timeout checks, and fix grammar error in comment ("important steps; if a query takes to log" → "important step; if a query takes too long")

Note: `time.time()` is correctly retained for token expiry comparisons (lines 337, 378, 640, 1021, 1066) because those compare against wall-clock Unix timestamps received from the Databricks server.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Claude Code (Opus 4.7) (no human review before posting)

<!-- pr-triage-fold: triaged=2026-07-28T17:12:50Z head=19d9f43 action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @magic-peach** · by `@potiuk` · 2026-07-28 17:12 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
