### PR TITLE
Restrict asset state store access to registered tasks

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_state_store.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/asset_state_store.py
@@ -22,19 +22,21 @@ existing ``/assets/by-name`` and ``/assets/by-uri`` pattern.  Callers pass
 whichever identifier their inlet type carries: ``Asset``/``AssetNameRef`` use
 the name routes, ``AssetUriRef`` uses the URI routes.
 
-Per-task asset registration checks are intentionally not implemented here
-(deferred to AIP-93 — see TODO comment below).
+Task tokens must be registered with an asset as an inlet or outlet before
+accessing that asset's state store. Watcher tokens are not backed by task
+instances and are allowed through this route separately.
 """
 
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Annotated
 from uuid import UUID
 
 from cadwyn import VersionedAPIRouter
-from fastapi import HTTPException, Query, status
-from sqlalchemy import select
+from fastapi import Depends, HTTPException, Query, status
+from sqlalchemy import exists, or_, select
 
 from airflow._shared.state import AssetScope, AssetStateStoreWriterKind
 from airflow.api_fastapi.common.db.common import SessionDep
@@ -44,13 +46,19 @@ from airflow.api_fastapi.execution_api.datamodels.asset_state_store import (
 )
 from airflow.api_fastapi.execution_api.datamodels.token import TIToken
 from airflow.api_fastapi.execution_api.security import CurrentTIToken, ExecutionAPIRoute
-from airflow.models.asset import AssetModel
+from airflow.models.asset import AssetModel, TaskInletAssetReference, TaskOutletAssetReference
 from airflow.models.taskinstance import TaskInstance
 from airflow.state import get_state_backend
 from airflow.state.metastore import MetastoreBackend
 
 _TIWriterFields = tuple[str, str, str, int]
 NULL_UUID = UUID(int=0)
+
+
+@dataclass(frozen=True)
+class _AssetStateStoreAccess:
+    asset_id: int
+    ti_fields: _TIWriterFields | None
 
 
 def _fetch_ti_writer_fields(token: TIToken, session: SessionDep) -> _TIWriterFields:
@@ -71,12 +79,6 @@ def _fetch_ti_writer_fields(token: TIToken, session: SessionDep) -> _TIWriterFie
     return row.dag_id, row.run_id, row.task_id, row.map_index
 
 
-# TODO(AIP-103): enforce that the requesting task is registered with the asset
-# (via task_inlet_asset_reference or task_outlet_asset_reference) before
-# allowing reads/writes. Currently any task with a valid execution token can
-# access any asset's state store — the same gap exists in /assets and /asset-events.
-# Proper fix is a unified asset-registration check across all asset routes,
-# not just here.
 router = VersionedAPIRouter(
     route_class=ExecutionAPIRoute,
     responses={
@@ -106,15 +108,69 @@ def _resolve_asset_id_by_uri(uri: str, session: SessionDep) -> int:
     return asset_id
 
 
+def _authorize_asset_state_store_access(
+    token: TIToken, asset_id: int, session: SessionDep
+) -> _TIWriterFields | None:
+    if token.id == NULL_UUID:
+        return None
+
+    ti_fields = _fetch_ti_writer_fields(token, session)
+    dag_id, _, task_id, _ = ti_fields
+    is_registered = session.scalar(
+        select(
+            or_(
+                exists().where(
+                    TaskInletAssetReference.asset_id == asset_id,
+                    TaskInletAssetReference.dag_id == dag_id,
+                    TaskInletAssetReference.task_id == task_id,
+                ),
+                exists().where(
+                    TaskOutletAssetReference.asset_id == asset_id,
+                    TaskOutletAssetReference.dag_id == dag_id,
+                    TaskOutletAssetReference.task_id == task_id,
+                ),
+            )
+        )
+    )
+    if not is_registered:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "reason": "forbidden",
+                "message": "Task is not registered with this asset as an inlet or outlet",
+            },
+        )
+    return ti_fields
+
+
+def _has_asset_state_store_access_by_name(
+    name: Annotated[str, Query(min_length=1)],
+    session: SessionDep,
+    token: TIToken = CurrentTIToken,
+) -> _AssetStateStoreAccess:
+    asset_id = _resolve_asset_id_by_name(name, session)
+    ti_fields = _authorize_asset_state_store_access(token, asset_id, session)
+    return _AssetStateStoreAccess(asset_id=asset_id, ti_fields=ti_fields)
+
+
+def _has_asset_state_store_access_by_uri(
+    uri: Annotated[str, Query(min_length=1)],
+    session: SessionDep,
+    token: TIToken = CurrentTIToken,
+) -> _AssetStateStoreAccess:
+    asset_id = _resolve_asset_id_by_uri(uri, session)
+    ti_fields = _authorize_asset_state_store_access(token, asset_id, session)
+    return _AssetStateStoreAccess(asset_id=asset_id, ti_fields=ti_fields)
+
+
 @router.get("/by-name/value")
 def get_asset_state_store_by_name(
-    name: Annotated[str, Query(min_length=1)],
     key: Annotated[str, Query(min_length=1)],
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_name)],
 ) -> AssetStateStoreResponse:
     """Get an asset state store value by asset name."""
-    asset_id = _resolve_asset_id_by_name(name, session)
-    value = get_state_backend().get(AssetScope(asset_id=asset_id), key, session=session)
+    value = get_state_backend().get(AssetScope(asset_id=access.asset_id), key, session=session)
     if value is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -129,6 +185,7 @@ def _put_asset_state_store(
     body: AssetStateStorePutBody,
     token: TIToken,
     session: SessionDep,
+    ti_fields: _TIWriterFields | None,
 ) -> None:
     backend = get_state_backend()
     if isinstance(backend, MetastoreBackend):
@@ -142,7 +199,8 @@ def _put_asset_state_store(
                 session=session,
             )
         else:
-            ti_fields = _fetch_ti_writer_fields(token, session)
+            if ti_fields is None:
+                ti_fields = _fetch_ti_writer_fields(token, session)
             dag_id, run_id, task_id, map_index = ti_fields
 
             backend.set_asset_state_store(
@@ -162,48 +220,43 @@ def _put_asset_state_store(
 
 @router.put("/by-name/value", status_code=status.HTTP_204_NO_CONTENT)
 def set_asset_state_store_by_name(
-    name: Annotated[str, Query(min_length=1)],
     key: Annotated[str, Query(min_length=1)],
     body: AssetStateStorePutBody,
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_name)],
     token: TIToken = CurrentTIToken,
 ) -> None:
     """Set an asset state store value by asset name."""
-    _put_asset_state_store(
-        AssetScope(asset_id=_resolve_asset_id_by_name(name, session)), key, body, token, session
-    )
+    _put_asset_state_store(AssetScope(asset_id=access.asset_id), key, body, token, session, access.ti_fields)
 
 
 @router.delete("/by-name/value", status_code=status.HTTP_204_NO_CONTENT)
 def delete_asset_state_store_by_name(
-    name: Annotated[str, Query(min_length=1)],
     key: Annotated[str, Query(min_length=1)],
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_name)],
 ) -> None:
     """Delete a single asset state store key by asset name."""
-    asset_id = _resolve_asset_id_by_name(name, session)
-    get_state_backend().delete(AssetScope(asset_id=asset_id), key, session=session)
+    get_state_backend().delete(AssetScope(asset_id=access.asset_id), key, session=session)
 
 
 @router.delete("/by-name/clear", status_code=status.HTTP_204_NO_CONTENT)
 def clear_asset_state_store_by_name(
-    name: Annotated[str, Query(min_length=1)],
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_name)],
 ) -> None:
     """Delete all state store keys for an asset by asset name."""
-    asset_id = _resolve_asset_id_by_name(name, session)
-    get_state_backend().clear(AssetScope(asset_id=asset_id), session=session)
+    get_state_backend().clear(AssetScope(asset_id=access.asset_id), session=session)
 
 
 @router.get("/by-uri/value")
 def get_asset_state_store_by_uri(
-    uri: Annotated[str, Query(min_length=1)],
     key: Annotated[str, Query(min_length=1)],
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_uri)],
 ) -> AssetStateStoreResponse:
     """Get an asset state store value by asset URI."""
-    asset_id = _resolve_asset_id_by_uri(uri, session)
-    value = get_state_backend().get(AssetScope(asset_id=asset_id), key, session=session)
+    value = get_state_backend().get(AssetScope(asset_id=access.asset_id), key, session=session)
     if value is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -214,34 +267,30 @@ def get_asset_state_store_by_uri(
 
 @router.put("/by-uri/value", status_code=status.HTTP_204_NO_CONTENT)
 def set_asset_state_store_by_uri(
-    uri: Annotated[str, Query(min_length=1)],
     key: Annotated[str, Query(min_length=1)],
     body: AssetStateStorePutBody,
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_uri)],
     token: TIToken = CurrentTIToken,
 ) -> None:
     """Set an asset state store value by asset URI."""
-    _put_asset_state_store(
-        AssetScope(asset_id=_resolve_asset_id_by_uri(uri, session)), key, body, token, session
-    )
+    _put_asset_state_store(AssetScope(asset_id=access.asset_id), key, body, token, session, access.ti_fields)
 
 
 @router.delete("/by-uri/value", status_code=status.HTTP_204_NO_CONTENT)
 def delete_asset_state_store_by_uri(
-    uri: Annotated[str, Query(min_length=1)],
     key: Annotated[str, Query(min_length=1)],
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_uri)],
 ) -> None:
     """Delete a single asset state store key by asset URI."""
-    asset_id = _resolve_asset_id_by_uri(uri, session)
-    get_state_backend().delete(AssetScope(asset_id=asset_id), key, session=session)
+    get_state_backend().delete(AssetScope(asset_id=access.asset_id), key, session=session)
 
 
 @router.delete("/by-uri/clear", status_code=status.HTTP_204_NO_CONTENT)
 def clear_asset_state_store_by_uri(
-    uri: Annotated[str, Query(min_length=1)],
     session: SessionDep,
+    access: Annotated[_AssetStateStoreAccess, Depends(_has_asset_state_store_access_by_uri)],
 ) -> None:
     """Delete all state store keys for an asset by asset URI."""
-    asset_id = _resolve_asset_id_by_uri(uri, session)
-    get_state_backend().clear(AssetScope(asset_id=asset_id), session=session)
+    get_state_backend().clear(AssetScope(asset_id=access.asset_id), session=session)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_state_store.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_asset_state_store.py
@@ -25,7 +25,7 @@ from sqlalchemy import delete, select
 
 from airflow.api_fastapi.execution_api.datamodels.token import TIClaims, TIToken
 from airflow.api_fastapi.execution_api.security import require_auth
-from airflow.models.asset import AssetActive, AssetModel
+from airflow.models.asset import AssetActive, AssetModel, TaskInletAssetReference, TaskOutletAssetReference
 from airflow.models.asset_state_store import AssetStateStoreModel
 from airflow.utils.session import create_session
 
@@ -49,6 +49,25 @@ def _create_asset_store_row(asset_id: int, key: str, value: str) -> None:
         s.add(AssetStateStoreModel(asset_id=asset_id, key=key, value=json.dumps(value)))
 
 
+def _create_task_asset_reference(
+    session: Session,
+    task_instance: TaskInstance,
+    asset: AssetModel,
+    reference_model=TaskOutletAssetReference,
+) -> None:
+    session.add(
+        reference_model(asset_id=asset.id, dag_id=task_instance.dag_id, task_id=task_instance.task_id)
+    )
+    session.commit()
+
+
+def _request_asset_state_store(client: TestClient, method: str, path: str, *, params, json_body=None):
+    kwargs = {"params": params}
+    if json_body is not None:
+        kwargs["json"] = json_body
+    return getattr(client, method)(path, **kwargs)
+
+
 _BY_NAME_CLEAR = "/execution/store/asset/by-name/clear"
 _BY_URI_VALUE = "/execution/store/asset/by-uri/value"
 _BY_URI_CLEAR = "/execution/store/asset/by-uri/clear"
@@ -58,6 +77,8 @@ _BY_URI_CLEAR = "/execution/store/asset/by-uri/clear"
 def reset_state_tables():
     with create_session() as session:
         session.execute(delete(AssetStateStoreModel))
+        session.execute(delete(TaskInletAssetReference))
+        session.execute(delete(TaskOutletAssetReference))
         session.execute(delete(AssetModel))
 
 
@@ -128,6 +149,10 @@ class TestPutAssetStateByName:
             return TIToken(id=self._ti.id, claims=TIClaims(scope="execution"))
 
         exec_app.dependency_overrides[require_auth] = _auth
+
+    @pytest.fixture(autouse=True)
+    def setup_asset_reference(self, setup_ti_auth, asset: AssetModel, session: Session):
+        _create_task_asset_reference(session, self._ti, asset)
 
     def test_put_creates_row(self, client: TestClient, asset: AssetModel, session: Session):
         response = client.put(
@@ -302,6 +327,10 @@ class TestPutAssetStateByUri:
 
         exec_app.dependency_overrides[require_auth] = _auth
 
+    @pytest.fixture(autouse=True)
+    def setup_asset_reference(self, setup_ti_auth, asset: AssetModel, session: Session):
+        _create_task_asset_reference(session, self._ti, asset)
+
     def test_put_creates_row(self, client: TestClient, asset: AssetModel, session: Session):
         response = client.put(
             _BY_URI_VALUE, params={"uri": asset.uri, "key": "watermark"}, json={"value": "2026-04-29"}
@@ -368,6 +397,90 @@ class TestClearAssetStateByUri:
                 select(AssetStateStoreModel).where(AssetStateStoreModel.asset_id == asset.id)
             )
             assert row is None
+
+
+class TestTaskAssetRegistration:
+    @pytest.fixture(autouse=True)
+    def setup_ti_auth(
+        self,
+        exec_app: FastAPI,
+        create_task_instance: CreateTaskInstance,
+    ):
+        self._ti: TaskInstance = create_task_instance()
+
+        async def _auth(request: Request) -> TIToken:
+            return TIToken(id=self._ti.id, claims=TIClaims(scope="execution"))
+
+        exec_app.dependency_overrides[require_auth] = _auth
+
+    @pytest.mark.parametrize(
+        ("method", "path", "params", "json_body"),
+        [
+            ("get", _BY_NAME_VALUE, {"name": "test_asset", "key": "watermark"}, None),
+            ("put", _BY_NAME_VALUE, {"name": "test_asset", "key": "watermark"}, {"value": "x"}),
+            ("delete", _BY_NAME_VALUE, {"name": "test_asset", "key": "watermark"}, None),
+            ("delete", _BY_NAME_CLEAR, {"name": "test_asset"}, None),
+            ("get", _BY_URI_VALUE, {"uri": "s3://bucket/test", "key": "watermark"}, None),
+            ("put", _BY_URI_VALUE, {"uri": "s3://bucket/test", "key": "watermark"}, {"value": "x"}),
+            ("delete", _BY_URI_VALUE, {"uri": "s3://bucket/test", "key": "watermark"}, None),
+            ("delete", _BY_URI_CLEAR, {"uri": "s3://bucket/test"}, None),
+        ],
+    )
+    def test_unregistered_task_is_forbidden(
+        self,
+        client: TestClient,
+        asset: AssetModel,
+        method: str,
+        path: str,
+        params: dict,
+        json_body: dict | None,
+    ):
+        response = _request_asset_state_store(client, method, path, params=params, json_body=json_body)
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["reason"] == "forbidden"
+
+    @pytest.mark.parametrize(
+        ("method", "path", "params", "json_body", "expected_status"),
+        [
+            ("get", _BY_NAME_VALUE, {"name": "test_asset", "key": "watermark"}, None, 200),
+            ("put", _BY_NAME_VALUE, {"name": "test_asset", "key": "watermark"}, {"value": "x"}, 204),
+            ("delete", _BY_NAME_VALUE, {"name": "test_asset", "key": "watermark"}, None, 204),
+            ("delete", _BY_NAME_CLEAR, {"name": "test_asset"}, None, 204),
+            ("get", _BY_URI_VALUE, {"uri": "s3://bucket/test", "key": "watermark"}, None, 200),
+            ("put", _BY_URI_VALUE, {"uri": "s3://bucket/test", "key": "watermark"}, {"value": "x"}, 204),
+            ("delete", _BY_URI_VALUE, {"uri": "s3://bucket/test", "key": "watermark"}, None, 204),
+            ("delete", _BY_URI_CLEAR, {"uri": "s3://bucket/test"}, None, 204),
+        ],
+    )
+    def test_outlet_registered_task_can_access_asset_state_store(
+        self,
+        client: TestClient,
+        asset: AssetModel,
+        session: Session,
+        method: str,
+        path: str,
+        params: dict,
+        json_body: dict | None,
+        expected_status: int,
+    ):
+        _create_task_asset_reference(session, self._ti, asset)
+        _create_asset_store_row(asset.id, "watermark", "2026-04-29")
+
+        response = _request_asset_state_store(client, method, path, params=params, json_body=json_body)
+
+        assert response.status_code == expected_status
+
+    def test_inlet_registered_task_can_access_asset_state_store(
+        self, client: TestClient, asset: AssetModel, session: Session
+    ):
+        _create_task_asset_reference(session, self._ti, asset, TaskInletAssetReference)
+        _create_asset_store_row(asset.id, "watermark", "2026-04-29")
+
+        response = client.get(_BY_NAME_VALUE, params={"name": asset.name, "key": "watermark"})
+
+        assert response.status_code == 200
+        assert response.json() == {"value": "2026-04-29"}
 
 
 class TestInactiveAssetRejected:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Why:

Asset state store entries are scoped to assets, but execution API task tokens should not be able to access every active asset.

Previously, any task with a valid execution token could read or mutate state for unrelated assets. This made asset state store access broader than the task's declared asset relationships.

## Solution:

Restrict the execution API asset state store routes so task tokens can only access assets registered to that task as an inlet or outlet.

The routes now check `TaskInletAssetReference` and `TaskOutletAssetReference` before allowing GET, PUT, DELETE, or CLEAR operations. Unregistered task access returns `403 Forbidden`.

Watcher writes keep using the existing non-task path because watcher tokens are not backed by task instances.

Tests cover forbidden access for unregistered tasks and allowed access for inlet/outlet-registered tasks.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
