### PR TITLE
fix: Boolean toggles in the Trigger Dag / FlexibleForm params grid were

### DIFF
--- a/airflow-core/newsfragments/67852.bugfix.rst
+++ b/airflow-core/newsfragments/67852.bugfix.rst
@@ -1,0 +1,1 @@
+Boolean params in the Trigger Dag form now right-align their toggle within the control column, instead of the toggle sitting immediately after the label. This matches the label-left/control-right layout of the other params in the form.

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.test.tsx
@@ -1,0 +1,57 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { FieldBool } from "./FieldBool";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockParamsDict: Record<string, any> = {};
+
+vi.mock("src/queries/useParamStore", () => ({
+  paramPlaceholder: {
+    schema: {},
+    value: null,
+  },
+  useParamStore: () => ({
+    disabled: false,
+    paramsDict: mockParamsDict,
+    setParamsDict: vi.fn(),
+  }),
+}));
+
+describe("FieldBool (issue #67852)", () => {
+  it("right-aligns the toggle within its control column", () => {
+    mockParamsDict.run_tests = {
+      schema: { title: "A rather long boolean parameter label", type: "boolean" },
+      value: true,
+    };
+
+    render(<FieldBool name="run_tests" onUpdate={vi.fn()} />, { wrapper: Wrapper });
+
+    const switchRoot = document.querySelector('[data-scope="switch"][data-part="root"]');
+
+    expect(switchRoot).not.toBeNull();
+    const style = getComputedStyle(switchRoot as Element);
+
+    expect(style.justifyContent).toBe("flex-end");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldBool.tsx
@@ -37,8 +37,10 @@ export const FieldBool = ({ name, namespace = "default" }: FlexibleFormElementPr
       checked={Boolean(param.value)}
       disabled={disabled}
       id={`element_${name}`}
+      justifyContent="flex-end"
       name={`element_${name}`}
       onCheckedChange={(event) => onCheck(event.checked)}
+      width="full"
     />
   );
 };


### PR DESCRIPTION
Fixes #67852

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

---

Boolean toggles in the Trigger Dag / FlexibleForm params grid were left-aligned right after the label instead of sharing the right edge with other controls; added width='full' and justifyContent='flex-end' to FieldBool's Switch so it right-aligns within its control column like AF2's FAB trigger form. The newsfragment was already present but untracked, so it was staged with git add to satisfy the changelog check.

**How this was tested:** `airflow dags test`

<!-- pr-triage-fold: triaged=2026-07-28T16:19:55Z head=5797732 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @singlaamitesh** · by `@potiuk` · 2026-07-28 16:19 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Other failing CI checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **402 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
