### PR TITLE
Fix timeout error message and use time.monotonic() in openai batch trigger

### DIFF
--- a/providers/openai/src/airflow/providers/openai/operators/openai.py
+++ b/providers/openai/src/airflow/providers/openai/operators/openai.py
@@ -194,7 +194,7 @@ class OpenAITriggerBatchOperator(BaseOperator):
                         conn_id=self.conn_id,
                         batch_id=self.batch_id,
                         poll_interval=60,
-                        end_time=time.time() + self.timeout,
+                        end_time=time.monotonic() + self.timeout,
                     ),
                     method_name="execute_complete",
                 )

--- a/providers/openai/src/airflow/providers/openai/triggers/openai.py
+++ b/providers/openai/src/airflow/providers/openai/triggers/openai.py
@@ -58,12 +58,12 @@ class OpenAIBatchTrigger(BaseTrigger):
         hook = OpenAIHook(conn_id=self.conn_id)
         try:
             while (batch := hook.get_batch(self.batch_id)) and BatchStatus.is_in_progress(batch.status):
-                if self.end_time < time.time():
+                if self.end_time < time.monotonic():
                     yield TriggerEvent(
                         {
                             "status": "error",
-                            "message": f"Batch {self.batch_id} has not reached a terminal status after "
-                            f"{time.time() - self.end_time} seconds.",
+                            "message": f"Batch {self.batch_id} has not reached a terminal status within "
+                            f"the configured timeout.",
                             "batch_id": self.batch_id,
                         }
                     )


### PR DESCRIPTION
Fix a logic bug in the OpenAI batch trigger timeout error message. The previous code computed `time.time() - self.end_time` which produces a negative number since `end_time` is already in the past when the timeout fires. Replace with a clear message stating the batch did not complete within the configured timeout.

Also switch to `time.monotonic()` for the timeout check to align with the project coding standard (AGENTS.md: "`time.monotonic()` for durations, not `time.time()`").

Changes:
- `openai/triggers/openai.py`: Fix timeout error message and use `time.monotonic()`
- `openai/operators/openai.py`: Use `time.monotonic()` when setting the trigger end_time

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Claude Code (Opus 4.7) (no human review before posting)

<!-- pr-triage-fold: triaged=2026-07-28T17:12:44Z head=33177bd action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @magic-peach** · by `@potiuk` · 2026-07-28 17:12 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
