### PR TITLE
Suppress noisy Alembic plugin setup logs

### DIFF
--- a/shared/logging/src/airflow_shared/logging/structlog.py
+++ b/shared/logging/src/airflow_shared/logging/structlog.py
@@ -709,6 +709,7 @@ def configure_logging(
             # These ones are too chatty even at info
             "httpx": {"level": "WARN"},
             "sqlalchemy.engine": {"level": "WARN"},
+            "alembic.runtime.plugins": {"level": "WARN"},
         }
     )
     config["root"] = {

--- a/shared/logging/tests/logging/test_structlog.py
+++ b/shared/logging/tests/logging/test_structlog.py
@@ -464,6 +464,19 @@ def test_logger_respects_configured_level(structlog_config):
     assert "[my_logger] Debug message\n" in written
 
 
+def test_alembic_runtime_plugin_setup_logs_are_suppressed(structlog_config):
+    with structlog_config(
+        colors=False,
+        log_format="[%(name)s] %(message)s",
+        log_level="INFO",
+    ) as sio:
+        logger = logging.getLogger("alembic.runtime.plugins")
+        logger.info("Filtered plugin setup message")
+        logger.warning("Visible warning")
+
+    assert sio.getvalue() == "[alembic.runtime.plugins] Visible warning\n"
+
+
 def test_excepthook_installed_when_json_output_true(structlog_config):
     import sys
 


### PR DESCRIPTION
Alembic emits autogenerate plugin registration messages at INFO during CLI startup. Those unrelated lines contaminate machine-readable command output, while warnings and errors still need to remain visible.

closes: #69911


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

GPT-5.6
