### PR TITLE
Fix OpenLineage e2e compat tests failing on docker compose pull

### DIFF
--- a/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
+++ b/airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py
@@ -644,9 +644,9 @@ def spin_up_airflow_environment(tmp_path_factory: pytest.TempPathFactory):
     #
     os.environ["FERNET_KEY"] = generate_fernet_key_string()
 
-    # If we are using the image from ghcr.io/apache/airflow we do not pull
-    # as it is already available and loaded using prepare_breeze_and_image step in workflow
-    pull = False if DOCKER_IMAGE.startswith("ghcr.io/apache/airflow/") else True
+    # ghcr.io/apache/airflow is already available and loaded using prepare_breeze_and_image step in workflow.
+    # openlineage-e2e is built locally and the workflow doesn't push it.
+    pull = not DOCKER_IMAGE.startswith(("ghcr.io/apache/airflow/", "openlineage-e2e/"))
 
     try:
         console.print(f"[blue]Spinning up airflow environment using {DOCKER_IMAGE}")


### PR DESCRIPTION
### Why

- On the scheduled `main` canary, the OpenLineage e2e compat tests fail cause of image pull.
  - https://github.com/apache/airflow/actions/runs/29302223579
  - https://github.com/apache/airflow/actions/runs/29259909772
  - https://github.com/apache/airflow/actions/runs/29196225169
  - https://github.com/apache/airflow/actions/runs/29177468641
  - https://github.com/apache/airflow/actions/runs/29156049928
  - https://github.com/apache/airflow/actions/runs/29137134659
- The compat workflow builds the image `openlineage-e2e/airflow:<version>-python<py>` locally and never pushes it to a registry.

### How

- Extend the no-pull prefix check in `spin_up_airflow_environment` to also cover the locally built `openlineage-e2e/` tag.

### Verification

- `breeze testing airflow-e2e-tests --python 3.10 --e2e-test-mode openlineage --airflow-version 3.0.6`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
