### PR TITLE
Clarify the dags reserialize command scope

### DIFF
--- a/airflow-core/docs/howto/usage-cli.rst
+++ b/airflow-core/docs/howto/usage-cli.rst
@@ -334,6 +334,22 @@ For a mapping between Airflow version and Alembic revision see :doc:`/migrations
     It's highly recommended that you reserialize your Dags with ``dags reserialize`` after you finish downgrading your Airflow environment (meaning, after you've downgraded the Airflow version installed in your Python environment, not immediately after you've downgraded the database).
     This is to ensure that the serialized Dags are compatible with the downgraded version of Airflow.
 
+.. _cli-reserialize-dags:
+
+Reserializing Dags
+------------------
+
+The ``dags reserialize`` command parses the Dag files visible to it and updates their
+serialized representation in the metadata database. It is a maintenance command, useful
+for example to refresh serialized Dags after upgrading or downgrading Airflow.
+
+.. note::
+
+    ``airflow dags reserialize`` serializes the Dag files visible to the process
+    running it. It does not deploy or synchronize Dag source files, and does not
+    replace normal Dag Processor bundle refreshes. In a distributed deployment,
+    run it from an environment that sees the same Dag bundle contents as the Dag Processor.
+
 .. _cli-export-connections:
 
 Exporting Connections

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1420,6 +1420,7 @@ reqs
 requeue
 requeued
 reserialize
+Reserializing
 resetdb
 resizable
 ResourceRequirements


### PR DESCRIPTION
Clarify that `airflow dags reserialize` only serializes the Dag bundle source visible to the process running the command. The documentation now explains that it does not publish Dag files or replace Dag Processor bundle refreshes in distributed deployments.

related: #48955

## How to reproduce


https://github.com/user-attachments/assets/a77410ce-9984-4593-ac80-2f8bd73568c5



---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)