### PR TITLE
Allow configuring key names in database credential secrets

### DIFF
--- a/chart/docs/production-guide.rst
+++ b/chart/docs/production-guide.rst
@@ -88,6 +88,21 @@ After secret creation, configure the chart to use the secret:
    data:
      metadataSecretName: mydatabase
 
+If your secret stores the connection string under a key other than ``connection`` (for
+example, `CloudNativePG <https://cloudnative-pg.io/>`_ generates credential secrets with
+the connection URI under the ``uri`` key), set ``metadataSecretKey`` accordingly:
+
+.. code-block:: yaml
+   :caption: values.yaml
+
+   data:
+     metadataSecretName: mydatabase-app
+     metadataSecretKey: uri
+
+Similarly, ``resultBackendSecretKey`` and ``brokerUrlSecretKey`` configure the key names
+used with ``resultBackendSecretName`` and ``brokerUrlSecretName``. All of these default to
+``connection`` and only apply when the corresponding secret name is provided.
+
 .. _production-guide:pgbouncer:
 
 Metadata DB Cleanup

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -75,14 +75,14 @@ If release name contains chart name it will be used as a full name.
     valueFrom:
       secretKeyRef:
         name: {{ template "airflow_metadata_secret" . }}
-        key: connection
+        key: {{ template "airflow_metadata_secret_key" . }}
   {{- end }}
   {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW_CONN_AIRFLOW_DB }}
   - name: AIRFLOW_CONN_AIRFLOW_DB
     valueFrom:
       secretKeyRef:
         name: {{ template "airflow_metadata_secret" . }}
-        key: connection
+        key: {{ template "airflow_metadata_secret_key" . }}
   {{- end }}
   {{- $triggererKedaEnabled := and .Values.triggerer.enabled .Values.triggerer.keda.enabled }}
   {{- $workersKedaNeedsDbConn := and .Values.workers.celery.keda.enabled (or (eq .Values.data.metadataConnection.protocol "mysql") (and .Values.pgbouncer.enabled (not .Values.workers.celery.keda.usePgbouncer))) }}
@@ -114,14 +114,14 @@ If release name contains chart name it will be used as a full name.
     valueFrom:
       secretKeyRef:
         name: {{ template "airflow_result_backend_secret" . }}
-        key: connection
+        key: {{ template "airflow_result_backend_secret_key" . }}
     {{- end }}
     {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CELERY__BROKER_URL }}
   - name: AIRFLOW__CELERY__BROKER_URL
     valueFrom:
       secretKeyRef:
         name: {{ template "airflow_broker_url_secret" . }}
-        key: connection
+        key: {{ template "airflow_broker_url_secret_key" . }}
     {{- end }}
   {{- end }}
   {{- if and .Values.elasticsearch.enabled .Values.enableBuiltInSecretEnvVars.AIRFLOW__ELASTICSEARCH__HOST }}
@@ -449,6 +449,30 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "airflow_result_backend_secret" -}}
   {{- default (printf "%s-result-backend" (include "airflow.fullname" .)) .Values.data.resultBackendSecretName }}
+{{- end }}
+
+{{- define "airflow_metadata_secret_key" -}}
+  {{- if .Values.data.metadataSecretName -}}
+    {{- .Values.data.metadataSecretKey | default "connection" -}}
+  {{- else -}}
+    connection
+  {{- end -}}
+{{- end }}
+
+{{- define "airflow_result_backend_secret_key" -}}
+  {{- if .Values.data.resultBackendSecretName -}}
+    {{- .Values.data.resultBackendSecretKey | default "connection" -}}
+  {{- else -}}
+    connection
+  {{- end -}}
+{{- end }}
+
+{{- define "airflow_broker_url_secret_key" -}}
+  {{- if .Values.data.brokerUrlSecretName -}}
+    {{- .Values.data.brokerUrlSecretKey | default "connection" -}}
+  {{- else -}}
+    connection
+  {{- end -}}
 {{- end }}
 
 {{- define "airflow_pod_template_file" -}}

--- a/chart/tests/helm_tests/airflow_aux/test_airflow_common.py
+++ b/chart/tests/helm_tests/airflow_aux/test_airflow_common.py
@@ -567,3 +567,98 @@ class TestAirflowCommon:
 
         for doc in docs:
             assert matcher(doc) == enable_service_links
+
+
+class TestDatabaseSecretKeys:
+    """Tests for configurable key names in database credential secrets."""
+
+    @staticmethod
+    def _secret_refs(doc):
+        env = jmespath.search("spec.template.spec.containers[0].env", doc)
+        return {
+            e["name"]: e["valueFrom"]["secretKeyRef"]
+            for e in env
+            if e.get("valueFrom", {}).get("secretKeyRef")
+        }
+
+    def test_metadata_secret_key_defaults_to_connection(self):
+        docs = render_chart(
+            values={"data": {"metadataSecretName": "my-metadata-secret"}},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        assert refs["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"]["key"] == "connection"
+        assert refs["AIRFLOW_CONN_AIRFLOW_DB"]["key"] == "connection"
+
+    def test_metadata_secret_key_custom(self):
+        docs = render_chart(
+            values={"data": {"metadataSecretName": "cnpg-cluster-app", "metadataSecretKey": "uri"}},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        for var in ("AIRFLOW__DATABASE__SQL_ALCHEMY_CONN", "AIRFLOW_CONN_AIRFLOW_DB"):
+            assert refs[var]["name"] == "cnpg-cluster-app"
+            assert refs[var]["key"] == "uri"
+
+    def test_metadata_secret_key_ignored_for_chart_created_secret(self):
+        docs = render_chart(
+            values={"data": {"metadataSecretKey": "uri"}},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        assert refs["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"]["key"] == "connection"
+        assert refs["AIRFLOW_CONN_AIRFLOW_DB"]["key"] == "connection"
+
+    def test_result_backend_secret_key_custom(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "data": {"resultBackendSecretName": "my-rb-secret", "resultBackendSecretKey": "uri"},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        assert refs["AIRFLOW__CELERY__RESULT_BACKEND"]["name"] == "my-rb-secret"
+        assert refs["AIRFLOW__CELERY__RESULT_BACKEND"]["key"] == "uri"
+
+    def test_result_backend_secret_key_ignored_for_chart_created_secret(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "data": {
+                    "resultBackendConnection": {
+                        "user": "postgres",
+                        "pass": "postgres",
+                        "protocol": "postgresql",
+                        "host": "example",
+                        "port": 5432,
+                        "db": "postgres",
+                        "sslmode": "disable",
+                    },
+                    "resultBackendSecretKey": "uri",
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        assert refs["AIRFLOW__CELERY__RESULT_BACKEND"]["key"] == "connection"
+
+    def test_broker_url_secret_key_custom(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "data": {"brokerUrlSecretName": "my-broker-secret", "brokerUrlSecretKey": "url"},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        assert refs["AIRFLOW__CELERY__BROKER_URL"]["name"] == "my-broker-secret"
+        assert refs["AIRFLOW__CELERY__BROKER_URL"]["key"] == "url"
+
+    def test_broker_url_secret_key_ignored_for_chart_created_secret(self):
+        docs = render_chart(
+            values={"executor": "CeleryExecutor", "data": {"brokerUrlSecretKey": "url"}},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        refs = self._secret_refs(docs[0])
+        assert refs["AIRFLOW__CELERY__BROKER_URL"]["key"] == "connection"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1315,6 +1315,14 @@
                     ],
                     "default": null
                 },
+                "metadataSecretKey": {
+                    "description": "Key in the metadata connection secret containing the connection string. Only used when `metadataSecretName` is set. Defaults to `connection`.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
                 "resultBackendSecretName": {
                     "description": "Result backend connection string secret.",
                     "type": [
@@ -1323,8 +1331,25 @@
                     ],
                     "default": null
                 },
+                "resultBackendSecretKey": {
+                    "description": "Key in the result backend connection secret containing the connection string. Only used when `resultBackendSecretName` is set. Defaults to `connection`.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
                 "brokerUrlSecretName": {
                     "description": "Redis broker URL secret.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "x-docsSection": "Redis",
+                    "default": null
+                },
+                "brokerUrlSecretKey": {
+                    "description": "Key in the broker URL secret containing the broker URL. Only used when `brokerUrlSecretName` is set. Defaults to `connection`.",
                     "type": [
                         "string",
                         "null"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1316,7 +1316,7 @@
                     "default": null
                 },
                 "metadataSecretKey": {
-                    "description": "Key in the metadata connection secret containing the connection string. Only used when `metadataSecretName` is set. Defaults to `connection`.",
+                    "description": "Key in the metadata connection secret containing the connection string. Only used when `metadataSecretName` is set.",
                     "type": [
                         "string",
                         "null"
@@ -1332,7 +1332,7 @@
                     "default": null
                 },
                 "resultBackendSecretKey": {
-                    "description": "Key in the result backend connection secret containing the connection string. Only used when `resultBackendSecretName` is set. Defaults to `connection`.",
+                    "description": "Key in the result backend connection secret containing the connection string. Only used when `resultBackendSecretName` is set.",
                     "type": [
                         "string",
                         "null"
@@ -1349,7 +1349,7 @@
                     "default": null
                 },
                 "brokerUrlSecretKey": {
-                    "description": "Key in the broker URL secret containing the broker URL. Only used when `brokerUrlSecretName` is set. Defaults to `connection`.",
+                    "description": "Key in the broker URL secret containing the broker URL. Only used when `brokerUrlSecretName` is set.",
                     "type": [
                         "string",
                         "null"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -445,12 +445,23 @@ data:
   #   postgresql+psycopg2://airflow:password@postgres/airflow
   metadataSecretName: ~
 
+  # When `metadataSecretName` is set, the key in that secret containing the connection string.
+  # Useful when the secret is managed externally, e.g. CloudNativePG stores the URI under the "uri" key.
+  metadataSecretKey: ~
+
   # If not set, falls back to metadataSecretName. The secret must contain 'connection' key which is
   # a base64-encoded connection string, e.g.:
   #   postgresql+psycopg2://user:password@host/db
   resultBackendSecretName: ~
 
+  # When `resultBackendSecretName` is set, the key in that secret containing the result backend
+  # connection string.
+  resultBackendSecretKey: ~
+
   brokerUrlSecretName: ~
+
+  # When `brokerUrlSecretName` is set, the key in that secret containing the broker URL.
+  brokerUrlSecretKey: ~
 
   # If `metadataSecretName` is not specified, pass connection values below
   metadataConnection:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -445,7 +445,7 @@ data:
   #   postgresql+psycopg2://airflow:password@postgres/airflow
   metadataSecretName: ~
 
-  # When `metadataSecretName` is set, the key in that secret containing the connection string.
+  # When `metadataSecretName` is set, the key in that secret contains the connection string.
   # Useful when the secret is managed externally, e.g. CloudNativePG stores the URI under the "uri" key.
   metadataSecretKey: ~
 
@@ -454,13 +454,13 @@ data:
   #   postgresql+psycopg2://user:password@host/db
   resultBackendSecretName: ~
 
-  # When `resultBackendSecretName` is set, the key in that secret containing the result backend
+  # When `resultBackendSecretName` is set, the key in that secret contains the result backend
   # connection string.
   resultBackendSecretKey: ~
 
   brokerUrlSecretName: ~
 
-  # When `brokerUrlSecretName` is set, the key in that secret containing the broker URL.
+  # When `brokerUrlSecretName` is set, the key in that secret contains the broker URL.
   brokerUrlSecretKey: ~
 
   # If `metadataSecretName` is not specified, pass connection values below


### PR DESCRIPTION
## Why

The chart hardcodes `key: connection` in the `secretKeyRef` for `AIRFLOW__DATABASE__SQL_ALCHEMY_CONN`, `AIRFLOW_CONN_AIRFLOW_DB`, `AIRFLOW__CELERY__RESULT_BACKEND`, and `AIRFLOW__CELERY__BROKER_URL`. Externally managed secrets that store the connection string under a different key cannot be used with `data.metadataSecretName` / `resultBackendSecretName` / `brokerUrlSecretName` — the concrete case from the issue is CloudNativePG, whose `Cluster` app secrets expose the connection URI under the `uri` key.

Builds on the approach from #54037, which was closed by the stale bot without receiving review.

## What

- New values `data.metadataSecretKey`, `data.resultBackendSecretKey`, `data.brokerUrlSecretKey`, all defaulting to `connection` — fully backward compatible.
- One deliberate difference from #54037: the custom key **only applies when the corresponding `*SecretName` is user-provided**. Applying it unconditionally would break deployments, because the chart-created secrets (`metadata-connection-secret.yaml`, `result-backend-connection-secret.yaml`, `redis-secrets.yaml`) always write their data under the `connection` key — the env refs would point at a key that doesn't exist. Implemented as three `airflow_*_secret_key` named templates alongside the existing `airflow_*_secret` name helpers.
- KEDA's `kedaConnection` key and the elasticsearch/opensearch host secrets are intentionally out of scope: `kedaConnection` is a chart-managed key with its own format contract, and the es/os secrets can be a follow-up if there's interest (the issue is scoped to database credentials).
- Docs: note + CloudNativePG example in the production guide's Kubernetes Secret section; schema and `values.yaml` comments updated.

## Tests

There was previously no test coverage asserting the `secretKeyRef` keys of the built-in secret env vars, so this adds a regression guard for the default `connection` behavior as well:

- default key remains `connection` when only `*SecretName` is set
- custom key is rendered for all consuming env vars when set together with `*SecretName`
- custom key is ignored when the secret is chart-created (no `*SecretName`), for all three secrets

closes: #57860
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Claude Fable 5

Generated-by: [Claude Fable 5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-28T16:32:28Z head=e16b802 action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @PreethamSanji** · by `@potiuk` · 2026-07-28 16:32 UTC
>
> Some review feedback from `Miretpl` is waiting on you:
> - There are **6 unresolved review threads** on this PR from `Miretpl`.
>
> **The ball is in your court** — you've been assigned to this PR. Push a fix or reply in each thread explaining why the feedback does not apply, then mark them resolved and ping the reviewer (`Miretpl`) for a final look.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **298 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
