### PR TITLE
Fix DAG details active runs count to exclude queued runs

### DIFF
--- a/airflow-core/newsfragments/69769.bugfix.rst
+++ b/airflow-core/newsfragments/69769.bugfix.rst
@@ -1,0 +1,1 @@
+Fix DAG details 'active runs' count to only include running runs, not queued ones, matching scheduler enforcement of max_active_runs

--- a/airflow-core/newsfragments/69769.bugfix.rst
+++ b/airflow-core/newsfragments/69769.bugfix.rst
@@ -1,1 +1,0 @@
-Fix DAG details 'active runs' count to only include running runs, not queued ones, matching scheduler enforcement of max_active_runs

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -250,7 +250,7 @@ def get_dag_details(
         session.scalar(
             select(func.count())
             .select_from(DagRun)
-            .where(DagRun.dag_id == dag_id, DagRun.state.in_([DagRunState.RUNNING, DagRunState.QUEUED]))
+            .where(DagRun.dag_id == dag_id, DagRun.state == DagRunState.RUNNING)
         )
         or 0
     )

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -1278,7 +1278,7 @@ class TestDagDetails(TestDagEndpoint):
         # Verify active_runs_count field is present and correct
         assert "active_runs_count" in body
         assert isinstance(body["active_runs_count"], int)
-        assert body["active_runs_count"] == 2  # 1 running + 1 queued
+        assert body["active_runs_count"] == 1  # only running counts, queued does not
 
         # Test with DAG that has no active runs
         response = test_client.get(f"/dags/{DAG1_ID}/details")


### PR DESCRIPTION
The "Max active runs" counter on the DAG details page ("X of Y") counts both `running` and `queued` DAG runs, but the scheduler only counts `running` runs when enforcing `max_active_runs`. After a backfill queues many runs, the UI counter can show a number far exceeding the configured limit even though the scheduler is behaving correctly.

This fixes the counter to only count `running` runs, matching what the scheduler actually enforces.

closes: #69765

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Partially