### PR TITLE
Support Pydantic structured outputs in OpenAIResponseOperator

### DIFF
--- a/providers/openai/docs/operators/openai.rst
+++ b/providers/openai/docs/operators/openai.rst
@@ -58,6 +58,20 @@ specify the OpenAI connection to use, and ``response_kwargs`` to pass through op
     :start-after: [START howto_operator_openai_response]
     :end-before: [END howto_operator_openai_response]
 
+Structured outputs (Pydantic models)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To request a structured response, pass a Pydantic ``BaseModel`` subclass as ``text_format``. The
+operator then calls the Responses API's structured-output path (``responses.parse``) and returns
+the parsed model as a ``dict`` (via ``model_dump()``), which is safe to push to XCom. This requires
+a model that supports structured outputs (``gpt-4o-2024-08-06`` or later). If the model refuses or
+returns non-parseable content, the operator raises ``ValueError``.
+
+.. exampleinclude:: /../../openai/tests/system/openai/example_openai.py
+    :language: python
+    :start-after: [START howto_operator_openai_response_structured]
+    :end-before: [END howto_operator_openai_response_structured]
+
 Using the OpenAIHook for Responses and Conversations
 =====================================================
 

--- a/providers/openai/docs/operators/openai.rst
+++ b/providers/openai/docs/operators/openai.rst
@@ -63,9 +63,11 @@ Structured outputs (Pydantic models)
 
 To request a structured response, pass a Pydantic ``BaseModel`` subclass as ``text_format``. The
 operator then calls the Responses API's structured-output path (``responses.parse``) and returns
-the parsed model as a ``dict`` (via ``model_dump()``), which is safe to push to XCom. This requires
-a model that supports structured outputs (``gpt-4o-2024-08-06`` or later). If the model refuses or
-returns non-parseable content, the operator raises ``ValueError``.
+the parsed model as a ``dict`` (via ``model_dump(mode="json")``), which is safe to push to XCom
+regardless of the field types the model uses (enums, dates, etc. are rendered as their JSON
+representations). If the model refuses, the response is incomplete, or the returned JSON cannot
+be coerced into ``text_format``, the operator raises ``ValueError`` with the API-reported
+``status``, ``error`` and ``incomplete_details``.
 
 .. exampleinclude:: /../../openai/tests/system/openai/example_openai.py
     :language: python
@@ -78,7 +80,8 @@ Using the OpenAIHook for Responses and Conversations
 The :class:`~airflow.providers.openai.hooks.openai.OpenAIHook` exposes the Responses and
 Conversations APIs directly for use inside ``@task`` functions or custom operators:
 
-- Responses: ``create_response``, ``get_response``, ``delete_response`` and ``cancel_response``
+- Responses: ``create_response``, ``parse_response`` (structured-output wrapper),
+  ``get_response``, ``delete_response`` and ``cancel_response``
   (the last cancels a response created with ``background=True``).
 - Conversations: ``create_conversation``, ``get_conversation``, ``update_conversation`` and
   ``delete_conversation``. Pass the conversation id to ``create_response`` (via the operator's

--- a/providers/openai/docs/operators/openai.rst
+++ b/providers/openai/docs/operators/openai.rst
@@ -65,9 +65,14 @@ To request a structured response, pass a Pydantic ``BaseModel`` subclass as ``te
 operator then calls the Responses API's structured-output path (``responses.parse``) and returns
 the parsed model as a ``dict`` (via ``model_dump(mode="json")``), which is safe to push to XCom
 regardless of the field types the model uses (enums, dates, etc. are rendered as their JSON
-representations). If the model refuses, the response is incomplete, or the returned JSON cannot
-be coerced into ``text_format``, the operator raises ``ValueError`` with the API-reported
-``status``, ``error`` and ``incomplete_details``.
+representations).
+
+The operator rejects incomplete and failed responses even if the partial output happens to match
+the Pydantic model. The resulting ``ValueError`` includes the response id and available API details,
+such as ``status``, ``error``, ``incomplete_details``, refusal text, or output item types. If the SDK
+cannot parse the model output, it raises ``ValidationError`` before returning a response object; the
+operator converts that to ``ValueError`` naming the requested model and notes that reaching
+``max_output_tokens`` is a likely cause. In that case, a response id and API details are unavailable.
 
 .. exampleinclude:: /../../openai/tests/system/openai/example_openai.py
     :language: python

--- a/providers/openai/src/airflow/providers/openai/hooks/openai.py
+++ b/providers/openai/src/airflow/providers/openai/hooks/openai.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import time
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, BinaryIO, Literal
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, TypeVar
 
 from deprecated import deprecated
 from openai import OpenAI
@@ -66,6 +66,11 @@ _ASSISTANTS_DEPRECATION_REASON = (
     "Use the Responses API (create_response) and Conversations API (create_conversation) instead. "
     "See https://platform.openai.com/docs/guides/migrate-to-responses."
 )
+
+#: Generic type variable for the Pydantic model used as the ``text_format`` in structured-output
+#: Responses API calls. Mirrors the SDK's ``TextFormatT`` so ``parse_response`` returns a
+#: ``ParsedResponse[T]`` — callers get ``output_parsed`` typed as ``T | None``.
+_TextFormatT = TypeVar("_TextFormatT", bound="BaseModel")
 
 
 class BatchStatus(str, Enum):
@@ -252,10 +257,10 @@ class OpenAIHook(BaseHook):
     def parse_response(
         self,
         input: Any,
-        text_format: type[BaseModel],
+        text_format: type[_TextFormatT],
         model: str = "gpt-4o-mini",
         **kwargs: Any,
-    ) -> ParsedResponse[Any]:
+    ) -> ParsedResponse[_TextFormatT]:
         """
         Create a model response and parse it into a Pydantic model via the Responses API.
 
@@ -266,8 +271,8 @@ class OpenAIHook(BaseHook):
 
         :param input: Text, image, or file input(s) to the model.
         :param text_format: A Pydantic ``BaseModel`` subclass describing the expected
-            structured output. Requires a model that supports structured outputs
-            (``gpt-4o-2024-08-06`` and later).
+            structured output. The SDK converts it to a JSON schema and sends the
+            structured-output request.
         :param model: ID of the model to use.
         """
         return self.conn.responses.parse(input=input, model=model, text_format=text_format, **kwargs)

--- a/providers/openai/src/airflow/providers/openai/hooks/openai.py
+++ b/providers/openai/src/airflow/providers/openai/hooks/openai.py
@@ -50,8 +50,9 @@ if TYPE_CHECKING:
         ChatCompletionUserMessageParam,
     )
     from openai.types.conversations import Conversation, ConversationDeletedResource
-    from openai.types.responses import Response
+    from openai.types.responses import ParsedResponse, Response
     from openai.types.vector_stores import VectorStoreFile, VectorStoreFileBatch, VectorStoreFileDeleted
+    from pydantic import BaseModel
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.module_loading import import_string
 from airflow.providers.common.compat.sdk import BaseHook
@@ -247,6 +248,29 @@ class OpenAIHook(BaseHook):
         :param model: ID of the model to use.
         """
         return self.conn.responses.create(model=model, input=input, **kwargs)
+
+    def parse_response(
+        self,
+        input: Any,
+        text_format: type[BaseModel],
+        model: str = "gpt-4o-mini",
+        **kwargs: Any,
+    ) -> ParsedResponse[Any]:
+        """
+        Create a model response and parse it into a Pydantic model via the Responses API.
+
+        Wraps :py:meth:`openai.resources.responses.Responses.parse`. The SDK converts
+        ``text_format`` into a JSON schema, sends it as a structured-output request, and
+        returns a :class:`~openai.types.responses.ParsedResponse` whose ``output_parsed``
+        attribute is an instance of ``text_format`` (or ``None`` if the model refused).
+
+        :param input: Text, image, or file input(s) to the model.
+        :param text_format: A Pydantic ``BaseModel`` subclass describing the expected
+            structured output. Requires a model that supports structured outputs
+            (``gpt-4o-2024-08-06`` and later).
+        :param model: ID of the model to use.
+        """
+        return self.conn.responses.parse(input=input, model=model, text_format=text_format, **kwargs)
 
     def get_response(self, response_id: str, **kwargs: Any) -> Response:
         """

--- a/providers/openai/src/airflow/providers/openai/operators/openai.py
+++ b/providers/openai/src/airflow/providers/openai/operators/openai.py
@@ -22,6 +22,8 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
+from pydantic import ValidationError
+
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 from airflow.providers.openai.exceptions import OpenAIBatchJobException
 from airflow.providers.openai.hooks.openai import OpenAIHook
@@ -88,9 +90,9 @@ class OpenAIResponseOperator(BaseOperator):
 
     By default the operator is synchronous and returns the response's aggregated output text.
     Pass ``text_format`` (a Pydantic ``BaseModel`` subclass) to request a structured output; the
-    operator then returns the parsed model as a ``dict`` (via ``model_dump()``), which is safe to
-    push to XCom. Requires a model that supports structured outputs (``gpt-4o-2024-08-06`` and
-    later). For ``previous_response_id`` chaining or ``background=True`` responses, use
+    operator then returns the parsed model as a ``dict`` (via ``model_dump(mode="json")``), which
+    is safe to push to XCom regardless of the field types the model uses (enums, dates, etc. are
+    rendered as their JSON representations). For ``background=True`` responses, use
     :class:`~airflow.providers.openai.hooks.openai.OpenAIHook` directly.
 
     :param conn_id: The OpenAI connection ID to use.
@@ -102,8 +104,8 @@ class OpenAIResponseOperator(BaseOperator):
         ``tools``, ``conversation`` or ``previous_response_id``.
     :param text_format: Optional. A Pydantic ``BaseModel`` subclass describing the expected
         structured output. When set, the operator calls ``parse_response`` and returns
-        ``output_parsed.model_dump()``; otherwise it calls ``create_response`` and returns
-        ``output_text``.
+        ``output_parsed.model_dump(mode="json")``; otherwise it calls ``create_response`` and
+        returns ``output_text``.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -137,22 +139,38 @@ class OpenAIResponseOperator(BaseOperator):
 
     def execute(self, context: Context) -> str | dict[str, Any]:
         if self.text_format is not None:
-            parsed = self.hook.parse_response(
-                input=self.input_text,
-                model=self.model,
-                text_format=self.text_format,
-                **self.response_kwargs,
-            )
+            try:
+                parsed = self.hook.parse_response(
+                    input=self.input_text,
+                    model=self.model,
+                    text_format=self.text_format,
+                    **self.response_kwargs,
+                )
+            except ValidationError as exc:
+                # ``responses.parse`` raises ``ValidationError`` when the model's JSON output
+                # can't be coerced into ``text_format`` — most commonly because the response
+                # was truncated (e.g. ``max_output_tokens`` hit) mid-JSON. Convert to a clean
+                # ``ValueError`` so callers see a consistent shape across all parse failures.
+                raise ValueError(
+                    f"OpenAI Responses API returned a payload that does not match "
+                    f"{self.text_format.__name__!r}: {exc}"
+                ) from exc
+
             self.log.info("Generated response %s", parsed.id)
             if parsed.output_parsed is None:
                 # No structured output — the model refused, the request errored, or the response
-                # was truncated. Surface a clear error so downstream tasks don't get None.
+                # was incomplete. Surface a clear error so downstream tasks don't get ``None``,
+                # and include what the API already told us so the user does not need a follow-up
+                # ``OpenAIHook.get_response`` call.
+                details: list[str] = [f"status={parsed.status!r}"]
+                if parsed.error is not None:
+                    details.append(f"error={parsed.error!r}")
+                if parsed.incomplete_details is not None:
+                    details.append(f"incomplete_details={parsed.incomplete_details!r}")
                 raise ValueError(
-                    f"Response {parsed.id} did not produce a parseable structured output "
-                    f"(status={parsed.status!r}). Inspect the response via OpenAIHook.get_response "
-                    f"for refusal / error details."
+                    f"Response {parsed.id} did not return a structured output ({', '.join(details)})."
                 )
-            return parsed.output_parsed.model_dump()
+            return parsed.output_parsed.model_dump(mode="json")
         response = self.hook.create_response(input=self.input_text, model=self.model, **self.response_kwargs)
         if response.status != "completed":
             self.log.warning(

--- a/providers/openai/src/airflow/providers/openai/operators/openai.py
+++ b/providers/openai/src/airflow/providers/openai/operators/openai.py
@@ -28,6 +28,8 @@ from airflow.providers.openai.hooks.openai import OpenAIHook
 from airflow.providers.openai.triggers.openai import OpenAIBatchTrigger
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from airflow.providers.common.compat.sdk import Context
 
 
@@ -84,16 +86,24 @@ class OpenAIResponseOperator(BaseOperator):
     """
     Operator that generates a model response using the OpenAI Responses API.
 
-    The operator is synchronous and returns the response's aggregated output text. For
-    ``previous_response_id`` chaining, ``background=True`` responses, or access to the full
-    structured response, use :class:`~airflow.providers.openai.hooks.openai.OpenAIHook` directly.
+    By default the operator is synchronous and returns the response's aggregated output text.
+    Pass ``text_format`` (a Pydantic ``BaseModel`` subclass) to request a structured output; the
+    operator then returns the parsed model as a ``dict`` (via ``model_dump()``), which is safe to
+    push to XCom. Requires a model that supports structured outputs (``gpt-4o-2024-08-06`` and
+    later). For ``previous_response_id`` chaining or ``background=True`` responses, use
+    :class:`~airflow.providers.openai.hooks.openai.OpenAIHook` directly.
 
     :param conn_id: The OpenAI connection ID to use.
     :param input_text: The input prompt for the model. This can be a string or a structured list of
         input items.
     :param model: The OpenAI model to use.
     :param response_kwargs: Additional keyword arguments to pass to the OpenAI ``create_response``
-        method (for example ``instructions``, ``tools``, ``conversation`` or ``previous_response_id``).
+        (or ``parse_response`` when ``text_format`` is set) method — for example ``instructions``,
+        ``tools``, ``conversation`` or ``previous_response_id``.
+    :param text_format: Optional. A Pydantic ``BaseModel`` subclass describing the expected
+        structured output. When set, the operator calls ``parse_response`` and returns
+        ``output_parsed.model_dump()``; otherwise it calls ``create_response`` and returns
+        ``output_text``.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -110,6 +120,7 @@ class OpenAIResponseOperator(BaseOperator):
         input_text: str | list[Any],
         model: str = "gpt-4o-mini",
         response_kwargs: dict | None = None,
+        text_format: type[BaseModel] | None = None,
         **kwargs: Any,
     ):
         super().__init__(**kwargs)
@@ -117,13 +128,31 @@ class OpenAIResponseOperator(BaseOperator):
         self.input_text = input_text
         self.model = model
         self.response_kwargs = response_kwargs or {}
+        self.text_format = text_format
 
     @cached_property
     def hook(self) -> OpenAIHook:
         """Return an instance of the OpenAIHook."""
         return OpenAIHook(conn_id=self.conn_id)
 
-    def execute(self, context: Context) -> str:
+    def execute(self, context: Context) -> str | dict[str, Any]:
+        if self.text_format is not None:
+            parsed = self.hook.parse_response(
+                input=self.input_text,
+                model=self.model,
+                text_format=self.text_format,
+                **self.response_kwargs,
+            )
+            self.log.info("Generated response %s", parsed.id)
+            if parsed.output_parsed is None:
+                # No structured output — the model refused, the request errored, or the response
+                # was truncated. Surface a clear error so downstream tasks don't get None.
+                raise ValueError(
+                    f"Response {parsed.id} did not produce a parseable structured output "
+                    f"(status={parsed.status!r}). Inspect the response via OpenAIHook.get_response "
+                    f"for refusal / error details."
+                )
+            return parsed.output_parsed.model_dump()
         response = self.hook.create_response(input=self.input_text, model=self.model, **self.response_kwargs)
         if response.status != "completed":
             self.log.warning(

--- a/providers/openai/src/airflow/providers/openai/operators/openai.py
+++ b/providers/openai/src/airflow/providers/openai/operators/openai.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from airflow.providers.common.compat.sdk import BaseOperator, conf
 from airflow.providers.openai.exceptions import OpenAIBatchJobException
@@ -30,9 +30,31 @@ from airflow.providers.openai.hooks.openai import OpenAIHook
 from airflow.providers.openai.triggers.openai import OpenAIBatchTrigger
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel
-
     from airflow.providers.common.compat.sdk import Context
+
+
+def _get_structured_response_details(response: Any) -> str:
+    """Return API-reported context for a structured-response failure."""
+    details = [f"status={response.status!r}"]
+    if response.error is not None:
+        details.append(f"error={response.error!r}")
+    if response.incomplete_details is not None:
+        details.append(f"incomplete_details={response.incomplete_details!r}")
+
+    refusals = [
+        content.refusal
+        for output in response.output
+        if output.type == "message"
+        for content in output.content
+        if content.type == "refusal"
+    ]
+    if refusals:
+        details.append(f"refusal={'; '.join(refusals)!r}")
+    else:
+        output_types = [output.type for output in response.output]
+        if output_types:
+            details.append(f"output_types={output_types!r}")
+    return ", ".join(details)
 
 
 class OpenAIEmbeddingOperator(BaseOperator):
@@ -90,9 +112,7 @@ class OpenAIResponseOperator(BaseOperator):
 
     By default the operator is synchronous and returns the response's aggregated output text.
     Pass ``text_format`` (a Pydantic ``BaseModel`` subclass) to request a structured output; the
-    operator then returns the parsed model as a ``dict`` (via ``model_dump(mode="json")``), which
-    is safe to push to XCom regardless of the field types the model uses (enums, dates, etc. are
-    rendered as their JSON representations). For ``background=True`` responses, use
+    operator then returns the parsed model as an XCom-safe ``dict``. For ``background=True`` responses, use
     :class:`~airflow.providers.openai.hooks.openai.OpenAIHook` directly.
 
     :param conn_id: The OpenAI connection ID to use.
@@ -103,9 +123,8 @@ class OpenAIResponseOperator(BaseOperator):
         (or ``parse_response`` when ``text_format`` is set) method — for example ``instructions``,
         ``tools``, ``conversation`` or ``previous_response_id``.
     :param text_format: Optional. A Pydantic ``BaseModel`` subclass describing the expected
-        structured output. When set, the operator calls ``parse_response`` and returns
-        ``output_parsed.model_dump(mode="json")``; otherwise it calls ``create_response`` and
-        returns ``output_text``.
+        structured output. When set, the operator calls ``parse_response``; otherwise it calls
+        ``create_response`` and returns ``output_text``.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -130,6 +149,10 @@ class OpenAIResponseOperator(BaseOperator):
         self.input_text = input_text
         self.model = model
         self.response_kwargs = response_kwargs or {}
+        if text_format is not None and (
+            not isinstance(text_format, type) or not issubclass(text_format, BaseModel)
+        ):
+            raise TypeError("text_format must be a Pydantic BaseModel subclass.")
         self.text_format = text_format
 
     @cached_property
@@ -153,23 +176,16 @@ class OpenAIResponseOperator(BaseOperator):
                 # ``ValueError`` so callers see a consistent shape across all parse failures.
                 raise ValueError(
                     f"OpenAI Responses API returned a payload that does not match "
-                    f"{self.text_format.__name__!r}: {exc}"
+                    f"{self.text_format.__name__!r}. The response may have been truncated because "
+                    f"max_output_tokens was reached: {exc}"
                 ) from exc
 
             self.log.info("Generated response %s", parsed.id)
+            details = _get_structured_response_details(parsed)
+            if parsed.status != "completed":
+                raise ValueError(f"Response {parsed.id} did not complete ({details}).")
             if parsed.output_parsed is None:
-                # No structured output — the model refused, the request errored, or the response
-                # was incomplete. Surface a clear error so downstream tasks don't get ``None``,
-                # and include what the API already told us so the user does not need a follow-up
-                # ``OpenAIHook.get_response`` call.
-                details: list[str] = [f"status={parsed.status!r}"]
-                if parsed.error is not None:
-                    details.append(f"error={parsed.error!r}")
-                if parsed.incomplete_details is not None:
-                    details.append(f"incomplete_details={parsed.incomplete_details!r}")
-                raise ValueError(
-                    f"Response {parsed.id} did not return a structured output ({', '.join(details)})."
-                )
+                raise ValueError(f"Response {parsed.id} did not return a structured output ({details}).")
             return parsed.output_parsed.model_dump(mode="json")
         response = self.hook.create_response(input=self.input_text, model=self.model, **self.response_kwargs)
         if response.status != "completed":

--- a/providers/openai/tests/system/openai/example_openai.py
+++ b/providers/openai/tests/system/openai/example_openai.py
@@ -118,8 +118,6 @@ def example_openai_dag():
     OpenAIResponseOperator(
         task_id="openai_response_structured",
         conn_id="openai_default",
-        # Structured outputs require a compatible model (gpt-4o-2024-08-06 or later).
-        model="gpt-4o-2024-08-06",
         input_text="Extract the name and age from: 'Alice is 30 years old'.",
         text_format=Person,
     )

--- a/providers/openai/tests/system/openai/example_openai.py
+++ b/providers/openai/tests/system/openai/example_openai.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pendulum
+from pydantic import BaseModel
 
 # This example uses common.compat for Airflow 2.x/3.x compatibility.
 # If you only need Airflow 3+, you can use: from airflow.sdk import dag, task
@@ -108,6 +109,21 @@ def example_openai_dag():
         response_kwargs={"instructions": "You are a helpful assistant."},
     )
     # [END howto_operator_openai_response]
+
+    # [START howto_operator_openai_response_structured]
+    class Person(BaseModel):
+        name: str
+        age: int
+
+    OpenAIResponseOperator(
+        task_id="openai_response_structured",
+        conn_id="openai_default",
+        # Structured outputs require a compatible model (gpt-4o-2024-08-06 or later).
+        model="gpt-4o-2024-08-06",
+        input_text="Extract the name and age from: 'Alice is 30 years old'.",
+        text_format=Person,
+    )
+    # [END howto_operator_openai_response_structured]
 
     create_embeddings_using_hook()
 

--- a/providers/openai/tests/unit/openai/hooks/test_openai.py
+++ b/providers/openai/tests/unit/openai/hooks/test_openai.py
@@ -35,6 +35,7 @@ from openai.types.beta import Assistant, AssistantDeleted, Thread, ThreadDeleted
 from openai.types.beta.threads import Message, Run
 from openai.types.chat import ChatCompletion
 from openai.types.vector_stores import VectorStoreFile, VectorStoreFileBatch, VectorStoreFileDeleted
+from pydantic import BaseModel
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
@@ -316,8 +317,6 @@ def test_create_response(mock_openai_hook):
 
 
 def test_parse_response(mock_openai_hook):
-    from pydantic import BaseModel
-
     class Person(BaseModel):
         name: str
 

--- a/providers/openai/tests/unit/openai/hooks/test_openai.py
+++ b/providers/openai/tests/unit/openai/hooks/test_openai.py
@@ -315,6 +315,28 @@ def test_create_response(mock_openai_hook):
     assert result is expected
 
 
+def test_parse_response(mock_openai_hook):
+    from pydantic import BaseModel
+
+    class Person(BaseModel):
+        name: str
+
+    expected = mock_openai_hook.conn.responses.parse.return_value
+    result = mock_openai_hook.parse_response(
+        input="Extract: Alice",
+        text_format=Person,
+        model=MODEL,
+        instructions="Be precise.",
+    )
+    mock_openai_hook.conn.responses.parse.assert_called_once_with(
+        model=MODEL,
+        input="Extract: Alice",
+        text_format=Person,
+        instructions="Be precise.",
+    )
+    assert result is expected
+
+
 def test_get_response(mock_openai_hook):
     expected = mock_openai_hook.conn.responses.retrieve.return_value
     result = mock_openai_hook.get_response("resp_123")

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -20,7 +20,8 @@ from unittest.mock import Mock
 
 import pytest
 from openai.types.batch import Batch
-from openai.types.responses import Response
+from openai.types.responses import ParsedResponse, Response
+from pydantic import BaseModel
 
 from airflow.providers.common.compat.sdk import Context, TaskDeferred
 from airflow.providers.openai.hooks.openai import OpenAIHook
@@ -102,6 +103,63 @@ def test_openai_response_operator_execute():
         instructions="Be concise.",
         previous_response_id="resp_prev",
     )
+
+
+class _StructuredPerson(BaseModel):
+    """Pydantic model used by the structured-output operator tests."""
+
+    name: str
+
+
+def test_openai_response_operator_structured_output_returns_dict():
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+        response_kwargs={"instructions": "Be precise."},
+    )
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.return_value = Mock(
+        spec=ParsedResponse,
+        id="resp_str_1",
+        status="completed",
+        output_parsed=_StructuredPerson(name="Alice"),
+    )
+    operator.hook = mock_hook_instance
+
+    result = operator.execute(Context())
+
+    assert result == {"name": "Alice"}
+    mock_hook_instance.parse_response.assert_called_once_with(
+        input="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+        instructions="Be precise.",
+    )
+    mock_hook_instance.create_response.assert_not_called()
+
+
+def test_openai_response_operator_structured_output_refusal_raises():
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+    )
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.return_value = Mock(
+        spec=ParsedResponse,
+        id="resp_refused",
+        status="incomplete",
+        output_parsed=None,
+    )
+    operator.hook = mock_hook_instance
+
+    with pytest.raises(ValueError, match="did not produce a parseable structured output"):
+        operator.execute(Context())
 
 
 @pytest.mark.parametrize("wait_for_completion", [True, False])

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -16,12 +16,13 @@
 # under the License.
 from __future__ import annotations
 
+from enum import Enum
 from unittest.mock import Mock
 
 import pytest
 from openai.types.batch import Batch
 from openai.types.responses import ParsedResponse, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from airflow.providers.common.compat.sdk import Context, TaskDeferred
 from airflow.providers.openai.hooks.openai import OpenAIHook
@@ -111,6 +112,23 @@ class _StructuredPerson(BaseModel):
     name: str
 
 
+class _Priority(str, Enum):
+    LOW = "low"
+    HIGH = "high"
+
+
+class _StructuredTask(BaseModel):
+    """Pydantic model with an enum field — exercises ``model_dump(mode="json")``.
+
+    A plain ``enum.Enum`` field returned as a live enum instance (``model_dump``'s default
+    ``mode="python"``) is not XCom-safe: Airflow's serde only unwraps enums that mix in
+    ``str``/``int``. Using ``mode="json"`` renders the enum via its JSON representation.
+    """
+
+    title: str
+    priority: _Priority
+
+
 def test_openai_response_operator_structured_output_returns_dict():
     operator = OpenAIResponseOperator(
         task_id=TASK_ID,
@@ -141,6 +159,31 @@ def test_openai_response_operator_structured_output_returns_dict():
     mock_hook_instance.create_response.assert_not_called()
 
 
+def test_openai_response_operator_structured_output_dumps_enum_as_json():
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Classify",
+        model="test_model",
+        text_format=_StructuredTask,
+    )
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.return_value = Mock(
+        spec=ParsedResponse,
+        id="resp_str_2",
+        status="completed",
+        output_parsed=_StructuredTask(title="Deploy", priority=_Priority.HIGH),
+    )
+    operator.hook = mock_hook_instance
+
+    result = operator.execute(Context())
+
+    # ``mode="json"`` renders the enum as its ``.value`` string, not the ``_Priority`` instance;
+    # this is what makes the returned dict safe to push to XCom without a serde helper.
+    assert result == {"title": "Deploy", "priority": "high"}
+    assert isinstance(result["priority"], str)
+
+
 def test_openai_response_operator_structured_output_refusal_raises():
     operator = OpenAIResponseOperator(
         task_id=TASK_ID,
@@ -155,10 +198,46 @@ def test_openai_response_operator_structured_output_refusal_raises():
         id="resp_refused",
         status="incomplete",
         output_parsed=None,
+        error="model refused",
+        incomplete_details="max_output_tokens",
     )
     operator.hook = mock_hook_instance
 
-    with pytest.raises(ValueError, match="did not produce a parseable structured output"):
+    with pytest.raises(ValueError, match="did not return a structured output") as excinfo:
+        operator.execute(Context())
+    # API-reported details are surfaced so users don't need a follow-up ``get_response`` call.
+    message = str(excinfo.value)
+    assert "status='incomplete'" in message
+    assert "error='model refused'" in message
+    assert "incomplete_details='max_output_tokens'" in message
+
+
+def test_openai_response_operator_structured_output_validation_error_raises():
+    # ``responses.parse`` raises ``pydantic.ValidationError`` when the model's JSON output
+    # can't be coerced into ``text_format`` (e.g. truncated mid-JSON on ``max_output_tokens``).
+    # The operator converts it to a ``ValueError`` so callers see one exception type across
+    # all parse failures.
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+    )
+    # Build a real ValidationError instance the same way the SDK's internal parse would --
+    # by feeding a payload that violates the model's schema. No public constructor exists.
+    try:
+        _StructuredPerson.model_validate({})
+    except ValidationError as real_exc:
+        validation_error = real_exc
+    else:
+        raise AssertionError("expected ValidationError when validating empty dict")
+
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.side_effect = validation_error
+    operator.hook = mock_hook_instance
+
+    with pytest.raises(ValueError, match="does not match '_StructuredPerson'"):
         operator.execute(Context())
 
 

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -17,12 +17,23 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
 from openai.types.batch import Batch
-from openai.types.responses import ParsedResponse, Response
+from openai.types.responses import (
+    ParsedResponse,
+    ParsedResponseOutputMessage,
+    ParsedResponseOutputText,
+    Response,
+    ResponseError,
+    ResponseFunctionToolCall,
+    ResponseOutputRefusal,
+)
+from openai.types.responses.response import IncompleteDetails
 from pydantic import BaseModel, ValidationError
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 from airflow.providers.common.compat.sdk import Context, TaskDeferred
 from airflow.providers.openai.hooks.openai import OpenAIHook
@@ -112,21 +123,66 @@ class _StructuredPerson(BaseModel):
     name: str
 
 
-class _Priority(str, Enum):
+class _Priority(Enum):
     LOW = "low"
     HIGH = "high"
 
 
 class _StructuredTask(BaseModel):
-    """Pydantic model with an enum field — exercises ``model_dump(mode="json")``.
-
-    A plain ``enum.Enum`` field returned as a live enum instance (``model_dump``'s default
-    ``mode="python"``) is not XCom-safe: Airflow's serde only unwraps enums that mix in
-    ``str``/``int``. Using ``mode="json"`` renders the enum via its JSON representation.
-    """
-
     title: str
     priority: _Priority
+
+
+def _build_parsed_response(
+    output_parsed: BaseModel | None = None,
+    *,
+    response_id: str = "resp_structured",
+    status: str = "completed",
+    error: ResponseError | None = None,
+    incomplete_details: IncompleteDetails | None = None,
+    refusal: str | None = None,
+    output_items: list[Any] | None = None,
+) -> ParsedResponse:
+    if output_items is not None:
+        output = output_items
+    elif output_parsed is not None:
+        content = [
+            ParsedResponseOutputText[BaseModel](
+                annotations=[],
+                text=output_parsed.model_dump_json(),
+                type="output_text",
+                parsed=output_parsed,
+            )
+        ]
+        output = [
+            ParsedResponseOutputMessage[BaseModel](
+                id=f"msg_{response_id}",
+                content=content,
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ]
+    elif refusal is not None:
+        content = [ResponseOutputRefusal(refusal=refusal, type="refusal")]
+        output = [
+            ParsedResponseOutputMessage[BaseModel](
+                id=f"msg_{response_id}",
+                content=content,
+                role="assistant",
+                status="completed",
+                type="message",
+            )
+        ]
+    else:
+        output = []
+    return ParsedResponse[BaseModel].model_construct(
+        id=response_id,
+        status=status,
+        output=output,
+        error=error,
+        incomplete_details=incomplete_details,
+    )
 
 
 def test_openai_response_operator_structured_output_returns_dict():
@@ -139,11 +195,8 @@ def test_openai_response_operator_structured_output_returns_dict():
         response_kwargs={"instructions": "Be precise."},
     )
     mock_hook_instance = Mock(spec=OpenAIHook)
-    mock_hook_instance.parse_response.return_value = Mock(
-        spec=ParsedResponse,
-        id="resp_str_1",
-        status="completed",
-        output_parsed=_StructuredPerson(name="Alice"),
+    mock_hook_instance.parse_response.return_value = _build_parsed_response(
+        _StructuredPerson(name="Alice"), response_id="resp_str_1"
     )
     operator.hook = mock_hook_instance
 
@@ -168,18 +221,13 @@ def test_openai_response_operator_structured_output_dumps_enum_as_json():
         text_format=_StructuredTask,
     )
     mock_hook_instance = Mock(spec=OpenAIHook)
-    mock_hook_instance.parse_response.return_value = Mock(
-        spec=ParsedResponse,
-        id="resp_str_2",
-        status="completed",
-        output_parsed=_StructuredTask(title="Deploy", priority=_Priority.HIGH),
+    mock_hook_instance.parse_response.return_value = _build_parsed_response(
+        _StructuredTask(title="Deploy", priority=_Priority.HIGH), response_id="resp_str_2"
     )
     operator.hook = mock_hook_instance
 
     result = operator.execute(Context())
 
-    # ``mode="json"`` renders the enum as its ``.value`` string, not the ``_Priority`` instance;
-    # this is what makes the returned dict safe to push to XCom without a serde helper.
     assert result == {"title": "Deploy", "priority": "high"}
     assert isinstance(result["priority"], str)
 
@@ -193,23 +241,96 @@ def test_openai_response_operator_structured_output_refusal_raises():
         text_format=_StructuredPerson,
     )
     mock_hook_instance = Mock(spec=OpenAIHook)
-    mock_hook_instance.parse_response.return_value = Mock(
-        spec=ParsedResponse,
-        id="resp_refused",
-        status="incomplete",
-        output_parsed=None,
-        error="model refused",
-        incomplete_details="max_output_tokens",
+    mock_hook_instance.parse_response.return_value = _build_parsed_response(
+        response_id="resp_refused",
+        refusal="I cannot help with that request.",
     )
     operator.hook = mock_hook_instance
 
     with pytest.raises(ValueError, match="did not return a structured output") as excinfo:
         operator.execute(Context())
-    # API-reported details are surfaced so users don't need a follow-up ``get_response`` call.
+    message = str(excinfo.value)
+    assert "status='completed'" in message
+    assert "refusal='I cannot help with that request.'" in message
+
+
+def test_openai_response_operator_structured_output_tools_only_raises():
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+    )
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.return_value = _build_parsed_response(
+        response_id="resp_tool_call",
+        output_items=[
+            ResponseFunctionToolCall(
+                arguments='{"name": "Alice"}',
+                call_id="call_1",
+                name="extract_person",
+                type="function_call",
+                status="completed",
+            )
+        ],
+    )
+    operator.hook = mock_hook_instance
+
+    with pytest.raises(ValueError, match="did not return a structured output") as excinfo:
+        operator.execute(Context())
+
+    assert "output_types=['function_call']" in str(excinfo.value)
+
+
+def test_openai_response_operator_structured_output_incomplete_raises_with_valid_model():
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+    )
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.return_value = _build_parsed_response(
+        _StructuredPerson(name="Alice"),
+        response_id="resp_incomplete",
+        status="incomplete",
+        incomplete_details=IncompleteDetails(reason="max_output_tokens"),
+    )
+    operator.hook = mock_hook_instance
+
+    with pytest.raises(ValueError, match="did not complete") as excinfo:
+        operator.execute(Context())
+
     message = str(excinfo.value)
     assert "status='incomplete'" in message
-    assert "error='model refused'" in message
-    assert "incomplete_details='max_output_tokens'" in message
+    assert "reason='max_output_tokens'" in message
+
+
+def test_openai_response_operator_structured_output_failed_raises_with_error():
+    operator = OpenAIResponseOperator(
+        task_id=TASK_ID,
+        conn_id=CONN_ID,
+        input_text="Extract: Alice",
+        model="test_model",
+        text_format=_StructuredPerson,
+    )
+    mock_hook_instance = Mock(spec=OpenAIHook)
+    mock_hook_instance.parse_response.return_value = _build_parsed_response(
+        response_id="resp_failed",
+        status="failed",
+        error=ResponseError(code="server_error", message="The model failed."),
+    )
+    operator.hook = mock_hook_instance
+
+    with pytest.raises(ValueError, match="did not complete") as excinfo:
+        operator.execute(Context())
+
+    message = str(excinfo.value)
+    assert "status='failed'" in message
+    assert "code='server_error'" in message
+    assert "message='The model failed.'" in message
 
 
 def test_openai_response_operator_structured_output_validation_error_raises():
@@ -224,21 +345,29 @@ def test_openai_response_operator_structured_output_validation_error_raises():
         model="test_model",
         text_format=_StructuredPerson,
     )
-    # Build a real ValidationError instance the same way the SDK's internal parse would --
-    # by feeding a payload that violates the model's schema. No public constructor exists.
-    try:
+    with pytest.raises(ValidationError) as exc_info:
         _StructuredPerson.model_validate({})
-    except ValidationError as real_exc:
-        validation_error = real_exc
-    else:
-        raise AssertionError("expected ValidationError when validating empty dict")
 
     mock_hook_instance = Mock(spec=OpenAIHook)
-    mock_hook_instance.parse_response.side_effect = validation_error
+    mock_hook_instance.parse_response.side_effect = exc_info.value
     operator.hook = mock_hook_instance
 
-    with pytest.raises(ValueError, match="does not match '_StructuredPerson'"):
+    with pytest.raises(ValueError, match="max_output_tokens"):
         operator.execute(Context())
+
+
+def test_openai_response_operator_rejects_non_base_model_text_format():
+    @pydantic_dataclass
+    class StructuredPerson:
+        name: str
+
+    with pytest.raises(TypeError, match="Pydantic BaseModel subclass"):
+        OpenAIResponseOperator(
+            task_id=TASK_ID,
+            conn_id=CONN_ID,
+            input_text="Extract: Alice",
+            text_format=StructuredPerson,
+        )
 
 
 @pytest.mark.parametrize("wait_for_completion", [True, False])

--- a/providers/openai/tests/unit/openai/operators/test_openai.py
+++ b/providers/openai/tests/unit/openai/operators/test_openai.py
@@ -143,6 +143,7 @@ def _build_parsed_response(
     refusal: str | None = None,
     output_items: list[Any] | None = None,
 ) -> ParsedResponse:
+    content: list[ParsedResponseOutputText[BaseModel] | ResponseOutputRefusal]
     if output_items is not None:
         output = output_items
     elif output_parsed is not None:


### PR DESCRIPTION
The `OpenAIResponseOperator` today only returns the aggregated `output_text`
of a Responses API call. Users who want a structured JSON output — the pattern
every AI-eng team uses for reliable extraction, tool selection, and downstream
DAG chaining — have to bypass the operator entirely. The operator's own
docstring instructs this:

> The operator is synchronous and returns the response's aggregated output text. For
> `previous_response_id` chaining, `background=True` responses, or **access to the full
> structured response, use `OpenAIHook` directly**.

This PR closes that gap. Pass a Pydantic `BaseModel` subclass as `text_format` and
the operator uses the SDK's structured-output path (`responses.parse`) and returns
`output_parsed.model_dump()` — a plain `dict`, XCom-safe, no manual serialization
dance. When `text_format` is `None` the existing plain-text behavior is preserved
bit-for-bit.

### How I found and verified this gap

Same audit approach as #69408, #69534, and #69673: read every operator/hook in the
AI/ML providers and compare surfaced API to underlying SDK. The Responses API is
OpenAI's recommended interface going forward (Chat Completions is on the deprecation
path), so gaps here are user-facing today, not legacy cleanup.

Before writing a line of code I confirmed:

1. **The API exists and is stable.** `openai.resources.responses.Responses.parse(input, model, text_format, ...)` is present in the pinned SDK (`openai>=2.37.0`) and returns `ParsedResponse[TextFormatT]` with `.output_parsed` as an instance of the passed model. Verified via `inspect.signature(Responses.parse)`.
2. **`output_parsed` is None on refusal / incomplete.** The SDK docs and source confirm the model returning a refusal or the response being truncated yields `output_parsed=None`. The operator raises `ValueError` in that case so downstream tasks don't silently get `None`.
3. **`model_dump()` produces XCom-safe dicts.** Every pinned Pydantic version supports it.
4. **`pydantic` is already a core Airflow dependency.** No new dep.

### Design decisions

- **Pydantic-only, not raw JSON schema.** The SDK's `responses.parse(text_format=Model)` path handles schema conversion, strict-mode, and response parsing in one call. Raw JSON schema via `responses.create(text={"format": {...}})` requires the caller to define a schema name, parse `output_text` manually, and handle refusals themselves. Pydantic is the pattern every AI-eng library (Instructor, LangChain, Pydantic-AI) wraps — starting there covers the primary use case cleanly. Raw-schema support can be added in a follow-up without breaking this API.
- **One operator, opt-in param — not a new class.** `text_format=None` (default) keeps the existing `str`-returning behavior. Set `text_format=SomeModel` and you get a `dict`. Return-type annotation is `str | dict[str, Any]`. Users who don't touch the new param see zero change.
- **`ValueError` on refusal, not silent None.** If `output_parsed is None`, the operator raises with the response ID and status. Silently returning `None` would break downstream tasks that assume a specific shape.
- **No new exception class.** Per `AGENTS.md` guidance ("prefer a Python built-in"), `ValueError` is semantically correct — the model returned something that can't be converted to the requested type.
- **`create_response` untouched.** All existing tests, DAGs, and behavior are preserved. The plain-text path is not touched.

### What changes

- `providers/openai/src/airflow/providers/openai/hooks/openai.py`
  - New `OpenAIHook.parse_response(input, text_format, model, **kwargs) -> ParsedResponse[Any]`, a thin wrapper over `client.responses.parse`.
- `providers/openai/src/airflow/providers/openai/operators/openai.py`
  - `OpenAIResponseOperator` gains a `text_format: type[BaseModel] | None = None` parameter. Return type widened to `str | dict[str, Any]`. Docstring updated to explain the two paths.
- `providers/openai/tests/unit/openai/hooks/test_openai.py`
  - `test_parse_response`: hook forwards `text_format`, `model`, and extra kwargs to `conn.responses.parse` and returns the SDK's return value.
- `providers/openai/tests/unit/openai/operators/test_openai.py`
  - `test_openai_response_operator_structured_output_returns_dict`: happy path — parsed model → dict via `model_dump()`, `create_response` not called.
  - `test_openai_response_operator_structured_output_refusal_raises`: `output_parsed=None` → `ValueError` with the response ID.
  - The existing `test_openai_response_operator_execute` is left untouched to guard the backward-compat path.
- `providers/openai/tests/system/openai/example_openai.py`
  - New `# [START/END] howto_operator_openai_response_structured` block with a Pydantic `Person` example.
- `providers/openai/docs/operators/openai.rst`
  - New **Structured outputs (Pydantic models)** subsection under the existing `OpenAIResponseOperator` how-to, with an `exampleinclude` pointing at the new markers.

No `provider.yaml` / `get_provider_info.py` changes needed: the registry lists python-modules, not classes, and no new module was added. No changelog edit either — per `AGENTS.md`, provider changelogs are regenerated from `git log` by the release manager.

### Testing

- **Full-provider `ruff check` + `ruff format --check`**: 29 files clean.
- **All hook + operator tests exercised via a standalone Windows-safe harness** stubbing airflow, `openai.auth`, and `openai.types.responses.ParsedResponse` (full airflow install cannot run on Windows). Four assertions pass: hook forwards args, operator structured path returns dict + skips `create_response`, operator refusal path raises `ValueError`, operator backward-compat plain-text path is unchanged.
- **Regression check**: the existing `test_openai_response_operator_execute` was not modified, so the plain-text return path is guarded by a test the reviewer can fail by reverting the PR.
- **Line-by-line reviewed by me** against every rule in `.github/instructions/code-review.instructions.md` — no red flags (no `time.time`, no `assert` in prod, no new `AirflowException`, no `mock.Mock()` without spec, imports at top of file, session-parameter and DB-query rules N/A here).

### Author review

I read every line of this PR — hook, operator, tests, example DAG, docs — end
to end before pushing, and validated the SDK contract claims myself against
the installed `openai` package (`inspect.signature(Responses.parse)`, the
`ParsedResponse.output_parsed` attribute check, and the `openai>=2.37.0`
availability of both). The design calls above — Pydantic-only for this first
cut, `ValueError` on refusal instead of silent `None`, opt-in `text_format`
param instead of a new class — are mine, not the agent's default choices.
The generated code was iterated on until it matched what I wanted to ship.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — GitHub Copilot (Claude Opus 4.7)

Generated-by: GitHub Copilot (Claude Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)