### PR TITLE
Helm: Add API server rollout restart CronJob

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -423,6 +423,10 @@ If release name contains chart name it will be used as a full name.
   {{- printf "%s:%s" .Values.images.otelCollector.repository .Values.images.otelCollector.tag }}
 {{- end }}
 
+{{- define "kubectl_image" -}}
+  {{- printf "%s:%s" .Values.images.kubectl.repository .Values.images.kubectl.tag }}
+{{- end }}
+
 {{- define "fernet_key_secret" -}}
   {{- default (printf "%s-fernet-key" (include "airflow.fullname" .)) .Values.fernetKeySecretName }}
 {{- end }}
@@ -761,6 +765,16 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{/* Create the name of the database cleanup service account to use */}}
 {{- define "databaseCleanup.serviceAccountName" -}}
   {{- include "_serviceAccountName" (merge (dict "key" "databaseCleanup" "nameSuffix" "database-cleanup") .) -}}
+{{- end }}
+
+{{/* Create the name of the API server rollout restart service account to use */}}
+{{- define "apiServerRolloutRestart.serviceAccountName" -}}
+  {{- $sa := .Values.apiServer.rolloutRestart.serviceAccount -}}
+  {{- if $sa.create -}}
+    {{- default (printf "%s-%s" (include "airflow.serviceAccountName" .) "api-server-rollout-restart") $sa.name | quote -}}
+  {{- else -}}
+    {{- default "default" $sa.name | quote -}}
+  {{- end -}}
 {{- end }}
 
 {{- define "wait-for-migrations-command" }}

--- a/chart/templates/api-server/api-server-rollout-restart-cronjob.yaml
+++ b/chart/templates/api-server/api-server-rollout-restart-cronjob.yaml
@@ -1,0 +1,110 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow API Server Rollout Restart CronJob
+#################################
+{{- if and .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+{{- $nodeSelector := or .Values.apiServer.rolloutRestart.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.apiServer.rolloutRestart.affinity .Values.affinity }}
+{{- $tolerations := or .Values.apiServer.rolloutRestart.tolerations .Values.tolerations }}
+{{- $topologySpreadConstraints := or .Values.apiServer.rolloutRestart.topologySpreadConstraints .Values.topologySpreadConstraints }}
+{{- $securityContext := include "airflowPodSecurityContext" (list .Values.apiServer.rolloutRestart .Values) }}
+{{- $containerSecurityContext := include "containerSecurityContext" (list .Values.apiServer.rolloutRestart .Values) }}
+{{- $deploymentName := .Values.apiServer.rolloutRestart.deploymentName | default (printf "%s-api-server" (include "airflow.fullname" .)) }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart
+  labels:
+    tier: airflow
+    component: api-server-rollout-restart
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.apiServer.rolloutRestart.jobAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: "{{ tpl .Values.apiServer.rolloutRestart.schedule . }}"
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
+  concurrencyPolicy: Forbid
+  {{- if not (eq .Values.apiServer.rolloutRestart.failedJobsHistoryLimit nil) }}
+  failedJobsHistoryLimit: {{ .Values.apiServer.rolloutRestart.failedJobsHistoryLimit }}
+  {{- end }}
+  {{- if not (eq .Values.apiServer.rolloutRestart.successfulJobsHistoryLimit nil) }}
+  successfulJobsHistoryLimit: {{ .Values.apiServer.rolloutRestart.successfulJobsHistoryLimit }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            tier: airflow
+            component: api-server-rollout-restart
+            release: {{ .Release.Name }}
+            {{- if or .Values.labels .Values.apiServer.rolloutRestart.labels }}
+              {{- mustMerge .Values.apiServer.rolloutRestart.labels .Values.labels | toYaml | nindent 12 }}
+            {{- end }}
+          annotations:
+            {{- if .Values.airflowPodAnnotations }}
+              {{- tpl (toYaml .Values.airflowPodAnnotations) . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.apiServer.rolloutRestart.podAnnotations }}
+              {{- tpl (toYaml .Values.apiServer.rolloutRestart.podAnnotations) . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: Never
+          {{- if .Values.apiServer.rolloutRestart.priorityClassName }}
+          priorityClassName: {{ .Values.apiServer.rolloutRestart.priorityClassName }}
+          {{- end }}
+          nodeSelector: {{- toYaml $nodeSelector | nindent 12 }}
+          affinity: {{- toYaml $affinity | nindent 12 }}
+          {{- if .Values.schedulerName }}
+          schedulerName: {{ .Values.schedulerName }}
+          {{- end }}
+          tolerations: {{- toYaml $tolerations | nindent 12 }}
+          topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 12 }}
+          serviceAccountName: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+          imagePullSecrets: {{- include "image_pull_secrets" . | nindent 12 }}
+          securityContext: {{ $securityContext | nindent 12 }}
+          containers:
+            - name: api-server-rollout-restart
+              image: {{ template "kubectl_image" . }}
+              imagePullPolicy: {{ .Values.images.kubectl.pullPolicy }}
+              securityContext: {{ $containerSecurityContext | nindent 16 }}
+              {{- if .Values.apiServer.rolloutRestart.command }}
+              command: {{ tpl (toYaml .Values.apiServer.rolloutRestart.command) . | nindent 16 }}
+              {{- end }}
+              {{- if .Values.apiServer.rolloutRestart.args }}
+              args: {{ tpl (toYaml .Values.apiServer.rolloutRestart.args) . | nindent 16 }}
+              {{- else }}
+              args:
+                - rollout
+                - restart
+                - deployment/{{ $deploymentName }}
+                - --namespace
+                - {{ .Release.Namespace }}
+              {{- end }}
+              resources: {{- toYaml .Values.apiServer.rolloutRestart.resources | nindent 16 }}
+{{- end }}

--- a/chart/templates/api-server/api-server-rollout-restart-serviceaccount.yaml
+++ b/chart/templates/api-server/api-server-rollout-restart-serviceaccount.yaml
@@ -1,0 +1,42 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow API Server Rollout Restart ServiceAccount
+#################################
+{{- if and .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled .Values.apiServer.rolloutRestart.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.apiServer.rolloutRestart.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+  labels:
+    tier: airflow
+    component: api-server-rollout-restart
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- if or .Values.labels .Values.apiServer.rolloutRestart.labels }}
+      {{- mustMerge .Values.apiServer.rolloutRestart.labels .Values.labels | toYaml | nindent 4 }}
+    {{- end }}
+  {{- with .Values.apiServer.rolloutRestart.serviceAccount.annotations }}
+  annotations:
+    {{- include "airflow.tplDict" (dict "values" . "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/rbac/api-server-rollout-restart-role.yaml
+++ b/chart/templates/rbac/api-server-rollout-restart-role.yaml
@@ -1,0 +1,44 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow API Server Rollout Restart Role
+#################################
+{{- if and .Values.rbac.create .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart-role
+  labels:
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+    verbs:
+      - "get"
+      - "patch"
+{{- end }}

--- a/chart/templates/rbac/api-server-rollout-restart-rolebinding.yaml
+++ b/chart/templates/rbac/api-server-rollout-restart-rolebinding.yaml
@@ -1,0 +1,44 @@
+{{/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/}}
+
+################################
+## Airflow API Server Rollout Restart Role Binding
+#################################
+{{- if and .Values.rbac.create .Values.apiServer.enabled .Values.apiServer.rolloutRestart.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart-rolebinding
+  labels:
+    tier: airflow
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "airflow.fullname" . }}-api-server-rollout-restart-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "apiServerRolloutRestart.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
+{{- end }}

--- a/chart/tests/helm_tests/apiserver/test_rollout_restart_cronjob.py
+++ b/chart/tests/helm_tests/apiserver/test_rollout_restart_cronjob.py
@@ -1,0 +1,91 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import jmespath
+from chart_utils.helm_template_generator import render_chart
+
+
+class TestAPIServerRolloutRestartCronJob:
+    """Tests API Server rollout restart CronJob."""
+
+    def test_should_create_cronjob_when_enabled(self):
+        docs = render_chart(
+            values={
+                "apiServer": {
+                    "enabled": True,
+                    "rolloutRestart": {
+                        "enabled": True,
+                    },
+                },
+            },
+            show_only=["templates/api-server/api-server-rollout-restart-cronjob.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "CronJob"
+        assert docs[0]["metadata"]["name"] == "release-name-api-server-rollout-restart"
+
+        containers = jmespath.search("spec.jobTemplate.spec.template.spec.containers", docs[0])
+        assert len(containers) == 1
+        assert containers[0]["name"] == "api-server-rollout-restart"
+        assert containers[0]["image"] == "bitnami/kubectl:1.30.2"
+        assert containers[0]["args"] == [
+            "rollout",
+            "restart",
+            "deployment/release-name-api-server",
+            "--namespace",
+            "default",
+        ]
+
+    def test_should_not_create_cronjob_when_disabled(self):
+        docs = render_chart(
+            values={
+                "apiServer": {
+                    "enabled": True,
+                    "rolloutRestart": {
+                        "enabled": False,
+                    },
+                },
+            },
+            show_only=["templates/api-server/api-server-rollout-restart-cronjob.yaml"],
+        )
+
+        assert len(docs) == 0
+
+    def test_should_use_custom_deployment_name(self):
+        docs = render_chart(
+            values={
+                "apiServer": {
+                    "enabled": True,
+                    "rolloutRestart": {
+                        "enabled": True,
+                        "deploymentName": "my-custom-deployment-name",
+                    },
+                },
+            },
+            show_only=["templates/api-server/api-server-rollout-restart-cronjob.yaml"],
+        )
+
+        containers = jmespath.search("spec.jobTemplate.spec.template.spec.containers", docs[0])
+        assert containers[0]["args"] == [
+            "rollout",
+            "restart",
+            "deployment/my-custom-deployment-name",
+            "--namespace",
+            "default",
+        ]

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1002,6 +1002,28 @@
                         }
                     },
                     "description": "Configuration of the OTel Collector image."
+                },
+                "kubectl": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "enum": [
+                                "Always",
+                                "Never",
+                                "IfNotPresent"
+                            ],
+                            "default": "IfNotPresent"
+                        }
+                    },
+                    "description": "Configuration of the kubectl image."
                 }
             }
         },
@@ -6489,6 +6511,245 @@
                             }
                         ],
                         "additionalProperties": false
+                    }
+                },
+                "rolloutRestart": {
+                    "description": "Periodic rollout restart configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable periodic rollout restart for API server deployment.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "deploymentName": {
+                            "description": "The API Server Deployment name for rollout restart.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "schedule": {
+                            "description": "CronJob schedule.",
+                            "type": "string",
+                            "default": "0 0 * * *"
+                        },
+                        "command": {
+                            "description": "Command to use when running the CronJob.",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": null
+                        },
+                        "args": {
+                            "description": "Args to use when running the CronJob.",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": null
+                        },
+                        "jobAnnotations": {
+                            "description": "Annotations on the CronJob.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "nodeSelector": {
+                            "description": "Select certain nodes.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "affinity": {
+                            "description": "Specify scheduling constraints.",
+                            "type": "object",
+                            "default": {},
+                            "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
+                        },
+                        "tolerations": {
+                            "description": "Specify Tolerations.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
+                            }
+                        },
+                        "topologySpreadConstraints": {
+                            "description": "Specify topology spread constraints.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
+                            }
+                        },
+                        "priorityClassName": {
+                            "description": "Specify priority.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "podAnnotations": {
+                            "description": "Annotations to add to pods.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "labels": {
+                            "description": "Labels to add to objects and pods.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "resources": {
+                            "description": "Resources for pods.",
+                            "type": "object",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                            "default": {}
+                        },
+                        "serviceAccount": {
+                            "description": "Create ServiceAccount.",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "automountServiceAccountToken": {
+                                    "description": "Specifies if ServiceAccount credentials should be mounted.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "create": {
+                                    "description": "Specifies whether a ServiceAccount should be created.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "name": {
+                                    "description": "The name of the ServiceAccount to use.",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "default": null
+                                },
+                                "annotations": {
+                                    "description": "Annotations to add to the ServiceAccount.",
+                                    "type": "object",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "env": {
+                            "description": "Add additional env vars.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    },
+                                    "valueFrom": {
+                                        "type": "object",
+                                        "properties": {
+                                            "configMapKeyRef": {
+                                                "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector"
+                                            },
+                                            "secretKeyRef": {
+                                                "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector"
+                                            }
+                                        },
+                                        "anyOf": [
+                                            {
+                                                "required": [
+                                                    "configMapKeyRef"
+                                                ]
+                                            },
+                                            {
+                                                "required": [
+                                                    "secretKeyRef"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "anyOf": [
+                                    {
+                                        "required": [
+                                            "value"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "valueFrom"
+                                        ]
+                                    }
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "securityContexts": {
+                            "description": "Security context definition.",
+                            "type": "object",
+                            "properties": {
+                                "pod": {
+                                    "description": "Pod security context definition.",
+                                    "type": "object",
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                                    "default": {}
+                                },
+                                "container": {
+                                    "description": "Container security context definition.",
+                                    "type": "object",
+                                    "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                                    "default": {}
+                                }
+                            }
+                        },
+                        "failedJobsHistoryLimit": {
+                            "description": "The failed jobs history limit.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "successfulJobsHistoryLimit": {
+                            "description": "The successful jobs history limit.",
+                            "type": [
+                                "integer",
+                                "null"
+                            ],
+                            "default": null
+                        }
                     }
                 }
             }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -120,6 +120,10 @@ images:
     repository: otel/opentelemetry-collector-contrib
     tag: "0.70.0"
     pullPolicy: IfNotPresent
+  kubectl:
+    repository: bitnami/kubectl
+    tag: 1.30.2
+    pullPolicy: IfNotPresent
 
 # Select certain nodes for Airflow pods.
 nodeSelector: {}
@@ -1753,6 +1757,74 @@ apiServer:
 
   # Container level lifecycle hooks
   containerLifecycleHooks: {}
+
+  # Periodic rollout restart configuration
+  rolloutRestart:
+    # Enable periodic rollout restart for API server deployment
+    enabled: false
+
+    # The API Server Deployment name for rollout restart. If not set, it defaults to the helm release name
+    deploymentName: ~
+
+    # Run every midnight (templated).
+    schedule: "0 0 * * *"
+
+    # Command to use when running the API server rollout restart CronJob (templated).
+    command: ~
+
+    # Args to use when running the API server rollout restart CronJob (templated).
+    args: ~
+
+    # `jobAnnotations` are annotations on the API server rollout restart CronJob
+    jobAnnotations: {}
+
+    # Select certain nodes for Airflow API server rollout restart pods.
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+    priorityClassName: ~
+
+    # Pod annotations for API server rollout restart pods (templated)
+    podAnnotations: {}
+
+    # Labels specific to API server rollout restart objects and pods
+    labels: {}
+
+    resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
+
+    # Create Service Account
+    serviceAccount:
+      # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+      automountServiceAccountToken: true
+
+      # Specifies whether a Service Account should be created
+      create: true
+
+      # The name of the Service Account to use.
+      # If not set and `create` is 'true', a name is generated using the release name
+      name: ~
+
+      # Annotations to add to API server rollout restart CronJob Kubernetes Service Account.
+      annotations: {}
+
+    env: []
+
+    # Detailed default security context for API server rollout restart for container level
+    securityContexts:
+      pod: {}
+      container: {}
+
+    # Specify history limit
+    # When set, overwrite the default k8s number of successful and failed CronJob executions that are saved.
+    failedJobsHistoryLimit: ~
+    successfulJobsHistoryLimit: ~
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1438,6 +1438,7 @@ Roadmap
 roadmap
 roc
 RoleBinding
+rollout
 rollup
 rom
 romeoandjuliet


### PR DESCRIPTION
This PR adds Helm chart support for periodic API server rollout restarts on Kubernetes.

Problem:
Long-running uvicorn processes in the API server can accumulate stale resources. Kubernetes provides kubectl rollout restart as a native mechanism, but the Airflow Helm chart has no built in support for scheduling this.

Fix:
Adds a new apiServer.rolloutRestart configuration section with a CronJob, ServiceAccount, Role, and RoleBinding following the exact same pattern as the existing databaseCleanup CronJob.

closes: #61432

---

##### Was generative AI tooling used to co-author this PR?

- [X]  Yes — Claude(For pr description)

<!-- pr-triage-fold: triaged=2026-07-28T16:10:34Z head=86dffc7 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Subham-KRLX** · by `@potiuk` · 2026-07-28 16:10 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Helm tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/testing/helm_unit_tests.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **355 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
