### PR TITLE
Fix Dag processor crash with PendingRollbackError on concurrent dag_tag inserts

### DIFF
--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -32,8 +32,9 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import structlog
 from sqlalchemy import delete, false, func, insert, select, tuple_, update
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import joinedload, load_only
+from sqlalchemy.orm.exc import StaleDataError
 
 from airflow._shared.timezones.timezone import utcnow
 from airflow.assets.manager import asset_manager
@@ -300,7 +301,9 @@ def _serialize_dag_capturing_errors(
             _sync_dag_perms(dag, session=session)
 
         return []
-    except OperationalError:
+    except (DBAPIError, StaleDataError):
+        # Retryable DB errors (the run_with_db_retries policy) must reach the retry loop in
+        # update_dag_parsing_results_in_db, not be recorded as import errors of this dag.
         raise
     except Exception:
         log.exception("Failed to write serialized DAG dag_id=%s fileloc=%s", dag.dag_id, dag.fileloc)
@@ -516,8 +519,8 @@ def update_dag_parsing_results_in_db(
         If None, will be inferred from dags and import_errors. Passing this explicitly ensures that
         import errors are cleared for files that were parsed but no longer contain DAGs.
     """
-    # Retry 'DAG.bulk_write_to_db' & 'SerializedDagModel.bulk_sync_to_db' in case
-    # of any Operational Errors
+    # Retry 'DAG.bulk_write_to_db' & 'SerializedDagModel.bulk_sync_to_db' on the
+    # retryable DB errors from the run_with_db_retries policy (DBAPIError, StaleDataError)
     # In case of failures, provide_session handles rollback
     try:
         duplicate_warnings = _build_duplicate_dag_id_warnings(dags, bundle_name, session)
@@ -558,7 +561,10 @@ def update_dag_parsing_results_in_db(
                             _prefetched=prefetched_metadata.get(dag.dag_id),
                         )
                     )
-            except OperationalError:
+            except (DBAPIError, StaleDataError):
+                # Roll back before run_with_db_retries retries: retrying on a session poisoned by
+                # e.g. an IntegrityError otherwise fails with PendingRollbackError, which is not
+                # retryable and masks the original error.
                 session.rollback()
                 raise
             # Only now we are "complete" do we update import_errors - don't want to record errors from

--- a/airflow-core/tests/unit/dag_processing/test_collection.py
+++ b/airflow-core/tests/unit/dag_processing/test_collection.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import delete, func, inspect as sa_inspect, select
-from sqlalchemy.exc import OperationalError, SAWarning
+from sqlalchemy.exc import IntegrityError, OperationalError, SAWarning
 
 import airflow.dag_processing.collection
 from airflow._shared.timezones import timezone as tz
@@ -38,6 +38,7 @@ from airflow.dag_processing.collection import (
     DagModelOperation,
     _get_latest_runs_stmt,
     _get_latest_runs_stmt_partitioned,
+    _serialize_dag_capturing_errors,
     _update_dag_tags,
     update_dag_parsing_results_in_db,
 )
@@ -693,6 +694,46 @@ class TestUpdateDagParsingResults:
         spy_agency.assert_spy_called_with(sync_perms_spy, dag, session=session)
 
         serialized_dags_count = session.scalar(select(func.count(SerializedDagModel.dag_id)))
+
+    @patch.object(SerializedDagModel, "write_dag")
+    @patch("airflow.serialization.definitions.dag.SerializedDAG.bulk_write_to_db")
+    def test_sync_to_db_rolls_back_before_retry_on_integrity_error(
+        self, mock_bulk_write_to_db, mock_s10n_write_dag, testing_dag_bundle, session
+    ):
+        """A retryable IntegrityError (e.g. concurrent dag_tag insert) must roll back the session first.
+
+        Retrying on the poisoned session otherwise raises PendingRollbackError, which is not
+        retryable and masks the original error.
+        """
+        integrity_error = IntegrityError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
+        mock_bulk_write_to_db.side_effect = [integrity_error, mock.ANY]
+
+        mock_session = mock.MagicMock()
+        update_dag_parsing_results_in_db(
+            "testing",
+            None,
+            dags=[mock.MagicMock()],
+            import_errors={},
+            parse_duration=None,
+            warnings=set(),
+            session=mock_session,
+        )
+
+        assert mock_bulk_write_to_db.call_count == 2
+        mock_session.rollback.assert_called_once_with()
+
+    @patch.object(SerializedDagModel, "write_dag")
+    def test_serialize_dag_capturing_errors_reraises_retryable_db_errors(self, mock_s10n_write_dag, session):
+        """Retryable DB errors must reach the retry loop, not be recorded as dag import errors."""
+        mock_s10n_write_dag.side_effect = IntegrityError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
+
+        with pytest.raises(IntegrityError):
+            _serialize_dag_capturing_errors(
+                dag=mock.MagicMock(),
+                bundle_name="testing",
+                bundle_version=None,
+                session=session,
+            )
 
     @patch.object(SerializedDagModel, "write_dag")
     @patch("airflow.serialization.definitions.dag.SerializedDAG.bulk_write_to_db")


### PR DESCRIPTION
Fixes #68263. Supersedes the stale draft #68267 (closed by maintainer triage with an invitation to open a fresh PR); credit to its author for the initial direction.

### Problem

- With multiple Dag processors (HA), concurrent parsing of the same dag races on the `dag_tag` insert; the loser gets an `IntegrityError`.
- `run_with_db_retries` retries every `DBAPIError`, but the retry loop in `update_dag_parsing_results_in_db` only rolled back on `OperationalError`.
- The retry then ran on the poisoned session and crashed with `PendingRollbackError` (not retryable), masking the original error and failing the whole parse batch. Matches the reporter's production traceback exactly.
- One level down, `_serialize_dag_capturing_errors` re-raised only `OperationalError`, so a retryable DB error from per-dag serialization was misrecorded as a dag import error instead of reaching the retry loop (also flagged by the reviewer on #68267).

### Change

- Align both except clauses with the `run_with_db_retries` policy `(DBAPIError, StaleDataError)`: roll back before the retry, and let retryable per-dag DB errors reach the retry loop.
- `OperationalError` is a `DBAPIError` subclass, so existing behavior is preserved; non-retryable exceptions propagate unchanged.

### Tests

- `test_sync_to_db_rolls_back_before_retry_on_integrity_error`: `IntegrityError` on attempt 1 rolls the session back and attempt 2 succeeds.
- `test_serialize_dag_capturing_errors_reraises_retryable_db_errors`: retryable DB errors are re-raised, not recorded as import errors.
- Both fail on the code before this change (recorded); full `test_collection.py` passes (61 passed, 2 pre-existing FAB skips). `mypy-airflow-core` clean.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)