### PR TITLE
fix: preserve exception args when serializing built-in exceptions

### DIFF
--- a/airflow-core/src/airflow/serialization/serialized_objects.py
+++ b/airflow-core/src/airflow/serialization/serialized_objects.py
@@ -555,7 +555,7 @@ class BaseSerialization:
                 cls.serialize(
                     {
                         "exc_cls_name": var.__class__.__name__,
-                        "args": [var.args],
+                        "args": list(var.args),
                         "kwargs": {},
                     },
                     strict=strict,

--- a/airflow-core/tests/unit/serialization/test_serialized_objects.py
+++ b/airflow-core/tests/unit/serialization/test_serialized_objects.py
@@ -444,6 +444,21 @@ class MockLazySelectSequence(LazySelectSequence):
             equal_exception,
         ),
         (
+            KeyError("boom"),
+            DAT.BASE_EXC_SER,
+            lambda a, b: a.__class__ == b.__class__ and a.args == b.args,
+        ),
+        (
+            AttributeError("boom"),
+            DAT.BASE_EXC_SER,
+            lambda a, b: a.__class__ == b.__class__ and a.args == b.args,
+        ),
+        (
+            KeyError("a", "b"),
+            DAT.BASE_EXC_SER,
+            lambda a, b: a.__class__ == b.__class__ and a.args == b.args,
+        ),
+        (
             DAG_WITH_TASKS,
             DAT.DAG,
             lambda _, b: list(b.task_group.children.keys()) == sorted(b.task_group.children.keys()),


### PR DESCRIPTION
## Description

`BaseSerialization` was adding an extra list/tuple layer around the `args` of built-in exceptions such as `KeyError` and `AttributeError` during serialization.

```python
"args": [var.args]
```

Because `var.args` is already a tuple, an exception such as `KeyError("boom")` was serialized incorrectly:

```python
from airflow.serialization.serialized_objects import BaseSerialization

result = BaseSerialization.deserialize(
    BaseSerialization.serialize(KeyError("boom"))
)

result.args  # (("boom",),) instead of ("boom",)
```

This change preserves the exception’s original `args` exactly during serialization and deserialization.

Closes #69743.

## Tests

Added parametrized test cases to `test_serialize_deserialize` in `test_serialized_objects.py` covering:

* `KeyError("boom")`
* `AttributeError("boom")`
* `KeyError("a", "b")`

The tests verify that `.args` is preserved exactly after serialization and deserialization. All 40 parametrized test cases pass.

---

##### Was generative AI tooling used to co-author this PR?

* [x] Yes

Generated-by: Claude Code, used in accordance with the project’s contribution guidelines.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=0830c3a action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Vishwaspatel2401** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
