### PR TITLE
Run OpenLineage e2e compat tests when the compat setup changes

### DIFF
--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -435,9 +435,13 @@ together using `pytest-xdist` (pytest-xdist distributes the tests among parallel
   `PROD Image building`.
 * `OpenLineage E2E compat tests` (the same suite rerun against older released Airflow versions with
   current provider code, exposed as the `run-openlineage-e2e-compat-tests` output) are costly, so
-  they do NOT run on every OpenLineage PR: only on `canary` runs or when the `full tests needed`
-  label is explicitly set. Deliberately not tied to *derived* `full tests needed` (large PRs, env
-  changes, pushes) — the same rationale as `run-ui-e2e-tests`.
+  they do NOT run on every OpenLineage PR: on `canary` runs, when the `full tests needed` label is
+  explicitly set, or when a file that drives the compat setup but does not itself force the full
+  matrix changes — the shared e2e harness
+  (`airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py` / `constants.py`) or the compat Dockerfile
+  (`airflow-e2e-tests/docker/openlineage-compat.Dockerfile`). The compat workflow
+  (`.github/workflows/openlineage-e2e-compat-tests.yml`) matches `ENVIRONMENT_FILES` and so already
+  forces the full matrix — the same rationale as `run-ui-e2e-tests`.
 * The specific unit test type is enabled only if changed files match the expected patterns for each type
   (`API`, `CLI`, `WWW`, `Providers` etc.). The `Always` test type is added always if any unit
   tests are run. `Providers` tests are removed if current branch is different than `main`

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -133,6 +133,7 @@ class FileGroupForCi(Enum):
     JAVA_SDK_E2E_FILES = auto()
     GO_SDK_E2E_FILES = auto()
     OPENLINEAGE_E2E_FILES = auto()
+    OPENLINEAGE_E2E_COMPAT_FILES = auto()
     ALL_PYPROJECT_TOML_FILES = auto()
     ALL_PYTHON_FILES = auto()
     ALL_SOURCE_FILES = auto()
@@ -259,6 +260,14 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
             r"^providers/common/compat/.*",
             r"^providers/common/io/.*",
             r"^providers/common/sql/.*",
+        ],
+        FileGroupForCi.OPENLINEAGE_E2E_COMPAT_FILES: [
+            # Only files that drive the compat setup yet do NOT already force the full matrix belong
+            # here. The compat workflow (.github/workflows/openlineage-e2e-compat-tests.yml) is
+            # intentionally absent: it matches ENVIRONMENT_FILES and so already forces full_tests.
+            r"^airflow-e2e-tests/tests/airflow_e2e_tests/conftest\.py$",
+            r"^airflow-e2e-tests/tests/airflow_e2e_tests/constants\.py$",
+            r"^airflow-e2e-tests/docker/openlineage-compat\.Dockerfile$",
         ],
         FileGroupForCi.PYTHON_PRODUCTION_FILES: [
             # Production Python source the runtime ships — excludes tests, docs,
@@ -1053,13 +1062,14 @@ class SelectiveChecks:
 
     @cached_property
     def run_openlineage_e2e_compat_tests(self) -> bool:
-        # The older-Airflow compat matrix is costly, so it does not run on every OpenLineage PR:
-        # only on canary (scheduled / main) or when a maintainer explicitly asks via the label.
-        # Deliberately not tied to derived full_tests_needed (large PRs, env changes, pushes) — same
-        # rationale as run_ui_e2e_tests.
+        # Costly older-Airflow matrix. Like run_ui_e2e_tests it is not triggered by *derived*
+        # full_tests_needed (pushes, env changes, large PRs) — only by canary, an explicit label, or
+        # an actual change to a file that drives the compat setup but does not itself force the full
+        # matrix: the shared e2e harness (conftest / constants) or the compat Dockerfile. The compat
+        # workflow already forces full_tests_needed via ENVIRONMENT_FILES.
         if self._is_canary_run() or FULL_TESTS_NEEDED_LABEL in self._pr_labels:
             return True
-        return False
+        return self._should_be_run(FileGroupForCi.OPENLINEAGE_E2E_COMPAT_FILES)
 
     @cached_property
     def run_amazon_tests(self) -> bool:
@@ -1204,6 +1214,7 @@ class SelectiveChecks:
             or self.run_java_sdk_e2e_tests
             or self.run_go_sdk_e2e_tests
             or self.run_openlineage_e2e_tests
+            or self.run_openlineage_e2e_compat_tests
             or self.run_ui_e2e_tests
         )
 

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -262,7 +262,7 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
             r"^providers/common/sql/.*",
         ],
         FileGroupForCi.OPENLINEAGE_E2E_COMPAT_FILES: [
-            # Only files that drive the compat setup yet do NOT already force the full matrix belong
+            # Only add files that affect the compat setup and do NOT already trigger the full matrix
             # here. The compat workflow (.github/workflows/openlineage-e2e-compat-tests.yml) is
             # intentionally absent: it matches ENVIRONMENT_FILES and so already forces full_tests.
             r"^airflow-e2e-tests/tests/airflow_e2e_tests/conftest\.py$",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1514,17 +1514,50 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
             ("airflow-e2e-tests/tests/airflow_e2e_tests/openlineage_tests/harness.py",),
             {
                 "run-openlineage-e2e-tests": "true",
+                "run-openlineage-e2e-compat-tests": "false",
                 "prod-image-build": "true",
             },
-            id="Run OpenLineage e2e tests when the e2e harness changes",
+            id="Run OpenLineage e2e tests (not the costly compat matrix) when the OL e2e suite changes",
         ),
         pytest.param(
             ("providers/ftp/src/airflow/providers/ftp/hooks/ftp.py",),
             {
                 "run-openlineage-e2e-tests": "false",
+                "run-openlineage-e2e-compat-tests": "false",
                 "prod-image-build": "false",
             },
             id="Do not run OpenLineage e2e tests for unrelated provider change",
+        ),
+        pytest.param(
+            ("airflow-e2e-tests/tests/airflow_e2e_tests/conftest.py",),
+            {
+                "run-openlineage-e2e-tests": "false",
+                "run-openlineage-e2e-compat-tests": "true",
+                "full-tests-needed": "false",
+                "prod-image-build": "true",
+            },
+            id="Run OpenLineage e2e compat tests when the shared e2e harness (conftest) changes",
+        ),
+        pytest.param(
+            ("airflow-e2e-tests/docker/openlineage-compat.Dockerfile",),
+            {
+                "run-openlineage-e2e-tests": "false",
+                "run-openlineage-e2e-compat-tests": "true",
+                "full-tests-needed": "false",
+                "prod-image-build": "true",
+            },
+            id="Run OpenLineage e2e compat tests when the compat Dockerfile changes",
+        ),
+        pytest.param(
+            (".github/workflows/openlineage-e2e-compat-tests.yml",),
+            {
+                # The compat workflow matches ENVIRONMENT_FILES, so it forces the full matrix.
+                # The compat therefore runs via full_tests_needed, not via OPENLINEAGE_E2E_COMPAT_FILES.
+                "run-openlineage-e2e-tests": "true",
+                "run-openlineage-e2e-compat-tests": "true",
+                "full-tests-needed": "true",
+            },
+            id="Compat workflow change forces the full matrix (compat runs via full_tests_needed)",
         ),
         (
             pytest.param(


### PR DESCRIPTION
### Why

- The OpenLineage compat matrix ran only on `canary` or the `full tests needed` label, never on file changes.
- So a PR confined to the compat path (the shared e2e test containers harness, or the compat Dockerfile) ran nothing that could exercise it: a compat-only breakage could merge green and surface only on the nightly canary.

### How

- Add an `OPENLINEAGE_E2E_COMPAT_FILES` file group listing the compat-specific files: the shared e2e harness (`conftest.py` / `constants.py`) and the compat Dockerfile.

### Verification

- `uv run --project dev/breeze pytest dev/breeze/tests/test_selective_checks.py`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
