### PR TITLE
Call listeners for running task instance when a Dag Run state is manually set

### DIFF
--- a/airflow-core/newsfragments/69874.bugfix.rst
+++ b/airflow-core/newsfragments/69874.bugfix.rst
@@ -1,0 +1,1 @@
+Listeners registered via ``on_task_instance_success`` / ``on_task_instance_failed`` are now called for non-teardown task instances that were running when a Dag Run state is manually set to a terminal state (e.g. via the API or UI).

--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -223,7 +223,7 @@ def _set_dag_run_terminal_state(
     ti_state: TaskInstanceState,
     commit: bool,
     session: SASession,
-) -> list[TaskInstance]:
+) -> tuple[list[TaskInstance], list[TaskInstance]]:
     """
     Set the dag run's state to the given terminal state.
 
@@ -237,11 +237,13 @@ def _set_dag_run_terminal_state(
     :param ti_state: state to set on running task instances
     :param commit: commit Dag and tasks to be altered to the database
     :param session: database session
-    :return: If commit is true, list of tasks that have been updated,
-             otherwise list of tasks that will be updated
+    :return: ``(all_updated_tis, running_tis)`` where ``all_updated_tis`` is the
+        combined list of pending (now SKIPPED) and running (now ``ti_state``) TIs,
+        and ``running_tis`` is only the TIs that were in an active state before
+        the transition (useful for firing terminal listener hooks).
     """
     if not dag:
-        return []
+        return [], []
     if not run_id:
         raise ValueError(f"Invalid dag_run_id: {run_id}")
 
@@ -302,13 +304,14 @@ def _set_dag_run_terminal_state(
         if not any(dag.task_dict[ti.task_id].is_teardown for ti in (running_tis + pending_tis)):
             _set_dag_run_state(dag.dag_id, run_id, run_state, session)
 
-    return pending_normal_tis + set_state(
+    all_updated = pending_normal_tis + set_state(
         tasks=running_tasks,
         run_id=run_id,
         state=ti_state,
         commit=commit,
         session=session,
     )
+    return all_updated, running_tis
 
 
 @provide_session
@@ -318,7 +321,7 @@ def set_dag_run_state_to_success(
     run_id: str | None = None,
     commit: bool = False,
     session: SASession = NEW_SESSION,
-) -> list[TaskInstance]:
+) -> tuple[list[TaskInstance], list[TaskInstance]]:
     """
     Set the dag run's state to success.
 
@@ -328,8 +331,13 @@ def set_dag_run_state_to_success(
     :param run_id: the run_id to start looking from
     :param commit: commit Dag and tasks to be altered to the database
     :param session: database session
-    :return: If commit is true, list of tasks that have been updated,
-             otherwise list of tasks that will be updated
+    :return: A tuple ``(all_updated_tis, running_tis)``.
+        ``all_updated_tis`` is the combined list of task instances that were updated:
+        previously-running ones (now SUCCESS) and non-finished pending ones (now SKIPPED).
+        If ``commit`` is ``False``, this is the list of task instances *that would be* updated.
+        ``running_tis`` contains only the task instances that were in an active running state
+        (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) before the transition —
+        useful for firing terminal listener hooks.
     :raises: ValueError if dag or logical_date is invalid
     """
     return _set_dag_run_terminal_state(
@@ -349,7 +357,7 @@ def set_dag_run_state_to_failed(
     run_id: str | None = None,
     commit: bool = False,
     session: SASession = NEW_SESSION,
-) -> list[TaskInstance]:
+) -> tuple[list[TaskInstance], list[TaskInstance]]:
     """
     Set the dag run's state to failed.
 
@@ -359,8 +367,13 @@ def set_dag_run_state_to_failed(
     :param run_id: the Dag run_id to start looking from
     :param commit: commit Dag and tasks to be altered to the database
     :param session: database session
-    :return: If commit is true, list of tasks that have been updated,
-             otherwise list of tasks that will be updated
+    :return: A tuple ``(all_updated_tis, running_tis)``.
+        ``all_updated_tis`` is the combined list of task instances that were updated:
+        previously-running ones (now FAILED) and non-finished pending ones (now SKIPPED).
+        If ``commit`` is ``False``, this is the list of task instances *that would be* updated.
+        ``running_tis`` contains only the task instances that were in an active running state
+        (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) before the transition —
+        useful for firing terminal listener hooks.
     """
     return _set_dag_run_terminal_state(
         dag=dag,

--- a/airflow-core/src/airflow/api/common/mark_tasks.py
+++ b/airflow-core/src/airflow/api/common/mark_tasks.py
@@ -237,10 +237,12 @@ def _set_dag_run_terminal_state(
     :param ti_state: state to set on running task instances
     :param commit: commit Dag and tasks to be altered to the database
     :param session: database session
-    :return: ``(all_updated_tis, running_tis)`` where ``all_updated_tis`` is the
+    :return: ``(all_updated_tis, killed_tis)`` where ``all_updated_tis`` is the
         combined list of pending (now SKIPPED) and running (now ``ti_state``) TIs,
-        and ``running_tis`` is only the TIs that were in an active state before
-        the transition (useful for firing terminal listener hooks).
+        and ``killed_tis`` contains only the non-teardown TIs that were in an active
+        running state and were forcefully terminated (teardown TIs are intentionally
+        left running so they can finish their own cleanup, and must not receive a
+        terminal listener event here).
     """
     if not dag:
         return [], []
@@ -266,9 +268,10 @@ def _set_dag_run_terminal_state(
             )
         ).all()
     )
-
     # Do not kill teardown tasks
     task_ids_of_running_tis = {ti.task_id for ti in running_tis if not dag.task_dict[ti.task_id].is_teardown}
+    # Keep task instances that were killed with no cleanup capability (all running minus teardown ones).
+    killed_tis = [ti for ti in running_tis if ti.task_id in task_ids_of_running_tis]
 
     def _set_running_task(task: Operator) -> Operator:
         task.dag = dag
@@ -311,7 +314,7 @@ def _set_dag_run_terminal_state(
         commit=commit,
         session=session,
     )
-    return all_updated, running_tis
+    return all_updated, killed_tis
 
 
 @provide_session
@@ -331,13 +334,15 @@ def set_dag_run_state_to_success(
     :param run_id: the run_id to start looking from
     :param commit: commit Dag and tasks to be altered to the database
     :param session: database session
-    :return: A tuple ``(all_updated_tis, running_tis)``.
+    :return: A tuple ``(all_updated_tis, killed_tis)``.
         ``all_updated_tis`` is the combined list of task instances that were updated:
         previously-running ones (now SUCCESS) and non-finished pending ones (now SKIPPED).
         If ``commit`` is ``False``, this is the list of task instances *that would be* updated.
-        ``running_tis`` contains only the task instances that were in an active running state
-        (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) before the transition —
-        useful for firing terminal listener hooks.
+        ``killed_tis`` contains only the non-teardown task instances that were in an active
+        running state (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) and were
+        forcefully terminated — teardown tasks are intentionally excluded because they are
+        left running to finish their own cleanup. Use ``killed_tis`` for firing terminal
+        listener hooks.
     :raises: ValueError if dag or logical_date is invalid
     """
     return _set_dag_run_terminal_state(
@@ -367,13 +372,15 @@ def set_dag_run_state_to_failed(
     :param run_id: the Dag run_id to start looking from
     :param commit: commit Dag and tasks to be altered to the database
     :param session: database session
-    :return: A tuple ``(all_updated_tis, running_tis)``.
+    :return: A tuple ``(all_updated_tis, killed_tis)``.
         ``all_updated_tis`` is the combined list of task instances that were updated:
         previously-running ones (now FAILED) and non-finished pending ones (now SKIPPED).
         If ``commit`` is ``False``, this is the list of task instances *that would be* updated.
-        ``running_tis`` contains only the task instances that were in an active running state
-        (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) before the transition —
-        useful for firing terminal listener hooks.
+        ``killed_tis`` contains only the non-teardown task instances that were in an active
+        running state (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) and were
+        forcefully terminated — teardown tasks are intentionally excluded because they are
+        left running to finish their own cleanup. Use ``killed_tis`` for firing terminal
+        listener hooks.
     """
     return _set_dag_run_terminal_state(
         dag=dag,

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -194,13 +194,10 @@ def patch_dag_run_state(
 ) -> None:
     """Set a Dag Run's state (success/queued/failed), firing the matching listener hooks."""
     if state == DagRunMutableStates.SUCCESS:
-        _, running_tis = set_dag_run_state_to_success(
+        _, killed_tis = set_dag_run_state_to_success(
             dag=dag, run_id=dag_run.run_id, commit=True, session=session
         )
-        try:
-            _emit_state_listener_hooks(running_tis, TaskInstanceState.SUCCESS)
-        except Exception:
-            log.exception("error calling listener")
+        _emit_state_listener_hooks(killed_tis, TaskInstanceState.SUCCESS)
         try:
             if dag_run.dag is None:
                 dag_run.dag = dag
@@ -216,13 +213,10 @@ def patch_dag_run_state(
         # Not notifying on queued - only notifying on RUNNING, which happens in the scheduler.
         set_dag_run_state_to_queued(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
     elif state == DagRunMutableStates.FAILED:
-        _, running_tis = set_dag_run_state_to_failed(
+        _, killed_tis = set_dag_run_state_to_failed(
             dag=dag, run_id=dag_run.run_id, commit=True, session=session
         )
-        try:
-            _emit_state_listener_hooks(running_tis, TaskInstanceState.FAILED)
-        except Exception:
-            log.exception("error calling listener")
+        _emit_state_listener_hooks(killed_tis, TaskInstanceState.FAILED)
         try:
             if dag_run.dag is None:
                 dag_run.dag = dag

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -57,6 +57,7 @@ from airflow.api_fastapi.core_api.datamodels.dag_run import (
 )
 from airflow.api_fastapi.core_api.datamodels.task_instances import NewTaskResponse
 from airflow.api_fastapi.core_api.services.public.common import BulkService
+from airflow.api_fastapi.core_api.services.public.task_instances import _emit_state_listener_hooks
 from airflow.listeners.listener import get_listener_manager
 from airflow.models.dagrun import DagRun, clear_partition_runs
 from airflow.models.taskinstance import TaskInstance
@@ -193,7 +194,13 @@ def patch_dag_run_state(
 ) -> None:
     """Set a Dag Run's state (success/queued/failed), firing the matching listener hooks."""
     if state == DagRunMutableStates.SUCCESS:
-        set_dag_run_state_to_success(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
+        _, running_tis = set_dag_run_state_to_success(
+            dag=dag, run_id=dag_run.run_id, commit=True, session=session
+        )
+        try:
+            _emit_state_listener_hooks(running_tis, TaskInstanceState.SUCCESS)
+        except Exception:
+            log.exception("error calling listener")
         try:
             if dag_run.dag is None:
                 dag_run.dag = dag
@@ -209,7 +216,13 @@ def patch_dag_run_state(
         # Not notifying on queued - only notifying on RUNNING, which happens in the scheduler.
         set_dag_run_state_to_queued(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
     elif state == DagRunMutableStates.FAILED:
-        set_dag_run_state_to_failed(dag=dag, run_id=dag_run.run_id, commit=True, session=session)
+        _, running_tis = set_dag_run_state_to_failed(
+            dag=dag, run_id=dag_run.run_id, commit=True, session=session
+        )
+        try:
+            _emit_state_listener_hooks(running_tis, TaskInstanceState.FAILED)
+        except Exception:
+            log.exception("error calling listener")
         try:
             if dag_run.dag is None:
                 dag_run.dag = dag

--- a/airflow-core/tests/unit/api/common/test_mark_tasks.py
+++ b/airflow-core/tests/unit/api/common/test_mark_tasks.py
@@ -50,9 +50,10 @@ def test_set_dag_run_state_to_failed(dag_maker: DagMaker[SerializedDAG]):
             ti.set_state(TaskInstanceState.RUNNING)
     dag_maker.session.flush()
 
-    updated_tis: list[TaskInstance] = set_dag_run_state_to_failed(
+    result: tuple[list[TaskInstance], list[TaskInstance]] = set_dag_run_state_to_failed(
         dag=dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
+    updated_tis, _ = result
     assert len(updated_tis) == 2
     task_dict = {ti.task_id: ti for ti in updated_tis}
     assert task_dict["running"].state == TaskInstanceState.FAILED
@@ -82,9 +83,10 @@ def test_set_dag_run_state_to_success_unfinished_teardown(
     dag_maker.session.flush()
     assert dr.state == DagRunState.RUNNING
 
-    updated_tis: list[TaskInstance] = set_dag_run_state_to_success(
+    result: tuple[list[TaskInstance], list[TaskInstance]] = set_dag_run_state_to_success(
         dag=dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
+    updated_tis, _ = result
     run = dag_maker.session.scalar(select(DagRun).filter_by(dag_id=dr.dag_id, run_id=dr.run_id))
     assert run is not None
     assert run.state != DagRunState.SUCCESS
@@ -111,9 +113,10 @@ def test_set_dag_run_state_to_success_keeps_finished_task_states(
     dag_maker.session.flush()
     dr.set_state(DagRunState.FAILED)
 
-    updated_tis: list[TaskInstance] = set_dag_run_state_to_success(
+    result: tuple[list[TaskInstance], list[TaskInstance]] = set_dag_run_state_to_success(
         dag=dag, run_id=dr.run_id, commit=True, session=dag_maker.session
     )
+    updated_tis, _ = result
     run = dag_maker.session.scalar(select(DagRun).filter_by(dag_id=dr.dag_id, run_id=dr.run_id))
     assert run is not None
     assert run.state == DagRunState.SUCCESS

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1609,7 +1609,7 @@ class TestPatchDagRun:
         listener_manager(listener)
         response = test_client.patch(f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}", json={"state": state})
         assert response.status_code == 200
-        assert listener.state == listener_state
+        assert listener.state == expected_dagrun_state
         if expected_msg is not None:
             assert listener.dag_run_msg == expected_msg
             assert listener.dag_has_dag_attr is True

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -48,7 +48,7 @@ from airflow.timetables.interval import CronDataIntervalTimetable
 from airflow.timetables.simple import PartitionedAssetTimetable, PartitionedAtRuntime
 from airflow.timetables.trigger import CronPartitionTimetable
 from airflow.utils.session import provide_session
-from airflow.utils.state import DagRunState, State
+from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.api_fastapi import _check_dag_run_note, _check_last_log
@@ -1626,6 +1626,70 @@ class TestPatchDagRun:
         )
         assert response.status_code == 200
         assert listener.dag_run_note_at_listener == "listener_note"
+
+    @pytest.mark.parametrize(
+        ("dag_run_state", "expected_ti_listener_state"),
+        [
+            ("success", TaskInstanceState.SUCCESS),
+            ("failed", TaskInstanceState.FAILED),
+        ],
+    )
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_patch_dag_run_notifies_ti_listeners_for_running_tasks(
+        self,
+        test_client,
+        dag_maker,
+        session,
+        listener_manager,
+        dag_run_state,
+        expected_ti_listener_state,
+    ):
+        with dag_maker(dag_id="test_ti_listeners", schedule=None, serialized=True):
+            EmptyOperator(task_id="t1")
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        ti = dr.get_task_instance(task_id="t1")
+        ti.state = TaskInstanceState.RUNNING
+        dag_maker.sync_dagbag_to_db()
+        session.commit()
+
+        listener = ClassBasedListener()
+        listener_manager(listener)
+
+        response = test_client.patch(
+            f"/dags/test_ti_listeners/dagRuns/{dr.run_id}", json={"state": dag_run_state}
+        )
+        assert response.status_code == 200
+        assert expected_ti_listener_state in listener.state
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_patch_dag_run_does_not_notify_ti_listeners_for_non_running_tasks(
+        self,
+        test_client,
+        dag_maker,
+        session,
+        listener_manager,
+    ):
+        with dag_maker(dag_id="test_ti_listeners_queued", schedule=None, serialized=True):
+            EmptyOperator(task_id="t1")
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        ti = dr.get_task_instance(task_id="t1")
+        ti.state = TaskInstanceState.QUEUED
+        dag_maker.sync_dagbag_to_db()
+        session.commit()
+
+        listener = ClassBasedListener()
+        listener_manager(listener)
+
+        response = test_client.patch(
+            f"/dags/test_ti_listeners_queued/dagRuns/{dr.run_id}", json={"state": "success"}
+        )
+        assert response.status_code == 200
+        # Only the dagrun-level hook should have fired; no TI hooks for a non-running task.
+        # DagRunState.SUCCESS and TaskInstanceState.SUCCESS share the string value 'success', so
+        # we check the exact type to distinguish them.
+        assert listener.state == [DagRunState.SUCCESS]
 
 
 class TestDeleteDagRun:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1666,7 +1666,6 @@ class TestPatchDagRun:
             f"/dags/test_ti_listeners/dagRuns/{dr.run_id}", json={"state": dag_run_state}
         )
         assert response.status_code == 200
-        # Use `is` for type-safe comparison between TaskInstanceState and DagRunState.
         assert listener.state[0] is expected_ti_state
         assert listener.state[1] is DagRunState(dag_run_state)
         assert len(listener.state) == 2
@@ -1739,7 +1738,6 @@ class TestPatchDagRun:
         )
         assert response.status_code == 200
         # Normal task was killed — its TI listener fires. Teardown task is intentionally skipped.
-        # Use `is` for type-safe comparison between TaskInstanceState and DagRunState.
         assert len(listener.state) == 2
         assert listener.state[0] is TaskInstanceState.SUCCESS
         assert listener.state[1] is DagRunState.SUCCESS

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -1594,7 +1594,7 @@ class TestPatchDagRun:
         assert body["detail"][0]["msg"] == "Input should be 'queued', 'success' or 'failed'"
 
     @pytest.mark.parametrize(
-        ("state", "listener_state", "expected_msg"),
+        ("state", "expected_dagrun_state", "expected_msg"),
         [
             ("queued", [], None),
             ("success", [DagRunState.SUCCESS], "Dag Run's state was manually set to `success`."),
@@ -1603,7 +1603,7 @@ class TestPatchDagRun:
     )
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_patch_dag_run_notifies_listeners(
-        self, test_client, state, listener_state, expected_msg, listener_manager
+        self, test_client, state, expected_dagrun_state, expected_msg, listener_manager
     ):
         listener = ClassBasedListener()
         listener_manager(listener)
@@ -1628,7 +1628,7 @@ class TestPatchDagRun:
         assert listener.dag_run_note_at_listener == "listener_note"
 
     @pytest.mark.parametrize(
-        ("dag_run_state", "expected_ti_listener_state"),
+        ("dag_run_state", "expected_ti_state"),
         [
             ("success", TaskInstanceState.SUCCESS),
             ("failed", TaskInstanceState.FAILED),
@@ -1642,13 +1642,19 @@ class TestPatchDagRun:
         session,
         listener_manager,
         dag_run_state,
-        expected_ti_listener_state,
+        expected_ti_state,
     ):
         with dag_maker(dag_id="test_ti_listeners", schedule=None, serialized=True):
             EmptyOperator(task_id="t1")
 
         dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
-        ti = dr.get_task_instance(task_id="t1")
+        ti = session.scalar(
+            select(TaskInstance).where(
+                TaskInstance.dag_id == dr.dag_id,
+                TaskInstance.run_id == dr.run_id,
+                TaskInstance.task_id == "t1",
+            )
+        )
         ti.state = TaskInstanceState.RUNNING
         dag_maker.sync_dagbag_to_db()
         session.commit()
@@ -1660,7 +1666,10 @@ class TestPatchDagRun:
             f"/dags/test_ti_listeners/dagRuns/{dr.run_id}", json={"state": dag_run_state}
         )
         assert response.status_code == 200
-        assert expected_ti_listener_state in listener.state
+        # Use `is` for type-safe comparison between TaskInstanceState and DagRunState.
+        assert listener.state[0] is expected_ti_state
+        assert listener.state[1] is DagRunState(dag_run_state)
+        assert len(listener.state) == 2
 
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_patch_dag_run_does_not_notify_ti_listeners_for_non_running_tasks(
@@ -1674,7 +1683,13 @@ class TestPatchDagRun:
             EmptyOperator(task_id="t1")
 
         dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
-        ti = dr.get_task_instance(task_id="t1")
+        ti = session.scalar(
+            select(TaskInstance).where(
+                TaskInstance.dag_id == dr.dag_id,
+                TaskInstance.run_id == dr.run_id,
+                TaskInstance.task_id == "t1",
+            )
+        )
         ti.state = TaskInstanceState.QUEUED
         dag_maker.sync_dagbag_to_db()
         session.commit()
@@ -1687,9 +1702,47 @@ class TestPatchDagRun:
         )
         assert response.status_code == 200
         # Only the dagrun-level hook should have fired; no TI hooks for a non-running task.
-        # DagRunState.SUCCESS and TaskInstanceState.SUCCESS share the string value 'success', so
-        # we check the exact type to distinguish them.
+        # The list length check distinguishes "only dagrun fired" from "both fired".
         assert listener.state == [DagRunState.SUCCESS]
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_patch_dag_run_does_not_notify_ti_listeners_for_running_teardown_tasks(
+        self,
+        test_client,
+        dag_maker,
+        session,
+        listener_manager,
+    ):
+        with dag_maker(dag_id="test_ti_listeners_teardown", schedule=None, serialized=True):
+            normal = EmptyOperator(task_id="normal")
+            teardown = EmptyOperator(task_id="teardown").as_teardown(setups=normal)
+            normal >> teardown
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        for task_id in ("normal", "teardown"):
+            ti = session.scalar(
+                select(TaskInstance).where(
+                    TaskInstance.dag_id == dr.dag_id,
+                    TaskInstance.run_id == dr.run_id,
+                    TaskInstance.task_id == task_id,
+                )
+            )
+            ti.state = TaskInstanceState.RUNNING
+        dag_maker.sync_dagbag_to_db()
+        session.commit()
+
+        listener = ClassBasedListener()
+        listener_manager(listener)
+
+        response = test_client.patch(
+            f"/dags/test_ti_listeners_teardown/dagRuns/{dr.run_id}", json={"state": "success"}
+        )
+        assert response.status_code == 200
+        # Normal task was killed — its TI listener fires. Teardown task is intentionally skipped.
+        # Use `is` for type-safe comparison between TaskInstanceState and DagRunState.
+        assert len(listener.state) == 2
+        assert listener.state[0] is TaskInstanceState.SUCCESS
+        assert listener.state[1] is DagRunState.SUCCESS
 
 
 class TestDeleteDagRun:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

When a task instance is individually set to success or failure via the API, `on_task_instance_success` / `on_task_instance_failed` is called from the API server, giving listeners a terminal event to act on. The same does not happen when an entire Dag Run is force-set to success or failure: running tasks are bulk-transitioned in the database, but their task-instance listeners are never fired. Listeners that registered a start event (`on_task_instance_running`) for those tasks receive no completion event, leaving them — notably OpenLineage — with a job permanently stuck in RUNNING.

This PR closes the gap:
- `_set_dag_run_terminal_state` now returns `(all_updated_tis, running_tis)` where `running_tis` is the snapshot of task instances that were in an active state (RUNNING, DEFERRED, UP_FOR_RESCHEDULE, AWAITING_INPUT) before the bulk transition, captured without an extra query.
- `set_dag_run_state_to_success` / `set_dag_run_state_to_failed` expose the same tuple so callers have access to the running subset.
- `patch_dag_run_state` fires `on_task_instance_success` / `on_task_instance_failed` for those running task instances before the dag-run-level hook. Each group has its own `try/except` so a listener failure in one cannot suppress the other.
Tasks that were only QUEUED or SCHEDULED (never started, no start event fired) are excluded — they transition to SKIPPED and receive no listener call, consistent with their lifecycle.

### Why the terminal event is missing
The gap is a deliberate design decision that becomes a problem specifically for the dag run force-terminate case:

1. _set_dag_run_terminal_state writes SUCCESS/FAILED into the TI rows in the DB. No listener is fired.
2. Next heartbeat from the supervisor gets 409 CONFLICT ("TI is no longer running"). The supervisor sets self._terminal_state = SERVER_TERMINATED and kills the process via SIGTERM.
3. After the process dies, update_task_state_if_needed() runs. Because SERVER_TERMINATED ∈ STATES_SENT_DIRECTLY (supervisor.py:205), the condition at line 1461 is false — finish() is intentionally skipped. The reasoning is: "the server already knows the state." That is true — but the server setting the state and the server firing listeners for it are two different things, and the latter never happened.
4. Task runner finalizers never ran — the process was killed mid-execution before the on_task_instance_success/failed call in task-sdk/src/airflow/sdk/execution_time/task_runner.py:2249.
5. Scheduler's process_executor_events sees the executor report the task exit, but when it queries the TI it finds state=SUCCESS/FAILED (already written in step 1), so ti_queued is false (scheduler_job_runner.py:1460) and handle_failure is never called.

Result: on_task_instance_running fired from the task runner → task process killed → nothing on the other end. OpenLineage has a dangling RUNNING job with no terminal event. We can't extend the live of the worker process, but we can fire from the api server in that case.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
