### PR TITLE
Add deferrable support for Cloud Functions invoke operator

### DIFF
--- a/airflow-core/newsfragments/69853.feature.rst
+++ b/airflow-core/newsfragments/69853.feature.rst
@@ -1,0 +1,1 @@
+Add deferrable support for CloudFunctionInvokeFunctionOperator to invoke Google Cloud Functions asynchronously without blocking workers.

--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -987,6 +987,9 @@ triggers:
   - integration-name: Google Cloud Generative AI
     python-modules:
       - airflow.providers.google.cloud.triggers.gen_ai
+  - integration-name: Google Cloud Functions
+    python-modules:
+      - airflow.providers.google.cloud.triggers.cloud_functions
 
 transfers:
   - source-integration-name: Presto

--- a/providers/google/src/airflow/providers/google/cloud/operators/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/functions.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 
 from googleapiclient.errors import HttpError
 
+from airflow.configuration import conf
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.hooks.functions import CloudFunctionsHook
 from airflow.providers.google.cloud.links.cloud_functions import (
@@ -32,6 +33,9 @@ from airflow.providers.google.cloud.links.cloud_functions import (
     CloudFunctionsListLink,
 )
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
+from airflow.providers.google.cloud.triggers.cloud_functions import (
+    CloudFunctionInvokeFunctionTrigger,
+)
 from airflow.providers.google.cloud.utils.field_validator import (
     GcpBodyFieldValidator,
     GcpFieldValidationException,
@@ -433,6 +437,7 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
+    :param deferrable: Run operator in the deferrable mode.
 
     :return: None
     """
@@ -456,6 +461,7 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
         impersonation_chain: str | Sequence[str] | None = None,
+        deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -466,6 +472,7 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self.impersonation_chain = impersonation_chain
+        self.deferrable = deferrable
 
     @property
     def extra_links_params(self) -> dict[str, Any]:
@@ -474,12 +481,48 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
             "function_name": self.function_id,
         }
 
+    def execute_complete(self, context: Context, event: dict):
+        """Handle trigger completion and process the result."""
+        if event["status"] == "error":
+            raise AirflowException(event["message"])
+
+        result = event["result"]
+        execution_id = event.get("execution_id")
+
+        self.log.info("Function called successfully. Execution id: %s", execution_id)
+        context["ti"].xcom_push(key="execution_id", value=execution_id)
+
+        project_id = self.project_id
+        if project_id:
+            CloudFunctionsDetailsLink.persist(
+                context=context,
+                location=self.location,
+                project_id=project_id,
+                function_name=self.function_id,
+            )
+        return result
+
     def execute(self, context: Context):
+        if self.deferrable:
+            self.defer(
+                trigger=CloudFunctionInvokeFunctionTrigger(
+                    function_id=self.function_id,
+                    input_data=self.input_data,
+                    location=self.location,
+                    project_id=self.project_id,
+                    gcp_conn_id=self.gcp_conn_id,
+                    api_version=self.api_version,
+                    impersonation_chain=self.impersonation_chain,
+                ),
+                method_name="execute_complete",
+            )
+
         hook = CloudFunctionsHook(
             api_version=self.api_version,
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
+
         self.log.info("Calling function %s.", self.function_id)
         result = hook.call_function(
             function_id=self.function_id,
@@ -494,7 +537,9 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
         if project_id:
             CloudFunctionsDetailsLink.persist(
                 context=context,
+                location=self.location,
                 project_id=project_id,
+                function_name=self.function_id,
             )
 
         return result

--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_functions.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
+
+from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.google.cloud.hooks.functions import CloudFunctionsHook
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+class CloudFunctionInvokeFunctionTrigger(BaseTrigger):
+    """
+    Trigger to invoke a Google Cloud Function and wait for its result.
+
+    This trigger invokes the function via the synchronous Cloud Functions API
+    using ``asyncio.to_thread`` and yields a single TriggerEvent with the
+    result.
+
+    :param function_id: ID of the function to be called.
+    :param input_data: Input to be passed to the function.
+    :param location: The location where the function is located.
+    :param project_id: Google Cloud Project ID where the function belongs.
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
+    :param api_version: API version used (for example v1).
+    :param impersonation_chain: Optional service account to impersonate using
+        short-term credentials, or chained list of accounts required to get
+        the access_token of the last account in the list, which will be
+        impersonated in the request.
+    """
+
+    def __init__(
+        self,
+        function_id: str,
+        input_data: dict,
+        location: str,
+        project_id: str,
+        gcp_conn_id: str = "google_cloud_default",
+        api_version: str = "v1",
+        impersonation_chain: str | Sequence[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self.function_id = function_id
+        self.input_data = input_data
+        self.location = location
+        self.project_id = project_id
+        self.gcp_conn_id = gcp_conn_id
+        self.api_version = api_version
+        self.impersonation_chain = impersonation_chain
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        """Serialize class arguments and classpath."""
+        return (
+            "airflow.providers.google.cloud.triggers.cloud_functions.CloudFunctionInvokeFunctionTrigger",
+            {
+                "function_id": self.function_id,
+                "input_data": self.input_data,
+                "location": self.location,
+                "project_id": self.project_id,
+                "gcp_conn_id": self.gcp_conn_id,
+                "api_version": self.api_version,
+                "impersonation_chain": self.impersonation_chain,
+            },
+        )
+
+    async def run(self) -> AsyncIterator[TriggerEvent]:
+        """Invoke the Cloud Function and yield a single result event."""
+        hook = CloudFunctionsHook(
+            api_version=self.api_version,
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
+        try:
+            result = await asyncio.to_thread(
+                hook.call_function,
+                function_id=self.function_id,
+                input_data=self.input_data,
+                location=self.location,
+                project_id=self.project_id,
+            )
+            yield TriggerEvent(
+                {
+                    "status": "success",
+                    "result": result,
+                    "execution_id": result.get("executionId"),
+                }
+            )
+        except AirflowException as e:
+            self.log.error("Cloud Function invocation failed: %s", e)
+            yield TriggerEvent({"status": "error", "message": str(e)})
+        except Exception as e:
+            self.log.exception("Unexpected error while invoking Cloud Function.")
+            yield TriggerEvent({"status": "error", "message": str(e)})

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1101,6 +1101,10 @@ def get_provider_info():
                 "python-modules": ["airflow.providers.google.cloud.triggers.cloud_build"],
             },
             {
+                "integration-name": "Google Cloud Functions",
+                "python-modules": ["airflow.providers.google.cloud.triggers.cloud_functions"],
+            },
+            {
                 "integration-name": "Managed Service for Apache Airflow",
                 "python-modules": ["airflow.providers.google.cloud.triggers.cloud_composer"],
             },

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -24,7 +24,7 @@ import httplib2
 import pytest
 from googleapiclient.errors import HttpError
 
-from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
 from airflow.providers.google.cloud.operators.functions import (
     CloudFunctionDeleteFunctionOperator,
     CloudFunctionDeployFunctionOperator,
@@ -736,3 +736,75 @@ class TestGcfFunctionInvokeOperator:
             key="execution_id",
             value=exec_id,
         )
+
+    @mock.patch("airflow.providers.google.cloud.operators.functions.CloudFunctionInvokeFunctionTrigger")
+    def test_execute_deferrable(self, mock_trigger_class):
+        function_id = "test_function"
+        payload = {"key": "value"}
+
+        op = CloudFunctionInvokeFunctionOperator(
+            task_id="test",
+            function_id=function_id,
+            input_data=payload,
+            location=GCP_LOCATION,
+            project_id=GCP_PROJECT_ID,
+            deferrable=True,
+        )
+        mock_context = {"ti": mock.MagicMock()}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = op
+
+        with pytest.raises(TaskDeferred) as ctx:
+            op.execute(mock_context)
+
+        mock_trigger_class.assert_called_once_with(
+            function_id=function_id,
+            input_data=payload,
+            location=GCP_LOCATION,
+            project_id=GCP_PROJECT_ID,
+            gcp_conn_id="google_cloud_default",
+            api_version="v1",
+            impersonation_chain=None,
+        )
+        assert ctx.value.trigger is not None
+
+    def test_execute_complete_success(self):
+        op = CloudFunctionInvokeFunctionOperator(
+            task_id="test",
+            function_id="test_function",
+            input_data={"key": "value"},
+            location=GCP_LOCATION,
+            project_id=GCP_PROJECT_ID,
+        )
+        mock_ti = mock.MagicMock()
+        mock_context = {"ti": mock_ti}
+        if not AIRFLOW_V_3_0_PLUS:
+            mock_context["task"] = op
+        event = {
+            "status": "success",
+            "result": {"executionId": "exec-123", "result": "ok"},
+            "execution_id": "exec-123",
+        }
+
+        result = op.execute_complete(mock_context, event)
+
+        assert result == {"executionId": "exec-123", "result": "ok"}
+        mock_ti.xcom_push.assert_any_call(key="execution_id", value="exec-123")
+        mock_ti.xcom_push.assert_any_call(
+            key="cloud_functions_details",
+            value={"location": GCP_LOCATION, "project_id": GCP_PROJECT_ID, "function_name": "test_function"},
+        )
+
+    def test_execute_complete_error(self):
+        op = CloudFunctionInvokeFunctionOperator(
+            task_id="test",
+            function_id="test_function",
+            input_data={"key": "value"},
+            location=GCP_LOCATION,
+            project_id=GCP_PROJECT_ID,
+        )
+        mock_context = {"ti": mock.MagicMock()}
+        event = {"status": "error", "message": "Function failed"}
+
+        with pytest.raises(AirflowException, match="Function failed"):
+            op.execute_complete(mock_context, event)

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_functions.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_functions.py
@@ -1,0 +1,142 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from airflow.providers.common.compat.sdk import AirflowException
+from airflow.providers.google.cloud.triggers.cloud_functions import CloudFunctionInvokeFunctionTrigger
+from airflow.triggers.base import TriggerEvent
+
+
+class TestCloudFunctionInvokeFunctionTrigger:
+    @pytest.fixture
+    def trigger(self):
+        return CloudFunctionInvokeFunctionTrigger(
+            function_id="test-function",
+            input_data={"key": "value"},
+            location="us-central1",
+            project_id="test-project",
+            gcp_conn_id="google_cloud_default",
+            api_version="v1",
+            impersonation_chain=None,
+        )
+
+    def test_serialize(self, trigger):
+        classpath, kwargs = trigger.serialize()
+        assert (
+            classpath
+            == "airflow.providers.google.cloud.triggers.cloud_functions.CloudFunctionInvokeFunctionTrigger"
+        )
+        assert kwargs == {
+            "function_id": "test-function",
+            "input_data": {"key": "value"},
+            "location": "us-central1",
+            "project_id": "test-project",
+            "gcp_conn_id": "google_cloud_default",
+            "api_version": "v1",
+            "impersonation_chain": None,
+        }
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.cloud_functions.CloudFunctionsHook")
+    async def test_run_success(self, mock_hook_class, trigger):
+        mock_hook = mock_hook_class.return_value
+        mock_hook.call_function.return_value = {"executionId": "exec-123", "result": "ok"}
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        event = events[0]
+        assert isinstance(event, TriggerEvent)
+        assert event.payload["status"] == "success"
+        assert event.payload["result"] == {"executionId": "exec-123", "result": "ok"}
+        assert event.payload["execution_id"] == "exec-123"
+
+        mock_hook_class.assert_called_once_with(
+            api_version="v1",
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=None,
+        )
+        mock_hook.call_function.assert_called_once_with(
+            function_id="test-function",
+            input_data={"key": "value"},
+            location="us-central1",
+            project_id="test-project",
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.cloud_functions.CloudFunctionsHook")
+    async def test_run_airflow_exception(self, mock_hook_class, trigger):
+        mock_hook = mock_hook_class.return_value
+        mock_hook.call_function.side_effect = AirflowException("Function error")
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.payload["status"] == "error"
+        assert event.payload["message"] == "Function error"
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.cloud_functions.CloudFunctionsHook")
+    async def test_run_generic_exception(self, mock_hook_class, trigger):
+        mock_hook = mock_hook_class.return_value
+        mock_hook.call_function.side_effect = RuntimeError("Unexpected error")
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        event = events[0]
+        assert event.payload["status"] == "error"
+        assert event.payload["message"] == "Unexpected error"
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.cloud_functions.CloudFunctionsHook")
+    async def test_run_with_impersonation_chain(self, mock_hook_class):
+        trigger = CloudFunctionInvokeFunctionTrigger(
+            function_id="test-function",
+            input_data={"key": "value"},
+            location="us-central1",
+            project_id="test-project",
+            gcp_conn_id="google_cloud_default",
+            api_version="v1",
+            impersonation_chain=["account1", "account2"],
+        )
+
+        mock_hook = mock_hook_class.return_value
+        mock_hook.call_function.return_value = {"executionId": "exec-123"}
+
+        events = []
+        async for event in trigger.run():
+            events.append(event)
+
+        assert len(events) == 1
+        mock_hook_class.assert_called_once_with(
+            api_version="v1",
+            gcp_conn_id="google_cloud_default",
+            impersonation_chain=["account1", "account2"],
+        )


### PR DESCRIPTION
- Add CloudFunctionInvokeFunctionTrigger for async invocation via asyncio.to_thread
- Add deferrable parameter to CloudFunctionInvokeFunctionOperator with execute_complete()
- Register trigger in provider.yaml and get_provider_info.py
- Add unit tests for trigger and operator deferrable path

Closes #68908

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.


<!-- pr-triage-fold: triaged=2026-07-18T15:46:56Z head=a1ee168 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @qotique** · by `@potiuk` · 2026-07-18 15:46 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for details.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
