### PR TITLE
Fix passphrase quoting in decrypt_remote_file_to_string for Windows

### DIFF
--- a/providers/teradata/src/airflow/providers/teradata/utils/encryption_utils.py
+++ b/providers/teradata/src/airflow/providers/teradata/utils/encryption_utils.py
@@ -21,6 +21,8 @@ import secrets
 import string
 import subprocess
 
+from airflow.providers.teradata.utils.tpt_util import get_remote_os
+
 
 def generate_random_password(length=12):
     # Define the character set: letters, digits, and special characters
@@ -51,25 +53,27 @@ def generate_encrypted_file_with_openssl(file_path: str, password: str, out_file
 
 
 def decrypt_remote_file_to_string(ssh_client, remote_enc_file, password, bteq_command_str):
-    # Run openssl decrypt command on remote machine
-    quoted_password = shell_quote_single(password)
+    remote_os = get_remote_os(ssh_client)
+    windows_remote = remote_os == "windows"
+
+    if windows_remote:
+        # Windows cmd.exe does not support single quotes; use double quotes with "" escaping
+        password_escaped = password.replace('"', '""')
+        quoted_password = f'"{password_escaped}"'
+    else:
+        # Unix shells require closing the single quote, adding an escaped quote, then reopening
+        password_escaped = password.replace("'", "'\\''")
+        quoted_password = f"'{password_escaped}'"
 
     decrypt_cmd = (
         f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass pass:{quoted_password} -in {remote_enc_file} | "
         + bteq_command_str
     )
-    # Clear password to prevent lingering sensitive data
+    # Clear sensitive data from memory
     password = None
     quoted_password = None
     stdin, stdout, stderr = ssh_client.exec_command(decrypt_cmd)
-    # Wait for command to finish
     exit_status = stdout.channel.recv_exit_status()
     output = stdout.read().decode()
     err = stderr.read().decode()
     return exit_status, output, err
-
-
-def shell_quote_single(s):
-    # Escape single quotes in s, then wrap in single quotes
-    # In shell, to include a single quote inside single quotes, close, add '\'' and reopen
-    return "'" + s.replace("'", "'\\''") + "'"

--- a/providers/teradata/src/airflow/providers/teradata/utils/encryption_utils.py
+++ b/providers/teradata/src/airflow/providers/teradata/utils/encryption_utils.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import secrets
+import shlex
 import string
 import subprocess
 
@@ -51,14 +52,13 @@ def decrypt_remote_file_to_string(ssh_client, remote_enc_file, password, bteq_co
     # Use -pass stdin to avoid shell quoting on any OS and keep the passphrase
     # out of the remote process table where ps could expose it.
     decrypt_cmd = (
-        f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass stdin -in {remote_enc_file} | " + bteq_command_str
+        f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass stdin -in {shlex.quote(remote_enc_file)} | "
+        + bteq_command_str
     )
     stdin, stdout, stderr = ssh_client.exec_command(decrypt_cmd)
     stdin.write(password + "\n")
     stdin.flush()
     stdin.channel.shutdown_write()
-    # Clear password to prevent lingering sensitive data
-    password = None
     exit_status = stdout.channel.recv_exit_status()
     output = stdout.read().decode()
     err = stderr.read().decode()

--- a/providers/teradata/src/airflow/providers/teradata/utils/encryption_utils.py
+++ b/providers/teradata/src/airflow/providers/teradata/utils/encryption_utils.py
@@ -18,23 +18,17 @@
 from __future__ import annotations
 
 import secrets
-import shlex
 import string
 import subprocess
 
 
 def generate_random_password(length=12):
-    # Define the character set: letters, digits, and special characters
     characters = string.ascii_letters + string.digits + string.punctuation
-    # Generate a random password
     password = "".join(secrets.choice(characters) for _ in range(length))
     return password
 
 
 def generate_encrypted_file_with_openssl(file_path: str, password: str, out_file: str):
-    # Write plaintext temporarily to file
-
-    # Run openssl enc with AES-256-CBC, pbkdf2, salt
     cmd = [
         "openssl",
         "enc",
@@ -54,25 +48,18 @@ def generate_encrypted_file_with_openssl(file_path: str, password: str, out_file
 
 
 def decrypt_remote_file_to_string(ssh_client, remote_enc_file, password, bteq_command_str):
-    # Run openssl decrypt command on remote machine
-    quoted_password = shell_quote_single(password)
-
+    # Use -pass stdin to avoid shell quoting on any OS and keep the passphrase
+    # out of the remote process table where ps could expose it.
     decrypt_cmd = (
-        f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass pass:{quoted_password} -in {shlex.quote(remote_enc_file)} | "
-        + bteq_command_str
+        f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass stdin -in {remote_enc_file} | " + bteq_command_str
     )
+    stdin, stdout, stderr = ssh_client.exec_command(decrypt_cmd)
+    stdin.write(password + "\n")
+    stdin.flush()
+    stdin.channel.shutdown_write()
     # Clear password to prevent lingering sensitive data
     password = None
-    quoted_password = None
-    stdin, stdout, stderr = ssh_client.exec_command(decrypt_cmd)
-    # Wait for command to finish
     exit_status = stdout.channel.recv_exit_status()
     output = stdout.read().decode()
     err = stderr.read().decode()
     return exit_status, output, err
-
-
-def shell_quote_single(s):
-    # Escape single quotes in s, then wrap in single quotes
-    # In shell, to include a single quote inside single quotes, close, add '\'' and reopen
-    return "'" + s.replace("'", "'\\''") + "'"

--- a/providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py
+++ b/providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py
@@ -23,7 +23,6 @@ from airflow.providers.teradata.utils.encryption_utils import (
     decrypt_remote_file_to_string,
     generate_encrypted_file_with_openssl,
     generate_random_password,
-    shell_quote_single,
 )
 
 
@@ -31,7 +30,6 @@ class TestEncryptionUtils:
     def test_generate_random_password_length(self):
         pwd = generate_random_password(16)
         assert len(pwd) == 16
-        # Check characters are in allowed set
         allowed_chars = string.ascii_letters + string.digits + string.punctuation
         assert (all(c in allowed_chars for c in pwd)) is True
 
@@ -60,43 +58,57 @@ class TestEncryptionUtils:
             check=True,
         )
 
-    def test_shell_quote_single_simple(self):
-        s = "simple"
-        quoted = shell_quote_single(s)
-        assert quoted == "'simple'"
-
-    def test_shell_quote_single_with_single_quote(self):
-        s = "O'Reilly"
-        quoted = shell_quote_single(s)
-        assert quoted == "'O'\\''Reilly'"
-
-    def test_decrypt_remote_file_to_string(self):
+    @patch("airflow.providers.teradata.utils.encryption_utils.get_remote_os")
+    def test_decrypt_remote_file_to_string_unix(self, mock_get_remote_os):
+        mock_get_remote_os.return_value = "unix"
         password = "mysecret"
         remote_enc_file = "/remote/encrypted.enc"
         bteq_command_str = "bteq -c UTF-8"
 
         ssh_client = MagicMock()
-        mock_stdin = MagicMock()
         mock_stdout = MagicMock()
-        mock_stderr = MagicMock()
-
-        # Setup mock outputs and exit code
         mock_stdout.channel.recv_exit_status.return_value = 0
         mock_stdout.read.return_value = b"decrypted output"
+        mock_stderr = MagicMock()
         mock_stderr.read.return_value = b""
-
-        ssh_client.exec_command.return_value = (mock_stdin, mock_stdout, mock_stderr)
+        ssh_client.exec_command.return_value = (MagicMock(), mock_stdout, mock_stderr)
 
         exit_status, output, err = decrypt_remote_file_to_string(
             ssh_client, remote_enc_file, password, bteq_command_str
         )
 
-        quoted_password = shell_quote_single(password)
         expected_cmd = (
-            f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass pass:{quoted_password} -in {remote_enc_file} | "
+            f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass pass:'mysecret' -in {remote_enc_file} | "
             + bteq_command_str
         )
+        ssh_client.exec_command.assert_called_once_with(expected_cmd)
+        assert exit_status == 0
+        assert output == "decrypted output"
+        assert err == ""
 
+    @patch("airflow.providers.teradata.utils.encryption_utils.get_remote_os")
+    def test_decrypt_remote_file_to_string_windows(self, mock_get_remote_os):
+        mock_get_remote_os.return_value = "windows"
+        password = "mysecret"
+        remote_enc_file = "/remote/encrypted.enc"
+        bteq_command_str = "bteq -c UTF-8"
+
+        ssh_client = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stdout.channel.recv_exit_status.return_value = 0
+        mock_stdout.read.return_value = b"decrypted output"
+        mock_stderr = MagicMock()
+        mock_stderr.read.return_value = b""
+        ssh_client.exec_command.return_value = (MagicMock(), mock_stdout, mock_stderr)
+
+        exit_status, output, err = decrypt_remote_file_to_string(
+            ssh_client, remote_enc_file, password, bteq_command_str
+        )
+
+        expected_cmd = (
+            f'openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass pass:"mysecret" -in {remote_enc_file} | '
+            + bteq_command_str
+        )
         ssh_client.exec_command.assert_called_once_with(expected_cmd)
         assert exit_status == 0
         assert output == "decrypted output"

--- a/providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py
+++ b/providers/teradata/tests/unit/teradata/utils/test_encryption_utils.py
@@ -23,7 +23,6 @@ from airflow.providers.teradata.utils.encryption_utils import (
     decrypt_remote_file_to_string,
     generate_encrypted_file_with_openssl,
     generate_random_password,
-    shell_quote_single,
 )
 
 
@@ -31,9 +30,8 @@ class TestEncryptionUtils:
     def test_generate_random_password_length(self):
         pwd = generate_random_password(16)
         assert len(pwd) == 16
-        # Check characters are in allowed set
         allowed_chars = string.ascii_letters + string.digits + string.punctuation
-        assert (all(c in allowed_chars for c in pwd)) is True
+        assert all(c in allowed_chars for c in pwd) is True
 
     @patch("subprocess.run")
     def test_generate_encrypted_file_with_openssl_calls_subprocess(self, mock_run):
@@ -72,16 +70,6 @@ class TestEncryptionUtils:
         assert not any(password in str(part) for part in cmd), "passphrase leaked onto argv"
         assert kwargs["input"] == f"{password}\n".encode()
 
-    def test_shell_quote_single_simple(self):
-        s = "simple"
-        quoted = shell_quote_single(s)
-        assert quoted == "'simple'"
-
-    def test_shell_quote_single_with_single_quote(self):
-        s = "O'Reilly"
-        quoted = shell_quote_single(s)
-        assert quoted == "'O'\\''Reilly'"
-
     def test_decrypt_remote_file_to_string(self):
         password = "mysecret"
         remote_enc_file = "/remote/encrypted.enc"
@@ -91,25 +79,42 @@ class TestEncryptionUtils:
         mock_stdin = MagicMock()
         mock_stdout = MagicMock()
         mock_stderr = MagicMock()
-
-        # Setup mock outputs and exit code
         mock_stdout.channel.recv_exit_status.return_value = 0
         mock_stdout.read.return_value = b"decrypted output"
         mock_stderr.read.return_value = b""
-
         ssh_client.exec_command.return_value = (mock_stdin, mock_stdout, mock_stderr)
 
         exit_status, output, err = decrypt_remote_file_to_string(
             ssh_client, remote_enc_file, password, bteq_command_str
         )
 
-        quoted_password = shell_quote_single(password)
         expected_cmd = (
-            f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass pass:{quoted_password} -in {remote_enc_file} | "
+            f"openssl enc -d -aes-256-cbc -salt -pbkdf2 -pass stdin -in {remote_enc_file} | "
             + bteq_command_str
         )
-
         ssh_client.exec_command.assert_called_once_with(expected_cmd)
+        mock_stdin.write.assert_called_once_with(password + "\n")
+        mock_stdin.flush.assert_called_once()
+        mock_stdin.channel.shutdown_write.assert_called_once()
         assert exit_status == 0
         assert output == "decrypted output"
         assert err == ""
+
+    def test_decrypt_remote_file_passphrase_not_on_argv(self):
+        """The passphrase is passed via stdin, never on the remote command line."""
+        password = "s3cr3t&rm -rf ~"
+        remote_enc_file = "/remote/encrypted.enc"
+        ssh_client = MagicMock()
+        mock_stdin = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stderr = MagicMock()
+        mock_stdout.channel.recv_exit_status.return_value = 0
+        mock_stdout.read.return_value = b""
+        mock_stderr.read.return_value = b""
+        ssh_client.exec_command.return_value = (mock_stdin, mock_stdout, mock_stderr)
+
+        decrypt_remote_file_to_string(ssh_client, remote_enc_file, password, "bteq")
+
+        cmd = ssh_client.exec_command.call_args[0][0]
+        assert password not in cmd, "passphrase leaked onto remote command line"
+        assert "-pass stdin" in cmd


### PR DESCRIPTION
…emotes

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
the fix detects the remote OS using the existing `get_remote_os()  helper, already used in tpt_utils.py and applies the  correct quoting:
- Windows: double quotes with `'''` escaping
- Unix/Linus: single quotes with `'\''` escaping
closes: #69396 
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
