### PR TITLE
Fix HttpSensor deferrable error allowlist

### DIFF
--- a/providers/http/src/airflow/providers/http/sensors/http.py
+++ b/providers/http/src/airflow/providers/http/sensors/http.py
@@ -170,6 +170,7 @@ class HttpSensor(BaseSensorOperator):
                     headers=self.headers,
                     method=self.method,
                     extra_options=self.extra_options,
+                    response_error_codes_allowlist=self.response_error_codes_allowlist,
                     poke_interval=self.poke_interval,
                 ),
                 method_name="execute_complete",

--- a/providers/http/src/airflow/providers/http/triggers/http.py
+++ b/providers/http/src/airflow/providers/http/triggers/http.py
@@ -230,6 +230,7 @@ class HttpSensorTrigger(BaseTrigger):
         data: dict[str, Any] | str | None = None,
         headers: dict[str, str] | None = None,
         extra_options: dict[str, Any] | None = None,
+        response_error_codes_allowlist: list[str] | tuple[str, ...] | None = None,
         poke_interval: float = 5.0,
     ):
         super().__init__()
@@ -238,6 +239,7 @@ class HttpSensorTrigger(BaseTrigger):
         self.data = data
         self.headers = headers
         self.extra_options = extra_options or {}
+        self.response_error_codes_allowlist = tuple(response_error_codes_allowlist or ("404",))
         self.http_conn_id = http_conn_id
         self.poke_interval = poke_interval
 
@@ -251,6 +253,7 @@ class HttpSensorTrigger(BaseTrigger):
                 "method": self.method,
                 "headers": self.headers,
                 "extra_options": self.extra_options,
+                "response_error_codes_allowlist": self.response_error_codes_allowlist,
                 "http_conn_id": self.http_conn_id,
                 "poke_interval": self.poke_interval,
             },
@@ -272,8 +275,10 @@ class HttpSensorTrigger(BaseTrigger):
                 yield TriggerEvent(True)
                 return
             except AirflowException as exc:
-                if str(exc).startswith("404"):
+                if str(exc).startswith(self.response_error_codes_allowlist):
                     await asyncio.sleep(self.poke_interval)
+                    continue
+                raise
 
     def _get_async_hook(self) -> HttpAsyncHook:
         return HttpAsyncHook(

--- a/providers/http/tests/unit/http/sensors/test_http.py
+++ b/providers/http/tests/unit/http/sensors/test_http.py
@@ -382,6 +382,23 @@ class TestHttpSensorAsync:
 
         assert isinstance(exc.value.trigger, HttpSensorTrigger), "Trigger is not a HttpTrigger"
 
+    @mock.patch(
+        "airflow.providers.http.sensors.http.HttpSensor.poke",
+        return_value=False,
+    )
+    def test_execute_passes_response_error_codes_allowlist_to_trigger(self, mock_poke):
+        task = HttpSensor(
+            task_id="run_now",
+            endpoint="test-endpoint",
+            response_error_codes_allowlist=["404", "503"],
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred) as exc:
+            task.execute({})
+
+        assert exc.value.trigger.response_error_codes_allowlist == ("404", "503")
+
     @mock.patch("airflow.providers.http.sensors.http.HttpSensor.defer")
     @mock.patch(
         "airflow.sdk.bases.sensor.BaseSensorOperator.execute"

--- a/providers/http/tests/unit/http/triggers/test_http.py
+++ b/providers/http/tests/unit/http/triggers/test_http.py
@@ -29,6 +29,7 @@ from requests.structures import CaseInsensitiveDict
 from yarl import URL
 
 from airflow.models import Connection
+from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.http.triggers.http import (
     HttpEventTrigger,
     HttpResponseSerializer,
@@ -207,8 +208,35 @@ class TestHttpSensorTrigger:
             "headers": TEST_HEADERS,
             "data": TEST_DATA,
             "extra_options": TEST_EXTRA_OPTIONS,
+            "response_error_codes_allowlist": ("404",),
             "poke_interval": 5.0,
         }
+
+    def test_serialization_with_response_error_codes_allowlist(self):
+        trigger = HttpSensorTrigger(
+            endpoint=TEST_ENDPOINT,
+            response_error_codes_allowlist=("404", "503"),
+        )
+
+        _, kwargs = trigger.serialize()
+
+        assert kwargs["response_error_codes_allowlist"] == ("404", "503")
+
+    @pytest.mark.asyncio
+    @mock.patch(HTTP_PATH.format("asyncio.sleep"))
+    @mock.patch(HTTP_PATH.format("HttpAsyncHook"))
+    async def test_run_retries_allowlisted_errors(self, mock_hook, mock_sleep):
+        trigger = HttpSensorTrigger(
+            endpoint=TEST_ENDPOINT,
+            response_error_codes_allowlist=["404", "503"],
+        )
+        mock_hook.return_value.run.side_effect = [AirflowException("503:Service Unavailable"), None]
+
+        generator = trigger.run()
+        actual = await generator.asend(None)
+
+        assert actual == TriggerEvent(True)
+        mock_sleep.assert_awaited_once_with(5.0)
 
 
 class TestHttpEventTrigger:


### PR DESCRIPTION
﻿## What changed

`HttpSensor` now passes its configured `response_error_codes_allowlist` into `HttpSensorTrigger` when running in deferrable mode.

`HttpSensorTrigger` now serializes that allowlist and uses it when deciding whether an HTTP error should keep waiting. Non-allowlisted HTTP errors are no longer silently retried in a tight loop.

Closes #69903

## Why

The synchronous `HttpSensor` path honored custom allowlisted status codes such as `503`, but the deferrable trigger path only retried `404`. This made the same sensor configuration behave differently after deferral.

## Tests

- `python -m py_compile providers/http/src/airflow/providers/http/sensors/http.py providers/http/src/airflow/providers/http/triggers/http.py providers/http/tests/unit/http/sensors/test_http.py providers/http/tests/unit/http/triggers/test_http.py`
- `git diff --check`

I could not run the focused pytest file in this local shell because the Airflow test dependencies are not installed (`tests_common` first, then `time_machine`).

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=63742f2 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Tomeshwari-02** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
