### PR TITLE
Avoid Vertex AI Feature Store system Dag import timeout

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/feature_store.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/feature_store.py
@@ -19,15 +19,9 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import (
-    TYPE_CHECKING,
-)
+from typing import TYPE_CHECKING
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
-from google.cloud.aiplatform_v1beta1 import (
-    FeatureOnlineStoreAdminServiceClient,
-    FeatureOnlineStoreServiceClient,
-)
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.common.consts import CLIENT_INFO
@@ -36,6 +30,10 @@ from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 if TYPE_CHECKING:
     from google.api_core.operation import Operation
     from google.api_core.retry import Retry
+    from google.cloud.aiplatform_v1beta1 import (
+        FeatureOnlineStoreAdminServiceClient,
+        FeatureOnlineStoreServiceClient,
+    )
     from google.cloud.aiplatform_v1beta1.types import (
         FeatureOnlineStore,
         FeatureView,
@@ -90,6 +88,8 @@ class FeatureStoreHook(GoogleBaseHook):
             If provided and not 'global', the client will be configured to use the
             region-specific API endpoint.
         """
+        from google.cloud.aiplatform_v1beta1 import FeatureOnlineStoreAdminServiceClient
+
         return FeatureOnlineStoreAdminServiceClient(
             credentials=self.get_credentials(),
             client_info=CLIENT_INFO,
@@ -101,6 +101,8 @@ class FeatureStoreHook(GoogleBaseHook):
         location: str | None = None,
         custom_endpoint: str | None = None,
     ) -> FeatureOnlineStoreServiceClient:
+        from google.cloud.aiplatform_v1beta1 import FeatureOnlineStoreServiceClient
+
         return FeatureOnlineStoreServiceClient(
             credentials=self.get_credentials(),
             client_info=CLIENT_INFO,
@@ -113,7 +115,7 @@ class FeatureStoreHook(GoogleBaseHook):
     def create_feature_online_store(
         self,
         feature_online_store_id: str,
-        feature_online_store: FeatureOnlineStore,
+        feature_online_store: FeatureOnlineStore | dict,
         project_id: str = PROVIDE_PROJECT_ID,
         location: str | None = None,
         timeout: float | _MethodDefault = DEFAULT,
@@ -127,7 +129,8 @@ class FeatureStoreHook(GoogleBaseHook):
         Feature Online Store aims to serve and manage features data as a part of VertexAI MLOps.
 
         :param feature_online_store_id: The ID of the online feature store.
-        :param feature_online_store: The configuration of the online repository.
+        :param feature_online_store: The configuration of the online repository as a
+            FeatureOnlineStore object or dictionary.
         :param project_id: The ID of the Google Cloud project that contains the
             feature store. If not provided, will attempt to determine from the environment.
         :param location: The Google Cloud region where the feature store is located
@@ -196,7 +199,7 @@ class FeatureStoreHook(GoogleBaseHook):
     def create_feature_view(
         self,
         feature_view_id: str,
-        feature_view: FeatureView,
+        feature_view: FeatureView | dict,
         feature_online_store_id: str,
         project_id: str = PROVIDE_PROJECT_ID,
         run_sync_immediately: bool = False,
@@ -215,7 +218,8 @@ class FeatureStoreHook(GoogleBaseHook):
             become the final component of the FeatureView's resource name.
             This value may be up to 60 characters, and valid characters are ``[a-z0-9_]``.
             The first character cannot be a number. The value must be unique within a FeatureOnlineStore.
-        :param feature_view: The configuration of the FeatureView to create.
+        :param feature_view: The configuration of the FeatureView to create as a FeatureView object
+            or dictionary.
         :param feature_online_store_id: The ID of the online feature store.
         :param run_sync_immediately: If set to true, one on demand sync will be run
             immediately, regardless the FeatureView.sync_config.
@@ -327,7 +331,7 @@ class FeatureStoreHook(GoogleBaseHook):
         entity_id: str | None = None,
         project_id: str = PROVIDE_PROJECT_ID,
         endpoint_domain_name: str | None = None,
-        data_key: FeatureViewDataKey | None = None,
+        data_key: FeatureViewDataKey | dict | None = None,
         data_format: int | None = None,
         location: str | None = None,
         timeout: float | _MethodDefault = DEFAULT,
@@ -346,7 +350,8 @@ class FeatureStoreHook(GoogleBaseHook):
             and default feature store endpoint will be used, based on location provided.
         :param feature_view_id: The FeatureView ID to fetch data from.
         :param feature_online_store_id: The ID of the online feature store.
-        :param data_key: Optional. The request key to fetch feature values for.
+        :param data_key: Optional. The request key to fetch feature values for as a
+            FeatureViewDataKey object or dictionary.
         :param data_format: Optional. Response data format. If not set, FeatureViewDataFormat.KEY_VALUE
             will be used.
         :param project_id: The ID of the Google Cloud project that contains the

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/feature_store.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/feature_store.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING, Any
 
 from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
-from google.cloud.aiplatform_v1beta1.types import FeatureViewDataFormat
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.hooks.vertex_ai.feature_store import FeatureStoreHook
@@ -127,8 +126,8 @@ class CreateFeatureOnlineStoreOperator(GoogleCloudBaseOperator, OperationHelper)
         This specifies the Google Cloud region where the feature store resources are located.
     :param feature_online_store_id: Required. The ID of the online feature store that contains
         the feature view to be synchronized. This store serves as the online serving layer.
-    :param feature_online_store: FeatureOnlineStore configuration object of the feature online store
-        to be created.
+    :param feature_online_store: FeatureOnlineStore configuration object or dictionary of the
+        feature online store to be created.
     :param gcp_conn_id: The connection ID to use for connecting to Google Cloud Platform.
         Defaults to 'google_cloud_default'.
     :param impersonation_chain: Optional service account to impersonate using short-term
@@ -153,7 +152,7 @@ class CreateFeatureOnlineStoreOperator(GoogleCloudBaseOperator, OperationHelper)
         project_id: str,
         location: str,
         feature_online_store_id: str,
-        feature_online_store: FeatureOnlineStore,
+        feature_online_store: FeatureOnlineStore | dict,
         timeout: float | _MethodDefault = DEFAULT,
         retry: Retry | _MethodDefault | None = DEFAULT,
         metadata: Sequence[tuple[str, str]] = (),
@@ -286,7 +285,7 @@ class CreateFeatureViewOperator(GoogleCloudBaseOperator, OperationHelper):
         of the FeatureView's resource name. This value may be up to 60 characters, and valid characters
         are ``[a-z0-9_]``. The first character cannot be a number.
         The value must be unique within a FeatureOnlineStore.
-    :param feature_view: The configuration of the FeatureView to create.
+    :param feature_view: The FeatureView configuration object or dictionary to create.
     :param feature_online_store_id: The ID of the online feature store.
     :param run_sync_immediately: If set to true, one on demand sync will be run
         immediately, regardless the FeatureView.sync_config.
@@ -316,7 +315,7 @@ class CreateFeatureViewOperator(GoogleCloudBaseOperator, OperationHelper):
         self,
         *,
         feature_view_id: str,
-        feature_view: FeatureView,
+        feature_view: FeatureView | dict,
         feature_online_store_id: str,
         run_sync_immediately: bool = False,
         project_id: str,
@@ -437,7 +436,7 @@ class FetchFeatureValuesOperator(GoogleCloudBaseOperator, OperationHelper):
     :param entity_id: Simple ID to identify Entity to fetch feature values for.
     :param feature_view_id: The FeatureView ID to fetch data from.
     :param feature_online_store_id: The ID of the online feature store.
-    :param data_key: The request key to fetch feature values for.
+    :param data_key: The FeatureViewDataKey object or dictionary used to fetch feature values.
     :param project_id: Required. The ID of the Google Cloud project that contains the feature store.
         This is used to identify which project's resources to interact with.
     :param location: Required. The location of the feature store (e.g., 'us-central1', 'us-east1').
@@ -470,7 +469,7 @@ class FetchFeatureValuesOperator(GoogleCloudBaseOperator, OperationHelper):
         project_id: str,
         location: str,
         entity_id: str | None = None,
-        data_key: FeatureViewDataKey | None = None,
+        data_key: FeatureViewDataKey | dict | None = None,
         timeout: float | _MethodDefault = DEFAULT,
         retry: Retry | _MethodDefault | None = DEFAULT,
         metadata: Sequence[tuple[str, str]] = (),
@@ -493,6 +492,8 @@ class FetchFeatureValuesOperator(GoogleCloudBaseOperator, OperationHelper):
 
     def execute(self, context: Context) -> dict[str, Any]:
         """Execute the get feature view sync operation."""
+        from google.cloud.aiplatform_v1beta1.types import FeatureViewDataFormat
+
         hook = FeatureStoreHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_feature_store.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_feature_store.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 import os
 from datetime import datetime, timedelta
 
-from google.cloud.aiplatform_v1beta1 import FeatureOnlineStore, FeatureView, FeatureViewDataKey
-
 from airflow import DAG
 from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCreateEmptyDatasetOperator,
@@ -127,7 +125,7 @@ with DAG(
         project_id=PROJECT_ID,
         location=REGION,
         feature_online_store_id=FEATURE_ONLINE_STORE_ID,
-        feature_online_store=FeatureOnlineStore(optimized=FeatureOnlineStore.Optimized()),
+        feature_online_store={"optimized": {}},
     )
     # [END how_to_cloud_vertex_ai_create_feature_online_store_operator]
 
@@ -138,13 +136,13 @@ with DAG(
         location=REGION,
         feature_online_store_id=FEATURE_ONLINE_STORE_ID,
         feature_view_id=FEATURE_VIEW_ID,
-        feature_view=FeatureView(
-            big_query_source=FeatureView.BigQuerySource(
-                uri=f"bq://{BQ_VIEW_FQN}",
-                entity_id_columns=["entity_id"],
-            ),
-            sync_config=FeatureView.SyncConfig(cron="TZ=America/Los_Angeles 56 * * * *"),
-        ),
+        feature_view={
+            "big_query_source": {
+                "uri": f"bq://{BQ_VIEW_FQN}",
+                "entity_id_columns": ["entity_id"],
+            },
+            "sync_config": {"cron": "TZ=America/Los_Angeles 56 * * * *"},
+        },
     )
     # [END how_to_cloud_vertex_ai_create_feature_view_store_operator]
 
@@ -193,7 +191,7 @@ with DAG(
         location=REGION,
         feature_online_store_id=FEATURE_ONLINE_STORE_ID,
         feature_view_id=FEATURE_VIEW_ID,
-        data_key=FeatureViewDataKey(FEATURE_VIEW_DATA_KEY),
+        data_key=FEATURE_VIEW_DATA_KEY,
         retries=3,
         retry_delay=timedelta(minutes=3),
     )

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_feature_store.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_feature_store.py
@@ -17,7 +17,11 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from unittest import mock
+
+import pytest
 
 from airflow.providers.google.cloud.hooks.vertex_ai.feature_store import FeatureStoreHook
 
@@ -27,6 +31,7 @@ from unit.google.cloud.utils.base_gcp_mock import (
 
 BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 FEATURE_STORE_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.feature_store.{}"
+FEATURE_STORE_CLIENT_STRING = "google.cloud.aiplatform_v1beta1.{}"
 
 TEST_GCP_CONN_ID = "test-gcp-conn-id"
 TEST_PROJECT_ID = "test-project"
@@ -37,6 +42,22 @@ TEST_FEATURE_VIEW = f"projects/{TEST_PROJECT_ID}/locations/{TEST_LOCATION}/featu
 TEST_FEATURE_VIEW_SYNC_NAME = f"{TEST_FEATURE_VIEW}/featureViewSyncs/sync123"
 
 
+@pytest.mark.parametrize(
+    "module",
+    (
+        "airflow.providers.google.cloud.hooks.vertex_ai.feature_store",
+        "airflow.providers.google.cloud.operators.vertex_ai.feature_store",
+    ),
+)
+def test_import_does_not_load_aiplatform_v1beta1(module):
+    code = (
+        f"import sys; import {module}; "
+        "assert 'google.cloud.aiplatform_v1beta1' not in sys.modules, "
+        "sorted(name for name in sys.modules if 'aiplatform_v1beta1' in name)"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, capture_output=True, text=True)
+
+
 class TestFeatureStoreHook:
     def setup_method(self):
         with mock.patch(
@@ -45,7 +66,7 @@ class TestFeatureStoreHook:
             self.hook = FeatureStoreHook(gcp_conn_id=TEST_GCP_CONN_ID)
 
     @mock.patch(BASE_STRING.format("GoogleBaseHook.get_client_options"))
-    @mock.patch(FEATURE_STORE_STRING.format("FeatureOnlineStoreAdminServiceClient"), autospec=True)
+    @mock.patch(FEATURE_STORE_CLIENT_STRING.format("FeatureOnlineStoreAdminServiceClient"), autospec=True)
     @mock.patch(BASE_STRING.format("GoogleBaseHook.get_credentials"))
     def test_get_feature_online_store_admin_service_client(
         self, mock_get_credentials, mock_client, mock_get_client_options
@@ -68,6 +89,23 @@ class TestFeatureStoreHook:
         )
         api_endpoint_override = mock_get_client_options.call_args[1]["api_endpoint_override"]
         assert not api_endpoint_override
+
+    @mock.patch(BASE_STRING.format("GoogleBaseHook.get_client_options"))
+    @mock.patch(FEATURE_STORE_CLIENT_STRING.format("FeatureOnlineStoreServiceClient"), autospec=True)
+    @mock.patch(BASE_STRING.format("GoogleBaseHook.get_credentials"))
+    def test_get_feature_online_store_service_client(
+        self,
+        mock_get_credentials,
+        mock_client,
+        mock_get_client_options,
+    ):
+        self.hook.get_feature_online_store_service_client(location=TEST_LOCATION)
+
+        mock_client.assert_called_once_with(
+            credentials=mock_get_credentials.return_value,
+            client_info=mock.ANY,
+            client_options=mock_get_client_options.return_value,
+        )
 
     @mock.patch(FEATURE_STORE_STRING.format("FeatureStoreHook.get_feature_online_store_admin_service_client"))
     def test_get_feature_view_sync(self, mock_client_getter):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->


Prevent the Google Vertex AI Feature Store system Dag from loading `aiplatform_v1beta1` while Airflow discovers Dags. The package's third-party import chain can exceed the default 30-second Dag import timeout before any task runs.

Defer the Feature Store clients and data-format type until their execution paths need them. Use GAPIC-supported mappings in the system Dag so parsing does not construct protobuf messages, while keeping the existing hook and operator type signatures unchanged.

Update the client mock targets for the deferred imports and cover both client getter paths.

Before/after cold-import comparison in the same Breeze environment:

| | Before | After |
|---|---:|---:|
| System Dag import time | 30+ seconds (timeout) | 10.278 seconds |
| `google.cloud.aiplatform_v1beta1` loaded during parsing | Yes | No |

The before result exceeds Airflow's default `dagbag_import_timeout` of 30 seconds. The after result keeps the Vertex AI Feature Store package out of the Dag parsing process entirely.

* closes: #69822 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - Codex 5.6 Sol

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
