### PR TITLE
Allow `AthenaOperator` queries without a `database` argument

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
@@ -50,6 +50,8 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
     :param database: Default database for query execution. (templated)
         This argument is optional when the query does not require a default database,
         such as when all referenced table names are fully qualified.
+        If omitted or set to ``None``, any ``Database`` value set in
+        the ``query_execution_context`` will be used instead.
     :param catalog: Catalog to select. (templated)
     :param output_location: s3 path to write the query results into. (templated)
         To run the query, you must specify the query results location using one of the ways:

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
@@ -47,7 +47,9 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
         :ref:`howto/operator:AthenaOperator`
 
     :param query: Trino/Presto query to be run on Amazon Athena. (templated)
-    :param database: Database to select. (templated)
+    :param database: Default database for query execution. (templated)
+        This argument is optional when the query does not require a default database,
+        such as when all referenced table names are fully qualified.
     :param catalog: Catalog to select. (templated)
     :param output_location: s3 path to write the query results into. (templated)
         To run the query, you must specify the query results location using one of the ways:
@@ -88,7 +90,7 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
         self,
         *,
         query: str,
-        database: str,
+        database: str | None = None,
         output_location: str | None = None,
         client_request_token: str | None = None,
         workgroup: str = "primary",
@@ -122,7 +124,8 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
 
     def execute(self, context: Context) -> str | None:
         """Run Trino/Presto Query on Amazon Athena."""
-        self.query_execution_context["Database"] = self.database
+        if self.database:
+            self.query_execution_context["Database"] = self.database
         self.query_execution_context["Catalog"] = self.catalog
         if self.output_location:
             self.result_configuration["OutputLocation"] = self.output_location

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/athena.py
@@ -254,11 +254,13 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
                 ],
             )
 
+        fallback_database = self.database or self.query_execution_context.get("Database")
+
         inputs: list[Dataset] = list(
             filter(
                 None,
                 [
-                    self.get_openlineage_dataset(table.schema or self.database, table.name)
+                    self.get_openlineage_dataset(table.schema or fallback_database, table.name)
                     for table in parse_result.in_tables
                 ],
             )
@@ -268,7 +270,7 @@ class AthenaOperator(AwsBaseOperator[AthenaHook]):
             filter(
                 None,
                 [
-                    self.get_openlineage_dataset(table.schema or self.database, table.name)
+                    self.get_openlineage_dataset(table.schema or fallback_database, table.name)
                     for table in parse_result.out_tables
                 ],
             )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
@@ -142,6 +142,26 @@ class TestAthenaOperator:
     @mock.patch.object(AthenaHook, "check_query_status", side_effect=("SUCCEEDED",))
     @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
     @mock.patch.object(AthenaHook, "get_conn")
+    def test_hook_run_without_database(self, mock_conn, mock_run_query, mock_check_query_status):
+        op_kwargs = self.default_op_kwargs.copy()
+        op_kwargs["task_id"] = "test_athena_operator_without_database"
+        op_kwargs.pop("database")
+        op = AthenaOperator(
+            **op_kwargs, output_location="s3://test_s3_bucket/", aws_conn_id=None, dag=self.dag
+        )
+        op.execute({})
+        mock_run_query.assert_called_once_with(
+            MOCK_DATA["query"],
+            {"Catalog": MOCK_DATA["catalog"]},
+            result_configuration,
+            MOCK_DATA["client_request_token"],
+            MOCK_DATA["workgroup"],
+        )
+        assert mock_check_query_status.call_count == 1
+
+    @mock.patch.object(AthenaHook, "check_query_status", side_effect=("SUCCEEDED",))
+    @mock.patch.object(AthenaHook, "run_query", return_value=ATHENA_QUERY_ID)
+    @mock.patch.object(AthenaHook, "get_conn")
     def test_hook_run_small_success_query(self, mock_conn, mock_run_query, mock_check_query_status):
         self.athena.execute({})
         mock_run_query.assert_called_once_with(

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_athena.py
@@ -341,6 +341,21 @@ class TestAthenaOperator:
         )
         assert operator.query_execution_id == query_execution_id
 
+    @mock.patch.object(AthenaOperator, "get_openlineage_dataset")
+    def test_openlineage_uses_database_from_query_execution_context(self, mock_get_dataset):
+        op = AthenaOperator(
+            task_id="test_athena_openlineage",
+            query="INSERT INTO TEST_TABLE SELECT CUSTOMER_EMAIL FROM DISCOUNTS",
+            database=None,
+            query_execution_context={"Database": "TEST_DATABASE"},
+            dag=self.dag,
+        )
+
+        op.get_openlineage_facets_on_complete(None)
+
+        mock_get_dataset.assert_any_call("TEST_DATABASE", "DISCOUNTS")
+        mock_get_dataset.assert_any_call("TEST_DATABASE", "TEST_TABLE")
+
     @mock.patch.object(AthenaHook, "region_name", new_callable=mock.PropertyMock)
     @mock.patch.object(AthenaHook, "get_conn")
     def test_operator_openlineage_data(self, mock_conn, mock_region_name):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

# Summary

This PR makes the `database` argument **optional** in `AthenaOperator`, allowing queries that do not require a default database.
This is useful when all referenced table names are fully qualified, such as in queries across multiple databases.

When `database` is not provided, `Database` from `query_execution_context` is used as the fallback database for OpenLineage dataset extraction.


# Testing

- ✅ `breeze run pytest providers/amazon/tests/unit/amazon/aws/operators/test_athena.py` **passed** (16 test cases).
- ✅ `prek run --from-ref upstream/main` **passed**.
- ✅ **Successfully** ran the system test against Amazon Athena
  1. Locally removed the `database` argument from the `read_table` task in [`example_athena.py`](https://github.com/apache/airflow/blob/main/providers/amazon/tests/system/amazon/aws/example_athena.py) like this:
      ```diff
      diff --git a/providers/amazon/tests/system/amazon/aws/example_athena.py b/providers/amazon/tests/system/amazon/aws/example_athena.py
      index 36a37a8e1c..3c72e9b309 100644
      --- a/providers/amazon/tests/system/amazon/aws/example_athena.py
      +++ b/providers/amazon/tests/system/amazon/aws/example_athena.py
      @@ -129,7 +129,6 @@ with DAG(
           read_table = AthenaOperator(
               task_id="read_table",
               query=query_read_table,
      -        database=athena_database,
               output_location=f"s3://{s3_bucket}/",
           )
           # [END howto_operator_athena]
      ```
  2. Ran the system test with the following command; it **passed** ✅:
      ```bash
      $ SYSTEM_TESTS_ENV_ID=airflowtest$(date +%s) breeze run --forward-credentials env AWS_PROFILE=airflow-test pytest --system providers/amazon/tests/system/amazon/aws/example_athena.py
      ...
      providers/amazon/tests/system/amazon/aws/example_athena.py::test_run <- devel-common/src/tests_common/test_utils/system_tests.py PASSED [100%]
      
      ================================================= 1 passed, 1 warning in 56.41s ==================================================
      ```
  3. Confirmed that the query succeeded with only `Catalog` in `QueryExecutionContext`:
      ```bash
      $ aws athena get-query-execution --query-execution-id <<<REDACTED>>> --profile airflow-test
      QueryExecution:
        ...
        Query: SELECT * from airflowtest1784003174_default.airflowtest1784003174_test_table
        QueryExecutionContext:
          Catalog: awsdatacatalog
        QueryExecutionId: <<<REDACTED>>>
        ...
        Status:
          CompletionDateTime: '2026-07-14T13:27:19.237000+09:00'
          State: SUCCEEDED
          SubmissionDateTime: '2026-07-14T13:27:17.950000+09:00'
        SubstatementType: SELECT
        WorkGroup: primary
      ```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: OpenAI Codex (GPT-5.5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: OpenAI Codex; reviewed by @te-horie before posting