### PR TITLE
Make Redshift system-test clusters non-public in sql_to_s3/s3_to_sql

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
@@ -115,6 +115,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         vpc_security_group_ids=[security_group_id],
         cluster_subnet_group_name=cluster_subnet_group_name,
+        publicly_accessible=False,
         cluster_type="single-node",
         node_type="ra3.large",
         master_username=DB_LOGIN,

--- a/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
@@ -122,6 +122,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         vpc_security_group_ids=[security_group_id],
         cluster_subnet_group_name=cluster_subnet_group_name,
+        publicly_accessible=False,
         cluster_type="single-node",
         node_type="ra3.large",
         master_username=DB_LOGIN,


### PR DESCRIPTION
The `example_sql_to_s3` and `example_s3_to_sql` system tests create a Redshift cluster without setting `publicly_accessible`, so it defaults to `True` (`RedshiftCreateClusterOperator` default) and the cluster gets a public endpoint. This trips AWS AppSec "Publicly Accessible Database" scans on the test account.

Set `publicly_accessible=False` on both, matching `example_redshift.py`. The test worker reaches the cluster from within the VPC, so a non-public endpoint is sufficient.
