### PR TITLE
Keep Go SDK variable lookups consistent

### DIFF
--- a/go-sdk/pkg/execution/client.go
+++ b/go-sdk/pkg/execution/client.go
@@ -22,8 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/apache/airflow/go-sdk/pkg/api"
 	"github.com/apache/airflow/go-sdk/pkg/execution/genmodels"
@@ -72,11 +70,7 @@ func NewCoordinatorClient(comm *CoordinatorComm) *CoordinatorClient {
 
 // GetVariable requests a variable value from the supervisor.
 func (c *CoordinatorClient) GetVariable(ctx context.Context, key string) (string, error) {
-	// TODO: this duplicates variableFromEnv in sdk/client.go. The env-first
-	// precedence is part of the SDK contract, so both clients should share a
-	// single helper (e.g. an exported sdk.VariableFromEnv) instead of two
-	// independent copies that can drift.
-	if env, ok := os.LookupEnv(sdk.VariableEnvPrefix + strings.ToUpper(key)); ok {
+	if env, ok := sdk.VariableFromEnv(key); ok {
 		return env, nil
 	}
 

--- a/go-sdk/sdk/client.go
+++ b/go-sdk/sdk/client.go
@@ -41,13 +41,14 @@ func NewClient() Client {
 	return &client{}
 }
 
-func variableFromEnv(key string) (string, bool) {
+// VariableFromEnv returns the AIRFLOW_VAR_<UPPER(key)> value and whether it is set.
+func VariableFromEnv(key string) (string, bool) {
 	return os.LookupEnv(VariableEnvPrefix + strings.ToUpper(key))
 }
 
 func (*client) GetVariable(ctx context.Context, key string) (string, error) {
 	// TODO: Let the lookup priority be configurable like it is in Python SDK
-	if env, ok := variableFromEnv(key); ok {
+	if env, ok := VariableFromEnv(key); ok {
 		return env, nil
 	}
 


### PR DESCRIPTION
## Summary

Share the `AIRFLOW_VAR_*` environment-override lookup through the exported `sdk.VariableFromEnv` helper.

Use the shared helper from both the HTTP-backed and coordinator clients so the env-first precedence has one canonical implementation. This also removes the duplicated coordinator lookup and its associated TODO.

closes: #67598

## Testing

- `go test ./...`
- `go vet ./...`
- `go mod tidy`
- Airflow prek hooks
