### PR TITLE
Detect Celery workers not consuming queues

### DIFF
--- a/airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst
+++ b/airflow-core/docs/administration-and-deployment/logging-monitoring/check-health.rst
@@ -143,8 +143,8 @@ For details about installation, see: :doc:`apache-airflow-providers-celery:celer
 CLI Check for Celery Workers
 ----------------------------
 
-To verify that the Celery workers are working correctly, you can use the ``celery inspect ping`` command. On failure, the command will exit
-with a non-zero error code.
+To verify that a Celery worker is running and consuming from at least one queue, use the
+``airflow celery check-worker`` command. On failure, the command exits with a non-zero error code.
 
 .. note::
 
@@ -155,12 +155,12 @@ To check if the worker running on the local host is working correctly, run:
 
 .. code-block:: bash
 
-    celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
+    airflow celery check-worker --celery-hostname celery@${HOSTNAME}
 
-To check if the all workers in the cluster running is working correctly, run:
+To list all workers and their active queues, run:
 
 .. code-block:: bash
 
-    celery --app airflow.providers.celery.executors.celery_executor.app inspect ping
+    airflow celery list-workers
 
 For more information, see: `Management Command-line Utilities (inspect/control) <https://docs.celeryproject.org/en/stable/userguide/monitoring.html#monitoring-control>`__ and `Workers Guide <https://docs.celeryproject.org/en/stable/userguide/workers.html>`__ in the Celery documentation.

--- a/airflow-core/docs/howto/docker-compose/docker-compose.yaml
+++ b/airflow-core/docs/howto/docker-compose/docker-compose.yaml
@@ -171,7 +171,7 @@ services:
     command: celery worker
     healthcheck:
       # yamllint disable rule:line-length
-      test: ["CMD-SHELL", 'celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}" || celery --app airflow.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"']
+      test: ["CMD-SHELL", 'airflow celery check-worker -H "celery@$${HOSTNAME}" || { status=$$?; [ "$$status" -eq 2 ] && exec celery --app airflow.providers.celery.executors.celery_executor.app inspect ping -d "celery@$${HOSTNAME}"; exit "$$status"; }']
       interval: 30s
       timeout: 10s
       retries: 5

--- a/chart/newsfragments/69807.bugfix.rst
+++ b/chart/newsfragments/69807.bugfix.rst
@@ -1,0 +1,1 @@
+Detect Celery workers that are no longer consuming queues in the default liveness probe.

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -281,7 +281,7 @@ spec:
                 {{- else }}
                 - sh
                 - -c
-                - CONNECTION_CHECK_MAX_COUNT=0 exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" . }} inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())')
+                - CONNECTION_CHECK_MAX_COUNT=0 /entrypoint airflow celery check-worker -H celery@$(python -c 'import socket; print(socket.gethostname())') || { status=$?; [ "$status" -eq 2 ] && exec /entrypoint python -m celery --app {{ include "celery_executor_namespace" . }} inspect ping -d celery@$(python -c 'import socket; print(socket.gethostname())'); exit "$status"; }
                 {{- end }}
           {{- end }}
           ports:

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -671,6 +671,7 @@ class TestWorker:
         livenessprobe_cmd = jmespath.search(
             "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
         )
+        assert "airflow celery check-worker" in livenessprobe_cmd[-1]
         assert "airflow.providers.celery.executors.celery_executor.app" in livenessprobe_cmd[-1]
         assert "socket.gethostname()" in livenessprobe_cmd[-1]
 

--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -415,6 +415,18 @@ def list_workers(args):
     AirflowConsole().print_as(data=workers, output=args.output)
 
 
+@_providers_configuration_loaded
+def check_worker(args):
+    """Check that a Celery worker is consuming from at least one queue."""
+    # This needs to be imported locally to not trigger Providers Manager initialization
+    from airflow.providers.celery.executors.celery_executor import app as celery_app
+
+    inspect = celery_app.control.inspect(destination=[args.celery_hostname])
+    active_workers = inspect.active_queues()
+    if not active_workers or not active_workers.get(args.celery_hostname):
+        raise SystemExit(f"Error: {args.celery_hostname} is not consuming from any queues!")
+
+
 @cli_utils.action_cli(check_db=False)
 @_providers_configuration_loaded
 def shutdown_worker(args):

--- a/providers/celery/src/airflow/providers/celery/cli/definition.py
+++ b/providers/celery/src/airflow/providers/celery/cli/definition.py
@@ -189,6 +189,12 @@ CELERY_COMMANDS = (
         args=(ARG_OUTPUT,),
     ),
     ActionCommand(
+        name="check-worker",
+        help="Check that a Celery worker is consuming from at least one queue",
+        func=lazy_load_command(f"{CELERY_CLI_COMMAND_PATH}.check_worker"),
+        args=(ARG_FULL_CELERY_HOSTNAME,),
+    ),
+    ActionCommand(
         name="shutdown-worker",
         help="Request graceful shutdown of celery workers",
         func=lazy_load_command(f"{CELERY_CLI_COMMAND_PATH}.shutdown_worker"),

--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -669,6 +669,36 @@ class TestRemoteCeleryControlCommands:
             assert key in celery_workers[0]
         assert any("celery@host_1" in h["worker_name"] for h in celery_workers)
 
+    @pytest.mark.parametrize(
+        "active_queues",
+        [
+            None,
+            {},
+            {"celery@other_host": [{"name": "default"}]},
+            {"celery@host_1": []},
+        ],
+    )
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
+    def test_check_worker_fails_when_worker_is_not_consuming(self, mock_inspect, active_queues):
+        mock_inspect.return_value.active_queues.return_value = active_queues
+        args = self.parser.parse_args(["celery", "check-worker", "-H", "celery@host_1"])
+
+        with pytest.raises(SystemExit, match="celery@host_1 is not consuming from any queues"):
+            celery_command.check_worker(args)
+
+        mock_inspect.assert_called_once_with(destination=["celery@host_1"])
+
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.inspect")
+    def test_check_worker_succeeds_when_worker_is_consuming(self, mock_inspect):
+        mock_inspect.return_value.active_queues.return_value = {
+            "celery@host_1": [{"name": "default"}],
+        }
+        args = self.parser.parse_args(["celery", "check-worker", "-H", "celery@host_1"])
+
+        celery_command.check_worker(args)
+
+        mock_inspect.assert_called_once_with(destination=["celery@host_1"])
+
     @mock.patch("airflow.providers.celery.executors.celery_executor.app.control.shutdown")
     def test_shutdown_worker(self, mock_shutdown):
         args = self.parser.parse_args(["celery", "shutdown-worker", "-H", "celery@host_1"])

--- a/providers/celery/tests/unit/celery/cli/test_definition.py
+++ b/providers/celery/tests/unit/celery/cli/test_definition.py
@@ -52,8 +52,8 @@ class TestCeleryCliDefinition:
         assert len(CELERY_CLI_COMMANDS) == 1
 
     def test_celery_commands_count(self):
-        """Test that CELERY_COMMANDS contains all 9 subcommands."""
-        assert len(CELERY_COMMANDS) == 9
+        """Test that CELERY_COMMANDS contains all 10 subcommands."""
+        assert len(CELERY_COMMANDS) == 10
 
     @pytest.mark.parametrize(
         "command",
@@ -62,6 +62,7 @@ class TestCeleryCliDefinition:
             "flower",
             "stop",
             "list-workers",
+            "check-worker",
             "shutdown-worker",
             "shutdown-all-workers",
             "add-queue",
@@ -116,6 +117,12 @@ class TestCeleryCliDefinition:
         params = ["celery", "list-workers", "--output", "json"]
         args = self.arg_parser.parse_args(params)
         assert args.output == "json"
+
+    def test_check_worker_command_args(self):
+        """Test check-worker command with celery hostname."""
+        params = ["celery", "check-worker", "--celery-hostname", "celery@worker1"]
+        args = self.arg_parser.parse_args(params)
+        assert args.celery_hostname == "celery@worker1"
 
     def test_shutdown_worker_command_args(self):
         """Test shutdown-worker command with celery hostname."""


### PR DESCRIPTION
closes: #63580

## Problem

After a Redis broker restart, a Celery worker can remain alive and continue responding to `ping` while no longer consuming tasks from any queue. The existing Docker Compose and Helm liveness probes therefore remain healthy while queued tasks accumulate.

## Solution

- Add `airflow celery check-worker`, targeted to a specific worker hostname.
- Fail the check when the worker does not reply, is absent from the response, or reports no active queues.
- Use the new command in the default Docker Compose and Helm worker liveness checks.
- Fall back to the existing Celery `inspect ping` command when an older Celery provider does not recognize `check-worker`.
- Update the Celery worker health-check documentation.

## Testing

- 27 focused Celery provider CLI tests passed, covering healthy workers, no response, an empty response, a different responding worker, and a worker with no queues.
- Ruff formatting and lint checks passed.
- YAML lint and Helm chart lint passed.
- Relevant pre-commit hooks passed.
- The local kubeconform hook could not run because the Breeze shim is not installed.
- The focused local Helm rendering test could not run because the `helm` executable is not installed.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — OpenAI Codex (GPT-5)

