### PR TITLE
Don't fail API server startup when a plugin uses an unknown team

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/app.py
+++ b/airflow-core/src/airflow/api_fastapi/app.py
@@ -132,11 +132,8 @@ def create_app(apps: str = "all") -> FastAPI:
         app.mount("/execution", task_exec_api_app)
 
     if "all" in apps_list or "core" in apps_list:
-        from airflow import plugins_manager
-
         app.state.dag_bag = dag_bag
         init_plugins(app)
-        plugins_manager.validate_plugin_teams()
         init_auth_manager(app)
         init_flask_plugins(app)
         init_views(app)  # Core views need to be the last routes added - it has a catch all route

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -233,6 +233,10 @@ def get_fastapi_plugins() -> tuple[list[Any], list[Any]]:
     """Collect extension points for the API."""
     log.debug("Initialize FastAPI plugins")
 
+    # Validate here (the API-server, DB-available path) so callers cannot mount
+    # plugins without the team check running.
+    validate_plugin_teams()
+
     fastapi_apps: list[Any] = []
     fastapi_root_middlewares: list[Any] = []
     for plugin in _get_plugins()[0]:
@@ -432,30 +436,26 @@ def validate_plugin_teams() -> None:
     metadata database access (the API server) — never in the Dag processor, triggerer,
     or workers, which reach the database only through the Execution API.
 
-    Raises ``AirflowConfigException`` if any plugin declares a ``team_name`` that is not
-    present in the database, naming the offending plugins and unknown teams so the
-    misconfiguration can be fixed quickly.
+    A plugin that declares a ``team_name`` not present in the database is recorded as a
+    plugin import error (surfaced like any other plugin load failure) and logged, rather
+    than raising, so a single misconfigured plugin does not stop the API server and every
+    other plugin from starting.
     """
     if not conf.getboolean("core", "multi_team"):
         return
 
-    from airflow.exceptions import AirflowConfigException
     from airflow.models.team import Team
 
+    plugins, import_errors = _get_plugins()
     known_teams = Team.get_all_team_names()
-    unknown_by_plugin = {
-        plugin.name: plugin.team_name
-        for plugin in _get_plugins()[0]
-        if plugin.team_name is not None and plugin.team_name not in known_teams
-    }
-    if unknown_by_plugin:
-        lines = [
-            f"  - Plugin '{plugin_name}' is assigned to team '{team_name}', which does not exist."
-            for plugin_name, team_name in unknown_by_plugin.items()
-        ]
-        raise AirflowConfigException(
-            "Some plugins are assigned to teams that do not exist:\n"
-            + "\n".join(lines)
-            + "\n\nCreate a team with `airflow teams create <team_name>`, "
+    for plugin in plugins:
+        if plugin.team_name is None or plugin.team_name in known_teams:
+            continue
+        message = (
+            f"Plugin '{plugin.name}' is assigned to team '{plugin.team_name}', which does not exist. "
+            "Create a team with `airflow teams create <team_name>`, "
             "or update the plugin to use an existing team."
         )
+        log.warning(message)
+        source = str(plugin.source) if plugin.source else plugin.name or ""
+        import_errors[source] = message

--- a/airflow-core/tests/unit/plugins/test_plugins_manager.py
+++ b/airflow-core/tests/unit/plugins/test_plugins_manager.py
@@ -490,14 +490,21 @@ class TestValidatePluginTeams:
 
     @conf_vars({("core", "multi_team"): "True"})
     @mock.patch("airflow.models.team.Team.get_all_team_names", return_value={"team_a"})
-    def test_raises_for_unknown_team(self, mock_get_all_team_names):
+    def test_get_fastapi_plugins_records_unknown_team_import_error(self, mock_get_all_team_names, caplog):
         from airflow import plugins_manager
-        from airflow.exceptions import AirflowConfigException
 
         class TeamPlugin(AirflowPlugin):
             name = "team_plugin"
             team_name = "unknown_team"
 
-        with mock_plugin_manager(plugins=[TeamPlugin()]):
-            with pytest.raises(AirflowConfigException, match="team_plugin.*unknown_team"):
-                plugins_manager.validate_plugin_teams()
+        # get_fastapi_plugins() is what init_plugins() calls, so validation runs
+        # automatically: a plugin on a nonexistent team is recorded as an import error
+        # and warned, not raised, so the API server and every other plugin still start.
+        with mock_plugin_manager(plugins=[TeamPlugin()], import_errors={}):
+            with caplog.at_level(logging.WARNING, logger="airflow.plugins_manager"):
+                plugins_manager.get_fastapi_plugins()
+            recorded = plugins_manager.get_import_errors()
+
+        assert "unknown_team" in recorded["team_plugin"]
+        warnings = [msg for _, level, msg in caplog.record_tuples if level == logging.WARNING]
+        assert any("team_plugin" in msg and "unknown_team" in msg for msg in warnings)


### PR DESCRIPTION
Follow-up of #69502.

#69502 added team validation for plugins, but a single plugin referencing a team that does not exist raised during app creation — so the whole API server, and every other plugin, failed to boot. A misconfigured plugin should be surfaced, not fatal, the same way other plugin load errors are.

The team check now records each offending plugin as a **plugin import error** (surfaced in the plugins API and UI, like any other plugin load failure) and logs a warning instead of raising. It also runs from `get_fastapi_plugins()` — which `init_plugins()` already calls — so validation happens automatically wherever plugins are mounted, rather than relying on a separate `validate_plugin_teams()` call that a caller could forget.

Only reached from the API server and the `airflow plugins` CLI (never workers/dag-processor/triggerer), and the DB is only touched when `[core] multi_team` is enabled.

---
### Before
<img width="751" height="468" alt="Screenshot 2026-07-16 at 18 00 20" src="https://github.com/user-attachments/assets/54d7171f-8c96-4627-a303-4c5cabf2c211" />


### After
<img width="740" height="128" alt="Screenshot 2026-07-16 at 17 55 20" src="https://github.com/user-attachments/assets/b24f6050-9b0b-437b-b36a-8dd78942816e" />
<img width="1371" height="624" alt="Screenshot 2026-07-16 at 17 55 36" src="https://github.com/user-attachments/assets/11274289-d9bc-4e3a-bfd4-59b781d86dea" />


##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)