### PR TITLE
validate id_token audience in azure and authentik oauth login

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/security_manager/override.py
@@ -156,6 +156,17 @@ log = logging.getLogger(__name__)
 MAX_NUM_DATABASE_USER_SESSIONS = 50000
 
 
+def _id_token_claims_options(client_id: str) -> dict[str, Any]:
+    """
+    Build the claims options used to validate an OAuth ID token.
+
+    ``authlib``'s ``validate_aud`` is a no-op unless an ``aud`` option is supplied, so the audience has to
+    be pinned explicitly here for OIDC Core 3.1.3.7 to hold: an ID token is only for us if it was issued to
+    our own ``client_id``.
+    """
+    return {"aud": {"essential": True, "values": [client_id]}}
+
+
 class FabException(Exception):
     """Custom exception for FAB security manager."""
 
@@ -404,11 +415,11 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             return resp.json()
         return {}
 
-    def _validate_jwt(self, id_token, jwks):
+    def _validate_jwt(self, id_token, jwks, audience):
         from authlib.jose import JsonWebKey, jwt as authlib_jwt
 
         keyset = JsonWebKey.import_key_set(jwks)
-        claims = authlib_jwt.decode(id_token, keyset)
+        claims = authlib_jwt.decode(id_token, keyset, claims_options=_id_token_claims_options(audience))
         claims.validate()
         log.info("JWT token is validated")
         return claims
@@ -421,7 +432,7 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             if jwks_uri:
                 jwks = self._get_authentik_jwks(jwks_uri)
                 if jwks:
-                    return self._validate_jwt(id_token, jwks)
+                    return self._validate_jwt(id_token, jwks, self.oauth_remotes["authentik"].client_id)
             else:
                 log.error("jwks_uri not specified in OAuth Providers, could not verify token signature")
         else:
@@ -2429,7 +2440,11 @@ class FabAirflowSecurityManagerOverride(AirflowSecurityManagerV2):
             from authlib.jose import JsonWebKey, jwt as authlib_jwt
 
             keyset = JsonWebKey.import_key_set(self._get_microsoft_jwks())  # type: ignore
-            claims = authlib_jwt.decode(id_token, keyset)
+            claims = authlib_jwt.decode(
+                id_token,
+                keyset,
+                claims_options=_id_token_claims_options(self.oauth_remotes["azure"].client_id),
+            )
             claims.validate()
             return claims
 

--- a/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
+++ b/providers/fab/tests/unit/fab/auth_manager/security_manager/test_override.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import time
 from unittest import mock
 from unittest.mock import Mock, call
 
@@ -36,6 +37,21 @@ from airflow.providers.fab.auth_manager.security_manager.override import (
     FabAirflowSecurityManagerOverride,
     FabException,
 )
+
+
+def _generate_jwks():
+    """Return a private signing key and the matching public JWKS."""
+    from authlib.jose import JsonWebKey
+
+    key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    return key, {"keys": [key.as_dict(is_private=False)]}
+
+
+def _sign_id_token(key, claims):
+    from authlib.jose import jwt as authlib_jwt
+
+    payload = {"iss": "https://issuer.example", "exp": int(time.time()) + 3600, **claims}
+    return authlib_jwt.encode({"alg": "RS256", "kid": key.as_dict()["kid"]}, payload, key).decode()
 
 
 class EmptySecurityManager(FabAirflowSecurityManagerOverride):
@@ -503,6 +519,76 @@ class TestFabAirflowSecurityManagerOverride:
 
         mock_jwks.assert_not_called()
         assert result == {"oid": "user-1"}
+
+    def test_decode_and_validate_azure_jwt_rejects_foreign_audience(self):
+        """An id_token minted for another client is rejected even though its signature is valid.
+
+        The Microsoft JWKS are the ``/common/`` multi-tenant keyset, so a token from any Azure AD tenant
+        carries a signature that verifies against it.
+        """
+        from authlib.jose.errors import InvalidClaimError
+
+        key, jwks = _generate_jwks()
+        id_token = _sign_id_token(key, {"aud": "some-other-client", "oid": "attacker"})
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {"azure": Mock(client_kwargs={}, client_id="airflow-client-id")}
+
+        with mock.patch.object(EmptySecurityManager, "_get_microsoft_jwks", return_value=jwks):
+            with pytest.raises(InvalidClaimError, match="aud"):
+                sm._decode_and_validate_azure_jwt(id_token)
+
+    def test_decode_and_validate_azure_jwt_accepts_own_audience(self):
+        """An id_token issued to the configured client_id still validates."""
+        key, jwks = _generate_jwks()
+        id_token = _sign_id_token(key, {"aud": "airflow-client-id", "oid": "user-1"})
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {"azure": Mock(client_kwargs={}, client_id="airflow-client-id")}
+
+        with mock.patch.object(EmptySecurityManager, "_get_microsoft_jwks", return_value=jwks):
+            claims = sm._decode_and_validate_azure_jwt(id_token)
+
+        assert claims["oid"] == "user-1"
+
+    def test_get_authentik_token_info_rejects_foreign_audience(self):
+        """An id_token minted for another client of the same authentik instance is rejected."""
+        from authlib.jose.errors import InvalidClaimError
+
+        key, jwks = _generate_jwks()
+        id_token = _sign_id_token(key, {"aud": "some-other-client", "nickname": "attacker"})
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "authentik": Mock(
+                client_kwargs={},
+                client_id="airflow-client-id",
+                server_metadata={"jwks_uri": "https://authentik.example/jwks"},
+            )
+        }
+
+        with mock.patch.object(EmptySecurityManager, "_get_authentik_jwks", return_value=jwks):
+            with pytest.raises(InvalidClaimError, match="aud"):
+                sm._get_authentik_token_info(id_token)
+
+    def test_get_authentik_token_info_accepts_own_audience(self):
+        """An id_token issued to the configured client_id still validates."""
+        key, jwks = _generate_jwks()
+        id_token = _sign_id_token(key, {"aud": "airflow-client-id", "nickname": "user-1"})
+
+        sm = EmptySecurityManager()
+        sm.oauth_remotes = {
+            "authentik": Mock(
+                client_kwargs={},
+                client_id="airflow-client-id",
+                server_metadata={"jwks_uri": "https://authentik.example/jwks"},
+            )
+        }
+
+        with mock.patch.object(EmptySecurityManager, "_get_authentik_jwks", return_value=jwks):
+            claims = sm._get_authentik_token_info(id_token)
+
+        assert claims["nickname"] == "user-1"
 
 
 def test_ldap_search_escapes_username_and_validates_filter():


### PR DESCRIPTION
`_decode_and_validate_azure_jwt` and `_validate_jwt` in the FAB security manager decode the OAuth id_token with authlib and call `claims.validate()` without passing `claims_options`, and authlib's `validate_aud` returns early when no `aud` option is supplied, so the audience is never checked against our own `client_id`. For azure the keyset comes from `MICROSOFT_KEY_SET_URL`, the `/common/` multi-tenant JWKS, so an id_token minted in any attacker-registered Azure AD tenant carries a signature that verifies, and `get_oauth_user_info` then takes `username` from `oid` and `role_keys` from the token's own `roles` claim, which the attacker controls in their own app registration; on the authentik path the issuer is pinned by the configured `jwks_uri`, but a token issued to any other client of the same instance is still accepted. Pin the expected audience to the configured `client_id` at both decode sites so a token that was not issued to this deployment is rejected.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---