### PR TITLE
Add optional debug spans for the scheduler loop

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1519,9 +1519,6 @@ traces:
       description: |
         If True, then traces from Airflow internal methods are exported. Defaults to False.
       version_added: 3.1.0
-      version_deprecated: 3.2.0
-      deprecation_reason: |
-        This parameter is no longer used.
       type: string
       example: ~
       default: "False"

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1530,9 +1530,6 @@ traces:
       description: |
         If True, then traces from Airflow internal methods are exported. Defaults to False.
       version_added: 3.1.0
-      version_deprecated: 3.2.0
-      deprecation_reason: |
-        This parameter is no longer used.
       type: string
       example: ~
       default: "False"

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import pendulum
 
 from airflow._shared.observability.metrics import stats
+from airflow._shared.observability.traces import start_debug_span
 from airflow.cli.cli_config import DefaultHelpParser
 from airflow.configuration import conf
 from airflow.executors import workloads
@@ -442,6 +443,7 @@ class BaseExecutor(LoggingMixin):
             reverse=False,
         )
 
+    @start_debug_span("base_executor.trigger_tasks")
     def trigger_tasks(self, open_slots: int) -> None:
         """
         Initiate async execution of queued workloads (tasks and callbacks), up to the number of available slots.

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import pendulum
 
 from airflow._shared.observability.metrics import stats
+from airflow._shared.observability.traces import start_debug_span
 from airflow.cli.cli_config import DefaultHelpParser
 from airflow.configuration import conf
 from airflow.executors import workloads
@@ -445,6 +446,7 @@ class BaseExecutor(LoggingMixin):
             reverse=True,
         )
 
+    @start_debug_span("base_executor.trigger_tasks")
     def trigger_tasks(self, open_slots: int) -> None:
         """
         Initiate async execution of queued workloads (tasks and callbacks), up to the number of available slots.

--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
+from airflow._shared.observability.traces import start_debug_span
 from airflow.executors.base_executor import BaseExecutor, get_execution_api_server_url
 
 # add logger to parameter of setproctitle to support logging
@@ -308,6 +309,7 @@ class LocalExecutor(BaseExecutor):
             proc.kill()
             proc.join(timeout=0.2)
 
+    @start_debug_span("local_executor._process_workloads")
     def _process_workloads(self, workload_list):
         for workload in workload_list:
             self.activity_queue.put(workload)

--- a/airflow-core/src/airflow/jobs/job.py
+++ b/airflow-core/src/airflow/jobs/job.py
@@ -30,6 +30,7 @@ from sqlalchemy.orm import Mapped, backref, foreign, mapped_column, relationship
 from sqlalchemy.orm.session import make_transient
 
 from airflow._shared.observability.metrics import stats
+from airflow._shared.observability.traces import start_debug_span
 from airflow._shared.timezones import timezone
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -187,6 +188,7 @@ class Job(Base, LoggingMixin):
         """Will be called when an external kill command is received."""
 
     @provide_session
+    @start_debug_span("job.heartbeat")
     def heartbeat(self, heartbeat_callback: Callable[..., None], *, session: Session = NEW_SESSION) -> None:
         """
         Update the job's entry in the database with the latest_heartbeat timestamp.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -34,6 +34,8 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
+from opentelemetry import trace
+from opentelemetry.context import context
 from sqlalchemy import (
     CTE,
     Text,
@@ -56,6 +58,7 @@ from sqlalchemy.sql import expression
 
 from airflow import settings
 from airflow._shared.observability.metrics import stats
+from airflow._shared.observability.traces import start_debug_span
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun as DRDataModel, TIRunContext
 from airflow.assets.evaluation import AssetEvaluator
@@ -411,6 +414,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return resetter
 
+    @start_debug_span("scheduler._get_team_names_for_dag_ids")
     def _get_team_names_for_dag_ids(
         self, dag_ids: Collection[str], session: Session
     ) -> dict[str, str | None]:
@@ -425,6 +429,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param session: Database session for queries
         :return: Dictionary mapping dag_id -> team_name (None if no team found)
         """
+        trace.get_current_span().set_attribute("airflow.scheduler.num_dag_ids", len(dag_ids))
         if not dag_ids:
             return {}
 
@@ -636,6 +641,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return True
 
+    @start_debug_span("scheduler._executable_task_instances_to_queued")
     def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
         """
         Find TIs that are ready for execution based on conditions.
@@ -660,11 +666,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Optimization: to avoid littering the DB errors of "ERROR: canceling statement due to lock
             # timeout", try to take out a transactional advisory lock (unlocks automatically on
             # COMMIT/ROLLBACK)
-            lock_acquired = session.execute(
-                text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
-                    id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
-                )
-            ).scalar()
+            with start_debug_span("scheduler.critical_section.advisory_lock") as advisory_lock_span:
+                lock_acquired = session.execute(
+                    text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
+                        id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
+                    )
+                ).scalar()
+                advisory_lock_span.set_attribute("airflow.scheduler.lock_acquired", bool(lock_acquired))
             if lock_acquired is None:
                 lock_acquired = False
             if not lock_acquired:
@@ -817,8 +825,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             timer.start()
 
             try:
-                locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
-                task_instances_to_examine = session.scalars(locked_query).all()
+                with start_debug_span("scheduler.critical_section.task_instances_to_examine") as select_span:
+                    locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
+                    task_instances_to_examine = session.scalars(locked_query).all()
+                    select_span.set_attribute(
+                        "airflow.scheduler.tis_examined", len(task_instances_to_examine)
+                    )
 
                 if self.log.isEnabledFor(logging.DEBUG):
                     self.log.debug("Length of the tis to examine is %d", len(task_instances_to_examine))
@@ -1097,33 +1109,37 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .execution_options(synchronize_session=False)
             )
 
-            if pre_assign_executors:
-                # Read the DB-generated UUIDs back onto the in-memory objects so the
-                # workload DTO carries them through to send_workload_to_executor (the
-                # objects are about to be detached by make_transient). Use RETURNING
-                # where supported (PostgreSQL); fall back to a SELECT for MySQL and
-                # SQLite (RETURNING requires SQLite 3.35+ which isn't guaranteed).
-                if get_dialect_name(session) == "postgresql":
-                    result = session.execute(queued_update.returning(TI.id, TI.external_executor_id))
-                    id_map = {row[0]: row[1] for row in result}
+            with start_debug_span("scheduler.critical_section.update_tis_to_queued") as update_span:
+                update_span.set_attribute("airflow.scheduler.tis_to_update", len(executable_tis))
+                if pre_assign_executors:
+                    # Read the DB-generated UUIDs back onto the in-memory objects so the
+                    # workload DTO carries them through to send_workload_to_executor (the
+                    # objects are about to be detached by make_transient). Use RETURNING
+                    # where supported (PostgreSQL); fall back to a SELECT for MySQL and
+                    # SQLite (RETURNING requires SQLite 3.35+ which isn't guaranteed).
+                    if get_dialect_name(session) == "postgresql":
+                        result = session.execute(queued_update.returning(TI.id, TI.external_executor_id))
+                        id_map = {row[0]: row[1] for row in result}
+                    else:
+                        session.execute(queued_update)
+                        id_rows = session.execute(
+                            select(TI.id, TI.external_executor_id).where(filter_for_tis)
+                        ).all()
+                        id_map = {row[0]: row[1] for row in id_rows}
+                    for ti in executable_tis:
+                        ti.external_executor_id = id_map.get(ti.id)
                 else:
                     session.execute(queued_update)
-                    id_rows = session.execute(
-                        select(TI.id, TI.external_executor_id).where(filter_for_tis)
-                    ).all()
-                    id_map = {row[0]: row[1] for row in id_rows}
-                for ti in executable_tis:
-                    ti.external_executor_id = id_map.get(ti.id)
-            else:
-                session.execute(queued_update)
 
             for ti in executable_tis:
                 ti.emit_state_change_metric(TaskInstanceState.QUEUED)
 
         for ti in executable_tis:
             make_transient(ti)
+        trace.get_current_span().set_attribute("airflow.scheduler.num_executable_tis", len(executable_tis))
         return executable_tis
 
+    @start_debug_span("scheduler._enqueue_task_instances_with_queued_state")
     def _enqueue_task_instances_with_queued_state(
         self, task_instances: list[TI], executor: BaseExecutor, session: Session
     ) -> None:
@@ -1134,6 +1150,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param executor: The executor to enqueue tasks for
         :param session: The session object
         """
+        enqueue_span = trace.get_current_span()
+        enqueue_span.set_attribute("airflow.executor.class", type(executor).__name__)
+        enqueue_span.set_attribute("airflow.scheduler.num_tis_to_enqueue", len(task_instances))
 
         def _get_sentry_integration(executor: BaseExecutor) -> str:
             try:
@@ -1154,32 +1173,39 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # actually enqueue them
         for ti in task_instances:
-            if ti.dag_run.state in State.finished_dr_states:
-                ti.set_state(None, session=session)
-                continue
-            if not ti.dag_version_id:
-                self.log.warning(
-                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
-                    "This would get unstuck and dag_version_id updated.",
+            with start_debug_span("scheduler.enqueue_ti") as enqueue_ti_span:
+                enqueue_ti_span.set_attribute("airflow.ti.dag_id", ti.dag_id)
+                enqueue_ti_span.set_attribute("airflow.ti.run_id", ti.run_id)
+                enqueue_ti_span.set_attribute("airflow.ti.task_id", ti.task_id)
+                enqueue_ti_span.set_attribute("airflow.ti.map_index", ti.map_index)
+                enqueue_ti_span.set_attribute("airflow.ti.try_number", ti.try_number)
+                if ti.dag_run.state in State.finished_dr_states:
+                    ti.set_state(None, session=session)
+                    continue
+                if not ti.dag_version_id:
+                    self.log.warning(
+                        "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
+                        "This would get unstuck and dag_version_id updated.",
+                        ti,
+                    )
+                    continue
+
+                self.log.debug(
+                    "Queueing workload for TI: %s try_number=%d state=%s scheduler_job_id=%s executor=%s",
                     ti,
+                    ti.try_number,
+                    ti.state,
+                    self.job.id,
+                    executor,
                 )
-                continue
+                workload = workloads.ExecuteTask.make(
+                    ti,
+                    generator=executor.jwt_generator,
+                    sentry_integration=_get_sentry_integration(executor),
+                )
+                executor.queue_workload(workload, session=session)
 
-            self.log.debug(
-                "Queueing workload for TI: %s try_number=%d state=%s scheduler_job_id=%s executor=%s",
-                ti,
-                ti.try_number,
-                ti.state,
-                self.job.id,
-                executor,
-            )
-            workload = workloads.ExecuteTask.make(
-                ti,
-                generator=executor.jwt_generator,
-                sentry_integration=_get_sentry_integration(executor),
-            )
-            executor.queue_workload(workload, session=session)
-
+    @start_debug_span("scheduler._critical_section_enqueue_task_instances")
     def _critical_section_enqueue_task_instances(self, session: Session) -> int:
         """
         Enqueues TaskInstances for execution.
@@ -1229,8 +1255,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             self._enqueue_task_instances_with_queued_state(queued_tis_per_executor, executor, session=session)
 
+        trace.get_current_span().set_attribute("airflow.scheduler.num_queued_tis", len(queued_tis))
         return len(queued_tis)
 
+    @start_debug_span("scheduler._enqueue_executor_callbacks")
     def _enqueue_executor_callbacks(self, session: Session) -> None:
         """
         Enqueue ExecutorCallback workloads to executors.
@@ -1254,6 +1282,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .order_by(ExecutorCallback.priority_weight.desc())
             .limit(max_callbacks)
         ).all()
+        trace.get_current_span().set_attribute("airflow.scheduler.pending_callbacks", len(pending_callbacks))
 
         if not pending_callbacks:
             return
@@ -1301,7 +1330,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 session.add(callback)
 
     @staticmethod
+    @start_debug_span("scheduler._process_task_event_logs")
     def _process_task_event_logs(log_records: deque[Log], session: Session):
+        trace.get_current_span().set_attribute("airflow.scheduler.num_task_event_logs", len(log_records))
         objects = (log_records.popleft() for _ in range(len(log_records)))
         session.bulk_save_objects(objects=objects, preserve_order=False)
 
@@ -1319,15 +1350,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     def _is_tracing_enabled():
         return conf.getboolean("traces", "otel_on")
 
+    @start_debug_span("scheduler._process_executor_events")
     def _process_executor_events(self, executor: BaseExecutor, session: Session) -> int:
         try:
-            return SchedulerJobRunner.process_executor_events(
+            events_processed = SchedulerJobRunner.process_executor_events(
                 executor=executor,
                 job_id=self.job.id,
                 scheduler_dag_bag=self.scheduler_dag_bag,
                 session=session,
                 eagerly_load_dag_tags=self._dag_tags_in_metrics,
             )
+            trace.get_current_span().set_attribute("airflow.scheduler.events_processed", events_processed)
+            return events_processed
         except Exception as exc:
             stats.incr("scheduler.executor_events.failed", tags={"exception_class": type(exc).__name__})
             raise
@@ -1869,7 +1903,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Reset per-loop team name cache so changes to bundle-team assignments
             # are picked up each iteration without requiring a scheduler restart.
             self._dag_id_to_team_name = {}
-            with stats.timer("scheduler.scheduler_loop_duration") as timer:
+            with (
+                start_debug_span(
+                    "scheduler.scheduler_loop",
+                    context=context.Context(),
+                    attributes={"airflow.scheduler.loop_count": loop_count},
+                ) as loop_iteration_span,
+                stats.timer("scheduler.scheduler_loop_duration") as timer,
+            ):
                 with create_session() as session:
                     # This will schedule for as many executors as possible.
                     num_queued_tis = self._do_scheduling(session)
@@ -1880,13 +1921,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # either a no-op, or they will check-in on currently running tasks and send out new
                 # events to be processed below.
                 for executor in self.executors:
-                    with stats.timer(
-                        "scheduler.executor_heartbeat_duration",
-                        tags=prune_dict(
-                            {
-                                "executor": type(executor).__name__,
-                                "team_name": executor.team_name,
-                            }
+                    with (
+                        start_debug_span(
+                            "scheduler.executor.heartbeat",
+                            attributes={"airflow.executor.class": type(executor).__name__},
+                        ),
+                        stats.timer(
+                            "scheduler.executor_heartbeat_duration",
+                            tags=prune_dict(
+                                {
+                                    "executor": type(executor).__name__,
+                                    "team_name": executor.team_name,
+                                }
+                            ),
                         ),
                     ):
                         executor.heartbeat()
@@ -1915,16 +1962,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         .where(~Deadline.missed)
                         .options(selectinload(Deadline.callback), selectinload(Deadline.dagrun))
                     )
-                    for deadline in session.scalars(
-                        with_row_locks(
-                            deadline_query,
-                            of=Deadline,
-                            session=session,
-                            skip_locked=True,
-                            key_share=False,
-                        )
-                    ):
-                        deadline.handle_miss(session)
+                    with start_debug_span("scheduler.handle_missed_deadlines"):
+                        for deadline in session.scalars(
+                            with_row_locks(
+                                deadline_query,
+                                of=Deadline,
+                                session=session,
+                                skip_locked=True,
+                                key_share=False,
+                            )
+                        ):
+                            with start_debug_span("scheduler.handle_deadline_miss"):
+                                deadline.handle_miss(session)
 
                     # Route ExecutorCallback workloads to executors (similar to task routing)
                     self._enqueue_executor_callbacks(session)
@@ -1937,12 +1986,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
 
                 # Run any pending timed events
-                next_event = timers.run(blocking=False)
-                self.log.debug("Next timed event is in %f", next_event)
+                with start_debug_span("scheduler.timers.run"):
+                    next_event = timers.run(blocking=False)
+                    self.log.debug("Next timed event is in %f", next_event)
+
+                loop_iteration_span.set_attribute("airflow.scheduler.num_queued_tis", num_queued_tis)
+                loop_iteration_span.set_attribute(
+                    "airflow.scheduler.num_finished_events", num_finished_events
+                )
+                idle_in_this_run = not num_queued_tis and not num_finished_events
+                loop_iteration_span.set_attribute("airflow.scheduler.loop_iteration.idle", idle_in_this_run)
 
             self.log.debug("Ran scheduling loop in %.2f ms", timer.duration)
 
-            idle_in_this_run = not num_queued_tis and not num_finished_events
             if not is_unit_test and idle_in_this_run:
                 # If the scheduler is doing things, don't sleep. This means when there is work to do, the
                 # scheduler will run "as quick as possible", but when it's stopped, it can sleep, dropping CPU
@@ -1964,6 +2020,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 break
 
+    @start_debug_span("scheduler._do_scheduling")
     def _do_scheduling(self, session: Session) -> int:
         """
         Make the main scheduling decisions.
@@ -2006,11 +2063,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # examining, rather than making one query per DagRun.
             # Materialize into a list because the multi-team block below iterates
             # the result and ScalarResult is a one-pass iterator.
-            dag_runs = list(
-                DagRun.get_running_dag_runs_to_examine(
-                    session=session, eagerly_load_dag_tags=self._dag_tags_in_metrics
+            with start_debug_span("dagrun.get_running_dag_runs_to_examine") as dag_runs_span:
+                dag_runs = list(
+                    DagRun.get_running_dag_runs_to_examine(
+                        session=session, eagerly_load_dag_tags=self._dag_tags_in_metrics
+                    )
                 )
-            )
+                # This span isn't added as a method decorator so that
+                # the below attribute can also be added as a tag.
+                dag_runs_span.set_attribute("airflow.scheduler.dagrun.dag_run_count", len(dag_runs))
 
             # Team name should be added before listeners are called in _schedule_all_dag_runs()
             self._stamp_team_names(dag_runs, session)
@@ -2030,13 +2091,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             else:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
 
-        with prohibit_commit(session) as guard:
+        with (
+            prohibit_commit(session) as guard,
+            start_debug_span("scheduler.critical_section") as critical_section_span,
+        ):
             # Without this, the session has an invalid view of the DB
             session.expunge_all()
             # END: schedule TIs
 
             # Attempt to schedule even if some executors are full but not all.
             total_free_executor_slots = sum([executor.slots_available for executor in self.executors])
+            critical_section_span.set_attribute(
+                "airflow.scheduler.free_executor_slots", total_free_executor_slots
+            )
             if total_free_executor_slots <= 0:
                 # We know we can't do anything here, so don't even try!
                 self.log.debug("All executors are full, skipping critical section")
@@ -2052,12 +2119,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
                     # metric, way down
                     timer.stop(send=True)
+                    critical_section_span.set_attribute("airflow.scheduler.lock_acquired", True)
+                    critical_section_span.set_attribute("airflow.scheduler.num_queued_tis", num_queued_tis)
                 except OperationalError as e:
                     timer.stop(send=False)
 
                     if is_lock_not_available_error(error=e):
                         self.log.debug("Critical section lock held by another Scheduler")
                         stats.incr("scheduler.critical_section_busy")
+                        critical_section_span.set_attribute("airflow.scheduler.lock_acquired", False)
                         session.rollback()
                         return 0
                     raise
@@ -2439,12 +2509,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         return partition_dag_ids
 
     @retry_db_transaction
+    @start_debug_span("scheduler._create_dagruns_for_dags")
     def _create_dagruns_for_dags(self, guard: CommitProhibitorGuard, session: Session) -> None:
         """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError."""
         partition_dag_ids: set[str] = self._create_dagruns_for_partitioned_asset_dags(session)
 
         query, triggered_date_by_dag = DagModel.dags_needing_dagruns(session)
         all_dags_needing_dag_runs = set(query.all())
+        trace.get_current_span().set_attribute(
+            "airflow.scheduler.dags_needing_runs", len(all_dags_needing_dag_runs)
+        )
         asset_triggered_dags = [d for d in all_dags_needing_dag_runs if d.dag_id in triggered_date_by_dag]
         non_asset_dags = {
             d
@@ -2495,8 +2569,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         for b in backfills:
             b.completed_at = now
 
+    @start_debug_span("scheduler._create_dag_runs")
     def _create_dag_runs(self, dag_models: Collection[DagModel], session: Session) -> None:
         """Create a DAG run and update the dag_model to control if/when the next DAGRun should be created."""
+        trace.get_current_span().set_attribute("airflow.scheduler.num_dag_models", len(dag_models))
         # Bulk Fetch DagRuns with dag_id and logical_date same
         # as DagModel.dag_id and DagModel.next_dagrun
         # This list is used to verify if the DagRun already exist so that we don't attempt to create
@@ -2631,6 +2707,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
             #  memory for larger dags? or expunge_all()
 
+    @start_debug_span("scheduler._create_dag_runs_asset_triggered")
     def _create_dag_runs_asset_triggered(
         self,
         *,
@@ -2638,6 +2715,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         session: Session,
     ) -> None:
         """For Dags that are triggered by assets, create Dag runs."""
+        trace.get_current_span().set_attribute("airflow.scheduler.num_asset_triggered_dags", len(dag_models))
         for dag_model in dag_models:
             dag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
             if not dag:
@@ -2790,9 +2868,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return locked_backfills
 
+    @start_debug_span("scheduler._start_queued_dagruns")
     def _start_queued_dagruns(self, session: Session) -> None:
         """Find DagRuns in queued state and decide moving them to running state."""
         dag_runs: Collection[DagRun] = list(DagRun.get_queued_dag_runs_to_set_running(session))
+        trace.get_current_span().set_attribute("airflow.scheduler.queued_dag_runs", len(dag_runs))
 
         # Lock backfills to prevent race conditions with concurrent schedulers
         locked_backfills = self._lock_backfills(dag_runs, session)
@@ -2846,46 +2926,54 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             dag_id = dag_run.dag_id
             run_id = dag_run.run_id
             backfill_id = dag_run.backfill_id
-            dag = dag_run.dag = cached_get_dag(dag_run)
-            if not dag:
-                self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
-                continue
-            active_runs = active_runs_of_dags[(dag_id, backfill_id)]
-            if backfill_id is not None:
-                if backfill_id not in locked_backfills:
-                    # Another scheduler has this backfill locked, skip this run
+            with start_debug_span("scheduler.update_dag_run_state_to_running") as update_state_span:
+                update_state_span.set_attribute("airflow.dag_run.dag_id", dag_id)
+                update_state_span.set_attribute("airflow.dag_run.run_id", run_id)
+                if backfill_id is not None:
+                    update_state_span.set_attribute("airflow.dag_run.backfill_id", backfill_id)
+                with start_debug_span("scheduler.cached_get_dag") as cached_get_dag_span:
+                    cached_get_dag_span.set_attribute("airflow.dag.dag_id", dag_id)
+                    dag = dag_run.dag = cached_get_dag(dag_run)
+                if not dag:
+                    self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
                     continue
-                backfill = dag_run.backfill
-                if active_runs >= backfill.max_active_runs:
-                    # todo: delete all "candidate dag runs" from list for this dag right now
-                    self.log.info(
-                        "dag cannot be started due to backfill max_active_runs constraint; "
-                        "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
-                        active_runs,
-                        backfill.max_active_runs,
-                        dag_id,
-                        run_id,
-                    )
-                    continue
-            elif dag_run.max_active_runs:
-                # Using dag_run.max_active_runs which links to DagModel to ensure we are checking
-                # against the most recent changes on the dag and not using stale serialized dag
-                if active_runs >= dag_run.max_active_runs:
-                    # todo: delete all candidate dag runs for this dag from list right now
-                    self.log.info(
-                        "dag cannot be started due to dag max_active_runs constraint; "
-                        "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
-                        active_runs,
-                        dag_run.max_active_runs,
-                        dag_run.dag_id,
-                        dag_run.run_id,
-                    )
-                    continue
-            active_runs_of_dags[(dag_run.dag_id, backfill_id)] += 1
-            _update_state(dag, dag_run)
-            dag_run.notify_dagrun_state_changed(msg="started")
+                active_runs = active_runs_of_dags[(dag_id, backfill_id)]
+                if backfill_id is not None:
+                    if backfill_id not in locked_backfills:
+                        # Another scheduler has this backfill locked, skip this run
+                        continue
+                    backfill = dag_run.backfill
+                    if active_runs >= backfill.max_active_runs:
+                        # todo: delete all "candidate dag runs" from list for this dag right now
+                        self.log.info(
+                            "dag cannot be started due to backfill max_active_runs constraint; "
+                            "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
+                            active_runs,
+                            backfill.max_active_runs,
+                            dag_id,
+                            run_id,
+                        )
+                        continue
+                elif dag_run.max_active_runs:
+                    # Using dag_run.max_active_runs which links to DagModel to ensure we are checking
+                    # against the most recent changes on the dag and not using stale serialized dag
+                    if active_runs >= dag_run.max_active_runs:
+                        # todo: delete all candidate dag runs for this dag from list right now
+                        self.log.info(
+                            "dag cannot be started due to dag max_active_runs constraint; "
+                            "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
+                            active_runs,
+                            dag_run.max_active_runs,
+                            dag_run.dag_id,
+                            dag_run.run_id,
+                        )
+                        continue
+                active_runs_of_dags[(dag_run.dag_id, backfill_id)] += 1
+                _update_state(dag, dag_run)
+                dag_run.notify_dagrun_state_changed(msg="started")
 
     @retry_db_transaction
+    @start_debug_span("scheduler._schedule_all_dag_runs")
     def _schedule_all_dag_runs(
         self,
         guard: CommitProhibitorGuard,
@@ -2903,8 +2991,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             except Exception:
                 self.log.exception("Error scheduling DAG run %s of %s", run.run_id, run.dag_id)
         guard.commit()
+        trace.get_current_span().set_attribute("airflow.scheduler.dag_runs_scheduled", len(callback_tuples))
         return callback_tuples
 
+    @start_debug_span("scheduler._schedule_dag_run")
     def _schedule_dag_run(
         self,
         dag_run: DagRun,
@@ -2916,6 +3006,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
         """
+        current_span = trace.get_current_span()
+        current_span.set_attribute("airflow.dag_run.dag_id", dag_run.dag_id)
+        current_span.set_attribute("airflow.dag_run.run_id", dag_run.run_id)
+
         callback: DagCallbackRequest | None = None
 
         dag = dag_run.dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
@@ -3014,6 +3108,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
+        current_span.set_attribute("airflow.scheduler.num_schedulable_tis", len(schedulable_tis))
+        current_span.set_attribute("airflow.dag_run.state", str(dag_run.state))
 
         if dag_run.state in State.finished_dr_states and dag_run.run_type in (
             DagRunType.SCHEDULED,
@@ -3984,6 +4080,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             delete(AssetStateStoreModel).where(AssetStateStoreModel.asset_id.not_in(active_asset_ids))
         )
 
+    @start_debug_span("scheduler._enqueue_connection_tests")
     def _enqueue_connection_tests(self, *, session: Session) -> None:
         """
         Enqueue pending connection tests to executors that support them.
@@ -4015,6 +4112,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
         stats.gauge("connection_test.active", active_count)
         stats.gauge("connection_test.pending", pending_count)
+        connection_test_span = trace.get_current_span()
+        connection_test_span.set_attribute("airflow.scheduler.connection_tests_active", active_count)
+        connection_test_span.set_attribute("airflow.scheduler.connection_tests_pending", pending_count)
 
         budget = max_concurrency - active_count
         if budget <= 0:
@@ -4119,6 +4219,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         session.flush()
 
+    @start_debug_span("scheduler._executor_to_workloads")
     def _executor_to_workloads(
         self,
         workloads: Iterable[SchedulerWorkload],

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -34,6 +34,8 @@ from itertools import groupby
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
+from opentelemetry import trace
+from opentelemetry.context import context
 from sqlalchemy import (
     CTE,
     Text,
@@ -56,6 +58,7 @@ from sqlalchemy.sql import expression
 
 from airflow import settings
 from airflow._shared.observability.metrics import stats
+from airflow._shared.observability.traces import start_debug_span
 from airflow._shared.timezones import timezone
 from airflow.api_fastapi.execution_api.datamodels.taskinstance import DagRun as DRDataModel, TIRunContext
 from airflow.assets.evaluation import AssetEvaluator
@@ -411,6 +414,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return resetter
 
+    @start_debug_span("scheduler._get_team_names_for_dag_ids")
     def _get_team_names_for_dag_ids(
         self, dag_ids: Collection[str], session: Session
     ) -> dict[str, str | None]:
@@ -425,6 +429,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param session: Database session for queries
         :return: Dictionary mapping dag_id -> team_name (None if no team found)
         """
+        trace.get_current_span().set_attribute("airflow.scheduler.num_dag_ids", len(dag_ids))
         if not dag_ids:
             return {}
 
@@ -618,6 +623,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return True
 
+    @start_debug_span("scheduler._executable_task_instances_to_queued")
     def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
         """
         Find TIs that are ready for execution based on conditions.
@@ -642,11 +648,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Optimization: to avoid littering the DB errors of "ERROR: canceling statement due to lock
             # timeout", try to take out a transactional advisory lock (unlocks automatically on
             # COMMIT/ROLLBACK)
-            lock_acquired = session.execute(
-                text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
-                    id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
-                )
-            ).scalar()
+            with start_debug_span("scheduler.critical_section.advisory_lock") as advisory_lock_span:
+                lock_acquired = session.execute(
+                    text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
+                        id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
+                    )
+                ).scalar()
+                advisory_lock_span.set_attribute("airflow.scheduler.lock_acquired", bool(lock_acquired))
             if lock_acquired is None:
                 lock_acquired = False
             if not lock_acquired:
@@ -799,8 +807,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             timer.start()
 
             try:
-                locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
-                task_instances_to_examine = session.scalars(locked_query).all()
+                with start_debug_span("scheduler.critical_section.task_instances_to_examine") as select_span:
+                    locked_query = with_row_locks(query, of=TI, session=session, skip_locked=True)
+                    task_instances_to_examine = session.scalars(locked_query).all()
+                    select_span.set_attribute(
+                        "airflow.scheduler.tis_examined", len(task_instances_to_examine)
+                    )
 
                 if self.log.isEnabledFor(logging.DEBUG):
                     self.log.debug("Length of the tis to examine is %d", len(task_instances_to_examine))
@@ -1079,33 +1091,37 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 .execution_options(synchronize_session=False)
             )
 
-            if pre_assign_executors:
-                # Read the DB-generated UUIDs back onto the in-memory objects so the
-                # workload DTO carries them through to send_workload_to_executor (the
-                # objects are about to be detached by make_transient). Use RETURNING
-                # where supported (PostgreSQL); fall back to a SELECT for MySQL and
-                # SQLite (RETURNING requires SQLite 3.35+ which isn't guaranteed).
-                if get_dialect_name(session) == "postgresql":
-                    result = session.execute(queued_update.returning(TI.id, TI.external_executor_id))
-                    id_map = {row[0]: row[1] for row in result}
+            with start_debug_span("scheduler.critical_section.update_tis_to_queued") as update_span:
+                update_span.set_attribute("airflow.scheduler.tis_to_update", len(executable_tis))
+                if pre_assign_executors:
+                    # Read the DB-generated UUIDs back onto the in-memory objects so the
+                    # workload DTO carries them through to send_workload_to_executor (the
+                    # objects are about to be detached by make_transient). Use RETURNING
+                    # where supported (PostgreSQL); fall back to a SELECT for MySQL and
+                    # SQLite (RETURNING requires SQLite 3.35+ which isn't guaranteed).
+                    if get_dialect_name(session) == "postgresql":
+                        result = session.execute(queued_update.returning(TI.id, TI.external_executor_id))
+                        id_map = {row[0]: row[1] for row in result}
+                    else:
+                        session.execute(queued_update)
+                        id_rows = session.execute(
+                            select(TI.id, TI.external_executor_id).where(filter_for_tis)
+                        ).all()
+                        id_map = {row[0]: row[1] for row in id_rows}
+                    for ti in executable_tis:
+                        ti.external_executor_id = id_map.get(ti.id)
                 else:
                     session.execute(queued_update)
-                    id_rows = session.execute(
-                        select(TI.id, TI.external_executor_id).where(filter_for_tis)
-                    ).all()
-                    id_map = {row[0]: row[1] for row in id_rows}
-                for ti in executable_tis:
-                    ti.external_executor_id = id_map.get(ti.id)
-            else:
-                session.execute(queued_update)
 
             for ti in executable_tis:
                 ti.emit_state_change_metric(TaskInstanceState.QUEUED)
 
         for ti in executable_tis:
             make_transient(ti)
+        trace.get_current_span().set_attribute("airflow.scheduler.num_executable_tis", len(executable_tis))
         return executable_tis
 
+    @start_debug_span("scheduler._enqueue_task_instances_with_queued_state")
     def _enqueue_task_instances_with_queued_state(
         self, task_instances: list[TI], executor: BaseExecutor, session: Session
     ) -> None:
@@ -1116,6 +1132,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param executor: The executor to enqueue tasks for
         :param session: The session object
         """
+        enqueue_span = trace.get_current_span()
+        enqueue_span.set_attribute("airflow.executor.class", type(executor).__name__)
+        enqueue_span.set_attribute("airflow.scheduler.num_tis_to_enqueue", len(task_instances))
 
         def _get_sentry_integration(executor: BaseExecutor) -> str:
             try:
@@ -1136,32 +1155,39 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # actually enqueue them
         for ti in task_instances:
-            if ti.dag_run.state in State.finished_dr_states:
-                ti.set_state(None, session=session)
-                continue
-            if not ti.dag_version_id:
-                self.log.warning(
-                    "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
-                    "This would get unstuck and dag_version_id updated.",
+            with start_debug_span("scheduler.enqueue_ti") as enqueue_ti_span:
+                enqueue_ti_span.set_attribute("airflow.ti.dag_id", ti.dag_id)
+                enqueue_ti_span.set_attribute("airflow.ti.run_id", ti.run_id)
+                enqueue_ti_span.set_attribute("airflow.ti.task_id", ti.task_id)
+                enqueue_ti_span.set_attribute("airflow.ti.map_index", ti.map_index)
+                enqueue_ti_span.set_attribute("airflow.ti.try_number", ti.try_number)
+                if ti.dag_run.state in State.finished_dr_states:
+                    ti.set_state(None, session=session)
+                    continue
+                if not ti.dag_version_id:
+                    self.log.warning(
+                        "TaskInstance %s does not have a dag_version_id set, cannot be enqueued. "
+                        "This would get unstuck and dag_version_id updated.",
+                        ti,
+                    )
+                    continue
+
+                self.log.debug(
+                    "Queueing workload for TI: %s try_number=%d state=%s scheduler_job_id=%s executor=%s",
                     ti,
+                    ti.try_number,
+                    ti.state,
+                    self.job.id,
+                    executor,
                 )
-                continue
+                workload = workloads.ExecuteTask.make(
+                    ti,
+                    generator=executor.jwt_generator,
+                    sentry_integration=_get_sentry_integration(executor),
+                )
+                executor.queue_workload(workload, session=session)
 
-            self.log.debug(
-                "Queueing workload for TI: %s try_number=%d state=%s scheduler_job_id=%s executor=%s",
-                ti,
-                ti.try_number,
-                ti.state,
-                self.job.id,
-                executor,
-            )
-            workload = workloads.ExecuteTask.make(
-                ti,
-                generator=executor.jwt_generator,
-                sentry_integration=_get_sentry_integration(executor),
-            )
-            executor.queue_workload(workload, session=session)
-
+    @start_debug_span("scheduler._critical_section_enqueue_task_instances")
     def _critical_section_enqueue_task_instances(self, session: Session) -> int:
         """
         Enqueues TaskInstances for execution.
@@ -1211,8 +1237,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             self._enqueue_task_instances_with_queued_state(queued_tis_per_executor, executor, session=session)
 
+        trace.get_current_span().set_attribute("airflow.scheduler.num_queued_tis", len(queued_tis))
         return len(queued_tis)
 
+    @start_debug_span("scheduler._enqueue_executor_callbacks")
     def _enqueue_executor_callbacks(self, session: Session) -> None:
         """
         Enqueue ExecutorCallback workloads to executors.
@@ -1236,6 +1264,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             .order_by(ExecutorCallback.priority_weight.desc())
             .limit(max_callbacks)
         ).all()
+        trace.get_current_span().set_attribute("airflow.scheduler.pending_callbacks", len(pending_callbacks))
 
         if not pending_callbacks:
             return
@@ -1283,7 +1312,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 session.add(callback)
 
     @staticmethod
+    @start_debug_span("scheduler._process_task_event_logs")
     def _process_task_event_logs(log_records: deque[Log], session: Session):
+        trace.get_current_span().set_attribute("airflow.scheduler.num_task_event_logs", len(log_records))
         objects = (log_records.popleft() for _ in range(len(log_records)))
         session.bulk_save_objects(objects=objects, preserve_order=False)
 
@@ -1301,15 +1332,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
     def _is_tracing_enabled():
         return conf.getboolean("traces", "otel_on")
 
+    @start_debug_span("scheduler._process_executor_events")
     def _process_executor_events(self, executor: BaseExecutor, session: Session) -> int:
         try:
-            return SchedulerJobRunner.process_executor_events(
+            events_processed = SchedulerJobRunner.process_executor_events(
                 executor=executor,
                 job_id=self.job.id,
                 scheduler_dag_bag=self.scheduler_dag_bag,
                 session=session,
                 eagerly_load_dag_tags=self._dag_tags_in_metrics,
             )
+            trace.get_current_span().set_attribute("airflow.scheduler.events_processed", events_processed)
+            return events_processed
         except Exception as exc:
             stats.incr("scheduler.executor_events.failed", tags={"exception_class": type(exc).__name__})
             raise
@@ -1853,7 +1887,14 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # Reset per-loop team name cache so changes to bundle-team assignments
             # are picked up each iteration without requiring a scheduler restart.
             self._dag_id_to_team_name = {}
-            with stats.timer("scheduler.scheduler_loop_duration") as timer:
+            with (
+                start_debug_span(
+                    "scheduler.scheduler_loop",
+                    context=context.Context(),
+                    attributes={"airflow.scheduler.loop_count": loop_count},
+                ) as loop_iteration_span,
+                stats.timer("scheduler.scheduler_loop_duration") as timer,
+            ):
                 with create_session() as session:
                     # This will schedule for as many executors as possible.
                     num_queued_tis = self._do_scheduling(session)
@@ -1864,13 +1905,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # either a no-op, or they will check-in on currently running tasks and send out new
                 # events to be processed below.
                 for executor in self.executors:
-                    with stats.timer(
-                        "scheduler.executor_heartbeat_duration",
-                        tags=prune_dict(
-                            {
-                                "executor": type(executor).__name__,
-                                "team_name": executor.team_name,
-                            }
+                    with (
+                        start_debug_span(
+                            "scheduler.executor.heartbeat",
+                            attributes={"airflow.executor.class": type(executor).__name__},
+                        ),
+                        stats.timer(
+                            "scheduler.executor_heartbeat_duration",
+                            tags=prune_dict(
+                                {
+                                    "executor": type(executor).__name__,
+                                    "team_name": executor.team_name,
+                                }
+                            ),
                         ),
                     ):
                         executor.heartbeat()
@@ -1899,16 +1946,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         .where(~Deadline.missed)
                         .options(selectinload(Deadline.callback), selectinload(Deadline.dagrun))
                     )
-                    for deadline in session.scalars(
-                        with_row_locks(
-                            deadline_query,
-                            of=Deadline,
-                            session=session,
-                            skip_locked=True,
-                            key_share=False,
-                        )
-                    ):
-                        deadline.handle_miss(session)
+                    with start_debug_span("scheduler.handle_missed_deadlines"):
+                        for deadline in session.scalars(
+                            with_row_locks(
+                                deadline_query,
+                                of=Deadline,
+                                session=session,
+                                skip_locked=True,
+                                key_share=False,
+                            )
+                        ):
+                            with start_debug_span("scheduler.handle_deadline_miss"):
+                                deadline.handle_miss(session)
 
                     # Route ExecutorCallback workloads to executors (similar to task routing)
                     self._enqueue_executor_callbacks(session)
@@ -1921,12 +1970,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
 
                 # Run any pending timed events
-                next_event = timers.run(blocking=False)
-                self.log.debug("Next timed event is in %f", next_event)
+                with start_debug_span("scheduler.timers.run"):
+                    next_event = timers.run(blocking=False)
+                    self.log.debug("Next timed event is in %f", next_event)
+
+                loop_iteration_span.set_attribute("airflow.scheduler.num_queued_tis", num_queued_tis)
+                loop_iteration_span.set_attribute(
+                    "airflow.scheduler.num_finished_events", num_finished_events
+                )
+                idle_in_this_run = not num_queued_tis and not num_finished_events
+                loop_iteration_span.set_attribute("airflow.scheduler.loop_iteration.idle", idle_in_this_run)
 
             self.log.debug("Ran scheduling loop in %.2f ms", timer.duration)
 
-            idle_in_this_run = not num_queued_tis and not num_finished_events
             if not is_unit_test and idle_in_this_run:
                 # If the scheduler is doing things, don't sleep. This means when there is work to do, the
                 # scheduler will run "as quick as possible", but when it's stopped, it can sleep, dropping CPU
@@ -1948,6 +2004,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 break
 
+    @start_debug_span("scheduler._do_scheduling")
     def _do_scheduling(self, session: Session) -> int:
         """
         Make the main scheduling decisions.
@@ -1990,11 +2047,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # examining, rather than making one query per DagRun.
             # Materialize into a list because the multi-team block below iterates
             # the result and ScalarResult is a one-pass iterator.
-            dag_runs = list(
-                DagRun.get_running_dag_runs_to_examine(
-                    session=session, eagerly_load_dag_tags=self._dag_tags_in_metrics
+            with start_debug_span("dagrun.get_running_dag_runs_to_examine") as dag_runs_span:
+                dag_runs = list(
+                    DagRun.get_running_dag_runs_to_examine(
+                        session=session, eagerly_load_dag_tags=self._dag_tags_in_metrics
+                    )
                 )
-            )
+                # This span isn't added as a method decorator so that
+                # the below attribute can also be added as a tag.
+                dag_runs_span.set_attribute("airflow.scheduler.dagrun.dag_run_count", len(dag_runs))
 
             if self._multi_team and dag_runs:
                 unique_dag_ids = {dr.dag_id for dr in dag_runs}
@@ -2018,13 +2079,19 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             else:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
 
-        with prohibit_commit(session) as guard:
+        with (
+            prohibit_commit(session) as guard,
+            start_debug_span("scheduler.critical_section") as critical_section_span,
+        ):
             # Without this, the session has an invalid view of the DB
             session.expunge_all()
             # END: schedule TIs
 
             # Attempt to schedule even if some executors are full but not all.
             total_free_executor_slots = sum([executor.slots_available for executor in self.executors])
+            critical_section_span.set_attribute(
+                "airflow.scheduler.free_executor_slots", total_free_executor_slots
+            )
             if total_free_executor_slots <= 0:
                 # We know we can't do anything here, so don't even try!
                 self.log.debug("All executors are full, skipping critical section")
@@ -2040,12 +2107,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
                     # metric, way down
                     timer.stop(send=True)
+                    critical_section_span.set_attribute("airflow.scheduler.lock_acquired", True)
+                    critical_section_span.set_attribute("airflow.scheduler.num_queued_tis", num_queued_tis)
                 except OperationalError as e:
                     timer.stop(send=False)
 
                     if is_lock_not_available_error(error=e):
                         self.log.debug("Critical section lock held by another Scheduler")
                         stats.incr("scheduler.critical_section_busy")
+                        critical_section_span.set_attribute("airflow.scheduler.lock_acquired", False)
                         session.rollback()
                         return 0
                     raise
@@ -2427,12 +2497,16 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         return partition_dag_ids
 
     @retry_db_transaction
+    @start_debug_span("scheduler._create_dagruns_for_dags")
     def _create_dagruns_for_dags(self, guard: CommitProhibitorGuard, session: Session) -> None:
         """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError."""
         partition_dag_ids: set[str] = self._create_dagruns_for_partitioned_asset_dags(session)
 
         query, triggered_date_by_dag = DagModel.dags_needing_dagruns(session)
         all_dags_needing_dag_runs = set(query.all())
+        trace.get_current_span().set_attribute(
+            "airflow.scheduler.dags_needing_runs", len(all_dags_needing_dag_runs)
+        )
         asset_triggered_dags = [d for d in all_dags_needing_dag_runs if d.dag_id in triggered_date_by_dag]
         non_asset_dags = {
             d
@@ -2483,8 +2557,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         for b in backfills:
             b.completed_at = now
 
+    @start_debug_span("scheduler._create_dag_runs")
     def _create_dag_runs(self, dag_models: Collection[DagModel], session: Session) -> None:
         """Create a DAG run and update the dag_model to control if/when the next DAGRun should be created."""
+        trace.get_current_span().set_attribute("airflow.scheduler.num_dag_models", len(dag_models))
         # Bulk Fetch DagRuns with dag_id and logical_date same
         # as DagModel.dag_id and DagModel.next_dagrun
         # This list is used to verify if the DagRun already exist so that we don't attempt to create
@@ -2619,6 +2695,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
             #  memory for larger dags? or expunge_all()
 
+    @start_debug_span("scheduler._create_dag_runs_asset_triggered")
     def _create_dag_runs_asset_triggered(
         self,
         *,
@@ -2626,6 +2703,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         session: Session,
     ) -> None:
         """For Dags that are triggered by assets, create Dag runs."""
+        trace.get_current_span().set_attribute("airflow.scheduler.num_asset_triggered_dags", len(dag_models))
         for dag_model in dag_models:
             dag = self._get_current_dag(dag_id=dag_model.dag_id, session=session)
             if not dag:
@@ -2795,9 +2873,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         return locked_backfills
 
+    @start_debug_span("scheduler._start_queued_dagruns")
     def _start_queued_dagruns(self, session: Session) -> None:
         """Find DagRuns in queued state and decide moving them to running state."""
         dag_runs: Collection[DagRun] = list(DagRun.get_queued_dag_runs_to_set_running(session))
+        trace.get_current_span().set_attribute("airflow.scheduler.queued_dag_runs", len(dag_runs))
 
         # Lock backfills to prevent race conditions with concurrent schedulers
         locked_backfills = self._lock_backfills(dag_runs, session)
@@ -2848,46 +2928,54 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             dag_id = dag_run.dag_id
             run_id = dag_run.run_id
             backfill_id = dag_run.backfill_id
-            dag = dag_run.dag = cached_get_dag(dag_run)
-            if not dag:
-                self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
-                continue
-            active_runs = active_runs_of_dags[(dag_id, backfill_id)]
-            if backfill_id is not None:
-                if backfill_id not in locked_backfills:
-                    # Another scheduler has this backfill locked, skip this run
+            with start_debug_span("scheduler.update_dag_run_state_to_running") as update_state_span:
+                update_state_span.set_attribute("airflow.dag_run.dag_id", dag_id)
+                update_state_span.set_attribute("airflow.dag_run.run_id", run_id)
+                if backfill_id is not None:
+                    update_state_span.set_attribute("airflow.dag_run.backfill_id", backfill_id)
+                with start_debug_span("scheduler.cached_get_dag") as cached_get_dag_span:
+                    cached_get_dag_span.set_attribute("airflow.dag.dag_id", dag_id)
+                    dag = dag_run.dag = cached_get_dag(dag_run)
+                if not dag:
+                    self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
                     continue
-                backfill = dag_run.backfill
-                if active_runs >= backfill.max_active_runs:
-                    # todo: delete all "candidate dag runs" from list for this dag right now
-                    self.log.info(
-                        "dag cannot be started due to backfill max_active_runs constraint; "
-                        "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
-                        active_runs,
-                        backfill.max_active_runs,
-                        dag_id,
-                        run_id,
-                    )
-                    continue
-            elif dag_run.max_active_runs:
-                # Using dag_run.max_active_runs which links to DagModel to ensure we are checking
-                # against the most recent changes on the dag and not using stale serialized dag
-                if active_runs >= dag_run.max_active_runs:
-                    # todo: delete all candidate dag runs for this dag from list right now
-                    self.log.info(
-                        "dag cannot be started due to dag max_active_runs constraint; "
-                        "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
-                        active_runs,
-                        dag_run.max_active_runs,
-                        dag_run.dag_id,
-                        dag_run.run_id,
-                    )
-                    continue
-            active_runs_of_dags[(dag_run.dag_id, backfill_id)] += 1
-            _update_state(dag, dag_run)
-            dag_run.notify_dagrun_state_changed(msg="started")
+                active_runs = active_runs_of_dags[(dag_id, backfill_id)]
+                if backfill_id is not None:
+                    if backfill_id not in locked_backfills:
+                        # Another scheduler has this backfill locked, skip this run
+                        continue
+                    backfill = dag_run.backfill
+                    if active_runs >= backfill.max_active_runs:
+                        # todo: delete all "candidate dag runs" from list for this dag right now
+                        self.log.info(
+                            "dag cannot be started due to backfill max_active_runs constraint; "
+                            "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
+                            active_runs,
+                            backfill.max_active_runs,
+                            dag_id,
+                            run_id,
+                        )
+                        continue
+                elif dag_run.max_active_runs:
+                    # Using dag_run.max_active_runs which links to DagModel to ensure we are checking
+                    # against the most recent changes on the dag and not using stale serialized dag
+                    if active_runs >= dag_run.max_active_runs:
+                        # todo: delete all candidate dag runs for this dag from list right now
+                        self.log.info(
+                            "dag cannot be started due to dag max_active_runs constraint; "
+                            "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
+                            active_runs,
+                            dag_run.max_active_runs,
+                            dag_run.dag_id,
+                            dag_run.run_id,
+                        )
+                        continue
+                active_runs_of_dags[(dag_run.dag_id, backfill_id)] += 1
+                _update_state(dag, dag_run)
+                dag_run.notify_dagrun_state_changed(msg="started")
 
     @retry_db_transaction
+    @start_debug_span("scheduler._schedule_all_dag_runs")
     def _schedule_all_dag_runs(
         self,
         guard: CommitProhibitorGuard,
@@ -2905,8 +2993,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             except Exception:
                 self.log.exception("Error scheduling DAG run %s of %s", run.run_id, run.dag_id)
         guard.commit()
+        trace.get_current_span().set_attribute("airflow.scheduler.dag_runs_scheduled", len(callback_tuples))
         return callback_tuples
 
+    @start_debug_span("scheduler._schedule_dag_run")
     def _schedule_dag_run(
         self,
         dag_run: DagRun,
@@ -2918,6 +3008,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
         """
+        current_span = trace.get_current_span()
+        current_span.set_attribute("airflow.dag_run.dag_id", dag_run.dag_id)
+        current_span.set_attribute("airflow.dag_run.run_id", dag_run.run_id)
+
         callback: DagCallbackRequest | None = None
 
         dag = dag_run.dag = self.scheduler_dag_bag.get_dag_for_run(dag_run=dag_run, session=session)
@@ -3014,6 +3108,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
+        current_span.set_attribute("airflow.scheduler.num_schedulable_tis", len(schedulable_tis))
+        current_span.set_attribute("airflow.dag_run.state", str(dag_run.state))
 
         if dag_run.state in State.finished_dr_states and dag_run.run_type in (
             DagRunType.SCHEDULED,
@@ -3971,6 +4067,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             delete(AssetStateStoreModel).where(AssetStateStoreModel.asset_id.not_in(active_asset_ids))
         )
 
+    @start_debug_span("scheduler._enqueue_connection_tests")
     def _enqueue_connection_tests(self, *, session: Session) -> None:
         """
         Enqueue pending connection tests to executors that support them.
@@ -4002,6 +4099,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         )
         stats.gauge("connection_test.active", active_count)
         stats.gauge("connection_test.pending", pending_count)
+        connection_test_span = trace.get_current_span()
+        connection_test_span.set_attribute("airflow.scheduler.connection_tests_active", active_count)
+        connection_test_span.set_attribute("airflow.scheduler.connection_tests_pending", pending_count)
 
         budget = max_concurrency - active_count
         if budget <= 0:
@@ -4106,6 +4206,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
         session.flush()
 
+    @start_debug_span("scheduler._executor_to_workloads")
     def _executor_to_workloads(
         self,
         workloads: Iterable[SchedulerWorkload],

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -28,6 +28,7 @@ import sqlalchemy as sa
 import structlog
 from cachetools import TTLCache, cached
 from dateutil.relativedelta import relativedelta
+from opentelemetry import trace
 from sqlalchemy import (
     Boolean,
     Float,
@@ -56,6 +57,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql import expression
 
 from airflow import settings
+from airflow._shared.observability.traces import start_debug_span
 from airflow._shared.timezones import timezone
 from airflow.assets.evaluation import AssetEvaluator
 from airflow.configuration import conf as airflow_conf
@@ -680,6 +682,7 @@ class DagModel(Base):
         return any_deactivated
 
     @classmethod
+    @start_debug_span("dag.dagmodel.dags_needing_dagruns")
     def dags_needing_dagruns(cls, session: Session) -> tuple[Any, dict[str, datetime]]:
         """
         Return (and lock) a list of Dag objects that are due to create a new DagRun.
@@ -803,6 +806,8 @@ class DagModel(Base):
             .order_by(cls.next_dagrun_create_after)
             .limit(cls.NUM_DAGS_PER_DAGRUN_QUERY)
         )
+
+        trace.get_current_span().set_attribute("airflow.dag.asset_triggered_dags", len(triggered_date_by_dag))
 
         return (
             session.scalars(with_row_locks(query, of=cls, session=session, skip_locked=True)),

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -28,6 +28,7 @@ import sqlalchemy as sa
 import structlog
 from cachetools import TTLCache, cached
 from dateutil.relativedelta import relativedelta
+from opentelemetry import trace
 from sqlalchemy import (
     Boolean,
     Float,
@@ -56,6 +57,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql import expression
 
 from airflow import settings
+from airflow._shared.observability.traces import start_debug_span
 from airflow._shared.timezones import timezone
 from airflow.assets.evaluation import AssetEvaluator
 from airflow.configuration import conf as airflow_conf
@@ -662,6 +664,7 @@ class DagModel(Base):
         return any_deactivated
 
     @classmethod
+    @start_debug_span("dag.dagmodel.dags_needing_dagruns")
     def dags_needing_dagruns(cls, session: Session) -> tuple[Any, dict[str, datetime]]:
         """
         Return (and lock) a list of Dag objects that are due to create a new DagRun.
@@ -785,6 +788,8 @@ class DagModel(Base):
             .order_by(cls.next_dagrun_create_after)
             .limit(cls.NUM_DAGS_PER_DAGRUN_QUERY)
         )
+
+        trace.get_current_span().set_attribute("airflow.dag.asset_triggered_dags", len(triggered_date_by_dag))
 
         return (
             session.scalars(with_row_locks(query, of=cls, session=session, skip_locked=True)),

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -78,6 +78,7 @@ from airflow._shared.observability.traces import (
     TRACE_SAMPLED_KEY,
     new_dagrun_trace_carrier,
     override_ids,
+    start_debug_span,
 )
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
@@ -953,6 +954,7 @@ class DagRun(Base, LoggingMixin):
         return DagRunType(run_type).generate_run_id(suffix=f"{run_after.isoformat()}_{get_random_string()}")
 
     @staticmethod
+    @start_debug_span("dagrun.fetch_task_instances")
     @provide_session
     def fetch_task_instances(
         dag_id: str | None = None,
@@ -989,7 +991,12 @@ class DagRun(Base, LoggingMixin):
 
         if task_ids is not None:
             tis = tis.where(TI.task_id.in_(task_ids))
-        return list(session.scalars(tis).all())
+        with start_debug_span("dagrun.fetch_task_instances.sql_execute"):
+            # This span covers the DB round trip for the query execution.
+            result = session.scalars(tis)
+        with start_debug_span("dagrun.fetch_task_instances.orm_hydration"):
+            # This span covers the building of mapped TaskInstance objects from the buffered rows.
+            return list(result.all())
 
     def _check_last_n_dagruns_failed(self, dag_id, max_consecutive_failed_dag_runs, session):
         """Check if last N dags failed."""
@@ -1036,6 +1043,7 @@ class DagRun(Base, LoggingMixin):
                 self.dag_id,
             )
 
+    @start_debug_span("dagrun.get_task_instances")
     @provide_session
     def get_task_instances(
         self,
@@ -1050,9 +1058,11 @@ class DagRun(Base, LoggingMixin):
         Keep this method because it is widely used across the code.
         """
         task_ids = DagRun._get_partial_task_ids(self.dag)
-        return DagRun.fetch_task_instances(
+        tis = DagRun.fetch_task_instances(
             dag_id=self.dag_id, run_id=self.run_id, task_ids=task_ids, state=state, session=session
         )
+        trace.get_current_span().set_attribute("num_tis_fetched", len(tis))
+        return tis
 
     @provide_session
     def get_task_instance(
@@ -1241,6 +1251,7 @@ class DagRun(Base, LoggingMixin):
             span.end()
 
     @provide_session
+    @start_debug_span("dagrun.update_state")
     def update_state(
         self, *, session: Session = NEW_SESSION, execute_callbacks: bool = True
     ) -> tuple[list[TI], DagCallbackRequest | None]:
@@ -1437,8 +1448,15 @@ class DagRun(Base, LoggingMixin):
         session.merge(self)
         # We do not flush here for performance reasons(It increases queries count by +20)
 
+        update_state_span = trace.get_current_span()
+        update_state_span.set_attribute("airflow.dag_run.dag_id", self.dag_id)
+        update_state_span.set_attribute("airflow.dag_run.run_id", self.run_id)
+        update_state_span.set_attribute("airflow.dag_run.state", str(self.state))
+        update_state_span.set_attribute("airflow.dag_run.num_schedulable_tis", len(schedulable_tis))
+
         return schedulable_tis, callback
 
+    @start_debug_span("dagrun.task_instance_scheduling_decisions")
     @provide_session
     def task_instance_scheduling_decisions(self, *, session: Session = NEW_SESSION) -> TISchedulingDecision:
         tis = self.get_task_instances(session=session, state=State.task_states)
@@ -1480,6 +1498,12 @@ class DagRun(Base, LoggingMixin):
         else:
             schedulable_tis = []
             changed_tis = False
+
+        decision_span = trace.get_current_span()
+        decision_span.set_attribute("airflow.dag_run.num_tis", len(tis))
+        decision_span.set_attribute("airflow.dag_run.num_schedulable_tis", len(schedulable_tis))
+        decision_span.set_attribute("airflow.dag_run.num_unfinished_tis", len(unfinished_tis))
+        decision_span.set_attribute("airflow.dag_run.num_finished_tis", len(finished_tis))
 
         return TISchedulingDecision(
             tis=tis,
@@ -1618,6 +1642,7 @@ class DagRun(Base, LoggingMixin):
                     ),
                 )
 
+    @start_debug_span("dagrun._get_ready_tis")
     def _get_ready_tis(
         self,
         schedulable_tis: list[TI],
@@ -1677,55 +1702,64 @@ class DagRun(Base, LoggingMixin):
         expansion_happened = False
         # Set of task ids for which was already done _revise_map_indexes_if_mapped
         revised_map_index_task_ids: set[str] = set()
-        for schedulable in itertools.chain(schedulable_tis, additional_tis):
-            if TYPE_CHECKING:
-                assert isinstance(schedulable.task, Operator)
-            old_state = schedulable.state
-            if not schedulable.are_dependencies_met(session=session, dep_context=dep_context):
-                old_states[schedulable.key] = old_state
-                continue
-            # If schedulable is not yet expanded, try doing it now. This is
-            # called in two places: First and ideally in the mini scheduler at
-            # the end of LocalTaskJob, and then as an "expansion of last resort"
-            # in the scheduler to ensure that the mapped task is correctly
-            # expanded before executed. Also see _revise_map_indexes_if_mapped
-            # docstring for additional information.
-            new_tis = None
-            if schedulable.map_index < 0:
-                new_tis = _expand_mapped_task_if_needed(schedulable)
-                if new_tis is not None:
-                    additional_tis.extend(new_tis)
-                    expansion_happened = True
-                    # Expansion changes a mapped task's instance count, which invalidates the
-                    # trigger-rule upstream-count memo on this DepContext (a downstream evaluated
-                    # later in this same pass must see the post-expansion count).
-                    dep_context.invalidate_upstream_task_id_counts()
-            if new_tis is None and schedulable.state in SCHEDULEABLE_STATES:
-                # It's enough to revise map index once per task id,
-                # checking the map index for each mapped task significantly slows down scheduling
-                if schedulable.task.task_id not in revised_map_index_task_ids:
-                    revised_tis = self._revise_map_indexes_if_mapped(
-                        schedulable.task, dag_version_id=schedulable.dag_version_id, session=session
-                    )
-                    ready_tis.extend(revised_tis)
-                    revised_map_index_task_ids.add(schedulable.task.task_id)
-                    if revised_tis:
-                        # Revising a mapped task can add new instances, growing its instance count
-                        # the same way expansion does. Drop the upstream-count memo so a downstream
-                        # evaluated later in this pass recomputes it instead of reading a stale value.
-                        dep_context.invalidate_upstream_task_id_counts()
+        with start_debug_span("dagrun.resolve_dependencies") as dep_span:
+            for schedulable in itertools.chain(schedulable_tis, additional_tis):
+                with start_debug_span("dagrun.resolve_dependencies_for_ti") as schedulable_span:
+                    if TYPE_CHECKING:
+                        assert isinstance(schedulable.task, Operator)
+                    schedulable_span.set_attribute("airflow.ti.task_id", schedulable.task.task_id)
+                    schedulable_span.set_attribute("airflow.ti.map_index", schedulable.map_index)
+                    old_state = schedulable.state
+                    if not schedulable.are_dependencies_met(session=session, dep_context=dep_context):
+                        old_states[schedulable.key] = old_state
+                        continue
+                    # If schedulable is not yet expanded, try doing it now. This is
+                    # called in two places: First and ideally in the mini scheduler at
+                    # the end of LocalTaskJob, and then as an "expansion of last resort"
+                    # in the scheduler to ensure that the mapped task is correctly
+                    # expanded before executed. Also see _revise_map_indexes_if_mapped
+                    # docstring for additional information.
+                    new_tis = None
+                    if schedulable.map_index < 0:
+                        new_tis = _expand_mapped_task_if_needed(schedulable)
+                        if new_tis is not None:
+                            additional_tis.extend(new_tis)
+                            expansion_happened = True
+                            # Expansion changes a mapped task's instance count, which invalidates the
+                            # trigger-rule upstream-count memo on this DepContext (a downstream evaluated
+                            # later in this same pass must see the post-expansion count).
+                            dep_context.invalidate_upstream_task_id_counts()
+                    if new_tis is None and schedulable.state in SCHEDULEABLE_STATES:
+                        # It's enough to revise map index once per task id,
+                        # checking the map index for each mapped task significantly slows down scheduling
+                        if schedulable.task.task_id not in revised_map_index_task_ids:
+                            revised_tis = self._revise_map_indexes_if_mapped(
+                                schedulable.task, dag_version_id=schedulable.dag_version_id, session=session
+                            )
+                            ready_tis.extend(revised_tis)
+                            revised_map_index_task_ids.add(schedulable.task.task_id)
+                            if revised_tis:
+                                # Revising a mapped task can add new instances, growing its instance count
+                                # the same way expansion does. Drop the upstream-count memo so a downstream
+                                # evaluated later in this pass recomputes it instead of reading a stale value.
+                                dep_context.invalidate_upstream_task_id_counts()
 
-                # _revise_map_indexes_if_mapped might mark the current task as REMOVED
-                # after calculating mapped task length, so we need to re-check
-                # the task state to ensure it's still schedulable
-                if schedulable.state in SCHEDULEABLE_STATES:
-                    ready_tis.append(schedulable)
+                        # _revise_map_indexes_if_mapped might mark the current task as REMOVED
+                        # after calculating mapped task length, so we need to re-check
+                        # the task state to ensure it's still schedulable
+                        if schedulable.state in SCHEDULEABLE_STATES:
+                            ready_tis.append(schedulable)
+            dep_span.set_attribute(
+                "airflow.dag_run.num_dep_checks", len(schedulable_tis) + len(additional_tis)
+            )
 
         # Check if any ti changed state
         tis_filter = TI.filter_for_tis(old_states)
         if tis_filter is not None:
             fresh_tis = session.scalars(select(TI).where(tis_filter)).all()
             changed_tis = any(ti.state != old_states[ti.key] for ti in fresh_tis)
+
+        trace.get_current_span().set_attribute("airflow.dag_run.num_ready_tis", len(ready_tis))
 
         return ready_tis, changed_tis, expansion_happened
 
@@ -2167,6 +2201,7 @@ class DagRun(Base, LoggingMixin):
             ).all()
         )
 
+    @start_debug_span("dagrun.schedule_tis")
     @provide_session
     def schedule_tis(
         self,
@@ -2302,6 +2337,8 @@ class DagRun(Base, LoggingMixin):
                     )
                 )
                 count += getattr(result, "rowcount", 0)
+
+        trace.get_current_span().set_attribute("airflow.dag_run.num_scheduled_tis", count)
 
         return count
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -78,6 +78,7 @@ from airflow._shared.observability.traces import (
     TRACE_SAMPLED_KEY,
     new_dagrun_trace_carrier,
     override_ids,
+    start_debug_span,
 )
 from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
@@ -961,6 +962,7 @@ class DagRun(Base, LoggingMixin):
         return DagRunType(run_type).generate_run_id(suffix=f"{run_after.isoformat()}_{get_random_string()}")
 
     @staticmethod
+    @start_debug_span("dagrun.fetch_task_instances")
     @provide_session
     def fetch_task_instances(
         dag_id: str | None = None,
@@ -997,7 +999,12 @@ class DagRun(Base, LoggingMixin):
 
         if task_ids is not None:
             tis = tis.where(TI.task_id.in_(task_ids))
-        return list(session.scalars(tis).all())
+        with start_debug_span("dagrun.fetch_task_instances.sql_execute"):
+            # This span covers the DB round trip for the query execution.
+            result = session.scalars(tis)
+        with start_debug_span("dagrun.fetch_task_instances.orm_hydration"):
+            # This span covers the building of mapped TaskInstance objects from the buffered rows.
+            return list(result.all())
 
     def _check_last_n_dagruns_failed(self, dag_id, max_consecutive_failed_dag_runs, session):
         """Check if last N dags failed."""
@@ -1044,6 +1051,7 @@ class DagRun(Base, LoggingMixin):
                 self.dag_id,
             )
 
+    @start_debug_span("dagrun.get_task_instances")
     @provide_session
     def get_task_instances(
         self,
@@ -1058,9 +1066,11 @@ class DagRun(Base, LoggingMixin):
         Keep this method because it is widely used across the code.
         """
         task_ids = DagRun._get_partial_task_ids(self.dag)
-        return DagRun.fetch_task_instances(
+        tis = DagRun.fetch_task_instances(
             dag_id=self.dag_id, run_id=self.run_id, task_ids=task_ids, state=state, session=session
         )
+        trace.get_current_span().set_attribute("num_tis_fetched", len(tis))
+        return tis
 
     @provide_session
     def get_task_instance(
@@ -1249,6 +1259,7 @@ class DagRun(Base, LoggingMixin):
             span.end()
 
     @provide_session
+    @start_debug_span("dagrun.update_state")
     def update_state(
         self, *, session: Session = NEW_SESSION, execute_callbacks: bool = True
     ) -> tuple[list[TI], DagCallbackRequest | None]:
@@ -1445,8 +1456,15 @@ class DagRun(Base, LoggingMixin):
         session.merge(self)
         # We do not flush here for performance reasons(It increases queries count by +20)
 
+        update_state_span = trace.get_current_span()
+        update_state_span.set_attribute("airflow.dag_run.dag_id", self.dag_id)
+        update_state_span.set_attribute("airflow.dag_run.run_id", self.run_id)
+        update_state_span.set_attribute("airflow.dag_run.state", str(self.state))
+        update_state_span.set_attribute("airflow.dag_run.num_schedulable_tis", len(schedulable_tis))
+
         return schedulable_tis, callback
 
+    @start_debug_span("dagrun.task_instance_scheduling_decisions")
     @provide_session
     def task_instance_scheduling_decisions(self, *, session: Session = NEW_SESSION) -> TISchedulingDecision:
         tis = self.get_task_instances(session=session, state=State.task_states)
@@ -1488,6 +1506,12 @@ class DagRun(Base, LoggingMixin):
         else:
             schedulable_tis = []
             changed_tis = False
+
+        decision_span = trace.get_current_span()
+        decision_span.set_attribute("airflow.dag_run.num_tis", len(tis))
+        decision_span.set_attribute("airflow.dag_run.num_schedulable_tis", len(schedulable_tis))
+        decision_span.set_attribute("airflow.dag_run.num_unfinished_tis", len(unfinished_tis))
+        decision_span.set_attribute("airflow.dag_run.num_finished_tis", len(finished_tis))
 
         return TISchedulingDecision(
             tis=tis,
@@ -1626,6 +1650,7 @@ class DagRun(Base, LoggingMixin):
                     ),
                 )
 
+    @start_debug_span("dagrun._get_ready_tis")
     def _get_ready_tis(
         self,
         schedulable_tis: list[TI],
@@ -1685,55 +1710,64 @@ class DagRun(Base, LoggingMixin):
         expansion_happened = False
         # Set of task ids for which was already done _revise_map_indexes_if_mapped
         revised_map_index_task_ids: set[str] = set()
-        for schedulable in itertools.chain(schedulable_tis, additional_tis):
-            if TYPE_CHECKING:
-                assert isinstance(schedulable.task, Operator)
-            old_state = schedulable.state
-            if not schedulable.are_dependencies_met(session=session, dep_context=dep_context):
-                old_states[schedulable.key] = old_state
-                continue
-            # If schedulable is not yet expanded, try doing it now. This is
-            # called in two places: First and ideally in the mini scheduler at
-            # the end of LocalTaskJob, and then as an "expansion of last resort"
-            # in the scheduler to ensure that the mapped task is correctly
-            # expanded before executed. Also see _revise_map_indexes_if_mapped
-            # docstring for additional information.
-            new_tis = None
-            if schedulable.map_index < 0:
-                new_tis = _expand_mapped_task_if_needed(schedulable)
-                if new_tis is not None:
-                    additional_tis.extend(new_tis)
-                    expansion_happened = True
-                    # Expansion changes a mapped task's instance count, which invalidates the
-                    # trigger-rule upstream-count memo on this DepContext (a downstream evaluated
-                    # later in this same pass must see the post-expansion count).
-                    dep_context.invalidate_upstream_task_id_counts()
-            if new_tis is None and schedulable.state in SCHEDULEABLE_STATES:
-                # It's enough to revise map index once per task id,
-                # checking the map index for each mapped task significantly slows down scheduling
-                if schedulable.task.task_id not in revised_map_index_task_ids:
-                    revised_tis = self._revise_map_indexes_if_mapped(
-                        schedulable.task, dag_version_id=schedulable.dag_version_id, session=session
-                    )
-                    ready_tis.extend(revised_tis)
-                    revised_map_index_task_ids.add(schedulable.task.task_id)
-                    if revised_tis:
-                        # Revising a mapped task can add new instances, growing its instance count
-                        # the same way expansion does. Drop the upstream-count memo so a downstream
-                        # evaluated later in this pass recomputes it instead of reading a stale value.
-                        dep_context.invalidate_upstream_task_id_counts()
+        with start_debug_span("dagrun.resolve_dependencies") as dep_span:
+            for schedulable in itertools.chain(schedulable_tis, additional_tis):
+                with start_debug_span("dagrun.resolve_dependencies_for_ti") as schedulable_span:
+                    if TYPE_CHECKING:
+                        assert isinstance(schedulable.task, Operator)
+                    schedulable_span.set_attribute("airflow.ti.task_id", schedulable.task.task_id)
+                    schedulable_span.set_attribute("airflow.ti.map_index", schedulable.map_index)
+                    old_state = schedulable.state
+                    if not schedulable.are_dependencies_met(session=session, dep_context=dep_context):
+                        old_states[schedulable.key] = old_state
+                        continue
+                    # If schedulable is not yet expanded, try doing it now. This is
+                    # called in two places: First and ideally in the mini scheduler at
+                    # the end of LocalTaskJob, and then as an "expansion of last resort"
+                    # in the scheduler to ensure that the mapped task is correctly
+                    # expanded before executed. Also see _revise_map_indexes_if_mapped
+                    # docstring for additional information.
+                    new_tis = None
+                    if schedulable.map_index < 0:
+                        new_tis = _expand_mapped_task_if_needed(schedulable)
+                        if new_tis is not None:
+                            additional_tis.extend(new_tis)
+                            expansion_happened = True
+                            # Expansion changes a mapped task's instance count, which invalidates the
+                            # trigger-rule upstream-count memo on this DepContext (a downstream evaluated
+                            # later in this same pass must see the post-expansion count).
+                            dep_context.invalidate_upstream_task_id_counts()
+                    if new_tis is None and schedulable.state in SCHEDULEABLE_STATES:
+                        # It's enough to revise map index once per task id,
+                        # checking the map index for each mapped task significantly slows down scheduling
+                        if schedulable.task.task_id not in revised_map_index_task_ids:
+                            revised_tis = self._revise_map_indexes_if_mapped(
+                                schedulable.task, dag_version_id=schedulable.dag_version_id, session=session
+                            )
+                            ready_tis.extend(revised_tis)
+                            revised_map_index_task_ids.add(schedulable.task.task_id)
+                            if revised_tis:
+                                # Revising a mapped task can add new instances, growing its instance count
+                                # the same way expansion does. Drop the upstream-count memo so a downstream
+                                # evaluated later in this pass recomputes it instead of reading a stale value.
+                                dep_context.invalidate_upstream_task_id_counts()
 
-                # _revise_map_indexes_if_mapped might mark the current task as REMOVED
-                # after calculating mapped task length, so we need to re-check
-                # the task state to ensure it's still schedulable
-                if schedulable.state in SCHEDULEABLE_STATES:
-                    ready_tis.append(schedulable)
+                        # _revise_map_indexes_if_mapped might mark the current task as REMOVED
+                        # after calculating mapped task length, so we need to re-check
+                        # the task state to ensure it's still schedulable
+                        if schedulable.state in SCHEDULEABLE_STATES:
+                            ready_tis.append(schedulable)
+            dep_span.set_attribute(
+                "airflow.dag_run.num_dep_checks", len(schedulable_tis) + len(additional_tis)
+            )
 
         # Check if any ti changed state
         tis_filter = TI.filter_for_tis(old_states)
         if tis_filter is not None:
             fresh_tis = session.scalars(select(TI).where(tis_filter)).all()
             changed_tis = any(ti.state != old_states[ti.key] for ti in fresh_tis)
+
+        trace.get_current_span().set_attribute("airflow.dag_run.num_ready_tis", len(ready_tis))
 
         return ready_tis, changed_tis, expansion_happened
 
@@ -2175,6 +2209,7 @@ class DagRun(Base, LoggingMixin):
             ).all()
         )
 
+    @start_debug_span("dagrun.schedule_tis")
     @provide_session
     def schedule_tis(
         self,
@@ -2310,6 +2345,8 @@ class DagRun(Base, LoggingMixin):
                     )
                 )
                 count += getattr(result, "rowcount", 0)
+
+        trace.get_current_span().set_attribute("airflow.dag_run.num_scheduled_tis", count)
 
         return count
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -74,6 +74,7 @@ from airflow._shared.observability.traces import (
     TASK_SPAN_DETAIL_LEVEL_KEY,
     new_dagrun_trace_carrier,
     new_task_run_carrier,
+    start_debug_span,
 )
 from airflow._shared.timezones import timezone
 from airflow.assets.manager import asset_manager
@@ -2135,13 +2136,18 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         return session.scalar(stmt) or 0
 
     @staticmethod
+    @start_debug_span("taskinstance.filter_for_tis")
     def filter_for_tis(tis: Iterable[TaskInstance | TaskInstanceKey]) -> ColumnElement[bool] | None:
         """Return SQLAlchemy filter to query selected task instances."""
         # DictKeys type, (what we often pass here from the scheduler) is not directly indexable :(
         # Or it might be a generator, but we need to be able to iterate over it more than once
         tis = list(tis)
 
+        filter_tis_span = trace.get_current_span()
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_tis", len(tis))
+
         if not tis:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "empty")
             return None
 
         first = tis[0]
@@ -2159,9 +2165,15 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             map_indices.add(t.map_index)
             task_ids.add(t.task_id)
 
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_dag_ids", len(dag_ids))
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_run_ids", len(run_ids))
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_task_ids", len(task_ids))
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_map_indices", len(map_indices))
+
         # Common path optimisations: when all TIs are for the same dag_id and run_id, or same dag_id
         # and task_id -- this can be over 150x faster for huge numbers of TIs (20k+)
         if dag_ids == {dag_id} and run_ids == {run_id} and map_indices == {map_index}:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "same_dag_run_map")
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id == run_id,
@@ -2169,6 +2181,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 TaskInstance.task_id.in_(task_ids),
             )
         if dag_ids == {dag_id} and task_ids == {first_task_id} and map_indices == {map_index}:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "same_dag_task_map")
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id.in_(run_ids),
@@ -2176,6 +2189,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 TaskInstance.task_id == first_task_id,
             )
         if dag_ids == {dag_id} and run_ids == {run_id} and task_ids == {first_task_id}:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "same_dag_run_task")
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id == run_id,
@@ -2220,6 +2234,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                         )
                     )
 
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "grouped")
         return or_(*filter_condition)
 
     @classmethod

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -74,6 +74,7 @@ from airflow._shared.observability.traces import (
     TASK_SPAN_DETAIL_LEVEL_KEY,
     new_dagrun_trace_carrier,
     new_task_run_carrier,
+    start_debug_span,
 )
 from airflow._shared.timezones import timezone
 from airflow.assets.manager import asset_manager
@@ -2143,13 +2144,18 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
         return session.scalar(stmt) or 0
 
     @staticmethod
+    @start_debug_span("taskinstance.filter_for_tis")
     def filter_for_tis(tis: Iterable[TaskInstance | TaskInstanceKey]) -> ColumnElement[bool] | None:
         """Return SQLAlchemy filter to query selected task instances."""
         # DictKeys type, (what we often pass here from the scheduler) is not directly indexable :(
         # Or it might be a generator, but we need to be able to iterate over it more than once
         tis = list(tis)
 
+        filter_tis_span = trace.get_current_span()
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_tis", len(tis))
+
         if not tis:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "empty")
             return None
 
         first = tis[0]
@@ -2167,9 +2173,15 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             map_indices.add(t.map_index)
             task_ids.add(t.task_id)
 
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_dag_ids", len(dag_ids))
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_run_ids", len(run_ids))
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_task_ids", len(task_ids))
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.num_map_indices", len(map_indices))
+
         # Common path optimisations: when all TIs are for the same dag_id and run_id, or same dag_id
         # and task_id -- this can be over 150x faster for huge numbers of TIs (20k+)
         if dag_ids == {dag_id} and run_ids == {run_id} and map_indices == {map_index}:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "same_dag_run_map")
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id == run_id,
@@ -2177,6 +2189,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 TaskInstance.task_id.in_(task_ids),
             )
         if dag_ids == {dag_id} and task_ids == {first_task_id} and map_indices == {map_index}:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "same_dag_task_map")
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id.in_(run_ids),
@@ -2184,6 +2197,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                 TaskInstance.task_id == first_task_id,
             )
         if dag_ids == {dag_id} and run_ids == {run_id} and task_ids == {first_task_id}:
+            filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "same_dag_run_task")
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id == run_id,
@@ -2228,6 +2242,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
                         )
                     )
 
+        filter_tis_span.set_attribute("airflow.taskinstance.filter_for_tis.result", "grouped")
         return or_(*filter_condition)
 
     @classmethod

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -816,6 +816,13 @@ def initialize():
     import_local_settings()
     configure_logging()
     configure_otel(conf)
+    # configure_otel configures only the airflow-core copy of the symlinked shared traces
+    # module. Set the resolved flag in the task-sdk copy that providers import.
+    from airflow._shared.observability import traces as _core_traces
+    from airflow.sdk._shared.observability.traces import set_debug_traces_enabled
+
+    debug_traces_on = _core_traces._otel_debug_traces_on
+    set_debug_traces_enabled(debug_traces_on)
     configure_adapters()
     # The webservers import this file from models.py with the default settings.
 

--- a/airflow-core/src/airflow/settings.py
+++ b/airflow-core/src/airflow/settings.py
@@ -815,6 +815,13 @@ def initialize():
     import_local_settings()
     configure_logging()
     configure_otel(conf)
+    # configure_otel configures only the airflow-core copy of the symlinked shared traces
+    # module. Set the resolved flag in the task-sdk copy that providers import.
+    from airflow._shared.observability import traces as _core_traces
+    from airflow.sdk._shared.observability.traces import set_debug_traces_enabled
+
+    debug_traces_on = _core_traces._otel_debug_traces_on
+    set_debug_traces_enabled(debug_traces_on)
     configure_adapters()
     # The webservers import this file from models.py with the default settings.
 

--- a/airflow-core/tests/integration/otel/dags/demo_dag.py
+++ b/airflow-core/tests/integration/otel/dags/demo_dag.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from airflow import DAG
+from airflow.sdk import task
+
+logger = logging.getLogger("airflow.demo_dag")
+
+args = {
+    "owner": "airflow",
+    "start_date": datetime(2024, 9, 1),
+    "retries": 0,
+}
+
+
+@task
+def task1():
+    logger.info("task1 running")
+
+
+@task
+def task2():
+    logger.info("task2 running")
+
+
+@task
+def task3():
+    logger.info("task3 running")
+
+
+@task
+def task4():
+    logger.info("task4 running")
+
+
+@task
+def task5():
+    logger.info("task5 running")
+
+
+with DAG(
+    "demo_dag",
+    default_args=args,
+    schedule=None,
+    catchup=False,
+) as dag:
+    t1 = task1()
+    t2 = task2()
+    t3 = task3()
+    t4 = task4()
+    t5 = task5()
+
+    # task1 and task2 fan out in parallel, task3 joins on both,
+    # then task4 and task5 fan out in parallel.
+    [t1, t2] >> t3 >> [t4, t5]

--- a/airflow-core/tests/integration/otel/test_otel.py
+++ b/airflow-core/tests/integration/otel/test_otel.py
@@ -38,9 +38,10 @@ from tests_common.test_utils.integration_setup import (
     unpause_trigger_dag_and_get_run_id,
     wait_for_dag_run,
 )
-from tests_common.test_utils.otel_utils import (
-    dump_airflow_metadata_db,
-    extract_metrics_from_output,
+from tests_common.test_utils.otel_console_utils import extract_metrics_from_output
+from tests_common.test_utils.otel_jaeger_utils import (
+    get_span_tags,
+    provided_child_spans_found_under_span,
 )
 
 if TYPE_CHECKING:
@@ -109,6 +110,20 @@ def print_ti_output_for_dag_run(dag_id: str, run_id: str):
                     log.error("Could not read %s: %s", full_path, e)
 
                 print("\n===== END =====\n")
+
+
+def get_non_idle_loop_trace(all_traces: list[dict]) -> dict | None:
+    for trace in all_traces:
+        scheduler_loop_span = next(
+            (s for s in trace["spans"] if s["operationName"] == "scheduler.scheduler_loop"),
+            None,
+        )
+        if scheduler_loop_span is None:
+            continue
+        # A non-idle scheduler_loop span means this iteration actually scheduled something.
+        if get_span_tags(scheduler_loop_span).get("airflow.scheduler.loop_iteration.idle") is False:
+            return trace
+    return None
 
 
 @pytest.mark.integration("otel")
@@ -183,7 +198,7 @@ class TestOtelIntegration:
         migrate_command = ["airflow", "db", "migrate"]
         subprocess.run(migrate_command, check=True, env=os.environ.copy())
 
-        cls.dags = serialize_and_get_dags(dag_folder=cls.dag_folder)
+        cls.dags = serialize_and_get_dags(dag_folder=cls.dag_folder, num_of_dags=2)
 
     def dag_execution_for_testing_metrics(self, capfd):
         # Metrics.
@@ -388,10 +403,6 @@ class TestOtelIntegration:
 
             print_ti_output_for_dag_run(dag_id=dag_id, run_id=run_id)
         finally:
-            if self.log_level == "debug":
-                with create_session() as session:
-                    dump_airflow_metadata_db(session)
-
             # Terminate the processes.
             terminate_process(scheduler_process)
             scheduler_status = scheduler_process.poll()
@@ -440,3 +451,70 @@ class TestOtelIntegration:
 
         nested = get_span_hierarchy()
         assert nested == expected_hierarchy
+
+    @pytest.mark.execution_timeout(160)
+    def test_scheduler_debug_traces(self, capfd):
+        # Enable debug traces.
+        os.environ["AIRFLOW__TRACES__OTEL_DEBUG_TRACES_ON"] = "True"
+
+        scheduler_process = None
+        apiserver_process = None
+        try:
+            # Start the processes here and not as fixtures or in a common setup,
+            # so that the test can capture their output.
+            scheduler_process, apiserver_process = start_scheduler()
+
+            dag_id = "demo_dag"
+
+            assert len(self.dags) > 0
+            dag = self.dags[dag_id]
+
+            assert dag is not None
+
+            conf = None
+
+            run_id_1 = unpause_trigger_dag_and_get_run_id(dag_id=dag_id, conf=conf)
+            run_id_2 = unpause_trigger_dag_and_get_run_id(dag_id=dag_id, conf=conf)
+
+            wait_for_dag_run(dag_id=dag_id, run_id=run_id_1, max_wait_time=90)
+            wait_for_dag_run(dag_id=dag_id, run_id=run_id_2, max_wait_time=90)
+
+            time.sleep(10)
+
+            print_ti_output_for_dag_run(dag_id=dag_id, run_id=run_id_1)
+            print_ti_output_for_dag_run(dag_id=dag_id, run_id=run_id_2)
+        finally:
+            # Terminate the processes.
+            terminate_process(scheduler_process)
+            scheduler_status = scheduler_process.poll()
+            assert scheduler_status is not None, (
+                "The scheduler_1 process status is None, which means that it hasn't terminated as expected."
+            )
+
+            terminate_process(apiserver_process)
+            apiserver_status = apiserver_process.poll()
+            assert apiserver_status is not None, (
+                "The apiserver process status is None, which means that it hasn't terminated as expected."
+            )
+
+        capfd.readouterr()
+
+        host = "jaeger"
+        service_name = os.environ.get("OTEL_SERVICE_NAME", "test")
+        r = requests.get(f"http://{host}:16686/api/traces?service={service_name}")
+        traces = r.json()["data"]
+
+        # There are spans that don't get exported on every loop iteration. The ones below
+        # reliably re-appear every time that the loop does some work.
+        expected_children_spans = [
+            "scheduler._do_scheduling",
+            "scheduler.critical_section",
+            "scheduler._process_executor_events",
+        ]
+
+        non_idle_trace = get_non_idle_loop_trace(traces)
+        assert non_idle_trace is not None, "expected at least one non-idle scheduler_loop span"
+
+        assert provided_child_spans_found_under_span(
+            non_idle_trace, "scheduler.scheduler_loop", expected_children_spans
+        ), f"expected {expected_children_spans} as descendants of scheduler.scheduler_loop"

--- a/devel-common/src/tests_common/test_utils/integration_setup.py
+++ b/devel-common/src/tests_common/test_utils/integration_setup.py
@@ -109,12 +109,16 @@ def start_scheduler(capture_output: bool = False):
     return scheduler_process, apiserver_process
 
 
-def serialize_and_get_dags(dag_folder) -> dict[str, SerializedDAG]:
+def serialize_and_get_dags(dag_folder: str, num_of_dags: int | None = None) -> dict[str, SerializedDAG]:
     log.info("Serializing Dags from directory %s", dag_folder)
     # Load DAGs from the dag directory.
     dag_bag = DagBag(dag_folder=dag_folder)
 
     dag_ids = dag_bag.dag_ids
+    if num_of_dags is None:
+        assert len(dag_ids) > 0
+    else:
+        assert len(dag_ids) == num_of_dags
 
     dag_dict: dict[str, SerializedDAG] = {}
     with create_session() as session:

--- a/devel-common/src/tests_common/test_utils/otel_console_utils.py
+++ b/devel-common/src/tests_common/test_utils/otel_console_utils.py
@@ -14,47 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Helpers for spans and metrics captured from the OTel console (stdout) exporter."""
+
 from __future__ import annotations
 
 import json
 import logging
-import pprint
 from collections import defaultdict
 from typing import Literal
 
-from sqlalchemy import inspect, select
-
-log = logging.getLogger("integration.otel.otel_utils")
-
-
-def dump_airflow_metadata_db(session):
-    from airflow.models import Base
-
-    inspector = inspect(session.bind)
-    all_tables = inspector.get_table_names()
-
-    # dump with the entire db
-    db_dump = {}
-
-    log.debug("\n-----START_airflow_db_dump-----\n")
-
-    for table_name in all_tables:
-        log.debug("\nDumping table: %s", table_name)
-        table = Base.metadata.tables.get(table_name)
-        if table is not None:
-            results = [dict(row._mapping) for row in session.execute(select(table)).all()]
-            db_dump[table_name] = results
-            # Pretty-print the table contents
-            if table_name == "connection":
-                filtered_results = [row for row in results if row.get("conn_id") == "airflow_db"]
-                pprint.pprint({table_name: filtered_results}, width=120)
-            else:
-                pprint.pprint({table_name: results}, width=120)
-        else:
-            log.debug("Table %s not found in metadata.", table_name)
-
-    log.debug("\nAirflow metadata database dump complete.")
-    log.debug("\n-----END_airflow_db_dump-----\n")
+log = logging.getLogger("integration.otel.otel_console_utils")
 
 
 def extract_task_event_value(line: str) -> str:

--- a/devel-common/src/tests_common/test_utils/otel_jaeger_utils.py
+++ b/devel-common/src/tests_common/test_utils/otel_jaeger_utils.py
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Helpers for spans fetched from the Jaeger REST API."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+def get_span_tags(span: dict) -> dict:
+    return {t["key"]: t["value"] for t in span.get("tags", [])}
+
+
+def get_parent_span_id(span: dict) -> str | None:
+    """Return the spanID of the span's CHILD_OF parent, or None if it has no parent."""
+    # Example:
+    #
+    # 'references': [{
+    #       'refType': 'CHILD_OF',
+    #       'traceID': 'f94df3c57603264e8247844c6c95d115',
+    #       'spanID': '16737863fd381188'
+    # }]
+    for ref in span.get("references", []):
+        if ref["refType"] == "CHILD_OF":
+            return ref["spanID"]
+    return None
+
+
+def get_descendant_span_names(parent_children_map: dict[str, list[dict]], span_id: str) -> set[str]:
+    """Recursively collect the operationNames of every span below span_id."""
+    names = set()
+    for child in parent_children_map.get(span_id, []):
+        names.add(child["operationName"])
+        names |= get_descendant_span_names(parent_children_map, child["spanID"])
+    return names
+
+
+def provided_child_spans_found_under_span(trace: dict, span_name: str, child_span_names: list[str]) -> bool:
+    """Return whether every child span appears in a Jaeger trace as a descendant of a given span_name."""
+    # Dictionary of every span id, mapped to its direct children spans for the provided trace.
+    parent_children_map: dict[str, list[dict]] = defaultdict(list)
+    parent_span_id = None
+    for span in trace["spans"]:
+        span_parent_id = get_parent_span_id(span)
+        if span_parent_id is not None:
+            parent_children_map[span_parent_id].append(span)
+        if span["operationName"] == span_name:
+            parent_span_id = span["spanID"]
+
+    if parent_span_id is None:
+        return False
+
+    descendant_names = get_descendant_span_names(parent_children_map, parent_span_id)
+    return all(name in descendant_names for name in child_span_names)

--- a/generated/known_sdk_imports_in_core.txt
+++ b/generated/known_sdk_imports_in_core.txt
@@ -31,7 +31,7 @@ airflow-core/src/airflow/serialization/definitions/mappedoperator.py::5
 airflow-core/src/airflow/serialization/encoders.py::11
 airflow-core/src/airflow/serialization/serialized_objects.py::17
 airflow-core/src/airflow/serialization/stub_arg_bindings.py::5
-airflow-core/src/airflow/settings.py::1
+airflow-core/src/airflow/settings.py::2
 airflow-core/src/airflow/stats.py::1
 airflow-core/src/airflow/timetables/simple.py::1
 airflow-core/src/airflow/triggers/base.py::3

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/aws_lambda/lambda_executor.py
@@ -46,6 +46,19 @@ from airflow.providers.amazon.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_
 from airflow.providers.common.compat.sdk import AirflowException, Stats, timezone
 from airflow.utils.helpers import prune_dict
 
+try:
+    from airflow.sdk._shared.observability.traces import start_debug_span
+except ImportError:
+
+    def start_debug_span(name, **_kwargs):
+        """No-op fallback so executor code can decorate methods unconditionally."""
+
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -242,6 +255,7 @@ class AwsLambdaExecutor(BaseExecutor):
             return
         raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
+    @start_debug_span("lambda_executor._process_workloads")
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         from airflow.executors import workloads
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/batch/batch_executor.py
@@ -59,6 +59,19 @@ from airflow.providers.amazon.aws.executors.batch.utils import (
 )
 from airflow.utils.state import State
 
+try:
+    from airflow.sdk._shared.observability.traces import start_debug_span
+except ImportError:
+
+    def start_debug_span(name, **_kwargs):
+        """No-op fallback so executor code can decorate methods unconditionally."""
+
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
 CommandType = Sequence[str]
 ExecutorConfigType = dict[str, Any]
 
@@ -143,6 +156,7 @@ class AwsBatchExecutor(BaseExecutor):
             return
         raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
+    @start_debug_span("batch_executor._process_workloads")
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         from airflow.executors import workloads
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/executors/ecs/ecs_executor.py
@@ -53,6 +53,19 @@ from airflow.providers.common.compat.sdk import AirflowException, Stats, timezon
 from airflow.utils.helpers import merge_dicts, prune_dict
 from airflow.utils.state import State
 
+try:
+    from airflow.sdk._shared.observability.traces import start_debug_span
+except ImportError:
+
+    def start_debug_span(name, **_kwargs):
+        """No-op fallback so executor code can decorate methods unconditionally."""
+
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
@@ -159,6 +172,7 @@ class AwsEcsExecutor(BaseExecutor):
             return
         raise RuntimeError(f"{type(self)} cannot handle workloads of type {type(workload)}")
 
+    @start_debug_span("ecs_executor._process_workloads")
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         """:sphinx-autoapi-skip:."""
         from airflow.executors import workloads

--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor.py
@@ -47,6 +47,19 @@ from airflow.providers.common.compat.sdk import AirflowTaskTimeout, Stats
 from airflow.utils.helpers import prune_dict
 from airflow.utils.state import TaskInstanceState
 
+try:
+    from airflow.sdk._shared.observability.traces import start_debug_span
+except ImportError:
+
+    def start_debug_span(name, **_kwargs):
+        """No-op fallback so executor code can decorate methods unconditionally."""
+
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
 log = logging.getLogger(__name__)
 
 
@@ -174,6 +187,7 @@ class CeleryExecutor(BaseExecutor):
 
         self._send_workloads(task_tuples_to_send)
 
+    @start_debug_span("celery_executor._process_workloads")
     def _process_workloads(self, workload_items: Sequence[workloads.All]) -> None:
         # Airflow V3 version -- have to delay imports until we know we are on v3.
         from airflow.executors.workloads import ExecuteTask

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -66,6 +66,19 @@ from airflow.utils.log.logging_mixin import remove_escape_codes
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import TaskInstanceState
 
+try:
+    from airflow.sdk._shared.observability.traces import start_debug_span
+except ImportError:
+
+    def start_debug_span(name, **_kwargs):
+        """No-op fallback so executor code can decorate methods unconditionally."""
+
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from multiprocessing.managers import SyncManager
@@ -380,6 +393,7 @@ class KubernetesExecutor(BaseExecutor):
         ti = workload.ti
         self.queued_tasks[ti.key] = workload
 
+    @start_debug_span("kubernetes_executor._process_workloads")
     def _process_workloads(self, workloads: Sequence[workloads.All]) -> None:
         from airflow.executors.workloads import ExecuteTask
 

--- a/shared/observability/src/airflow_shared/observability/traces/__init__.py
+++ b/shared/observability/src/airflow_shared/observability/traces/__init__.py
@@ -29,13 +29,32 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.sdk.trace.sampling import Decision
-from opentelemetry.trace import NonRecordingSpan, Span, SpanContext, TraceFlags, TraceState
+from opentelemetry.trace import INVALID_SPAN, NonRecordingSpan, Span, SpanContext, TraceFlags, TraceState
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from configparser import ConfigParser
 log = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
+
+_otel_debug_traces_on = False
+
+
+@contextmanager
+def start_debug_span(name: str, **kwargs) -> Iterator[Span]:
+    """
+    Start a current span if the ``[traces] otel_debug_traces_on`` flag is enabled.
+
+    Usable as a context manager or as a decorator.
+    When the flag is disabled, a non-recording span is yielded.
+    """
+    if not _otel_debug_traces_on:
+        yield INVALID_SPAN
+        return
+    with tracer.start_as_current_span(name, **kwargs) as span:
+        yield span
+
 
 OVERRIDE_SPAN_ID_KEY = context.create_key("override_span_id")
 OVERRIDE_TRACE_ID_KEY = context.create_key("override_trace_id")
@@ -248,10 +267,20 @@ def _load_exporter_from_env() -> SpanExporter:
     return ep.load()()
 
 
+def set_debug_traces_enabled(enabled: bool) -> None:
+    """Set the debug-traces flag on this module instance."""
+    global _otel_debug_traces_on
+    _otel_debug_traces_on = enabled
+
+
 def configure_otel(conf: ConfigParser):
+    global _otel_debug_traces_on
+
     otel_on = conf.getboolean("traces", "otel_on", fallback=False)
     if not otel_on:
         return
+
+    _otel_debug_traces_on = conf.getboolean("traces", "otel_debug_traces_on", fallback=False)
 
     # ideally both endpoint and resource are None here
     # they would only be something other than None if user is using deprecated

--- a/shared/observability/tests/observability/test_otel_console_utils.py
+++ b/shared/observability/tests/observability/test_otel_console_utils.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from tests_common.test_utils.otel_utils import (
+from tests_common.test_utils.otel_console_utils import (
     clean_task_lines,
     extract_metrics_from_output,
     extract_spans_from_output,
@@ -26,7 +26,7 @@ from tests_common.test_utils.otel_utils import (
 )
 
 
-class TestUtilsUnit:
+class TestConsoleUtilsUnit:
     # The method that extracts the spans from the output,
     # counts that there is no indentation on the cli, when a span starts and finishes.
     example_output = """

--- a/shared/observability/tests/observability/test_otel_jaeger_utils.py
+++ b/shared/observability/tests/observability/test_otel_jaeger_utils.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from tests_common.test_utils.otel_jaeger_utils import (
+    get_descendant_span_names,
+    get_parent_span_id,
+    get_span_tags,
+    provided_child_spans_found_under_span,
+)
+
+# A Jaeger trace with the following span hierarchy:
+#
+# scheduler.scheduler_loop
+# ├── scheduler._do_scheduling
+# │   └── scheduler.critical_section
+# └── scheduler._process_executor_events
+LOOP_SPAN = {
+    "spanID": "loop",
+    "operationName": "scheduler.scheduler_loop",
+    "references": [],
+    "tags": [
+        {"key": "airflow.scheduler.loop_iteration.idle", "type": "bool", "value": False},
+        {"key": "airflow.category", "type": "string", "value": "scheduler"},
+    ],
+}
+DO_SCHEDULING_SPAN = {
+    "spanID": "do_scheduling",
+    "operationName": "scheduler._do_scheduling",
+    "references": [{"refType": "CHILD_OF", "traceID": "trace-1", "spanID": "loop"}],
+    "tags": [],
+}
+CRITICAL_SECTION_SPAN = {
+    "spanID": "critical_section",
+    "operationName": "scheduler.critical_section",
+    "references": [{"refType": "CHILD_OF", "traceID": "trace-1", "spanID": "do_scheduling"}],
+    "tags": [],
+}
+PROCESS_EVENTS_SPAN = {
+    "spanID": "process_events",
+    "operationName": "scheduler._process_executor_events",
+    "references": [{"refType": "CHILD_OF", "traceID": "trace-1", "spanID": "loop"}],
+    "tags": [],
+}
+
+TRACE = {
+    "traceID": "trace-1",
+    "spans": [LOOP_SPAN, DO_SCHEDULING_SPAN, CRITICAL_SECTION_SPAN, PROCESS_EVENTS_SPAN],
+}
+
+PARENT_CHILDREN_MAP = {
+    "loop": [DO_SCHEDULING_SPAN, PROCESS_EVENTS_SPAN],
+    "do_scheduling": [CRITICAL_SECTION_SPAN],
+}
+
+
+class TestJaegerUtilsUnit:
+    def test_get_span_tags(self):
+        assert get_span_tags(LOOP_SPAN) == {
+            "airflow.scheduler.loop_iteration.idle": False,
+            "airflow.category": "scheduler",
+        }
+
+    @pytest.mark.parametrize(
+        "span",
+        [
+            pytest.param({"tags": []}, id="empty-tags"),
+            pytest.param({}, id="missing-tags-key"),
+        ],
+    )
+    def test_get_span_tags_without_tags(self, span: dict):
+        assert get_span_tags(span) == {}
+
+    @pytest.mark.parametrize(
+        ("span", "expected_parent_id"),
+        [
+            pytest.param(DO_SCHEDULING_SPAN, "loop", id="direct-child"),
+            pytest.param(CRITICAL_SECTION_SPAN, "do_scheduling", id="child-of-intermediate-span"),
+            pytest.param(LOOP_SPAN, None, id="root-span-empty-references"),
+            pytest.param({"operationName": "test"}, None, id="missing-references-key"),
+            pytest.param(
+                {"references": [{"refType": "FOLLOWS_FROM", "spanID": "other"}]},
+                None,
+                id="non-child-of-ref-type",
+            ),
+        ],
+    )
+    def test_get_parent_span_id(self, span: dict, expected_parent_id: str):
+        assert get_parent_span_id(span) == expected_parent_id
+
+    @pytest.mark.parametrize(
+        ("span_id", "expected_names"),
+        [
+            pytest.param(
+                "loop",
+                {
+                    "scheduler._do_scheduling",
+                    "scheduler.critical_section",
+                    "scheduler._process_executor_events",
+                },
+                id="root-collects-all-even-nested",
+            ),
+            pytest.param("do_scheduling", {"scheduler.critical_section"}, id="intermediate-node"),
+            pytest.param("critical_section", set(), id="leaf-has-no-descendants"),
+            pytest.param("unknown", set(), id="unknown-span-id"),
+        ],
+    )
+    def test_get_descendant_span_names(self, span_id: str, expected_names: set):
+        assert get_descendant_span_names(PARENT_CHILDREN_MAP, span_id) == expected_names
+
+    @pytest.mark.parametrize(
+        ("span_name", "child_span_names", "expected_bool_result"),
+        [
+            pytest.param(
+                "scheduler.scheduler_loop",
+                ["scheduler._do_scheduling", "scheduler._process_executor_events"],
+                True,
+                id="all-direct-children-present",
+            ),
+            pytest.param(
+                "scheduler.scheduler_loop",
+                ["scheduler.critical_section"],
+                True,
+                id="nested-descendant-present",
+            ),
+            pytest.param(
+                "scheduler.scheduler_loop",
+                ["scheduler._do_scheduling", "scheduler.unknown_span"],
+                False,
+                id="unknown-child-span",
+            ),
+            pytest.param(
+                "scheduler.unknown_span",
+                ["scheduler._do_scheduling"],
+                False,
+                id="unknown-parent-span",
+            ),
+            pytest.param(
+                "scheduler._do_scheduling",
+                ["scheduler.critical_section"],
+                True,
+                id="descendant-under-intermediate-span",
+            ),
+            pytest.param(
+                "scheduler._do_scheduling",
+                ["scheduler._process_executor_events"],
+                False,
+                id="sibling-is-not-a-descendant",
+            ),
+        ],
+    )
+    def test_provided_child_spans_found_under_span(
+        self, span_name: str, child_span_names: list, expected_bool_result
+    ):
+        assert (
+            provided_child_spans_found_under_span(TRACE, span_name, child_span_names) is expected_bool_result
+        )

--- a/shared/observability/tests/observability/test_traces.py
+++ b/shared/observability/tests/observability/test_traces.py
@@ -20,21 +20,25 @@ from __future__ import annotations
 import pytest
 from opentelemetry import context, trace
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import (
     ALWAYS_OFF,
     ALWAYS_ON,
     ParentBased,
     TraceIdRatioBased,
 )
-from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
+from opentelemetry.trace import INVALID_SPAN, NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
+from airflow_shared.observability import traces
 from airflow_shared.observability.traces import (
     DEFAULT_TASK_SPAN_DETAIL_LEVEL,
     TASK_SPAN_DETAIL_LEVEL_KEY,
     build_trace_state_entries,
     get_task_span_detail_level,
     new_dagrun_trace_carrier,
+    start_debug_span,
 )
 
 
@@ -360,3 +364,86 @@ class TestGetTaskSpanDetailLevel:
 
         span = trace.get_current_span(ctx)
         assert get_task_span_detail_level(span) == 3
+
+
+@pytest.fixture
+def set_debug_flag(monkeypatch):
+    """Set the module-level debug flag; monkeypatch restores it on teardown."""
+
+    def _set(value: bool):
+        monkeypatch.setattr(traces, "_otel_debug_traces_on", value)
+
+    return _set
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """Use an in memory exporter and patch the module tracer to use it."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(traces, "tracer", provider.get_tracer(__name__))
+    return exporter
+
+
+class TestStartDebugSpan:
+    @pytest.mark.parametrize(
+        ("debug_flag_val", "expected_span_num"),
+        [
+            pytest.param(True, 1, id="flag_enabled"),
+            pytest.param(False, 0, id="flag_disabled"),
+        ],
+    )
+    def test_start_debug_span_context_manager(
+        self, debug_flag_val: bool, expected_span_num: int, set_debug_flag, in_memory_exporter
+    ):
+        set_debug_flag(debug_flag_val)
+        span_name = "ctx_mgr_test_span"
+
+        # If the flag is enabled, then the span will be recording, else it won't be.
+        is_recording = debug_flag_val
+
+        with start_debug_span("ctx_mgr_test_span") as span:
+            if expected_span_num > 0:
+                expected_span = trace.get_current_span()
+            else:
+                expected_span = INVALID_SPAN
+            assert span.is_recording() is is_recording
+            assert span is expected_span
+            # If the span is non-recording, enriching it is a safe no-op
+            span.set_attribute("a", 1)
+
+        finished_spans = in_memory_exporter.get_finished_spans()
+
+        assert len(finished_spans) == expected_span_num
+        if expected_span_num > 0:
+            assert finished_spans[0].name == span_name
+            assert finished_spans[0].attributes["a"] == 1
+
+    @pytest.mark.parametrize(
+        ("debug_flag_val", "expected_span_num"),
+        [
+            pytest.param(True, 1, id="flag_enabled"),
+            pytest.param(False, 0, id="flag_disabled"),
+        ],
+    )
+    def test_start_debug_span_decorator(
+        self, debug_flag_val: bool, expected_span_num: int, set_debug_flag, in_memory_exporter
+    ):
+        span_name = "decorator_test_span"
+
+        @start_debug_span(span_name)
+        def double(x):
+            trace.get_current_span().set_attribute("a", 1)
+            return x * 2
+
+        set_debug_flag(debug_flag_val)
+
+        assert double(2) == 4
+
+        finished_spans = in_memory_exporter.get_finished_spans()
+
+        assert len(finished_spans) == expected_span_num
+        if expected_span_num > 0:
+            assert finished_spans[0].name == span_name
+            assert finished_spans[0].attributes["a"] == 1


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

This patch is adding a trace for every iteration of the scheduler loop and debug spans around all the major steps and queries.

## Context

There is a config option for exporting debug traces. 

https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/config_templates/config.yml#L1504-L1513

We used to export random spans for multiple methods of the scheduler but these spans were never grouped together under a common trace and also didn't have any meaningful attributes. They were providing little to no benefit while they were actually adding more noise. Eventually, all such spans were removed and the config option was deprecated as unused but kept around in case we wanted to try a different approach in the future.

So far we only have traces for dag_runs but there are some operations across the project that are worth tracking with spans. The spans could help us pin-point the root cause of performance issues and come up with appropriate solutions.

There have been a lot of discussions around scheduler performance, task starvation, etc. with no solid way of consistently reproducing the issues or identifying the exact pain points. The spans added in this patch could be a good 1st step towards improving the scheduler.

In the future, we could also add debug spans for the dag_processor or the triggerer or operations in the task-sdk.

## Current changes + examples

I've added a new function with a `start_as_current_span` call guarded by the debug traces flag so that we can enable and disable the new traces (disabled by default).

The parent span for each iteration always starts as a root span and it has an attribute `airflow.scheduler.loop_iteration.idle` which can help us distinguish the iterations that actually did some work. We can use it to filter the spans and find the interesting ones.

<img width="1070" height="1484" alt="image" src="https://github.com/user-attachments/assets/2ba2a9aa-06ea-4d77-bd35-da312d85e3ee" />

Then we can sort by the longest first and start examining them

<img width="4080" height="2330" alt="image" src="https://github.com/user-attachments/assets/7417e597-de48-48a5-9446-671eb78e97ad" />

Not all iteration traces look the same. In the above example, this is the longest

<img width="4094" height="2268" alt="image" src="https://github.com/user-attachments/assets/46441e46-2278-49c2-8b68-e29b6b2ca10f" />

<img width="4078" height="2332" alt="image" src="https://github.com/user-attachments/assets/ae7c5a63-1879-419d-b869-c22d21c82bfa" />

2nd longest

<img width="4086" height="2324" alt="image" src="https://github.com/user-attachments/assets/7a017de5-3844-427e-a533-57bce2299273" />

<img width="4072" height="2338" alt="image" src="https://github.com/user-attachments/assets/e7836d20-36c0-4db4-baa5-2820f2bbe026" />

3rd longest

<img width="4082" height="2342" alt="image" src="https://github.com/user-attachments/assets/8a4568f2-bf24-4ad1-9e82-62fbd6031824" />

<img width="4082" height="2342" alt="image" src="https://github.com/user-attachments/assets/e46f57ad-a8d4-4c9d-86d6-eb206bca4171" />

And we are also exposing various internal values. I've only added attributes that are available at the moment of the span and avoided doing any calculations that will add more load to the system.

<img width="4042" height="2268" alt="image" src="https://github.com/user-attachments/assets/aa2746da-5f6f-4b6f-aa68-ffd2028af577" />

<img width="4068" height="2322" alt="image" src="https://github.com/user-attachments/assets/b4a3d951-a89c-4367-92a9-78bcfd435bb5" />

## Testing

Apart from manual testing, I've added unit tests for the new `start_debug_span` function and an integration test that checks for certain spans that we can expect to consistently appear in every iteration.


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Claude-code Opus 4.8

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
