### PR TITLE
Fix `Trigger.submit_event` to route asset events through the configured `asset_manager`

### DIFF
--- a/airflow-core/src/airflow/models/trigger.py
+++ b/airflow-core/src/airflow/models/trigger.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Mapped, Session, mapped_column, relationship, selecti
 from sqlalchemy.sql.functions import coalesce
 
 from airflow._shared.timezones import timezone
-from airflow.assets.manager import AssetManager
+from airflow.assets.manager import asset_manager
 from airflow.configuration import conf
 from airflow.models.asset import AssetWatcherModel
 from airflow.models.base import Base
@@ -295,7 +295,7 @@ class Trigger(Base):
             # Already deleted for some reason
             return
         for asset in trigger.assets:
-            AssetManager.register_asset_change(
+            asset_manager.register_asset_change(
                 asset=asset.to_serialized(),
                 extra={"from_trigger": True, "payload": event.payload},
                 session=session,

--- a/airflow-core/tests/unit/models/test_trigger.py
+++ b/airflow-core/tests/unit/models/test_trigger.py
@@ -235,8 +235,39 @@ def test_submit_event(mock_callback_handle_event, session, create_task_instance)
     mock_callback_handle_event.assert_called_once_with(event, session)
 
 
+def test_submit_event_uses_configured_asset_manager(session):
+    """
+    Regression test: ``Trigger.submit_event`` must notify assets through the
+    configured ``[core] asset_manager_class`` instance (the module-level
+    ``asset_manager`` singleton), not the hardcoded base ``AssetManager`` class.
+
+    Before the fix, ``submit_event`` called ``AssetManager.register_asset_change``
+    on the base class, so a custom asset manager set via ``asset_manager_class``
+    was silently bypassed for asset events produced by triggers / asset watchers.
+    Patching the module-level ``asset_manager`` reference stands in for a
+    configured custom manager, since that singleton is exactly what
+    ``resolve_asset_manager()`` builds from config.
+    """
+    trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})
+    session.add(trigger)
+    session.flush()
+
+    asset = AssetModel(name="configured_manager_asset")
+    asset.add_trigger(trigger, "test_asset_watcher")
+    session.add(asset)
+    session.commit()
+
+    with patch("airflow.models.trigger.asset_manager") as mock_asset_manager:
+        Trigger.submit_event(trigger.id, TriggerEvent("payload"), session=session)
+
+    # The configured singleton -- not the base class -- must be the one notified.
+    mock_asset_manager.register_asset_change.assert_called_once()
+    _, kwargs = mock_asset_manager.register_asset_change.call_args
+    assert kwargs["extra"] == {"from_trigger": True, "payload": "payload"}
+
+
 @pytest.mark.parametrize(("asset_count", "expected_query_count"), [(1, 6), (5, 6)])
-@patch("airflow.models.trigger.AssetManager.register_asset_change")
+@patch("airflow.assets.manager.AssetManager.register_asset_change")
 def test_submit_event_no_n_plus_one_for_assets(_, session, asset_count, expected_query_count):
     """Ensure asset notifications do not trigger per-asset lazy-load queries."""
     trigger = Trigger(classpath="airflow.triggers.testing.SuccessTrigger", kwargs={})


### PR DESCRIPTION
closes: #69962

## What

`Trigger.submit_event` imported the base `AssetManager` class and called
`AssetManager.register_asset_change(...)` on it, instead of using the resolved
`asset_manager` singleton like every other call site
(`taskinstance.py`, the public assets REST route). Because
`register_asset_change` is a classmethod invoked on the base class, a custom
manager configured via `[core] asset_manager_class` was silently bypassed for
asset events produced by triggers / asset watchers.

This swaps the import and call to the configured `asset_manager` instance, so
`asset_manager_class` now applies uniformly regardless of how an asset event is
produced.

## Why

`asset_manager_class` is the only supported extension point for asset-event
handling, and it did not apply to trigger/watcher-produced events — the one
place a custom manager could not be reached.

## Tests

- Added `test_submit_event_uses_configured_asset_manager`: asserts
  `submit_event` dispatches through the module-level `asset_manager` instance.
  Fails on `main`, passes with the fix.
- Updated `test_submit_event_no_n_plus_one_for_assets` to patch
  `airflow.assets.manager.AssetManager.register_asset_change` (where the
  classmethod is defined) so it no longer depends on the removed module symbol.