### PR TITLE
Respect retries when a deferrable trigger ends a task with TaskFailedEvent

### DIFF
--- a/airflow-core/newsfragments/69821.bugfix.rst
+++ b/airflow-core/newsfragments/69821.bugfix.rst
@@ -1,0 +1,1 @@
+Deferrable tasks that fail via a trigger-emitted ``TaskFailedEvent`` now respect retries: if the task has retries remaining it goes ``up_for_retry`` and runs ``on_retry_callback``, instead of always failing terminally and running ``on_failure_callback``.

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -561,13 +561,42 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
     from airflow.callbacks.database_callback_sink import DatabaseCallbackSink
     from airflow.utils.state import TaskInstanceState
 
-    # Mark the task with terminal state and prevent it from resuming on worker
+    # Prevent the task from resuming on a worker.
     task_instance.trigger_id = None
-    task_instance.set_state(event.task_instance_state, session=session)
+
+    callback_type = event.task_instance_state
+    handle_via_failure = False
+
+    if event.task_instance_state == TaskInstanceState.FAILED:
+        # Load the serialized task: needed both for is_eligible_to_retry() and for
+        # handle_failure() (which asserts self.task / self.task.dag). Mirrors the
+        # scheduler executor-event path (see is_eligible_to_retry / PR #56586).
+        try:
+            from airflow.models.dagbag import DBDagBag
+
+            dag = DBDagBag().get_dag_for_run(dag_run=task_instance.dag_run, session=session)
+            if dag is not None:
+                task_instance.task = dag.get_task(task_instance.task_id)
+                handle_via_failure = True
+        except Exception:
+            log.exception(
+                "Could not load task for %s; failing terminally without retry routing", task_instance
+            )
+        if handle_via_failure and task_instance.is_eligible_to_retry():
+            callback_type = TaskInstanceState.UP_FOR_RETRY
+
+    # Persist trigger_id=None before handle_failure: fetch_handle_failure_context calls
+    # refresh_from_db(keep_local_changes=False), which would otherwise reload the old trigger_id.
+    if handle_via_failure:
+        session.flush()
 
     def _submit_callback_if_necessary() -> None:
-        """Submit a callback request if the task state is SUCCESS or FAILED."""
-        if event.task_instance_state in (TaskInstanceState.SUCCESS, TaskInstanceState.FAILED):
+        """Submit a callback request if the task state is SUCCESS, FAILED, or UP_FOR_RETRY."""
+        if callback_type in (
+            TaskInstanceState.SUCCESS,
+            TaskInstanceState.FAILED,
+            TaskInstanceState.UP_FOR_RETRY,
+        ):
             if task_instance.dag_model.relative_fileloc is None:
                 raise RuntimeError("relative_fileloc should not be None for a finished task")
             from airflow.models.dag_version import _resolve_version_data
@@ -591,7 +620,7 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
             request = TaskCallbackRequest(
                 filepath=task_instance.dag_model.relative_fileloc,
                 ti=task_instance,
-                task_callback_type=event.task_instance_state,
+                task_callback_type=callback_type,
                 bundle_name=bundle_name,
                 bundle_version=bundle_version,
                 version_data=version_data,
@@ -604,10 +633,21 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
 
     def _push_xcoms_if_necessary() -> None:
         """Pushes XComs to the database if they are provided."""
-        if event.xcoms:
+        if event.xcoms and callback_type != TaskInstanceState.UP_FOR_RETRY:
             for key, value in event.xcoms.items():
                 task_instance.xcom_push(key=key, value=value)
 
+    # Send the callback before handle_failure (mirrors the scheduler executor-event ordering):
+    # handle_failure -> save_to_db commits, which also persists the DatabaseCallbackSink row atomically.
     _submit_callback_if_necessary()
+
+    if handle_via_failure:
+        # Canonical failure handling: sets UP_FOR_RETRY/FAILED by retry-eligibility, fires the
+        # on_task_instance_failed listener + failure metrics + Log audit row, and clears
+        # next_method args. Mirrors the scheduler executor-event path (PR #56586).
+        task_instance.handle_failure(error="Task failed via trigger event", session=session)
+    else:
+        task_instance.set_state(event.task_instance_state, session=session)
+
     _push_xcoms_if_necessary()
     session.flush()

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -565,30 +565,23 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
     task_instance.trigger_id = None
 
     callback_type = event.task_instance_state
-    handle_via_failure = False
+    should_retry = False
 
     if event.task_instance_state == TaskInstanceState.FAILED:
-        # Load the serialized task: needed both for is_eligible_to_retry() and for
-        # handle_failure() (which asserts self.task / self.task.dag). Mirrors the
-        # scheduler executor-event path (see is_eligible_to_retry / PR #56586).
+        # Load the serialized task so retry eligibility matches the normal task path.
         try:
             from airflow.models.dagbag import DBDagBag
 
             dag = DBDagBag().get_dag_for_run(dag_run=task_instance.dag_run, session=session)
             if dag is not None:
                 task_instance.task = dag.get_task(task_instance.task_id)
-                handle_via_failure = True
+                should_retry = task_instance.is_eligible_to_retry()
         except Exception:
             log.exception(
                 "Could not load task for %s; failing terminally without retry routing", task_instance
             )
-        if handle_via_failure and task_instance.is_eligible_to_retry():
+        if should_retry:
             callback_type = TaskInstanceState.UP_FOR_RETRY
-
-    # Persist trigger_id=None before handle_failure: fetch_handle_failure_context calls
-    # refresh_from_db(keep_local_changes=False), which would otherwise reload the old trigger_id.
-    if handle_via_failure:
-        session.flush()
 
     def _submit_callback_if_necessary() -> None:
         """Submit a callback request if the task state is SUCCESS, FAILED, or UP_FOR_RETRY."""
@@ -638,14 +631,15 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
                 task_instance.xcom_push(key=key, value=value)
 
     # Send the callback before handle_failure (mirrors the scheduler executor-event ordering):
-    # handle_failure -> save_to_db commits, which also persists the DatabaseCallbackSink row atomically.
+    # the callback request should reflect the retry/terminal decision derived above.
     _submit_callback_if_necessary()
 
-    if handle_via_failure:
-        # Canonical failure handling: sets UP_FOR_RETRY/FAILED by retry-eligibility, fires the
-        # on_task_instance_failed listener + failure metrics + Log audit row, and clears
-        # next_method args. Mirrors the scheduler executor-event path (PR #56586).
-        task_instance.handle_failure(error="Task failed via trigger event", session=session)
+    if should_retry:
+        task_instance.end_date = timezone.utcnow()
+        task_instance.set_duration()
+        task_instance.clear_next_method_args()
+        task_instance.prepare_db_for_next_try(session)
+        task_instance.state = TaskInstanceState.UP_FOR_RETRY
     else:
         task_instance.set_state(event.task_instance_state, session=session)
 

--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -630,8 +630,8 @@ def _(event: BaseTaskEndEvent, *, task_instance: TaskInstance, session: Session)
             for key, value in event.xcoms.items():
                 task_instance.xcom_push(key=key, value=value)
 
-    # Send the callback before handle_failure (mirrors the scheduler executor-event ordering):
-    # the callback request should reflect the retry/terminal decision derived above.
+    # Send the callback before mutating task state so it reflects the retry-vs-terminal
+    # decision derived above.
     _submit_callback_if_necessary()
 
     if should_retry:

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -20,7 +20,7 @@ import datetime
 import json
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pendulum
 import pytest
@@ -48,7 +48,7 @@ from airflow.triggers.base import (
     TriggerEvent,
 )
 from airflow.utils.session import create_session
-from airflow.utils.state import State
+from airflow.utils.state import State, TaskInstanceState
 
 from tests_common.test_utils.asserts import assert_queries_count
 from tests_common.test_utils.config import conf_vars
@@ -296,11 +296,15 @@ def test_submit_event_task_end(mock_utcnow, session, create_task_instance, event
     # Make a trigger
     trigger = Trigger(classpath="does.not.matter", kwargs={})
     session.add(trigger)
-    # Make a TaskInstance that's deferred and waiting on it
+    # Make a TaskInstance that's deferred and waiting on it. A deferred task has
+    # already started running, so it has a start_date; set one so duration can be
+    # computed. Unlike set_state, handle_failure (used by the FAILED path) does not
+    # synthesize a missing start_date, matching the scheduler executor-event path.
     task_instance = create_task_instance(
         session=session, logical_date=timezone.utcnow(), state=State.DEFERRED
     )
     task_instance.trigger_id = trigger.id
+    task_instance.start_date = now.subtract(seconds=10)
     session.commit()
 
     def get_xcoms(ti):
@@ -360,6 +364,63 @@ def test_submit_event_task_end_callback_includes_version_data(mock_send, session
     request = mock_send.call_args.kwargs["callback"]
     assert request.bundle_version == "some_hash"
     assert request.version_data == version_data
+
+
+@pytest.mark.parametrize(
+    ("retries", "expected_state", "expected_callback_type"),
+    [
+        (1, TaskInstanceState.UP_FOR_RETRY, TaskInstanceState.UP_FOR_RETRY),
+        (0, TaskInstanceState.FAILED, TaskInstanceState.FAILED),
+    ],
+)
+@patch("airflow.callbacks.database_callback_sink.DatabaseCallbackSink.send")
+def test_submit_event_task_end_failed_respects_retries(
+    mock_send, session, create_task_instance, retries, expected_state, expected_callback_type
+):
+    """A trigger-emitted TaskFailedEvent should respect retry-eligibility: a deferred task with
+    retries remaining goes UP_FOR_RETRY (on_retry_callback), not straight to FAILED.
+
+    Failures are routed through ``TaskInstance.handle_failure`` (mirroring the scheduler
+    executor-event path), so the ``on_task_instance_failed`` listener fires in both cases.
+    """
+    from airflow.listeners.listener import get_listener_manager
+
+    listener_callback = MagicMock()
+    get_listener_manager().pm.hook.on_task_instance_failed = listener_callback
+    try:
+        trigger = Trigger(classpath="does.not.matter", kwargs={})
+        session.add(trigger)
+        task_instance = create_task_instance(
+            session=session,
+            logical_date=timezone.utcnow(),
+            state=State.DEFERRED,
+            default_args={"retries": retries},
+        )
+        task_instance.trigger_id = trigger.id
+        task_instance.try_number = 1
+        task_instance.max_tries = retries
+        session.commit()
+
+        Trigger.submit_event(trigger.id, TaskFailedEvent(), session=session)
+        session.flush()
+
+        ti = session.scalar(select(TaskInstance))
+        assert ti.state == expected_state
+
+        mock_send.assert_called_once()
+        request = mock_send.call_args.kwargs["callback"]
+        assert request.task_callback_type == expected_callback_type
+
+        # handle_failure clears next_method args and sets end_date on both the retry and
+        # the terminal-failure paths.
+        assert ti.next_method is None
+        assert ti.next_kwargs is None
+        assert ti.end_date is not None
+
+        # The canonical failure path fires the on_task_instance_failed listener.
+        listener_callback.assert_called_once()
+    finally:
+        get_listener_manager().clear()
 
 
 @pytest.fixture

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -20,7 +20,7 @@ import datetime
 import json
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pendulum
 import pytest
@@ -34,6 +34,7 @@ from airflow.jobs.triggerer_job_runner import TriggererJobRunner
 from airflow.models import TaskInstance, Trigger
 from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel
 from airflow.models.callback import Callback, TriggererCallback
+from airflow.models.taskinstancehistory import TaskInstanceHistory
 from airflow.models.xcom import XComModel
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.sdk.definitions.callback import AsyncCallback
@@ -367,60 +368,70 @@ def test_submit_event_task_end_callback_includes_version_data(mock_send, session
 
 
 @pytest.mark.parametrize(
-    ("retries", "expected_state", "expected_callback_type"),
+    ("retries", "expected_state", "expected_callback_type", "expect_history_row"),
     [
-        (1, TaskInstanceState.UP_FOR_RETRY, TaskInstanceState.UP_FOR_RETRY),
-        (0, TaskInstanceState.FAILED, TaskInstanceState.FAILED),
+        (1, TaskInstanceState.UP_FOR_RETRY, TaskInstanceState.UP_FOR_RETRY, True),
+        (0, TaskInstanceState.FAILED, TaskInstanceState.FAILED, False),
     ],
 )
 @patch("airflow.callbacks.database_callback_sink.DatabaseCallbackSink.send")
 def test_submit_event_task_end_failed_respects_retries(
-    mock_send, session, create_task_instance, retries, expected_state, expected_callback_type
+    mock_send,
+    session,
+    create_task_instance,
+    retries,
+    expected_state,
+    expected_callback_type,
+    expect_history_row,
 ):
     """A trigger-emitted TaskFailedEvent should respect retry-eligibility: a deferred task with
     retries remaining goes UP_FOR_RETRY (on_retry_callback), not straight to FAILED.
 
-    Failures are routed through ``TaskInstance.handle_failure`` (mirroring the scheduler
-    executor-event path), so the ``on_task_instance_failed`` listener fires in both cases.
+    On the retry path, the finished try must also be archived to task_instance_history so
+    prior-try log lookups keep working after the trigger ends the deferred try.
     """
-    from airflow.listeners.listener import get_listener_manager
+    trigger = Trigger(classpath="does.not.matter", kwargs={})
+    session.add(trigger)
+    task_instance = create_task_instance(
+        session=session,
+        logical_date=timezone.utcnow(),
+        state=State.DEFERRED,
+        default_args={"retries": retries},
+    )
+    task_instance.trigger_id = trigger.id
+    task_instance.try_number = 1
+    task_instance.max_tries = retries
+    old_ti_id = task_instance.id
+    session.commit()
 
-    listener_callback = MagicMock()
-    get_listener_manager().pm.hook.on_task_instance_failed = listener_callback
-    try:
-        trigger = Trigger(classpath="does.not.matter", kwargs={})
-        session.add(trigger)
-        task_instance = create_task_instance(
-            session=session,
-            logical_date=timezone.utcnow(),
-            state=State.DEFERRED,
-            default_args={"retries": retries},
+    Trigger.submit_event(trigger.id, TaskFailedEvent(), session=session)
+    session.flush()
+
+    ti = session.scalar(select(TaskInstance))
+    assert ti.state == expected_state
+
+    mock_send.assert_called_once()
+    request = mock_send.call_args.kwargs["callback"]
+    assert request.task_callback_type == expected_callback_type
+
+    assert ti.next_method is None
+    assert ti.next_kwargs is None
+    assert ti.end_date is not None
+
+    tih = session.scalars(
+        select(TaskInstanceHistory).where(
+            TaskInstanceHistory.dag_id == ti.dag_id,
+            TaskInstanceHistory.task_id == ti.task_id,
+            TaskInstanceHistory.run_id == ti.run_id,
         )
-        task_instance.trigger_id = trigger.id
-        task_instance.try_number = 1
-        task_instance.max_tries = retries
-        session.commit()
-
-        Trigger.submit_event(trigger.id, TaskFailedEvent(), session=session)
-        session.flush()
-
-        ti = session.scalar(select(TaskInstance))
-        assert ti.state == expected_state
-
-        mock_send.assert_called_once()
-        request = mock_send.call_args.kwargs["callback"]
-        assert request.task_callback_type == expected_callback_type
-
-        # handle_failure clears next_method args and sets end_date on both the retry and
-        # the terminal-failure paths.
-        assert ti.next_method is None
-        assert ti.next_kwargs is None
-        assert ti.end_date is not None
-
-        # The canonical failure path fires the on_task_instance_failed listener.
-        listener_callback.assert_called_once()
-    finally:
-        get_listener_manager().clear()
+    ).all()
+    if expect_history_row:
+        assert len(tih) == 1
+        assert ti.id != old_ti_id
+        assert tih[0].task_instance_id == old_ti_id
+    else:
+        assert tih == []
+        assert ti.id == old_ti_id
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

When a deferrable operator's trigger yields a terminal `TaskFailedEvent`, the task was always marked `failed` and its `on_failure_callback` ran, even when the task still had retries remaining. A worker-side failure with retries left instead goes `up_for_retry` and runs `on_retry_callback`. This makes trigger-driven failures behave the same way.

The `BaseTaskEndEvent` handler in `airflow-core/src/airflow/models/trigger.py` now, for a `FAILED` event, loads the serialized task and routes through `TaskInstance.handle_failure()`, the same path the scheduler executor-event handling has used since #56586. `handle_failure` sets `up_for_retry` or `failed` based on retry-eligibility and fires the `on_task_instance_failed` listener, failure metrics, and a Log entry. The callback request now carries the resolved `task_callback_type` so the DAG processor runs `on_retry_callback` vs `on_failure_callback` correctly. `TaskSuccessEvent` and `TaskSkippedEvent` are unchanged.

closes: #69819

## Changes

- `airflow-core/src/airflow/models/trigger.py`: route trigger-emitted failures through `handle_failure`, thread the retry-aware `task_callback_type` into the callback, and skip the xcom push on the retry path.
- `airflow-core/tests/unit/models/test_trigger.py`: new parametrized test covering the retry-eligible case (`up_for_retry` + `on_retry_callback` + `on_task_instance_failed` listener) and the exhausted case (`failed` + `on_failure_callback`); the existing end-event test now sets a realistic `start_date` (a deferred task has already run).
- `airflow-core/newsfragments/69821.bugfix.rst`.

## Testing

- `pytest airflow-core/tests/unit/models/test_trigger.py` (39 passed).
- Confirmed the new test fails on `main` (the task stays `failed` and the callback is routed as a failure) and passes with this change.

This change was written with AI assistance (Claude); the author reviewed the diff and reproduction.