### PR TITLE
Fix Celery worker crash on Airflow 3.0 with json_logs

### DIFF
--- a/providers/celery/src/airflow/providers/celery/cli/celery_command.py
+++ b/providers/celery/src/airflow/providers/celery/cli/celery_command.py
@@ -39,6 +39,7 @@ from airflow.cli.simple_table import AirflowConsole
 from airflow.exceptions import AirflowConfigException
 from airflow.providers.celery.version_compat import (
     AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
     AIRFLOW_V_3_2_PLUS,
     AIRFLOW_V_3_3_PLUS,
 )
@@ -263,12 +264,19 @@ def worker(args):
     if AIRFLOW_V_3_0_PLUS:
         from airflow.sdk.log import configure_logging
 
-        _celery_json = config.get("celery", "json_logs", fallback="")
-        if _celery_json and _celery_json.lower() != "none":
-            json_output = config.getboolean("celery", "json_logs")
+        if AIRFLOW_V_3_1_PLUS:
+            _celery_json = config.get("celery", "json_logs", fallback="")
+            if _celery_json and _celery_json.lower() != "none":
+                json_output = config.getboolean("celery", "json_logs")
+            else:
+                json_output = config.getboolean("logging", "json_logs", fallback=False)
+            configure_logging(output=sys.stdout.buffer, json_output=json_output)
         else:
-            json_output = config.getboolean("logging", "json_logs", fallback=False)
-        configure_logging(output=sys.stdout.buffer, json_output=json_output)
+            # Airflow 3.0.x ships an SDK whose configure_logging predates the
+            # json_output parameter (added in the Task SDK 1.1 / Airflow 3.1
+            # structlog migration). Passing it there raises TypeError and crashes
+            # the worker, so honor json_logs only from 3.1 onwards.
+            configure_logging(output=sys.stdout.buffer)
     else:
         # Disable connection pool so that celery worker does not hold an unnecessary db connection
         settings.reconfigure_orm(disable_connection_pool=True)

--- a/providers/celery/src/airflow/providers/celery/version_compat.py
+++ b/providers/celery/src/airflow/providers/celery/version_compat.py
@@ -27,8 +27,15 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
 AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
 AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
 
-__all__ = ["AIRFLOW_V_3_0_PLUS", "AIRFLOW_V_3_1_9_PLUS", "AIRFLOW_V_3_2_PLUS", "AIRFLOW_V_3_3_PLUS"]
+__all__ = [
+    "AIRFLOW_V_3_0_PLUS",
+    "AIRFLOW_V_3_1_PLUS",
+    "AIRFLOW_V_3_1_9_PLUS",
+    "AIRFLOW_V_3_2_PLUS",
+    "AIRFLOW_V_3_3_PLUS",
+]

--- a/providers/celery/tests/unit/celery/cli/test_celery_command.py
+++ b/providers/celery/tests/unit/celery/cli/test_celery_command.py
@@ -38,6 +38,7 @@ from airflow.providers.common.compat.sdk import conf
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import (
     AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_PLUS,
     AIRFLOW_V_3_2_PLUS,
     AIRFLOW_V_3_3_PLUS,
 )
@@ -433,6 +434,9 @@ class TestWorkerJsonLogs:
             importlib.reload(cli_parser)
             cls.parser = cli_parser.get_parser()
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_1_PLUS, reason="json_output only passed to configure_logging on Airflow 3.1+"
+    )
     @mock.patch("airflow.providers.celery.cli.celery_command.Process")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
     @mock.patch("airflow.sdk.log.configure_logging")
@@ -445,6 +449,9 @@ class TestWorkerJsonLogs:
         _, kwargs = mock_configure_logging.call_args
         assert kwargs.get("json_output") is False
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_1_PLUS, reason="json_output only passed to configure_logging on Airflow 3.1+"
+    )
     @mock.patch("airflow.providers.celery.cli.celery_command.Process")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
     @mock.patch("airflow.sdk.log.configure_logging")
@@ -458,6 +465,9 @@ class TestWorkerJsonLogs:
         _, kwargs = mock_configure_logging.call_args
         assert kwargs.get("json_output") is True
 
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_1_PLUS, reason="json_output only passed to configure_logging on Airflow 3.1+"
+    )
     @mock.patch("airflow.providers.celery.cli.celery_command.Process")
     @mock.patch("airflow.providers.celery.executors.celery_executor.app")
     @mock.patch("airflow.sdk.log.configure_logging")
@@ -470,6 +480,22 @@ class TestWorkerJsonLogs:
         mock_configure_logging.assert_called_once()
         _, kwargs = mock_configure_logging.call_args
         assert kwargs.get("json_output") is False
+
+    @mock.patch("airflow.providers.celery.cli.celery_command.AIRFLOW_V_3_1_PLUS", False)
+    @mock.patch("airflow.providers.celery.cli.celery_command.Process")
+    @mock.patch("airflow.providers.celery.executors.celery_executor.app")
+    @mock.patch("airflow.sdk.log.configure_logging")
+    def test_json_output_not_passed_on_airflow_3_0(
+        self, mock_configure_logging, mock_celery_app, mock_popen, mock_pre_exec
+    ):
+        # Airflow 3.0.x's configure_logging has no json_output parameter; passing it
+        # crashes the worker with TypeError. Ensure we omit it below Airflow 3.1.
+        args = self.parser.parse_args(["celery", "worker"])
+        with conf_vars({("logging", "json_logs"): "True"}):
+            celery_command.worker(args)
+        mock_configure_logging.assert_called_once()
+        _, kwargs = mock_configure_logging.call_args
+        assert "json_output" not in kwargs
 
 
 @pytest.mark.backend("mysql", "postgres")


### PR DESCRIPTION
## What

The Celery worker CLI passes `json_output` to `airflow.sdk.log.configure_logging` under an `AIRFLOW_V_3_0_PLUS` gate (added in #68916 "Honor json_logs config in Celery worker startup"):

```python
if AIRFLOW_V_3_0_PLUS:
    from airflow.sdk.log import configure_logging
    ...
    configure_logging(output=sys.stdout.buffer, json_output=json_output)
```

But `json_output` was only added to the Task SDK's `configure_logging` in **SDK 1.1 / Airflow 3.1** (the structlog migration, #52651). On **Airflow 3.0.x** that parameter does not exist, so the call raises:

```
TypeError: configure_logging() got an unexpected keyword argument 'json_output'
```

…and the Celery worker crashes on startup. The `AIRFLOW_V_3_0_PLUS` gate is too loose — this affects any plain Airflow 3.0.x deployment running celery provider >= 3.22.0.

## How

- Add an `AIRFLOW_V_3_1_PLUS` constant to the provider's `version_compat`.
- Gate the `json_logs` handling on `AIRFLOW_V_3_1_PLUS`. On Airflow 3.0.x, fall back to `configure_logging(output=sys.stdout.buffer)` (no `json_output`), matching the pre-#68916 behavior.

This keeps the provider compatible across the full Airflow 3.x range it declares support for; `json_logs` is honored from 3.1+ where the SDK supports it.

## Tests

Added `test_json_output_not_passed_on_airflow_3_0` (patches `AIRFLOW_V_3_1_PLUS = False`, asserts `configure_logging` is called without `json_output`). Existing `json_logs` tests continue to assert the 3.1+ behavior.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

I reviewed and understand all of the generated code, verified it against the actual `worker()` code path, and ran the relevant static checks and tests locally.