### PR TITLE
Release DB connection before deserializing DAGs in grid structure endpoint

### DIFF
--- a/airflow-core/newsfragments/69832.bugfix.rst
+++ b/airflow-core/newsfragments/69832.bugfix.rst
@@ -1,0 +1,1 @@
+Release the metadata DB connection in the grid ``structure`` endpoint before deserializing historical DAG versions, so it is not held open across CPU-bound work and does not exhaust the connection pool on large DAGs.

--- a/airflow-core/newsfragments/69832.bugfix.rst
+++ b/airflow-core/newsfragments/69832.bugfix.rst
@@ -1,1 +1,0 @@
-Release the metadata DB connection in the grid ``structure`` endpoint before deserializing historical DAG versions, so it is not held open across CPU-bound work and does not exhaust the connection pool on large DAGs.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -69,6 +69,7 @@ from airflow.models.dagrun import DagRun, DagRunNote
 from airflow.models.deadline import Deadline
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstanceNote
+from airflow.utils.helpers import chunks
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
@@ -193,53 +194,64 @@ def get_dag_structure(
     _merge_node_dicts(merged_nodes, nodes)
     del latest_dag
 
-    # Fetch the historical serialized Dags for the visible runs, then detach them
-    # and release the DB connection *before* the CPU-bound deserialization + merge
-    # below. Deserializing (``serdag.dag``) and merging a large DAG's task groups is
-    # expensive; doing it while a server-side cursor (``yield_per``) is open keeps the
-    # transaction — and, under PgBouncer transaction pooling, the pooled server
-    # connection — pinned for the entire render. At scale that exhausts the pool and
-    # starves task-instance heartbeats, so the connection must not be held across the
-    # deserialization. See https://github.com/apache/airflow/issues/65712.
+    # Identify the historical serialized Dags for the visible runs (ids only, cheap),
+    # then process them in small batches so we never hold a DB connection open across
+    # the CPU-bound deserialization/merge below.
     #
-    # ``SerializedDagModel.dag`` only reads the already-loaded ``data`` column, so it
-    # works on detached instances after the session is released. The result set is
-    # bounded by this endpoint's page of runs (one DAG's versions), so materializing
-    # it is a safe trade for not holding the connection open.
-    serdags_query = select(SerializedDagModel).where(
-        # Even though dag_id is filtered in base_query,
-        # adding this line here can improve the performance of this endpoint
-        SerializedDagModel.dag_id == dag_id,
-        SerializedDagModel.id != latest_serdag_id,
-        SerializedDagModel.dag_version_id.in_(
-            select(TaskInstance.dag_version_id)
-            .join(TaskInstance.dag_run)
-            .where(
-                DagRun.id.in_(run_ids),
-            )
-            .distinct()
-        ),
+    # Deserializing (``serdag.dag``) and merging a large DAG's task groups is
+    # expensive. Streaming the rows with a server-side cursor (``yield_per``) and
+    # deserializing between fetches keeps the transaction — and, under PgBouncer
+    # transaction pooling, the pooled server connection — pinned for the entire
+    # render; at scale that exhausts the pool and starves task-instance heartbeats.
+    # See https://github.com/apache/airflow/issues/65712.
+    #
+    # Each batch is loaded and detached in its own short-lived session that is closed
+    # before the batch is deserialized, so the connection is released during the CPU
+    # work while peak memory stays bounded to one batch (``SerializedDagModel.dag``
+    # only reads the already-loaded ``data`` column, so it works on detached rows).
+    serdag_id_query = (
+        select(SerializedDagModel.id)
+        .where(
+            # Even though dag_id is filtered in base_query,
+            # adding this line here can improve the performance of this endpoint
+            SerializedDagModel.dag_id == dag_id,
+            SerializedDagModel.id != latest_serdag_id,
+            SerializedDagModel.dag_version_id.in_(
+                select(TaskInstance.dag_version_id)
+                .join(TaskInstance.dag_run)
+                .where(
+                    DagRun.id.in_(run_ids),
+                )
+                .distinct()
+            ),
+        )
+        .order_by(SerializedDagModel.id)
     )
-    serdags = session.scalars(serdags_query).all()
-    for serdag in serdags:
-        session.expunge(serdag)  # detach so `.dag` deserializes without the session
-    # End the read transaction so the connection returns to the pool during the
-    # deserialization/merge below instead of sitting idle-in-transaction.
+    serdag_ids = list(session.scalars(serdag_id_query))
+    # Release the request session's transaction/connection before the batched work.
     session.commit()
 
-    for serdag in serdags:
-        filtered_dag = serdag.dag
-        # Apply the same filtering to historical Dag versions
-        if root:
-            filtered_dag = filtered_dag.partial_subset(
-                task_ids=root,
-                include_upstream=include_upstream,
-                include_downstream=include_downstream,
-                depth=depth,
-            )
-        # Merge immediately instead of collecting all Dags in memory
-        nodes = [task_group_to_dict_grid(x) for x in task_group_sort(filtered_dag.task_group)]
-        _merge_node_dicts(merged_nodes, nodes)
+    for serdag_id_batch in chunks(serdag_ids, 5):  # balance memory usage and round trips
+        with create_session(scoped=False) as batch_session:
+            serdags = batch_session.scalars(
+                select(SerializedDagModel).where(SerializedDagModel.id.in_(serdag_id_batch))
+            ).all()
+            for serdag in serdags:
+                batch_session.expunge(serdag)  # detach so `.dag` deserializes without the session
+        # Connection is released here; deserialize + merge this batch outside the transaction.
+        for serdag in serdags:
+            filtered_dag = serdag.dag
+            # Apply the same filtering to historical Dag versions
+            if root:
+                filtered_dag = filtered_dag.partial_subset(
+                    task_ids=root,
+                    include_upstream=include_upstream,
+                    include_downstream=include_downstream,
+                    depth=depth,
+                )
+            # Merge immediately instead of collecting all Dags in memory
+            nodes = [task_group_to_dict_grid(x) for x in task_group_sort(filtered_dag.task_group)]
+            _merge_node_dicts(merged_nodes, nodes)
 
     return [GridNodeResponse(**n) for n in merged_nodes]
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -193,29 +193,41 @@ def get_dag_structure(
     _merge_node_dicts(merged_nodes, nodes)
     del latest_dag
 
-    # Process serdags one by one and merge immediately to reduce memory usage.
-    # Use yield_per() for streaming results and expunge each serdag after processing
-    # to allow garbage collection and prevent memory buildup in the session identity map.
-    serdags_query = (
-        select(SerializedDagModel)
-        .where(
-            # Even though dag_id is filtered in base_query,
-            # adding this line here can improve the performance of this endpoint
-            SerializedDagModel.dag_id == dag_id,
-            SerializedDagModel.id != latest_serdag_id,
-            SerializedDagModel.dag_version_id.in_(
-                select(TaskInstance.dag_version_id)
-                .join(TaskInstance.dag_run)
-                .where(
-                    DagRun.id.in_(run_ids),
-                )
-                .distinct()
-            ),
-        )
-        .execution_options(yield_per=5)  # balance between peak memory usage and round trips
+    # Fetch the historical serialized Dags for the visible runs, then detach them
+    # and release the DB connection *before* the CPU-bound deserialization + merge
+    # below. Deserializing (``serdag.dag``) and merging a large DAG's task groups is
+    # expensive; doing it while a server-side cursor (``yield_per``) is open keeps the
+    # transaction — and, under PgBouncer transaction pooling, the pooled server
+    # connection — pinned for the entire render. At scale that exhausts the pool and
+    # starves task-instance heartbeats, so the connection must not be held across the
+    # deserialization. See https://github.com/apache/airflow/issues/65712.
+    #
+    # ``SerializedDagModel.dag`` only reads the already-loaded ``data`` column, so it
+    # works on detached instances after the session is released. The result set is
+    # bounded by this endpoint's page of runs (one DAG's versions), so materializing
+    # it is a safe trade for not holding the connection open.
+    serdags_query = select(SerializedDagModel).where(
+        # Even though dag_id is filtered in base_query,
+        # adding this line here can improve the performance of this endpoint
+        SerializedDagModel.dag_id == dag_id,
+        SerializedDagModel.id != latest_serdag_id,
+        SerializedDagModel.dag_version_id.in_(
+            select(TaskInstance.dag_version_id)
+            .join(TaskInstance.dag_run)
+            .where(
+                DagRun.id.in_(run_ids),
+            )
+            .distinct()
+        ),
     )
+    serdags = session.scalars(serdags_query).all()
+    for serdag in serdags:
+        session.expunge(serdag)  # detach so `.dag` deserializes without the session
+    # End the read transaction so the connection returns to the pool during the
+    # deserialization/merge below instead of sitting idle-in-transaction.
+    session.commit()
 
-    for serdag in session.scalars(serdags_query):
+    for serdag in serdags:
         filtered_dag = serdag.dag
         # Apply the same filtering to historical Dag versions
         if root:
@@ -228,8 +240,6 @@ def get_dag_structure(
         # Merge immediately instead of collecting all Dags in memory
         nodes = [task_group_to_dict_grid(x) for x in task_group_sort(filtered_dag.task_group)]
         _merge_node_dicts(merged_nodes, nodes)
-
-        session.expunge(serdag)  # to allow garbage collection
 
     return [GridNodeResponse(**n) for n in merged_nodes]
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -73,6 +73,7 @@ from airflow.models.dagrun import DagRun, DagRunNote
 from airflow.models.deadline import Deadline
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance, TaskInstanceNote
+from airflow.utils.helpers import chunks
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
@@ -215,57 +216,68 @@ def get_dag_structure(
     _merge_node_dicts(merged_nodes, nodes)
     del latest_dag, latest_group_dict
 
-    # Fetch the historical serialized Dags for the visible runs, then detach them
-    # and release the DB connection *before* the CPU-bound deserialization + merge
-    # below. Deserializing (``serdag.dag``) and merging a large DAG's task groups is
-    # expensive; doing it while a server-side cursor (``yield_per``) is open keeps the
-    # transaction — and, under PgBouncer transaction pooling, the pooled server
-    # connection — pinned for the entire render. At scale that exhausts the pool and
-    # starves task-instance heartbeats, so the connection must not be held across the
-    # deserialization. See https://github.com/apache/airflow/issues/65712.
+    # Identify the historical serialized Dags for the visible runs (ids only, cheap),
+    # then process them in small batches so we never hold a DB connection open across
+    # the CPU-bound deserialization/merge below.
     #
-    # ``SerializedDagModel.dag`` only reads the already-loaded ``data`` column, so it
-    # works on detached instances after the session is released. The result set is
-    # bounded by this endpoint's page of runs (one DAG's versions), so materializing
-    # it is a safe trade for not holding the connection open.
-    serdags_query = select(SerializedDagModel).where(
-        # Even though dag_id is filtered in base_query,
-        # adding this line here can improve the performance of this endpoint
-        SerializedDagModel.dag_id == dag_id,
-        SerializedDagModel.id != latest_serdag_id,
-        SerializedDagModel.dag_version_id.in_(
-            select(TaskInstance.dag_version_id)
-            .join(TaskInstance.dag_run)
-            .where(
-                DagRun.id.in_(run_ids),
-            )
-            .distinct()
-        ),
+    # Deserializing (``serdag.dag``) and merging a large DAG's task groups is
+    # expensive. Streaming the rows with a server-side cursor (``yield_per``) and
+    # deserializing between fetches keeps the transaction — and, under PgBouncer
+    # transaction pooling, the pooled server connection — pinned for the entire
+    # render; at scale that exhausts the pool and starves task-instance heartbeats.
+    # See https://github.com/apache/airflow/issues/65712.
+    #
+    # Each batch is loaded and detached in its own short-lived session that is closed
+    # before the batch is deserialized, so the connection is released during the CPU
+    # work while peak memory stays bounded to one batch (``SerializedDagModel.dag``
+    # only reads the already-loaded ``data`` column, so it works on detached rows).
+    serdag_id_query = (
+        select(SerializedDagModel.id)
+        .where(
+            # Even though dag_id is filtered in base_query,
+            # adding this line here can improve the performance of this endpoint
+            SerializedDagModel.dag_id == dag_id,
+            SerializedDagModel.id != latest_serdag_id,
+            SerializedDagModel.dag_version_id.in_(
+                select(TaskInstance.dag_version_id)
+                .join(TaskInstance.dag_run)
+                .where(
+                    DagRun.id.in_(run_ids),
+                )
+                .distinct()
+            ),
+        )
+        .order_by(SerializedDagModel.id)
     )
-    serdags = session.scalars(serdags_query).all()
-    for serdag in serdags:
-        session.expunge(serdag)  # detach so `.dag` deserializes without the session
-    # End the read transaction so the connection returns to the pool during the
-    # deserialization/merge below instead of sitting idle-in-transaction.
+    serdag_ids = list(session.scalars(serdag_id_query))
+    # Release the request session's transaction/connection before the batched work.
     session.commit()
 
-    for serdag in serdags:
-        filtered_dag = serdag.dag
-        # Apply the same filtering to historical Dag versions
-        if root:
-            filtered_dag = filtered_dag.partial_subset(
-                task_ids=root,
-                include_upstream=include_upstream,
-                include_downstream=include_downstream,
-                depth=depth,
-            )
-        # Merge immediately instead of collecting all Dags in memory
-        filtered_group_dict = filtered_dag.task_group.get_task_group_dict()
-        nodes = [
-            task_group_to_dict_grid(x, group_dict=filtered_group_dict)
-            for x in task_group_sort(filtered_dag.task_group, filtered_group_dict)
-        ]
-        _merge_node_dicts(merged_nodes, nodes)
+    for serdag_id_batch in chunks(serdag_ids, 5):  # balance memory usage and round trips
+        with create_session(scoped=False) as batch_session:
+            serdags = batch_session.scalars(
+                select(SerializedDagModel).where(SerializedDagModel.id.in_(serdag_id_batch))
+            ).all()
+            for serdag in serdags:
+                batch_session.expunge(serdag)  # detach so `.dag` deserializes without the session
+        # Connection is released here; deserialize + merge this batch outside the transaction.
+        for serdag in serdags:
+            filtered_dag = serdag.dag
+            # Apply the same filtering to historical Dag versions
+            if root:
+                filtered_dag = filtered_dag.partial_subset(
+                    task_ids=root,
+                    include_upstream=include_upstream,
+                    include_downstream=include_downstream,
+                    depth=depth,
+                )
+            # Merge immediately instead of collecting all Dags in memory
+            filtered_group_dict = filtered_dag.task_group.get_task_group_dict()
+            nodes = [
+                task_group_to_dict_grid(x, group_dict=filtered_group_dict)
+                for x in task_group_sort(filtered_dag.task_group, filtered_group_dict)
+            ]
+            _merge_node_dicts(merged_nodes, nodes)
 
     return [GridNodeResponse(**n) for n in merged_nodes]
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -216,42 +216,24 @@ def get_dag_structure(
     _merge_node_dicts(merged_nodes, nodes)
     del latest_dag, latest_group_dict
 
-    # Identify the historical serialized Dags for the visible runs (ids only, cheap),
-    # then process them in small batches so we never hold a DB connection open across
-    # the CPU-bound deserialization/merge below.
-    #
-    # Deserializing (``serdag.dag``) and merging a large DAG's task groups is
-    # expensive. Streaming the rows with a server-side cursor (``yield_per``) and
-    # deserializing between fetches keeps the transaction — and, under PgBouncer
-    # transaction pooling, the pooled server connection — pinned for the entire
-    # render; at scale that exhausts the pool and starves task-instance heartbeats.
-    # See https://github.com/apache/airflow/issues/65712.
-    #
-    # Each batch is loaded and detached in its own short-lived session that is closed
-    # before the batch is deserialized, so the connection is released during the CPU
-    # work while peak memory stays bounded to one batch (``SerializedDagModel.dag``
-    # only reads the already-loaded ``data`` column, so it works on detached rows).
-    serdag_id_query = (
-        select(SerializedDagModel.id)
-        .where(
-            # Even though dag_id is filtered in base_query,
-            # adding this line here can improve the performance of this endpoint
-            SerializedDagModel.dag_id == dag_id,
-            SerializedDagModel.id != latest_serdag_id,
-            SerializedDagModel.dag_version_id.in_(
-                select(TaskInstance.dag_version_id)
-                .join(TaskInstance.dag_run)
-                .where(
-                    DagRun.id.in_(run_ids),
-                )
-                .distinct()
-            ),
-        )
-        .order_by(SerializedDagModel.id)
+    # we get the ids so that we can split serialization into batches and balance round trips and mem usage
+    serdag_id_query = select(SerializedDagModel.id).where(
+        # Even though dag_id is filtered in base_query,
+        # adding this line here can improve the performance of this endpoint
+        SerializedDagModel.dag_id == dag_id,
+        SerializedDagModel.id != latest_serdag_id,
+        SerializedDagModel.dag_version_id.in_(
+            select(TaskInstance.dag_version_id)
+            .join(TaskInstance.dag_run)
+            .where(
+                DagRun.id.in_(run_ids),
+            )
+            .distinct()
+        ),
     )
     serdag_ids = list(session.scalars(serdag_id_query))
     # Release the request session's transaction/connection before the batched work.
-    session.commit()
+    session.close()
 
     for serdag_id_batch in chunks(serdag_ids, 5):  # balance memory usage and round trips
         with create_session(scoped=False) as batch_session:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -215,29 +215,41 @@ def get_dag_structure(
     _merge_node_dicts(merged_nodes, nodes)
     del latest_dag, latest_group_dict
 
-    # Process serdags one by one and merge immediately to reduce memory usage.
-    # Use yield_per() for streaming results and expunge each serdag after processing
-    # to allow garbage collection and prevent memory buildup in the session identity map.
-    serdags_query = (
-        select(SerializedDagModel)
-        .where(
-            # Even though dag_id is filtered in base_query,
-            # adding this line here can improve the performance of this endpoint
-            SerializedDagModel.dag_id == dag_id,
-            SerializedDagModel.id != latest_serdag_id,
-            SerializedDagModel.dag_version_id.in_(
-                select(TaskInstance.dag_version_id)
-                .join(TaskInstance.dag_run)
-                .where(
-                    DagRun.id.in_(run_ids),
-                )
-                .distinct()
-            ),
-        )
-        .execution_options(yield_per=5)  # balance between peak memory usage and round trips
+    # Fetch the historical serialized Dags for the visible runs, then detach them
+    # and release the DB connection *before* the CPU-bound deserialization + merge
+    # below. Deserializing (``serdag.dag``) and merging a large DAG's task groups is
+    # expensive; doing it while a server-side cursor (``yield_per``) is open keeps the
+    # transaction — and, under PgBouncer transaction pooling, the pooled server
+    # connection — pinned for the entire render. At scale that exhausts the pool and
+    # starves task-instance heartbeats, so the connection must not be held across the
+    # deserialization. See https://github.com/apache/airflow/issues/65712.
+    #
+    # ``SerializedDagModel.dag`` only reads the already-loaded ``data`` column, so it
+    # works on detached instances after the session is released. The result set is
+    # bounded by this endpoint's page of runs (one DAG's versions), so materializing
+    # it is a safe trade for not holding the connection open.
+    serdags_query = select(SerializedDagModel).where(
+        # Even though dag_id is filtered in base_query,
+        # adding this line here can improve the performance of this endpoint
+        SerializedDagModel.dag_id == dag_id,
+        SerializedDagModel.id != latest_serdag_id,
+        SerializedDagModel.dag_version_id.in_(
+            select(TaskInstance.dag_version_id)
+            .join(TaskInstance.dag_run)
+            .where(
+                DagRun.id.in_(run_ids),
+            )
+            .distinct()
+        ),
     )
+    serdags = session.scalars(serdags_query).all()
+    for serdag in serdags:
+        session.expunge(serdag)  # detach so `.dag` deserializes without the session
+    # End the read transaction so the connection returns to the pool during the
+    # deserialization/merge below instead of sitting idle-in-transaction.
+    session.commit()
 
-    for serdag in session.scalars(serdags_query):
+    for serdag in serdags:
         filtered_dag = serdag.dag
         # Apply the same filtering to historical Dag versions
         if root:
@@ -254,8 +266,6 @@ def get_dag_structure(
             for x in task_group_sort(filtered_dag.task_group, filtered_group_dict)
         ]
         _merge_node_dicts(merged_nodes, nodes)
-
-        session.expunge(serdag)  # to allow garbage collection
 
     return [GridNodeResponse(**n) for n in merged_nodes]
 


### PR DESCRIPTION
## Overview

`get_dag_structure` (`GET /ui/grid/structure/{dag_id}`) streams historical `SerializedDagModel` rows with a `yield_per` server-side cursor while performing CPU-bound `serdag.dag` deserialization and task-group merging *between* fetches. Because the cursor stays open across that work, the read transaction — and, under PgBouncer transaction pooling, the pooled server connection — stays pinned for the entire render of a large DAG.

For DAGs with many tasks and many historical versions this holds a connection open for a long time (multiple minutes in the field). At scale that exhausts the PgBouncer pool and starves task-instance heartbeat updates, contributing to the metadata-DB contention tracked in #65712.

## Why this matters

The UI API and the execution API are served by the same api-server process and share a single metadata-DB connection pool. A UI endpoint that holds a pooled connection across a multi-minute render therefore directly starves execution-API calls — task-SDK heartbeats and state updates — competing for that pool. When those heartbeat/state calls are delayed, workers time out and retry, which piles more load onto the same pool. Keeping UI read handlers from holding connections across CPU-bound work is what prevents UI traffic from degrading task execution.

## Change

Materialize the (page-bounded) set of historical serialized DAGs, detach them from the session, and commit the read transaction so the connection returns to the pool **before** the deserialization/merge loop runs.

`SerializedDagModel.dag` only reads the already-loaded `data` column, so deserialization works on detached instances with no further DB access. The result set is bounded by this endpoint's page of runs (a single DAG's versions), so materializing it is a safe trade for not holding the connection open across CPU-bound work.

This mirrors the per-unit session-release pattern already applied to the streaming `ti_summaries` endpoint in #65010.

## Related

- Contributes to #65712

## Testing

- Existing grid `structure` endpoint tests pass, including `test_structure_includes_historical_removed_task_with_proper_shape`, which exercises the historical-versions loop that was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (1M context)
