### PR TITLE
Fix create_delta_data_intervals being ignored for timedelta schedules

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/timetable.rst
+++ b/airflow-core/docs/authoring-and-scheduling/timetable.rst
@@ -372,6 +372,10 @@ This transition can happen without editing a Dag, in two ways:
 
 - Flipping ``[scheduler] create_cron_data_intervals`` changes how every Dag
   with a bare cron string in ``schedule=`` resolves its timetable.
+- Flipping ``[scheduler] create_delta_data_intervals`` changes how every Dag
+  with a ``timedelta`` or ``relativedelta`` in ``schedule=`` resolves its timetable.
+  The same one-period skip applies when switching from ``DeltaTriggerTimetable``
+  to ``DeltaDataIntervalTimetable``.
 - Crossing a version boundary where the default differs. Airflow 3 defaults
   to ``False``; Airflow 2.x defaults to ``True``.
 

--- a/airflow-core/docs/authoring-and-scheduling/timetable.rst
+++ b/airflow-core/docs/authoring-and-scheduling/timetable.rst
@@ -368,7 +368,7 @@ scheduled run, because the next run is advanced one period to avoid colliding
 with the previous run's ``logical_date``. The reverse direction (data
 interval -> trigger) does not skip a run.
 
-This transition can happen without editing a Dag, in two ways:
+This transition can happen without editing a Dag, in three ways:
 
 - Flipping ``[scheduler] create_cron_data_intervals`` changes how every Dag
   with a bare cron string in ``schedule=`` resolves its timetable.

--- a/airflow-core/docs/installation/upgrading_to_airflow3.rst
+++ b/airflow-core/docs/installation/upgrading_to_airflow3.rst
@@ -388,6 +388,26 @@ These include:
   Airflow 3 dagruns already exist (going
   ``CronTriggerTimetable`` -> ``CronDataIntervalTimetable``), one scheduled run
   is skipped to avoid colliding with the previous run's ``logical_date``.
+
+- The ``create_delta_data_intervals`` configuration is now **functional**. Previously, a bug caused
+  ``create_cron_data_intervals`` to silently control timetable selection for both cron-string DAGs
+  **and** ``timedelta``/``relativedelta`` DAGs, making ``create_delta_data_intervals`` a no-op.
+
+  This affects users who set ``create_cron_data_intervals = True`` to preserve Airflow 2
+  data-interval semantics for cron DAGs (as the upgrade guide recommends). Because of the bug,
+  that flag was also keeping ``timedelta``/``relativedelta`` DAGs on ``DeltaDataIntervalTimetable``.
+  After this fix those DAGs fall through to ``DeltaTriggerTimetable`` instead, shifting
+  ``logical_date``, ``ds``, ``ts``, and ``data_interval_*`` by one period. The same applies
+  to DAGs migrated via ``conversion_v1_to_v2``.
+
+  If you want ``timedelta``/``relativedelta`` DAGs to keep ``DeltaDataIntervalTimetable``
+  behavior, set ``create_delta_data_intervals = True`` explicitly.
+
+  Set this **before** the upgrade. Setting ``create_delta_data_intervals = True`` on the
+  current unpatched Airflow 3 is safe -- the key was previously ignored, so it takes effect
+  only once this fix is in place. If you flip this flag from ``False`` to ``True`` after
+  Airflow 3 DAG runs already exist (``DeltaTriggerTimetable`` -> ``DeltaDataIntervalTimetable``),
+  one scheduled run is skipped to avoid colliding with the previous run's ``logical_date``.
 - **Manual Dag runs and data intervals**: In Airflow 3, do not assume that a manually triggered Dag run's ``data_interval`` is derived from, or equal to, the supplied ``logical_date``. If your Dag logic needs the user-specified trigger date, use ``logical_date`` explicitly. This especially affects workflows that read ``data_interval_start`` or ``data_interval_end`` during manual triggering or when using ``TriggerDagRunOperator``. For detailed migration guidance, see :ref:`data-interval-manual-triggering`.
 - **Simple Auth** is now default ``auth_manager``. To continue using FAB as the Auth Manager, please install the FAB provider and set ``auth_manager`` to ``FabAuthManager``:
 

--- a/airflow-core/newsfragments/69869.significant.rst
+++ b/airflow-core/newsfragments/69869.significant.rst
@@ -33,7 +33,7 @@ DAGs (i.e. you need contiguous data intervals and ``ds``/``ts`` anchored at
     create_delta_data_intervals = True
 
 You can safely set this flag on current ``main`` (before this fix ships) because
-``create_delta_data_intervals`` was previously a no-op — setting it to ``True``
+``create_delta_data_intervals`` was previously a no-op - setting it to ``True``
 will have no effect until the fix is in place, so there is no risk of an
 unexpected timetable switch during the transition.
 

--- a/airflow-core/newsfragments/69869.significant.rst
+++ b/airflow-core/newsfragments/69869.significant.rst
@@ -1,0 +1,63 @@
+Fix ``create_delta_data_intervals`` being ignored for timedelta/relativedelta schedules
+
+``[scheduler] create_delta_data_intervals`` now correctly controls timetable selection
+for DAGs that pass a ``timedelta`` or ``relativedelta`` to ``schedule=``. Before this
+fix, ``create_cron_data_intervals`` silently governed both cron-string DAGs **and**
+timedelta/relativedelta DAGs, making ``create_delta_data_intervals`` a no-op.
+
+**Who is affected:**
+
+Users who set ``create_cron_data_intervals = True`` in their Airflow 3 config to
+preserve Airflow 2 data-interval semantics for cron DAGs (as recommended by
+``upgrading_to_airflow3.rst``) are also unintentionally running their
+``timedelta``/``relativedelta`` DAGs on ``DeltaDataIntervalTimetable``. After this
+fix, those DAGs will fall through to the correct default (``DeltaTriggerTimetable``)
+unless ``create_delta_data_intervals`` is also set to ``True``.
+
+This also affects DAGs migrated from Airflow 2 via ``conversion_v1_to_v2``, which
+rebuilds timetables through the same code path.
+
+**Behaviour changes:**
+
+- ``create_delta_data_intervals`` now takes effect as documented.
+- ``create_cron_data_intervals`` now affects **only** cron-string DAGs.
+- The two config keys are independent, as ``config.yml`` always documented.
+
+**Migration:**
+
+If you rely on ``DeltaDataIntervalTimetable`` for ``timedelta``/``relativedelta``
+DAGs (i.e. you need contiguous data intervals and ``ds``/``ts`` anchored at
+``data_interval_start``), set this **before** the next scheduler restart::
+
+    [scheduler]
+    create_delta_data_intervals = True
+
+You can safely set this flag on current ``main`` (before this fix ships) because
+``create_delta_data_intervals`` was previously a no-op — setting it to ``True``
+will have no effect until the fix is in place, so there is no risk of an
+unexpected timetable switch during the transition.
+
+Switching a DAG from ``DeltaTriggerTimetable`` to ``DeltaDataIntervalTimetable``
+(i.e. flipping ``create_delta_data_intervals`` from ``False`` to ``True`` when
+existing DAG runs are present) skips one scheduled run to avoid colliding with
+the previous run's ``logical_date``. Plan for this one-period gap or convert
+affected DAGs to an explicit ``DeltaDataIntervalTimetable(...)`` instance in
+``schedule=`` before the flag changes.
+
+* Types of change
+
+  * [ ] DAG changes
+  * [x] Config changes
+  * [ ] API changes
+  * [ ] CLI changes
+  * [x] Behaviour changes
+  * [ ] Plugin changes
+  * [ ] Dependency changes
+  * [ ] Code interface changes
+
+* Migration rules needed
+
+  * Users who set ``create_cron_data_intervals = True`` to preserve Airflow 2
+    data-interval behavior for cron DAGs should also set
+    ``create_delta_data_intervals = True`` if they have ``timedelta``/
+    ``relativedelta`` DAGs that depended on ``DeltaDataIntervalTimetable``.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -2836,6 +2836,10 @@ scheduler:
         Notably, for **DeltaTriggerTimetable**, the logical date is the same as the time the DAG Run will
         try to schedule, while for **DeltaDataIntervalTimetable**, the logical date is the beginning of
         the data interval, but the DAG Run will try to schedule at the end of the data interval.
+
+        When a DAG is switched from **DeltaTriggerTimetable** to **DeltaDataIntervalTimetable** (for example,
+        by flipping this setting from ``False`` to ``True``), the next scheduled run skips one period past
+        the most recent **DeltaTriggerTimetable** run to avoid colliding with its logical date.
       version_added: 2.11.0
       type: boolean
       example: ~

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -147,7 +147,7 @@ def _create_timetable(interval: ScheduleInterval, timezone: Timezone | FixedTime
     if interval == "@continuous":
         return ContinuousTimetable()
     if isinstance(interval, timedelta | relativedelta):
-        if airflow_conf.getboolean("scheduler", "create_cron_data_intervals"):
+        if airflow_conf.getboolean("scheduler", "create_delta_data_intervals"):
             return DeltaDataIntervalTimetable(interval)
         return DeltaTriggerTimetable(interval)
     if isinstance(interval, str):

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -447,6 +447,46 @@ class TestDag:
         with pytest.raises(ValueError, match="ContinuousTimetable requires max_active_runs <= 1"):
             dag = DAG("continuous", start_date=DEFAULT_DATE, schedule="@continuous", max_active_runs=25)
 
+    def test_timedelta_schedule_respects_create_delta_data_intervals_config(self):
+        """Regression guard: create_delta_data_intervals must control DeltaTriggerTimetable vs
+        DeltaDataIntervalTimetable for timedelta/relativedelta schedules, independently of
+        create_cron_data_intervals (which governs only cron-string schedules).
+        """
+        from airflow.sdk.definitions.timetables.interval import DeltaDataIntervalTimetable
+        from airflow.sdk.definitions.timetables.trigger import DeltaTriggerTimetable
+
+        from tests_common.test_utils.config import conf_vars
+
+        # Both False (the shipped airflow.cfg default): timedelta schedules use the trigger-based timetable.
+        with conf_vars(
+            {
+                ("scheduler", "create_delta_data_intervals"): "False",
+                ("scheduler", "create_cron_data_intervals"): "False",
+            }
+        ):
+            dag = DAG("delta_default", start_date=DEFAULT_DATE, schedule=timedelta(days=1))
+            assert isinstance(dag.timetable, DeltaTriggerTimetable)
+
+        # create_delta_data_intervals=True switches timedelta schedules to the data-interval timetable.
+        with conf_vars(
+            {
+                ("scheduler", "create_delta_data_intervals"): "True",
+                ("scheduler", "create_cron_data_intervals"): "False",
+            }
+        ):
+            dag = DAG("delta_data_interval", start_date=DEFAULT_DATE, schedule=timedelta(days=1))
+            assert isinstance(dag.timetable, DeltaDataIntervalTimetable)
+
+        # create_cron_data_intervals only affects cron/str schedules, not timedelta ones.
+        with conf_vars(
+            {
+                ("scheduler", "create_delta_data_intervals"): "False",
+                ("scheduler", "create_cron_data_intervals"): "True",
+            }
+        ):
+            dag = DAG("delta_unaffected_by_cron_config", start_date=DEFAULT_DATE, schedule=timedelta(days=1))
+            assert isinstance(dag.timetable, DeltaTriggerTimetable)
+
     def test_only_partitioned_at_runtime_has_partitioned_at_runtime_flag(self):
         """Regression guard: across every BaseTimetable subclass, only PartitionedAtRuntime sets partitioned_at_runtime=True."""
 

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest import mock
 
+from dateutil.relativedelta import relativedelta
 import pytest
 
 from airflow.sdk import (
@@ -37,6 +38,8 @@ from airflow.sdk import (
 )
 from airflow.sdk.bases.operator import BaseOperator
 from airflow.sdk.bases.timetable import BaseTimetable
+from airflow.sdk.definitions.timetables.interval import DeltaDataIntervalTimetable
+from airflow.sdk.definitions.timetables.trigger import DeltaTriggerTimetable
 from airflow.sdk.definitions.param import DagParam, ParamsDict
 from airflow.sdk.exceptions import AirflowDagCycleException, DuplicateTaskIdFound, RemovedInAirflow4Warning
 from airflow.utils.types import DagRunType
@@ -449,43 +452,30 @@ class TestDag:
         with pytest.raises(ValueError, match="ContinuousTimetable requires max_active_runs <= 1"):
             dag = DAG("continuous", start_date=DEFAULT_DATE, schedule="@continuous", max_active_runs=25)
 
-    def test_timedelta_schedule_respects_create_delta_data_intervals_config(self):
+    @pytest.mark.parametrize("schedule", [timedelta(days=1), relativedelta(days=1)])
+    @pytest.mark.parametrize(
+        ("delta", "cron", "expected"),
+        [
+            pytest.param("False", "False", DeltaTriggerTimetable, id="both-false"),
+            pytest.param("True", "False", DeltaDataIntervalTimetable, id="delta-true"),
+            pytest.param("False", "True", DeltaTriggerTimetable, id="cron-true"),
+        ],
+    )
+    def test_timedelta_schedule_respects_create_delta_data_intervals_config(
+        self, schedule, delta, cron, expected
+    ):
         """Regression guard: create_delta_data_intervals must control DeltaTriggerTimetable vs
         DeltaDataIntervalTimetable for timedelta/relativedelta schedules, independently of
         create_cron_data_intervals (which governs only cron-string schedules).
         """
-        from airflow.sdk.definitions.timetables.interval import DeltaDataIntervalTimetable
-        from airflow.sdk.definitions.timetables.trigger import DeltaTriggerTimetable
-
-        # Both False (the shipped airflow.cfg default): timedelta schedules use the trigger-based timetable.
         with conf_vars(
             {
-                ("scheduler", "create_delta_data_intervals"): "False",
-                ("scheduler", "create_cron_data_intervals"): "False",
+                ("scheduler", "create_delta_data_intervals"): delta,
+                ("scheduler", "create_cron_data_intervals"): cron,
             }
         ):
-            dag = DAG("delta_default", start_date=DEFAULT_DATE, schedule=timedelta(days=1))
-            assert isinstance(dag.timetable, DeltaTriggerTimetable)
-
-        # create_delta_data_intervals=True switches timedelta schedules to the data-interval timetable.
-        with conf_vars(
-            {
-                ("scheduler", "create_delta_data_intervals"): "True",
-                ("scheduler", "create_cron_data_intervals"): "False",
-            }
-        ):
-            dag = DAG("delta_data_interval", start_date=DEFAULT_DATE, schedule=timedelta(days=1))
-            assert isinstance(dag.timetable, DeltaDataIntervalTimetable)
-
-        # create_cron_data_intervals only affects cron/str schedules, not timedelta ones.
-        with conf_vars(
-            {
-                ("scheduler", "create_delta_data_intervals"): "False",
-                ("scheduler", "create_cron_data_intervals"): "True",
-            }
-        ):
-            dag = DAG("delta_unaffected_by_cron_config", start_date=DEFAULT_DATE, schedule=timedelta(days=1))
-            assert isinstance(dag.timetable, DeltaTriggerTimetable)
+            dag = DAG("test_dag", start_date=DEFAULT_DATE, schedule=schedule)
+            assert isinstance(dag.timetable, expected)
 
     def test_only_partitioned_at_runtime_has_partitioned_at_runtime_flag(self):
         """Regression guard: across every BaseTimetable subclass, only PartitionedAtRuntime sets partitioned_at_runtime=True."""

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -41,6 +41,8 @@ from airflow.sdk.definitions.param import DagParam, ParamsDict
 from airflow.sdk.exceptions import AirflowDagCycleException, DuplicateTaskIdFound, RemovedInAirflow4Warning
 from airflow.utils.types import DagRunType
 
+from tests_common.test_utils.config import conf_vars
+
 DEFAULT_DATE = datetime(2016, 1, 1, tzinfo=timezone.utc)
 
 
@@ -454,8 +456,6 @@ class TestDag:
         """
         from airflow.sdk.definitions.timetables.interval import DeltaDataIntervalTimetable
         from airflow.sdk.definitions.timetables.trigger import DeltaTriggerTimetable
-
-        from tests_common.test_utils.config import conf_vars
 
         # Both False (the shipped airflow.cfg default): timedelta schedules use the trigger-based timetable.
         with conf_vars(

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -23,8 +23,8 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest import mock
 
-from dateutil.relativedelta import relativedelta
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from airflow.sdk import (
     DAG,
@@ -38,9 +38,9 @@ from airflow.sdk import (
 )
 from airflow.sdk.bases.operator import BaseOperator
 from airflow.sdk.bases.timetable import BaseTimetable
+from airflow.sdk.definitions.param import DagParam, ParamsDict
 from airflow.sdk.definitions.timetables.interval import DeltaDataIntervalTimetable
 from airflow.sdk.definitions.timetables.trigger import DeltaTriggerTimetable
-from airflow.sdk.definitions.param import DagParam, ParamsDict
 from airflow.sdk.exceptions import AirflowDagCycleException, DuplicateTaskIdFound, RemovedInAirflow4Warning
 from airflow.utils.types import DagRunType
 


### PR DESCRIPTION
Fixes a bug where `create_delta_data_intervals` had no effect on DAGs with a
`timedelta`/`relativedelta` schedule.

`_create_timetable()` in `task-sdk/src/airflow/sdk/definitions/dag.py` checked
`create_cron_data_intervals` for **both** the cron-string branch and the
`timedelta`/`relativedelta` branch. As a result:

- `create_delta_data_intervals` had no effect at all - it's referenced nowhere
  else in the codebase besides CLI config-list metadata and docs.
- `create_cron_data_intervals` silently controlled timetable selection for
  `timedelta`/`relativedelta` schedules too, which isn't what it's documented
  to do (`config.yml` describes it as governing only cron-string schedules).

The `timedelta | relativedelta` branch now checks `create_delta_data_intervals`
instead, matching `config.yml`'s documented behavior and making the two config
keys independent, as intended.

### Tests

`test_timedelta_schedule_respects_create_delta_data_intervals_config` in
`task-sdk/tests/task_sdk/definitions/test_dag.py` is parametrized over
`(delta, cron, expected)` and over the schedule type:

- both `False` (the shipped default) -> `DeltaTriggerTimetable`
- `create_delta_data_intervals=True` -> `DeltaDataIntervalTimetable`
- `create_cron_data_intervals=True` alone -> still `DeltaTriggerTimetable`
  (regression guard against the exact bug fixed here)

each run against `timedelta(days=1)` and `relativedelta(days=1)`, for six
independent cases.

Verified locally: all six pass against the fix, and four of the six fail
against the pre-fix code (both `delta-true` rows and both `cron-true` rows,
including the `relativedelta` ones). Full `test_dag.py` suite: 99 passed.

Note: `unit_tests.cfg` sets both `create_cron_data_intervals` and
`create_delta_data_intervals` to `true`, which is why the existing test suite
never caught this - both keys being `true` produced the same (accidentally
correct) result before and after this fix for any test not overriding them
individually.

### Docs and newsfragment

The fix changes behavior for anyone who set `create_cron_data_intervals = True`
on the upgrade guide's advice, so this PR documents it in four places:

- `airflow-core/newsfragments/69869.significant.rst` - who is affected and the
  remedy.
- `upgrading_to_airflow3.rst` - a bullet next to the existing
  `create_cron_data_intervals` one.
- `timetable.rst` - `create_delta_data_intervals` added to "Switching between
  trigger and data interval timetables".
- `config.yml` - the skip-one-period paragraph the cron entry already had but
  the delta entry lacked.

Setting `create_delta_data_intervals = True` is a no-op before this fix, so it
can be set ahead of upgrading to keep current behavior.

* closes: #69868

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
