### PR TITLE
Rename coordinator label to area:coordinator and align CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,8 @@ Dockerfile.ci @potiuk @ashb @gopidesupavan @amoghrajesh @jscheffl @bugraoz93 @ja
 # AIP-108 - Coordinators
 /task-sdk/src/airflow/sdk/coordinators/ @jason810496 @uranusjr
 /task-sdk/src/airflow/sdk/execution_time/coordinator.py @jason810496 @uranusjr
+/task-sdk/tests/task_sdk/coordinators/ @jason810496 @uranusjr
+/task-sdk/tests/task_sdk/execution_time/test_coordinator.py @jason810496 @uranusjr
 
 # Golang SDK
 /go-sdk/ @ashb @amoghrajesh @jason810496

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -566,7 +566,7 @@ labelPRBasedOnFilePath:
   area:ts-sdk:
     - ts-sdk/**/*
 
-  "AIP-108: Coordinator":
+  area:coordinator:
     - task-sdk/src/airflow/sdk/coordinators/**/*
     - task-sdk/src/airflow/sdk/execution_time/coordinator.py
     - task-sdk/tests/task_sdk/coordinators/**/*


### PR DESCRIPTION
I just renamed `"AIP-108: Coordinator"` label on GitHub to `area:coordinator` so we change make the `.github/boring-cyborg.yml` up to date.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
