### PR TITLE
Fix AirbyteJobSensor marking a cancelled job as success in deferrable mode

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -33,7 +33,7 @@ devel-common/src/tests_common/test_utils/sftp_system_helpers.py::1
 devel-common/src/tests_common/test_utils/watcher.py::1
 providers/airbyte/src/airflow/providers/airbyte/hooks/airbyte.py::8
 providers/airbyte/src/airflow/providers/airbyte/operators/airbyte.py::3
-providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py::6
+providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py::5
 providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/analyticdb_spark.py::6
 providers/alibaba/src/airflow/providers/alibaba/cloud/hooks/oss.py::11
 providers/alibaba/src/airflow/providers/alibaba/cloud/operators/analyticdb_spark.py::1

--- a/providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py
@@ -126,15 +126,16 @@ class AirbyteJobSensor(BaseSensorOperator):
                 )
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
-        """
-        Invoke this callback when the trigger fires; return immediately.
-
-        Relies on trigger to throw an exception, otherwise it assumes execution was
-        successful.
-        """
+        """Invoke this callback when the trigger fires and fail unless the job succeeded."""
         if event["status"] == "error":
             self.log.debug("An error occurred with context: %s", context)
             raise AirflowException(event["message"])
+
+        if event["status"] != "success":
+            # A cancelled job must fail the sensor, matching the poke() behavior;
+            # fail closed on any status this sensor does not recognize.
+            self.log.debug("Job did not succeed, context: %s", context)
+            raise RuntimeError(event["message"])
 
         self.log.info("%s completed successfully.", self.task_id)
         return None

--- a/providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py
+++ b/providers/airbyte/src/airflow/providers/airbyte/sensors/airbyte.py
@@ -127,15 +127,21 @@ class AirbyteJobSensor(BaseSensorOperator):
 
     def execute_complete(self, context: Context, event: Any = None) -> None:
         """Invoke this callback when the trigger fires and fail unless the job succeeded."""
-        if event["status"] == "error":
-            self.log.debug("An error occurred with context: %s", context)
-            raise AirflowException(event["message"])
+        status = event["status"]
 
-        if event["status"] != "success":
-            # A cancelled job must fail the sensor, matching the poke() behavior;
-            # fail closed on any status this sensor does not recognize.
-            self.log.debug("Job did not succeed, context: %s", context)
+        if status == "success":
+            self.log.info("%s completed successfully.", self.task_id)
+            return None
+
+        if status == "error":
+            self.log.debug("An error occurred with context: %s", context)
             raise RuntimeError(event["message"])
 
-        self.log.info("%s completed successfully.", self.task_id)
-        return None
+        if status == "cancelled":
+            # A cancelled job must fail the sensor, matching the poke() behavior.
+            self.log.debug("Job was cancelled, context: %s", context)
+            raise RuntimeError(event["message"])
+
+        # Fail closed: a status this sensor does not model must not reach the success path.
+        self.log.debug("Unexpected status %r, context: %s", status, context)
+        raise RuntimeError(event["message"])

--- a/providers/airbyte/tests/unit/airbyte/sensors/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/sensors/test_airbyte.py
@@ -121,6 +121,7 @@ class TestAirbyteJobSensor:
     @pytest.mark.parametrize(
         ("status", "message"),
         [
+            pytest.param("error", "Job run 1 has failed.", id="error"),
             pytest.param("cancelled", "Job run 1 has been cancelled.", id="cancelled"),
             pytest.param("unmapped_status", "Job run 1 did something unexpected.", id="fail-closed"),
         ],

--- a/providers/airbyte/tests/unit/airbyte/sensors/test_airbyte.py
+++ b/providers/airbyte/tests/unit/airbyte/sensors/test_airbyte.py
@@ -117,3 +117,36 @@ class TestAirbyteJobSensor:
         )
         assert sensor.poke_interval == 10
         assert sensor.timeout == 3600
+
+    @pytest.mark.parametrize(
+        ("status", "message"),
+        [
+            pytest.param("cancelled", "Job run 1 has been cancelled.", id="cancelled"),
+            pytest.param("unmapped_status", "Job run 1 did something unexpected.", id="fail-closed"),
+        ],
+    )
+    def test_execute_complete_fails_when_job_did_not_succeed(self, status, message):
+        """A deferred sensor must fail on a non-success event, matching the poke() behavior."""
+        sensor = AirbyteJobSensor(
+            task_id=self.task_id,
+            airbyte_job_id=self.job_id,
+            airbyte_conn_id=self.airbyte_conn_id,
+            deferrable=True,
+        )
+        with pytest.raises(RuntimeError, match=message):
+            sensor.execute_complete(context={}, event={"status": status, "message": message, "job_id": 1})
+
+    def test_execute_complete_succeeds_on_success_event(self):
+        sensor = AirbyteJobSensor(
+            task_id=self.task_id,
+            airbyte_job_id=self.job_id,
+            airbyte_conn_id=self.airbyte_conn_id,
+            deferrable=True,
+        )
+        assert (
+            sensor.execute_complete(
+                context={},
+                event={"status": "success", "message": "Job run 1 has completed successfully.", "job_id": 1},
+            )
+            is None
+        )


### PR DESCRIPTION
### Problem

- `AirbyteJobSensor` in deferrable mode resumes via `execute_complete`, which only fails on an `error` event.
- A job cancelled while the sensor is deferred makes `AirbyteSyncTrigger` yield a `cancelled` event, which fell through to the success path: the task is marked SUCCESS and downstream tasks run against a sync that never completed.
- The same sensor fails correctly on a cancelled job in every other path: non-deferrable `poke()` raises, the deferrable `execute()` raises when it sees `CANCELLED` before deferring, and the sibling `AirbyteTriggerSyncOperator.execute_complete` already fails on the `cancelled` event (added in #64051, which did not cover the sensor).

### Change

- Fail on any non-success event in the sensor's `execute_complete`, matching `poke()`. The `cancelled` event now fails the task, and unrecognized statuses fail closed instead of being treated as success.

### Live verification

Ran a real `airflow standalone` (scheduler, triggerer, API server) against a live local endpoint serving the Airbyte jobs API, with the connection host pointed at it. Both runs: sensor deferred while the job was `running`, then the job was flipped to `cancelled`.

- Control run on current main: trigger yielded the cancelled event, task log shows "completed successfully.", run marked **Success**.
- Same scenario with this fix: task fails with `RuntimeError: Job run 1 has been cancelled.`, run marked **Failed**.

<img width="900" alt="control run on main marked Success on a cancelled job; fixed run marked Failed" src="https://raw.githubusercontent.com/steveahnahn/airflow/pr-screenshots/airbyte_cancel_control_vs_fixed.jpeg" />

### Tests

- `test_execute_complete_fails_when_job_did_not_succeed` (parametrized: `cancelled`, unrecognized status) fails on the code before this change; the failure output shows the bug verbatim ("completed successfully." on a cancelled event).
- `test_execute_complete_succeeds_on_success_event` guards the happy path.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)