### PR TITLE
Standardize task run state conflict error response

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -214,16 +214,14 @@ def ti_run(
             previous_state=previous_state,
         )
 
-        # TODO: Pass a RFC 9457 compliant error message in "detail" field
-        # https://datatracker.ietf.org/doc/html/rfc9457
-        # to provide more information about the error
-        # FastAPI will automatically convert this to a JSON response
-        # This might be added in FastAPI in https://github.com/fastapi/fastapi/issues/10370
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail={
+                "type": "about:blank",
+                "title": "Conflict",
+                "status": status.HTTP_409_CONFLICT,
+                "detail": "TI was not in a state where it could be marked as running",
                 "reason": "invalid_state",
-                "message": "TI was not in a state where it could be marked as running",
                 "previous_state": previous_state,
             },
         )

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -29,6 +29,7 @@ import attrs
 import structlog
 from cadwyn import VersionedAPIRouter
 from fastapi import Body, HTTPException, Query, Response, Security, status
+from fastapi.responses import JSONResponse
 from opentelemetry import trace
 from opentelemetry.trace import StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -122,6 +123,7 @@ tracer = trace.get_tracer(__name__)
             (HTTP_422_UNPROCESSABLE_CONTENT, "Invalid payload for the state transition"),
         ]
     ),
+    response_model=TIRunContext,
     response_model_exclude_unset=True,
 )
 def ti_run(
@@ -214,16 +216,20 @@ def ti_run(
             previous_state=previous_state,
         )
 
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "type": "about:blank",
-                "title": "Conflict",
-                "status": status.HTTP_409_CONFLICT,
-                "detail": "TI was not in a state where it could be marked as running",
-                "reason": "invalid_state",
-                "previous_state": previous_state,
-            },
+        return cast(
+            "TIRunContext",
+            JSONResponse(
+                status_code=status.HTTP_409_CONFLICT,
+                media_type="application/problem+json",
+                content={
+                    "type": "about:blank",
+                    "title": "Conflict",
+                    "status": status.HTTP_409_CONFLICT,
+                    "detail": "TI was not in a state where it could be marked as running",
+                    "reason": "invalid_state",
+                    "previous_state": previous_state,
+                },
+            ),
         )
     else:
         log.info("Task started", previous_state=previous_state, hostname=ti_run_payload.hostname)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -51,9 +51,13 @@ from airflow.api_fastapi.execution_api.versions.v2026_06_30 import (
     AddTeamNameField,
     AddVariableKeysEndpoint,
 )
+from airflow.api_fastapi.execution_api.versions.v2026_08_10 import (
+    UseProblemDetailsForTaskRunStateConflict,
+)
 
 bundle = VersionBundle(
     HeadVersion(),
+    Version("2026-08-10", UseProblemDetailsForTaskRunStateConflict),
     Version(
         "2026-06-30",
         AddVariableKeysEndpoint,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_08_10.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_08_10.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from cadwyn import ResponseInfo, VersionChange, convert_response_to_previous_version_for
+
+
+class UseProblemDetailsForTaskRunStateConflict(VersionChange):
+    """Use RFC 9457 problem details for task run state conflict responses."""
+
+    description = __doc__
+    instructions_to_migrate_to_previous_version = ()
+
+    @convert_response_to_previous_version_for(  # type: ignore[arg-type]
+        "/task-instances/{task_instance_id}/run",
+        ["PATCH"],
+        migrate_http_errors=True,
+    )
+    def restore_legacy_task_run_state_conflict_error(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Restore the legacy FastAPI HTTPException error shape for older clients."""
+        if response.status_code != 409 or not isinstance(response.body, dict):
+            return
+        if response.body.get("reason") != "invalid_state" or response.body.get("previous_state") is None:
+            return
+
+        response.body = {
+            "detail": {
+                "reason": response.body["reason"],
+                "message": response.body.get("detail"),
+                "previous_state": response.body["previous_state"],
+            }
+        }
+        response.headers["content-type"] = "application/json"

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -855,15 +855,14 @@ class TestTIRunState:
         )
 
         assert response.status_code == 409
+        assert response.headers["content-type"] == "application/problem+json"
         assert response.json() == {
-            "detail": {
-                "type": "about:blank",
-                "title": "Conflict",
-                "status": 409,
-                "detail": "TI was not in a state where it could be marked as running",
-                "previous_state": initial_ti_state,
-                "reason": "invalid_state",
-            }
+            "type": "about:blank",
+            "title": "Conflict",
+            "status": 409,
+            "detail": "TI was not in a state where it could be marked as running",
+            "previous_state": initial_ti_state,
+            "reason": "invalid_state",
         }
 
         assert session.scalar(select(TaskInstance.state).where(TaskInstance.id == ti.id)) == initial_ti_state

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -857,7 +857,10 @@ class TestTIRunState:
         assert response.status_code == 409
         assert response.json() == {
             "detail": {
-                "message": "TI was not in a state where it could be marked as running",
+                "type": "about:blank",
+                "title": "Conflict",
+                "status": 409,
+                "detail": "TI was not in a state where it could be marked as running",
                 "previous_state": initial_ti_state,
                 "reason": "invalid_state",
             }

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_08_10/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_08_10/test_task_instances.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow.utils.state import State
+
+from tests_common.test_utils.db import (
+    clear_db_assets,
+    clear_db_dags,
+    clear_db_logs,
+    clear_db_runs,
+    clear_db_serialized_dags,
+)
+
+pytestmark = pytest.mark.db_test
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    clear_db_logs()
+    clear_db_runs()
+    clear_db_serialized_dags()
+    clear_db_dags()
+    clear_db_assets()
+    yield
+    clear_db_logs()
+    clear_db_runs()
+    clear_db_serialized_dags()
+    clear_db_dags()
+    clear_db_assets()
+
+
+def test_task_run_state_conflict_error_uses_legacy_shape_for_older_versions(
+    client, session, create_task_instance
+):
+    client.headers["Airflow-API-Version"] = "2026-06-30"
+    ti = create_task_instance(task_id="test_ti_run_state_conflict_legacy_error", state=State.SUCCESS)
+    session.commit()
+
+    response = client.patch(
+        f"/execution/task-instances/{ti.id}/run",
+        json={
+            "state": "running",
+            "hostname": "random-hostname",
+            "unixname": "random-unixname",
+            "pid": 100,
+            "start_date": "2024-10-31T12:00:00Z",
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.headers["content-type"] == "application/json"
+    assert response.json() == {
+        "detail": {
+            "message": "TI was not in a state where it could be marked as running",
+            "previous_state": State.SUCCESS,
+            "reason": "invalid_state",
+        }
+    }

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1325,21 +1325,28 @@ class ServerResponseError(httpx.HTTPStatusError):
         if not (400 <= response.status_code < 600):
             return None
 
-        if response.headers.get("content-type") != "application/json":
+        content_type = response.headers.get("content-type", "").split(";")[0]
+        if content_type != "application/json" and not content_type.endswith("+json"):
             return None
 
         detail: list[RemoteValidationError] | dict[str, Any] | None = None
         try:
-            body = _ErrorBody.model_validate_json(response.read())
+            body = msgspec.json.decode(response.read())
 
-            if isinstance(body.detail, list):
-                detail = body.detail
-                msg = "Remote server returned validation error"
-            elif isinstance(body.detail, dict):
-                detail = body.detail
+            if isinstance(body, dict) and {"type", "title", "status"}.issubset(body):
+                detail = body
                 msg = "Server returned error"
             else:
-                msg = body.detail or "Un-parseable error"
+                body = _ErrorBody.model_validate(body)
+
+                if isinstance(body.detail, list):
+                    detail = body.detail
+                    msg = "Remote server returned validation error"
+                elif isinstance(body.detail, dict):
+                    detail = body.detail
+                    msg = "Server returned error"
+                else:
+                    msg = body.detail or "Un-parseable error"
         except Exception:
             try:
                 detail = msgspec.json.decode(response.content)

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -27,7 +27,7 @@ from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, JsonValue, RootModel
 
-API_VERSION: Final[str] = "2026-06-30"
+API_VERSION: Final[str] = "2026-08-10"
 
 
 class AssetAliasReferenceAssetEventDagRun(BaseModel):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -365,8 +365,11 @@ class TestTaskInstanceOperations:
                     409,
                     json={
                         "detail": {
+                            "type": "about:blank",
+                            "title": "Conflict",
+                            "status": 409,
+                            "detail": "TI was not in a state where it could be marked as running",
                             "reason": "invalid_state",
-                            "message": "TI was not in a state where it could be marked as running",
                             "previous_state": "running",
                         }
                     },
@@ -389,8 +392,11 @@ class TestTaskInstanceOperations:
                     409,
                     json={
                         "detail": {
+                            "type": "about:blank",
+                            "title": "Conflict",
+                            "status": 409,
+                            "detail": "TI was not in a state where it could be marked as running",
                             "reason": "invalid_state",
-                            "message": "TI was not in a state where it could be marked as running",
                             "previous_state": previous_state,
                         }
                     },

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -363,15 +363,14 @@ class TestTaskInstanceOperations:
             if request.url.path == f"/task-instances/{ti_id}/run":
                 return httpx.Response(
                     409,
+                    headers={"content-type": "application/problem+json"},
                     json={
-                        "detail": {
-                            "type": "about:blank",
-                            "title": "Conflict",
-                            "status": 409,
-                            "detail": "TI was not in a state where it could be marked as running",
-                            "reason": "invalid_state",
-                            "previous_state": "running",
-                        }
+                        "type": "about:blank",
+                        "title": "Conflict",
+                        "status": 409,
+                        "detail": "TI was not in a state where it could be marked as running",
+                        "reason": "invalid_state",
+                        "previous_state": "running",
                     },
                 )
             return httpx.Response(status_code=204)
@@ -390,15 +389,14 @@ class TestTaskInstanceOperations:
             if request.url.path == f"/task-instances/{ti_id}/run":
                 return httpx.Response(
                     409,
+                    headers={"content-type": "application/problem+json"},
                     json={
-                        "detail": {
-                            "type": "about:blank",
-                            "title": "Conflict",
-                            "status": 409,
-                            "detail": "TI was not in a state where it could be marked as running",
-                            "reason": "invalid_state",
-                            "previous_state": previous_state,
-                        }
+                        "type": "about:blank",
+                        "title": "Conflict",
+                        "status": 409,
+                        "detail": "TI was not in a state where it could be marked as running",
+                        "reason": "invalid_state",
+                        "previous_state": previous_state,
                     },
                 )
             return httpx.Response(status_code=204)

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -959,15 +959,14 @@ class TestWatchedSubprocess:
             if request.url.path == f"/task-instances/{ti_id}/run":
                 return httpx.Response(
                     409,
+                    headers={"content-type": "application/problem+json"},
                     json={
-                        "detail": {
-                            "type": "about:blank",
-                            "title": "Conflict",
-                            "status": 409,
-                            "detail": "TI was not in a state where it could be marked as running",
-                            "reason": "invalid_state",
-                            "previous_state": "running",
-                        }
+                        "type": "about:blank",
+                        "title": "Conflict",
+                        "status": 409,
+                        "detail": "TI was not in a state where it could be marked as running",
+                        "reason": "invalid_state",
+                        "previous_state": "running",
                     },
                 )
             return httpx.Response(status_code=204)

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -961,8 +961,11 @@ class TestWatchedSubprocess:
                     409,
                     json={
                         "detail": {
+                            "type": "about:blank",
+                            "title": "Conflict",
+                            "status": 409,
+                            "detail": "TI was not in a state where it could be marked as running",
                             "reason": "invalid_state",
-                            "message": "TI was not in a state where it could be marked as running",
                             "previous_state": "running",
                         }
                     },


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Update the Execution API response for task run state conflicts to use RFC 9457-style problem detail fields.

The response still keeps Airflow-specific fields like `reason` and `previous_state`, so clients can continue using machine-readable context while receiving a more standard error shape.

Updated the related API, Task SDK client, and supervisor tests to match the new response payload.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
