### PR TITLE
Add option to include resolved package versions in venv cache hash

### DIFF
--- a/providers/standard/docs/operators/python.rst
+++ b/providers/standard/docs/operators/python.rst
@@ -262,6 +262,17 @@ In case you have problems during runtime with broken cached virtual environments
 Note that any modification of a cached virtual environment (like temp files in binary path, post-installing further requirements) might pollute a cached virtual environment and the
 operator is not maintaining or cleaning the cache path.
 
+By default the cache key is calculated from the requirements as you specified them. If your requirements are not fully pinned (for example ``pandas`` or ``boto3>=1.30``),
+a new release of such a dependency does not change the cache key. The cached virtual environment keeps the versions that were resolved when it was first created and
+different workers may have resolved different versions.
+
+If you want new releases to be picked up while still using caching, set ``hash_resolved_requirements=True``. The operator then resolves the requirements (without
+installing them) at the start of every task run and includes the resolved versions in the cache key. As long as the resolution stays the same, the cached virtual
+environment is reused, otherwise a new one is created. Note that every task run then pays the overhead of the dependency resolution, needs network access to the
+package index and fails if the index is not reachable. Also every new release of an unpinned dependency leaves one more virtual environment behind in
+``venv_cache_path``, so you should clean up that folder periodically. With the pip install method this requires pip 23.0 or newer on the worker. If you rather want
+full reproducibility, pin all your requirements and the default cache behavior is already correct.
+
 
 .. _howto/operator:ExternalPythonOperator:
 

--- a/providers/standard/src/airflow/providers/standard/exceptions.py
+++ b/providers/standard/src/airflow/providers/standard/exceptions.py
@@ -67,3 +67,7 @@ class HITLTimeoutError(HITLTriggerEventError):
 
 class HITLRejectException(AirflowException):
     """Raised when an ApprovalOperator receives a "Reject" response when fail_on_reject is set to True."""
+
+
+class RequirementsResolutionError(Exception):
+    """Raised when resolving requirements to pinned package versions fails."""

--- a/providers/standard/src/airflow/providers/standard/operators/python.py
+++ b/providers/standard/src/airflow/providers/standard/operators/python.py
@@ -64,6 +64,7 @@ from airflow.providers.standard.hooks.package_index import PackageIndexHook
 from airflow.providers.standard.utils.python_virtualenv import (
     _execute_in_subprocess,
     prepare_virtualenv,
+    resolve_requirements_versions,
     write_python_script,
 )
 from airflow.providers.standard.version_compat import (
@@ -821,6 +822,12 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         virtual environment will be cached, creates a sub-folder venv-{hash} whereas hash will be replaced
         with a checksum of requirements. If not provided the virtual environment will be created and deleted
         in a temp folder for every execution.
+    :param hash_resolved_requirements: Only used with ``venv_cache_path``. If True, the cache checksum
+        additionally includes the resolved versions of the requirements, obtained by a dependency
+        resolution (without installing) at the start of every task run. A new release of any
+        (transitively) unpinned dependency then results in a new cached virtual environment. Each run
+        pays the resolution overhead and outdated environments accumulate in ``venv_cache_path``.
+        Requires pip >= 23.0 when pip is the configured install method.
     :param env_vars: A dictionary containing additional environment variables to set for the virtual
         environment when it is executed.
     :param inherit_env: Whether to inherit the current environment variables when executing the virtual
@@ -855,6 +862,7 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         index_urls: None | Collection[str] | str = None,
         index_urls_from_connection_ids: None | Collection[str] | str = None,
         venv_cache_path: None | os.PathLike[str] = None,
+        hash_resolved_requirements: bool = False,
         env_vars: dict[str, str] | None = None,
         inherit_env: bool = True,
         **kwargs,
@@ -895,6 +903,8 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         else:
             self.index_urls_from_connection_ids = None
         self.venv_cache_path = venv_cache_path
+        self.hash_resolved_requirements = hash_resolved_requirements
+        self._resolved_requirements_cache: dict[tuple[str, ...], list[str]] = {}
         super().__init__(
             python_callable=python_callable,
             serializer=serializer,
@@ -925,18 +935,32 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         requirements.sort()  # Ensure a hash is stable
         return requirements
 
+    @property
+    def _python_bin(self) -> str:
+        return f"python{self.python_version}" if self.python_version else "python"
+
     def _prepare_venv(self, venv_path: Path) -> None:
         """Prepare the requirements and installs the virtual environment."""
         requirements_file = venv_path / "requirements.txt"
         requirements_file.write_text("\n".join(self._requirements_list()))
         prepare_virtualenv(
             venv_directory=str(venv_path),
-            python_bin=f"python{self.python_version}" if self.python_version else "python",
+            python_bin=self._python_bin,
             system_site_packages=self.system_site_packages,
             requirements_file_path=str(requirements_file),
             pip_install_options=self.pip_install_options,
             index_urls=self.index_urls,
         )
+
+    def _resolve_requirements(self, exclude_cloudpickle: bool = False) -> list[str]:
+        """Resolve the requirements to pinned versions, once per distinct requirements list."""
+        requirements = self._requirements_list(exclude_cloudpickle=exclude_cloudpickle)
+        cache_key = tuple(requirements)
+        if cache_key not in self._resolved_requirements_cache:
+            self._resolved_requirements_cache[cache_key] = resolve_requirements_versions(
+                requirements=requirements, python_bin=self._python_bin, index_urls=self.index_urls
+            )
+        return self._resolved_requirements_cache[cache_key]
 
     def _calculate_cache_hash(self, exclude_cloudpickle: bool = False) -> tuple[str, str]:
         """
@@ -949,6 +973,7 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
         - python version
         - Variable to override the hash with a cache key
         - Index URLs
+        - resolved requirement versions (only with ``hash_resolved_requirements``)
 
         Returns a hash and the data dict which is the base for the hash as text.
         """
@@ -960,6 +985,10 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             "python_version": self.python_version,
             "system_site_packages": self.system_site_packages,
         }
+        if self.hash_resolved_requirements:
+            hash_dict["resolved_requirements"] = self._resolve_requirements(
+                exclude_cloudpickle=exclude_cloudpickle
+            )
         hash_text = json.dumps(hash_dict, sort_keys=True)
         hash_object = hashlib_wrapper.md5(hash_text.encode())
         requirements_hash = hash_object.hexdigest()
@@ -1045,6 +1074,11 @@ class PythonVirtualenvOperator(_BasePythonVirtualenvOperator):
             venv_path = self._ensure_venv_cache_exists(Path(self.venv_cache_path))
             python_path = venv_path / "bin" / "python"
             return self._execute_python_callable_in_subprocess(python_path)
+
+        if self.hash_resolved_requirements:
+            self.log.warning(
+                "The 'hash_resolved_requirements' option has no effect unless 'venv_cache_path' is set."
+            )
 
         with TemporaryDirectory(prefix="venv") as tmp_dir:
             tmp_path = Path(tmp_dir)

--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shlex
@@ -26,11 +27,13 @@ import shutil
 import subprocess
 import warnings
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import jinja2
 from jinja2 import select_autoescape
 
 from airflow.providers.common.compat.sdk import conf
+from airflow.providers.standard.exceptions import RequirementsResolutionError
 
 
 def _is_uv_installed() -> bool:
@@ -225,6 +228,90 @@ def prepare_virtualenv(
         _execute_in_subprocess(pip_cmd, env={**os.environ, **_index_urls_to_uv_env_vars(index_urls)})
 
     return f"{venv_directory}/bin/python"
+
+
+def _generate_uv_resolve_cmd(python_bin: str, requirements_file_path: str) -> list[str]:
+    return [
+        "uv",
+        "pip",
+        "compile",
+        "--python",
+        python_bin,
+        "--no-header",
+        "--no-annotate",
+        "--quiet",
+        requirements_file_path,
+    ]
+
+
+def _generate_pip_resolve_cmd(
+    python_bin: str, requirements_file_path: str, index_urls: list[str] | None
+) -> list[str]:
+    cmd = [python_bin, "-m", "pip", "install", "--dry-run", "--ignore-installed", "--quiet"]
+    cmd += ["--report", "-", "-r", requirements_file_path]
+    if index_urls is not None:
+        if not index_urls:
+            cmd += ["--no-index"]
+        else:
+            cmd += ["--index-url", index_urls[0]]
+            for url in index_urls[1:]:
+                cmd += ["--extra-index-url", url]
+    return cmd
+
+
+def _parse_pip_installation_report(report_text: str) -> list[str]:
+    try:
+        report = json.loads(report_text)
+        return sorted(
+            f"{entry['metadata']['name']}=={entry['metadata']['version']}" for entry in report["install"]
+        )
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise RequirementsResolutionError(f"Cannot parse pip installation report: {e}") from e
+
+
+def resolve_requirements_versions(
+    requirements: list[str],
+    python_bin: str,
+    index_urls: list[str] | None = None,
+) -> list[str]:
+    """
+    Resolve requirements to pinned package versions without installing them.
+
+    Runs a full dependency resolution via ``uv pip compile`` or ``pip install --dry-run --report``,
+    depending on the configured install method (pip needs to be at least 23.0 for this).
+    Install options are not applied during resolution.
+
+    :param requirements: list of requirement specifiers to resolve.
+    :param python_bin: path to the Python executable to resolve for.
+    :param index_urls: an optional list of index urls to load Python packages from.
+        If not provided the system pip conf will be used to source packages from.
+    :return: sorted list of ``package==version`` pins.
+    """
+    log = logging.getLogger(__name__)
+    use_uv = _use_uv()
+    with TemporaryDirectory(prefix="requirements-resolve") as tmp_dir:
+        requirements_file = Path(tmp_dir) / "requirements.txt"
+        requirements_file.write_text("\n".join(requirements))
+        if use_uv:
+            cmd = _generate_uv_resolve_cmd(python_bin, str(requirements_file))
+            env = {**os.environ, **_index_urls_to_uv_env_vars(index_urls)}
+            proc = subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+        else:
+            cmd = _generate_pip_resolve_cmd(python_bin, str(requirements_file), index_urls)
+            proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RequirementsResolutionError(
+            f"Resolving requirement versions failed with exit code {proc.returncode} "
+            f"(command: {' '.join(shlex.quote(c) for c in cmd)}): {proc.stderr}"
+        )
+    if use_uv:
+        pins = sorted(
+            line.strip() for line in proc.stdout.splitlines() if line.strip() and not line.startswith("#")
+        )
+    else:
+        pins = _parse_pip_installation_report(proc.stdout)
+    log.debug("Resolved requirements %s to %s", requirements, pins)
+    return pins
 
 
 def write_python_script(

--- a/providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/decorators/test_python_virtualenv.py
@@ -393,3 +393,13 @@ class TestPythonVirtualenvDecorator:
         xcom = ti.xcom_pull(task_ids=ti.task_id, key="return_value")
         assert isinstance(xcom, str)
         assert xcom == unique_id
+
+    def test_hash_resolved_requirements_forwarded_to_operator(self, dag_maker):
+        @task.virtualenv(hash_resolved_requirements=True)
+        def f():
+            return 1
+
+        with dag_maker():
+            res = f()
+
+        assert res.operator.hash_resolved_requirements is True

--- a/providers/standard/tests/unit/standard/operators/test_python.py
+++ b/providers/standard/tests/unit/standard/operators/test_python.py
@@ -2093,6 +2093,76 @@ class TestPythonVirtualenvOperator(_VenvTestBase):
         pycache_cleanup_mock.assert_called_once_with(expected_cleanup_path)
 
 
+@mock.patch("airflow.providers.standard.operators.python.Variable", autospec=True)
+@mock.patch("airflow.providers.standard.operators.python.resolve_requirements_versions", autospec=True)
+class TestPythonVirtualenvOperatorResolvedRequirementsHash:
+    @staticmethod
+    def _build_operator(**kwargs):
+        def f():
+            return 42
+
+        return PythonVirtualenvOperator(
+            task_id="venv_op", python_callable=f, requirements=["colormap>=1.0"], **kwargs
+        )
+
+    def test_hash_does_not_resolve_requirements_by_default(self, mock_resolve, mock_variable):
+        mock_variable.get.return_value = ""
+        op = self._build_operator()
+
+        _, hash_text = op._calculate_cache_hash()
+
+        mock_resolve.assert_not_called()
+        assert "resolved_requirements" not in hash_text
+
+    def test_hash_includes_resolved_requirements_when_enabled(self, mock_resolve, mock_variable):
+        mock_variable.get.return_value = ""
+        mock_resolve.return_value = ["colormap==1.1.0", "numpy==2.0.1"]
+        op = self._build_operator(hash_resolved_requirements=True)
+
+        _, hash_text = op._calculate_cache_hash()
+
+        mock_resolve.assert_called_once_with(
+            requirements=["colormap>=1.0"], python_bin="python", index_urls=None
+        )
+        assert '"resolved_requirements": ["colormap==1.1.0", "numpy==2.0.1"]' in hash_text
+
+    def test_hash_changes_only_when_resolution_changes(self, mock_resolve, mock_variable):
+        mock_variable.get.return_value = ""
+        mock_resolve.side_effect = [["colormap==1.0.4"], ["colormap==1.0.4"], ["colormap==1.1.0"]]
+
+        hashes = [
+            self._build_operator(hash_resolved_requirements=True)._calculate_cache_hash()[0] for _ in range(3)
+        ]
+
+        assert hashes[0] == hashes[1]
+        assert hashes[0] != hashes[2]
+
+    def test_resolution_performed_once_per_operator(self, mock_resolve, mock_variable):
+        mock_variable.get.return_value = ""
+        mock_resolve.return_value = ["colormap==1.1.0"]
+        op = self._build_operator(hash_resolved_requirements=True)
+
+        op._calculate_cache_hash()
+        op._calculate_cache_hash()
+
+        mock_resolve.assert_called_once()
+
+    @mock.patch.object(PythonVirtualenvOperator, "_cleanup_python_pycache_dir", autospec=True)
+    @mock.patch.object(PythonVirtualenvOperator, "_execute_python_callable_in_subprocess", autospec=True)
+    @mock.patch.object(PythonVirtualenvOperator, "_prepare_venv", autospec=True)
+    def test_flag_without_cache_path_warns_and_skips_resolution(
+        self, mock_prepare_venv, mock_execute, mock_cleanup, mock_resolve, mock_variable
+    ):
+        op = self._build_operator(hash_resolved_requirements=True)
+
+        with mock.patch.object(op.log, "warning", autospec=True) as mock_warning:
+            op.execute_callable()
+
+        mock_resolve.assert_not_called()
+        mock_warning.assert_called_once()
+        mock_execute.assert_called_once()
+
+
 # when venv tests are run in parallel to other test they create new processes and this might take
 # quite some time in shared docker environment and get some contention even between different containers
 # therefore we have to extend timeouts for those tests

--- a/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
@@ -17,13 +17,21 @@
 # under the License.
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
 import pytest
 
-from airflow.providers.standard.utils.python_virtualenv import _generate_pip_conf, _use_uv, prepare_virtualenv
+from airflow.providers.standard.exceptions import RequirementsResolutionError
+from airflow.providers.standard.utils.python_virtualenv import (
+    _generate_pip_conf,
+    _use_uv,
+    prepare_virtualenv,
+    resolve_requirements_versions,
+)
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import remove_task_decorator
@@ -275,3 +283,137 @@ class TestPrepareVirtualenv:
 
         res = remove_task_decorator(python_source=py_source, task_decorator_name="@task.virtualenv")
         assert res == expected_source
+
+
+PIP_INSTALL_REPORT = json.dumps(
+    {
+        "version": "1",
+        "install": [
+            {"metadata": {"name": "numpy", "version": "2.0.1"}},
+            {"metadata": {"name": "colormap", "version": "1.1.0"}},
+        ],
+    }
+)
+
+
+class TestResolveRequirementsVersions:
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.subprocess.run", autospec=True)
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_resolve_with_uv_builds_pip_compile_command(self, mock_run):
+        captured = {}
+
+        def capture_run(cmd, **kwargs):
+            captured["requirements"] = Path(cmd[-1]).read_text()
+            return subprocess.CompletedProcess(cmd, 0, stdout="pkg==1.0\n", stderr="")
+
+        mock_run.side_effect = capture_run
+
+        result = resolve_requirements_versions(requirements=["pkg"], python_bin="pythonVER")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:-1] == [
+            "uv",
+            "pip",
+            "compile",
+            "--python",
+            "pythonVER",
+            "--no-header",
+            "--no-annotate",
+            "--quiet",
+        ]
+        assert captured["requirements"] == "pkg"
+        assert result == ["pkg==1.0"]
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.subprocess.run", autospec=True)
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_resolve_with_uv_passes_index_urls_as_env_vars(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="pkg==1.0\n", stderr="")
+
+        resolve_requirements_versions(
+            requirements=["pkg"],
+            python_bin="pythonVER",
+            index_urls=["http://one", "http://two", "http://three"],
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["UV_DEFAULT_INDEX"] == "http://one"
+        assert env["UV_INDEX"] == "http://two http://three"
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.subprocess.run", autospec=True)
+    @conf_vars({("standard", "venv_install_method"): "uv"})
+    def test_resolve_with_uv_ignores_comments_and_sorts_output(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 0, stdout="numpy==2.0.1\n\n# via pandas\ncolormap==1.1.0\n", stderr=""
+        )
+
+        result = resolve_requirements_versions(requirements=["pkg"], python_bin="python")
+
+        assert result == ["colormap==1.1.0", "numpy==2.0.1"]
+
+    @pytest.mark.parametrize(
+        ("index_urls", "expected_index_args"),
+        [
+            (None, []),
+            ([], ["--no-index"]),
+            (["http://one"], ["--index-url", "http://one"]),
+            (
+                ["http://one", "http://two", "http://three"],
+                [
+                    "--index-url",
+                    "http://one",
+                    "--extra-index-url",
+                    "http://two",
+                    "--extra-index-url",
+                    "http://three",
+                ],
+            ),
+        ],
+    )
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.subprocess.run", autospec=True)
+    def test_resolve_with_pip_builds_dry_run_command(self, mock_run, index_urls, expected_index_args):
+        captured = {}
+
+        def capture_run(cmd, **kwargs):
+            captured["requirements"] = Path(cmd[cmd.index("-r") + 1]).read_text()
+            return subprocess.CompletedProcess(cmd, 0, stdout=PIP_INSTALL_REPORT, stderr="")
+
+        mock_run.side_effect = capture_run
+
+        with conf_vars({("standard", "venv_install_method"): "pip"}):
+            result = resolve_requirements_versions(
+                requirements=["colormap>=1.0", "numpy"], python_bin="pythonVER", index_urls=index_urls
+            )
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:9] == [
+            "pythonVER",
+            "-m",
+            "pip",
+            "install",
+            "--dry-run",
+            "--ignore-installed",
+            "--quiet",
+            "--report",
+            "-",
+        ]
+        assert cmd[9] == "-r"
+        assert cmd[11:] == expected_index_args
+        assert captured["requirements"] == "colormap>=1.0\nnumpy"
+        assert result == ["colormap==1.1.0", "numpy==2.0.1"]
+
+    @pytest.mark.parametrize("install_method", ["uv", "pip"])
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.subprocess.run", autospec=True)
+    def test_resolve_failure_raises_with_stderr(self, mock_run, install_method):
+        mock_run.return_value = subprocess.CompletedProcess([], 1, stdout="", stderr="resolution exploded")
+
+        with conf_vars({("standard", "venv_install_method"): install_method}):
+            with pytest.raises(RequirementsResolutionError, match="resolution exploded"):
+                resolve_requirements_versions(requirements=["pkg"], python_bin="python")
+
+    @mock.patch("airflow.providers.standard.utils.python_virtualenv.subprocess.run", autospec=True)
+    @conf_vars({("standard", "venv_install_method"): "pip"})
+    def test_resolve_with_pip_invalid_report_raises(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="not json", stderr="")
+
+        with pytest.raises(RequirementsResolutionError, match="installation report"):
+            resolve_requirements_versions(requirements=["pkg"], python_bin="python")


### PR DESCRIPTION
With `venv_cache_path` set, the venv cache key of `PythonVirtualenvOperator` only reflects the requirements as written. Unpinned requirements (e.g. `pandas` or `boto3>=1.30`) therefore never pick up new upstream releases once a cached venv exists, and different workers can silently freeze different resolutions.

This adds an opt-in `hash_resolved_requirements` flag (off by default, following the maintainer guidance in the issue discussion). When enabled, the operator resolves the requirements without installing them (`uv pip compile`, or `pip install --dry-run --report` with the pip install method) at the start of each task run and includes the resolved pins in the cache hash. An unchanged resolution keeps reusing the cached venv, a changed one builds a new immutable cached venv. Resolution failures raise a dedicated `RequirementsResolutionError` instead of silently reusing a possibly stale environment. The per-run resolution overhead and the accumulation of cached venvs are documented in the operator guide.

closes: #41328