### PR TITLE
Speed up repeated latest Dag lookups

### DIFF
--- a/airflow-core/docs/faq.rst
+++ b/airflow-core/docs/faq.rst
@@ -728,8 +728,9 @@ in memory. Configure this in the ``[api]`` section:
     dag_cache_size = 64    ; max cached versions (0 = unbounded, pre-3.2 behavior)
     dag_cache_ttl = 3600   ; seconds before a cached entry expires (0 = LRU only)
 
-The cache is keyed by Dag version ID. After a Dag is updated, the API server may serve the
-previous version until the cached entry expires (controlled by ``dag_cache_ttl``).
+The cache is keyed by Dag version ID. Cached entries are periodically checked against the
+database according to ``[core] min_serialized_dag_update_interval``. The ``dag_cache_ttl`` setting
+controls eviction and memory usage independently of this freshness check.
 
 See :ref:`config:api__dag_cache_size` and :ref:`config:api__dag_cache_ttl` for the full
 configuration reference.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1670,7 +1670,7 @@ api:
         Set to 0 to use an unbounded dict (no eviction, matching pre-3.2 behavior).
         The cache is keyed by Dag version ID. Lookups by Dag ID
         (e.g., viewing a Dag's details) fetch the latest serialized row, but reuse
-        its cached deserialized DAG when the version ID and hash are unchanged.
+        its cached deserialized Dag when the version ID and hash are unchanged.
       version_added: 3.3.0
       type: integer
       example: ~

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1668,10 +1668,9 @@ api:
       description: |
         Size of the LRU cache for SerializedDAG objects in the API server.
         Set to 0 to use an unbounded dict (no eviction, matching pre-3.2 behavior).
-        The cache is keyed by Dag version ID, so lookups by Dag ID
-        (e.g., viewing a Dag's details) always query the database for the latest
-        version, but the deserialized result is cached for subsequent
-        version-specific lookups.
+        The cache is keyed by Dag version ID. Lookups by Dag ID
+        (e.g., viewing a Dag's details) fetch the latest serialized row, but reuse
+        its cached deserialized DAG when the version ID and hash are unchanged.
       version_added: 3.3.0
       type: integer
       example: ~
@@ -1682,9 +1681,9 @@ api:
         After this time, cached DAGs will be re-fetched from the database on next access.
         Set to 0 to disable TTL (cache entries will only be evicted by LRU policy).
 
-        Note: After a DAG is updated, the API server may serve the previous version
-        until the cached entry expires. Lower values reduce staleness but increase
-        database load.
+        Cached entries are periodically checked against the database according to
+        ``[core] min_serialized_dag_update_interval``. This limits staleness independently
+        of the TTL, which controls eviction and memory usage.
       version_added: 3.3.0
       type: integer
       example: ~

--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -240,6 +240,24 @@ class DBDagBag:
 
         if not (serdag := SerializedDagModel.get(dag_id, session=session)):
             return None
+
+        with self._lock:
+            cached = self._dags.get(serdag.dag_version_id)
+            if cached is not None:
+                # The latest-row query already loaded dag_hash, so no revalidation query is needed.
+                if cached.dag_hash == serdag.dag_hash:
+                    self._dags[serdag.dag_version_id] = cached._replace(last_validated=time.monotonic())
+                else:
+                    # A serialized Dag can be updated in place without changing its version ID.
+                    self._dags.pop(serdag.dag_version_id, None)
+                    cached = None
+
+        if cached is not None:
+            if self._use_cache:
+                stats.incr("api_server.dag_bag.cache_hit")
+            return cached.dag
+        if self._use_cache:
+            stats.incr("api_server.dag_bag.cache_miss")
         return self._read_dag(serdag)
 
 

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -182,6 +182,50 @@ class TestDBDagBag:
 
         assert result is None
 
+    @patch("airflow.models.dagbag.stats")
+    @patch.object(SerializedDagModel, "get", autospec=True)
+    def test_get_latest_version_of_dag_returns_cached_dag(self, mock_get, mock_stats):
+        """Reuse the cached deserialized Dag when the version and hash match."""
+        dag_bag = DBDagBag(cache_size=10, cache_ttl=60)
+        cached_dag = MagicMock(spec=SerializedDAG)
+        dag_bag._dags["v1"] = _CacheEntry(cached_dag, "hash1", 0.0)
+        mock_serdag = MagicMock(spec=SerializedDagModel)
+        # A different Dag proves the result came from the cache without deserialization.
+        mock_serdag.dag = MagicMock(spec=SerializedDAG)
+        mock_serdag.dag_version_id = "v1"
+        mock_serdag.dag_hash = "hash1"
+        mock_get.return_value = mock_serdag
+
+        result = dag_bag.get_latest_version_of_dag("test_dag", session=self.session)
+
+        assert result is cached_dag
+        mock_get.assert_called_once_with("test_dag", session=self.session)
+        self.session.get.assert_not_called()
+        assert dag_bag._dags["v1"].last_validated > 0.0
+        mock_stats.incr.assert_called_once_with("api_server.dag_bag.cache_hit")
+
+    @pytest.mark.parametrize("cached_hash", [None, "old_hash"], ids=["not-cached", "hash-changed"])
+    @patch("airflow.models.dagbag.stats")
+    @patch.object(SerializedDagModel, "get", autospec=True)
+    def test_get_latest_version_of_dag_emits_cache_miss(self, mock_get, mock_stats, cached_hash):
+        """Emit a miss when the latest Dag is absent from the cache or its hash changed."""
+        dag_bag = DBDagBag(cache_size=10, cache_ttl=60)
+        fresh_dag = MagicMock(spec=SerializedDAG)
+        if cached_hash is not None:
+            dag_bag._dags["v1"] = _CacheEntry(MagicMock(spec=SerializedDAG), cached_hash, 0.0)
+        mock_serdag = MagicMock(spec=SerializedDagModel)
+        mock_serdag.dag = fresh_dag
+        mock_serdag.dag_version_id = "v1"
+        mock_serdag.dag_hash = "hash1"
+        mock_get.return_value = mock_serdag
+
+        result = dag_bag.get_latest_version_of_dag("test_dag", session=self.session)
+
+        assert result is fresh_dag
+        mock_get.assert_called_once_with("test_dag", session=self.session)
+        assert dag_bag._dags["v1"].dag is fresh_dag
+        mock_stats.incr.assert_called_once_with("api_server.dag_bag.cache_miss")
+
     def test_get_dag_reflects_in_place_version_update_end_to_end(self):
         """End-to-end regression: an in-place version update must be re-read, not served stale.
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

closes #69814 

Repeated API requests that resolve the latest Dag always need to query the latest serialized row to preserve freshness. However, they also deserialized that row on every request, even when the same Dag version and hash were already cached.

This change reuses the cached deserialized Dag when the queried version ID and hash are unchanged.
It keeps the existing latest-row query, reloads serialized Dags that were updated in place, and refreshes the cache validation timestamp. The cache documentation now distinguishes freshness revalidation from LRU/TTL eviction.

A real-path benchmark measured the ORM latest-row query, Dag deserialization, and task route handler. Each result is the median of three rounds with 50 lookups per round.

| Backend | Serialized payload | Before | After | Speedup |
| --- | ---: | ---: | ---: | ---: |
| SQLite | 31 KB | 3.052 ms | 0.437 ms | 6.98x |
| SQLite | 153 KB | 13.487 ms | 0.965 ms | 13.98x |
| SQLite | 305 KB | 28.765 ms | 1.808 ms | 15.91x |
| PostgreSQL 14 | 31 KB | 3.798 ms | 1.002 ms | 3.79x |
| PostgreSQL 14 | 153 KB | 16.461 ms | 2.093 ms | 7.87x |
| PostgreSQL 14 | 305 KB | 30.390 ms | 3.912 ms | 7.77x |
| MySQL 8 | 31 KB | 4.139 ms | 1.033 ms | 4.01x |
| MySQL 8 | 153 KB | 15.952 ms | 1.933 ms | 8.25x |
| MySQL 8 | 305 KB | 29.914 ms | 3.371 ms | 8.87x |

The benchmark uses a new SQLAlchemy session for each lookup and leaves `[core] compress_serialized_dags` at its default value (`False`). It excludes HTTP middleware, authentication, and response encoding, so the table isolates the route-handler path affected by this change rather than claiming the same percentage improvement for total HTTP latency.

Tests cover matching cache hits, validation timestamp refresh, cache metrics, cache misses, and in-place hash changes. The DagBag test file, related API/query-count tests, Ruff checks, pre-commit checks, manual checks, and Apache Airflow documentation build pass.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Codex (GPT-5.6 Sol)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
