### PR TITLE
Uncouple skill-eval harness string match from promptfoo version banner

### DIFF
--- a/dev/skill-evals/eval.py
+++ b/dev/skill-evals/eval.py
@@ -91,7 +91,11 @@ def find_sdk_modules() -> Path:
     """
     promptfoo_bin = shutil.which("promptfoo")
     if promptfoo_bin:
-        version = run(["promptfoo", "--version"]).stdout.strip()
+        # PROMPTFOO_DISABLE_UPDATE avoids an outdated version banner on stdout when a newer
+        # promptfoo is published upstream, which would otherwise break this exact match.
+        version = run(
+            ["promptfoo", "--version"], env={**os.environ, "PROMPTFOO_DISABLE_UPDATE": "1"}
+        ).stdout.strip()
         if version == PROMPTFOO_VERSION:
             pf_pkg = Path(promptfoo_bin).resolve()
             while pf_pkg.name != "promptfoo" or not (pf_pkg / "package.json").is_file():


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

`promptfoo` prints an update-nag banner on stdout when npm has a newerm release than the pinned version, which broke the exact-version check used to locate the Claude Agent SDK modules. I faced this today:

```shell
amoghrajesh.desai  …/caplog-testing-standard   clarify-caplog-testing-standard $⇡    orbstack  ♥ 13:57  promptfoo --version                

amoghrajesh.desai  …/caplog-testing-standard   clarify-caplog-testing-standard $⇡    orbstack  ♥ 13:57  prek run run-skill-eval --hook-stage manual --all-files
Run skill-eval against AGENTS.md and cases...............................Failed
- hook id: run-skill-eval
- duration: 1.66s
- exit code: 1

  Error: promptfoo with the Claude Agent SDK not found. Run the eval via:
    prek run run-skill-eval --hook-stage manual --all-files
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
