### PR TITLE
Remove duplicated dag_id and run_id fields from Execution API DagRun …

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -323,12 +323,6 @@ class AssetEventDagRunReference(StrictBaseModel):
 class DagRun(StrictBaseModel):
     """Schema for DagRun model with minimal required fields needed for Runtime."""
 
-    # TODO: `dag_id` and `run_id` are duplicated from TaskInstance
-    #   See if we can avoid sending these fields from API server and instead
-    #   use the TaskInstance data to get the DAG run information in the client (Task Execution Interface).
-    dag_id: str
-    run_id: str
-
     logical_date: UtcDateTime | None
     data_interval_start: UtcDateTime | None
     data_interval_end: UtcDateTime | None

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -701,7 +701,6 @@ class DagModelOperation(NamedTuple):
             if not dag.timetable.asset_condition:
                 dm.schedule_asset_references = []
                 dm.schedule_asset_alias_references = []
-            # FIXME: STORE NEW REFERENCES.
 
             if dag.tags:
                 _update_dag_tags(set(dag.tags), dm, session=session)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -253,8 +253,6 @@ class TestTIRunState:
         result = response.json()
         assert result == {
             "dag_run": {
-                "dag_id": ti.dag_id,
-                "run_id": "test",
                 "clear_number": 0,
                 "logical_date": instant_str,
                 "data_interval_start": instant.subtract(days=1).to_iso8601_string(),

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -968,8 +968,6 @@ class TestTIRunState:
         assert dag_run["triggering_user_name"] == "test_user"
 
         # Verify other expected fields are still present
-        assert dag_run["dag_id"] == ti.dag_id
-        assert dag_run["run_id"] == "test"
         assert dag_run["state"] == "running"
 
     @pytest.mark.parametrize(

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_04_28/test_task_instances.py
@@ -92,7 +92,7 @@ class TestTIUpdateState:
         result = response.json()
         # upstream_map_indexes is now computed by SDK, server returns None
         assert result["upstream_map_indexes"] is None
-        assert result["dag_run"]["dag_id"] == "dag"
+
         assert result["task_reschedule_count"] == 0
         assert result["max_tries"] == 0
         assert result["should_retry"] is False

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_09_23/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2025_09_23/test_task_instances.py
@@ -93,8 +93,6 @@ class TestTIRunStateV20250923:
         )
 
         # Verify other expected fields are still present
-        assert dag_run["dag_id"] == ti.dag_id
-        assert dag_run["run_id"] == "test"
         assert dag_run["state"] == "running"
         assert dag_run["conf"] == {}
 
@@ -151,6 +149,3 @@ class TestTIRunConfV20250923:
         # In older API versions, None should be converted to empty dict
         assert dag_run["conf"] == {}, "NULL conf should be converted to empty dict in API version 2025-09-23"
 
-        # Verify other expected fields
-        assert dag_run["dag_id"] == ti.dag_id
-        assert dag_run["run_id"] == "test"

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -762,8 +762,6 @@ class DagRun(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    dag_id: Annotated[str, Field(title="Dag Id")]
-    run_id: Annotated[str, Field(title="Run Id")]
     logical_date: Annotated[AwareDatetime | None, Field(title="Logical Date")] = None
     data_interval_start: Annotated[AwareDatetime | None, Field(title="Data Interval Start")] = None
     data_interval_end: Annotated[AwareDatetime | None, Field(title="Data Interval End")] = None

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -410,14 +410,8 @@ class AssetEventSourceTaskInstance:
     dag_run: DagRun
     task_id: str
     map_index: int
-
-    @property
-    def dag_id(self) -> str:
-        return self.dag_run.dag_id
-
-    @property
-    def run_id(self) -> str:
-        return self.dag_run.run_id
+    dag_id: str
+    run_id: str
 
     def xcom_pull(self, *, key: str = "return_value", default: Any = None) -> Any:
         from airflow.sdk.execution_time.xcom import XCom
@@ -459,6 +453,8 @@ class AssetEventResult(AssetEventResponse):
             dag_run=dag_run,
             task_id=self.source_task_id,
             map_index=self.source_map_index,
+            dag_id=self.source_dag_id,
+            run_id=self.source_run_id,
         )
 
 
@@ -511,6 +507,8 @@ class AssetEventDagRunReferenceResult(AssetEventDagRunReference):
             dag_run=dag_run,
             task_id=self.source_task_id,
             map_index=self.source_map_index,
+            dag_id=self.source_dag_id,
+            run_id=self.source_run_id,
         )
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -340,7 +340,7 @@ class RuntimeTaskInstance(TaskInstance):
                     AssetEventDagRunReferenceResult.from_asset_event_dag_run_reference(event)
                     for event in dag_run.consumed_asset_events
                 ),
-                "task_instance_key_str": f"{self.task.dag_id}__{self.task.task_id}__{dag_run.run_id}",
+                "task_instance_key_str": f"{self.task.dag_id}__{self.task.task_id}__{self.run_id}",
                 "task_reschedule_count": from_server.task_reschedule_count or 0,
                 "prev_start_date_success": lazy_object_proxy.Proxy(
                     lambda: coerce_datetime(get_previous_dagrun_success(self.id).start_date)

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -1534,8 +1534,6 @@ class TestDagRunOperations:
                 return httpx.Response(
                     status_code=200,
                     json={
-                        "dag_id": "test_dag",
-                        "run_id": "prev_run",
                         "logical_date": "2024-01-14T12:00:00+00:00",
                         "start_date": "2024-01-14T12:05:00+00:00",
                         "run_after": "2024-01-14T12:00:00+00:00",
@@ -1550,8 +1548,6 @@ class TestDagRunOperations:
         result = client.dag_runs.get_previous(dag_id="test_dag", logical_date=logical_date)
 
         assert isinstance(result, PreviousDagRunResult)
-        assert result.dag_run.dag_id == "test_dag"
-        assert result.dag_run.run_id == "prev_run"
         assert result.dag_run.state == "success"
 
     def test_get_previous_with_state_filter(self):
@@ -1569,8 +1565,6 @@ class TestDagRunOperations:
                 return httpx.Response(
                     status_code=200,
                     json={
-                        "dag_id": "test_dag",
-                        "run_id": "prev_success_run",
                         "logical_date": "2024-01-14T12:00:00+00:00",
                         "start_date": "2024-01-14T12:05:00+00:00",
                         "run_after": "2024-01-14T12:00:00+00:00",
@@ -1585,8 +1579,6 @@ class TestDagRunOperations:
         result = client.dag_runs.get_previous(dag_id="test_dag", logical_date=logical_date, state="success")
 
         assert isinstance(result, PreviousDagRunResult)
-        assert result.dag_run.dag_id == "test_dag"
-        assert result.dag_run.run_id == "prev_success_run"
         assert result.dag_run.state == "success"
 
     def test_get_previous_not_found(self):

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -693,7 +693,9 @@ class TestTriggeringAssetEventsAccessor:
         mock_dag_run = mock.Mock(dag_id="d1", run_id="r1")
         mock_supervisor_comms.send.side_effect = [mock_dag_run]
         source = events[0].source_task_instance
-        assert source == AssetEventSourceTaskInstance(dag_run=mock_dag_run, task_id="t2", map_index=-1)
+        assert source == AssetEventSourceTaskInstance(
+            dag_run=mock_dag_run, task_id="t2", map_index=-1, dag_id="d1", run_id="r1"
+        )
         assert mock_supervisor_comms.send.mock_calls == [mock.call(GetDagRun(dag_id="d1", run_id="r1"))]
 
         mock_supervisor_comms.reset_mock()
@@ -1027,7 +1029,9 @@ class TestInletEventAccessor:
         mock_supervisor_comms.send.side_effect = [dag_run_result]
         assert events[1].source_task_instance is None
         source = events[0].source_task_instance
-        assert source == AssetEventSourceTaskInstance(dag_run=dag_run_result, task_id="__task__", map_index=0)
+        assert source == AssetEventSourceTaskInstance(
+            dag_run=dag_run_result, task_id="__task__", map_index=0, dag_id="__dag__", run_id="__run__"
+        )
         assert mock_supervisor_comms.send.mock_calls == [
             mock.call(GetDagRun(dag_id="__dag__", run_id="__run__"))
         ]


### PR DESCRIPTION
Removes the `dag_id` and `run_id` fields from the Execution API `DagRun` schema (`airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py`).

These fields are redundant because the worker already has the DAG ID and Run ID natively from the `TaskInstance` context. This resolves an existing `TODO` in the codebase and streamlines the JSON payload. The Task SDK client (`task_runner.py`) has been updated to rely on the `TaskInstance` identifiers instead of expecting them to be nested in the `DagRun` payload.

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

-->

---

closes: #69935
##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

<!--
Generated-by: Antigravity following the guidelines (https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-28T17:14:04Z head=8a4295d action=close -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @KushagraB424** · by `@potiuk` · 2026-07-28 17:14 UTC
>
> This draft PR has been inactive since the last triage note, with no response from the author. Closing to keep the queue clean:
> - You are welcome to reopen this PR when you resume work, or open a new one addressing the issues previously raised.
> - If you pick it back up, please rebase onto the current `main` branch first.
>
> **The ball is in your court** — you've been assigned to this PR. Reopen or open a fresh PR once addressed — no rush.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
