### PR TITLE
Support excluding files from `common.ai` Agent Skills discovery

### DIFF
--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -246,7 +246,7 @@ Extra           Dependencies
 ``openai``      ``pydantic-ai-slim[openai]``
 ``mcp``         ``pydantic-ai-slim[mcp]``
 ``code-mode``   ``pydantic-ai-harness[codemode]>=0.3.0``
-``skills``      ``apache-airflow-providers-git>=0.4.0``, ``pydantic-ai-skills>=0.11.0``
+``skills``      ``apache-airflow-providers-git>=0.4.0``, ``pydantic-ai-skills>=1.2.0``
 ``avro``        ``fastavro>=1.10.0; python_version < "3.14"``, ``fastavro>=1.12.1; python_version >= "3.14"``
 ``parquet``     ``pyarrow>=18.0.0; python_version < '3.14'``, ``pyarrow>=22.0.0; python_version >= '3.14'``
 ``sql``         ``apache-airflow-providers-common-sql``, ``sqlglot>=30.0.0``

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -437,6 +437,16 @@ Parameters
   :class:`~airflow.providers.common.ai.skills.GitSkills`.
 - ``exclude_tools``: Optional set of skill tool names to hide from the agent
   (e.g. ``{"run_skill_script"}`` to disable on-worker script execution).
+- ``exclude_resources``: Optional glob patterns to exclude from resource
+  discovery, added on top of the built-in defaults (``__pycache__``, ``*.pyc``,
+  ``*.pyo``, ``.DS_Store``, ``.git``). A skill exposes every readable text file
+  it contains as a resource; these patterns keep matched files out of the
+  resource list and the ``read_skill_resource`` tool (e.g.
+  ``["*.env", "secrets/*"]``). Each pattern matches the full skill-relative path
+  or any single path component. This hides files from resource discovery only --
+  it does not stop a skill's ``run_skill_script`` from reading them off disk, so
+  pair it with ``exclude_tools={"run_skill_script"}`` when the files are
+  genuinely sensitive.
 
 Using Agent Skills with other frameworks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
 # upstream in pydantic/pydantic-ai#5230; revisit this extra once that lands.
 "skills" = [
     "apache-airflow-providers-git>=0.4.0",
-    "pydantic-ai-skills>=0.11.0",
+    "pydantic-ai-skills>=1.2.0",
 ]
 "avro" = [
     'fastavro>=1.10.0; python_version < "3.14"',
@@ -136,7 +136,7 @@ dev = [
     # Additional devel dependencies (do not remove this line and add extra development dependencies)
     "sqlglot>=30.0.0",
     "pydantic-ai-slim[mcp]",
-    "pydantic-ai-skills>=0.11.0",
+    "pydantic-ai-skills>=1.2.0",
     "apache-airflow-providers-common-sql[datafusion]",
     "langchain>=1.0.0",
     "llama-index-core>=0.13.0",

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/skills.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/skills.py
@@ -57,6 +57,16 @@ class AgentSkillsToolset(AbstractToolset):
     :param sources: Skill sources -- local directory paths and/or ``GitSkills``.
     :param exclude_tools: Optional set of skill tool names to hide from the agent
         (e.g. ``{"run_skill_script"}`` to disable on-worker script execution).
+    :param exclude_resources: Optional glob patterns to exclude from resource
+        discovery, added on top of the built-in defaults (``__pycache__``,
+        ``*.pyc``, ``*.pyo``, ``.DS_Store``, ``.git``). A skill exposes every
+        readable text file it contains as a resource; these patterns keep matched
+        files out of the resource list and the ``read_skill_resource`` tool
+        (e.g. ``["*.env", "secrets/*"]``). Patterns match the full skill-relative
+        path or any single path component. This hides files from resource
+        discovery only -- it does not stop a skill's ``run_skill_script`` from
+        reading them off disk, so pair it with ``exclude_tools={"run_skill_script"}``
+        when the files are genuinely sensitive. Requires ``pydantic-ai-skills>=1.2.0``.
 
     Requires the ``skills`` extra: ``pip install "apache-airflow-providers-common-ai[skills]"``.
     """
@@ -66,9 +76,11 @@ class AgentSkillsToolset(AbstractToolset):
         sources: list[SkillSource],
         *,
         exclude_tools: set[str] | None = None,
+        exclude_resources: list[str] | None = None,
     ) -> None:
         self._sources = list(sources)
         self._exclude_tools = exclude_tools
+        self._exclude_resources = exclude_resources
         self._inner: Any = None
         self._cleanup: Callable[[], None] | None = None
 
@@ -80,7 +92,11 @@ class AgentSkillsToolset(AbstractToolset):
         # Per-run isolation: pydantic-ai shares one toolset instance across runs,
         # but we hold per-run clone/cleanup state on __aenter__/__aexit__. Hand
         # each run its own instance so concurrent runs never clobber each other.
-        return AgentSkillsToolset(self._sources, exclude_tools=self._exclude_tools)
+        return AgentSkillsToolset(
+            self._sources,
+            exclude_tools=self._exclude_tools,
+            exclude_resources=self._exclude_resources,
+        )
 
     async def __aenter__(self) -> AgentSkillsToolset:
         # Resolve + clone at run time, on the worker -- not at DAG-parse time.
@@ -98,6 +114,8 @@ class AgentSkillsToolset(AbstractToolset):
             kwargs: dict[str, Any] = {"directories": directories}
             if self._exclude_tools:
                 kwargs["exclude_tools"] = self._exclude_tools
+            if self._exclude_resources:
+                kwargs["exclude_resources"] = self._exclude_resources
             self._inner = SkillsToolset(**kwargs)
             await self._inner.__aenter__()
         except BaseException:

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_skills.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_skills.py
@@ -107,6 +107,56 @@ class TestLifecycle:
         assert captured["exclude_tools"] == {"run_skill_script"}
         assert captured["directories"] == ["/x"]
 
+    def test_exclude_resources_passed_to_inner(self):
+        captured: dict = {}
+
+        def fake_skillstoolset(**kwargs):
+            captured.update(kwargs)
+            return _FakeInner(**kwargs)
+
+        toolset = AgentSkillsToolset(sources=["/x"], exclude_resources=["*.env", "secrets/*"])
+        with patch(
+            "airflow.providers.common.ai.toolsets.skills._materialize_skills",
+            autospec=True,
+            return_value=(["/x"], lambda: None),
+        ):
+            with patch("pydantic_ai_skills.SkillsToolset", fake_skillstoolset):  # noqa: spec
+                asyncio.run(_enter_exit(toolset))
+
+        assert captured["exclude_resources"] == ["*.env", "secrets/*"]
+
+    def test_no_optional_kwargs_when_unset(self):
+        # Omit exclude_tools/exclude_resources entirely so an older pydantic-ai-skills
+        # that lacks the kwarg still works when the feature is not used.
+        captured: dict = {}
+
+        def fake_skillstoolset(**kwargs):
+            captured.update(kwargs)
+            return _FakeInner(**kwargs)
+
+        toolset = AgentSkillsToolset(sources=["/x"])
+        with patch(
+            "airflow.providers.common.ai.toolsets.skills._materialize_skills",
+            autospec=True,
+            return_value=(["/x"], lambda: None),
+        ):
+            with patch("pydantic_ai_skills.SkillsToolset", fake_skillstoolset):  # noqa: spec
+                asyncio.run(_enter_exit(toolset))
+
+        assert "exclude_tools" not in captured
+        assert "exclude_resources" not in captured
+
+    def test_for_run_propagates_optional_kwargs(self):
+        # for_run hands each run its own instance; dropping a kwarg here would
+        # silently expose excluded files in concurrent runs.
+        toolset = AgentSkillsToolset(
+            sources=["/x"], exclude_tools={"run_skill_script"}, exclude_resources=["*.env"]
+        )
+        per_run = asyncio.run(toolset.for_run(MagicMock()))  # noqa: spec  (for_run ignores ctx)
+        assert per_run is not toolset
+        assert per_run._exclude_tools == {"run_skill_script"}
+        assert per_run._exclude_resources == ["*.env"]
+
 
 class TestCleanup:
     def test_cleanup_runs_if_inner_construction_fails(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1560,6 +1560,12 @@ apache-airflow-task-sdk-integration-tests = false
 
 # Manual overrides (kept outside the auto-generated block above so the
 # update_airflow_pyproject_toml.py script doesn't clobber them).
+# Temporary: pydantic-ai-skills 1.2.0 (adds exclude_resources, required by the
+# apache-airflow-providers-common-ai[skills] floor) was published 2026-07-15,
+# inside the "4 days" exclude-newer window. This pins the per-package cutoff just
+# past that release so 1.2.0 resolves while any later release stays quarantined.
+# Remove once the rolling window advances past 2026-07-15.
+pydantic-ai-skills = "2026-07-16T00:00:00Z"
 
 [tool.uv.pip]
 # Synchroonize with scripts/ci/prek/upgrade_important_versions.py
@@ -1706,6 +1712,8 @@ apache-airflow-task-sdk-integration-tests = false
 
 # Manual overrides — see the matching block under
 # `[tool.uv.exclude-newer-package]` above for rationale.
+# Temporary: see the pydantic-ai-skills note in `[tool.uv.exclude-newer-package]`.
+pydantic-ai-skills = "2026-07-16T00:00:00Z"
 
 [tool.uv.sources]
 # These names must match the names as defined in the pyproject.toml of the workspace items,

--- a/uv.lock
+++ b/uv.lock
@@ -33,6 +33,7 @@ apache-airflow-providers-openlineage = false
 apache-airflow-providers-sftp = false
 apache-airflow-e2e-tests = false
 apache-airflow-shared-logging = false
+apache-airflow-providers-common-dataquality = false
 apache-airflow-providers-apache-drill = false
 apache-airflow-providers-pgvector = false
 apache-airflow-providers-imap = false
@@ -52,7 +53,6 @@ apache-airflow-providers-telegram = false
 apache-airflow-providers-celery = false
 apache-airflow-providers-docker = false
 apache-airflow-providers-sendgrid = false
-apache-airflow-providers-common-dataquality = false
 apache-airflow-providers-common-ai = false
 apache-airflow = false
 apache-airflow-shared-observability = false
@@ -64,9 +64,9 @@ apache-airflow-providers-apache-cassandra = false
 apache-airflow-providers-asana = false
 apache-airflow-providers-oracle = false
 apache-airflow-providers-mysql = false
+apache-airflow-providers-teradata = false
 apache-airflow-providers-alibaba = false
 apache-airflow-providers-microsoft-mssql = false
-apache-airflow-providers-teradata = false
 apache-airflow-providers-jdbc = false
 apache-airflow-helm-chart = false
 apache-airflow-providers-anthropic = false
@@ -83,6 +83,7 @@ apache-airflow-providers-salesforce = false
 apache-airflow-providers-ssh = false
 apache-airflow-providers-papermill = false
 apache-airflow-providers-google = false
+pydantic-ai-skills = "2026-07-16T00:00:00Z"
 apache-airflow-providers-microsoft-psrp = false
 apache-airflow-providers-vertica = false
 apache-airflow-providers-apache-hdfs = false
@@ -204,12 +205,12 @@ members = [
     "apache-airflow-providers-cohere",
     "apache-airflow-providers-common-ai",
     "apache-airflow-providers-common-compat",
+    "apache-airflow-providers-common-dataquality",
     "apache-airflow-providers-common-io",
     "apache-airflow-providers-common-messaging",
     "apache-airflow-providers-common-sql",
     "apache-airflow-providers-databricks",
     "apache-airflow-providers-datadog",
-    "apache-airflow-providers-common-dataquality",
     "apache-airflow-providers-dbt-cloud",
     "apache-airflow-providers-dingding",
     "apache-airflow-providers-discord",
@@ -1034,12 +1035,12 @@ all = [
     { name = "apache-airflow-providers-cohere" },
     { name = "apache-airflow-providers-common-ai" },
     { name = "apache-airflow-providers-common-compat" },
+    { name = "apache-airflow-providers-common-dataquality" },
     { name = "apache-airflow-providers-common-io" },
     { name = "apache-airflow-providers-common-messaging" },
     { name = "apache-airflow-providers-common-sql", extra = ["pandas", "polars"] },
     { name = "apache-airflow-providers-databricks" },
     { name = "apache-airflow-providers-datadog" },
-    { name = "apache-airflow-providers-common-dataquality" },
     { name = "apache-airflow-providers-dbt-cloud" },
     { name = "apache-airflow-providers-dingding" },
     { name = "apache-airflow-providers-discord" },
@@ -1221,6 +1222,9 @@ common-ai = [
 common-compat = [
     { name = "apache-airflow-providers-common-compat" },
 ]
+common-dataquality = [
+    { name = "apache-airflow-providers-common-dataquality" },
+]
 common-io = [
     { name = "apache-airflow-providers-common-io" },
 ]
@@ -1235,9 +1239,6 @@ databricks = [
 ]
 datadog = [
     { name = "apache-airflow-providers-datadog" },
-]
-common-dataquality = [
-    { name = "apache-airflow-providers-common-dataquality" },
 ]
 dbt-cloud = [
     { name = "apache-airflow-providers-dbt-cloud" },
@@ -1636,6 +1637,8 @@ requires-dist = [
     { name = "apache-airflow-providers-common-ai", marker = "extra == 'common-ai'", editable = "providers/common/ai" },
     { name = "apache-airflow-providers-common-compat", marker = "extra == 'all'", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-compat", marker = "extra == 'common-compat'", editable = "providers/common/compat" },
+    { name = "apache-airflow-providers-common-dataquality", marker = "extra == 'all'", editable = "providers/common/dataquality" },
+    { name = "apache-airflow-providers-common-dataquality", marker = "extra == 'common-dataquality'", editable = "providers/common/dataquality" },
     { name = "apache-airflow-providers-common-io", marker = "extra == 'all'", editable = "providers/common/io" },
     { name = "apache-airflow-providers-common-io", marker = "extra == 'common-io'", editable = "providers/common/io" },
     { name = "apache-airflow-providers-common-messaging", marker = "extra == 'all'", editable = "providers/common/messaging" },
@@ -1648,8 +1651,6 @@ requires-dist = [
     { name = "apache-airflow-providers-databricks", marker = "extra == 'databricks'", editable = "providers/databricks" },
     { name = "apache-airflow-providers-datadog", marker = "extra == 'all'", editable = "providers/datadog" },
     { name = "apache-airflow-providers-datadog", marker = "extra == 'datadog'", editable = "providers/datadog" },
-    { name = "apache-airflow-providers-common-dataquality", marker = "extra == 'all'", editable = "providers/common/dataquality" },
-    { name = "apache-airflow-providers-common-dataquality", marker = "extra == 'common-dataquality'", editable = "providers/common/dataquality" },
     { name = "apache-airflow-providers-dbt-cloud", marker = "extra == 'all'", editable = "providers/dbt/cloud" },
     { name = "apache-airflow-providers-dbt-cloud", marker = "extra == 'dbt-cloud'", editable = "providers/dbt/cloud" },
     { name = "apache-airflow-providers-dingding", marker = "extra == 'all'", editable = "providers/dingding" },
@@ -1796,7 +1797,7 @@ requires-dist = [
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.30.0" },
     { name = "uv", marker = "extra == 'uv'", specifier = ">=0.11.26" },
 ]
-provides-extras = ["all-core", "async", "graphviz", "gunicorn", "kerberos", "memray", "otel", "statsd", "all-task-sdk", "airbyte", "akeyless", "alibaba", "amazon", "anthropic", "apache-cassandra", "apache-drill", "apache-druid", "apache-flink", "apache-hdfs", "apache-hive", "apache-iceberg", "apache-impala", "apache-kafka", "apache-kylin", "apache-livy", "apache-pig", "apache-pinot", "apache-spark", "apache-tinkerpop", "apprise", "arangodb", "asana", "atlassian-jira", "celery", "clickhousedb", "cloudant", "cncf-kubernetes", "cohere", "common-ai", "common-compat", "common-io", "common-messaging", "common-sql", "databricks", "datadog", "common-dataquality", "dbt-cloud", "dingding", "discord", "docker", "edge3", "elasticsearch", "exasol", "fab", "facebook", "ftp", "git", "github", "google", "grpc", "hashicorp", "http", "ibm-mq", "imap", "influxdb", "informatica", "jdbc", "jenkins", "keycloak", "microsoft-azure", "microsoft-mssql", "microsoft-psrp", "microsoft-winrm", "mongo", "mysql", "neo4j", "odbc", "openai", "openfaas", "openlineage", "opensearch", "opsgenie", "oracle", "pagerduty", "papermill", "pgvector", "pinecone", "postgres", "presto", "qdrant", "redis", "salesforce", "samba", "segment", "sendgrid", "sftp", "singularity", "slack", "smtp", "snowflake", "sqlite", "ssh", "standard", "tableau", "telegram", "teradata", "trino", "vertica", "vespa", "weaviate", "yandex", "ydb", "zendesk", "all", "aiobotocore", "apache-atlas", "apache-webhdfs", "amazon-aws-auth", "cloudpickle", "github-enterprise", "google-auth", "ldap", "pandas", "polars", "rabbitmq", "sentry", "s3fs", "uv"]
+provides-extras = ["all-core", "async", "graphviz", "gunicorn", "kerberos", "memray", "otel", "statsd", "all-task-sdk", "airbyte", "akeyless", "alibaba", "amazon", "anthropic", "apache-cassandra", "apache-drill", "apache-druid", "apache-flink", "apache-hdfs", "apache-hive", "apache-iceberg", "apache-impala", "apache-kafka", "apache-kylin", "apache-livy", "apache-pig", "apache-pinot", "apache-spark", "apache-tinkerpop", "apprise", "arangodb", "asana", "atlassian-jira", "celery", "clickhousedb", "cloudant", "cncf-kubernetes", "cohere", "common-ai", "common-compat", "common-dataquality", "common-io", "common-messaging", "common-sql", "databricks", "datadog", "dbt-cloud", "dingding", "discord", "docker", "edge3", "elasticsearch", "exasol", "fab", "facebook", "ftp", "git", "github", "google", "grpc", "hashicorp", "http", "ibm-mq", "imap", "influxdb", "informatica", "jdbc", "jenkins", "keycloak", "microsoft-azure", "microsoft-mssql", "microsoft-psrp", "microsoft-winrm", "mongo", "mysql", "neo4j", "odbc", "openai", "openfaas", "openlineage", "opensearch", "opsgenie", "oracle", "pagerduty", "papermill", "pgvector", "pinecone", "postgres", "presto", "qdrant", "redis", "salesforce", "samba", "segment", "sendgrid", "sftp", "singularity", "slack", "smtp", "snowflake", "sqlite", "ssh", "standard", "tableau", "telegram", "teradata", "trino", "vertica", "vespa", "weaviate", "yandex", "ydb", "zendesk", "all", "aiobotocore", "apache-atlas", "apache-webhdfs", "amazon-aws-auth", "cloudpickle", "github-enterprise", "google-auth", "ldap", "pandas", "polars", "rabbitmq", "sentry", "s3fs", "uv"]
 
 [package.metadata.requires-dev]
 ci-image = [
@@ -4494,7 +4495,7 @@ requires-dist = [
     { name = "pyarrow", marker = "python_full_version >= '3.14' and extra == 'parquet'", specifier = ">=22.0.0" },
     { name = "pyarrow", marker = "python_full_version < '3.14' and extra == 'parquet'", specifier = ">=18.0.0" },
     { name = "pydantic-ai-harness", extras = ["codemode"], marker = "extra == 'code-mode'", specifier = ">=0.3.0" },
-    { name = "pydantic-ai-skills", marker = "extra == 'skills'", specifier = ">=0.11.0" },
+    { name = "pydantic-ai-skills", marker = "extra == 'skills'", specifier = ">=1.2.0" },
     { name = "pydantic-ai-slim", specifier = ">=2.0.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'" },
     { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'" },
@@ -4521,7 +4522,7 @@ dev = [
     { name = "llama-index-core", specifier = ">=0.13.0" },
     { name = "llama-index-embeddings-openai", specifier = ">=0.6.0" },
     { name = "llama-index-llms-openai", specifier = ">=0.6.0" },
-    { name = "pydantic-ai-skills", specifier = ">=0.11.0" },
+    { name = "pydantic-ai-skills", specifier = ">=1.2.0" },
     { name = "pydantic-ai-slim", extras = ["mcp"] },
     { name = "sqlglot", specifier = ">=30.0.0" },
 ]
@@ -4570,6 +4571,35 @@ dev = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-providers-openlineage", editable = "providers/openlineage" },
+    { name = "apache-airflow-task-sdk", editable = "task-sdk" },
+]
+docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
+
+[[package]]
+name = "apache-airflow-providers-common-dataquality"
+version = "0.1.0"
+source = { editable = "providers/common/dataquality" }
+dependencies = [
+    { name = "apache-airflow" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "apache-airflow" },
+    { name = "apache-airflow-devel-common" },
+    { name = "apache-airflow-task-sdk" },
+]
+docs = [
+    { name = "apache-airflow-devel-common", extra = ["docs"] },
+]
+
+[package.metadata]
+requires-dist = [{ name = "apache-airflow", editable = "." }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "apache-airflow", editable = "." },
+    { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
@@ -4903,37 +4933,6 @@ dev = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
-    { name = "apache-airflow-task-sdk", editable = "task-sdk" },
-]
-docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
-
-[[package]]
-name = "apache-airflow-providers-common-dataquality"
-version = "0.1.0"
-source = { editable = "providers/common/dataquality" }
-dependencies = [
-    { name = "apache-airflow" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "apache-airflow" },
-    { name = "apache-airflow-devel-common" },
-    { name = "apache-airflow-task-sdk" },
-]
-docs = [
-    { name = "apache-airflow-devel-common", extra = ["docs"] },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "apache-airflow", editable = "." },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "apache-airflow", editable = "." },
-    { name = "apache-airflow-devel-common", editable = "devel-common" },
     { name = "apache-airflow-task-sdk", editable = "task-sdk" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
@@ -6741,7 +6740,7 @@ source = { editable = "providers/openai" }
 dependencies = [
     { name = "apache-airflow" },
     { name = "apache-airflow-providers-common-compat" },
-    { name = "openai", extra = ["datalib"] },
+    { name = "openai" },
 ]
 
 [package.dev-dependencies]
@@ -6759,7 +6758,7 @@ docs = [
 requires-dist = [
     { name = "apache-airflow", editable = "." },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
-    { name = "openai", extras = ["datalib"], specifier = ">=2.37.0" },
+    { name = "openai", specifier = ">=2.37.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -17447,16 +17446,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
 ]
 
-[package.optional-dependencies]
-datalib = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pandas" },
-    { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-
 [[package]]
 name = "openapi-schema-validator"
 version = "0.9.0"
@@ -18099,48 +18088,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/b9/f2dfa655e840cda5bc6ac5404695bf132e2fcafb2d7dfa5d1c8ea26b524a/pandas_gbq-0.35.0.tar.gz", hash = "sha256:596c908487ef0649a161e86ef272c00c267e581b95dc5ee0dc3518545b33bcfc", size = 79219, upload-time = "2026-04-10T00:41:19.354Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/3d/2f0e9c5cbc456d34f48215645d876f7885a15e09a72a07d1de3ddb181c38/pandas_gbq-0.35.0-py3-none-any.whl", hash = "sha256:258de481019566611031919997bf9c1ece4ca30a4dd02d3fc3664b251d446182", size = 50773, upload-time = "2026-04-10T00:40:59.337Z" },
-]
-
-[[package]]
-name = "pandas-stubs"
-version = "2.3.3.260113"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "(python_full_version < '3.11' and platform_machine != 'arm64') or (python_full_version < '3.11' and sys_platform != 'darwin')",
-]
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "types-pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
-]
-
-[[package]]
-name = "pandas-stubs"
-version = "3.0.3.260530"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*'",
-    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "(python_full_version == '3.13.*' and platform_machine != 'arm64') or (python_full_version == '3.13.*' and sys_platform != 'darwin')",
-    "python_full_version == '3.12.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "(python_full_version == '3.12.*' and platform_machine != 'arm64') or (python_full_version == '3.12.*' and sys_platform != 'darwin')",
-    "python_full_version == '3.11.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "(python_full_version == '3.11.*' and platform_machine != 'arm64') or (python_full_version == '3.11.*' and sys_platform != 'darwin')",
-]
-dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
 ]
 
 [[package]]
@@ -19277,16 +19224,16 @@ codemode = [
 
 [[package]]
 name = "pydantic-ai-skills"
-version = "1.1.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "pydantic-ai-slim" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/0c/ee3e5bd2d003170f96f2fe5d1ec3f4525930183378841fb1b9147c5129cc/pydantic_ai_skills-1.1.0.tar.gz", hash = "sha256:66f85a63088a30863a3363a36830beedf60c32517473663c3da6557f1a838006", size = 9028209, upload-time = "2026-06-27T18:48:29.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/90/5f20728badc7d17ca0e81f24dc35a96c02f008323dce393d0e70a8465144/pydantic_ai_skills-1.2.0.tar.gz", hash = "sha256:e52f7e8243343dfa94206aae11cd142120edb8990fc392b1d8af32f99b6d351e", size = 9031839, upload-time = "2026-07-15T02:37:26.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/6c/406ce642127956ac3068bc12e0f64d876af53688ca6992ca5aa077926c3d/pydantic_ai_skills-1.1.0-py3-none-any.whl", hash = "sha256:72a0d9099f4562c96ed7f882f6b3e77589cd5e7d4c6d48c550904931ca56df1d", size = 62211, upload-time = "2026-06-27T18:48:27.272Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/74/143ca60dd9bfa11ce0349ee58bbdd646798c8bdc031588d67a8bea96797d/pydantic_ai_skills-1.2.0-py3-none-any.whl", hash = "sha256:7ff4eb4b307deb6ef3bf31a6d9493c1e3a8e9b866a13b866a9ea4606bd914206", size = 63883, upload-time = "2026-07-15T02:37:24.117Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`AgentSkillsToolset` gains an optional `exclude_resources` parameter — a list of glob patterns forwarded to `pydantic-ai-skills`' `SkillsToolset` that keeps matched files out of a skill's discovered resources. It mirrors the existing `exclude_tools` escape hatch and is resolved per-run on the worker (so nothing is baked into the serialized DAG).

## Why now

[`pydantic-ai-skills` 1.2.0](https://github.com/DougTrajano/pydantic-ai-skills/releases/tag/v1.2.0) broadened resource discovery from a fixed seven-extension allowlist (`.md/.json/.yaml/.yml/.csv/.xml/.txt`) to **every readable text file** in a skill bundle, so `.sql`, `.toml`, `.jinja`, and similar assets are exposed with no extra config ([DougTrajano/pydantic-ai-skills#54](https://github.com/DougTrajano/pydantic-ai-skills/issues/54), [#55](https://github.com/DougTrajano/pydantic-ai-skills/pull/55)).

That broader discovery also means more files reach the model, so `exclude_resources` is the trim knob for secrets or scratch files that happen to live in a skill directory. The two ship together: broaden discovery, and give users a way to narrow it back.

## Usage

```python
from airflow.providers.common.ai.toolsets.skills import AgentSkillsToolset

toolset = AgentSkillsToolset(
    sources=["./skills"],
    exclude_resources=["*.env", "secrets/*"],  # added on top of the built-in defaults
)
```

Patterns extend the built-in defaults (`__pycache__`, `*.pyc`, `*.pyo`, `.DS_Store`, `.git`) and match either the full skill-relative path or any single path component.

## Scope of the guarantee

`exclude_resources` hides files from **resource discovery only** — the resource list and the `read_skill_resource` tool. It does **not** stop a skill's `run_skill_script` from reading an excluded file off disk (a skill script runs as a subprocess with the worker's filesystem permissions). When files are genuinely sensitive, pair it with `exclude_tools={"run_skill_script"}`. This is called out in both the docstring and the toolset guide.

## Packaging notes

- The `[skills]` extra floor moves to `pydantic-ai-skills>=1.2.0` (the version that adds the parameter).
- 1.2.0 was published inside the repo's `exclude-newer = "4 days"` window, so a **temporary** per-package `exclude-newer-package` cutoff (`2026-07-16T00:00:00Z`) is added in both `[tool.uv.exclude-newer-package]` and `[tool.uv.pip.exclude-newer-package]` so it resolves. The comment marks it for removal once the rolling window advances past 2026-07-15.
- Regenerating `uv.lock` for the floor bump also picked up **pre-existing drift on `main`** unrelated to this change: the `openai` provider had already dropped its `[datalib]` extra in `pyproject.toml` but the lock was never refreshed, and `common-dataquality` is re-sorted. `uv lock` always fully syncs, so this churn is unavoidable when touching the lock.
