### PR TITLE
Fix remaining SQLAlchemy 1.4/2.1 doc references and fact-check migration

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -683,7 +683,7 @@ database:
         Check connection at the start of each connection pool checkout.
         Typically, this is a simple statement like "SELECT 1".
         See `SQLAlchemy Pooling: Disconnect Handling - Pessimistic
-        <https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic>`__
+        <https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic>`__
         for more details.
       version_added: 2.3.0
       type: boolean

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -90,8 +90,10 @@ if TYPE_CHECKING:
     from airflow.models.connection import Connection
     from airflow.typing_compat import Self
 
-    # TODO: Import this from sqlalchemy.orm instead when switching to SQLA 2.
-    # https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.MappedClassProtocol
+    # Note: SQLAlchemy 2.x (already required by this package) ships its own
+    # sqlalchemy.orm.MappedClassProtocol, but it checks for __table__/__mapper__/__call__
+    # rather than __tablename__, so it isn't a drop-in replacement for this local protocol.
+    # See https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.MappedClassProtocol
     class MappedClassProtocol(Protocol):
         """Protocol for SQLALchemy model base."""
 

--- a/airflow-core/tests/unit/utils/test_orm_event_handlers.py
+++ b/airflow-core/tests/unit/utils/test_orm_event_handlers.py
@@ -17,7 +17,7 @@
 
 """
 These tests ensure compatibility with the deprecation of `sqlalchemy.orm.mapper()` in SQLAlchemy 2.0.0.b1.
-See also: https://docs.sqlalchemy.org/en/21/orm/mapping_styles.html#orm-imperative-mapping
+See also: https://docs.sqlalchemy.org/en/20/orm/mapping_styles.html#orm-imperative-mapping
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Addresses  #69164 

(follow-up to #69203 )

## What this does

#69200 already fixed most of the 1.4→2.0 doc links. This PR:
1. Fixes the one remaining `en/14` link (`config.yml`, `sql_alchemy_pool_pre_ping`)
2. Fixes an adjacent `en/21` (beta) link that wasn't in the original 9 but has
   the same root problem — airflow-core requires `sqlalchemy>=2.0.48`, not 2.1
3. Does the fact-check the issue actually asked for (not just link-swapping)

## Verification table

| Location | Old | New | How verified |
|---|---|---|---|
| `config.yml:686` | en/14#disconnect-handling-pessimistic | en/20#disconnect-handling-pessimistic | Fetched live page, confirmed the anchor exists; confirmed our description text still matches 2.0 behavior |
| `test_orm_event_handlers.py:20` | en/21 (beta) | en/20 | Confirmed identical content/anchor exists on en/20; consistent with the rest of the codebase and our actual version floor |
| `utils/db.py:93-94` | Stale TODO suggesting a swap to `sqlalchemy.orm.MappedClassProtocol` | Corrected comment, TODO removed | The real class checks `__table__`/`__mapper__`/`__call__`; ours checks `__tablename__`. They're not interchangeable — the TODO was wrong, not just outdated |

## Deliberately NOT changed

- `set-up-database.rst:201` — correctly stays on `en/20/changelog/changelog_14.html` even
  though it documents 1.4-era behavior, because SQLAlchemy hosts historical changelogs
  under the current docs version's URL tree. `settings.py` already relies on this same
  pattern independently, which cross-confirms it's correct.
- Historical "as of SQLAlchemy 1.4..." mentions in `configuration.py`, provider changelogs,
  and `RELEASE_NOTES.rst` — true historical statements, not stale references.

## Testing
- `pre-commit run --files airflow-core/src/airflow/config_templates/config.yml airflow-core/src/airflow/utils/db.py airflow-core/tests/unit/utils/test_orm_event_handlers.py` — all content-inspecting hooks pass (ruff, mypy, yamllint, license headers, codespell, newsfragment check)
- Manually re-verified the changed links by clicking through myself

<!-- pr-triage-fold: triaged=2026-07-28T16:10:09Z head=ff7713d action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @joshuabvarghese** · by `@potiuk` · 2026-07-28 16:10 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **362 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
