### PR TITLE
Enhance/standardize documentation for `AssetOrTimeSchedule`

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/timetable.rst
+++ b/airflow-core/docs/authoring-and-scheduling/timetable.rst
@@ -264,8 +264,9 @@ first, event for the data interval. Otherwise, manual runs begin with a ``data_i
 
 .. _asset-timetable-section:
 
-Asset event based scheduling with time based scheduling
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+AssetOrTimeSchedule
+^^^^^^^^^^^^^^^^^^^
+
 Combining conditional asset expressions with time-based schedules enhances scheduling flexibility.
 
 The ``AssetOrTimeSchedule`` is a specialized timetable that allows for the scheduling of Dags based on both time-based schedules and asset events. It also facilitates the creation of both scheduled runs, as per traditional timetables, and asset-triggered runs, which operate independently.
@@ -283,13 +284,11 @@ Here's an example of a Dag using ``AssetOrTimeSchedule``:
     @dag(
         schedule=AssetOrTimeSchedule(
             timetable=CronTriggerTimetable("0 1 * * 3", timezone="UTC"), assets=(dag1_asset & dag2_asset)
-        )
-        # Additional arguments here, replace this comment with actual arguments
+        ),
+        ...,
     )
     def example_dag():
-        # Dag tasks go here
         pass
-
 
 
 Timetables comparisons


### PR DESCRIPTION
## Description

Upon reviewing the custom Timetable documentation, I noticed that the ``AssetOrTimeSchedule`` timetable was not listed in the index like the other custom Timetables. I took the opportunity to clean this up to ensure that the same standard was applied.

Below is a screenshot of what this previously looked like. Now, this should be fixed.

<img width="272" height="392" alt="image" src="https://github.com/user-attachments/assets/c2d2d6d8-61b5-49e3-8218-eb46c1f1e9a2" />

Note that #69826 was closed when the branch name was changed.

## Testing

No testing was needed, this was a docs-only change.
