### PR TITLE
Progressively load interactive elements of Dag Card

### DIFF
--- a/airflow-core/src/airflow/ui/src/hooks/useNearViewport.test.tsx
+++ b/airflow-core/src/airflow/ui/src/hooks/useNearViewport.test.tsx
@@ -1,0 +1,167 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useNearViewport } from "./useNearViewport";
+
+type MockObserver = {
+  callback: IntersectionObserverCallback;
+} & IntersectionObserver;
+
+const observers: Array<MockObserver> = [];
+
+const createEntry = (target: Element, isIntersecting: boolean): IntersectionObserverEntry => ({
+  boundingClientRect: target.getBoundingClientRect(),
+  intersectionRatio: isIntersecting ? 1 : 0,
+  intersectionRect: target.getBoundingClientRect(),
+  isIntersecting,
+  rootBounds: null,
+  target,
+  time: 0,
+});
+
+const takeNoRecords = () => [];
+
+const MockIntersectionObserver = function MockIntersectionObserver(
+  callback: IntersectionObserverCallback,
+  options?: IntersectionObserverInit,
+): IntersectionObserver {
+  const observer = {
+    callback,
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    root: null,
+    rootMargin: options?.rootMargin ?? "0px",
+    scrollMargin: options?.scrollMargin ?? "0px",
+    takeRecords: vi.fn(takeNoRecords),
+    thresholds: [0],
+    unobserve: vi.fn(),
+  } satisfies MockObserver;
+
+  observers.push(observer);
+
+  return observer;
+};
+
+const installIntersectionObserver = () => {
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+};
+
+const TestCard = ({ name }: { readonly name: string }) => {
+  const { isNearViewport, ref } = useNearViewport<HTMLDivElement>();
+
+  return (
+    <div data-testid={`${name}-shell`} ref={ref}>
+      {name}
+      {isNearViewport ? <span>{`${name} controls`}</span> : <span>{`${name} placeholder`}</span>}
+    </div>
+  );
+};
+
+afterEach(() => {
+  observers.length = 0;
+  vi.unstubAllGlobals();
+});
+
+describe("useNearViewport", () => {
+  it("mounts deferred content when its shell approaches the viewport and keeps it mounted", () => {
+    installIntersectionObserver();
+    render(<TestCard name="first" />);
+
+    expect(screen.getByTestId("first-shell")).toBeInTheDocument();
+    expect(screen.getByText("first placeholder")).toBeInTheDocument();
+    expect(screen.queryByText("first controls")).not.toBeInTheDocument();
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.rootMargin).toBe("600px 0px");
+    expect(observers[0]?.scrollMargin).toBe("600px 0px");
+
+    const [observer] = observers;
+    const shell = screen.getByTestId("first-shell");
+
+    if (observer === undefined) {
+      throw new Error("Expected an IntersectionObserver");
+    }
+
+    act(() => {
+      observer.callback([createEntry(shell, true)], observer);
+    });
+
+    expect(screen.getByText("first controls")).toBeInTheDocument();
+    expect(screen.queryByText("first placeholder")).not.toBeInTheDocument();
+    expect(observer.unobserve).toHaveBeenCalledWith(shell);
+
+    act(() => {
+      observer.callback([createEntry(shell, false)], observer);
+    });
+
+    expect(screen.getByText("first controls")).toBeInTheDocument();
+  });
+
+  it("shares one observer across multiple shells", () => {
+    installIntersectionObserver();
+    render(
+      <>
+        <TestCard name="first" />
+        <TestCard name="second" />
+      </>,
+    );
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.observe).toHaveBeenCalledTimes(2);
+
+    const [observer] = observers;
+    const secondShell = screen.getByTestId("second-shell");
+
+    if (observer === undefined) {
+      throw new Error("Expected an IntersectionObserver");
+    }
+
+    act(() => {
+      observer.callback([createEntry(secondShell, true)], observer);
+    });
+
+    expect(screen.getByText("first placeholder")).toBeInTheDocument();
+    expect(screen.getByText("second controls")).toBeInTheDocument();
+  });
+
+  it("unobserves a pending shell and releases the shared observer on unmount", () => {
+    installIntersectionObserver();
+    const { unmount } = render(<TestCard name="first" />);
+
+    const [observer] = observers;
+    const shell = screen.getByTestId("first-shell");
+
+    if (observer === undefined) {
+      throw new Error("Expected an IntersectionObserver");
+    }
+
+    unmount();
+
+    expect(observer.unobserve).toHaveBeenCalledWith(shell);
+    expect(observer.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("mounts content when IntersectionObserver is unavailable", async () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    render(<TestCard name="first" />);
+
+    expect(await screen.findByText("first controls")).toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/hooks/useNearViewport.test.tsx
+++ b/airflow-core/src/airflow/ui/src/hooks/useNearViewport.test.tsx
@@ -47,7 +47,7 @@ const MockIntersectionObserver = function MockIntersectionObserver(
     callback,
     disconnect: vi.fn(),
     observe: vi.fn(),
-    root: null,
+    root: options?.root ?? null,
     rootMargin: options?.rootMargin ?? "0px",
     scrollMargin: options?.scrollMargin ?? "0px",
     takeRecords: vi.fn(takeNoRecords),
@@ -90,7 +90,7 @@ describe("useNearViewport", () => {
     expect(screen.queryByText("first controls")).not.toBeInTheDocument();
     expect(observers).toHaveLength(1);
     expect(observers[0]?.rootMargin).toBe("600px 0px");
-    expect(observers[0]?.scrollMargin).toBe("600px 0px");
+    expect(observers[0]?.scrollMargin).toBe("0px");
 
     const [observer] = observers;
     const shell = screen.getByTestId("first-shell");
@@ -139,6 +139,56 @@ describe("useNearViewport", () => {
 
     expect(screen.getByText("first placeholder")).toBeInTheDocument();
     expect(screen.getByText("second controls")).toBeInTheDocument();
+  });
+
+  it("uses the nearest scroll container as the preload root", () => {
+    installIntersectionObserver();
+    render(
+      <div
+        data-testid="scroll-root"
+        ref={(element) => {
+          if (element !== null) {
+            Object.defineProperties(element, {
+              clientHeight: { configurable: true, value: 100 },
+              scrollHeight: { configurable: true, value: 1000 },
+            });
+          }
+        }}
+        style={{ overflowY: "auto" }}
+      >
+        <TestCard name="first" />
+      </div>,
+    );
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.root).toBe(screen.getByTestId("scroll-root"));
+    expect(observers[0]?.rootMargin).toBe("600px 0px");
+  });
+
+  it("skips an overflow wrapper that does not actually scroll", () => {
+    installIntersectionObserver();
+    render(
+      <div
+        data-testid="scroll-root"
+        ref={(element) => {
+          if (element !== null) {
+            Object.defineProperties(element, {
+              clientHeight: { configurable: true, value: 100 },
+              scrollHeight: { configurable: true, value: 1000 },
+            });
+          }
+        }}
+        style={{ overflowY: "auto" }}
+      >
+        <div data-testid="overflow-wrapper" style={{ overflowY: "auto" }}>
+          <TestCard name="first" />
+        </div>
+      </div>,
+    );
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0]?.root).toBe(screen.getByTestId("scroll-root"));
+    expect(observers[0]?.root).not.toBe(screen.getByTestId("overflow-wrapper"));
   });
 
   it("unobserves a pending shell and releases the shared observer on unmount", () => {

--- a/airflow-core/src/airflow/ui/src/hooks/useNearViewport.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useNearViewport.ts
@@ -31,6 +31,8 @@ const getScrollRoot = (element: Element): Element | null => {
   let ancestor = element.parentElement;
   let overflowAncestor: Element | null = null;
 
+  // Use the nearest ancestor that actually scrolls, falling back to the nearest
+  // overflow container when its content currently fits without scrolling.
   while (ancestor !== null) {
     const { overflowY } = globalThis.getComputedStyle(ancestor);
 

--- a/airflow-core/src/airflow/ui/src/hooks/useNearViewport.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useNearViewport.ts
@@ -16,22 +16,57 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { startTransition, useEffect, useRef, useState, type RefObject } from "react";
+import { startTransition, useCallback, useEffect, useRef, useState, type RefObject } from "react";
 
 const NEAR_VIEWPORT_MARGIN = "600px 0px";
 
-const listeners = new Map<Element, () => void>();
-let sharedObserver: IntersectionObserver | undefined;
+type ObserverState = {
+  readonly listeners: Map<Element, () => void>;
+  readonly observer: IntersectionObserver;
+};
 
-const releaseObserverWhenIdle = () => {
-  if (listeners.size === 0) {
-    sharedObserver?.disconnect();
-    sharedObserver = undefined;
+const observerStates = new Map<Element | null, ObserverState>();
+
+const getScrollRoot = (element: Element): Element | null => {
+  let ancestor = element.parentElement;
+  let overflowAncestor: Element | null = null;
+
+  while (ancestor !== null) {
+    const { overflowY } = globalThis.getComputedStyle(ancestor);
+
+    if (/^(?:auto|overlay|scroll)$/u.test(overflowY)) {
+      overflowAncestor ??= ancestor;
+
+      if (ancestor.scrollHeight > ancestor.clientHeight) {
+        return ancestor;
+      }
+    }
+
+    ancestor = ancestor.parentElement;
+  }
+
+  return overflowAncestor;
+};
+
+const releaseObserverWhenIdle = (root: Element | null, state: ObserverState) => {
+  if (state.listeners.size === 0) {
+    state.observer.disconnect();
+
+    if (observerStates.get(root) === state) {
+      observerStates.delete(root);
+    }
   }
 };
 
-const getSharedObserver = (observerConstructor: typeof IntersectionObserver) => {
-  sharedObserver ??= new observerConstructor(
+const getSharedObserver = (observerConstructor: typeof IntersectionObserver, root: Element | null) => {
+  const currentState = observerStates.get(root);
+
+  if (currentState !== undefined) {
+    return currentState;
+  }
+
+  const listeners = new Map<Element, () => void>();
+  const observer = new observerConstructor(
     (entries) => {
       entries.forEach((entry) => {
         if (!entry.isIntersecting) {
@@ -42,44 +77,58 @@ const getSharedObserver = (observerConstructor: typeof IntersectionObserver) => 
 
         if (listener !== undefined) {
           listeners.delete(entry.target);
-          sharedObserver?.unobserve(entry.target);
+          observer.unobserve(entry.target);
           listener();
         }
       });
-      releaseObserverWhenIdle();
+      const observerState = observerStates.get(root);
+
+      if (observerState !== undefined) {
+        releaseObserverWhenIdle(root, observerState);
+      }
     },
-    { rootMargin: NEAR_VIEWPORT_MARGIN, scrollMargin: NEAR_VIEWPORT_MARGIN },
+    { root, rootMargin: NEAR_VIEWPORT_MARGIN },
   );
 
-  return sharedObserver;
+  const state = { listeners, observer };
+
+  observerStates.set(root, state);
+
+  return state;
 };
 
 const observeNearViewport = (element: Element, listener: () => void) => {
   const observerConstructor = (globalThis as { IntersectionObserver?: typeof IntersectionObserver })
     .IntersectionObserver;
 
+  // If observation is unavailable, we immediately call the listener.
   if (observerConstructor === undefined) {
     listener();
 
     return undefined;
   }
 
-  listeners.set(element, listener);
-  getSharedObserver(observerConstructor).observe(element);
+  const root = getScrollRoot(element);
+  const state = getSharedObserver(observerConstructor, root);
+
+  state.listeners.set(element, listener);
+  state.observer.observe(element);
 
   return () => {
-    listeners.delete(element);
-    sharedObserver?.unobserve(element);
-    releaseObserverWhenIdle();
+    state.listeners.delete(element);
+    state.observer.unobserve(element);
+    releaseObserverWhenIdle(root, state);
   };
 };
 
 export const useNearViewport = <TElement extends Element>(): {
   readonly isNearViewport: boolean;
   readonly ref: RefObject<TElement | null>;
+  readonly showContent: () => void;
 } => {
   const ref = useRef<TElement>(null);
   const [isNearViewport, setIsNearViewport] = useState(false);
+  const showContent = useCallback(() => setIsNearViewport(true), []);
 
   useEffect(() => {
     const element = ref.current;
@@ -89,9 +138,9 @@ export const useNearViewport = <TElement extends Element>(): {
     }
 
     return observeNearViewport(element, () => {
-      startTransition(() => setIsNearViewport(true));
+      startTransition(showContent);
     });
-  }, [isNearViewport]);
+  }, [isNearViewport, showContent]);
 
-  return { isNearViewport, ref };
+  return { isNearViewport, ref, showContent };
 };

--- a/airflow-core/src/airflow/ui/src/hooks/useNearViewport.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useNearViewport.ts
@@ -1,0 +1,97 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { startTransition, useEffect, useRef, useState, type RefObject } from "react";
+
+const NEAR_VIEWPORT_MARGIN = "600px 0px";
+
+const listeners = new Map<Element, () => void>();
+let sharedObserver: IntersectionObserver | undefined;
+
+const releaseObserverWhenIdle = () => {
+  if (listeners.size === 0) {
+    sharedObserver?.disconnect();
+    sharedObserver = undefined;
+  }
+};
+
+const getSharedObserver = (observerConstructor: typeof IntersectionObserver) => {
+  sharedObserver ??= new observerConstructor(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+
+        const listener = listeners.get(entry.target);
+
+        if (listener !== undefined) {
+          listeners.delete(entry.target);
+          sharedObserver?.unobserve(entry.target);
+          listener();
+        }
+      });
+      releaseObserverWhenIdle();
+    },
+    { rootMargin: NEAR_VIEWPORT_MARGIN, scrollMargin: NEAR_VIEWPORT_MARGIN },
+  );
+
+  return sharedObserver;
+};
+
+const observeNearViewport = (element: Element, listener: () => void) => {
+  const observerConstructor = (globalThis as { IntersectionObserver?: typeof IntersectionObserver })
+    .IntersectionObserver;
+
+  if (observerConstructor === undefined) {
+    listener();
+
+    return undefined;
+  }
+
+  listeners.set(element, listener);
+  getSharedObserver(observerConstructor).observe(element);
+
+  return () => {
+    listeners.delete(element);
+    sharedObserver?.unobserve(element);
+    releaseObserverWhenIdle();
+  };
+};
+
+export const useNearViewport = <TElement extends Element>(): {
+  readonly isNearViewport: boolean;
+  readonly ref: RefObject<TElement | null>;
+} => {
+  const ref = useRef<TElement>(null);
+  const [isNearViewport, setIsNearViewport] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+
+    if (isNearViewport || element === null) {
+      return undefined;
+    }
+
+    return observeNearViewport(element, () => {
+      startTransition(() => setIsNearViewport(true));
+    });
+  }, [isNearViewport]);
+
+  return { isNearViewport, ref };
+};

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -53,23 +53,6 @@ const GMTWrapper = ({ children }: PropsWithChildren) => (
   </BaseWrapper>
 );
 
-// Render with the run-state-counts row in its loading state so it renders
-// skeletons rather than StateBadges. Without this, every card would emit
-// 4 extra "state-badge" testids and break getByTestId assertions in tests
-// that target the latest-run badge.
-const renderCard = (dag: DAGWithLatestDagRunsResponse, deferContent = false) => {
-  if (!deferContent) {
-    vi.stubGlobal("IntersectionObserver", undefined);
-  }
-
-  return render(
-    <DagCard dag={dag} runStateCounts={undefined} runStateCountsLoading stateCountLimit={undefined} />,
-    {
-      wrapper: GMTWrapper,
-    },
-  );
-};
-
 const takeNoObserverRecords = () => [];
 
 type MockDagCardObserver = {
@@ -86,7 +69,7 @@ const MockDagCardIntersectionObserver = function MockDagCardIntersectionObserver
     callback: nextCallback,
     disconnect: vi.fn(),
     observe: vi.fn(),
-    root: null,
+    root: options?.root ?? null,
     rootMargin: options?.rootMargin ?? "0px",
     scrollMargin: options?.scrollMargin ?? "0px",
     takeRecords: vi.fn(takeNoObserverRecords),
@@ -97,6 +80,57 @@ const MockDagCardIntersectionObserver = function MockDagCardIntersectionObserver
   dagCardObservers.push(observer);
 
   return observer;
+};
+
+type CardContentMode = "fallback" | "hydrated" | "pending";
+
+// Render with the run-state-counts row in its loading state so it renders
+// skeletons rather than StateBadges. Without this, every card would emit
+// 4 extra "state-badge" testids and break getByTestId assertions in tests
+// that target the latest-run badge.
+const renderCard = (dag: DAGWithLatestDagRunsResponse, contentMode: CardContentMode = "hydrated") => {
+  dagCardObservers.length = 0;
+
+  if (contentMode === "fallback") {
+    vi.stubGlobal("IntersectionObserver", undefined);
+  } else {
+    vi.stubGlobal("IntersectionObserver", MockDagCardIntersectionObserver);
+  }
+
+  const result = render(
+    <DagCard dag={dag} runStateCounts={undefined} runStateCountsLoading stateCountLimit={undefined} />,
+    {
+      wrapper: GMTWrapper,
+    },
+  );
+
+  if (contentMode === "hydrated") {
+    const [observer] = dagCardObservers;
+    const card = screen.getByTestId("dag-card");
+
+    if (observer === undefined) {
+      throw new Error("Expected the Dag card to register an IntersectionObserver");
+    }
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            boundingClientRect: card.getBoundingClientRect(),
+            intersectionRatio: 1,
+            intersectionRect: card.getBoundingClientRect(),
+            isIntersecting: true,
+            rootBounds: null,
+            target: card,
+            time: 0,
+          },
+        ],
+        observer,
+      );
+    });
+  }
+
+  return result;
 };
 
 const mockDag = {
@@ -185,7 +219,7 @@ describe("DagCard", () => {
   it("renders its shell before mounting near-viewport controls", () => {
     dagCardObservers.length = 0;
     vi.stubGlobal("IntersectionObserver", MockDagCardIntersectionObserver);
-    renderCard(mockDag, true);
+    renderCard(mockDag, "pending");
 
     const card = screen.getByTestId("dag-card");
 
@@ -219,6 +253,18 @@ describe("DagCard", () => {
 
     expect(screen.getByTestId("toggle-pause")).toBeInTheDocument();
     expect(screen.getAllByTestId("recent-run")).toHaveLength(mockDag.latest_dag_runs.length);
+  });
+
+  it("mounts deferred controls when keyboard focus enters the card", () => {
+    dagCardObservers.length = 0;
+    vi.stubGlobal("IntersectionObserver", MockDagCardIntersectionObserver);
+    renderCard(mockDag, "pending");
+
+    expect(screen.queryByTestId("toggle-pause")).not.toBeInTheDocument();
+
+    fireEvent.focus(screen.getByTestId("dag-id"));
+
+    expect(screen.getByTestId("toggle-pause")).toBeInTheDocument();
   });
 
   it("DagCard should render without tags", () => {

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.test.tsx
@@ -57,10 +57,47 @@ const GMTWrapper = ({ children }: PropsWithChildren) => (
 // skeletons rather than StateBadges. Without this, every card would emit
 // 4 extra "state-badge" testids and break getByTestId assertions in tests
 // that target the latest-run badge.
-const renderCard = (dag: DAGWithLatestDagRunsResponse) =>
-  render(<DagCard dag={dag} runStateCounts={undefined} runStateCountsLoading stateCountLimit={undefined} />, {
-    wrapper: GMTWrapper,
-  });
+const renderCard = (dag: DAGWithLatestDagRunsResponse, deferContent = false) => {
+  if (!deferContent) {
+    vi.stubGlobal("IntersectionObserver", undefined);
+  }
+
+  return render(
+    <DagCard dag={dag} runStateCounts={undefined} runStateCountsLoading stateCountLimit={undefined} />,
+    {
+      wrapper: GMTWrapper,
+    },
+  );
+};
+
+const takeNoObserverRecords = () => [];
+
+type MockDagCardObserver = {
+  callback: IntersectionObserverCallback;
+} & IntersectionObserver;
+
+const dagCardObservers: Array<MockDagCardObserver> = [];
+
+const MockDagCardIntersectionObserver = function MockDagCardIntersectionObserver(
+  nextCallback: IntersectionObserverCallback,
+  options?: IntersectionObserverInit,
+): IntersectionObserver {
+  const observer = {
+    callback: nextCallback,
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    root: null,
+    rootMargin: options?.rootMargin ?? "0px",
+    scrollMargin: options?.scrollMargin ?? "0px",
+    takeRecords: vi.fn(takeNoObserverRecords),
+    thresholds: [0],
+    unobserve: vi.fn(),
+  } satisfies MockDagCardObserver;
+
+  dagCardObservers.push(observer);
+
+  return observer;
+};
 
 const mockDag = {
   allowed_run_types: null,
@@ -141,9 +178,49 @@ beforeAll(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("DagCard", () => {
+  it("renders its shell before mounting near-viewport controls", () => {
+    dagCardObservers.length = 0;
+    vi.stubGlobal("IntersectionObserver", MockDagCardIntersectionObserver);
+    renderCard(mockDag, true);
+
+    const card = screen.getByTestId("dag-card");
+
+    expect(screen.getByTestId("dag-id")).toBeInTheDocument();
+    expect(screen.getByTestId("schedule")).toHaveTextContent(mockDag.timetable_summary);
+    expect(screen.queryByTestId("toggle-pause")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recent-run")).not.toBeInTheDocument();
+
+    const [observer] = dagCardObservers;
+
+    if (observer === undefined) {
+      throw new Error("Expected the Dag card to register an IntersectionObserver");
+    }
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            boundingClientRect: card.getBoundingClientRect(),
+            intersectionRatio: 1,
+            intersectionRect: card.getBoundingClientRect(),
+            isIntersecting: true,
+            rootBounds: null,
+            target: card,
+            time: 0,
+          },
+        ],
+        observer,
+      );
+    });
+
+    expect(screen.getByTestId("toggle-pause")).toBeInTheDocument();
+    expect(screen.getAllByTestId("recent-run")).toHaveLength(mockDag.latest_dag_runs.length);
+  });
+
   it("DagCard should render without tags", () => {
     renderCard(mockDag);
     expect(screen.getByText(mockDag.dag_display_name)).toBeInTheDocument();

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -44,7 +44,7 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
   const { t: translate } = useTranslation(["common", "dag"]);
   const [latestRun] = dag.latest_dag_runs;
   const multiTeamEnabled = Boolean(useConfig("multi_team"));
-  const { isNearViewport, ref } = useNearViewport<HTMLDivElement>();
+  const { isNearViewport, ref, showContent } = useNearViewport<HTMLDivElement>();
 
   const refetchInterval = useAutoRefresh({});
 
@@ -55,6 +55,7 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
       borderWidth={1}
       data-testid="dag-card"
       minHeight="140px"
+      onFocusCapture={showContent}
       overflow="hidden"
       ref={ref}
     >
@@ -67,7 +68,7 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
           </Tooltip>
           <DagTags tags={dag.tags} />
         </HStack>
-        <HStack data-testid="dag-card-actions" gap={1} minHeight="32px" minWidth="200px">
+        <HStack data-testid="dag-card-actions" gap={1} minHeight="32px">
           {isNearViewport ? <DagCardActions dag={dag} /> : undefined}
         </HStack>
       </Flex>
@@ -144,7 +145,7 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
           </Box>
         </GridItem>
         <GridItem alignSelf="end" gridColumn={1} gridRow={2}>
-          <Box minHeight="22px" minWidth="200px">
+          <Box minHeight="22px">
             {isNearViewport ? (
               <DagRunStateCounts
                 counts={runStateCounts}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -16,21 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Box, Flex, Grid, GridItem, HStack, Spinner } from "@chakra-ui/react";
+import { Box, Flex, Grid, GridItem, HStack, Spinner, Text } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
-import { DeleteDagButton } from "src/components/DagActions/DeleteDagButton";
-import { FavoriteDagButton } from "src/components/DagActions/FavoriteDagButton";
 import DagRunInfo from "src/components/DagRunInfo";
-import { NeedsReviewBadge } from "src/components/NeedsReviewBadge";
 import { Stat } from "src/components/Stat";
-import { TogglePause } from "src/components/TogglePause";
-import { TriggerDAGButton } from "src/components/TriggerDag/TriggerDAGButton";
 import { RouterLink, Tooltip } from "src/components/ui";
+import { useNearViewport } from "src/hooks/useNearViewport";
 import { useConfig } from "src/queries/useConfig";
 import { isStatePending, useAutoRefresh } from "src/utils";
 
+import { DagCardActions } from "./DagCardActions";
 import { DagRunStateCounts } from "./DagRunStateCounts";
 import { DagTags } from "./DagTags";
 import { RecentRuns } from "./RecentRuns";
@@ -47,6 +44,7 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
   const { t: translate } = useTranslation(["common", "dag"]);
   const [latestRun] = dag.latest_dag_runs;
   const multiTeamEnabled = Boolean(useConfig("multi_team"));
+  const { isNearViewport, ref } = useNearViewport<HTMLDivElement>();
 
   const refetchInterval = useAutoRefresh({});
 
@@ -56,7 +54,9 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
       borderRadius={8}
       borderWidth={1}
       data-testid="dag-card"
+      minHeight="140px"
       overflow="hidden"
+      ref={ref}
     >
       <Flex alignItems="center" bg="bg.muted" justifyContent="space-between" px={3} py={1}>
         <HStack>
@@ -67,17 +67,8 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
           </Tooltip>
           <DagTags tags={dag.tags} />
         </HStack>
-        <HStack gap={1}>
-          <NeedsReviewBadge pendingActions={dag.pending_actions} />
-          <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
-          <TriggerDAGButton
-            allowedRunTypes={dag.allowed_run_types}
-            dagDisplayName={dag.dag_display_name}
-            dagId={dag.dag_id}
-            isPaused={dag.is_paused}
-          />
-          <FavoriteDagButton dagId={dag.dag_id} isFavorite={dag.is_favorite} />
-          <DeleteDagButton dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} />
+        <HStack data-testid="dag-card-actions" gap={1} minHeight="32px" minWidth="200px">
+          {isNearViewport ? <DagCardActions dag={dag} /> : undefined}
         </HStack>
       </Flex>
       <Grid
@@ -89,13 +80,17 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
       >
         <GridItem gridColumn={1} gridRow={1}>
           <Stat data-testid="schedule" label={translate("dagDetails.schedule")}>
-            <Schedule
-              assetExpression={dag.asset_expression}
-              dagId={dag.dag_id}
-              timetableDescription={dag.timetable_description}
-              timetablePartitioned={dag.timetable_partitioned}
-              timetableSummary={dag.timetable_summary}
-            />
+            {isNearViewport ? (
+              <Schedule
+                assetExpression={dag.asset_expression}
+                dagId={dag.dag_id}
+                timetableDescription={dag.timetable_description}
+                timetablePartitioned={dag.timetable_partitioned}
+                timetableSummary={dag.timetable_summary}
+              />
+            ) : (
+              <Text fontSize="sm">{dag.timetable_summary}</Text>
+            )}
           </Stat>
         </GridItem>
         <GridItem gridColumn={2} gridRow={1}>
@@ -144,15 +139,21 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
           gridRow="1 / 3"
           justifyContent="flex-end"
         >
-          <RecentRuns latestRuns={dag.latest_dag_runs} />
+          <Box minHeight="65px">
+            {isNearViewport ? <RecentRuns latestRuns={dag.latest_dag_runs} /> : undefined}
+          </Box>
         </GridItem>
         <GridItem alignSelf="end" gridColumn={1} gridRow={2}>
-          <DagRunStateCounts
-            counts={runStateCounts}
-            dagId={dag.dag_id}
-            isLoading={runStateCountsLoading}
-            stateCountLimit={stateCountLimit}
-          />
+          <Box minHeight="22px" minWidth="200px">
+            {isNearViewport ? (
+              <DagRunStateCounts
+                counts={runStateCounts}
+                dagId={dag.dag_id}
+                isLoading={runStateCountsLoading}
+                stateCountLimit={stateCountLimit}
+              />
+            ) : undefined}
+          </Box>
         </GridItem>
       </Grid>
     </Box>

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCardActions.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCardActions.tsx
@@ -1,0 +1,39 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import { DeleteDagButton } from "src/components/DagActions/DeleteDagButton";
+import { FavoriteDagButton } from "src/components/DagActions/FavoriteDagButton";
+import { NeedsReviewBadge } from "src/components/NeedsReviewBadge";
+import { TogglePause } from "src/components/TogglePause";
+import { TriggerDAGButton } from "src/components/TriggerDag/TriggerDAGButton";
+
+export const DagCardActions = ({ dag }: { readonly dag: DAGWithLatestDagRunsResponse }) => (
+  <>
+    <NeedsReviewBadge pendingActions={dag.pending_actions} />
+    <TogglePause dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} isPaused={dag.is_paused} />
+    <TriggerDAGButton
+      allowedRunTypes={dag.allowed_run_types}
+      dagDisplayName={dag.dag_display_name}
+      dagId={dag.dag_id}
+      isPaused={dag.is_paused}
+    />
+    <FavoriteDagButton dagId={dag.dag_id} isFavorite={dag.is_favorite} />
+    <DeleteDagButton dagDisplayName={dag.dag_display_name} dagId={dag.dag_id} />
+  </>
+);


### PR DESCRIPTION
Follow-up to #69681.

The DAG Card view can render up to 50 cards with 14 recent runs per card. On cached navigation, rebuilding hundreds of run bars and repeated interactive controls can delay the page even though most cards are below the viewport.

This change renders every card shell and its static DAG information immediately, while deferring the expensive interactive content until the card approaches the viewport:

- pause, trigger, favorite, delete, and review controls
- full schedule and asset-expression UI
- recent-run bars
- run-state badges

The cards share one `IntersectionObserver` per scroll root. Hydration is one-way, so scrolling away does not unmount controls or disturb focus or open menus. The observer finds the actual scrolling ancestor and applies a 600 px `rootMargin`, avoiding a dependency on the newer `scrollMargin` option. Keyboard focus entering a deferred card hydrates its controls, and browsers without `IntersectionObserver` fall back to eager rendering.

This is intentionally not list virtualization. All card shells, DAG names, DAG identity links, sorting behavior, and browser find are available immediately. Interactive controls and recent-run links for fully offscreen cards appear when their card approaches the viewport or receives focus. All cards eventually hydrate, so the final page state is unchanged.

https://github.com/user-attachments/assets/42ad0846-4c71-4cd2-ae8d-261690a8f4dc


Closes: #69609

### Testing

- 31 focused Vitest tests covering shared-observer behavior, scroll-root selection, one-way hydration, keyboard focus, fallback behavior, cleanup, stable geometry, and card interactions
- targeted ESLint and Prettier checks
- full UI TypeScript check with `pnpm tsc --noEmit`
- production Vite build and Airflow `prek` UI hooks
- `git diff --check`
- live Breeze sort, scroll, hover, keyboard, and exact run-link smoke tests

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
