### PR TITLE
Remove airflow.utils dependency from Docker provider

### DIFF
--- a/providers/docker/src/airflow/providers/docker/operators/docker_swarm.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker_swarm.py
@@ -18,8 +18,10 @@
 
 from __future__ import annotations
 
+import random
 import re
 import shlex
+import string
 from datetime import datetime
 from time import sleep
 from typing import TYPE_CHECKING, Literal
@@ -29,10 +31,15 @@ from docker.errors import APIError
 
 from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.docker.operators.docker import DockerOperator
-from airflow.utils.strings import get_random_string
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
+
+
+def _generate_service_name(prefix: str) -> str:
+    """Generate a unique Docker Swarm service name."""
+    suffix = "".join(random.choices(string.ascii_letters + string.digits, k=8))
+    return f"{prefix}-{suffix}"
 
 
 class DockerSwarmOperator(DockerOperator):
@@ -191,7 +198,7 @@ class DockerSwarmOperator(DockerOperator):
                 placement=self.placement,
                 log_driver=self.log_driver_config,
             ),
-            name=f"{self.service_prefix}-{get_random_string()}",
+            name=_generate_service_name(self.service_prefix),
             labels={"name": f"airflow__{self.dag_id}__{self.task_id}"},
             mode=self.mode,
         )

--- a/providers/docker/tests/unit/docker/operators/test_docker_swarm.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker_swarm.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 from unittest import mock
 
 import pytest
@@ -27,10 +28,13 @@ from docker.constants import DEFAULT_TIMEOUT_SECONDS
 from docker.errors import APIError
 
 from airflow.providers.common.compat.sdk import AirflowException
-from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator
+from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator, _generate_service_name
 
 
 class TestDockerSwarmOperator:
+    def test_generate_service_name(self):
+        assert re.fullmatch(r"custom-prefix-[A-Za-z0-9]{8}", _generate_service_name("custom-prefix"))
+
     @mock.patch("airflow.providers.docker.operators.docker_swarm.types")
     def test_execute(self, types_mock, docker_api_client_patcher, caplog):
         mock_obj = mock.Mock()

--- a/providers/docker/tests/unit/docker/operators/test_docker_swarm.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker_swarm.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import re
 from unittest import mock
 
 import pytest
@@ -28,13 +27,10 @@ from docker.constants import DEFAULT_TIMEOUT_SECONDS
 from docker.errors import APIError
 
 from airflow.providers.common.compat.sdk import AirflowException
-from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator, _generate_service_name
+from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator
 
 
 class TestDockerSwarmOperator:
-    def test_generate_service_name(self):
-        assert re.fullmatch(r"custom-prefix-[A-Za-z0-9]{8}", _generate_service_name("custom-prefix"))
-
     @mock.patch("airflow.providers.docker.operators.docker_swarm.types")
     def test_execute(self, types_mock, docker_api_client_patcher, caplog):
         mock_obj = mock.Mock()


### PR DESCRIPTION
## Why

Issue #62063 tracks removing provider dependencies on `airflow.utils` as part of the provider/client separation work. The Docker provider had one remaining dependency in `DockerSwarmOperator` for generating temporary service names.

## What changed

- Replaced the `airflow.utils.strings.get_random_string` import with a private provider-local helper.
- Preserved the existing service-name format: the configured prefix followed by eight alphanumeric characters.
- Added focused unit coverage for the generated service name.
- Confirmed that `providers/docker/src` no longer imports `airflow.utils`.

This does not introduce any user-facing behavior changes.

## Testing

- Commit and pre-commit checks passed.
- Docker Swarm operator tests: 25 passed.
- Full Docker provider suite attempted: 143 passed and 2 skipped; 15 Docker-dependent tests could not run because a local Docker daemon was unavailable.

related: #62063

--- 
