### PR TITLE
Fix Azure Data Factory test broken by azure-mgmt-datafactory update

### DIFF
--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py
@@ -22,7 +22,6 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from azure.mgmt.datafactory.aio import DataFactoryManagementClient
-from azure.mgmt.datafactory.models import FactoryListResponse
 
 from airflow.models.connection import Connection
 from airflow.providers.common.compat.sdk import AirflowException
@@ -522,7 +521,7 @@ def test_cancel_trigger(hook: AzureDataFactoryHook):
 
 @pytest.mark.parametrize(
     argnames="factory_list_result",
-    argvalues=[iter([FactoryListResponse]), iter([])],
+    argvalues=[iter([object()]), iter([])],
     ids=["factory_exists", "factory_does_not_exist"],
 )
 def test_connection_success(hook, factory_list_result):


### PR DESCRIPTION
The Azure Data Factory hook test imported `FactoryListResponse` from
`azure.mgmt.datafactory.models` only to use it as an arbitrary non-empty
placeholder in a mocked `factories.list()` iterator — `test_connection`
never inspects the returned item. A recent `azure-mgmt-datafactory`
release removed that model class, so test collection failed with
`ImportError: cannot import name 'FactoryListResponse'` in the
uncapped-dependency Compat CI jobs, breaking the scheduled `main` build
(and every PR that runs the full matrix, e.g. #69737).

Replace the placeholder with a neutral `object()` so the test no longer
depends on a specific SDK model.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
