### PR TITLE
Clarify AssetPartitionDagRun provisional-run docstring

### DIFF
--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -913,9 +913,15 @@ class AssetPartitionDagRun(Base):
     We can look up the AssetEvents that contribute to AssetPartitionDagRun entities
     with the PartitionedAssetKeyLog mapping table.
 
-    Where dag_run_id is null, the dag run has not yet been created.
-    We should not allow more than one like this. But to guard against
-    an accident, we should always work on the latest one.
+    Rows are never deleted from this table, so multiple records with the same
+    target_dag_id / partition_key are expected in general; each dag run that
+    gets created leaves its APDR record behind.
+
+    Where created_dag_run_id is null, the dag run has not yet been created.
+    We should not allow more than one row with the same target_dag_id /
+    partition_key where created_dag_run_id is null, and this is what the
+    `_lock_asset_model` mutex control is for. In case a duplicate somehow
+    gets created, we always work on the latest matching APDR record.
     """
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)


### PR DESCRIPTION
Clarify the `AssetPartitionDagRun` docstring.

The previous wording ("we should not allow more than one like this") didn't state the
actual invariant. This spells out that:

- rows are never deleted from the table, so multiple records per
  `target_dag_id` / `partition_key` are expected in general (each created dag run leaves
  its record behind), and
- the real constraint is at most one row with a **null** `created_dag_run_id` per
  `target_dag_id` / `partition_key` (the outstanding provisional run), which the
  `_lock_asset_model` mutex enforces.

Docstring-only; no behavior change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
