### PR TITLE
Migrate Exasol provider to pyexasol 2.x

### DIFF
--- a/providers/exasol/docs/changelog.rst
+++ b/providers/exasol/docs/changelog.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+4.10.5
+......
+
+Misc
+~~~~
+
+* ``Migrate Exasol provider to pyexasol 2.x (#69123)``
+
 4.10.4
 ......
 

--- a/providers/exasol/pyproject.toml
+++ b/providers/exasol/pyproject.toml
@@ -62,9 +62,7 @@ dependencies = [
     "apache-airflow>=2.11.0",
     "apache-airflow-providers-common-compat>=1.12.0",
     "apache-airflow-providers-common-sql>=1.32.0",
-    # Capped to 1.x: pyexasol 2.x ships stricter types that break the exasol hook.
-    # Remove the cap after migrating; tracked at https://github.com/apache/airflow/issues/69123
-    "pyexasol>=0.26.0,<2",
+    "pyexasol>=2.0.0,<3",
     'pandas>=2.1.2; python_version <"3.13"',
     'pandas>=2.2.3; python_version >="3.13" and python_version <"3.14"',
     'pandas>=2.3.3; python_version >="3.14"',

--- a/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
+++ b/providers/exasol/src/airflow/providers/exasol/hooks/exasol.py
@@ -68,20 +68,33 @@ class ExasolHook(DbApiHook):
         self._sqlalchemy_scheme = sqlalchemy_scheme
 
     def get_conn(self) -> ExaConnection:
-        conn = self.get_connection(self.get_conn_id())
+        airflow_conn = self.get_connection(self.get_conn_id())
         conn_args = {
-            "dsn": f"{conn.host}:{conn.port}",
-            "user": conn.login,
-            "password": conn.password,
-            "schema": self.schema or conn.schema,
+            "dsn": f"{airflow_conn.host}:{airflow_conn.port}",
+            "user": airflow_conn.login,
+            "password": airflow_conn.password,
+            "schema": self.schema or airflow_conn.schema,
         }
         # check for parameters in conn.extra
-        for arg_name, arg_val in conn.extra_dejson.items():
+        for arg_name, arg_val in airflow_conn.extra_dejson.items():
             if arg_name in ["compression", "encryption", "json_lib", "client_name"]:
                 conn_args[arg_name] = arg_val
 
-        conn = pyexasol.connect(**conn_args)
-        return conn
+        exa_conn = pyexasol.connect(**conn_args)
+        return exa_conn
+
+    @staticmethod
+    def _validate_query_params(
+        parameters: Iterable | Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if parameters is None:
+            return None
+        if not isinstance(parameters, dict):
+            raise TypeError(
+                f"Exasol (pyexasol) only supports named/dict-style query parameters, "
+                f"got {type(parameters).__name__!r}. Pass a dict instead, e.g. {{'col': 'value'}}."
+            )
+        return parameters
 
     @property
     def sqlalchemy_scheme(self) -> str:
@@ -145,7 +158,7 @@ class ExasolHook(DbApiHook):
         ``pyexasol.ExaConnection.export_to_pandas``.
         """
         with closing(self.get_conn()) as conn:
-            df = conn.export_to_pandas(sql, query_params=parameters, **kwargs)
+            df = conn.export_to_pandas(sql, query_params=self._validate_query_params(parameters), **kwargs)
             return df
 
     @deprecated(
@@ -178,17 +191,19 @@ class ExasolHook(DbApiHook):
 
     def get_records(
         self,
-        sql: str | list[str],
+        sql: str,
         parameters: Iterable | Mapping[str, Any] | None = None,
     ) -> list[dict | tuple[Any, ...]]:
         """
         Execute the SQL and return a set of records.
 
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
+        :param sql: the sql statement to be executed
         :param parameters: The parameters to render the SQL query with.
         """
-        with closing(self.get_conn()) as conn, closing(conn.execute(sql, parameters)) as cur:
+        if not isinstance(sql, str):
+            raise TypeError("ExasolHook.get_records() only accepts a single SQL string, not a list.")
+        query_params = self._validate_query_params(parameters)
+        with closing(self.get_conn()) as conn, closing(conn.execute(sql, query_params)) as cur:
             send_sql_hook_lineage(
                 context=self,
                 sql=sql,
@@ -197,15 +212,17 @@ class ExasolHook(DbApiHook):
             )
             return cur.fetchall()
 
-    def get_first(self, sql: str | list[str], parameters: Iterable | Mapping[str, Any] | None = None) -> Any:
+    def get_first(self, sql: str, parameters: Iterable | Mapping[str, Any] | None = None) -> Any:
         """
         Execute the SQL and return the first resulting row.
 
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
+        :param sql: the sql statement to be executed
         :param parameters: The parameters to render the SQL query with.
         """
-        with closing(self.get_conn()) as conn, closing(conn.execute(sql, parameters)) as cur:
+        if not isinstance(sql, str):
+            raise TypeError("ExasolHook.get_first() only accepts a single SQL string, not a list.")
+        query_params = self._validate_query_params(parameters)
+        with closing(self.get_conn()) as conn, closing(conn.execute(sql, query_params)) as cur:
             send_sql_hook_lineage(
                 context=self,
                 sql=sql,
@@ -329,12 +346,13 @@ class ExasolHook(DbApiHook):
         else:
             raise ValueError("List of SQL statements is empty")
         _last_result = None
+        query_params = self._validate_query_params(parameters)
         with closing(self.get_conn()) as conn:
             self.set_autocommit(conn, autocommit)
             results = []
             for sql_statement in sql_list:
                 self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
-                with closing(conn.execute(sql_statement, parameters)) as exa_statement:
+                with closing(conn.execute(sql_statement, query_params)) as exa_statement:
                     if handler is not None:
                         result = self._make_common_data_structure(handler(exa_statement))
 

--- a/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
+++ b/providers/exasol/tests/unit/exasol/hooks/test_exasol.py
@@ -194,11 +194,31 @@ class TestExasolHook:
 
     def test_run_with_parameters(self):
         sql = "SQL"
-        parameters = ("param1", "param2")
+        parameters = {"param1": "value1", "param2": "value2"}
         self.db_hook.run(sql, autocommit=True, parameters=parameters)
         self.conn.set_autocommit.assert_called_once_with(True)
         self.conn.execute.assert_called_once_with(sql, parameters)
         self.conn.commit.assert_not_called()
+
+    def test_run_with_non_dict_parameters_raises(self):
+        with pytest.raises(TypeError, match="only supports named/dict-style query parameters"):
+            self.db_hook.run("SQL", parameters=("param1", "param2"))
+        self.conn.execute.assert_not_called()
+
+    @pytest.mark.parametrize("method", ["get_records", "get_first"])
+    def test_get_records_and_get_first_reject_list_sql(self, method):
+        with pytest.raises(TypeError, match="only accepts a single SQL string"):
+            getattr(self.db_hook, method)(["SELECT 1", "SELECT 2"])
+
+    @pytest.mark.parametrize("method", ["get_records", "get_first"])
+    def test_get_records_and_get_first_reject_non_dict_parameters(self, method):
+        with pytest.raises(TypeError, match="only supports named/dict-style query parameters"):
+            getattr(self.db_hook, method)("SELECT 1", parameters=("p1",))
+
+    def test_get_df_pandas_rejects_non_dict_parameters(self):
+        with pytest.raises(TypeError, match="only supports named/dict-style query parameters"):
+            self.db_hook.get_df("SQL", df_type="pandas", parameters=("p1",))
+        self.conn.export_to_pandas.assert_not_called()
 
     def test_run_multi_queries(self):
         sql = ["SQL1", "SQL2"]


### PR DESCRIPTION
pyexasol 2.x ships a `py.typed` marker that exposed 8 type mismatches in
the Exasol hook, causing CI to cap the dependency at `<2`. This PR removes
the cap by fixing the hook to be compatible with pyexasol 2.x.

**Changes:**
- Rename reused `conn` variable in `get_conn()` to `airflow_conn` / `exa_conn`
  to eliminate the mypy type-narrowing conflict.
- Add `_validate_query_params()` static method to narrow
  `Iterable|Mapping|None` → `dict|None`, matching pyexasol 2.x's
  `execute()` and `export_to_pandas()` signatures. Raises `TypeError`
  with a clear message for non-dict input.
- Narrow `sql: str | list[str]` → `sql: str` in `get_records()` and
  `get_first()`, matching what pyexasol actually accepts.
- Bump `pyexasol` dependency from `>=0.26.0,<2` to `>=2.0.0,<3`.
- Update existing test to use `dict` parameters (tuples were never valid).
- Add negative tests for non-dict parameters and list SQL inputs.

closes: #69123