### PR TITLE
prevent path traversal in ObjectStoragePath recursive copy to local

### DIFF
--- a/task-sdk/src/airflow/sdk/io/path.py
+++ b/task-sdk/src/airflow/sdk/io/path.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlsplit
@@ -339,6 +340,25 @@ class ObjectStoragePath(ProxyUPath):
         """Size in bytes of the file at this path."""
         return self.fs.size(self.path)
 
+    def _raise_if_remote_keys_escape(self, local_dir: str, **kwargs) -> None:
+        """
+        Refuse a recursive download when a remote object key resolves outside ``local_dir``.
+
+        Object-store keys are arbitrary strings and may contain ``..`` segments written by
+        anyone who can put objects in the source prefix; ``fs.get`` follows them verbatim and
+        would write outside the destination directory.
+        """
+        dst_root = os.path.realpath(local_dir)
+        for src_key in self.fs.expand_path(self.path, recursive=True, **kwargs):
+            if self.fs.isdir(src_key):
+                continue
+            target = os.path.realpath(os.path.join(local_dir, os.path.relpath(src_key, self.path)))
+            if target != dst_root and os.path.commonpath([dst_root, target]) != dst_root:
+                raise ValueError(
+                    f"Refusing to copy remote object {src_key!r}: it resolves outside the "
+                    f"destination directory {local_dir!r}"
+                )
+
     def _cp_file(self, dst: ObjectStoragePath, **kwargs):
         """Copy a single file from this path to another location by streaming the data."""
         # create the directory or bucket if required
@@ -387,6 +407,8 @@ class ObjectStoragePath(ProxyUPath):
             return
 
         if dst.protocol == "file":
+            if recursive:
+                self._raise_if_remote_keys_escape(dst.path, **kwargs)
             self.fs.get(self.path, dst.path, recursive=recursive, **kwargs)
             return
 

--- a/task-sdk/src/airflow/sdk/io/path.py
+++ b/task-sdk/src/airflow/sdk/io/path.py
@@ -349,9 +349,7 @@ class ObjectStoragePath(ProxyUPath):
         would write outside the destination directory.
         """
         dst_root = os.path.realpath(local_dir)
-        for src_key in self.fs.expand_path(self.path, recursive=True, **kwargs):
-            if self.fs.isdir(src_key):
-                continue
+        for src_key in self.fs.find(self.path, **kwargs):
             target = os.path.realpath(os.path.join(local_dir, os.path.relpath(src_key, self.path)))
             if target != dst_root and os.path.commonpath([dst_root, target]) != dst_root:
                 raise ValueError(

--- a/task-sdk/tests/task_sdk/io/test_path.py
+++ b/task-sdk/tests/task_sdk/io/test_path.py
@@ -337,6 +337,49 @@ class TestConnIdCredentialResolution:
         assert all(c.__wrapped__._fs_cached is fake_fs_with_conn for c in children)
 
 
+class TestRecursiveCopyToLocal:
+    """Recursive remote->local copy must not follow ``..`` in object keys outside the destination."""
+
+    @pytest.fixture(autouse=True)
+    def restore_cache(self):
+        cache = _STORE_CACHE.copy()
+        yield
+        _STORE_CACHE.clear()
+        _STORE_CACHE.update(cache)
+
+    @pytest.fixture
+    def remote_fs(self):
+        fs = _FakeRemoteFileSystem(conn_id="my_conn")
+        attach(protocol="ffs2", conn_id="my_conn", fs=fs)
+        try:
+            yield fs
+        finally:
+            _FakeRemoteFileSystem.store.clear()
+            _FakeRemoteFileSystem.pseudo_dirs[:] = [""]
+
+    def test_rejects_key_escaping_destination(self, remote_fs, tmp_path):
+        remote_fs.pipe_file("bucket/srcdir/normal.txt", b"ok")
+        remote_fs.pipe_file("bucket/srcdir/../../escape/pwned.txt", b"pwned")
+        src = ObjectStoragePath("ffs2://my_conn@bucket/srcdir", conn_id="my_conn")
+        dst = ObjectStoragePath(f"file://{tmp_path.as_posix()}/dest")
+
+        with pytest.raises(ValueError, match="resolves outside"):
+            src.copy(dst, recursive=True)
+
+        assert not (tmp_path / "escape" / "pwned.txt").exists()
+
+    def test_allows_contained_keys(self, remote_fs, tmp_path):
+        remote_fs.pipe_file("bucket/srcdir/a.txt", b"a")
+        remote_fs.pipe_file("bucket/srcdir/sub/b.txt", b"b")
+        src = ObjectStoragePath("ffs2://my_conn@bucket/srcdir", conn_id="my_conn")
+        dst = ObjectStoragePath(f"file://{tmp_path.as_posix()}/dest")
+
+        src.copy(dst, recursive=True)
+
+        assert (tmp_path / "dest" / "a.txt").read_bytes() == b"a"
+        assert (tmp_path / "dest" / "sub" / "b.txt").read_bytes() == b"b"
+
+
 class TestRemotePath:
     def test_bucket_key_protocol(self):
         bucket = "bkt"


### PR DESCRIPTION
ObjectStoragePath.copy() delegates a recursive remote-to-local transfer straight to fsspec's fs.get, so object keys containing .. segments (which anyone able to write to the source prefix controls) are followed verbatim and land outside the destination directory. Add a containment check on the recursive remote-to-local branch that expands the source keys and refuses any whose resolved local path escapes the destination, matching the guards already in the S3 and GCS sync_to_local_dir helpers. Non-recursive and same-store copies are untouched, so valid transfers behave exactly as before.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)