### PR TITLE
Re-render only the changed column when Grid summaries stream in

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -20,7 +20,7 @@ import { Box, Flex } from "@chakra-ui/react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import dayjs from "dayjs";
 import dayjsDuration from "dayjs/plugin/duration";
-import { useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { RefObject } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 
@@ -141,7 +141,12 @@ export const Grid = ({
     showVersionIndicatorMode,
   });
 
-  const { flatNodes } = flattenNodes(dagStructure, openGroupIds);
+  // React Compiler skips optimizing this whole component: `useVirtualizer` (@tanstack/react-virtual) is
+  // on the compiler's known-incompatible list — its return value exposes functions that can't be
+  // memoized safely — so it declines to memoize anything in Grid. Without the manual memoization here
+  // and on the click handlers below, `flatNodes` and the handlers get fresh references every render, so
+  // each TI-summaries stream line re-renders every column instead of only the run whose summary changed.
+  const { flatNodes } = useMemo(() => flattenNodes(dagStructure, openGroupIds), [dagStructure, openGroupIds]);
 
   const taskNameColumnWidthPx = showGantt ? estimateTaskNameColumnWidthPx(flatNodes) : undefined;
 
@@ -166,9 +171,9 @@ export const Grid = ({
     tasks: flatNodes,
   });
 
-  const handleRowClick = () => setMode(NavigationModes.TASK);
-  const handleCellClick = () => setMode(NavigationModes.TI);
-  const handleColumnClick = () => setMode(NavigationModes.RUN);
+  const handleRowClick = useCallback(() => setMode(NavigationModes.TASK), [setMode]);
+  const handleCellClick = useCallback(() => setMode(NavigationModes.TI), [setMode]);
+  const handleColumnClick = useCallback(() => setMode(NavigationModes.RUN), [setMode]);
 
   const rowVirtualizer = useVirtualizer({
     count: flatNodes.length,

--- a/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
@@ -144,8 +144,10 @@ export const useGridTiSummariesStream = ({
       return undefined;
     }
 
-    // Kick off an immediate refresh so the stream doesn't have to wait for the first interval to elapse.
-    setRefreshTick((tick) => tick + 1);
+    // The stream already fetches on mount and whenever runIdsKey changes, so there is no first-interval
+    // wait to avoid. Bumping refreshTick here would abort that just-opened mount stream and immediately
+    // reopen it — a redundant connection plus an AbortError on every grid mount — so let the interval be
+    // the only re-stream trigger.
     const timer = setInterval(() => {
       setRefreshTick((tick) => tick + 1);
     }, baseRefetchInterval);


### PR DESCRIPTION
Second of two stacked PRs improving Dag Grid performance. Stacked on #69912 (the hover-cascade fix) — that PR's commit shows first in this diff, so the change to review here is the second commit.

The Grid streams TI summaries as one NDJSON line per run. Every line replaced the summaries `Map` and re-rendered `Grid`, and because `useVirtualizer` (`@tanstack/react-virtual`) is on the React Compiler's hardcoded known-incompatible list, the compiler skips optimizing the whole `Grid` component. So `flatNodes` and the click handlers took fresh references on every render, and *every* column re-rendered on *every* stream line — not just the run whose summary arrived.

This memoizes the values handed down to the columns by hand. That is the escape hatch the compiler's own bailout message points to for incompatible-library APIs (the compiler source string: *"TanStack Virtual's `useVirtualizer()` API returns functions that cannot be memoized safely"*). It also drops a redundant immediate stream restart that aborted and reopened the just-opened mount stream on every grid mount with active runs.

Measured on a 20-run × 30-task grid: column re-renders per load dropped 171 → 54 (all now legitimate), grid load render work ~47% lower.

closes: https://github.com/apache/airflow/issues/69531

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)