### PR TITLE
Scope plugin listeners to teams in multi-team airflow

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/dag_run.py
@@ -58,7 +58,7 @@ from airflow.api_fastapi.core_api.datamodels.dag_run import (
 from airflow.api_fastapi.core_api.datamodels.task_instances import NewTaskResponse
 from airflow.api_fastapi.core_api.services.public.common import BulkService
 from airflow.api_fastapi.core_api.services.public.task_instances import _emit_state_listener_hooks
-from airflow.listeners.listener import get_listener_manager
+from airflow.listeners.listener import get_listener_manager_for_dag
 from airflow.models.dagrun import DagRun, clear_partition_runs
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.xcom import XCOM_RETURN_KEY, XComModel
@@ -197,11 +197,11 @@ def patch_dag_run_state(
         _, killed_tis = set_dag_run_state_to_success(
             dag=dag, run_id=dag_run.run_id, commit=True, session=session
         )
-        _emit_state_listener_hooks(killed_tis, TaskInstanceState.SUCCESS)
+        _emit_state_listener_hooks(killed_tis, TaskInstanceState.SUCCESS, session)
         try:
             if dag_run.dag is None:
                 dag_run.dag = dag
-            get_listener_manager().hook.on_dag_run_success(
+            get_listener_manager_for_dag(dag_run.dag_id, session=session).hook.on_dag_run_success(
                 dag_run=dag_run,
                 msg=f"Dag Run's state was manually set to `{DagRunMutableStates.SUCCESS.value}`.",
             )
@@ -216,11 +216,11 @@ def patch_dag_run_state(
         _, killed_tis = set_dag_run_state_to_failed(
             dag=dag, run_id=dag_run.run_id, commit=True, session=session
         )
-        _emit_state_listener_hooks(killed_tis, TaskInstanceState.FAILED)
+        _emit_state_listener_hooks(killed_tis, TaskInstanceState.FAILED, session)
         try:
             if dag_run.dag is None:
                 dag_run.dag = dag
-            get_listener_manager().hook.on_dag_run_failed(
+            get_listener_manager_for_dag(dag_run.dag_id, session=session).hook.on_dag_run_failed(
                 dag_run=dag_run,
                 msg=f"Dag Run's state was manually set to `{DagRunMutableStates.FAILED.value}`.",
             )

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/task_instances.py
@@ -49,7 +49,7 @@ from airflow.api_fastapi.core_api.datamodels.task_instances import (
 from airflow.api_fastapi.core_api.security import GetUserDep
 from airflow.api_fastapi.core_api.services.public.common import BulkService
 from airflow.configuration import conf
-from airflow.listeners.listener import get_listener_manager
+from airflow.listeners.listener import get_listener_manager_for_dag
 from airflow.models.dag import DagModel
 from airflow.models.taskinstance import TaskInstance as TI
 from airflow.serialization.definitions.dag import SerializedDAG
@@ -106,20 +106,23 @@ def _validate_patch_task_instance_body(
     return body.model_dump(include=fields_to_update, by_alias=True)
 
 
-def _emit_state_listener_hooks(updated_tis: list[TI], new_state: str | TaskInstanceState) -> None:
+def _emit_state_listener_hooks(
+    updated_tis: list[TI], new_state: str | TaskInstanceState, session: Session
+) -> None:
     """Fire listener hooks for the given TIs based on their new state. Listener errors are logged."""
     for ti in updated_tis:
+        listener_manager = get_listener_manager_for_dag(ti.dag_id, session=session)
         try:
             if new_state == TaskInstanceState.SUCCESS:
-                get_listener_manager().hook.on_task_instance_success(previous_state=None, task_instance=ti)
+                listener_manager.hook.on_task_instance_success(previous_state=None, task_instance=ti)
             elif new_state == TaskInstanceState.FAILED:
-                get_listener_manager().hook.on_task_instance_failed(
+                listener_manager.hook.on_task_instance_failed(
                     previous_state=None,
                     task_instance=ti,
                     error=f"TaskInstance's state was manually set to `{TaskInstanceState.FAILED}`.",
                 )
             elif new_state == TaskInstanceState.SKIPPED:
-                get_listener_manager().hook.on_task_instance_skipped(previous_state=None, task_instance=ti)
+                listener_manager.hook.on_task_instance_skipped(previous_state=None, task_instance=ti)
         except Exception:
             log.exception("error calling listener")
 
@@ -265,7 +268,7 @@ def _patch_task_instance_state(
     if data["new_state"] == TaskInstanceState.SUCCESS:
         _clear_task_state_store_on_success(updated_tis, session)
 
-    _emit_state_listener_hooks(updated_tis, data["new_state"])
+    _emit_state_listener_hooks(updated_tis, data["new_state"], session)
 
     return updated_tis
 
@@ -300,7 +303,7 @@ def _patch_task_group_state(
     if data["new_state"] == TaskInstanceState.SUCCESS:
         _clear_task_state_store_on_success(updated_tis, session)
 
-    _emit_state_listener_hooks(updated_tis, data["new_state"])
+    _emit_state_listener_hooks(updated_tis, data["new_state"], session)
 
     return updated_tis
 

--- a/airflow-core/src/airflow/listeners/listener.py
+++ b/airflow-core/src/airflow/listeners/listener.py
@@ -18,15 +18,33 @@
 from __future__ import annotations
 
 from functools import cache
+from typing import TYPE_CHECKING
 
 from airflow._shared.listeners.listener import ListenerManager
 from airflow._shared.listeners.spec import lifecycle, taskinstance
+from airflow.configuration import conf
 from airflow.listeners.spec import asset, dagrun, importerrors
 from airflow.plugins_manager import integrate_listener_plugins
 
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
 
 @cache
-def get_listener_manager() -> ListenerManager:
+def _build_listener_manager(team_name: str | None) -> ListenerManager:
+    _listener_manager = ListenerManager()
+
+    _listener_manager.add_hookspecs(lifecycle)
+    _listener_manager.add_hookspecs(dagrun)
+    _listener_manager.add_hookspecs(taskinstance)
+    _listener_manager.add_hookspecs(asset)
+    _listener_manager.add_hookspecs(importerrors)
+
+    integrate_listener_plugins(_listener_manager, team_name=team_name)
+    return _listener_manager
+
+
+def get_listener_manager(team_name: str | None = None) -> ListenerManager:
     """
     Get a listener manager for Airflow core.
 
@@ -36,17 +54,37 @@ def get_listener_manager() -> ListenerManager:
     - taskinstance: on_task_instance_running, on_task_instance_success, etc.
     - asset: on_asset_created, on_asset_changed, etc.
     - importerrors: on_new_dag_import_error, on_existing_dag_import_error
+
+    :param team_name: In multi-team mode, the team whose (and the global) plugin
+        listeners this manager should contain. ``None`` yields a manager with only
+        global-plugin listeners (used by team-agnostic events such as lifecycle,
+        asset, and import-error hooks). When multi-team mode is disabled this
+        argument is ignored and the manager holds every plugin's listeners.
+
+    Calls are cached per ``team_name``. The single positional delegation to
+    ``_build_listener_manager`` guarantees that ``get_listener_manager()``,
+    ``get_listener_manager(None)`` and ``get_listener_manager(team_name=None)`` all
+    return the identical (global) manager instance rather than distinct cache
+    entries.
     """
-    _listener_manager = ListenerManager()
-
-    _listener_manager.add_hookspecs(lifecycle)
-    _listener_manager.add_hookspecs(dagrun)
-    _listener_manager.add_hookspecs(taskinstance)
-    _listener_manager.add_hookspecs(asset)
-    _listener_manager.add_hookspecs(importerrors)
-
-    integrate_listener_plugins(_listener_manager)
-    return _listener_manager
+    return _build_listener_manager(team_name)
 
 
-__all__ = ["get_listener_manager", "ListenerManager"]
+def get_listener_manager_for_dag(dag_id: str, session: Session | None = None) -> ListenerManager:
+    """
+    Get the listener manager scoped to the team that owns ``dag_id``.
+
+    When multi-team mode is disabled this returns the single manager holding all
+    listeners. Otherwise it resolves the Dag's owning team and returns a manager
+    containing the global listeners plus that team's listeners.
+    """
+    if not conf.getboolean("core", "multi_team"):
+        return get_listener_manager()
+
+    from airflow.models.dag import DagModel
+
+    team_name = DagModel.get_team_name(dag_id, session=session) if session else DagModel.get_team_name(dag_id)
+    return get_listener_manager(team_name)
+
+
+__all__ = ["get_listener_manager", "get_listener_manager_for_dag", "ListenerManager"]

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -62,6 +62,7 @@ from sqlalchemy.orm import (
     declared_attr,
     joinedload,
     mapped_column,
+    object_session,
     relationship,
     synonym,
     validates,
@@ -83,7 +84,7 @@ from airflow._shared.timezones import timezone
 from airflow.callbacks.callback_requests import DagCallbackRequest, DagRunContext
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, NotMapped, TaskNotFound
-from airflow.listeners.listener import get_listener_manager
+from airflow.listeners.listener import get_listener_manager_for_dag
 from airflow.models import Deadline, Log
 from airflow.models.backfill import Backfill
 from airflow.models.base import Base, StringID
@@ -1491,12 +1492,13 @@ class DagRun(Base, LoggingMixin):
 
     def notify_dagrun_state_changed(self, msg: str):
         try:
+            listener_manager = get_listener_manager_for_dag(self.dag_id, session=object_session(self))
             if self.state == DagRunState.RUNNING:
-                get_listener_manager().hook.on_dag_run_running(dag_run=self, msg=msg)
+                listener_manager.hook.on_dag_run_running(dag_run=self, msg=msg)
             elif self.state == DagRunState.SUCCESS:
-                get_listener_manager().hook.on_dag_run_success(dag_run=self, msg=msg)
+                listener_manager.hook.on_dag_run_success(dag_run=self, msg=msg)
             elif self.state == DagRunState.FAILED:
-                get_listener_manager().hook.on_dag_run_failed(dag_run=self, msg=msg)
+                listener_manager.hook.on_dag_run_failed(dag_run=self, msg=msg)
         except Exception:
             self.log.exception("Error while calling listener")
         # deliberately not notifying on QUEUED

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -80,7 +80,7 @@ from airflow.assets.manager import asset_manager
 from airflow.configuration import conf
 from airflow.exceptions import RemovedInAirflow4Warning
 from airflow.executors.workloads import BaseWorkload
-from airflow.listeners.listener import get_listener_manager
+from airflow.listeners.listener import get_listener_manager_for_dag
 from airflow.models.asset import AssetModel
 from airflow.models.base import Base, StringID, TaskInstanceDependencies
 from airflow.models.dag_version import DagVersion
@@ -1897,7 +1897,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
             ti.state = State.UP_FOR_RETRY
 
         try:
-            get_listener_manager().hook.on_task_instance_failed(
+            get_listener_manager_for_dag(ti.dag_id, session=session).hook.on_task_instance_failed(
                 previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
             )
         except Exception:

--- a/airflow-core/src/airflow/plugins_manager.py
+++ b/airflow-core/src/airflow/plugins_manager.py
@@ -328,13 +328,22 @@ def integrate_macros_plugins() -> None:
     )
 
 
-def integrate_listener_plugins(listener_manager: ListenerManager) -> None:
-    """Add listeners from plugins."""
+def integrate_listener_plugins(listener_manager: ListenerManager, team_name: str | None = None) -> None:
+    """
+    Add listeners from plugins to the given listener manager.
+
+    In multi-team mode, only listeners from global plugins (``team_name is None``)
+    and plugins belonging to ``team_name`` are registered, so a team-scoped manager
+    never receives another team's listeners. When multi-team mode is disabled every
+    plugin's listeners are registered (``team_name`` is ignored).
+    """
     from airflow._shared.plugins_manager import (
         integrate_listener_plugins as _integrate_listener_plugins,
     )
 
     plugins, _ = _get_plugins()
+    if conf.getboolean("core", "multi_team"):
+        plugins = [plugin for plugin in plugins if plugin.team_name in (None, team_name)]
     _integrate_listener_plugins(listener_manager, plugins=plugins)
 
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -9335,7 +9335,7 @@ class TestSchedulerJob:
             last_ti=dag_run.get_task_instance(task_id="test_task"),
         )
 
-    @mock.patch("airflow.models.dagrun.get_listener_manager")
+    @mock.patch("airflow.models.dagrun.get_listener_manager_for_dag")
     def test_dag_start_notifies_with_started_msg(self, mock_get_listener_manager, dag_maker, session):
         """Test that notify_dagrun_state_changed is called with msg='started' when DAG starts."""
         mock_listener_manager = MagicMock()
@@ -9360,7 +9360,7 @@ class TestSchedulerJob:
         assert call_args.kwargs["msg"] == "started"
         assert call_args.kwargs["dag_run"].dag_id == dag_run.dag_id
 
-    @mock.patch("airflow.models.dagrun.get_listener_manager")
+    @mock.patch("airflow.models.dagrun.get_listener_manager_for_dag")
     def test_dag_timeout_notifies_with_timed_out_msg(self, mock_get_listener_manager, dag_maker, session):
         """Test that notify_dagrun_state_changed is called with msg='timed_out' when DAG times out."""
         mock_listener_manager = MagicMock()

--- a/airflow-core/tests/unit/listeners/test_listeners.py
+++ b/airflow-core/tests/unit/listeners/test_listeners.py
@@ -20,16 +20,22 @@ import contextlib
 import logging
 import os
 from typing import TYPE_CHECKING
+from unittest import mock
 
 import pytest
 
+from airflow._shared.listeners.listener import ListenerManager
 from airflow._shared.timezones import timezone
 from airflow.exceptions import AirflowException
 from airflow.jobs.job import Job, run_job
+from airflow.listeners import hookimpl, listener as listener_module
+from airflow.plugins_manager import AirflowPlugin, integrate_listener_plugins
 from airflow.providers.standard.operators.bash import BashOperator
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState, TaskInstanceState
 
+from tests_common.test_utils.config import conf_vars
+from tests_common.test_utils.mock_plugins import mock_plugin_manager
 from unit.listeners import (
     class_listener,
     full_listener,
@@ -184,3 +190,104 @@ def test_listener_logs_call(caplog, create_task_instance, listener_manager, *, s
     assert listener_logs[3][-1].startswith("Calling 'on_task_instance_success' with {'")
     assert listener_logs[4][-1].startswith("Hook impls: [<HookImpl plugin")
     assert listener_logs[5][-1] == "Result from 'on_task_instance_success': []"
+
+
+class _RecordingListener:
+    """Minimal task-instance listener used to verify registration/isolation."""
+
+    @hookimpl
+    def on_task_instance_running(self, previous_state, task_instance):
+        pass
+
+
+def _make_team_plugin(name: str, team_name: str | None, listener: object) -> AirflowPlugin:
+    plugin = AirflowPlugin()
+    plugin.name = name
+    plugin.team_name = team_name
+    plugin.listeners = [listener]
+    return plugin
+
+
+@pytest.fixture
+def team_listener_plugins():
+    global_listener = _RecordingListener()
+    team_a_listener = _RecordingListener()
+    team_b_listener = _RecordingListener()
+    plugins = [
+        _make_team_plugin("global_plugin", None, global_listener),
+        _make_team_plugin("team_a_plugin", "team_a", team_a_listener),
+        _make_team_plugin("team_b_plugin", "team_b", team_b_listener),
+    ]
+    return plugins, global_listener, team_a_listener, team_b_listener
+
+
+class TestIntegrateListenerPluginsTeamFiltering:
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_team_manager_gets_global_and_own_team_only(self, team_listener_plugins):
+        plugins, global_listener, team_a_listener, team_b_listener = team_listener_plugins
+        manager = ListenerManager()
+        with mock_plugin_manager(plugins=plugins):
+            integrate_listener_plugins(manager, team_name="team_a")
+
+        registered = set(manager.pm.get_plugins())
+        assert global_listener in registered
+        assert team_a_listener in registered
+        assert team_b_listener not in registered
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_global_manager_gets_only_global(self, team_listener_plugins):
+        plugins, global_listener, team_a_listener, team_b_listener = team_listener_plugins
+        manager = ListenerManager()
+        with mock_plugin_manager(plugins=plugins):
+            integrate_listener_plugins(manager, team_name=None)
+
+        registered = set(manager.pm.get_plugins())
+        assert global_listener in registered
+        assert team_a_listener not in registered
+        assert team_b_listener not in registered
+
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_multi_team_disabled_registers_all_listeners(self, team_listener_plugins):
+        plugins, global_listener, team_a_listener, team_b_listener = team_listener_plugins
+        manager = ListenerManager()
+        with mock_plugin_manager(plugins=plugins):
+            integrate_listener_plugins(manager, team_name="team_a")
+
+        registered = set(manager.pm.get_plugins())
+        assert {global_listener, team_a_listener, team_b_listener} <= registered
+
+
+class TestGetListenerManagerTeamKeying:
+    def test_global_calls_return_same_instance(self):
+        listener_module._build_listener_manager.cache_clear()
+        default_manager = listener_module.get_listener_manager()
+        assert default_manager is listener_module.get_listener_manager(None)
+        assert default_manager is listener_module.get_listener_manager(team_name=None)
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_distinct_team_returns_distinct_instance(self):
+        listener_module._build_listener_manager.cache_clear()
+        with mock_plugin_manager(plugins=[]):
+            global_manager = listener_module.get_listener_manager()
+            team_manager = listener_module.get_listener_manager("team_a")
+        assert global_manager is not team_manager
+
+
+class TestGetListenerManagerForDag:
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_returns_global_manager_when_multi_team_disabled(self):
+        with mock.patch("airflow.models.dag.DagModel.get_team_name") as mock_get_team_name:
+            resolved = listener_module.get_listener_manager_for_dag("some_dag")
+        assert resolved is listener_module.get_listener_manager()
+        mock_get_team_name.assert_not_called()
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_resolves_team_and_returns_team_manager(self):
+        listener_module._build_listener_manager.cache_clear()
+        with mock_plugin_manager(plugins=[]):
+            with mock.patch(
+                "airflow.models.dag.DagModel.get_team_name", return_value="team_a"
+            ) as mock_get_team_name:
+                resolved = listener_module.get_listener_manager_for_dag("some_dag")
+            assert resolved is listener_module.get_listener_manager("team_a")
+        mock_get_team_name.assert_called_once()

--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -3107,7 +3107,7 @@ def listener_manager():
         get_sdk_lm = None
 
     core_lm = get_core_lm()
-    sdk_lm = get_sdk_lm() if get_sdk_lm else None
+    sdk_lm = get_sdk_lm() if get_sdk_lm is not None else None
 
     core_lm.clear()
     if sdk_lm:

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -259,6 +259,13 @@ class RuntimeTaskInstance(TaskInstance):
     sentry_integration: str = ""
 
     @property
+    def team_name(self) -> str | None:
+        """The team that owns this task, as provided by the server context, if any."""
+        if self._ti_context_from_server:
+            return self._ti_context_from_server.dag_run.team_name
+        return None
+
+    @property
     def stats_tags(self) -> dict[str, str]:
         """Metric tags for this task instance, including dag tags and team_name when available."""
         tags: dict[str, str] = {}
@@ -272,8 +279,8 @@ class RuntimeTaskInstance(TaskInstance):
             # than "dagruntype.scheduled" (matching the scheduler, which emits the plain string).
             run_type = self._ti_context_from_server.dag_run.run_type
             tags["run_type"] = getattr(run_type, "value", run_type)
-            if self._ti_context_from_server.dag_run.team_name:
-                tags["team_name"] = self._ti_context_from_server.dag_run.team_name
+            if self.team_name:
+                tags["team_name"] = self.team_name
         return tags
 
     def __rich_repr__(self):
@@ -1440,7 +1447,7 @@ def _prepare(ti: RuntimeTaskInstance, log: Logger, context: Context) -> ToSuperv
 
     try:
         # TODO: Call pre execute etc.
-        get_listener_manager().hook.on_task_instance_running(
+        get_listener_manager(team_name=ti.team_name).hook.on_task_instance_running(
             previous_state=TaskInstanceState.QUEUED, task_instance=ti
         )
     except Exception:
@@ -2281,7 +2288,7 @@ def finalize(
     if state == TaskInstanceState.SUCCESS:
         _run_task_state_change_callbacks(task, "on_success_callback", context, log)
         try:
-            get_listener_manager().hook.on_task_instance_success(
+            get_listener_manager(team_name=ti.team_name).hook.on_task_instance_success(
                 previous_state=TaskInstanceState.RUNNING, task_instance=ti
             )
         except Exception:
@@ -2289,7 +2296,7 @@ def finalize(
     elif state == TaskInstanceState.SKIPPED:
         _run_task_state_change_callbacks(task, "on_skipped_callback", context, log)
         try:
-            get_listener_manager().hook.on_task_instance_skipped(
+            get_listener_manager(team_name=ti.team_name).hook.on_task_instance_skipped(
                 previous_state=TaskInstanceState.RUNNING, task_instance=ti
             )
         except Exception:
@@ -2297,7 +2304,7 @@ def finalize(
     elif state == TaskInstanceState.UP_FOR_RETRY:
         _run_task_state_change_callbacks(task, "on_retry_callback", context, log)
         try:
-            get_listener_manager().hook.on_task_instance_failed(
+            get_listener_manager(team_name=ti.team_name).hook.on_task_instance_failed(
                 previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
             )
         except Exception:
@@ -2307,7 +2314,7 @@ def finalize(
     elif state == TaskInstanceState.FAILED:
         _run_task_state_change_callbacks(task, "on_failure_callback", context, log)
         try:
-            get_listener_manager().hook.on_task_instance_failed(
+            get_listener_manager(team_name=ti.team_name).hook.on_task_instance_failed(
                 previous_state=TaskInstanceState.RUNNING, task_instance=ti, error=error
             )
         except Exception:

--- a/task-sdk/src/airflow/sdk/listener.py
+++ b/task-sdk/src/airflow/sdk/listener.py
@@ -25,21 +25,37 @@ from airflow.sdk.plugins_manager import integrate_listener_plugins
 
 
 @cache
-def get_listener_manager() -> ListenerManager:
+def _build_listener_manager(team_name: str | None) -> ListenerManager:
+    _listener_manager = ListenerManager()
+
+    _listener_manager.add_hookspecs(lifecycle)
+    _listener_manager.add_hookspecs(taskinstance)
+
+    integrate_listener_plugins(_listener_manager, team_name=team_name)  # type: ignore[arg-type]
+    return _listener_manager
+
+
+def get_listener_manager(team_name: str | None = None) -> ListenerManager:
     """
     Get a listener manager for task sdk.
 
     Registers the following listeners:
     - lifecycle: on_starting, before_stopping
     - taskinstance: on_task_instance_running, on_task_instance_success, etc.
+
+    :param team_name: The team of the task being executed, as provided by the server
+        in the task instance context. The manager contains the global plugin
+        listeners plus that team's listeners. ``None`` (a teamless task, or multi-team
+        disabled) yields a manager with only the global plugin listeners. The worker
+        deliberately relies on this server-provided value rather than reading
+        ``core.multi_team`` from its own (possibly incomplete) configuration.
+
+    Calls are cached per ``team_name``. The single positional delegation to
+    ``_build_listener_manager`` guarantees that ``get_listener_manager()``,
+    ``get_listener_manager(None)`` and ``get_listener_manager(team_name=None)`` all
+    return the identical (global) manager instance.
     """
-    _listener_manager = ListenerManager()
-
-    _listener_manager.add_hookspecs(lifecycle)
-    _listener_manager.add_hookspecs(taskinstance)
-
-    integrate_listener_plugins(_listener_manager)  # type: ignore[arg-type]
-    return _listener_manager
+    return _build_listener_manager(team_name)
 
 
 __all__ = ["get_listener_manager", "ListenerManager"]

--- a/task-sdk/src/airflow/sdk/plugins_manager.py
+++ b/task-sdk/src/airflow/sdk/plugins_manager.py
@@ -128,9 +128,17 @@ def integrate_macros_plugins() -> None:
     )
 
 
-def integrate_listener_plugins(listener_manager: ListenerManager) -> None:
-    """Add listeners from plugins."""
+def integrate_listener_plugins(listener_manager: ListenerManager, team_name: str | None = None) -> None:
+    """
+    Add listeners from plugins to the given listener manager.
+
+    Only listeners from global plugins (``team_name is None``) and plugins belonging
+    to ``team_name`` are registered. On the worker, ``team_name`` comes from the
+    server-provided task instance context; filtering here is always applied and does
+    not depend on the worker reading ``core.multi_team`` from its own configuration.
+    """
     plugins, _ = _get_plugins()
+    plugins = [plugin for plugin in plugins if plugin.team_name in (None, team_name)]
     _integrate_listener_plugins(listener_manager, plugins=plugins)
 
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -3521,6 +3521,20 @@ class TestRuntimeTaskInstance:
         assert response.dag_id == "test_dag"
         assert response.is_paused is False
 
+    def test_team_name_from_context(self, create_runtime_ti):
+        runtime_ti = create_runtime_ti(task=BaseOperator(task_id="task"))
+        runtime_ti._ti_context_from_server.dag_run.team_name = "team_a"
+        assert runtime_ti.team_name == "team_a"
+
+    def test_team_name_none_when_context_has_no_team(self, create_runtime_ti):
+        runtime_ti = create_runtime_ti(task=BaseOperator(task_id="task"))
+        assert runtime_ti.team_name is None
+
+    def test_team_name_none_without_server_context(self, create_runtime_ti):
+        runtime_ti = create_runtime_ti(task=BaseOperator(task_id="task"))
+        runtime_ti._ti_context_from_server = None
+        assert runtime_ti.team_name is None
+
 
 class TestXComAfterTaskExecution:
     @pytest.mark.parametrize(

--- a/task-sdk/tests/task_sdk/test_plugins_manager.py
+++ b/task-sdk/tests/task_sdk/test_plugins_manager.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.listeners import hookimpl
+from airflow.sdk._shared.listeners.listener import ListenerManager
+from airflow.sdk.plugins_manager import AirflowPlugin, integrate_listener_plugins
+
+from tests_common.test_utils.mock_plugins import mock_plugin_manager
+
+
+class _RecordingListener:
+    @hookimpl
+    def on_task_instance_running(self, previous_state, task_instance):
+        pass
+
+
+def _make_plugin(name: str, team_name: str | None, listener: object) -> AirflowPlugin:
+    plugin = AirflowPlugin()
+    plugin.name = name
+    plugin.team_name = team_name
+    plugin.listeners = [listener]
+    return plugin
+
+
+class TestIntegrateListenerPluginsTeamFiltering:
+    """The worker always scopes by the server-provided team, independent of any
+    local ``core.multi_team`` configuration."""
+
+    def test_team_scoped_manager_excludes_other_teams(self):
+        global_listener = _RecordingListener()
+        team_a_listener = _RecordingListener()
+        team_b_listener = _RecordingListener()
+        plugins = [
+            _make_plugin("global_plugin", None, global_listener),
+            _make_plugin("team_a_plugin", "team_a", team_a_listener),
+            _make_plugin("team_b_plugin", "team_b", team_b_listener),
+        ]
+        manager = ListenerManager()
+        with mock_plugin_manager(plugins=plugins):
+            integrate_listener_plugins(manager, team_name="team_a")
+
+        registered = set(manager.pm.get_plugins())
+        assert global_listener in registered
+        assert team_a_listener in registered
+        assert team_b_listener not in registered
+
+    def test_teamless_manager_gets_only_global(self):
+        global_listener = _RecordingListener()
+        team_a_listener = _RecordingListener()
+        plugins = [
+            _make_plugin("global_plugin", None, global_listener),
+            _make_plugin("team_a_plugin", "team_a", team_a_listener),
+        ]
+        manager = ListenerManager()
+        with mock_plugin_manager(plugins=plugins):
+            integrate_listener_plugins(manager, team_name=None)
+
+        registered = set(manager.pm.get_plugins())
+        assert global_listener in registered
+        assert team_a_listener not in registered


### PR DESCRIPTION
When multi-team mode is enabled, a team-scoped plugin's listeners now only receive events for that team's Dags, while global plugins (no team_name) continue to receive everything. Component-lifecycle, asset, and import-error hooks remain global because they are not associated with a single team.

On the worker the team is taken from the server-provided task instance context rather than local configuration, so scoping does not depend on whether core.multi_team happens to be set on the worker which is not entirely reliable.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
