### PR TITLE
Make cheat-sheet test independent of rich table padding

### DIFF
--- a/airflow-core/tests/unit/cli/commands/test_cheat_sheet_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_cheat_sheet_command.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import re
 from unittest import mock
 
 from airflow.cli import cli_parser
@@ -72,18 +73,23 @@ MOCK_COMMANDS: list[CLICommand] = [
 ]
 
 ALL_COMMANDS = """\
-airflow cmd_b                                   | Help text D
+airflow cmd_b | Help text D
 """
 
 SECTION_A = """\
-airflow cmd_a cmd_b                             | Help text B
-airflow cmd_a cmd_c                             | Help text C
+airflow cmd_a cmd_b | Help text B
+airflow cmd_a cmd_c | Help text C
 """
 
 SECTION_E = """\
-airflow cmd_e cmd_f                             | Help text F
-airflow cmd_e cmd_g                             | Help text G
+airflow cmd_e cmd_f | Help text F
+airflow cmd_e cmd_g | Help text G
 """
+
+
+def normalize_spaces(text: str) -> str:
+    """Collapse runs of spaces so assertions do not depend on the rich version's exact column padding."""
+    return re.sub(r" +", " ", text)
 
 
 class TestCheatSheetCommand:
@@ -96,7 +102,7 @@ class TestCheatSheetCommand:
         with stdout_capture as temp_stdout:
             args = self.parser.parse_args(["cheat-sheet"])
             args.func(args)
-        output = temp_stdout.getvalue()
+        output = normalize_spaces(temp_stdout.getvalue())
         assert ALL_COMMANDS in output
         assert SECTION_A in output
         assert SECTION_E in output


### PR DESCRIPTION
## Why

- The CI dependency upgrade PR (#69694) bumps `rich` 13.9.4 → 14.3.4, and all core test jobs fail on `test_cheat_sheet_command.py::TestCheatSheetCommand::test_should_display_index`.

## How
- Ignore padding space. Rewrite the expected rows in single-space form and normalize runs of spaces in the captured output before asserting.

## Verification

- `uv run --frozen --project airflow-core --with ./shared/secrets_masker pytest airflow-core/tests/unit/cli/commands/test_cheat_sheet_command.py`
- `uv run --frozen --project airflow-core --with ./shared/secrets_masker --with "rich==14.3.4" pytest airflow-core/tests/unit/cli/commands/test_cheat_sheet_command.py`
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
