### PR TITLE
Bump azure-mgmt-datafactory to 10.0 and fix compat

### DIFF
--- a/providers/microsoft/azure/README.rst
+++ b/providers/microsoft/azure/README.rst
@@ -74,7 +74,7 @@ PIP package                                 Version required
 ``azure-synapse-artifacts``                 ``>=0.17.0``
 ``azure-storage-file-datalake``             ``>=12.9.1``
 ``azure-kusto-data``                        ``>=4.1.0,!=5.0.0``
-``azure-mgmt-datafactory``                  ``>=2.0.0``
+``azure-mgmt-datafactory``                  ``>=10.0.0``
 ``azure-mgmt-containerregistry``            ``>=8.0.0``
 ``azure-mgmt-compute``                      ``>=33.0.0``
 ``azure-mgmt-containerinstance``            ``>=10.1.0``

--- a/providers/microsoft/azure/docs/index.rst
+++ b/providers/microsoft/azure/docs/index.rst
@@ -128,7 +128,7 @@ PIP package                                 Version required
 ``azure-synapse-artifacts``                 ``>=0.17.0``
 ``azure-storage-file-datalake``             ``>=12.9.1``
 ``azure-kusto-data``                        ``>=4.1.0,!=5.0.0``
-``azure-mgmt-datafactory``                  ``>=2.0.0``
+``azure-mgmt-datafactory``                  ``>=10.0.0``
 ``azure-mgmt-containerregistry``            ``>=8.0.0``
 ``azure-mgmt-compute``                      ``>=33.0.0``
 ``azure-mgmt-containerinstance``            ``>=10.1.0``

--- a/providers/microsoft/azure/pyproject.toml
+++ b/providers/microsoft/azure/pyproject.toml
@@ -84,7 +84,7 @@ dependencies = [
     "azure-storage-file-datalake>=12.9.1",
     # azure-kusto-data 5.0.0 pins requests to a specific version which makes resolving dependencies harder
     "azure-kusto-data>=4.1.0,!=5.0.0",
-    "azure-mgmt-datafactory>=2.0.0",
+    "azure-mgmt-datafactory>=10.0.0",
     "azure-mgmt-containerregistry>=8.0.0",
     "azure-mgmt-compute>=33.0.0",
     "azure-mgmt-containerinstance>=10.1.0",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -278,7 +278,7 @@ class AzureDataFactoryHook(BaseHook):
             raise AirflowException(f"Factory {factory!r} does not exist.")
 
         return self.get_conn().factories.create_or_update(
-            resource_group_name, factory_name, factory, if_match, **config
+            resource_group_name, factory_name, factory, etag=if_match, **config
         )
 
     @provide_targeted_factory
@@ -339,7 +339,7 @@ class AzureDataFactoryHook(BaseHook):
         :return: The linked service.
         """
         return self.get_conn().linked_services.get(
-            resource_group_name, factory_name, linked_service_name, if_none_match, **config
+            resource_group_name, factory_name, linked_service_name, etag=if_none_match, **config
         )
 
     def _linked_service_exists(self, resource_group_name, factory_name, linked_service_name) -> bool:
@@ -549,7 +549,7 @@ class AzureDataFactoryHook(BaseHook):
         :return: The DataFlowResource.
         """
         return self.get_conn().data_flows.get(
-            resource_group_name, factory_name, dataflow_name, if_none_match, **config
+            resource_group_name, factory_name, dataflow_name, etag=if_none_match, **config
         )
 
     def _dataflow_exists(
@@ -597,7 +597,7 @@ class AzureDataFactoryHook(BaseHook):
             raise AirflowException(f"Dataflow {dataflow_name!r} does not exist.")
 
         return self.get_conn().data_flows.create_or_update(
-            resource_group_name, factory_name, dataflow_name, dataflow, if_match, **config
+            resource_group_name, factory_name, dataflow_name, dataflow, etag=if_match, **config
         )
 
     @provide_targeted_factory
@@ -627,7 +627,7 @@ class AzureDataFactoryHook(BaseHook):
             raise AirflowException(f"Dataflow {dataflow_name!r} already exists.")
 
         return self.get_conn().data_flows.create_or_update(
-            resource_group_name, factory_name, dataflow_name, dataflow, if_match, **config
+            resource_group_name, factory_name, dataflow_name, dataflow, etag=if_match, **config
         )
 
     @provide_targeted_factory
@@ -923,7 +923,7 @@ class AzureDataFactoryHook(BaseHook):
             raise AirflowException(f"Trigger {trigger_name!r} does not exist.")
 
         return self.get_conn().triggers.create_or_update(
-            resource_group_name, factory_name, trigger_name, trigger, if_match, **config
+            resource_group_name, factory_name, trigger_name, trigger, etag=if_match, **config
         )
 
     @provide_targeted_factory

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_data_factory.py
@@ -247,7 +247,7 @@ def test_update_factory(hook: AzureDataFactoryHook):
         mock_factory_exists.return_value = True
         hook.update_factory(MODEL, RESOURCE_GROUP, FACTORY)
 
-    hook._conn.factories.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, MODEL, None)
+    hook._conn.factories.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, MODEL, etag=None)
 
 
 def test_update_factory_non_existent(hook: AzureDataFactoryHook):
@@ -267,7 +267,7 @@ def test_delete_factory(hook: AzureDataFactoryHook):
 def test_get_linked_service(hook: AzureDataFactoryHook):
     hook.get_linked_service(NAME, RESOURCE_GROUP, FACTORY)
 
-    hook._conn.linked_services.get.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, None)
+    hook._conn.linked_services.get.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, etag=None)
 
 
 def test_create_linked_service(hook: AzureDataFactoryHook):
@@ -335,13 +335,13 @@ def test_delete_dataset(hook: AzureDataFactoryHook):
 def test_get_dataflow(hook: AzureDataFactoryHook):
     hook.get_dataflow(NAME, RESOURCE_GROUP, FACTORY)
 
-    hook._conn.data_flows.get.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, None)
+    hook._conn.data_flows.get.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, etag=None)
 
 
 def test_create_dataflow(hook: AzureDataFactoryHook):
     hook.create_dataflow(NAME, MODEL, RESOURCE_GROUP, FACTORY)
 
-    hook._conn.data_flows.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, MODEL, None)
+    hook._conn.data_flows.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, MODEL, etag=None)
 
 
 def test_update_dataflow(hook: AzureDataFactoryHook):
@@ -349,7 +349,7 @@ def test_update_dataflow(hook: AzureDataFactoryHook):
         mock_dataflow_exists.return_value = True
         hook.update_dataflow(NAME, MODEL, RESOURCE_GROUP, FACTORY)
 
-    hook._conn.data_flows.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, MODEL, None)
+    hook._conn.data_flows.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, MODEL, etag=None)
 
 
 def test_update_dataflow_non_existent(hook: AzureDataFactoryHook):
@@ -478,7 +478,7 @@ def test_update_trigger(hook: AzureDataFactoryHook):
         mock_trigger_exists.return_value = True
         hook.update_trigger(NAME, MODEL, RESOURCE_GROUP, FACTORY)
 
-    hook._conn.triggers.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, MODEL, None)
+    hook._conn.triggers.create_or_update.assert_called_with(RESOURCE_GROUP, FACTORY, NAME, MODEL, etag=None)
 
 
 def test_update_trigger_non_existent(hook: AzureDataFactoryHook):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Noticed this failure in CI:
```
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:280: error: No overload variant of "create_or_update" of "FactoriesOperations" matches argument types "str", "str",
    "Factory", "str | None", "dict[str, Any]"  [call-overload]
                return self.get_conn().factories.create_or_update(
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:280: note: Possible overload variants:
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:280: note:     def create_or_update(self, resource_group_name: str, factory_name: str, factory: Factory, *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> Factory
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:280: note:     def create_or_update(self, resource_group_name: str, factory_name: str, factory: IO[bytes], *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> Factory
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:341: error: Too many positional arguments for "get" of "LinkedServicesOperations"  [misc]
                return self.get_conn().linked_services.get(
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:551: error: Too many positional arguments for "get" of "DataFlowsOperations"  [misc]
                return self.get_conn().data_flows.get(
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:599: error: No overload variant of "create_or_update" of "DataFlowsOperations" matches argument types "str", "str",
    "str", "DataFlowResource | IO[Any]", "str | None", "dict[str, Any]"  [call-overload]
                return self.get_conn().data_flows.create_or_update(
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:599: note: Possible overload variants:
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:599: note:     def create_or_update(self, resource_group_name: str, factory_name: str, data_flow_name: str, data_flow: DataFlowResource, *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> DataFlowResource
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:599: note:     def create_or_update(self, resource_group_name: str, factory_name: str, data_flow_name: str, data_flow: IO[bytes], *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> DataFlowResource
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:629: error: No overload variant of "create_or_update" of "DataFlowsOperations" matches argument types "str", "str",
    "str", "DataFlowResource", "str | None", "dict[str, Any]"  [call-overload]
                return self.get_conn().data_flows.create_or_update(
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:629: note: Possible overload variants:
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:629: note:     def create_or_update(self, resource_group_name: str, factory_name: str, data_flow_name: str, data_flow: DataFlowResource, *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> DataFlowResource
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:629: note:     def create_or_update(self, resource_group_name: str, factory_name: str, data_flow_name: str, data_flow: IO[bytes], *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> DataFlowResource
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:925: error: No overload variant of "create_or_update" of "TriggersOperations" matches argument types "str", "str",
    "str", "TriggerResource", "str | None", "dict[str, Any]"  [call-overload]
                return self.get_conn().triggers.create_or_update(
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:925: note: Possible overload variants:
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:925: note:     def create_or_update(self, resource_group_name: str, factory_name: str, trigger_name: str, trigger: TriggerResource, *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> TriggerResource
    providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_factory.py:925: note:     def create_or_update(self, resource_group_name: str, factory_name: str, trigger_name: str, trigger: IO[bytes], *, content_type: str = ..., etag: str | None = ..., match_condition: MatchConditions | None = ..., **kwargs: Any) -> TriggerResource
    Found 6 errors in 1 file (checked 4724 source files)

    Error 1 returned

```

Caused due to 
```diff
116c116
< azure-mgmt-datafactory==9.3.0
---
> azure-mgmt-datafactory==10.0.0
```

The 10.0.0 release regenerated the SDK's operations classes and dropped the positional `if_match`/`if_none_match` parameters on `create_or_update`/`get` in favor of a keyword-only `etag` parameter (the standard azure-core conditional-request pattern, where `etag` maps to `If-Match` on writes and `If-None-Match` on reads).


Instead of band-aiding it, a better way would be to bump to 10.0+ lower bound cos current lower bound is ~5years old 
<img width="705" height="127" alt="image" src="https://github.com/user-attachments/assets/c2d33662-d5ae-4bed-869f-0944f2b19bd4" />

### User implications / backcompat

None for Airflow users - the hook's public API (`if_match`/`if_none_match` parameter names on `update_factory`, `get_linked_service`, `get_dataflow`, `update_dataflow`, `create_dataflow`, `update_trigger`) is unchanged. Only the internal SDK call shape and the minimum installed SDK version changed.


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
