### PR TITLE
Secure AWS auth cookies behind TLS proxies

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/auth_manager/routes/login.py
@@ -118,7 +118,7 @@ def login_callback(request: Request):
 
     if relay_state == "login-redirect":
         response = RedirectResponse(url=url, status_code=303)
-        secure = bool(conf.get("api", "ssl_cert", fallback=""))
+        secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
         # In Airflow 3.1.1 authentication changes, front-end no longer handle the token
         # See https://github.com/apache/airflow/pull/55506
         cookie_path = get_cookie_path()

--- a/providers/amazon/tests/unit/amazon/aws/auth_manager/routes/test_login.py
+++ b/providers/amazon/tests/unit/amazon/aws/auth_manager/routes/test_login.py
@@ -80,7 +80,7 @@ def test_client():
             yield TestClient(create_app())
 
 
-def get_login_callback_response(relay_state: str):
+def get_login_callback_response(relay_state: str, *, base_url: str = "http://testserver"):
     with conf_vars(
         {
             (
@@ -88,7 +88,7 @@ def get_login_callback_response(relay_state: str):
                 "auth_manager",
             ): "airflow.providers.amazon.aws.auth_manager.aws_auth_manager.AwsAuthManager",
             ("aws_auth_manager", "saml_metadata_url"): SAML_METADATA_URL,
-            ("api", "ssl_cert"): "false",
+            ("api", "ssl_cert"): "",
         }
     ):
         with (
@@ -112,7 +112,7 @@ def get_login_callback_response(relay_state: str):
                 "email": ["email"],
             }
             mock_init_saml_auth.return_value = auth
-            client = TestClient(create_app())
+            client = TestClient(create_app(), base_url=base_url)
             return client.post(
                 AUTH_MANAGER_FASTAPI_APP_PREFIX + "/login_callback",
                 follow_redirects=False,
@@ -140,6 +140,11 @@ class TestLoginRouter:
         assert "location" in response.headers
         assert "_token" in response.cookies
         assert response.headers["location"].startswith("http://localhost:8080/")
+
+    def test_login_callback_sets_secure_cookie_behind_tls_proxy(self):
+        response = get_login_callback_response("login-redirect", base_url="https://testserver")
+
+        assert "Secure" in response.headers["set-cookie"]
 
     def test_login_callback_successful_with_relay_state_token(self):
         response = get_login_callback_response("login-token")


### PR DESCRIPTION
The AWS auth manager determined the JWT cookie's `Secure` flag only from
`api.ssl_cert`. Deployments terminating TLS at a reverse proxy normally leave
that setting empty, causing the login callback to emit a non-Secure session
cookie even when the request scheme is HTTPS.

This applies the proxy-aware scheme-or-certificate check already used by the
core, FAB, and Keycloak auth managers. It also adds regression coverage for an
HTTPS request without a locally configured certificate.

related: #47878

### Validation

- Ruff formatting and lint checks passed.
- Provider tests are delegated to GitHub Actions because no Docker runtime is available locally.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)
