### PR TITLE
Fix date range filter updating on each keystroke

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateInput.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateInput.tsx
@@ -37,6 +37,7 @@ type DateInputProps = {
   readonly onClear: () => void;
   readonly onDateBlur?: () => void;
   readonly onFocus?: () => void;
+  readonly onKeyDown?: (event: React.KeyboardEvent) => void;
   readonly placeholder: string;
 };
 
@@ -51,6 +52,7 @@ export const DateInput = ({
   onClear,
   onDateBlur,
   onFocus,
+  onKeyDown,
   placeholder,
 }: DateInputProps) => {
   const fieldName = inputType === "date" ? field : (`${field}Time` as const);
@@ -69,6 +71,7 @@ export const DateInput = ({
           onBlur={onDateBlur}
           onChange={handleInputChange(field, inputType)}
           onFocus={onFocus}
+          onKeyDown={onKeyDown}
           placeholder={placeholder}
           value={inputValue}
           w="full"

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.tsx
@@ -148,7 +148,6 @@ export const DateRangeFilter = ({ filter, onChange, onRemove }: FilterPluginProp
                 endDateValue={endDateValue}
                 getFieldError={getFieldError}
                 handleInputChange={handleInputChange}
-                onApply={applyDateRange}
                 onChange={onChange}
                 setEditingState={setEditingState}
                 startDateValue={startDateValue}

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.tsx
@@ -39,13 +39,13 @@ export const DateRangeFilter = ({ filter, onChange, onRemove }: FilterPluginProp
   const hasValue = isValidFilterValue(filter.config.type, filter.value);
 
   const {
+    applyDateRange,
     editingState,
     endDateValue,
     formatDisplayValue,
     getFieldError,
     handleDateClick,
     handleInputChange,
-    applyDateRange,
     setEditingState,
     startDateValue,
   } = useDateRangeFilter({

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeFilter.tsx
@@ -45,6 +45,7 @@ export const DateRangeFilter = ({ filter, onChange, onRemove }: FilterPluginProp
     getFieldError,
     handleDateClick,
     handleInputChange,
+    applyDateRange,
     setEditingState,
     startDateValue,
   } = useDateRangeFilter({
@@ -64,6 +65,12 @@ export const DateRangeFilter = ({ filter, onChange, onRemove }: FilterPluginProp
           defaultOpen={!hasValue}
           key={filter.id}
           lazyMount
+          onOpenChange={(details) => {
+            if (!details.open) {
+              // Submit the current editing state when the popover closes
+              applyDateRange();
+            }
+          }}
           positioning={{ placement: "bottom-start" }}
           unmountOnExit
         >
@@ -141,6 +148,7 @@ export const DateRangeFilter = ({ filter, onChange, onRemove }: FilterPluginProp
                 endDateValue={endDateValue}
                 getFieldError={getFieldError}
                 handleInputChange={handleInputChange}
+                onApply={applyDateRange}
                 onChange={onChange}
                 setEditingState={setEditingState}
                 startDateValue={startDateValue}

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeInputs.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeInputs.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { HStack, Text, VStack } from "@chakra-ui/react";
+import { Button, HStack, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import type { TFunction } from "i18next";
 import { MdAccessTime } from "react-icons/md";
@@ -36,6 +36,7 @@ type DateRangeInputsProps = {
     field: "end" | "start",
     inputType: "date" | "time",
   ) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+  readonly onApply?: () => void;
   readonly onChange: (value: DateRangeValue) => void;
   readonly setEditingState: React.Dispatch<React.SetStateAction<DateRangeEditingState>>;
   readonly startDateValue: dayjs.Dayjs | undefined;
@@ -48,6 +49,7 @@ export const DateRangeInputs = ({
   endDateValue,
   getFieldError,
   handleInputChange,
+  onApply,
   onChange,
   setEditingState,
   startDateValue,
@@ -55,6 +57,12 @@ export const DateRangeInputs = ({
   value,
 }: DateRangeInputsProps) => {
   const { selectedTimezone } = useTimezone();
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" && onApply) {
+      onApply();
+    }
+  };
 
   const getBorderColor = (fieldName: ValidationError["field"]) => {
     if (getFieldError(fieldName)) {
@@ -137,6 +145,7 @@ export const DateRangeInputs = ({
           onClear={() => clearField("start")}
           onDateBlur={handleDateBlur("start")}
           onFocus={handleFocus("start")}
+          onKeyDown={handleKeyDown}
           placeholder={DATE_INPUT_FORMAT}
         />
 
@@ -151,6 +160,7 @@ export const DateRangeInputs = ({
           onClear={() => clearField("end")}
           onDateBlur={handleDateBlur("end")}
           onFocus={handleFocus("end")}
+          onKeyDown={handleKeyDown}
           placeholder={DATE_INPUT_FORMAT}
         />
       </HStack>
@@ -165,6 +175,7 @@ export const DateRangeInputs = ({
           inputValue={editingState.inputs.startTime}
           label={translate("common:filters.startTime")}
           onClear={clearTime("start")}
+          onKeyDown={handleKeyDown}
           placeholder={TIME_INPUT_FORMAT}
         />
 
@@ -177,6 +188,7 @@ export const DateRangeInputs = ({
           inputValue={editingState.inputs.endTime}
           label={translate("common:filters.endTime")}
           onClear={clearTime("end")}
+          onKeyDown={handleKeyDown}
           placeholder={TIME_INPUT_FORMAT}
         />
       </HStack>
@@ -185,6 +197,20 @@ export const DateRangeInputs = ({
         <Text color="danger.fg" fontSize="xs" textAlign="center">
           {getFieldError("range")?.message}
         </Text>
+      )}
+
+      {onApply && (
+        <Button
+          borderRadius="md"
+          colorPalette="blue"
+          disabled={editingState.validationErrors.length > 0}
+          mt={1}
+          onClick={onApply}
+          size="sm"
+          width="full"
+        >
+          Apply
+        </Button>
       )}
     </VStack>
   );

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeInputs.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/filters/DateRangeInputs.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Button, HStack, Text, VStack } from "@chakra-ui/react";
+import { HStack, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import type { TFunction } from "i18next";
 import { MdAccessTime } from "react-icons/md";
@@ -36,7 +36,6 @@ type DateRangeInputsProps = {
     field: "end" | "start",
     inputType: "date" | "time",
   ) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-  readonly onApply?: () => void;
   readonly onChange: (value: DateRangeValue) => void;
   readonly setEditingState: React.Dispatch<React.SetStateAction<DateRangeEditingState>>;
   readonly startDateValue: dayjs.Dayjs | undefined;
@@ -49,7 +48,6 @@ export const DateRangeInputs = ({
   endDateValue,
   getFieldError,
   handleInputChange,
-  onApply,
   onChange,
   setEditingState,
   startDateValue,
@@ -57,12 +55,6 @@ export const DateRangeInputs = ({
   value,
 }: DateRangeInputsProps) => {
   const { selectedTimezone } = useTimezone();
-
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" && onApply) {
-      onApply();
-    }
-  };
 
   const getBorderColor = (fieldName: ValidationError["field"]) => {
     if (getFieldError(fieldName)) {
@@ -145,7 +137,6 @@ export const DateRangeInputs = ({
           onClear={() => clearField("start")}
           onDateBlur={handleDateBlur("start")}
           onFocus={handleFocus("start")}
-          onKeyDown={handleKeyDown}
           placeholder={DATE_INPUT_FORMAT}
         />
 
@@ -160,7 +151,6 @@ export const DateRangeInputs = ({
           onClear={() => clearField("end")}
           onDateBlur={handleDateBlur("end")}
           onFocus={handleFocus("end")}
-          onKeyDown={handleKeyDown}
           placeholder={DATE_INPUT_FORMAT}
         />
       </HStack>
@@ -175,7 +165,6 @@ export const DateRangeInputs = ({
           inputValue={editingState.inputs.startTime}
           label={translate("common:filters.startTime")}
           onClear={clearTime("start")}
-          onKeyDown={handleKeyDown}
           placeholder={TIME_INPUT_FORMAT}
         />
 
@@ -188,7 +177,6 @@ export const DateRangeInputs = ({
           inputValue={editingState.inputs.endTime}
           label={translate("common:filters.endTime")}
           onClear={clearTime("end")}
-          onKeyDown={handleKeyDown}
           placeholder={TIME_INPUT_FORMAT}
         />
       </HStack>
@@ -197,20 +185,6 @@ export const DateRangeInputs = ({
         <Text color="danger.fg" fontSize="xs" textAlign="center">
           {getFieldError("range")?.message}
         </Text>
-      )}
-
-      {onApply && (
-        <Button
-          borderRadius="md"
-          colorPalette="blue"
-          disabled={editingState.validationErrors.length > 0}
-          mt={1}
-          onClick={onApply}
-          size="sm"
-          width="full"
-        >
-          Apply
-        </Button>
       )}
     </VStack>
   );

--- a/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
@@ -19,7 +19,7 @@
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import type { TFunction } from "i18next";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import type { DateRangeValue } from "src/components/FilterBar/types";
 import { isValidDateValue } from "src/components/FilterBar/utils";
@@ -304,7 +304,7 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
 
   const hasValidationErrors = editingState.validationErrors.length > 0;
 
-  const applyDateRange = useCallback(() => {
+  const applyDateRange = () => {
     const { inputs } = editingState;
     const errors = validateInputs(inputs);
 
@@ -325,7 +325,7 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
       endDate: endDateTime,
       startDate: startDateTime,
     });
-  }, [editingState, onChange, selectedTimezone, value]);
+  };
 
   return {
     editingState,

--- a/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
@@ -328,6 +328,7 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
   };
 
   return {
+    applyDateRange,
     editingState,
     endDateValue,
     formatDisplayValue,
@@ -337,6 +338,5 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
     hasValidationErrors,
     setEditingState,
     startDateValue,
-    applyDateRange,
   };
 };

--- a/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useDateRangeFilter.ts
@@ -19,7 +19,7 @@
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import type { TFunction } from "i18next";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { DateRangeValue } from "src/components/FilterBar/types";
 import { isValidDateValue } from "src/components/FilterBar/utils";
@@ -260,20 +260,6 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
         const newInputs = { ...prev.inputs, [inputKey]: inputValue };
         const validationErrors = validateInputs(newInputs);
 
-        const dateStr = field === "start" ? newInputs.start : newInputs.end;
-        const timeStr = field === "start" ? newInputs.startTime : newInputs.endTime;
-
-        if (dayjs(dateStr, DATE_INPUT_FORMAT, true).isValid()) {
-          const combinedDateTime = combineDateAndTime(dateStr, timeStr, selectedTimezone);
-
-          if (Boolean(combinedDateTime)) {
-            onChange({
-              ...value,
-              [field === "start" ? "startDate" : "endDate"]: combinedDateTime,
-            });
-          }
-        }
-
         return {
           ...prev,
           inputs: newInputs,
@@ -318,6 +304,29 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
 
   const hasValidationErrors = editingState.validationErrors.length > 0;
 
+  const applyDateRange = useCallback(() => {
+    const { inputs } = editingState;
+    const errors = validateInputs(inputs);
+
+    // Don't apply if there are validation errors
+    if (errors.length > 0) {
+      return;
+    }
+
+    const startDateTime = inputs.start
+      ? combineDateAndTime(inputs.start, inputs.startTime, selectedTimezone)
+      : undefined;
+    const endDateTime = inputs.end
+      ? combineDateAndTime(inputs.end, inputs.endTime, selectedTimezone)
+      : undefined;
+
+    onChange({
+      ...value,
+      endDate: endDateTime,
+      startDate: startDateTime,
+    });
+  }, [editingState, onChange, selectedTimezone, value]);
+
   return {
     editingState,
     endDateValue,
@@ -328,5 +337,6 @@ export const useDateRangeFilter = ({ onChange, translate, value }: UseDateRangeF
     hasValidationErrors,
     setEditingState,
     startDateValue,
+    applyDateRange,
   };
 };


### PR DESCRIPTION
Fix the date range filter inputs calling `onChange` on every valid keystroke, which triggered URL search param updates and caused the editing state to be overwritten by the synced value from the parent. This made the date picker effectively unusable - typed values would appear to flash or get replaced with formatted values.

**Fix:** Remove the auto-submit from the input change handler. The editing state stays local until the user explicitly applies it via any of these paths:
- Clicking a date in the calendar popover
- Pressing Enter in any date/time input
- Clicking the new Apply button
- Closing the popover (clicking outside or pressing Escape)

closes: #69891

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude Code (DeepSeek V4 Flash)

Generated-by: Claude Code (DeepSeek V4 Flash) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-28T16:32:14Z head=bd945fe action=ping -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @anmolxlight** · by `@potiuk` · 2026-07-28 16:32 UTC
>
> Some review feedback from `pierrejeambrun` is waiting on you:
> - There are **2 unresolved review threads** on this PR from `pierrejeambrun`.
>
> **The ball is in your court** — you've been assigned to this PR. Push a fix or reply in each thread explaining why the feedback does not apply, then mark them resolved and ping the reviewer (`pierrejeambrun`) for a final look.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **298 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
