### PR TITLE
Let area:e2e-tests label force the airflow-e2e-tests suite

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -596,7 +596,7 @@ labelPRBasedOnFilePath:
   area:docker-tests:
     - docker-tests/**/*
 
-  area:e2e-test:
+  area:e2e-tests:
     - airflow-e2e-tests/**/*
 
   area:kubernetes-tests:

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -596,6 +596,9 @@ labelPRBasedOnFilePath:
   area:docker-tests:
     - docker-tests/**/*
 
+  area:e2e-test:
+    - airflow-e2e-tests/**/*
+
   area:kubernetes-tests:
     - kubernetes-tests/**/*
 

--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -642,7 +642,7 @@ This table summarizes the labels you can use on PRs to control the selective che
 |----------------------------------|----------------------------------|-------------------------------------------------------------------------------------------|
 | all versions                     | all-versions, *-versions-*       | Run tests for all python and k8s versions.                                                |
 | allow suspended provider changes | allow-suspended-provider-changes | Allow changes to suspended providers.                                                     |
-| area:e2e-test                    | prod-image-build                 | If set, the Airflow E2E tests are run regardless of changed files (does not force the full test matrix). |
+| area:e2e-tests                   | prod-image-build                 | If set, the Airflow E2E tests are run regardless of changed files (does not force the full test matrix). |
 | area:kubernetes-tests            | run-kubernetes-tests             | If set, the Kubernetes tests job is run regardless of changed files (does not force the full test matrix). |
 | canary                           | is-canary-run                    | If set, the PR run from apache/airflow repo behaves as `canary` run.                      |
 | debug ci resources               | debug-ci-resources               | If set, then debugging resources is enabled during parallel tests and you can see them.   |

--- a/dev/breeze/doc/ci/04_selective_checks.md
+++ b/dev/breeze/doc/ci/04_selective_checks.md
@@ -642,6 +642,7 @@ This table summarizes the labels you can use on PRs to control the selective che
 |----------------------------------|----------------------------------|-------------------------------------------------------------------------------------------|
 | all versions                     | all-versions, *-versions-*       | Run tests for all python and k8s versions.                                                |
 | allow suspended provider changes | allow-suspended-provider-changes | Allow changes to suspended providers.                                                     |
+| area:e2e-test                    | prod-image-build                 | If set, the Airflow E2E tests are run regardless of changed files (does not force the full test matrix). |
 | area:kubernetes-tests            | run-kubernetes-tests             | If set, the Kubernetes tests job is run regardless of changed files (does not force the full test matrix). |
 | canary                           | is-canary-run                    | If set, the PR run from apache/airflow repo behaves as `canary` run.                      |
 | debug ci resources               | debug-ci-resources               | If set, then debugging resources is enabled during parallel tests and you can see them.   |

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -92,7 +92,7 @@ UPGRADE_TO_NEWER_DEPENDENCIES_LABEL = "upgrade to newer dependencies"
 USE_PUBLIC_RUNNERS_LABEL = "use public runners"
 ALLOW_PROVIDER_DEPENDENCY_BUMP_LABEL = "allow provider dependency bump"
 SKIP_COMMON_COMPAT_CHECK_LABEL = "skip common compat check"
-AREA_E2E_TEST_LABEL = "area:e2e-test"
+AREA_E2E_TESTS_LABEL = "area:e2e-tests"
 AREA_KUBERNETES_TESTS_LABEL = "area:kubernetes-tests"
 ALL_CI_SELECTIVE_TEST_TYPES = "API Always CLI Core Other Serialization"
 
@@ -1206,10 +1206,10 @@ class SelectiveChecks:
 
     @cached_property
     def prod_image_build(self) -> bool:
-        if AREA_E2E_TEST_LABEL in self._pr_labels:
+        if AREA_E2E_TESTS_LABEL in self._pr_labels:
             console_print(
                 "[warning]Building the PROD image to run Airflow E2E tests because "
-                f"label '{AREA_E2E_TEST_LABEL}' is in {self._pr_labels}[/]"
+                f"label '{AREA_E2E_TESTS_LABEL}' is in {self._pr_labels}[/]"
             )
             return True
         return (

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -92,6 +92,7 @@ UPGRADE_TO_NEWER_DEPENDENCIES_LABEL = "upgrade to newer dependencies"
 USE_PUBLIC_RUNNERS_LABEL = "use public runners"
 ALLOW_PROVIDER_DEPENDENCY_BUMP_LABEL = "allow provider dependency bump"
 SKIP_COMMON_COMPAT_CHECK_LABEL = "skip common compat check"
+AREA_E2E_TEST_LABEL = "area:e2e-test"
 AREA_KUBERNETES_TESTS_LABEL = "area:kubernetes-tests"
 ALL_CI_SELECTIVE_TEST_TYPES = "API Always CLI Core Other Serialization"
 
@@ -1205,6 +1206,12 @@ class SelectiveChecks:
 
     @cached_property
     def prod_image_build(self) -> bool:
+        if AREA_E2E_TEST_LABEL in self._pr_labels:
+            console_print(
+                "[warning]Building the PROD image to run Airflow E2E tests because "
+                f"label '{AREA_E2E_TEST_LABEL}' is in {self._pr_labels}[/]"
+            )
+            return True
         return (
             self.run_kubernetes_tests
             or self.run_helm_tests

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3719,13 +3719,13 @@ def test_run_kubernetes_tests_forced_by_label_with_no_changed_files():
 
 
 @pytest.mark.parametrize("files", [("INTHEWILD.md",), ()], ids=["unrelated-file", "no-files"])
-def test_prod_image_build_forced_by_e2e_test_label(files):
+def test_prod_image_build_forced_by_e2e_tests_label(files):
     checks = SelectiveChecks(
         files=files,
         commit_ref=NEUTRAL_COMMIT,
         github_event=GithubEvents.PULL_REQUEST,
         default_branch="main",
-        pr_labels=("area:e2e-test",),
+        pr_labels=("area:e2e-tests",),
     )
     assert checks.prod_image_build is True
     assert checks.full_tests_needed is False

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -3718,6 +3718,19 @@ def test_run_kubernetes_tests_forced_by_label_with_no_changed_files():
     assert checks.full_tests_needed is False
 
 
+@pytest.mark.parametrize("files", [("INTHEWILD.md",), ()], ids=["unrelated-file", "no-files"])
+def test_prod_image_build_forced_by_e2e_test_label(files):
+    checks = SelectiveChecks(
+        files=files,
+        commit_ref=NEUTRAL_COMMIT,
+        github_event=GithubEvents.PULL_REQUEST,
+        default_branch="main",
+        pr_labels=("area:e2e-test",),
+    )
+    assert checks.prod_image_build is True
+    assert checks.full_tests_needed is False
+
+
 def test_filter_platform_excluded_test_types_handles_all_shapes():
     """Direct unit check of the in-place filter for the three Providers[...] shapes."""
     checks = SelectiveChecks(


### PR DESCRIPTION
- Related: https://github.com/apache/airflow/pull/69519

## Why

Changes that need E2E coverage beyond selective-checks' file heuristics currently have no focused way to request it without running the full test matrix.

## What

- Let "'`area:e2e-tests` force the PROD image build and standard Airflow E2E tests without forcing the full test matrix.
- Register and document the label, with coverage for label-only runs.


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)