### PR TITLE
Reduce scheduler memory for asset-triggered Dag runs

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -169,11 +169,11 @@ MAX_PARTITION_DAG_RUNS_PER_LOOP = 500
 def _associate_asset_events_with_dag_run(
     *,
     dag_run: DagRun,
-    asset_event_ids: Select[tuple[int]],
+    asset_event_ids_select: Select[tuple[int]],
     session: Session,
 ) -> None:
     """Associate selected asset events without materializing ORM objects."""
-    selected_event_ids = asset_event_ids.subquery()
+    selected_event_ids = asset_event_ids_select.subquery()
     session.execute(
         insert(association_table).from_select(
             ["dag_run_id", "event_id"],
@@ -2362,13 +2362,13 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 creating_job_id=self.job.id,
                 session=session,
             )
-            asset_event_ids = select(AssetEvent.id.label("event_id")).where(
+            asset_event_ids_select = select(AssetEvent.id.label("event_id")).where(
                 PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
                 PartitionedAssetKeyLog.asset_event_id == AssetEvent.id,
             )
             _associate_asset_events_with_dag_run(
                 dag_run=dag_run,
-                asset_event_ids=asset_event_ids,
+                asset_event_ids_select=asset_event_ids_select,
                 session=session,
             )
             session.flush()
@@ -2642,21 +2642,25 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
             event_window_floor.append(date.min)
 
-            asset_event_ids = select(AssetEvent.id.label("event_id")).where(
-                or_(
-                    AssetEvent.asset_id.in_(
-                        select(DagScheduleAssetReference.asset_id).where(
-                            DagScheduleAssetReference.dag_id == dag.dag_id
+            asset_event_ids_select = (
+                select(AssetEvent.id.label("event_id"))
+                .where(
+                    or_(
+                        AssetEvent.asset_id.in_(
+                            select(DagScheduleAssetReference.asset_id).where(
+                                DagScheduleAssetReference.dag_id == dag.dag_id
+                            ),
+                        ),
+                        AssetEvent.source_aliases.any(
+                            AssetAliasModel.scheduled_dags.any(
+                                DagScheduleAssetAliasReference.dag_id == dag.dag_id
+                            )
                         ),
                     ),
-                    AssetEvent.source_aliases.any(
-                        AssetAliasModel.scheduled_dags.any(
-                            DagScheduleAssetAliasReference.dag_id == dag.dag_id
-                        )
-                    ),
-                ),
-                AssetEvent.timestamp <= triggered_date,
-                AssetEvent.timestamp > func.coalesce(*event_window_floor),
+                    AssetEvent.timestamp <= triggered_date,
+                    AssetEvent.timestamp > func.coalesce(*event_window_floor),
+                )
+                .order_by(AssetEvent.timestamp.asc(), AssetEvent.id.asc())
             )
 
             dag_run = dag.create_dagrun(
@@ -2680,7 +2684,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             stats.incr("asset.triggered_dagruns", tags=prune_dict({"team_name": team_name}))
             _associate_asset_events_with_dag_run(
                 dag_run=dag_run,
-                asset_event_ids=asset_event_ids,
+                asset_event_ids_select=asset_event_ids_select,
                 session=session,
             )
             consumed_asset_event_count = (

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -43,7 +43,9 @@ from sqlalchemy import (
     delete,
     exists,
     func,
+    insert,
     inspect,
+    literal,
     or_,
     select,
     text,
@@ -85,6 +87,7 @@ from airflow.models.asset import (
     PartitionedAssetKeyLog,
     TaskInletAssetReference,
     TaskOutletAssetReference,
+    association_table,
 )
 from airflow.models.asset_state_store import AssetStateStoreModel
 from airflow.models.backfill import Backfill, BackfillDagRun
@@ -138,6 +141,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import CursorResult
     from sqlalchemy.orm import Session
     from sqlalchemy.orm.interfaces import LoaderOption
+    from sqlalchemy.sql import Select
     from sqlalchemy.sql.selectable import Subquery
 
     from airflow._shared.logging.types import Logger
@@ -160,6 +164,23 @@ TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 # Internal constant rather than a user setting — this is a performance
 # safety bound, not a behavioural knob operators need to tune.
 MAX_PARTITION_DAG_RUNS_PER_LOOP = 500
+
+
+def _associate_asset_events_with_dag_run(
+    *,
+    dag_run: DagRun,
+    asset_event_ids: Select[tuple[int]],
+    session: Session,
+) -> None:
+    """Associate selected asset events without materializing ORM objects."""
+    selected_event_ids = asset_event_ids.subquery()
+    session.execute(
+        insert(association_table).from_select(
+            ["dag_run_id", "event_id"],
+            select(literal(dag_run.id), selected_event_ids.c.event_id),
+        )
+    )
+    session.expire(dag_run, ["consumed_asset_events"])
 
 
 def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
@@ -2341,13 +2362,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 creating_job_id=self.job.id,
                 session=session,
             )
-            asset_events = session.scalars(
-                select(AssetEvent).where(
-                    PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
-                    PartitionedAssetKeyLog.asset_event_id == AssetEvent.id,
-                )
+            asset_event_ids = select(AssetEvent.id.label("event_id")).where(
+                PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
+                PartitionedAssetKeyLog.asset_event_id == AssetEvent.id,
             )
-            dag_run.consumed_asset_events.extend(asset_events)
+            _associate_asset_events_with_dag_run(
+                dag_run=dag_run,
+                asset_event_ids=asset_event_ids,
+                session=session,
+            )
             session.flush()
             apdr.created_dag_run_id = dag_run.id
             session.flush()
@@ -2619,27 +2642,21 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
             event_window_floor.append(date.min)
 
-            asset_events = list(
-                session.scalars(
-                    select(AssetEvent)
-                    .where(
-                        or_(
-                            AssetEvent.asset_id.in_(
-                                select(DagScheduleAssetReference.asset_id).where(
-                                    DagScheduleAssetReference.dag_id == dag.dag_id
-                                )
-                            ),
-                            AssetEvent.source_aliases.any(
-                                AssetAliasModel.scheduled_dags.any(
-                                    DagScheduleAssetAliasReference.dag_id == dag.dag_id
-                                )
-                            ),
+            asset_event_ids = select(AssetEvent.id.label("event_id")).where(
+                or_(
+                    AssetEvent.asset_id.in_(
+                        select(DagScheduleAssetReference.asset_id).where(
+                            DagScheduleAssetReference.dag_id == dag.dag_id
                         ),
-                        AssetEvent.timestamp <= triggered_date,
-                        AssetEvent.timestamp > func.coalesce(*event_window_floor),
-                    )
-                    .order_by(AssetEvent.timestamp.asc(), AssetEvent.id.asc())
-                )
+                    ),
+                    AssetEvent.source_aliases.any(
+                        AssetAliasModel.scheduled_dags.any(
+                            DagScheduleAssetAliasReference.dag_id == dag.dag_id
+                        )
+                    ),
+                ),
+                AssetEvent.timestamp <= triggered_date,
+                AssetEvent.timestamp > func.coalesce(*event_window_floor),
             )
 
             dag_run = dag.create_dagrun(
@@ -2661,12 +2678,24 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 else None
             )
             stats.incr("asset.triggered_dagruns", tags=prune_dict({"team_name": team_name}))
-            dag_run.consumed_asset_events.extend(asset_events)
+            _associate_asset_events_with_dag_run(
+                dag_run=dag_run,
+                asset_event_ids=asset_event_ids,
+                session=session,
+            )
+            consumed_asset_event_count = (
+                session.scalar(
+                    select(func.count())
+                    .select_from(association_table)
+                    .where(association_table.c.dag_run_id == dag_run.id)
+                )
+                or 0
+            )
             self.log.info(
                 "Created asset-triggered DagRun for '%s': run_id=%s, consumed %d asset events",
                 dag.dag_id,
                 dag_run.run_id,
-                len(asset_events),
+                consumed_asset_event_count,
             )
 
             # Delete only consumed ADRQ rows to avoid dropping newly queued events

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -43,7 +43,9 @@ from sqlalchemy import (
     delete,
     exists,
     func,
+    insert,
     inspect,
+    literal,
     or_,
     select,
     text,
@@ -138,6 +140,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import CursorResult
     from sqlalchemy.orm import Session
     from sqlalchemy.orm.interfaces import LoaderOption
+    from sqlalchemy.sql import Select
     from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.selectable import Subquery
 
@@ -161,6 +164,23 @@ TASK_STUCK_IN_QUEUED_RESCHEDULE_EVENT = "stuck in queued reschedule"
 # Internal constant rather than a user setting — this is a performance
 # safety bound, not a behavioural knob operators need to tune.
 MAX_PARTITION_DAG_RUNS_PER_LOOP = 500
+
+
+def _associate_asset_events_with_dag_run(
+    *,
+    dag_run: DagRun,
+    asset_event_ids_select: Select[tuple[int]],
+    session: Session,
+) -> None:
+    """Associate selected asset events without materializing ORM objects."""
+    selected_event_ids = asset_event_ids_select.subquery()
+    session.execute(
+        insert(association_table).from_select(
+            ["dag_run_id", "event_id"],
+            select(literal(dag_run.id), selected_event_ids.c.event_id),
+        )
+    )
+    session.expire(dag_run, ["consumed_asset_events"])
 
 
 def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
@@ -2425,13 +2445,15 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 creating_job_id=self.job.id,
                 session=session,
             )
-            asset_events = session.scalars(
-                select(AssetEvent).where(
-                    PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
-                    PartitionedAssetKeyLog.asset_event_id == AssetEvent.id,
-                )
+            asset_event_ids_select = select(AssetEvent.id.label("event_id")).where(
+                PartitionedAssetKeyLog.asset_partition_dag_run_id == apdr.id,
+                PartitionedAssetKeyLog.asset_event_id == AssetEvent.id,
             )
-            dag_run.consumed_asset_events.extend(asset_events)
+            _associate_asset_events_with_dag_run(
+                dag_run=dag_run,
+                asset_event_ids_select=asset_event_ids_select,
+                session=session,
+            )
             session.flush()
             apdr.created_dag_run_id = dag_run.id
             session.flush()
@@ -2688,26 +2710,33 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         )
                     ),
                 )
-            asset_events = list(
-                session.scalars(
-                    select(AssetEvent)
-                    .where(
-                        event_predicate,
-                        ~(
-                            select(association_table.c.event_id)
-                            .join(DagRun, DagRun.id == association_table.c.dag_run_id)
-                            .where(
-                                DagRun.dag_id == dag.dag_id,
-                                association_table.c.event_id == AssetEvent.id,
-                            )
-                            .exists()
-                        ),
-                    )
-                    .order_by(AssetEvent.timestamp.asc(), AssetEvent.id.asc())
+            selected_asset_events = (
+                select(
+                    AssetEvent.id.label("event_id"),
+                    AssetEvent.timestamp.label("timestamp"),
                 )
+                .where(
+                    event_predicate,
+                    ~(
+                        select(association_table.c.event_id)
+                        .join(DagRun, DagRun.id == association_table.c.dag_run_id)
+                        .where(
+                            DagRun.dag_id == dag.dag_id,
+                            association_table.c.event_id == AssetEvent.id,
+                        )
+                        .exists()
+                    ),
+                )
+                .cte()
             )
-            if asset_events:
-                triggered_date = timezone.coerce_datetime(max(event.timestamp for event in asset_events))
+            triggered_date, max_selected_event_id = session.execute(
+                select(
+                    func.max(selected_asset_events.c.timestamp),
+                    func.max(selected_asset_events.c.event_id),
+                )
+            ).one()
+            if triggered_date is not None and max_selected_event_id is not None:
+                triggered_date = timezone.coerce_datetime(triggered_date)
                 self.log.debug(
                     "Creating asset-triggered DagRun for '%s': %d queued assets, triggered_date=%s",
                     dag.dag_id,
@@ -2733,12 +2762,32 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     else None
                 )
                 stats.incr("asset.triggered_dagruns", tags=prune_dict({"team_name": team_name}))
-                dag_run.consumed_asset_events.extend(asset_events)
+                _associate_asset_events_with_dag_run(
+                    dag_run=dag_run,
+                    asset_event_ids_select=select(selected_asset_events.c.event_id)
+                    .where(
+                        selected_asset_events.c.timestamp <= triggered_date,
+                        selected_asset_events.c.event_id <= max_selected_event_id,
+                    )
+                    .order_by(
+                        selected_asset_events.c.timestamp.asc(),
+                        selected_asset_events.c.event_id.asc(),
+                    ),
+                    session=session,
+                )
+                consumed_asset_event_count = (
+                    session.scalar(
+                        select(func.count())
+                        .select_from(association_table)
+                        .where(association_table.c.dag_run_id == dag_run.id)
+                    )
+                    or 0
+                )
                 self.log.info(
                     "Created asset-triggered DagRun for '%s': run_id=%s, consumed %d asset events",
                     dag.dag_id,
                     dag_run.run_id,
-                    len(asset_events),
+                    consumed_asset_event_count,
                 )
             else:
                 self.log.info(

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5596,7 +5596,7 @@ class TestSchedulerJob:
         with assert_queries_count(1, session=session):
             _associate_asset_events_with_dag_run(
                 dag_run=dag_run,
-                asset_event_ids=select(AssetEvent.id.label("event_id")).where(
+                asset_event_ids_select=select(AssetEvent.id.label("event_id")).where(
                     AssetEvent.id == asset_event_id
                 ),
                 session=session,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -36,7 +36,7 @@ import pendulum
 import psutil
 import pytest
 import time_machine
-from sqlalchemy import delete, func, inspect, select, update
+from sqlalchemy import delete, event as sqlalchemy_event, func, inspect, select, update
 from sqlalchemy.dialects import mysql
 from sqlalchemy.orm import joinedload
 
@@ -57,7 +57,7 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.executor_utils import ExecutorName
 from airflow.executors.local_executor import LocalExecutor
 from airflow.jobs.job import Job, run_job
-from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner, _associate_asset_events_with_dag_run
 from airflow.models.asset import (
     AssetActive,
     AssetAliasModel,
@@ -189,6 +189,29 @@ EXAMPLE_STANDARD_DAGS_FOLDER = (
     / "standard"
     / "example_dags"
 )
+
+
+@contextmanager
+def assert_no_asset_event_materialization(session: Session) -> Generator[None, None, None]:
+    """Assert a scheduler operation does not select full AssetEvent entities."""
+    materializing_queries = []
+
+    def track_orm_execute(orm_execute_state):
+        if orm_execute_state.is_select and any(
+            description.get("expr") is AssetEvent
+            for description in orm_execute_state.statement.column_descriptions
+        ):
+            materializing_queries.append(orm_execute_state.statement)
+
+    sqlalchemy_event.listen(session, "do_orm_execute", track_orm_execute)
+    try:
+        yield
+    finally:
+        sqlalchemy_event.remove(session, "do_orm_execute", track_orm_execute)
+
+    assert materializing_queries == []
+
+
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 DEFAULT_LOGICAL_DATE = timezone.coerce_datetime(DEFAULT_DATE)
 TRY_NUMBER = 1
@@ -5557,6 +5580,30 @@ class TestSchedulerJob:
         assert dr.start_date is None
         assert dr.creating_job_id == scheduler_job.id
 
+    def test_associate_asset_events_with_dag_run_keeps_relationship_coherent(self, session, dag_maker):
+        with dag_maker(dag_id="asset-event-association"):
+            pass
+        dag_run = dag_maker.create_dagrun()
+        asset = AssetModel(name="association-asset", uri="association-asset", group="asset")
+        session.add(asset)
+        session.flush()
+        asset_event = AssetEvent(asset_id=asset.id)
+        session.add(asset_event)
+        session.flush()
+        asset_event_id = asset_event.id
+        session.expunge(asset_event)
+
+        with assert_queries_count(1, session=session):
+            _associate_asset_events_with_dag_run(
+                dag_run=dag_run,
+                asset_event_ids=select(AssetEvent.id.label("event_id")).where(
+                    AssetEvent.id == asset_event_id
+                ),
+                session=session,
+            )
+
+        assert [event.id for event in dag_run.consumed_asset_events] == [asset_event_id]
+
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_assets(self, session, dag_maker):
         """
@@ -5632,7 +5679,8 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         with create_session() as session:
-            self.job_runner._create_dagruns_for_dags(session, session)
+            with assert_no_asset_event_materialization(session):
+                self.job_runner._create_dagruns_for_dags(session, session)
 
         def dict_from_obj(obj):
             """Get dict of column attrs from SqlAlchemy object."""
@@ -10727,7 +10775,8 @@ def test_partitioned_dag_run_with_customized_mapper(
             dag_maker=dag_maker,
             expected_partition_key="key-1",
         )
-        partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+        with assert_no_asset_event_materialization(session):
+            partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
     session.refresh(apdr)
     # Since asset event for Asset(name="asset-2") with key "key-1" has not yet been created,
     # no Dag run will be created

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -38,7 +38,7 @@ import pendulum
 import psutil
 import pytest
 import time_machine
-from sqlalchemy import delete, func, inspect, select, update
+from sqlalchemy import delete, event as sqlalchemy_event, func, inspect, select, update
 from sqlalchemy.dialects import mysql
 from sqlalchemy.orm import joinedload
 
@@ -64,7 +64,7 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.executors.executor_utils import ExecutorName
 from airflow.executors.local_executor import LocalExecutor
 from airflow.jobs.job import Job, run_job
-from airflow.jobs.scheduler_job_runner import SchedulerJobRunner
+from airflow.jobs.scheduler_job_runner import SchedulerJobRunner, _associate_asset_events_with_dag_run
 from airflow.models.asset import (
     AssetActive,
     AssetAliasModel,
@@ -196,6 +196,29 @@ EXAMPLE_STANDARD_DAGS_FOLDER = (
     / "standard"
     / "example_dags"
 )
+
+
+@contextmanager
+def assert_no_asset_event_materialization(session: Session) -> Generator[None, None, None]:
+    """Assert a scheduler operation does not select full AssetEvent entities."""
+    materializing_queries = []
+
+    def track_orm_execute(orm_execute_state):
+        if orm_execute_state.is_select and any(
+            description.get("expr") is AssetEvent
+            for description in orm_execute_state.statement.column_descriptions
+        ):
+            materializing_queries.append(orm_execute_state.statement)
+
+    sqlalchemy_event.listen(session, "do_orm_execute", track_orm_execute)
+    try:
+        yield
+    finally:
+        sqlalchemy_event.remove(session, "do_orm_execute", track_orm_execute)
+
+    assert materializing_queries == []
+
+
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 DEFAULT_LOGICAL_DATE = timezone.coerce_datetime(DEFAULT_DATE)
 TRY_NUMBER = 1
@@ -5658,6 +5681,31 @@ class TestSchedulerJob:
         assert dr.start_date is None
         assert dr.creating_job_id == scheduler_job.id
 
+    def test_associate_asset_events_with_dag_run_keeps_relationship_coherent(self, session, dag_maker):
+        with dag_maker(dag_id="asset-event-association"):
+            pass
+        dag_run = dag_maker.create_dagrun()
+        asset = AssetModel(name="association-asset", uri="association-asset", group="asset")
+        session.add(asset)
+        session.flush()
+        asset_event = AssetEvent(asset_id=asset.id)
+        session.add(asset_event)
+        session.flush()
+        asset_event_id = asset_event.id
+        session.expunge(asset_event)
+        assert dag_run.consumed_asset_events == []
+
+        with assert_queries_count(1, session=session):
+            _associate_asset_events_with_dag_run(
+                dag_run=dag_run,
+                asset_event_ids_select=select(AssetEvent.id.label("event_id")).where(
+                    AssetEvent.id == asset_event_id
+                ),
+                session=session,
+            )
+
+        assert [event.id for event in dag_run.consumed_asset_events] == [asset_event_id]
+
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_assets(self, session, dag_maker):
         """
@@ -5731,7 +5779,8 @@ class TestSchedulerJob:
         self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
 
         with create_session() as session:
-            self.job_runner._create_dagruns_for_dags(session, session)
+            with assert_no_asset_event_materialization(session):
+                self.job_runner._create_dagruns_for_dags(session, session)
 
         def dict_from_obj(obj):
             """Get dict of column attrs from SqlAlchemy object."""
@@ -5938,6 +5987,84 @@ class TestSchedulerJob:
 
         # We do not create a new DagRun since the ADRQ has already been consumed
         assert session.scalars(select(DagRun).where(DagRun.dag_id == dag_model.dag_id)).one_or_none() is None
+
+    @pytest.mark.need_serialized_dag
+    @mock.patch("airflow.jobs.scheduler_job_runner._associate_asset_events_with_dag_run", autospec=True)
+    def test_asset_event_queued_during_association_waits_for_next_run(
+        self, mock_associate_asset_events, session, dag_maker
+    ):
+        asset = Asset(name="event-queued-during-association")
+        with dag_maker(
+            dag_id="event-queued-during-association-consumer",
+            schedule=[asset],
+            catchup=True,
+            session=session,
+        ):
+            pass
+        dag_model = dag_maker.dag_model
+        asset_id = session.scalar(select(AssetModel.id).where(AssetModel.uri == asset.uri))
+        first_timestamp = timezone.utcnow()
+        first_event = AssetEvent(asset_id=asset_id, timestamp=first_timestamp)
+        session.add(first_event)
+        session.flush()
+        session.add(
+            AssetDagRunQueue(
+                target_dag_id=dag_model.dag_id,
+                asset_id=asset_id,
+                asset_event_id=first_event.id,
+            )
+        )
+        session.flush()
+
+        second_timestamp = first_timestamp + timedelta(minutes=1)
+        second_event_ids = []
+
+        def queue_second_event_then_associate(*, dag_run, asset_event_ids_select, session):
+            if not second_event_ids:
+                second_event = AssetEvent(asset_id=asset_id, timestamp=second_timestamp)
+                session.add(second_event)
+                session.flush()
+                second_event_ids.append(second_event.id)
+                session.add(
+                    AssetDagRunQueue(
+                        target_dag_id=dag_model.dag_id,
+                        asset_id=asset_id,
+                        asset_event_id=second_event.id,
+                    )
+                )
+                session.flush()
+            _associate_asset_events_with_dag_run(
+                dag_run=dag_run,
+                asset_event_ids_select=asset_event_ids_select,
+                session=session,
+            )
+
+        mock_associate_asset_events.side_effect = queue_second_event_then_associate
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        self.job_runner._create_dag_runs_asset_triggered(dag_models=[dag_model], session=session)
+
+        first_run = session.scalars(select(DagRun).where(DagRun.dag_id == dag_model.dag_id)).one()
+        assert [event.id for event in first_run.consumed_asset_events] == [first_event.id]
+        assert first_run.run_after == first_timestamp
+        assert (
+            session.scalars(
+                select(AssetDagRunQueue.asset_event_id).where(
+                    AssetDagRunQueue.target_dag_id == dag_model.dag_id
+                )
+            ).all()
+            == second_event_ids
+        )
+
+        self.job_runner._create_dag_runs_asset_triggered(dag_models=[dag_model], session=session)
+
+        runs = session.scalars(
+            select(DagRun).where(DagRun.dag_id == dag_model.dag_id).order_by(DagRun.run_after)
+        ).all()
+        assert len(runs) == 2
+        assert [event.id for event in runs[1].consumed_asset_events] == second_event_ids
+        assert runs[1].run_after == second_timestamp
 
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_asset_triggered_deletes_only_selected_adrq_rows(
@@ -11589,7 +11716,8 @@ def test_partitioned_dag_run_with_customized_mapper(
             dag_maker=dag_maker,
             expected_partition_key="key-1",
         )
-        partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
+        with assert_no_asset_event_materialization(session):
+            partition_dags = runner._create_dagruns_for_partitioned_asset_dags(session=session)
     session.refresh(apdr)
     # Since asset event for Asset(name="asset-2") with key "key-1" has not yet been created,
     # no Dag run will be created


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Description

closes #69848 

Asset-triggered Dag run creation currently materializes every matching `AssetEvent` ORM object, including its JSON metadata, before writing the Dag run association rows. Large event windows can therefore cause scheduler memory spikes far beyond the raw payload size.

This change writes the association rows with a server-side `INSERT ... SELECT` while preserving the existing event predicates, transaction boundary, exact event membership, and relationship behavior.

Scheduler-side `AssetEvent` ORM and JSON payload materialization drops **from O(events) to approximately O(1).** The database still performs O(events) work to select event IDs and persist one association row per event; this change moves that set operation out of Python rather than eliminating it.

The partitioned-asset path uses the same set-based association helper. No schema or configuration change is needed.

## Benchmark

The benchmark invokes the real scheduler path on SQLite, PostgreSQL, and MySQL with a 512-byte JSON
payload per event. Setup is outside the measured interval.

| Database | Events | Duration (before/after) | Speedup | Python peak (before/after) | Peak reduction |
|---|---:|---:|---:|---:|---:|
| SQLite | 1,000 | 0.537 / 0.255s | 2.11× | 6.23 / 0.16 MB | 97.2% |
| SQLite | 10,000 | 1.785 / 0.024s | 74.38× | 54.24 / 0.11 MB | 99.8% |
| SQLite | 50,000 | 12.545 / 0.071s | **176.69×** | 274.21 / 0.13 MB | **99.95%** |
| PostgreSQL | 1,000 | 0.339 / 0.237s | 1.43× | 7.39 / 1.84 MB | 75.1% |
| PostgreSQL | 10,000 | 2.510 / 0.096s | **26.15×** | 62.34 / 0.12 MB | 99.8% |
| PostgreSQL | 50,000 | 10.046 / 0.688s | 14.60× | 289.72 / 0.14 MB | **99.95%** |
| MySQL | 1,000 | 0.161 / 0.032s | 5.00× | 5.80 / 0.16 MB | 97.2% |
| MySQL | 10,000 | 4.478 / 0.185s | **24.21×** | 54.54 / 0.11 MB | 99.8% |
| MySQL | 50,000 | 21.502 / 1.977s | 10.88× | 272.63 / 0.13 MB | **99.95%** |

The 1,000-event result includes first-call and tracing warm-up overhead.

## Notes

* `consumed_asset_event_count` is designed for logging, can discuss leave it or not.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - Codex (GPT 5.6 Sol)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.