### PR TITLE
Add async Kotlin client support to the Java SDK

### DIFF
--- a/java-sdk/README.md
+++ b/java-sdk/README.md
@@ -47,6 +47,53 @@ development tools may have further requirements (see the toolchain in
 This uses [Dokka](https://kotl.in/dokka) to build documentation of the Java SDK.
 This generates both an HTML representation and Javadoc.
 
+## Coroutine tasks in Kotlin
+
+Kotlin tasks can use the coroutine-native client instead of blocking for each
+Airflow API call. Apply KAPT to the SDK annotation processor in the bundle's
+Gradle build:
+
+```kotlin
+plugins {
+    kotlin("jvm") version "<kotlin-version>"
+    kotlin("kapt") version "<kotlin-version>"
+    id("org.apache.airflow.sdk") version "<airflow-java-sdk-version>"
+}
+
+dependencies {
+    implementation("org.apache.airflow:airflow-sdk:<airflow-java-sdk-version>")
+    kapt("org.apache.airflow:airflow-sdk-processor:<airflow-java-sdk-version>")
+}
+```
+
+The existing annotations automatically recognize a `suspend` task function and
+generate an asynchronous task implementation:
+
+```kotlin
+import org.apache.airflow.sdk.Builder
+import org.apache.airflow.sdk.kotlin.AsyncClient
+
+@Builder.Dag(id = "kotlin_example")
+class KotlinExample {
+    @Builder.Task
+    suspend fun extract(client: AsyncClient): String =
+        client.getVariable("input") as String
+
+    @Builder.Task
+    suspend fun transform(
+        client: AsyncClient,
+        @Builder.XCom(task = "extract") input: String,
+    ): String {
+        val suffix = client.getVariable("suffix") as String
+        return "$input$suffix"
+    }
+}
+```
+
+Return values are pushed to XCom in the same way as synchronous annotated task
+functions. Existing Java tasks and the synchronous `Task` and `Client` APIs are
+unchanged.
+
 
 ## Running the example
 

--- a/java-sdk/processor/build.gradle.kts
+++ b/java-sdk/processor/build.gradle.kts
@@ -21,7 +21,12 @@ plugins {
     `java-library`
     id("airflow-jvm-conventions")
     id("airflow-publish")
+    kotlin("kapt")
 }
+
+val processorJar = tasks.named<Jar>("jar")
+
+kapt { includeCompileClasspath = false }
 
 dependencies {
     compileOnly("javax.annotation:javax.annotation-api:1.3.2")
@@ -30,6 +35,9 @@ dependencies {
 
     testImplementation(kotlin("test"))
     testImplementation("com.google.testing.compile:compile-testing:0.23.0")
+    add("kaptTest", files(processorJar))
+    add("kaptTest", project(":sdk"))
+    add("kaptTest", "com.squareup:javapoet:1.13.0")
 }
 
 java {

--- a/java-sdk/processor/src/main/kotlin/org/apache/airflow/sdk/BuilderProcessor.kt
+++ b/java-sdk/processor/src/main/kotlin/org/apache/airflow/sdk/BuilderProcessor.kt
@@ -25,8 +25,10 @@ import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.WildcardTypeName
 import java.util.Optional
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.ProcessingEnvironment
@@ -39,6 +41,7 @@ import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.type.TypeKind
 import javax.lang.model.type.TypeMirror
+import javax.lang.model.type.WildcardType
 import javax.tools.Diagnostic
 
 /**
@@ -53,13 +56,15 @@ import javax.tools.Diagnostic
  * For each class annotated with [Builder.Dag], generates a `*Builder` class
  * containing:
  *
- * - One inner class per [Builder.Task]-annotated method, implementing [Task].
+ * - One inner class per [Builder.Task]-annotated method, implementing [Task] or
+ *   `AsyncTask` for a Kotlin suspending function.
  * - A static `build()` method that constructs the [Dag] and registers those
  *   inner classes as tasks.
  *
  * [Builder.XCom]-annotated parameters are resolved via `client.getXCom` in the
  * generated `execute` body, with the result cast to the parameter's declared
- * type. Non-`void` return values are forwarded to `client.setXCom`.
+ * type. Non-`void` synchronous and non-`Unit` suspending return values are
+ * forwarded to `client.setXCom`.
  */
 @SupportedAnnotationTypes("org.apache.airflow.sdk.Builder.Dag")
 @SupportedSourceVersion(SourceVersion.RELEASE_11)
@@ -116,7 +121,7 @@ class BuilderProcessor : AbstractProcessor() {
       builderClass.addType(task.spec)
 
       buildMethod.addStatement(
-        $$"dag.addTask($S, $L.class)",
+        if (task.isAsync) $$"dag.addAsyncTask($S, $L.class)" else $$"dag.addTask($S, $L.class)",
         ann.id.ifBlank { inner.simpleName },
         innerName,
       )
@@ -128,6 +133,17 @@ class BuilderProcessor : AbstractProcessor() {
   }
 
   private fun buildTask(
+    name: String,
+    inner: ExecutableElement,
+    parent: TypeElement,
+  ): BuildTaskResult =
+    if (processingEnv.isSuspendFunction(inner)) {
+      buildAsyncTask(name, inner, parent)
+    } else {
+      buildSyncTask(name, inner, parent)
+    }
+
+  private fun buildSyncTask(
     name: String,
     inner: ExecutableElement,
     parent: TypeElement,
@@ -185,7 +201,107 @@ class BuilderProcessor : AbstractProcessor() {
         .addModifiers(Modifier.PUBLIC, Modifier.FINAL, Modifier.STATIC)
         .addMethod(executeSpec.build())
         .build()
-    return BuildTaskResult(spec)
+    return BuildTaskResult(spec, isAsync = false)
+  }
+
+  private fun buildAsyncTask(
+    name: String,
+    inner: ExecutableElement,
+    parent: TypeElement,
+  ): BuildTaskResult {
+    val asyncClientType = ClassName.get("org.apache.airflow.sdk.kotlin", "AsyncClient")
+    val asyncTaskType = ClassName.get("org.apache.airflow.sdk.kotlin", "AsyncTask")
+    val bridgeType = ClassName.get("org.apache.airflow.sdk.kotlin", "AsyncTaskBridge")
+    val contextType = ClassName.get(Context::class.java)
+    val continuationType = ClassName.get("kotlin.coroutines", "Continuation")
+    val unitType = ClassName.get("kotlin", "Unit")
+    val completionType =
+      ParameterizedTypeName.get(
+        continuationType,
+        WildcardTypeName.supertypeOf(unitType),
+      )
+
+    val required = mutableListOf<RequiredXCom>()
+    val innerArgs =
+      with(processingEnv) {
+        inner.parameters.dropLast(1).map { param ->
+          val anno = param.getAnnotation(Builder.XCom::class.java)
+          val type = param.asType()
+          when {
+            anno != null -> {
+              val xcom = RequiredXCom(type, param.simpleName.toString(), anno.task.ifBlank { param.simpleName.toString() })
+              required += xcom
+              xcomAccess(xcom, CodeBlock.of($$"xcomValues.get($L)", required.lastIndex))
+            }
+            isType(type, asyncClientType) -> CodeBlock.of("client")
+            isType(type, contextType) -> CodeBlock.of("context")
+            else -> throw IllegalArgumentException("Unsupported async task parameter '${param.simpleName}' with type: $type")
+          }
+        }
+      }
+
+    val taskCall =
+      CodeBlock.of(
+        $$"new $T().$L($L)",
+        ClassName.get(parent),
+        inner.simpleName,
+        CodeBlock.join(innerArgs + CodeBlock.of("taskContinuation"), ", "),
+      )
+    val xcomTaskIds =
+      CodeBlock
+        .builder()
+        .add("new String[] {")
+        .apply {
+          required.forEachIndexed { index, xcom ->
+            if (index > 0) add(", ")
+            add($$"$S", xcom.taskId)
+          }
+        }.add("}")
+        .build()
+    val publishResult = !processingEnv.isType(processingEnv.suspendResultType(inner), unitType)
+
+    val executeSpec =
+      MethodSpec
+        .methodBuilder("execute")
+        .addAnnotation(Override::class.java)
+        .addModifiers(Modifier.PUBLIC)
+        .returns(TypeName.OBJECT)
+        .addParameter(contextType, "context")
+        .addParameter(asyncClientType, "client")
+        .addParameter(completionType, "continuation")
+        .addException(Exception::class.java)
+        .addStatement(
+          $$"return $T.execute(client, $L, $L, (xcomValues, taskContinuation) -> $L, continuation)",
+          bridgeType,
+          xcomTaskIds,
+          publishResult,
+          taskCall,
+        ).build()
+
+    val spec =
+      TypeSpec
+        .classBuilder(name)
+        .addSuperinterface(asyncTaskType)
+        .addModifiers(Modifier.PUBLIC, Modifier.FINAL, Modifier.STATIC)
+        .addMethod(executeSpec)
+        .build()
+    return BuildTaskResult(spec, isAsync = true)
+  }
+}
+
+private fun ProcessingEnvironment.isSuspendFunction(inner: ExecutableElement): Boolean {
+  val continuation = elementUtils.getTypeElement("kotlin.coroutines.Continuation") ?: return false
+  val lastParameter = inner.parameters.lastOrNull() ?: return false
+  return typeUtils.isSameType(typeUtils.erasure(lastParameter.asType()), typeUtils.erasure(continuation.asType()))
+}
+
+private fun ProcessingEnvironment.suspendResultType(inner: ExecutableElement): TypeMirror {
+  val continuation = inner.parameters.last().asType() as javax.lang.model.type.DeclaredType
+  val result = continuation.typeArguments.single()
+  return if (result is WildcardType) {
+    result.superBound ?: result.extendsBound
+  } else {
+    result
   }
 }
 
@@ -215,7 +331,10 @@ private val NUMBER_ACCESSORS: Map<TypeName, String> =
     }
   }
 
-private fun xcomAccess(xcom: RequiredXCom): CodeBlock {
+private fun xcomAccess(
+  xcom: RequiredXCom,
+  call: CodeBlock = CodeBlock.of($$"client.getXCom($S)", xcom.taskId),
+): CodeBlock {
   val type = TypeName.get(xcom.paramType)
   val accessor = NUMBER_ACCESSORS[type]
   val number = ClassName.get(Number::class.java)
@@ -225,15 +344,15 @@ private fun xcomAccess(xcom: RequiredXCom): CodeBlock {
   val value =
     if (type.isPrimitive) {
       CodeBlock.of(
-        $$"$T.ofNullable(client.getXCom($S)).orElseThrow(() -> new $T($S, $S))",
+        $$"$T.ofNullable($L).orElseThrow(() -> new $T($S, $S))",
         optional,
-        xcom.taskId,
+        call,
         ClassName.get(MissingXComException::class.java),
         xcom.taskId,
         xcom.paramName,
       )
     } else {
-      CodeBlock.of($$"client.getXCom($S)", xcom.taskId)
+      call
     }
   // Wire integers decode to Long and floats to Double, so a direct (Integer)/(Float)
   // cast throws ClassCastException; widen via Number instead.
@@ -254,4 +373,5 @@ private fun xcomAccess(xcom: RequiredXCom): CodeBlock {
 
 private data class BuildTaskResult(
   val spec: TypeSpec,
+  val isAsync: Boolean,
 )

--- a/java-sdk/processor/src/test/kotlin/org/apache/airflow/sdk/BuilderTest.kt
+++ b/java-sdk/processor/src/test/kotlin/org/apache/airflow/sdk/BuilderTest.kt
@@ -120,6 +120,103 @@ class BuilderTest {
   }
 
   @Test
+  @DisplayName("generate async tasks from Kotlin suspend descriptors")
+  fun generateAsyncTasksFromKotlinSuspendDescriptors() {
+    val compilation =
+      compile(
+        """
+        package org.apache.airflow.example;
+
+        import kotlin.Unit;
+        import kotlin.coroutines.Continuation;
+        import org.apache.airflow.sdk.Builder;
+        import org.apache.airflow.sdk.Context;
+        import org.apache.airflow.sdk.kotlin.AsyncClient;
+
+        @Builder.Dag
+        public class TestExample {
+          @Builder.Task
+          public Object transform(
+              Context context,
+              AsyncClient client,
+              @Builder.XCom(task = "upstream") int value,
+              Continuation<? super Integer> completion) {
+            return value;
+          }
+
+          @Builder.Task
+          public Object load(Continuation<? super Unit> completion) {
+            return Unit.INSTANCE;
+          }
+        }
+        """,
+      )
+
+    assertThat(compilation).succeeded()
+    assertThat(compilation)
+      .generatedSourceFile("org.apache.airflow.example.TestExampleBuilder")
+      .hasSourceEquivalentTo(
+        "org.apache.airflow.example.TestExampleBuilder",
+        """
+         package org.apache.airflow.example;
+
+         import java.lang.Exception;
+         import java.lang.Number;
+         import java.lang.Object;
+         import java.lang.Override;
+         import java.util.Optional;
+         import kotlin.Unit;
+         import kotlin.coroutines.Continuation;
+         import org.apache.airflow.sdk.Context;
+         import org.apache.airflow.sdk.Dag;
+         import org.apache.airflow.sdk.MissingXComException;
+         import org.apache.airflow.sdk.kotlin.AsyncClient;
+         import org.apache.airflow.sdk.kotlin.AsyncTask;
+         import org.apache.airflow.sdk.kotlin.AsyncTaskBridge;
+
+         public final class TestExampleBuilder {
+           public static Dag build() {
+             var dag = new Dag("TestExample");
+             dag.addAsyncTask("transform", Transform.class);
+             dag.addAsyncTask("load", Load.class);
+             return dag;
+           }
+           public static final class Transform implements AsyncTask {
+             @Override
+             public Object execute(
+                 Context context,
+                 AsyncClient client,
+                 Continuation<? super Unit> continuation) throws Exception {
+               return AsyncTaskBridge.execute(
+                   client,
+                   new String[] {"upstream"},
+                   true,
+                   (xcomValues, taskContinuation) ->
+                       new TestExample().transform(
+                           context, client, ((Number) Optional.ofNullable(xcomValues.get(0)).orElseThrow(() -> new MissingXComException("upstream", "value"))).intValue(), taskContinuation),
+                   continuation);
+             }
+           }
+           public static final class Load implements AsyncTask {
+             @Override
+             public Object execute(
+                 Context context,
+                 AsyncClient client,
+                 Continuation<? super Unit> continuation) throws Exception {
+               return AsyncTaskBridge.execute(
+                   client,
+                   new String[] {},
+                   false,
+                   (xcomValues, taskContinuation) -> new TestExample().load(taskContinuation),
+                   continuation);
+             }
+           }
+         }
+        """,
+      )
+  }
+
+  @Test
   @DisplayName("widen primitive numerics directly and boxed numerics null-safely")
   fun generateBuilderWidensNumericXCom() {
     val compilation =

--- a/java-sdk/processor/src/test/kotlin/org/apache/airflow/sdk/KotlinSuspendBuilderTest.kt
+++ b/java-sdk/processor/src/test/kotlin/org/apache/airflow/sdk/KotlinSuspendBuilderTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk
+
+import org.apache.airflow.sdk.kotlin.AsyncClient
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@Builder.Dag
+internal class KotlinSuspendDag {
+  @Builder.Task
+  suspend fun transform(
+    client: AsyncClient,
+    @Builder.XCom(task = "upstream") value: Int,
+  ): Int = value + (client.getVariable("offset") as Int)
+}
+
+class KotlinSuspendBuilderTest {
+  @Test
+  fun shouldGenerateBuilderFromKotlinSuspendFunction() {
+    Assertions.assertNotNull(KotlinSuspendDagBuilder.build())
+  }
+}

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Builder.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Builder.kt
@@ -65,6 +65,10 @@ class Builder internal constructor() {
   /**
    * Annotation to automate task definition in a Dag-builder pattern.
    *
+   * A regular function generates a synchronous [Task]. A Kotlin `suspend`
+   * function generates an [org.apache.airflow.sdk.kotlin.AsyncTask] and can
+   * receive an [org.apache.airflow.sdk.kotlin.AsyncClient].
+   *
    * @param id Override the task ID. If empty or not provided, the annotated
    *    function's name is used by default.
    */

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Client.kt
@@ -20,6 +20,7 @@
 package org.apache.airflow.sdk
 
 import org.apache.airflow.sdk.execution.Client
+import org.apache.airflow.sdk.execution.comm.ConnectionResult
 import org.apache.airflow.sdk.execution.comm.StartupDetails
 
 /**
@@ -70,21 +71,7 @@ class Client internal constructor(
    * @return The connection.
    * @throws ApiError if the connection does not exist or the API call fails.
    */
-  fun getConnection(id: String): Connection =
-    with(impl.getConnection(id)) {
-      Connection(
-        id = connId,
-        type = connType,
-        host = host as String?,
-        schema = schema as String?,
-        login = login as String?,
-        password = password as String?,
-        // The msgpack decoder yields Long for wire integers, so convert
-        // numerically instead of casting.
-        port = (port as Number?)?.toInt(),
-        extra = extra,
-      )
-    }
+  fun getConnection(id: String): Connection = impl.getConnection(id).toSdkConnection()
 
   /**
    * Retrieves an Airflow variable.
@@ -169,3 +156,17 @@ class MissingXComException(
       "(e.g. Integer instead of int) to receive null.",
   )
 }
+
+internal fun ConnectionResult.toSdkConnection() =
+  Connection(
+    id = connId,
+    type = connType,
+    host = host as String?,
+    schema = schema as String?,
+    login = login as String?,
+    password = password as String?,
+    // The msgpack decoder yields Long for wire integers, so convert
+    // numerically instead of casting.
+    port = (port as Number?)?.toInt(),
+    extra = extra,
+  )

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Dag.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Dag.kt
@@ -19,7 +19,9 @@
 
 package org.apache.airflow.sdk
 
+import org.apache.airflow.sdk.kotlin.AsyncTask
 import kotlin.Throws
+import kotlin.jvm.JvmName
 
 /**
  * A collection of tasks with directional dependencies.
@@ -38,7 +40,7 @@ import kotlin.Throws
 class Dag(
   val id: String, // TODO: charset check?
 ) {
-  internal var tasks = mutableMapOf<String, Class<out Task>>()
+  internal val tasks = mutableMapOf<String, TaskDefinition>()
 
   /**
    * Registers a task with this Dag.
@@ -57,11 +59,52 @@ class Dag(
     id: String,
     definition: Class<out Task>,
   ): Dag {
+    addTask(id, TaskDefinition.Sync(definition))
+    return this
+  }
+
+  /**
+   * Registers a coroutine-based task with this Dag.
+   *
+   * Kotlin callers use the same `addTask` name for synchronous and asynchronous
+   * tasks. The JVM name is `addAsyncTask` so generated Java builder classes can
+   * register an [AsyncTask] without colliding with the type-erased synchronous
+   * overload.
+   *
+   * @param id Task identifier, unique within this Dag.
+   * @param definition Class that implements [AsyncTask]. Must have a public
+   *    no-argument constructor.
+   * @return This Dag, for chaining.
+   * @throws IllegalArgumentException if a task already exists in the Dag with
+   *    the same ID.
+   */
+  @JvmName("addAsyncTask")
+  fun addTask(
+    id: String,
+    definition: Class<out AsyncTask>,
+  ): Dag {
+    addTask(id, TaskDefinition.Async(definition))
+    return this
+  }
+
+  private fun addTask(
+    id: String,
+    definition: TaskDefinition,
+  ) {
     require(tasks.putIfAbsent(id, definition) == null) {
       "Tasks in Dag have duplicate ID: $id"
     }
-    return this
   }
+}
+
+internal sealed interface TaskDefinition {
+  data class Sync(
+    val definition: Class<out Task>,
+  ) : TaskDefinition
+
+  data class Async(
+    val definition: Class<out AsyncTask>,
+  ) : TaskDefinition
 }
 
 /**

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/AsyncClient.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/AsyncClient.kt
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk.execution
+
+import org.apache.airflow.sdk.execution.comm.ConnectionResult
+import org.apache.airflow.sdk.execution.comm.GetConnection
+import org.apache.airflow.sdk.execution.comm.GetVariable
+import org.apache.airflow.sdk.execution.comm.GetXCom
+import org.apache.airflow.sdk.execution.comm.SetXCom
+import org.apache.airflow.sdk.execution.comm.VariableResult
+import org.apache.airflow.sdk.execution.comm.XComResult
+
+/** @suppress */
+interface AsyncClient {
+  suspend fun getConnection(id: String): ConnectionResult
+
+  suspend fun getVariable(key: String): VariableResult
+
+  suspend fun getXCom(
+    key: String,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int? = null,
+    includePriorDates: Boolean = false,
+  ): XComResult
+
+  suspend fun setXCom(
+    key: String,
+    value: Any,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int,
+  )
+}
+
+/** @suppress */
+class CoordinatorAsyncClient(
+  val exec: CoordinatorComm,
+) : AsyncClient {
+  override suspend fun getConnection(id: String) = exec.communicate<ConnectionResult>(GetConnection().apply { connId = id })
+
+  override suspend fun getVariable(key: String) = exec.communicate<VariableResult>(GetVariable().also { it.key = key })
+
+  override suspend fun setXCom(
+    key: String,
+    value: Any,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int,
+  ) {
+    val message =
+      SetXCom().also {
+        it.key = key
+        it.value = value
+        it.dagId = dagId
+        it.taskId = taskId
+        it.runId = runId
+        it.mapIndex = mapIndex
+      }
+    exec.communicate<Unit>(message)
+  }
+
+  override suspend fun getXCom(
+    key: String,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int?,
+    includePriorDates: Boolean,
+  ): XComResult {
+    val message =
+      GetXCom().also {
+        it.key = key
+        it.dagId = dagId
+        it.taskId = taskId
+        it.runId = runId
+        it.mapIndex = mapIndex
+        it.includePriorDates = includePriorDates
+      }
+    return exec.communicate<XComResult>(message)
+  }
+}

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Task.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Task.kt
@@ -19,14 +19,17 @@
 
 package org.apache.airflow.sdk.execution
 
+import kotlinx.coroutines.runBlocking
 import org.apache.airflow.sdk.Bundle
 import org.apache.airflow.sdk.Client
 import org.apache.airflow.sdk.Context
+import org.apache.airflow.sdk.TaskDefinition
 import org.apache.airflow.sdk.execution.comm.AssetProfile
 import org.apache.airflow.sdk.execution.comm.RetryTask
 import org.apache.airflow.sdk.execution.comm.StartupDetails
 import org.apache.airflow.sdk.execution.comm.SucceedTask
 import org.apache.airflow.sdk.execution.comm.TaskState
+import org.apache.airflow.sdk.kotlin.AsyncClient
 import java.time.OffsetDateTime
 
 internal object TaskResult {
@@ -69,10 +72,24 @@ internal object TaskRunner {
     bundle: Bundle,
     request: StartupDetails,
     client: Client,
+    asyncClient: AsyncClient,
   ): Any {
     val task = bundle.dags[request.ti.dagId]?.tasks[request.ti.taskId] ?: return TaskResult.of(TaskState.State.REMOVED)
     return try {
-      task.getDeclaredConstructor().newInstance().execute(Context.from(request), client)
+      when (task) {
+        is TaskDefinition.Sync ->
+          task.definition
+            .getDeclaredConstructor()
+            .newInstance()
+            .execute(Context.from(request), client)
+        is TaskDefinition.Async ->
+          runBlocking {
+            task.definition
+              .getDeclaredConstructor()
+              .newInstance()
+              .execute(Context.from(request), asyncClient)
+          }
+      }
       TaskResult.success()
     } catch (e: Throwable) {
       logger.error("Error executing task", mapOf("ti" to request.ti, "error" to e, "trace" to e.stackTraceToString()))
@@ -90,10 +107,17 @@ internal fun runTask(
   bundle: Bundle,
   request: StartupDetails,
   comm: CoordinatorComm,
-): Any = TaskRunner.runTask(bundle, request, Client(request, CoordinatorClient(comm)))
+): Any =
+  TaskRunner.runTask(
+    bundle,
+    request,
+    Client(request, CoordinatorClient(comm)),
+    AsyncClient(request, CoordinatorAsyncClient(comm)),
+  )
 
 internal fun runTask(
   bundle: Bundle,
   request: StartupDetails,
   client: Client,
-) = TaskRunner.runTask(bundle, request, client)
+  asyncClient: AsyncClient,
+) = TaskRunner.runTask(bundle, request, client, asyncClient)

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/kotlin/AsyncClient.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/kotlin/AsyncClient.kt
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk.kotlin
+
+import org.apache.airflow.sdk.Connection
+import org.apache.airflow.sdk.execution.comm.StartupDetails
+import org.apache.airflow.sdk.toSdkConnection
+import org.apache.airflow.sdk.execution.AsyncClient as TransportClient
+
+/**
+ * Coroutine-native client for Airflow API calls scoped to the current task
+ * instance.
+ *
+ * An instance is provided to [AsyncTask.execute]. All operations suspend their
+ * coroutine while waiting for the coordinator and can participate in structured
+ * concurrency.
+ */
+class AsyncClient internal constructor(
+  internal val details: StartupDetails,
+  internal val impl: TransportClient,
+) {
+  internal companion object {
+    const val XCOM_RETURN_KEY = "return_value"
+  }
+
+  /** Retrieves a connection from the Airflow connection store. */
+  suspend fun getConnection(id: String): Connection = impl.getConnection(id).toSdkConnection()
+
+  /** Retrieves an Airflow variable, or `null` if it is not set. */
+  suspend fun getVariable(key: String): Any? = impl.getVariable(key).value
+
+  /**
+   * Reads an XCom value pushed by another task.
+   *
+   * The current Dag run and task-instance context provide the default Dag and
+   * run identifiers.
+   */
+  suspend fun getXCom(
+    key: String = XCOM_RETURN_KEY,
+    dagId: String = details.ti.dagId,
+    taskId: String,
+    runId: String = details.ti.runId,
+    mapIndex: Int? = null,
+    includePriorDates: Boolean = false,
+  ): Any? =
+    impl
+      .getXCom(
+        key = key,
+        dagId = dagId,
+        taskId = taskId,
+        runId = runId,
+        mapIndex = mapIndex,
+        includePriorDates = includePriorDates,
+      ).value
+
+  /** Pushes an XCom value for downstream tasks to read. */
+  suspend fun setXCom(
+    key: String = XCOM_RETURN_KEY,
+    value: Any,
+  ) = impl.setXCom(
+    key = key,
+    value = value,
+    dagId = details.ti.dagId,
+    taskId = details.ti.taskId,
+    runId = details.ti.runId,
+    mapIndex = details.ti.mapIndex ?: -1,
+  )
+}

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/kotlin/AsyncTask.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/kotlin/AsyncTask.kt
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk.kotlin
+
+import org.apache.airflow.sdk.Builder
+import org.apache.airflow.sdk.Context
+import kotlin.Throws
+
+/**
+ * A coroutine-based unit of work executed by Airflow.
+ *
+ * Prefer annotating a suspending function with [Builder.Task] so the annotation
+ * processor generates this implementation. Implement the interface directly
+ * only for low-level plumbing.
+ */
+interface AsyncTask {
+  /** Executes this task without blocking its thread during Airflow API calls. */
+  @Throws(Exception::class)
+  suspend fun execute(
+    context: Context,
+    client: AsyncClient,
+  )
+}

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/kotlin/AsyncTaskBridge.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/kotlin/AsyncTaskBridge.kt
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk.kotlin
+
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+/** @suppress */
+fun interface SuspendTaskCall<T> {
+  fun invoke(
+    xcomValues: List<Any?>,
+    continuation: Continuation<T>,
+  ): Any?
+}
+
+/**
+ * Runtime bridge used by Java sources generated for Kotlin suspending tasks.
+ *
+ * @suppress
+ */
+object AsyncTaskBridge {
+  @JvmStatic
+  fun <T> execute(
+    client: AsyncClient,
+    xcomTaskIds: Array<String>,
+    publishResult: Boolean,
+    call: SuspendTaskCall<T>,
+    completion: Continuation<Unit>,
+  ): Any? =
+    suspend {
+      val xcomValues = xcomTaskIds.map { client.getXCom(taskId = it) }
+      val result =
+        suspendCoroutineUninterceptedOrReturn<T> { continuation ->
+          call.invoke(xcomValues, continuation)
+        }
+      if (publishResult) {
+        client.setXCom(value = result as Any)
+      }
+    }.startCoroutineUninterceptedOrReturn(completion)
+}

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/BundleTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/BundleTest.kt
@@ -19,6 +19,8 @@
 
 package org.apache.airflow.sdk
 
+import org.apache.airflow.sdk.kotlin.AsyncClient
+import org.apache.airflow.sdk.kotlin.AsyncTask
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -43,5 +45,34 @@ internal class BundleTest {
       }
 
     Assertions.assertEquals("Dags in bundle have duplicate ID: dag", error.message)
+  }
+
+  @Test
+  @DisplayName("Should reject duplicate task ids across sync and async tasks")
+  fun shouldRejectDuplicateTaskIdsAcrossTaskTypes() {
+    val dag = Dag("dag").addTask("task", SyncTask::class.java)
+
+    val error =
+      Assertions.assertThrows(IllegalArgumentException::class.java) {
+        dag.addTask("task", CoroutineTask::class.java)
+      }
+
+    Assertions.assertEquals("Tasks in Dag have duplicate ID: task", error.message)
+  }
+
+  class SyncTask : Task {
+    override fun execute(
+      context: Context,
+      client: Client,
+    ) {
+    }
+  }
+
+  class CoroutineTask : AsyncTask {
+    override suspend fun execute(
+      context: Context,
+      client: AsyncClient,
+    ) {
+    }
   }
 }

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/CommTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/CommTest.kt
@@ -22,6 +22,9 @@ package org.apache.airflow.sdk.execution
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.readByteArray
 import io.ktor.utils.io.writeByteArray
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.apache.airflow.sdk.ApiError
 import org.apache.airflow.sdk.Bundle
@@ -40,6 +43,7 @@ import java.time.ZoneOffset
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
 import org.apache.airflow.sdk.Client as PublicClient
+import org.apache.airflow.sdk.kotlin.AsyncClient as PublicAsyncClient
 
 fun byteArrayFromHexString(hexString: String): ByteArray =
   hexString
@@ -190,4 +194,43 @@ class CommsTest {
     Assertions.assertTrue(errors.isEmpty(), "concurrent public-client calls failed: $errors")
     Assertions.assertEquals(n, results.size)
   }
+
+  @Test
+  @DisplayName("Should serve concurrent coroutine client calls")
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  fun asyncPublicClientServesConcurrentCoroutineCalls() =
+    runBlocking {
+      val toClient = ByteChannel(autoFlush = true)
+      val fromClient = ByteChannel(autoFlush = true)
+      val comm = CoordinatorComm(Bundle(emptyList()), toClient, fromClient)
+      val details =
+        StartupDetails().also {
+          it.ti =
+            TaskInstance().also { ti ->
+              ti.dagId = "d"
+              ti.runId = "r"
+            }
+        }
+      val client = PublicAsyncClient(details, CoordinatorAsyncClient(comm))
+      val n = 50
+
+      val server =
+        launch {
+          repeat(n) {
+            val prefix = fromClient.readByteArray(4)
+            val payload = fromClient.readByteArray(Frame.parseLengthPrefix(prefix))
+            val response = responseFrame(CoordinatorComm.decode(payload).id)
+            toClient.writeByteArray(Frame.lengthPrefix(response.size))
+            toClient.writeByteArray(response)
+          }
+        }
+      val results =
+        (1..n)
+          .map {
+            async { client.getXCom(taskId = "upstream") }
+          }.awaitAll()
+      server.join()
+
+      Assertions.assertEquals(n, results.size)
+    }
 }

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/TaskTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/TaskTest.kt
@@ -19,6 +19,7 @@
 
 package org.apache.airflow.sdk.execution
 
+import kotlinx.coroutines.yield
 import org.apache.airflow.sdk.Bundle
 import org.apache.airflow.sdk.Client
 import org.apache.airflow.sdk.Context
@@ -32,6 +33,8 @@ import org.apache.airflow.sdk.execution.comm.SucceedTask
 import org.apache.airflow.sdk.execution.comm.TIRunContext
 import org.apache.airflow.sdk.execution.comm.TaskInstance
 import org.apache.airflow.sdk.execution.comm.TaskState
+import org.apache.airflow.sdk.kotlin.AsyncClient
+import org.apache.airflow.sdk.kotlin.AsyncTask
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -42,7 +45,7 @@ class TaskTest {
   @Test
   @DisplayName("Should execute task and return success")
   fun shouldExecuteTaskAndReturnSuccess() {
-    val result = runTask(bundleWith("success", SuccessTask::class.java), startupDetails(taskId = "success"), noOpClient())
+    val result = runTask(bundleWith("success", SuccessTask::class.java), startupDetails(taskId = "success"))
 
     Assertions.assertInstanceOf(SucceedTask::class.java, result)
   }
@@ -50,7 +53,7 @@ class TaskTest {
   @Test
   @DisplayName("Should return removed when task is missing")
   fun shouldReturnRemovedWhenTaskIsMissing() {
-    val result = runTask(bundleWith("other", SuccessTask::class.java), startupDetails(taskId = "missing"), noOpClient())
+    val result = runTask(bundleWith("other", SuccessTask::class.java), startupDetails(taskId = "missing"))
 
     Assertions.assertInstanceOf(TaskState::class.java, result)
     Assertions.assertEquals(TaskState.State.REMOVED, (result as TaskState).state)
@@ -59,7 +62,7 @@ class TaskTest {
   @Test
   @DisplayName("Should return failed when task throws")
   fun shouldReturnFailedWhenTaskThrows() {
-    val result = runTask(bundleWith("failing", FailingTask::class.java), startupDetails(taskId = "failing"), noOpClient())
+    val result = runTask(bundleWith("failing", FailingTask::class.java), startupDetails(taskId = "failing"))
 
     Assertions.assertInstanceOf(TaskState::class.java, result)
     Assertions.assertEquals(TaskState.State.FAILED, (result as TaskState).state)
@@ -70,7 +73,7 @@ class TaskTest {
   fun shouldReturnRetryWhenTaskThrowsAndShouldRetryIsTrue() {
     val details = startupDetails(taskId = "failing")
     details.tiContext?.shouldRetry = true
-    val result = runTask(bundleWith("failing", FailingTask::class.java), details, noOpClient())
+    val result = runTask(bundleWith("failing", FailingTask::class.java), details)
 
     Assertions.assertInstanceOf(RetryTask::class.java, result)
   }
@@ -78,15 +81,46 @@ class TaskTest {
   @Test
   @DisplayName("Should return failed when task throws an Error")
   fun shouldReturnFailedWhenTaskThrowsError() {
-    val result = runTask(bundleWith("erroring", ErrorThrowingTask::class.java), startupDetails(taskId = "erroring"), noOpClient())
+    val result = runTask(bundleWith("erroring", ErrorThrowingTask::class.java), startupDetails(taskId = "erroring"))
 
     Assertions.assertInstanceOf(TaskState::class.java, result)
     Assertions.assertEquals(TaskState.State.FAILED, (result as TaskState).state)
   }
 
+  @Test
+  @DisplayName("Should execute async task and return success")
+  fun shouldExecuteAsyncTaskAndReturnSuccess() {
+    val result = runTask(asyncBundleWith("async", SuccessAsyncTask::class.java), startupDetails(taskId = "async"))
+
+    Assertions.assertInstanceOf(SucceedTask::class.java, result)
+  }
+
+  @Test
+  @DisplayName("Should return failed when async task throws")
+  fun shouldReturnFailedWhenAsyncTaskThrows() {
+    val result = runTask(asyncBundleWith("async", FailingAsyncTask::class.java), startupDetails(taskId = "async"))
+
+    Assertions.assertInstanceOf(TaskState::class.java, result)
+    Assertions.assertEquals(TaskState.State.FAILED, (result as TaskState).state)
+  }
+
+  private fun runTask(
+    bundle: Bundle,
+    details: StartupDetails,
+  ) = runTask(bundle, details, noOpClient(), noOpAsyncClient())
+
   private fun bundleWith(
     taskId: String,
     taskClass: Class<out Task>,
+  ): Bundle {
+    val dag = Dag("test_dag")
+    dag.addTask(taskId, taskClass)
+    return Bundle(listOf(dag))
+  }
+
+  private fun asyncBundleWith(
+    taskId: String,
+    taskClass: Class<out AsyncTask>,
   ): Bundle {
     val dag = Dag("test_dag")
     dag.addTask(taskId, taskClass)
@@ -150,6 +184,34 @@ class TaskTest {
       },
     )
 
+  private fun noOpAsyncClient() =
+    AsyncClient(
+      startupDetails(taskId = "unused"),
+      object : org.apache.airflow.sdk.execution.AsyncClient {
+        override suspend fun getConnection(id: String) = throw UnsupportedOperationException("not used in test")
+
+        override suspend fun getVariable(key: String) = throw UnsupportedOperationException("not used in test")
+
+        override suspend fun getXCom(
+          key: String,
+          dagId: String,
+          taskId: String,
+          runId: String,
+          mapIndex: Int?,
+          includePriorDates: Boolean,
+        ) = throw UnsupportedOperationException("not used in test")
+
+        override suspend fun setXCom(
+          key: String,
+          value: Any,
+          dagId: String,
+          taskId: String,
+          runId: String,
+          mapIndex: Int,
+        ): Unit = throw UnsupportedOperationException("not used in test")
+      },
+    )
+
   class SuccessTask : Task {
     override fun execute(
       context: Context,
@@ -170,5 +232,21 @@ class TaskTest {
       context: Context,
       client: Client,
     ): Unit = throw NoClassDefFoundError("simulated")
+  }
+
+  class SuccessAsyncTask : AsyncTask {
+    override suspend fun execute(
+      context: Context,
+      client: AsyncClient,
+    ) {
+      yield()
+    }
+  }
+
+  class FailingAsyncTask : AsyncTask {
+    override suspend fun execute(
+      context: Context,
+      client: AsyncClient,
+    ): Unit = throw IllegalStateException("boom")
   }
 }

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/kotlin/AsyncClientTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/kotlin/AsyncClientTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk.kotlin
+
+import kotlinx.coroutines.runBlocking
+import org.apache.airflow.sdk.execution.comm.ConnectionResult
+import org.apache.airflow.sdk.execution.comm.StartupDetails
+import org.apache.airflow.sdk.execution.comm.TaskInstance
+import org.apache.airflow.sdk.execution.comm.VariableResult
+import org.apache.airflow.sdk.execution.comm.XComResult
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+private class FakeAsyncTransport : org.apache.airflow.sdk.execution.AsyncClient {
+  val setXComCalls = mutableListOf<List<Any?>>()
+
+  override suspend fun getConnection(id: String) =
+    ConnectionResult().apply {
+      connId = id
+      connType = "http"
+      port = 8080L
+    }
+
+  override suspend fun getVariable(key: String) = VariableResult().apply { value = "value:$key" }
+
+  override suspend fun getXCom(
+    key: String,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int?,
+    includePriorDates: Boolean,
+  ) = XComResult().apply { value = listOf(key, dagId, taskId, runId, mapIndex, includePriorDates) }
+
+  override suspend fun setXCom(
+    key: String,
+    value: Any,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int,
+  ) {
+    setXComCalls += listOf(key, value, dagId, taskId, runId, mapIndex)
+  }
+}
+
+class AsyncClientTest {
+  @Test
+  fun shouldForwardOperationsWithTaskContext() =
+    runBlocking {
+      val transport = FakeAsyncTransport()
+      val details =
+        StartupDetails().apply {
+          ti =
+            TaskInstance().apply {
+              dagId = "dag"
+              taskId = "task"
+              runId = "run"
+              mapIndex = 3
+            }
+        }
+      val client = AsyncClient(details, transport)
+
+      val connection = client.getConnection("http")
+      val variable = client.getVariable("key")
+      val xcom = client.getXCom(taskId = "upstream")
+      client.setXCom(value = 42)
+      val explicitXCom =
+        client.getXCom(
+          key = "custom",
+          dagId = "other-dag",
+          taskId = "other-task",
+          runId = "other-run",
+          mapIndex = 7,
+          includePriorDates = true,
+        )
+      details.ti.mapIndex = null
+      client.setXCom(key = "custom", value = 43)
+
+      Assertions.assertEquals("http", connection.id)
+      Assertions.assertEquals(8080, connection.port)
+      Assertions.assertEquals("value:key", variable)
+      Assertions.assertEquals(listOf("return_value", "dag", "upstream", "run", null, false), xcom)
+      Assertions.assertEquals(listOf("custom", "other-dag", "other-task", "other-run", 7, true), explicitXCom)
+      Assertions.assertEquals(
+        listOf(
+          listOf("return_value", 42, "dag", "task", "run", 3),
+          listOf("custom", 43, "dag", "task", "run", -1),
+        ),
+        transport.setXComCalls,
+      )
+    }
+}

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/kotlin/AsyncTaskBridgeTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/kotlin/AsyncTaskBridgeTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.airflow.sdk.kotlin
+
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.apache.airflow.sdk.execution.comm.ConnectionResult
+import org.apache.airflow.sdk.execution.comm.StartupDetails
+import org.apache.airflow.sdk.execution.comm.TaskInstance
+import org.apache.airflow.sdk.execution.comm.VariableResult
+import org.apache.airflow.sdk.execution.comm.XComResult
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
+
+private class BridgeTransport : org.apache.airflow.sdk.execution.AsyncClient {
+  val published = mutableListOf<Any>()
+
+  override suspend fun getConnection(id: String): ConnectionResult = throw UnsupportedOperationException()
+
+  override suspend fun getVariable(key: String): VariableResult = throw UnsupportedOperationException()
+
+  override suspend fun getXCom(
+    key: String,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int?,
+    includePriorDates: Boolean,
+  ) = XComResult().apply { value = taskId.length }
+
+  override suspend fun setXCom(
+    key: String,
+    value: Any,
+    dagId: String,
+    taskId: String,
+    runId: String,
+    mapIndex: Int,
+  ) {
+    published += value
+  }
+}
+
+class AsyncTaskBridgeTest {
+  @Test
+  fun shouldResolveXComsAndPublishTaskResult() =
+    runBlocking {
+      val transport = BridgeTransport()
+      val client =
+        AsyncClient(
+          StartupDetails().apply {
+            ti =
+              TaskInstance().apply {
+                dagId = "dag"
+                taskId = "task"
+                runId = "run"
+              }
+          },
+          transport,
+        )
+
+      suspendCoroutineUninterceptedOrReturn<Unit> { completion ->
+        AsyncTaskBridge.execute<Int>(
+          client,
+          arrayOf("upstream"),
+          publishResult = true,
+          call =
+            SuspendTaskCall<Int> { values, taskCompletion ->
+              val result = (values.single() as Int) + 1
+              launch {
+                yield()
+                taskCompletion.resume(result)
+              }
+              COROUTINE_SUSPENDED
+            },
+          completion,
+        )
+      }
+
+      Assertions.assertEquals(listOf(9), transport.published)
+    }
+
+  @Test
+  fun shouldSkipPublishingUnitResult() =
+    runBlocking {
+      val transport = BridgeTransport()
+      val client =
+        AsyncClient(
+          StartupDetails().apply { ti = TaskInstance() },
+          transport,
+        )
+
+      suspendCoroutineUninterceptedOrReturn<Unit> { completion ->
+        AsyncTaskBridge.execute<Unit>(
+          client,
+          emptyArray(),
+          publishResult = false,
+          call = SuspendTaskCall<Unit> { _, _ -> Unit },
+          completion,
+        )
+      }
+
+      Assertions.assertTrue(transport.published.isEmpty())
+    }
+}


### PR DESCRIPTION
Closes #67683
## Why

The Java SDK currently exposes blocking task and client APIs. Kotlin tasks need coroutine-native equivalents so suspending functions can call Airflow APIs without blocking for each request.

## What

- Add coroutine-native `AsyncClient` and `AsyncTask` APIs.
- Add an asynchronous coordinator transport and task-runner dispatch.
- Preserve the existing synchronous `Client` and `Task` behavior.
- Extend `BuilderProcessor` to recognize Kotlin `suspend` functions.
- Support `Context`, XCom inputs, and non-`Unit` return values in generated asynchronous tasks.
- Add KAPT integration, suspension, concurrency, failure, and client-forwarding tests.
- Document Kotlin coroutine task usage.

## Testing

- `./gradlew clean build --console=plain -Pkotlin.incremental=false`
- `./gradlew :sdk:check :processor:check --console=plain -Pkotlin.incremental=false`
- Repository commit hooks passed, except `lychee-docker`, which could not run because Docker was unavailable.


##### Was generative AI tooling used to co-author this PR?
[X] Yes (OpenAI Codex)


<!-- pr-triage-fold: triaged=2026-07-18T15:46:56Z head=eceeea1 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @shaealh** · by `@potiuk` · 2026-07-18 15:46 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**: with `main`. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for details.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
