### PR TITLE
Document that connection secrets without conn_type remain supported

### DIFF
--- a/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
+++ b/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
@@ -122,12 +122,13 @@ class BaseSecretsBackend(ABC):
     def _deserialize_connection_value(conn_class: type, conn_id: str, value: str):
         value = value.strip()
         if value[0] == "{":
-            # JSON secrets stored by Airflow 2-era backends may lack both "conn_type"
+            # JSON secrets stored by Airflow 2 backends may lack both "conn_type"
             # and "uri" (e.g. {"host": ..., "login": ..., "password": ...}). This is
             # valid: conn_type is intentionally optional on the SDK Connection model
-            # for Airflow 2 -> 3 migration compatibility. Do not add validation here
-            # that rejects such secrets; see
-            # https://github.com/apache/airflow/pull/61728
+            # for Airflow 2 -> 3 migration compatibility.
+            # Check: https://github.com/apache/airflow/pull/61728
+            # TODO: Remove this compatibility once the minimum supported Airflow
+            #   version in providers is 3.0.
             return conn_class.from_json(value=value, conn_id=conn_id)  # type: ignore[attr-defined]
 
         # TODO: Only sdk has from_uri defined on it. Is it worthwhile developing the core path or not?

--- a/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
+++ b/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from abc import ABC
 from collections.abc import Callable
 
@@ -122,6 +123,11 @@ class BaseSecretsBackend(ABC):
     def _deserialize_connection_value(conn_class: type, conn_id: str, value: str):
         value = value.strip()
         if value[0] == "{":
+            connection_data = json.loads(value)
+            conn_type = connection_data.get("conn_type")
+            uri = connection_data.get("uri")
+            if not (isinstance(conn_type, str) and conn_type.strip() or isinstance(uri, str) and uri.strip()):
+                raise ValueError("Connection secret JSON must include a non-empty 'conn_type' or 'uri'.")
             return conn_class.from_json(value=value, conn_id=conn_id)  # type: ignore[attr-defined]
 
         # TODO: Only sdk has from_uri defined on it. Is it worthwhile developing the core path or not?

--- a/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
+++ b/shared/secrets_backend/src/airflow_shared/secrets_backend/base.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import inspect
-import json
 from abc import ABC
 from collections.abc import Callable
 
@@ -123,11 +122,12 @@ class BaseSecretsBackend(ABC):
     def _deserialize_connection_value(conn_class: type, conn_id: str, value: str):
         value = value.strip()
         if value[0] == "{":
-            connection_data = json.loads(value)
-            conn_type = connection_data.get("conn_type")
-            uri = connection_data.get("uri")
-            if not (isinstance(conn_type, str) and conn_type.strip() or isinstance(uri, str) and uri.strip()):
-                raise ValueError("Connection secret JSON must include a non-empty 'conn_type' or 'uri'.")
+            # JSON secrets stored by Airflow 2-era backends may lack both "conn_type"
+            # and "uri" (e.g. {"host": ..., "login": ..., "password": ...}). This is
+            # valid: conn_type is intentionally optional on the SDK Connection model
+            # for Airflow 2 -> 3 migration compatibility. Do not add validation here
+            # that rejects such secrets; see
+            # https://github.com/apache/airflow/pull/61728
             return conn_class.from_json(value=value, conn_id=conn_id)  # type: ignore[attr-defined]
 
         # TODO: Only sdk has from_uri defined on it. Is it worthwhile developing the core path or not?

--- a/shared/secrets_backend/tests/secrets_backend/test_base.py
+++ b/shared/secrets_backend/tests/secrets_backend/test_base.py
@@ -124,6 +124,39 @@ class TestBaseSecretsBackend:
         assert conn.conn_id == "test_conn"
         assert conn._kwargs["conn_type"] == "mysql"
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            '{"host": "example.com"}',
+            '{"conn_type": null}',
+            '{"conn_type": ""}',
+            '{"conn_type": "   "}',
+        ],
+    )
+    def test_deserialize_connection_json_requires_conn_type(self, value):
+        backend = _TestBackend()
+        backend._set_connection_class(MockConnection)
+
+        with pytest.raises(
+            ValueError, match="Connection secret JSON must include a non-empty 'conn_type' or 'uri'."
+        ):
+            backend.deserialize_connection("test_conn", value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            '{"uri": "http://example.com"}',
+            '{"conn_type": null, "uri": "http://example.com"}',
+        ],
+    )
+    def test_deserialize_connection_json_with_uri_does_not_require_conn_type(self, value):
+        backend = _TestBackend()
+        backend._set_connection_class(MockConnection)
+
+        conn = backend.deserialize_connection("test_conn", value)
+
+        assert conn.uri == "http://example.com"
+
     def test_deserialize_connection_uri(self, sample_conn_uri):
         """Test deserialize_connection with URI format through _TestBackend."""
         backend = _TestBackend()

--- a/shared/secrets_backend/tests/secrets_backend/test_base.py
+++ b/shared/secrets_backend/tests/secrets_backend/test_base.py
@@ -125,8 +125,7 @@ class TestBaseSecretsBackend:
         assert conn._kwargs["conn_type"] == "mysql"
 
     def test_deserialize_connection_json_without_conn_type(self):
-        """Airflow 2-era JSON secrets without conn_type or uri must keep deserializing.
-
+        """
         Guards the Airflow 2 -> 3 migration compatibility established in
         https://github.com/apache/airflow/pull/61728.
         """

--- a/shared/secrets_backend/tests/secrets_backend/test_base.py
+++ b/shared/secrets_backend/tests/secrets_backend/test_base.py
@@ -124,38 +124,21 @@ class TestBaseSecretsBackend:
         assert conn.conn_id == "test_conn"
         assert conn._kwargs["conn_type"] == "mysql"
 
-    @pytest.mark.parametrize(
-        "value",
-        [
-            '{"host": "example.com"}',
-            '{"conn_type": null}',
-            '{"conn_type": ""}',
-            '{"conn_type": "   "}',
-        ],
-    )
-    def test_deserialize_connection_json_requires_conn_type(self, value):
+    def test_deserialize_connection_json_without_conn_type(self):
+        """Airflow 2-era JSON secrets without conn_type or uri must keep deserializing.
+
+        Guards the Airflow 2 -> 3 migration compatibility established in
+        https://github.com/apache/airflow/pull/61728.
+        """
         backend = _TestBackend()
         backend._set_connection_class(MockConnection)
 
-        with pytest.raises(
-            ValueError, match="Connection secret JSON must include a non-empty 'conn_type' or 'uri'."
-        ):
-            backend.deserialize_connection("test_conn", value)
-
-    @pytest.mark.parametrize(
-        "value",
-        [
-            '{"uri": "http://example.com"}',
-            '{"conn_type": null, "uri": "http://example.com"}',
-        ],
-    )
-    def test_deserialize_connection_json_with_uri_does_not_require_conn_type(self, value):
-        backend = _TestBackend()
-        backend._set_connection_class(MockConnection)
-
-        conn = backend.deserialize_connection("test_conn", value)
-
-        assert conn.uri == "http://example.com"
+        conn = backend.deserialize_connection(
+            "test_conn", '{"host": "example.com", "login": "admin", "password": "secret"}'
+        )
+        assert isinstance(conn, MockConnection)
+        assert conn.conn_id == "test_conn"
+        assert conn._kwargs == {"host": "example.com", "login": "admin", "password": "secret"}
 
     def test_deserialize_connection_uri(self, sample_conn_uri):
         """Test deserialize_connection with URI format through _TestBackend."""


### PR DESCRIPTION
## Why

Connection secrets in JSON format could omit `conn_type`. Although the secrets backend deserialized those values, the Execution API requires a connection type and the task could ultimately receive a misleading “connection not found” error.

This addresses the `conn_type` portion of related: #57864.

## What

- Reject JSON connection secrets whose `conn_type` is missing, null, empty, or whitespace-only.
- Raise a clear `ValueError` before constructing an incomplete Connection.
- Add regression coverage for each invalid `conn_type` value.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
