### PR TITLE
Fix Azure Data Factory async test on azure-mgmt-datafactory 10

### DIFF
--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py
@@ -679,19 +679,16 @@ class TestAzureDataFactoryAsyncHook:
         assert response == mock_status
 
     @pytest.mark.asyncio
-    @mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")
     @mock.patch(f"{MODULE}.AzureDataFactoryAsyncHook.get_connection")
     @mock.patch(f"{MODULE}.AzureDataFactoryAsyncHook.get_async_conn")
-    async def test_get_pipeline_run_exception_without_resource(
-        self, mock_conn, mock_get_connection, mock_pipeline_run
-    ):
+    async def test_get_pipeline_run_exception_without_resource(self, mock_conn, mock_get_connection):
         """
         Test get_pipeline_run function without passing the resource name to check the decorator function and
         raise exception
         """
         mock_connection = Connection(extra={"factory_name": DATAFACTORY_NAME})
         mock_get_connection.return_value = mock_connection
-        mock_conn.return_value.pipeline_runs.get.return_value = mock_pipeline_run
+        mock_conn.return_value.pipeline_runs.get.return_value = MagicMock()
         hook = AzureDataFactoryAsyncHook(AZURE_DATA_FACTORY_CONN_ID)
         with pytest.raises(AirflowException):
             await hook.get_pipeline_run(RUN_ID, None, DATAFACTORY_NAME)


### PR DESCRIPTION
- related: #69785

## Why

`TestAzureDataFactoryAsyncHook::test_get_pipeline_run_exception_without_resource` fails on main in the uncapped-dependency CI jobs with `ModuleNotFoundError: No module named 'azure.mgmt.datafactory.models._models_py3'` — the regenerated `azure-mgmt-datafactory` 10.0.0 removed that private module, and the test `mock.patch`es a class inside it at run time (#69785 fixed the collection-time break in the same file, but this run-time patch was left behind).

## What

- Drop the `@mock.patch("azure.mgmt.datafactory.models._models_py3.PipelineRun")` decorator and use a plain `MagicMock()` as the mocked `pipeline_runs.get` return value. The value is an opaque placeholder — the test asserts `get_pipeline_run` raises before the connection is ever used — so the test no longer depends on any specific SDK module layout and passes on both 9.3.0 (locked) and 10.0.0.

## Verification

- `uv run --project providers/microsoft/azure --with "azure-mgmt-datafactory==10.0.0" pytest providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py -q` → 78 passed (the unfixed test fails on 10.0.0 with the CI error)
- `uv run --project providers/microsoft/azure pytest providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py -q` → 78 passed on locked 9.3.0

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
