### PR TITLE
Enable repair of failed Databricks Workflow tasks from Airflow 3 UI

### DIFF
--- a/devel-common/src/tests_common/test_utils/version_compat.py
+++ b/devel-common/src/tests_common/test_utils/version_compat.py
@@ -36,6 +36,7 @@ AIRFLOW_V_3_0_1 = get_base_airflow_version_tuple() == (3, 0, 1)
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_0_3_PLUS = get_base_airflow_version_tuple() >= (3, 0, 3)
 AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
+AIRFLOW_V_3_1_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 1)
 AIRFLOW_V_3_1_3_PLUS = get_base_airflow_version_tuple() >= (3, 1, 3)
 AIRFLOW_V_3_1_7_PLUS = get_base_airflow_version_tuple() >= (3, 1, 7)
 AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
@@ -63,6 +64,7 @@ __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_0_1",
     "AIRFLOW_V_3_1_PLUS",
+    "AIRFLOW_V_3_1_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
     "AIRFLOW_V_3_3_PLUS",
     "AIRFLOW_V_3_4_PLUS",

--- a/providers/databricks/docs/operators/workflow.rst
+++ b/providers/databricks/docs/operators/workflow.rst
@@ -68,3 +68,22 @@ To minimize update conflicts, we recommend that you keep parameters in the ``not
 ``DatabricksWorkflowTaskGroup`` and not in the ``DatabricksNotebookOperator`` whenever possible.
 This is because, tasks in the ``DatabricksWorkflowTaskGroup`` are passed in on the job trigger time and
 do not modify the job definition.
+
+Repairing a failed workflow run
+-------------------------------
+
+When a Databricks Workflow run fails, each task instance of the task group exposes repair links in the
+Airflow UI:
+
+* **Repair a single task** (on a notebook/task operator) re-runs that one Databricks task.
+* **Repair All Failed Tasks** (on the ``launch`` task) re-runs every failed task of the run.
+
+Clicking a repair link calls the Databricks `repair_run <https://docs.databricks.com/api/workspace/jobs/repairrun>`_
+API on the existing run (continuing the repair chain via ``latest_repair_id``) and reruns the dependent
+tasks, then clears the corresponding Airflow task instances and their downstream tasks so the run resumes
+without having to clear the whole Dag.
+
+On Airflow 3 the repair action is served by a FastAPI endpoint registered by the
+``DatabricksWorkflowPlugin``; the set of failed tasks is resolved from the live Databricks run state. On
+Airflow 2 it is served by the legacy Flask-AppBuilder view. In both cases the repair links are
+authorized with Dag-run edit access.

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -563,6 +563,28 @@ class DatabricksHook(BaseDatabricksHook):
 
         return all_tasks
 
+    def get_run_failed_task_keys(self, run_id: int) -> list[str]:
+        """
+        Return the ``task_key`` of every sub-task of a run that is in a terminal failure state.
+
+        Resolved from the live Databricks run rather than from Airflow's metadata DB, so it
+        reflects the actual per-task state Databricks ``repair_run`` will act on. The returned
+        keys are the values to pass as ``rerun_tasks`` to :meth:`repair_run`.
+
+        :param run_id: id of the run
+        :return: a list of Databricks ``task_key`` values for failed sub-tasks
+        """
+        failed_result_states = {"FAILED", "TIMEDOUT", "CANCELED", "MAXIMUM_CONCURRENT_RUNS_REACHED"}
+        failed_task_keys = []
+        for task in self.get_run_tasks(run_id):
+            state = task.get("state", {})
+            if (
+                state.get("result_state") in failed_result_states
+                or state.get("life_cycle_state") == "INTERNAL_ERROR"
+            ):
+                failed_task_keys.append(task["task_key"])
+        return failed_task_keys
+
     def get_run(self, run_id: int) -> dict[str, Any]:
         """
         Retrieve run information.

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -575,14 +575,24 @@ class DatabricksHook(BaseDatabricksHook):
         :return: a list of Databricks ``task_key`` values for failed sub-tasks
         """
         failed_result_states = {"FAILED", "TIMEDOUT", "CANCELED", "MAXIMUM_CONCURRENT_RUNS_REACHED"}
+
+        # ``get_run_tasks`` returns one entry per attempt and is not ordered by attempt, so a
+        # retried or already-repaired task appears several times under the same ``task_key``. Keep
+        # only the latest attempt per key (sort by ``start_time``, same idiom as
+        # ``DatabricksTaskBaseOperator._get_current_databricks_task``) before judging its state, so
+        # the result never contains duplicate keys — Databricks rejects duplicates in
+        # ``rerun_tasks`` — and a task whose latest attempt succeeded is not reported as failed.
+        sorted_tasks = sorted(self.get_run_tasks(run_id), key=lambda task: task["start_time"])
+        latest_by_key = {task["task_key"]: task for task in sorted_tasks}
+
         failed_task_keys = []
-        for task in self.get_run_tasks(run_id):
+        for task_key, task in latest_by_key.items():
             state = task.get("state", {})
             if (
                 state.get("result_state") in failed_result_states
                 or state.get("life_cycle_state") == "INTERNAL_ERROR"
             ):
-                failed_task_keys.append(task["task_key"])
+                failed_task_keys.append(task_key)
         return failed_task_keys
 
     def get_run(self, run_id: int) -> dict[str, Any]:

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -582,7 +582,8 @@ class DatabricksHook(BaseDatabricksHook):
         # ``DatabricksTaskBaseOperator._get_current_databricks_task``) before judging its state, so
         # the result never contains duplicate keys — Databricks rejects duplicates in
         # ``rerun_tasks`` — and a task whose latest attempt succeeded is not reported as failed.
-        sorted_tasks = sorted(self.get_run_tasks(run_id), key=lambda task: task["start_time"])
+        # Never-started sub-tasks omit ``start_time`` or send null; treat those as 0.
+        sorted_tasks = sorted(self.get_run_tasks(run_id), key=lambda task: task.get("start_time") or 0)
         latest_by_key = {task["task_key"]: task for task in sorted_tasks}
 
         failed_task_keys = []

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -608,6 +608,28 @@ class DatabricksHook(BaseDatabricksHook):
         """
         return self.get_run(run_id).get("tasks", [])
 
+    def get_run_failed_task_keys(self, run_id: int) -> list[str]:
+        """
+        Return the ``task_key`` of every sub-task of a run that is in a terminal failure state.
+
+        Resolved from the live Databricks run rather than from Airflow's metadata DB, so it
+        reflects the actual per-task state Databricks ``repair_run`` will act on. The returned
+        keys are the values to pass as ``rerun_tasks`` to :meth:`repair_run`.
+
+        :param run_id: id of the run
+        :return: a list of Databricks ``task_key`` values for failed sub-tasks
+        """
+        failed_result_states = {"FAILED", "TIMEDOUT", "CANCELED", "MAXIMUM_CONCURRENT_RUNS_REACHED"}
+        failed_task_keys = []
+        for task in self.get_run_tasks(run_id):
+            state = task.get("state", {})
+            if (
+                state.get("result_state") in failed_result_states
+                or state.get("life_cycle_state") == "INTERNAL_ERROR"
+            ):
+                failed_task_keys.append(task["task_key"])
+        return failed_task_keys
+
     def get_run(self, run_id: int) -> dict[str, Any]:
         """
         Retrieve run information.

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -627,7 +627,8 @@ class DatabricksHook(BaseDatabricksHook):
         # ``DatabricksTaskBaseOperator._get_current_databricks_task``) before judging its state, so
         # the result never contains duplicate keys — Databricks rejects duplicates in
         # ``rerun_tasks`` — and a task whose latest attempt succeeded is not reported as failed.
-        sorted_tasks = sorted(self.get_run_tasks(run_id), key=lambda task: task["start_time"])
+        # Never-started sub-tasks omit ``start_time`` or send null; treat those as 0.
+        sorted_tasks = sorted(self.get_run_tasks(run_id), key=lambda task: task.get("start_time") or 0)
         latest_by_key = {task["task_key"]: task for task in sorted_tasks}
 
         failed_task_keys = []

--- a/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/hooks/databricks.py
@@ -620,14 +620,24 @@ class DatabricksHook(BaseDatabricksHook):
         :return: a list of Databricks ``task_key`` values for failed sub-tasks
         """
         failed_result_states = {"FAILED", "TIMEDOUT", "CANCELED", "MAXIMUM_CONCURRENT_RUNS_REACHED"}
+
+        # ``get_run_tasks`` returns one entry per attempt and is not ordered by attempt, so a
+        # retried or already-repaired task appears several times under the same ``task_key``. Keep
+        # only the latest attempt per key (sort by ``start_time``, same idiom as
+        # ``DatabricksTaskBaseOperator._get_current_databricks_task``) before judging its state, so
+        # the result never contains duplicate keys — Databricks rejects duplicates in
+        # ``rerun_tasks`` — and a task whose latest attempt succeeded is not reported as failed.
+        sorted_tasks = sorted(self.get_run_tasks(run_id), key=lambda task: task["start_time"])
+        latest_by_key = {task["task_key"]: task for task in sorted_tasks}
+
         failed_task_keys = []
-        for task in self.get_run_tasks(run_id):
+        for task_key, task in latest_by_key.items():
             state = task.get("state", {})
             if (
                 state.get("result_state") in failed_result_states
                 or state.get("life_cycle_state") == "INTERNAL_ERROR"
             ):
-                failed_task_keys.append(task["task_key"])
+                failed_task_keys.append(task_key)
         return failed_task_keys
 
     def get_run(self, run_id: int) -> dict[str, Any]:

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -1688,16 +1688,10 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
         super().__init__(**kwargs)
 
         if self._databricks_workflow_task_group is not None:
-            # Conditionally set operator_extra_links based on Airflow version. In Airflow 3, only show the job run link.
-            # In Airflow 2, show the job run link and the repair link.
-            # TODO: Once we expand the plugin functionality in Airflow 3.1, this can be re-evaluated on how to handle the repair link.
-            if AIRFLOW_V_3_0_PLUS:
-                self.operator_extra_links = (WorkflowJobRunLink(),)
-            else:
-                self.operator_extra_links = (
-                    WorkflowJobRunLink(),
-                    WorkflowJobRepairSingleTaskLink(),
-                )
+            self.operator_extra_links = (
+                WorkflowJobRunLink(),
+                WorkflowJobRepairSingleTaskLink(),
+            )
         else:
             # Databricks does not support repair for non-workflow tasks, hence do not show the repair link.
             self.operator_extra_links = (DatabricksJobRunLink(),)

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks.py
@@ -1858,16 +1858,10 @@ class DatabricksTaskBaseOperator(BaseOperator, ABC):
         super().__init__(**kwargs)
 
         if self._databricks_workflow_task_group is not None:
-            # Conditionally set operator_extra_links based on Airflow version. In Airflow 3, only show the job run link.
-            # In Airflow 2, show the job run link and the repair link.
-            # TODO: Once we expand the plugin functionality in Airflow 3.1, this can be re-evaluated on how to handle the repair link.
-            if AIRFLOW_V_3_0_PLUS:
-                self.operator_extra_links = (WorkflowJobRunLink(),)
-            else:
-                self.operator_extra_links = (
-                    WorkflowJobRunLink(),
-                    WorkflowJobRepairSingleTaskLink(),
-                )
+            self.operator_extra_links = (
+                WorkflowJobRunLink(),
+                WorkflowJobRepairSingleTaskLink(),
+            )
         else:
             # Databricks does not support repair for non-workflow tasks, hence do not show the repair link.
             self.operator_extra_links = (DatabricksJobRunLink(),)

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -120,16 +120,10 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
         "spark_submit_params",
     )
     caller = "_CreateDatabricksWorkflowOperator"
-    # Conditionally set operator_extra_links based on Airflow version
-    if AIRFLOW_V_3_0_PLUS:
-        # In Airflow 3, disable "Repair All Failed Tasks" since we can't pre-determine failed tasks
-        operator_extra_links = (WorkflowJobRunLink(),)
-    else:
-        # In Airflow 2.x, keep both links
-        operator_extra_links = (  # type: ignore[assignment]
-            WorkflowJobRunLink(),
-            WorkflowJobRepairAllFailedLink(),
-        )
+    operator_extra_links = (
+        WorkflowJobRunLink(),
+        WorkflowJobRepairAllFailedLink(),
+    )
 
     def __init__(
         self,

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -49,11 +49,15 @@ class WorkflowRunMetadata:
     :param run_id: The ID of the Databricks workflow run.
     :param job_id: The ID of the Databricks workflow job.
     :param conn_id: The connection ID used to connect to Databricks.
+    :param task_key_map: Airflow ``task_id`` → Databricks ``task_key`` for the workflow's tasks.
+        Optional and defaulted for backward compatibility with runs launched before it was added
+        (those XComs carry only conn_id/job_id/run_id).
     """
 
     conn_id: str
     job_id: int
     run_id: int
+    task_key_map: dict[str, str] = field(default_factory=dict)
 
 
 def _flatten_node(
@@ -273,6 +277,14 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
             "conn_id": self.databricks_conn_id,
             "job_id": job_id,
             "run_id": run_id,
+            # Map each workflow task's Airflow task_id to the task_key registered with Databricks,
+            # captured here from the live operators. The repair endpoint needs it because an
+            # explicit ``databricks_task_key`` does not survive Dag serialization, so the API server
+            # cannot otherwise recover the true key from the serialized Dag.
+            "task_key_map": {
+                task.task_id: task.databricks_task_key  # type: ignore[attr-defined]
+                for task in self.tasks_to_convert.values()
+            },
         }
 
     def on_kill(self) -> None:

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
@@ -44,6 +45,8 @@ if TYPE_CHECKING:
     from airflow.providers.databricks.operators.databricks import DatabricksTaskBaseOperator
     from airflow.sdk.types import Logger
 
+log = logging.getLogger(__name__)
+
 
 def get_databricks_task_ids(
     group_id: str, task_map: dict[str, DatabricksTaskBaseOperator], log: Logger
@@ -65,6 +68,50 @@ def get_databricks_task_ids(
         log.debug("databricks task id for task %s is %s", task_id, databricks_task_id)
         task_ids.append(databricks_task_id)
     return task_ids
+
+
+def _repair_task(
+    databricks_conn_id: str,
+    databricks_run_id: int,
+    tasks_to_repair: list[str],
+    logger: Logger | logging.Logger,
+) -> int:
+    """
+    Repair a Databricks task using the Databricks API.
+
+    This function allows the Airflow repair buttons to create a repair job for Databricks.
+    It uses the Databricks API to get the latest repair ID before sending the repair query.
+
+    :param databricks_conn_id: The Databricks connection ID.
+    :param databricks_run_id: The Databricks run ID.
+    :param tasks_to_repair: A list of Databricks task IDs to repair.
+    :param logger: The logger to use for logging.
+    :return: the repair id returned by the Databricks API.
+    """
+    hook = DatabricksHook(databricks_conn_id=databricks_conn_id)
+
+    repair_history_id = hook.get_latest_repair_id(databricks_run_id)
+    logger.debug("Latest repair ID is %s", repair_history_id)
+    logger.debug(
+        "Sending repair query for tasks %s on run %s",
+        tasks_to_repair,
+        databricks_run_id,
+    )
+
+    run_data = hook.get_run(databricks_run_id)
+    repair_json = {
+        "run_id": databricks_run_id,
+        "latest_repair_id": repair_history_id,
+        "rerun_tasks": tasks_to_repair,
+        # Also rerun dependents so upstream-failed downstream tasks resume rather than
+        # staying skipped after the repaired task succeeds.
+        "rerun_dependent_tasks": True,
+    }
+
+    if "overriding_parameters" in run_data:
+        repair_json["overriding_parameters"] = run_data["overriding_parameters"]
+
+    return hook.repair_run(repair_json)
 
 
 # TODO: Need to re-think on how to support the currently unavailable repair functionality in Airflow 3. Probably a
@@ -194,46 +241,6 @@ if not AIRFLOW_V_3_0_PLUS:
         if not ti:
             raise TaskInstanceNotFound("Task instance not found")
         return ti
-
-    def _repair_task(
-        databricks_conn_id: str,
-        databricks_run_id: int,
-        tasks_to_repair: list[str],
-        logger: Logger,
-    ) -> int:
-        """
-        Repair a Databricks task using the Databricks API.
-
-        This function allows the Airflow retry function to create a repair job for Databricks.
-        It uses the Databricks API to get the latest repair ID before sending the repair query.
-
-        :param databricks_conn_id: The Databricks connection ID.
-        :param databricks_run_id: The Databricks run ID.
-        :param tasks_to_repair: A list of Databricks task IDs to repair.
-        :param logger: The logger to use for logging.
-        :return: None
-        """
-        hook = DatabricksHook(databricks_conn_id=databricks_conn_id)
-
-        repair_history_id = hook.get_latest_repair_id(databricks_run_id)
-        logger.debug("Latest repair ID is %s", repair_history_id)
-        logger.debug(
-            "Sending repair query for tasks %s on run %s",
-            tasks_to_repair,
-            databricks_run_id,
-        )
-
-        run_data = hook.get_run(databricks_run_id)
-        repair_json = {
-            "run_id": databricks_run_id,
-            "latest_repair_id": repair_history_id,
-            "rerun_tasks": tasks_to_repair,
-        }
-
-        if "overriding_parameters" in run_data:
-            repair_json["overriding_parameters"] = run_data["overriding_parameters"]
-
-        return hook.repair_run(repair_json)
 
 
 def get_launch_task_id(task_group: TaskGroup) -> str:
@@ -381,6 +388,17 @@ class WorkflowJobRepairAllFailedLink(BaseOperatorLink, LoggingMixin):
         *,
         ti_key: TaskInstanceKey | None = None,
     ) -> str:
+        if AIRFLOW_V_3_0_PLUS:
+            if ti_key is None:
+                return ""
+            metadata = _get_launch_metadata_v3(operator, ti_key)
+            if not metadata:
+                return ""
+            # The set of failed tasks is resolved from the live Databricks run by the endpoint.
+            return _build_repair_url(
+                ti_key.dag_id, ti_key.run_id, metadata.conn_id, metadata.run_id, repair_all=True
+            )
+
         if not ti_key:
             ti = get_task_instance(operator, dttm)
             ti_key = ti.key
@@ -478,6 +496,20 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
         *,
         ti_key: TaskInstanceKey | None = None,
     ) -> str:
+        if AIRFLOW_V_3_0_PLUS:
+            if ti_key is None:
+                return ""
+            metadata = _get_launch_metadata_v3(operator, ti_key)
+            if not metadata:
+                return ""
+            return _build_repair_url(
+                ti_key.dag_id,
+                ti_key.run_id,
+                metadata.conn_id,
+                metadata.run_id,
+                tasks_to_repair=[operator.databricks_task_key],
+            )
+
         if not ti_key:
             ti = get_task_instance(operator, dttm)
             ti_key = ti.key
@@ -515,6 +547,193 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
         return url_for("RepairDatabricksTasks.repair", **query_params)
 
 
+# Airflow-3 repair backend. Flask-AppBuilder was dropped in Airflow 3, so the repair
+# action is re-implemented as a FastAPI sub-application mounted on the API server, and the
+# repair links (below) build URLs that point at it.
+REPAIR_URL_PREFIX = "/databricks/workflow/repair"
+
+
+def _build_repair_url(
+    dag_id: str,
+    run_id: str,
+    databricks_conn_id: str,
+    databricks_run_id: int,
+    *,
+    repair_all: bool = False,
+    tasks_to_repair: list[str] | None = None,
+) -> str:
+    """Build the URL to the Airflow-3 FastAPI repair endpoint for a workflow run."""
+    from urllib.parse import quote, urlencode
+
+    from airflow.configuration import conf
+
+    query: dict[str, Any] = {
+        "databricks_conn_id": databricks_conn_id,
+        "databricks_run_id": databricks_run_id,
+    }
+    if repair_all:
+        query["repair_all"] = "true"
+    if tasks_to_repair:
+        query["tasks_to_repair"] = ",".join(tasks_to_repair)
+
+    base_url = conf.get("api", "base_url", fallback="").rstrip("/")
+    return f"{base_url}{REPAIR_URL_PREFIX}/{dag_id}/{quote(run_id, safe='')}?{urlencode(query)}"
+
+
+def _get_launch_metadata_v3(operator: BaseOperator, ti_key: TaskInstanceKey) -> Any:
+    """
+    Read the launch task's ``WorkflowRunMetadata`` (conn_id, job_id, run_id) from XCom.
+
+    Uses only the public XCom API keyed by ``ti_key`` — no metadata-DB access — which is the
+    only mechanism available to extra links on Airflow 3.
+    """
+    task_group = operator.task_group
+    if not task_group:
+        return None
+    if ".launch" not in ti_key.task_id:
+        launch_task_id = get_launch_task_id(task_group)
+        ti_key = _get_launch_task_key(ti_key, task_id=launch_task_id)
+    result = XCom.get_value(ti_key=ti_key, key="return_value")
+    if not result:
+        return None
+    from airflow.providers.databricks.operators.databricks_workflow import WorkflowRunMetadata
+
+    return WorkflowRunMetadata(**result)
+
+
+if AIRFLOW_V_3_0_PLUS:
+    from fastapi import Depends, FastAPI, HTTPException, Request
+    from fastapi.responses import RedirectResponse
+
+    from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
+    from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
+    from airflow.api_fastapi.core_api.security import resolve_user_from_token
+
+    repair_app = FastAPI(
+        title="Databricks Workflow Repair",
+        description="Repair failed tasks of a Databricks workflow run from Airflow.",
+    )
+
+    async def _resolve_request_user(request: Request):
+        """Authenticate via the bearer header (UI XHR) or the ``_token`` cookie (link navigation)."""
+        token = None
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.lower().startswith("bearer "):
+            token = auth_header.split(" ", 1)[1]
+        if not token:
+            token = request.cookies.get(COOKIE_NAME_JWT_TOKEN)
+        # resolve_user_from_token raises HTTP 401 for a missing/invalid token.
+        return await resolve_user_from_token(token)
+
+    async def _require_dag_run_edit(dag_id: str, request: Request):
+        from airflow.api_fastapi.app import get_auth_manager
+
+        user = await _resolve_request_user(request)
+        authorized = get_auth_manager().is_authorized_dag(
+            method="PUT",
+            access_entity=DagAccessEntity.RUN,
+            details=DagDetails(id=dag_id),
+            user=user,
+        )
+        if not authorized:
+            raise HTTPException(status_code=403, detail="Not authorized to repair runs of this Dag.")
+        return user
+
+    def _clear_repaired_and_downstream(
+        dag_id: str, run_id: str, task_keys: list[str], logger: logging.Logger
+    ) -> None:
+        """
+        Clear the repaired tasks' instances and their downstream instances for this run.
+
+        Runs inside the API server (the DB-facing component), so clearing the repaired tasks plus
+        their downstream lets the upstream-failed dependents resume deterministically when the
+        repaired Databricks sub-runs succeed — without clearing the whole Dag.
+        """
+        import hashlib
+
+        from sqlalchemy import select
+
+        from airflow.models.serialized_dag import SerializedDagModel
+        from airflow.models.taskinstance import clear_task_instances
+        from airflow.utils.session import create_session
+
+        with create_session() as session:
+            dag = SerializedDagModel.get_dag(dag_id, session=session)
+            if dag is None:
+                raise HTTPException(status_code=404, detail=f"Dag {dag_id} not found.")
+
+            # Serialized tasks don't expose the operator's ``databricks_task_key`` property, so
+            # reproduce its default: an explicit key if present, else md5(dag_id__task_id).
+            key_to_task_id = {}
+            for task in dag.tasks:
+                task_key = (
+                    getattr(task, "databricks_task_key", None)
+                    or hashlib.md5(f"{dag_id}__{task.task_id}".encode()).hexdigest()
+                )
+                key_to_task_id[task_key] = task.task_id
+
+            repaired_task_ids = [key_to_task_id[k] for k in task_keys if k in key_to_task_id]
+            target_task_ids: set[str] = set(repaired_task_ids)
+            for task_id in repaired_task_ids:
+                target_task_ids.update(dag.get_task(task_id).get_flat_relative_ids(upstream=False))
+
+            dr = session.scalars(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)).one()
+            tis_to_clear = [
+                ti for ti in dr.get_task_instances(session=session) if ti.task_id in target_task_ids
+            ]
+            logger.info("Clearing %s task instances after Databricks repair", len(tis_to_clear))
+            clear_task_instances(tis_to_clear, session)
+            session.commit()
+
+    @repair_app.get("/{dag_id}/{run_id}")
+    def repair_databricks_workflow(
+        dag_id: str,
+        run_id: str,
+        databricks_conn_id: str,
+        databricks_run_id: int,
+        tasks_to_repair: str | None = None,
+        repair_all: bool = False,
+        _user=Depends(_require_dag_run_edit),
+    ):
+        """Repair failed Databricks tasks for a workflow run and resume the Airflow run."""
+        run_id = unquote(run_id)
+        from airflow.configuration import conf
+
+        base_url = conf.get("api", "base_url", fallback="").rstrip("/")
+        return_url = f"{base_url}/dags/{dag_id}/runs/{run_id}"
+
+        # Databricks API calls can fail (e.g. expired/invalid connection token); surface a clear
+        # error to the UI instead of a bare 500.
+        try:
+            hook = DatabricksHook(databricks_conn_id=databricks_conn_id)
+            if repair_all:
+                task_keys = hook.get_run_failed_task_keys(databricks_run_id)
+            elif tasks_to_repair:
+                task_keys = tasks_to_repair.split(",")
+            else:
+                task_keys = []
+
+            if not task_keys:
+                log.info("No failed Databricks tasks to repair for run %s", databricks_run_id)
+                return RedirectResponse(return_url, status_code=303)
+
+            log.info("Repairing Databricks run %s tasks %s", databricks_run_id, task_keys)
+            _repair_task(
+                databricks_conn_id=databricks_conn_id,
+                databricks_run_id=databricks_run_id,
+                tasks_to_repair=task_keys,
+                logger=log,
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            log.exception("Databricks repair failed for run %s", databricks_run_id)
+            raise HTTPException(status_code=502, detail=f"Databricks repair request failed: {e}") from e
+
+        _clear_repaired_and_downstream(dag_id, run_id, task_keys, log)
+        return RedirectResponse(return_url, status_code=303)
+
+
 class DatabricksWorkflowPlugin(AirflowPlugin):
     """
     Databricks Workflows plugin for Airflow.
@@ -526,19 +745,23 @@ class DatabricksWorkflowPlugin(AirflowPlugin):
 
     name = "databricks_workflow"
 
-    # Conditionally set operator_extra_links based on Airflow version
+    operator_extra_links = [
+        WorkflowJobRepairAllFailedLink(),
+        WorkflowJobRepairSingleTaskLink(),
+        WorkflowJobRunLink(),
+    ]
+
     if AIRFLOW_V_3_0_PLUS:
-        # In Airflow 3, disable the links for repair functionality until it is figured out it can be supported
-        operator_extra_links = [
-            WorkflowJobRunLink(),
+        # Airflow 3: repair is served by a FastAPI sub-application on the API server.
+        fastapi_apps = [
+            {
+                "app": repair_app,
+                "name": "Databricks Workflow Repair",
+                "url_prefix": REPAIR_URL_PREFIX,
+            }
         ]
     else:
-        # In Airflow 2.x, keep all links including repair all failed tasks
-        operator_extra_links = [
-            WorkflowJobRepairAllFailedLink(),
-            WorkflowJobRepairSingleTaskLink(),
-            WorkflowJobRunLink(),
-        ]
+        # Airflow 2.x: repair is served by a Flask-AppBuilder view.
         repair_databricks_view = RepairDatabricksTasks()
         repair_databricks_package = {
             "view": repair_databricks_view,

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -639,19 +639,22 @@ if AIRFLOW_V_3_1_PLUS:
             raise HTTPException(status_code=403, detail="Not authorized to repair runs of this Dag.")
         return user
 
-    def _serialized_task_key(dag_id: str, task: Any) -> str:
+    def _task_id_to_key(dag_id: str, task_id: str, task_key_map: dict[str, str]) -> str:
         """
-        Reproduce an operator's ``databricks_task_key`` from a serialized task.
+        Resolve a task's Databricks ``task_key`` from the launch task's trusted key map.
 
-        Serialized tasks don't expose the operator property, so mirror its default: an explicit key
-        if one was set, else ``md5(dag_id__task_id)``.
+        An explicit ``databricks_task_key`` does not survive Dag serialization, so the serialized
+        task can't be trusted to reproduce it. The launch task captured the real keys from the live
+        operators into ``task_key_map``. Runs launched before that map existed fall back to the
+        operator's default derivation, ``md5(dag_id__task_id)`` — correct for any task that did not
+        set an explicit key (the common case).
         """
+        mapped = task_key_map.get(task_id)
+        if mapped:
+            return mapped
         import hashlib
 
-        return (
-            getattr(task, "databricks_task_key", None)
-            or hashlib.md5(f"{dag_id}__{task.task_id}".encode()).hexdigest()
-        )
+        return hashlib.md5(f"{dag_id}__{task_id}".encode()).hexdigest()
 
     def _read_launch_metadata(dag_id: str, run_id: str, launch_task_id: str, session) -> Any:
         """
@@ -772,10 +775,13 @@ if AIRFLOW_V_3_1_PLUS:
                 if repair_all:
                     hook = DatabricksHook(databricks_conn_id=metadata.conn_id)
                     task_keys = hook.get_run_failed_task_keys(metadata.run_id)
-                    key_to_task_id = {_serialized_task_key(dag_id, t): t.task_id for t in dag.tasks}
+                    key_to_task_id = {
+                        _task_id_to_key(dag_id, t.task_id, metadata.task_key_map): t.task_id
+                        for t in dag.tasks
+                    }
                     repaired_task_ids = [key_to_task_id[k] for k in task_keys if k in key_to_task_id]
                 else:
-                    task_keys = [_serialized_task_key(dag_id, dag.get_task(repaired_task_ids[0]))]
+                    task_keys = [_task_id_to_key(dag_id, repaired_task_ids[0], metadata.task_key_map)]
 
                 if not task_keys:
                     log.info("No failed Databricks tasks to repair for run %s", metadata.run_id)

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -554,7 +554,13 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
             assert isinstance(task, DatabricksTaskBaseOperator)
 
         if ".launch" not in ti_key.task_id:
-            launch_task_id = get_launch_task_id(task_group)
+            try:
+                launch_task_id = get_launch_task_id(task_group)
+            except AirflowException:
+                # Declaring ``operators`` attaches this link to standalone Databricks tasks too, which
+                # have no launch task; render no URL rather than raising (which is a 500 in the
+                # Airflow 2 extra-links view). Mirrors the graceful "" the Airflow 3 branch returns.
+                return ""
             ti_key = _get_launch_task_key(ti_key, task_id=launch_task_id)
         metadata = get_xcom_result(ti_key, "return_value")
 

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -680,7 +680,7 @@ if AIRFLOW_V_3_1_PLUS:
         return WorkflowRunMetadata(**XComModel.deserialize_value(result))
 
     def _clear_repaired_and_downstream(
-        dag, run_id: str, task_ids: list[str], session, logger: logging.Logger
+        dag, dag_run: DagRun, task_ids: list[str], session, logger: logging.Logger
     ) -> None:
         """
         Clear the repaired tasks' instances and their downstream instances for this run.
@@ -689,16 +689,15 @@ if AIRFLOW_V_3_1_PLUS:
         their downstream lets the upstream-failed dependents resume deterministically when the
         repaired Databricks sub-runs succeed — without clearing the whole Dag.
         """
-        from sqlalchemy import select
-
         from airflow.models.taskinstance import clear_task_instances
 
         target_task_ids: set[str] = set(task_ids)
         for task_id in task_ids:
             target_task_ids.update(dag.get_task(task_id).get_flat_relative_ids(upstream=False))
 
-        dr = session.scalars(select(DagRun).where(DagRun.dag_id == dag.dag_id, DagRun.run_id == run_id)).one()
-        tis_to_clear = [ti for ti in dr.get_task_instances(session=session) if ti.task_id in target_task_ids]
+        tis_to_clear = [
+            ti for ti in dag_run.get_task_instances(session=session) if ti.task_id in target_task_ids
+        ]
         logger.info("Clearing %s task instances after Databricks repair", len(tis_to_clear))
         clear_task_instances(tis_to_clear, session)
 
@@ -718,7 +717,6 @@ if AIRFLOW_V_3_1_PLUS:
     def repair_databricks_workflow_confirm(
         dag_id: str,
         run_id: str,
-        request: Request,
         launch_task_id: str,
         task_id: str | None = None,
         repair_all: bool = False,
@@ -731,9 +729,11 @@ if AIRFLOW_V_3_1_PLUS:
             if repair_all
             else f"This will repair task '{task_id}' and resume its downstream tasks."
         )
-        # Same-site relative action; SameSite=Lax on the auth cookie means a cross-site POST cannot
-        # carry it, so moving the mutation to POST is what protects it from CSRF.
-        action = f"{request.url.path}?{request.url.query}"
+        # Rebuild the same-site POST target from the validated identifiers rather than echoing the
+        # request URL, so no request-controlled string reaches the rendered form action. SameSite=Lax
+        # on the auth cookie means a cross-site POST cannot carry it, so moving the mutation to POST
+        # is what protects it from CSRF.
+        action = _build_repair_url(dag_id, run_id, launch_task_id, repair_all=repair_all, task_id=task_id)
         return _repair_confirmation_page(dag_id, run_id, action, summary)
 
     @repair_app.post("/{dag_id}/{run_id}")
@@ -748,9 +748,7 @@ if AIRFLOW_V_3_1_PLUS:
         """Repair failed Databricks tasks for a workflow run and resume the Airflow run."""
         run_id = unquote(run_id)
 
-        # Redirect to a same-site relative path with the identifiers percent-encoded, so the
-        # target can never be steered to another host or scheme (CodeQL open-redirect).
-        return_url = f"/dags/{quote(dag_id, safe='')}/runs/{quote(run_id, safe='')}"
+        from sqlalchemy import select
 
         from airflow.models.serialized_dag import SerializedDagModel
         from airflow.utils.session import create_session
@@ -759,6 +757,17 @@ if AIRFLOW_V_3_1_PLUS:
             dag = SerializedDagModel.get_dag(dag_id, session=session)
             if dag is None:
                 raise HTTPException(status_code=404, detail="Dag not found.")
+
+            dag_run = session.scalars(
+                select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)
+            ).one_or_none()
+            if dag_run is None:
+                raise HTTPException(status_code=404, detail="Dag run not found.")
+
+            # Build the redirect target from the run's own persisted identifiers, not the request,
+            # so it is a fixed same-site path that request input cannot influence (CodeQL
+            # open-redirect).
+            return_url = f"/dags/{quote(dag_run.dag_id, safe='')}/runs/{quote(dag_run.run_id, safe='')}"
 
             metadata = _read_launch_metadata(dag_id, run_id, launch_task_id, session)
 
@@ -801,7 +810,7 @@ if AIRFLOW_V_3_1_PLUS:
                 raise HTTPException(status_code=502, detail="Databricks repair request failed.")
 
             # Clear only after a successful repair call, so a failed repair leaves state untouched.
-            _clear_repaired_and_downstream(dag, run_id, repaired_task_ids, session, log)
+            _clear_repaired_and_downstream(dag, dag_run, repaired_task_ids, session, log)
             session.commit()
 
         return RedirectResponse(return_url, status_code=303)

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlencode, urlsplit
 
 from airflow.exceptions import TaskInstanceNotFound
 from airflow.models.dagrun import DagRun
@@ -382,6 +382,16 @@ class WorkflowJobRepairAllFailedLink(BaseOperatorLink, LoggingMixin):
 
     name = "Repair All Failed Tasks"
 
+    @property
+    def operators(self):
+        # Declared so deserialization keeps this plugin link instead of replacing it with
+        # XComOperatorLink. Lazy import avoids a circular import with the operator module.
+        from airflow.providers.databricks.operators.databricks_workflow import (
+            _CreateDatabricksWorkflowOperator,
+        )
+
+        return [_CreateDatabricksWorkflowOperator]
+
     def get_link(  # type: ignore[override]  # Signature intentionally kept this way for Airflow 2.x compatibility
         self,
         operator,
@@ -489,6 +499,17 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
 
     name = "Repair a single task"
 
+    @property
+    def operators(self):
+        # Declared so deserialization keeps this plugin link instead of replacing it with
+        # XComOperatorLink. Lazy import avoids a circular import with the operator module.
+        from airflow.providers.databricks.operators.databricks import (
+            DatabricksNotebookOperator,
+            DatabricksTaskOperator,
+        )
+
+        return [DatabricksNotebookOperator, DatabricksTaskOperator]
+
     def get_link(  # type: ignore[override]  # Signature intentionally kept this way for Airflow 2.x compatibility
         self,
         operator,
@@ -570,34 +591,57 @@ def _build_repair_url(
     link — the endpoint derives them server-side, so the request cannot point the repair at an
     arbitrary connection or Databricks run.
     """
-    from urllib.parse import urlencode
-
     query: dict[str, Any] = {"launch_task_id": launch_task_id}
     if repair_all:
         query["repair_all"] = "true"
     if task_id:
         query["task_id"] = task_id
 
-    base_url = conf.get("api", "base_url", fallback="").rstrip("/")
+    # Same-site relative path only. Using the full ``[api] base_url`` (scheme + host) would make
+    # the confirmation POST cross-origin when that setting names a different domain than the UI,
+    # and SameSite=Lax would then withhold the auth cookie.
     return (
-        f"{base_url}{REPAIR_URL_PREFIX}/{quote(dag_id, safe='')}/{quote(run_id, safe='')}?{urlencode(query)}"
+        f"{_api_root_path()}{REPAIR_URL_PREFIX}/{quote(dag_id, safe='')}/"
+        f"{quote(run_id, safe='')}?{urlencode(query)}"
     )
+
+
+def _api_root_path() -> str:
+    """Path prefix from ``[api] base_url``, or empty when the API is mounted at the origin root."""
+    return urlsplit(conf.get("api", "base_url", fallback="") or "").path.rstrip("/")
+
+
+def _ui_run_path(dag_id: str, run_id: str) -> str:
+    """Same-site relative path to the Dag run in the UI, including the API root path if set."""
+    return f"{_api_root_path()}/dags/{quote(dag_id, safe='')}/runs/{quote(run_id, safe='')}"
 
 
 def _get_launch_task_id_v3(operator: BaseOperator, ti_key: TaskInstanceKey) -> str | None:
     """
     Resolve the ``task_id`` of the workflow's launch task for an extra-link render.
 
-    The link only needs to name the launch task; the repair endpoint reads that task's trusted
-    ``WorkflowRunMetadata`` XCom server-side. Returns ``None`` when the operator is not part of a
-    Databricks workflow task group (so the link is not rendered).
+    Works on both live operators and deserialized ones. ``SerializedTaskGroup`` has no
+    ``get_child_by_label``, so this never calls it. Returns ``None`` when the launch task
+    cannot be found (so the link is not rendered).
     """
-    task_group = operator.task_group
-    if not task_group:
-        return None
-    if ".launch" in ti_key.task_id:
+    if ti_key.task_id.endswith(".launch"):
         return ti_key.task_id
-    return get_launch_task_id(task_group)
+
+    for tid in getattr(operator, "upstream_task_ids", ()) or ():
+        if tid.endswith(".launch"):
+            return tid
+
+    task_group = getattr(operator, "task_group", None)
+    while task_group is not None:
+        child_id = getattr(task_group, "child_id", None)
+        children = getattr(task_group, "children", None)
+        if callable(child_id) and children is not None:
+            launch_id = child_id("launch")
+            if launch_id in children:
+                child = children[launch_id]
+                return getattr(child, "task_id", launch_id)
+        task_group = getattr(task_group, "parent_group", None)
+    return None
 
 
 if AIRFLOW_V_3_1_PLUS:
@@ -729,10 +773,9 @@ if AIRFLOW_V_3_1_PLUS:
             if repair_all
             else f"This will repair task '{task_id}' and resume its downstream tasks."
         )
-        # Rebuild the same-site POST target from the validated identifiers rather than echoing the
-        # request URL, so no request-controlled string reaches the rendered form action. SameSite=Lax
-        # on the auth cookie means a cross-site POST cannot carry it, so moving the mutation to POST
-        # is what protects it from CSRF.
+        # Rebuild a same-site relative POST target from the validated identifiers rather than
+        # echoing the request URL. SameSite=Lax on the auth cookie means a cross-site POST cannot
+        # carry it, so moving the mutation to POST is what protects it from CSRF.
         action = _build_repair_url(dag_id, run_id, launch_task_id, repair_all=repair_all, task_id=task_id)
         return _repair_confirmation_page(dag_id, run_id, action, summary)
 
@@ -766,8 +809,9 @@ if AIRFLOW_V_3_1_PLUS:
 
             # Build the redirect target from the run's own persisted identifiers, not the request,
             # so it is a fixed same-site path that request input cannot influence (CodeQL
-            # open-redirect).
-            return_url = f"/dags/{quote(dag_run.dag_id, safe='')}/runs/{quote(dag_run.run_id, safe='')}"
+            # open-redirect). Include the API root path so a non-root ``[api] base_url`` does
+            # not 404 the UI after repair.
+            return_url = _ui_run_path(dag_run.dag_id, dag_run.run_id)
 
             metadata = _read_launch_metadata(dag_id, run_id, launch_task_id, session)
 
@@ -788,7 +832,20 @@ if AIRFLOW_V_3_1_PLUS:
                         _task_id_to_key(dag_id, t.task_id, metadata.task_key_map): t.task_id
                         for t in dag.tasks
                     }
-                    repaired_task_ids = [key_to_task_id[k] for k in task_keys if k in key_to_task_id]
+                    repaired_task_ids = []
+                    unmapped_keys = []
+                    for task_key in task_keys:
+                        mapped_task_id = key_to_task_id.get(task_key)
+                        if mapped_task_id is None:
+                            unmapped_keys.append(task_key)
+                        else:
+                            repaired_task_ids.append(mapped_task_id)
+                    if unmapped_keys:
+                        log.warning(
+                            "Databricks repair returned task keys that could not be mapped "
+                            "to Airflow tasks: %s",
+                            unmapped_keys,
+                        )
                 else:
                     task_keys = [_task_id_to_key(dag_id, repaired_task_ids[0], metadata.task_key_map)]
 

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 from airflow.exceptions import TaskInstanceNotFound
 from airflow.models.dagrun import DagRun
@@ -31,9 +31,10 @@ from airflow.providers.common.compat.sdk import (
     BaseOperatorLink,
     TaskGroup,
     XCom,
+    conf,
 )
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
-from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS
+from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
 
@@ -389,15 +390,14 @@ class WorkflowJobRepairAllFailedLink(BaseOperatorLink, LoggingMixin):
         ti_key: TaskInstanceKey | None = None,
     ) -> str:
         if AIRFLOW_V_3_0_PLUS:
-            if ti_key is None:
+            if not AIRFLOW_V_3_1_PLUS or ti_key is None:
+                # The Airflow-3 repair backend requires 3.1+ (see DatabricksWorkflowPlugin).
                 return ""
-            metadata = _get_launch_metadata_v3(operator, ti_key)
-            if not metadata:
+            launch_task_id = _get_launch_task_id_v3(operator, ti_key)
+            if not launch_task_id:
                 return ""
             # The set of failed tasks is resolved from the live Databricks run by the endpoint.
-            return _build_repair_url(
-                ti_key.dag_id, ti_key.run_id, metadata.conn_id, metadata.run_id, repair_all=True
-            )
+            return _build_repair_url(ti_key.dag_id, ti_key.run_id, launch_task_id, repair_all=True)
 
         if not ti_key:
             ti = get_task_instance(operator, dttm)
@@ -497,17 +497,17 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
         ti_key: TaskInstanceKey | None = None,
     ) -> str:
         if AIRFLOW_V_3_0_PLUS:
-            if ti_key is None:
+            if not AIRFLOW_V_3_1_PLUS or ti_key is None:
+                # The Airflow-3 repair backend requires 3.1+ (see DatabricksWorkflowPlugin).
                 return ""
-            metadata = _get_launch_metadata_v3(operator, ti_key)
-            if not metadata:
+            launch_task_id = _get_launch_task_id_v3(operator, ti_key)
+            if not launch_task_id:
                 return ""
             return _build_repair_url(
                 ti_key.dag_id,
                 ti_key.run_id,
-                metadata.conn_id,
-                metadata.run_id,
-                tasks_to_repair=[operator.databricks_task_key],
+                launch_task_id,
+                task_id=operator.task_id,
             )
 
         if not ti_key:
@@ -556,54 +556,54 @@ REPAIR_URL_PREFIX = "/databricks/workflow/repair"
 def _build_repair_url(
     dag_id: str,
     run_id: str,
-    databricks_conn_id: str,
-    databricks_run_id: int,
+    launch_task_id: str,
     *,
     repair_all: bool = False,
-    tasks_to_repair: list[str] | None = None,
+    task_id: str | None = None,
 ) -> str:
-    """Build the URL to the Airflow-3 FastAPI repair endpoint for a workflow run."""
-    from urllib.parse import quote, urlencode
+    """
+    Build the URL to the Airflow-3 FastAPI repair confirmation page for a workflow run.
 
-    from airflow.configuration import conf
+    The URL carries only Airflow identifiers: the run's launch ``task_id`` (from which the
+    endpoint reads the trusted ``WorkflowRunMetadata`` XCom) and, for a single-task repair, the
+    target ``task_id``. The Databricks connection, run id, and task keys are never placed in the
+    link — the endpoint derives them server-side, so the request cannot point the repair at an
+    arbitrary connection or Databricks run.
+    """
+    from urllib.parse import urlencode
 
-    query: dict[str, Any] = {
-        "databricks_conn_id": databricks_conn_id,
-        "databricks_run_id": databricks_run_id,
-    }
+    query: dict[str, Any] = {"launch_task_id": launch_task_id}
     if repair_all:
         query["repair_all"] = "true"
-    if tasks_to_repair:
-        query["tasks_to_repair"] = ",".join(tasks_to_repair)
+    if task_id:
+        query["task_id"] = task_id
 
     base_url = conf.get("api", "base_url", fallback="").rstrip("/")
-    return f"{base_url}{REPAIR_URL_PREFIX}/{dag_id}/{quote(run_id, safe='')}?{urlencode(query)}"
+    return (
+        f"{base_url}{REPAIR_URL_PREFIX}/{quote(dag_id, safe='')}/{quote(run_id, safe='')}?{urlencode(query)}"
+    )
 
 
-def _get_launch_metadata_v3(operator: BaseOperator, ti_key: TaskInstanceKey) -> Any:
+def _get_launch_task_id_v3(operator: BaseOperator, ti_key: TaskInstanceKey) -> str | None:
     """
-    Read the launch task's ``WorkflowRunMetadata`` (conn_id, job_id, run_id) from XCom.
+    Resolve the ``task_id`` of the workflow's launch task for an extra-link render.
 
-    Uses only the public XCom API keyed by ``ti_key`` — no metadata-DB access — which is the
-    only mechanism available to extra links on Airflow 3.
+    The link only needs to name the launch task; the repair endpoint reads that task's trusted
+    ``WorkflowRunMetadata`` XCom server-side. Returns ``None`` when the operator is not part of a
+    Databricks workflow task group (so the link is not rendered).
     """
     task_group = operator.task_group
     if not task_group:
         return None
-    if ".launch" not in ti_key.task_id:
-        launch_task_id = get_launch_task_id(task_group)
-        ti_key = _get_launch_task_key(ti_key, task_id=launch_task_id)
-    result = XCom.get_value(ti_key=ti_key, key="return_value")
-    if not result:
-        return None
-    from airflow.providers.databricks.operators.databricks_workflow import WorkflowRunMetadata
-
-    return WorkflowRunMetadata(**result)
+    if ".launch" in ti_key.task_id:
+        return ti_key.task_id
+    return get_launch_task_id(task_group)
 
 
-if AIRFLOW_V_3_0_PLUS:
+if AIRFLOW_V_3_1_PLUS:
     from fastapi import Depends, FastAPI, HTTPException, Request
-    from fastapi.responses import RedirectResponse
+    from fastapi.responses import HTMLResponse, RedirectResponse
+    from markupsafe import escape
 
     from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
     from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
@@ -639,8 +639,45 @@ if AIRFLOW_V_3_0_PLUS:
             raise HTTPException(status_code=403, detail="Not authorized to repair runs of this Dag.")
         return user
 
+    def _serialized_task_key(dag_id: str, task: Any) -> str:
+        """
+        Reproduce an operator's ``databricks_task_key`` from a serialized task.
+
+        Serialized tasks don't expose the operator property, so mirror its default: an explicit key
+        if one was set, else ``md5(dag_id__task_id)``.
+        """
+        import hashlib
+
+        return (
+            getattr(task, "databricks_task_key", None)
+            or hashlib.md5(f"{dag_id}__{task.task_id}".encode()).hexdigest()
+        )
+
+    def _read_launch_metadata(dag_id: str, run_id: str, launch_task_id: str, session) -> Any:
+        """
+        Read the launch task's trusted ``WorkflowRunMetadata`` XCom (conn_id, job_id, run_id).
+
+        The Databricks connection and run id come from here — never from the request — so a crafted
+        link cannot redirect the repair at an arbitrary connection or Databricks run.
+        """
+        from airflow.models.xcom import XComModel
+        from airflow.providers.databricks.operators.databricks_workflow import WorkflowRunMetadata
+
+        result = session.scalars(
+            XComModel.get_many(
+                run_id=run_id,
+                key="return_value",
+                task_ids=launch_task_id,
+                dag_ids=dag_id,
+                limit=1,
+            )
+        ).first()
+        if result is None:
+            raise HTTPException(status_code=404, detail="Databricks workflow run metadata not found.")
+        return WorkflowRunMetadata(**XComModel.deserialize_value(result))
+
     def _clear_repaired_and_downstream(
-        dag_id: str, run_id: str, task_keys: list[str], logger: logging.Logger
+        dag, run_id: str, task_ids: list[str], session, logger: logging.Logger
     ) -> None:
         """
         Clear the repaired tasks' instances and their downstream instances for this run.
@@ -649,88 +686,118 @@ if AIRFLOW_V_3_0_PLUS:
         their downstream lets the upstream-failed dependents resume deterministically when the
         repaired Databricks sub-runs succeed — without clearing the whole Dag.
         """
-        import hashlib
-
         from sqlalchemy import select
 
-        from airflow.models.serialized_dag import SerializedDagModel
         from airflow.models.taskinstance import clear_task_instances
-        from airflow.utils.session import create_session
 
-        with create_session() as session:
-            dag = SerializedDagModel.get_dag(dag_id, session=session)
-            if dag is None:
-                raise HTTPException(status_code=404, detail=f"Dag {dag_id} not found.")
+        target_task_ids: set[str] = set(task_ids)
+        for task_id in task_ids:
+            target_task_ids.update(dag.get_task(task_id).get_flat_relative_ids(upstream=False))
 
-            # Serialized tasks don't expose the operator's ``databricks_task_key`` property, so
-            # reproduce its default: an explicit key if present, else md5(dag_id__task_id).
-            key_to_task_id = {}
-            for task in dag.tasks:
-                task_key = (
-                    getattr(task, "databricks_task_key", None)
-                    or hashlib.md5(f"{dag_id}__{task.task_id}".encode()).hexdigest()
-                )
-                key_to_task_id[task_key] = task.task_id
+        dr = session.scalars(select(DagRun).where(DagRun.dag_id == dag.dag_id, DagRun.run_id == run_id)).one()
+        tis_to_clear = [ti for ti in dr.get_task_instances(session=session) if ti.task_id in target_task_ids]
+        logger.info("Clearing %s task instances after Databricks repair", len(tis_to_clear))
+        clear_task_instances(tis_to_clear, session)
 
-            repaired_task_ids = [key_to_task_id[k] for k in task_keys if k in key_to_task_id]
-            target_task_ids: set[str] = set(repaired_task_ids)
-            for task_id in repaired_task_ids:
-                target_task_ids.update(dag.get_task(task_id).get_flat_relative_ids(upstream=False))
-
-            dr = session.scalars(select(DagRun).where(DagRun.dag_id == dag_id, DagRun.run_id == run_id)).one()
-            tis_to_clear = [
-                ti for ti in dr.get_task_instances(session=session) if ti.task_id in target_task_ids
-            ]
-            logger.info("Clearing %s task instances after Databricks repair", len(tis_to_clear))
-            clear_task_instances(tis_to_clear, session)
-            session.commit()
+    def _repair_confirmation_page(dag_id: str, run_id: str, action: str, summary: str) -> HTMLResponse:
+        """Render the read-only confirmation page whose form issues the state-changing POST."""
+        return HTMLResponse(
+            "<!doctype html><html><head><title>Repair Databricks workflow</title></head><body>"
+            "<h2>Repair Databricks workflow tasks</h2>"
+            f"<p>Dag <b>{escape(dag_id)}</b>, run <b>{escape(run_id)}</b>.</p>"
+            f"<p>{escape(summary)}</p>"
+            f'<form method="post" action="{escape(action)}">'
+            '<button type="submit">Repair</button></form>'
+            "</body></html>"
+        )
 
     @repair_app.get("/{dag_id}/{run_id}")
+    def repair_databricks_workflow_confirm(
+        dag_id: str,
+        run_id: str,
+        request: Request,
+        launch_task_id: str,
+        task_id: str | None = None,
+        repair_all: bool = False,
+        _user=Depends(_require_dag_run_edit),
+    ):
+        """Render a read-only confirmation page; the repair itself happens on the POST below."""
+        run_id = unquote(run_id)
+        summary = (
+            "This will repair all failed tasks of the run and resume their downstream tasks."
+            if repair_all
+            else f"This will repair task '{task_id}' and resume its downstream tasks."
+        )
+        # Same-site relative action; SameSite=Lax on the auth cookie means a cross-site POST cannot
+        # carry it, so moving the mutation to POST is what protects it from CSRF.
+        action = f"{request.url.path}?{request.url.query}"
+        return _repair_confirmation_page(dag_id, run_id, action, summary)
+
+    @repair_app.post("/{dag_id}/{run_id}")
     def repair_databricks_workflow(
         dag_id: str,
         run_id: str,
-        databricks_conn_id: str,
-        databricks_run_id: int,
-        tasks_to_repair: str | None = None,
+        launch_task_id: str,
+        task_id: str | None = None,
         repair_all: bool = False,
         _user=Depends(_require_dag_run_edit),
     ):
         """Repair failed Databricks tasks for a workflow run and resume the Airflow run."""
         run_id = unquote(run_id)
-        from airflow.configuration import conf
 
-        base_url = conf.get("api", "base_url", fallback="").rstrip("/")
-        return_url = f"{base_url}/dags/{dag_id}/runs/{run_id}"
+        # Redirect to a same-site relative path with the identifiers percent-encoded, so the
+        # target can never be steered to another host or scheme (CodeQL open-redirect).
+        return_url = f"/dags/{quote(dag_id, safe='')}/runs/{quote(run_id, safe='')}"
 
-        # Databricks API calls can fail (e.g. expired/invalid connection token); surface a clear
-        # error to the UI instead of a bare 500.
-        try:
-            hook = DatabricksHook(databricks_conn_id=databricks_conn_id)
+        from airflow.models.serialized_dag import SerializedDagModel
+        from airflow.utils.session import create_session
+
+        with create_session() as session:
+            dag = SerializedDagModel.get_dag(dag_id, session=session)
+            if dag is None:
+                raise HTTPException(status_code=404, detail="Dag not found.")
+
+            metadata = _read_launch_metadata(dag_id, run_id, launch_task_id, session)
+
             if repair_all:
-                task_keys = hook.get_run_failed_task_keys(databricks_run_id)
-            elif tasks_to_repair:
-                task_keys = tasks_to_repair.split(",")
+                repaired_task_ids: list[str] = []  # resolved from live Databricks state below
             else:
-                task_keys = []
+                if task_id is None or not dag.has_task(task_id):
+                    raise HTTPException(status_code=404, detail="Task not found in Dag.")
+                repaired_task_ids = [task_id]
 
-            if not task_keys:
-                log.info("No failed Databricks tasks to repair for run %s", databricks_run_id)
-                return RedirectResponse(return_url, status_code=303)
+            # Databricks API calls can fail (e.g. expired/invalid connection token); surface a
+            # generic error to the UI without leaking the upstream exception text.
+            try:
+                if repair_all:
+                    hook = DatabricksHook(databricks_conn_id=metadata.conn_id)
+                    task_keys = hook.get_run_failed_task_keys(metadata.run_id)
+                    key_to_task_id = {_serialized_task_key(dag_id, t): t.task_id for t in dag.tasks}
+                    repaired_task_ids = [key_to_task_id[k] for k in task_keys if k in key_to_task_id]
+                else:
+                    task_keys = [_serialized_task_key(dag_id, dag.get_task(repaired_task_ids[0]))]
 
-            log.info("Repairing Databricks run %s tasks %s", databricks_run_id, task_keys)
-            _repair_task(
-                databricks_conn_id=databricks_conn_id,
-                databricks_run_id=databricks_run_id,
-                tasks_to_repair=task_keys,
-                logger=log,
-            )
-        except HTTPException:
-            raise
-        except Exception as e:
-            log.exception("Databricks repair failed for run %s", databricks_run_id)
-            raise HTTPException(status_code=502, detail=f"Databricks repair request failed: {e}") from e
+                if not task_keys:
+                    log.info("No failed Databricks tasks to repair for run %s", metadata.run_id)
+                    return RedirectResponse(return_url, status_code=303)
 
-        _clear_repaired_and_downstream(dag_id, run_id, task_keys, log)
+                log.info("Repairing Databricks run %s tasks %s", metadata.run_id, task_keys)
+                _repair_task(
+                    databricks_conn_id=metadata.conn_id,
+                    databricks_run_id=metadata.run_id,
+                    tasks_to_repair=task_keys,
+                    logger=log,
+                )
+            except HTTPException:
+                raise
+            except Exception:
+                log.exception("Databricks repair failed for run %s", metadata.run_id)
+                raise HTTPException(status_code=502, detail="Databricks repair request failed.")
+
+            # Clear only after a successful repair call, so a failed repair leaves state untouched.
+            _clear_repaired_and_downstream(dag, run_id, repaired_task_ids, session, log)
+            session.commit()
+
         return RedirectResponse(return_url, status_code=303)
 
 
@@ -751,8 +818,10 @@ class DatabricksWorkflowPlugin(AirflowPlugin):
         WorkflowJobRunLink(),
     ]
 
-    if AIRFLOW_V_3_0_PLUS:
-        # Airflow 3: repair is served by a FastAPI sub-application on the API server.
+    if AIRFLOW_V_3_1_PLUS:
+        # Airflow 3.1+: repair is served by a FastAPI sub-application on the API server. The app
+        # relies on cookie-or-bearer auth resolution (`resolve_user_from_token`) that is only
+        # available from 3.1, so on 3.0.x the repair backend and its links are not registered.
         fastapi_apps = [
             {
                 "app": repair_app,
@@ -760,7 +829,7 @@ class DatabricksWorkflowPlugin(AirflowPlugin):
                 "url_prefix": REPAIR_URL_PREFIX,
             }
         ]
-    else:
+    elif not AIRFLOW_V_3_0_PLUS:
         # Airflow 2.x: repair is served by a Flask-AppBuilder view.
         repair_databricks_view = RepairDatabricksTasks()
         repair_databricks_package = {

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -34,7 +34,10 @@ from airflow.providers.common.compat.sdk import (
     conf,
 )
 from airflow.providers.databricks.hooks.databricks import DatabricksHook
-from airflow.providers.databricks.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from airflow.providers.databricks.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_1_1_PLUS,
+)
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
 
@@ -404,8 +407,11 @@ class WorkflowJobRepairAllFailedLink(BaseOperatorLink, LoggingMixin):
         ti_key: TaskInstanceKey | None = None,
     ) -> str:
         if AIRFLOW_V_3_0_PLUS:
-            if not AIRFLOW_V_3_1_PLUS or ti_key is None:
-                # The Airflow-3 repair backend requires 3.1+ (see DatabricksWorkflowPlugin).
+            # The Airflow-3 repair backend is only registered on 3.1.1+ (see
+            # DatabricksWorkflowPlugin), so render no link below that.
+            if not AIRFLOW_V_3_1_1_PLUS:
+                return ""
+            if ti_key is None:
                 return ""
             launch_task_id = _get_launch_task_id_v3(operator, ti_key)
             if not launch_task_id:
@@ -526,8 +532,11 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
         ti_key: TaskInstanceKey | None = None,
     ) -> str:
         if AIRFLOW_V_3_0_PLUS:
-            if not AIRFLOW_V_3_1_PLUS or ti_key is None:
-                # The Airflow-3 repair backend requires 3.1+ (see DatabricksWorkflowPlugin).
+            # The Airflow-3 repair backend is only registered on 3.1.1+ (see
+            # DatabricksWorkflowPlugin), so render no link below that.
+            if not AIRFLOW_V_3_1_1_PLUS:
+                return ""
+            if ti_key is None:
                 return ""
             launch_task_id = _get_launch_task_id_v3(operator, ti_key)
             if not launch_task_id:
@@ -658,7 +667,7 @@ def _get_launch_task_id_v3(operator: BaseOperator, ti_key: TaskInstanceKey) -> s
     return None
 
 
-if AIRFLOW_V_3_1_PLUS:
+if AIRFLOW_V_3_1_1_PLUS:
     from fastapi import Depends, FastAPI, HTTPException
     from fastapi.responses import HTMLResponse, RedirectResponse
     from markupsafe import escape
@@ -881,11 +890,11 @@ class DatabricksWorkflowPlugin(AirflowPlugin):
         WorkflowJobRunLink(),
     ]
 
-    if AIRFLOW_V_3_1_PLUS:
-        # Airflow 3.1+: repair is served by a FastAPI sub-application on the API server. Gated at
-        # 3.1 because a repair link clicked in the browser authenticates via the ``_token`` cookie,
-        # and the API server's ``get_user`` only honours that cookie from 3.1 onward; on 3.0.x the
-        # backend and its links are not registered.
+    if AIRFLOW_V_3_1_1_PLUS:
+        # Airflow 3.1.1+: repair is served by a FastAPI sub-application on the API server. Gated at
+        # 3.1.1 because a repair link clicked in the browser authenticates via the ``_token`` cookie,
+        # and the API server's ``get_user`` only honours that cookie from 3.1.1 onward (3.1.0 reads
+        # the bearer/oauth schemes only); below that the backend and its links are not registered.
         fastapi_apps = [
             {
                 "app": repair_app,

--- a/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
+++ b/providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py
@@ -384,8 +384,12 @@ class WorkflowJobRepairAllFailedLink(BaseOperatorLink, LoggingMixin):
 
     @property
     def operators(self):
-        # Declared so deserialization keeps this plugin link instead of replacing it with
-        # XComOperatorLink. Lazy import avoids a circular import with the operator module.
+        # On Airflow 3 a plugin extra link that declares no ``operators`` is replaced at
+        # deserialization by an ``XComOperatorLink`` that just returns a URL the task stored in
+        # XCom under ``xcom_key``. This link stores no such URL — it builds the URL at request time
+        # in ``get_link`` from the run's XCom metadata — so it must survive as the real object.
+        # Declaring the operators it applies to keeps it from being swapped out. Lazy import avoids
+        # a circular import with the operator module.
         from airflow.providers.databricks.operators.databricks_workflow import (
             _CreateDatabricksWorkflowOperator,
         )
@@ -501,8 +505,12 @@ class WorkflowJobRepairSingleTaskLink(BaseOperatorLink, LoggingMixin):
 
     @property
     def operators(self):
-        # Declared so deserialization keeps this plugin link instead of replacing it with
-        # XComOperatorLink. Lazy import avoids a circular import with the operator module.
+        # On Airflow 3 a plugin extra link that declares no ``operators`` is replaced at
+        # deserialization by an ``XComOperatorLink`` that just returns a URL the task stored in
+        # XCom under ``xcom_key``. This link stores no such URL — it builds the URL at request time
+        # in ``get_link`` from the run's XCom metadata — so it must survive as the real object.
+        # Declaring the operators it applies to keeps it from being swapped out. Lazy import avoids
+        # a circular import with the operator module.
         from airflow.providers.databricks.operators.databricks import (
             DatabricksNotebookOperator,
             DatabricksTaskOperator,
@@ -651,43 +659,25 @@ def _get_launch_task_id_v3(operator: BaseOperator, ti_key: TaskInstanceKey) -> s
 
 
 if AIRFLOW_V_3_1_PLUS:
-    from fastapi import Depends, FastAPI, HTTPException, Request
+    from fastapi import Depends, FastAPI, HTTPException
     from fastapi.responses import HTMLResponse, RedirectResponse
     from markupsafe import escape
 
-    from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
-    from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
-    from airflow.api_fastapi.core_api.security import resolve_user_from_token
+    from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity
+    from airflow.api_fastapi.core_api.security import requires_access_dag
 
     repair_app = FastAPI(
         title="Databricks Workflow Repair",
         description="Repair failed tasks of a Databricks workflow run from Airflow.",
     )
 
-    async def _resolve_request_user(request: Request):
-        """Authenticate via the bearer header (UI XHR) or the ``_token`` cookie (link navigation)."""
-        token = None
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.lower().startswith("bearer "):
-            token = auth_header.split(" ", 1)[1]
-        if not token:
-            token = request.cookies.get(COOKIE_NAME_JWT_TOKEN)
-        # resolve_user_from_token raises HTTP 401 for a missing/invalid token.
-        return await resolve_user_from_token(token)
-
-    async def _require_dag_run_edit(dag_id: str, request: Request):
-        from airflow.api_fastapi.app import get_auth_manager
-
-        user = await _resolve_request_user(request)
-        authorized = get_auth_manager().is_authorized_dag(
-            method="PUT",
-            access_entity=DagAccessEntity.RUN,
-            details=DagDetails(id=dag_id),
-            user=user,
-        )
-        if not authorized:
-            raise HTTPException(status_code=403, detail="Not authorized to repair runs of this Dag.")
-        return user
+    # Authenticate (bearer header or the UI's ``_token`` cookie) and authorize Dag-run edit access
+    # through the API server's own dependency, rather than parsing the request or assuming how the
+    # auth manager maps requests to users. ``requires_access_dag`` reads the ``dag_id`` path param
+    # and calls the auth manager; ``get_user`` behind it already honours both the bearer header and
+    # the cookie, so a repair link clicked in the browser is authorized. Bound to a module-level
+    # name so tests can override just this dependency.
+    _require_dag_run_edit = requires_access_dag(method="PUT", access_entity=DagAccessEntity.RUN)
 
     def _task_id_to_key(dag_id: str, task_id: str, task_key_map: dict[str, str]) -> str:
         """
@@ -763,17 +753,15 @@ if AIRFLOW_V_3_1_PLUS:
             "</body></html>"
         )
 
-    @repair_app.get("/{dag_id}/{run_id}")
+    @repair_app.get("/{dag_id}/{run_id}", dependencies=[Depends(_require_dag_run_edit)])
     def repair_databricks_workflow_confirm(
         dag_id: str,
         run_id: str,
         launch_task_id: str,
         task_id: str | None = None,
         repair_all: bool = False,
-        _user=Depends(_require_dag_run_edit),
     ):
         """Render a read-only confirmation page; the repair itself happens on the POST below."""
-        run_id = unquote(run_id)
         summary = (
             "This will repair all failed tasks of the run and resume their downstream tasks."
             if repair_all
@@ -785,18 +773,15 @@ if AIRFLOW_V_3_1_PLUS:
         action = _build_repair_url(dag_id, run_id, launch_task_id, repair_all=repair_all, task_id=task_id)
         return _repair_confirmation_page(dag_id, run_id, action, summary)
 
-    @repair_app.post("/{dag_id}/{run_id}")
+    @repair_app.post("/{dag_id}/{run_id}", dependencies=[Depends(_require_dag_run_edit)])
     def repair_databricks_workflow(
         dag_id: str,
         run_id: str,
         launch_task_id: str,
         task_id: str | None = None,
         repair_all: bool = False,
-        _user=Depends(_require_dag_run_edit),
     ):
         """Repair failed Databricks tasks for a workflow run and resume the Airflow run."""
-        run_id = unquote(run_id)
-
         from sqlalchemy import select
 
         from airflow.models.serialized_dag import SerializedDagModel
@@ -897,9 +882,10 @@ class DatabricksWorkflowPlugin(AirflowPlugin):
     ]
 
     if AIRFLOW_V_3_1_PLUS:
-        # Airflow 3.1+: repair is served by a FastAPI sub-application on the API server. The app
-        # relies on cookie-or-bearer auth resolution (`resolve_user_from_token`) that is only
-        # available from 3.1, so on 3.0.x the repair backend and its links are not registered.
+        # Airflow 3.1+: repair is served by a FastAPI sub-application on the API server. Gated at
+        # 3.1 because a repair link clicked in the browser authenticates via the ``_token`` cookie,
+        # and the API server's ``get_user`` only honours that cookie from 3.1 onward; on 3.0.x the
+        # backend and its links are not registered.
         fastapi_apps = [
             {
                 "app": repair_app,

--- a/providers/databricks/src/airflow/providers/databricks/version_compat.py
+++ b/providers/databricks/src/airflow/providers/databricks/version_compat.py
@@ -33,7 +33,9 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
+AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
+    "AIRFLOW_V_3_1_PLUS",
 ]

--- a/providers/databricks/src/airflow/providers/databricks/version_compat.py
+++ b/providers/databricks/src/airflow/providers/databricks/version_compat.py
@@ -34,8 +34,10 @@ def get_base_airflow_version_tuple() -> tuple[int, int, int]:
 
 AIRFLOW_V_3_0_PLUS = get_base_airflow_version_tuple() >= (3, 0, 0)
 AIRFLOW_V_3_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 0)
+AIRFLOW_V_3_1_1_PLUS = get_base_airflow_version_tuple() >= (3, 1, 1)
 
 __all__ = [
     "AIRFLOW_V_3_0_PLUS",
     "AIRFLOW_V_3_1_PLUS",
+    "AIRFLOW_V_3_1_1_PLUS",
 ]

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -749,6 +749,20 @@ class TestDatabricksHook:
         assert len(tasks) == 2
         assert tasks == GET_RUN_RESPONSE["tasks"] * 2
 
+    def test_get_run_failed_task_keys(self):
+        run_tasks = [
+            {"task_key": "ok", "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"}},
+            {"task_key": "boom", "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"}},
+            {"task_key": "slow", "state": {"result_state": "TIMEDOUT", "life_cycle_state": "TERMINATED"}},
+            {"task_key": "killed", "state": {"result_state": "CANCELED", "life_cycle_state": "SKIPPED"}},
+            {"task_key": "crashed", "state": {"life_cycle_state": "INTERNAL_ERROR"}},
+            {"task_key": "running", "state": {"life_cycle_state": "RUNNING"}},
+        ]
+        with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
+            failed = self.hook.get_run_failed_task_keys(RUN_ID)
+
+        assert failed == ["boom", "slow", "killed", "crashed"]
+
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_cancel_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -751,17 +751,70 @@ class TestDatabricksHook:
 
     def test_get_run_failed_task_keys(self):
         run_tasks = [
-            {"task_key": "ok", "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"}},
-            {"task_key": "boom", "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"}},
-            {"task_key": "slow", "state": {"result_state": "TIMEDOUT", "life_cycle_state": "TERMINATED"}},
-            {"task_key": "killed", "state": {"result_state": "CANCELED", "life_cycle_state": "SKIPPED"}},
-            {"task_key": "crashed", "state": {"life_cycle_state": "INTERNAL_ERROR"}},
-            {"task_key": "running", "state": {"life_cycle_state": "RUNNING"}},
+            {
+                "task_key": "ok",
+                "start_time": 1,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "boom",
+                "start_time": 1,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "slow",
+                "start_time": 1,
+                "state": {"result_state": "TIMEDOUT", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "killed",
+                "start_time": 1,
+                "state": {"result_state": "CANCELED", "life_cycle_state": "SKIPPED"},
+            },
+            {"task_key": "crashed", "start_time": 1, "state": {"life_cycle_state": "INTERNAL_ERROR"}},
+            {"task_key": "running", "start_time": 1, "state": {"life_cycle_state": "RUNNING"}},
         ]
         with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
             failed = self.hook.get_run_failed_task_keys(RUN_ID)
 
         assert failed == ["boom", "slow", "killed", "crashed"]
+
+    def test_get_run_failed_task_keys_dedupes_to_latest_attempt(self):
+        # get_run_tasks returns one entry per attempt (unordered). A retried task appears under the
+        # same task_key several times; the key must be reported once and judged by its latest
+        # attempt, so a task whose newest attempt succeeded is not reported as failed.
+        run_tasks = [
+            {
+                "task_key": "flaky",
+                "start_time": 100,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": 300,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": 200,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "still_bad",
+                "start_time": 100,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "still_bad",
+                "start_time": 200,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+        ]
+        with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
+            failed = self.hook.get_run_failed_task_keys(RUN_ID)
+
+        # "flaky" latest attempt (start_time 300) succeeded → excluded; "still_bad" latest failed.
+        assert failed == ["still_bad"]
 
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_cancel_run(self, mock_requests):

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -816,6 +816,33 @@ class TestDatabricksHook:
         # "flaky" latest attempt (start_time 300) succeeded → excluded; "still_bad" latest failed.
         assert failed == ["still_bad"]
 
+    def test_get_run_failed_task_keys_treats_missing_start_time_as_oldest(self):
+        run_tasks = [
+            {
+                "task_key": "never_started",
+                "state": {"life_cycle_state": "PENDING"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": None,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": 200,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "still_bad",
+                "start_time": 100,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+        ]
+        with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
+            failed = self.hook.get_run_failed_task_keys(RUN_ID)
+
+        assert failed == ["still_bad"]
+
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_cancel_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -750,6 +750,20 @@ class TestDatabricksHook:
         assert len(tasks) == 2
         assert tasks == GET_RUN_RESPONSE["tasks"] * 2
 
+    def test_get_run_failed_task_keys(self):
+        run_tasks = [
+            {"task_key": "ok", "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"}},
+            {"task_key": "boom", "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"}},
+            {"task_key": "slow", "state": {"result_state": "TIMEDOUT", "life_cycle_state": "TERMINATED"}},
+            {"task_key": "killed", "state": {"result_state": "CANCELED", "life_cycle_state": "SKIPPED"}},
+            {"task_key": "crashed", "state": {"life_cycle_state": "INTERNAL_ERROR"}},
+            {"task_key": "running", "state": {"life_cycle_state": "RUNNING"}},
+        ]
+        with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
+            failed = self.hook.get_run_failed_task_keys(RUN_ID)
+
+        assert failed == ["boom", "slow", "killed", "crashed"]
+
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_get_run_collects_every_page(self, mock_requests):
         mock_requests.codes.ok = 200

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -817,6 +817,33 @@ class TestDatabricksHook:
         # "flaky" latest attempt (start_time 300) succeeded → excluded; "still_bad" latest failed.
         assert failed == ["still_bad"]
 
+    def test_get_run_failed_task_keys_treats_missing_start_time_as_oldest(self):
+        run_tasks = [
+            {
+                "task_key": "never_started",
+                "state": {"life_cycle_state": "PENDING"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": None,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": 200,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "still_bad",
+                "start_time": 100,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+        ]
+        with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
+            failed = self.hook.get_run_failed_task_keys(RUN_ID)
+
+        assert failed == ["still_bad"]
+
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_get_run_collects_every_page(self, mock_requests):
         mock_requests.codes.ok = 200

--- a/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/hooks/test_databricks.py
@@ -752,17 +752,70 @@ class TestDatabricksHook:
 
     def test_get_run_failed_task_keys(self):
         run_tasks = [
-            {"task_key": "ok", "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"}},
-            {"task_key": "boom", "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"}},
-            {"task_key": "slow", "state": {"result_state": "TIMEDOUT", "life_cycle_state": "TERMINATED"}},
-            {"task_key": "killed", "state": {"result_state": "CANCELED", "life_cycle_state": "SKIPPED"}},
-            {"task_key": "crashed", "state": {"life_cycle_state": "INTERNAL_ERROR"}},
-            {"task_key": "running", "state": {"life_cycle_state": "RUNNING"}},
+            {
+                "task_key": "ok",
+                "start_time": 1,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "boom",
+                "start_time": 1,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "slow",
+                "start_time": 1,
+                "state": {"result_state": "TIMEDOUT", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "killed",
+                "start_time": 1,
+                "state": {"result_state": "CANCELED", "life_cycle_state": "SKIPPED"},
+            },
+            {"task_key": "crashed", "start_time": 1, "state": {"life_cycle_state": "INTERNAL_ERROR"}},
+            {"task_key": "running", "start_time": 1, "state": {"life_cycle_state": "RUNNING"}},
         ]
         with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
             failed = self.hook.get_run_failed_task_keys(RUN_ID)
 
         assert failed == ["boom", "slow", "killed", "crashed"]
+
+    def test_get_run_failed_task_keys_dedupes_to_latest_attempt(self):
+        # get_run_tasks returns one entry per attempt (unordered). A retried task appears under the
+        # same task_key several times; the key must be reported once and judged by its latest
+        # attempt, so a task whose newest attempt succeeded is not reported as failed.
+        run_tasks = [
+            {
+                "task_key": "flaky",
+                "start_time": 100,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": 300,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "flaky",
+                "start_time": 200,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "still_bad",
+                "start_time": 100,
+                "state": {"result_state": "SUCCESS", "life_cycle_state": "TERMINATED"},
+            },
+            {
+                "task_key": "still_bad",
+                "start_time": 200,
+                "state": {"result_state": "FAILED", "life_cycle_state": "TERMINATED"},
+            },
+        ]
+        with mock.patch.object(self.hook, "get_run_tasks", return_value=run_tasks):
+            failed = self.hook.get_run_failed_task_keys(RUN_ID)
+
+        # "flaky" latest attempt (start_time 300) succeeded → excluded; "still_bad" latest failed.
+        assert failed == ["still_bad"]
 
     @mock.patch("airflow.providers.databricks.hooks.databricks_base.requests")
     def test_get_run_collects_every_page(self, mock_requests):

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_workflow.py
@@ -202,6 +202,7 @@ def test_execute(mock_databricks_hook, context, mock_task_group):
     )
 
     task = MagicMock(spec=BaseOperator, task_id="task_1")
+    task.databricks_task_key = "explicit_key_1"
     task._convert_to_databricks_workflow_task = MagicMock(return_value={})
     operator.add_task(task.task_id, task)
 
@@ -211,6 +212,7 @@ def test_execute(mock_databricks_hook, context, mock_task_group):
         "conn_id": "databricks_default",
         "job_id": 123,
         "run_id": 789,
+        "task_key_map": {"task_1": "explicit_key_1"},
     }
     mock_hook_instance.run_now.assert_called_once()
 

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -30,10 +30,14 @@ from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstanceKey
 from airflow.providers.common.compat.sdk import AirflowException, AirflowPlugin
 from airflow.providers.databricks.plugins.databricks_workflow import (
+    REPAIR_URL_PREFIX,
     DatabricksWorkflowPlugin,
+    WorkflowJobRepairAllFailedLink,
     WorkflowJobRepairSingleTaskLink,
     WorkflowJobRunLink,
+    _build_repair_url,
     _get_launch_task_key,
+    _repair_task,
     get_databricks_task_ids,
     get_launch_task_id,
     store_databricks_job_run_link,
@@ -45,7 +49,6 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 if not AIRFLOW_V_3_0_PLUS:
     from airflow.providers.databricks.plugins.databricks_workflow import (
         RepairDatabricksTasks,
-        _repair_task,
     )
 
 DAG_ID = "test_dag"
@@ -84,7 +87,6 @@ def test_get_dagrun_airflow2():
     assert isinstance(result, DagRun)
 
 
-@pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow < 3.0")
 @patch("airflow.providers.databricks.plugins.databricks_workflow.DatabricksHook")
 def test_repair_task(mock_databricks_hook):
     mock_hook_instance = mock_databricks_hook.return_value
@@ -97,9 +99,10 @@ def test_repair_task(mock_databricks_hook):
     assert result == 200
     mock_hook_instance.get_latest_repair_id.assert_called_once_with(DATABRICKS_RUN_ID)
     mock_hook_instance.repair_run.assert_called_once()
+    # downstream dependents must also be rerun so upstream-failed tasks resume
+    assert mock_hook_instance.repair_run.call_args[0][0]["rerun_dependent_tasks"] is True
 
 
-@pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow < 3.0")
 @patch("airflow.providers.databricks.plugins.databricks_workflow.DatabricksHook")
 def test_repair_task_with_params(mock_databricks_hook):
     mock_hook_instance = mock_databricks_hook.return_value
@@ -119,6 +122,7 @@ def test_repair_task_with_params(mock_databricks_hook):
         "run_id": DATABRICKS_RUN_ID,
         "rerun_tasks": tasks_to_repair,
         "latest_repair_id": 100,
+        "rerun_dependent_tasks": True,
         "overriding_parameters": {
             "key1": "value1",
             "key2": "value2",
@@ -296,24 +300,131 @@ def test_appbuilder_views_airflow2(plugin):
 class TestDatabricksWorkflowPluginAirflow3:
     """Test Databricks Workflow Plugin functionality specific to Airflow 3.x."""
 
-    def test_plugin_operator_extra_links_limited_functionality(self):
-        """Test that operator_extra_links are limited in Airflow 3.x (only job run link)."""
+    def test_plugin_operator_extra_links_include_repair(self):
+        """All three extra links (incl. repair) are registered in Airflow 3.x."""
         plugin = DatabricksWorkflowPlugin()
 
-        # In Airflow 3, only WorkflowJobRunLink should be present
-        assert len(plugin.operator_extra_links) == 1
-        assert isinstance(plugin.operator_extra_links[0], WorkflowJobRunLink)
+        link_types = {type(link).__name__ for link in plugin.operator_extra_links}
+        assert link_types == {
+            "WorkflowJobRunLink",
+            "WorkflowJobRepairAllFailedLink",
+            "WorkflowJobRepairSingleTaskLink",
+        }
 
-        # Verify repair links are not present
-        link_types = [type(link).__name__ for link in plugin.operator_extra_links]
-        assert not any("Repair" in link_type for link_type in link_types)
-
-    def test_plugin_no_appbuilder_views(self):
-        """Test that appbuilder_views are not configured in Airflow 3.x."""
+    def test_plugin_registers_fastapi_repair_app(self):
+        """Repair is served by a FastAPI app (not Flask-AppBuilder) in Airflow 3.x."""
         plugin = DatabricksWorkflowPlugin()
 
-        # In Airflow 3, appbuilder_views should not be set (repair functionality disabled)
         assert not getattr(plugin, "appbuilder_views", [])
+        assert len(plugin.fastapi_apps) == 1
+        app = plugin.fastapi_apps[0]
+        assert app["url_prefix"] == REPAIR_URL_PREFIX
+        assert app["app"] is not None
+
+    def test_build_repair_url_single_task(self):
+        url = _build_repair_url("my_dag", "run 1", "databricks_default", 999, tasks_to_repair=["abc", "def"])
+        assert url.startswith(f"{REPAIR_URL_PREFIX}/my_dag/run%201") or REPAIR_URL_PREFIX in url
+        assert "databricks_conn_id=databricks_default" in url
+        assert "databricks_run_id=999" in url
+        assert "tasks_to_repair=abc%2Cdef" in url
+        assert "repair_all" not in url
+
+    def test_build_repair_url_repair_all(self):
+        url = _build_repair_url("my_dag", "run1", "databricks_default", 999, repair_all=True)
+        assert "repair_all=true" in url
+        assert "tasks_to_repair" not in url
+
+    def test_repair_single_task_link_uses_endpoint_url(self):
+        """The single-task repair link points at the FastAPI endpoint, built from XCom only."""
+        link = WorkflowJobRepairSingleTaskLink()
+        operator = Mock(databricks_task_key="abc123")
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="grp.nb", run_id="run1", try_number=1)
+        metadata = Mock(conn_id="databricks_default", run_id=555)
+        with patch(
+            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_metadata_v3",
+            return_value=metadata,
+        ):
+            url = link.get_link(operator, ti_key=ti_key)
+        assert REPAIR_URL_PREFIX in url
+        assert "tasks_to_repair=abc123" in url
+        assert "databricks_run_id=555" in url
+
+    def test_repair_all_link_uses_endpoint_url(self):
+        link = WorkflowJobRepairAllFailedLink()
+        operator = Mock()
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="grp.nb", run_id="run1", try_number=1)
+        metadata = Mock(conn_id="databricks_default", run_id=555)
+        with patch(
+            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_metadata_v3",
+            return_value=metadata,
+        ):
+            url = link.get_link(operator, ti_key=ti_key)
+        assert REPAIR_URL_PREFIX in url
+        assert "repair_all=true" in url
+
+    def test_repair_link_returns_empty_without_metadata(self):
+        """When the launch XCom isn't available yet, the link renders empty (no crash)."""
+        link = WorkflowJobRepairSingleTaskLink()
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="grp.nb", run_id="run1", try_number=1)
+        with patch(
+            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_metadata_v3",
+            return_value=None,
+        ):
+            assert link.get_link(Mock(databricks_task_key="x"), ti_key=ti_key) == ""
+
+    def test_repair_endpoint_calls_repair_and_clear(self):
+        """The FastAPI endpoint resolves failed tasks, repairs, clears, and redirects."""
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        try:
+            with (
+                patch.object(m, "DatabricksHook") as mock_hook,
+                patch.object(m, "_repair_task") as mock_repair,
+                patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
+            ):
+                mock_hook.return_value.get_run_failed_task_keys.return_value = ["k1", "k2"]
+                client = TestClient(m.repair_app)
+                resp = client.get(
+                    "/my_dag/run1",
+                    params={
+                        "databricks_conn_id": "databricks_default",
+                        "databricks_run_id": 999,
+                        "repair_all": "true",
+                    },
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 303
+            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["k1", "k2"]
+            mock_clear.assert_called_once()
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    def test_repair_endpoint_returns_502_on_databricks_error(self):
+        """A Databricks/hook failure surfaces as a clean 502, not a bare 500."""
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        try:
+            with patch.object(m, "DatabricksHook") as mock_hook:
+                mock_hook.return_value.get_run_failed_task_keys.side_effect = Exception("Invalid Token")
+                client = TestClient(m.repair_app, raise_server_exceptions=False)
+                resp = client.get(
+                    "/my_dag/run1",
+                    params={
+                        "databricks_conn_id": "databricks_default",
+                        "databricks_run_id": 1,
+                        "repair_all": "true",
+                    },
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 502
+        finally:
+            m.repair_app.dependency_overrides.clear()
 
     def test_store_databricks_job_run_link_function_works(self):
         """Test that store_databricks_job_run_link works correctly in Airflow 3.x."""

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -296,6 +296,23 @@ def test_appbuilder_views_airflow2(plugin):
     assert repair_view.default_view == "repair"
 
 
+def _patched_create_session(dag_run):
+    """Return a ``create_session`` replacement whose session yields ``dag_run`` for the run query.
+
+    The POST handler fetches the DagRun via ``session.scalars(...).one_or_none()`` and builds the
+    redirect from its persisted identifiers, so tests must supply a real-valued DagRun there.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _factory(*args, **kwargs):
+        session = MagicMock()
+        session.scalars.return_value.one_or_none.return_value = dag_run
+        yield session
+
+    return _factory
+
+
 @pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Airflow-3 repair backend requires 3.1+")
 class TestDatabricksWorkflowPluginAirflow3:
     """Test Databricks Workflow Plugin functionality specific to Airflow 3.1+."""
@@ -434,10 +451,11 @@ class TestDatabricksWorkflowPluginAirflow3:
         # The task uses an EXPLICIT databricks_task_key that does not survive serialization; the
         # endpoint must recover it from the launch task's trusted task_key_map, not reconstruct md5.
         metadata = Mock(conn_id="c", run_id=999, task_key_map={"grp.nb": "EXPLICIT_KEY"})
+        dag_run = Mock(dag_id="my_dag", run_id="run1")
         try:
             with (
                 patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
-                patch("airflow.utils.session.create_session"),
+                patch("airflow.utils.session.create_session", _patched_create_session(dag_run)),
                 patch.object(m, "_read_launch_metadata", return_value=metadata),
                 patch.object(m, "DatabricksHook") as mock_hook,
                 patch.object(m, "_repair_task") as mock_repair,
@@ -451,6 +469,7 @@ class TestDatabricksWorkflowPluginAirflow3:
                     follow_redirects=False,
                 )
             assert resp.status_code == 303
+            # Redirect target is built from the DagRun's own persisted identifiers, not the request.
             assert resp.headers["location"] == "/dags/my_dag/runs/run1"
             assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["EXPLICIT_KEY"]
             assert mock_repair.call_args.kwargs["databricks_run_id"] == 999
@@ -468,10 +487,11 @@ class TestDatabricksWorkflowPluginAirflow3:
 
         m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
         dag = Mock(dag_id="my_dag", tasks=[])
+        dag_run = Mock(dag_id="my_dag", run_id="run1")
         try:
             with (
                 patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
-                patch("airflow.utils.session.create_session"),
+                patch("airflow.utils.session.create_session", _patched_create_session(dag_run)),
                 patch.object(m, "_read_launch_metadata", return_value=Mock(conn_id="c", run_id=1)),
                 patch.object(m, "DatabricksHook") as mock_hook,
                 patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
@@ -499,10 +519,11 @@ class TestDatabricksWorkflowPluginAirflow3:
         dag = Mock(dag_id="my_dag")
         dag.has_task.return_value = True
         metadata = Mock(conn_id="c", run_id=42, task_key_map={"grp.nb": "EXPLICIT_KEY"})
+        dag_run = Mock(dag_id="my_dag", run_id="run1")
         try:
             with (
                 patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
-                patch("airflow.utils.session.create_session"),
+                patch("airflow.utils.session.create_session", _patched_create_session(dag_run)),
                 patch.object(m, "_read_launch_metadata", return_value=metadata),
                 patch.object(m, "_repair_task") as mock_repair,
                 patch.object(m, "_clear_repaired_and_downstream"),
@@ -532,10 +553,11 @@ class TestDatabricksWorkflowPluginAirflow3:
         dag.has_task.return_value = True
         metadata = Mock(conn_id="c", run_id=42, task_key_map={})
         expected = hashlib.md5(b"my_dag__grp.nb").hexdigest()
+        dag_run = Mock(dag_id="my_dag", run_id="run1")
         try:
             with (
                 patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
-                patch("airflow.utils.session.create_session"),
+                patch("airflow.utils.session.create_session", _patched_create_session(dag_run)),
                 patch.object(m, "_read_launch_metadata", return_value=metadata),
                 patch.object(m, "_repair_task") as mock_repair,
                 patch.object(m, "_clear_repaired_and_downstream"),

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -698,7 +698,7 @@ class TestDatabricksWorkflowPluginAirflow3:
             # Verify no XCom was pushed due to the exception
             ti_mock.xcom_push.assert_not_called()
 
-    def test_post_repair_all_warns_on_unmapped_keys(self, caplog):
+    def test_post_repair_all_warns_on_unmapped_keys(self):
         from fastapi.testclient import TestClient
 
         from airflow.providers.databricks.plugins import databricks_workflow as m
@@ -718,6 +718,7 @@ class TestDatabricksWorkflowPluginAirflow3:
                 patch.object(m, "DatabricksHook") as mock_hook,
                 patch.object(m, "_repair_task") as mock_repair,
                 patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
+                patch.object(m.log, "warning") as mock_warning,
             ):
                 mock_hook.return_value.get_run_failed_task_keys.return_value = ["KNOWN_KEY", "LEGACY_KEY"]
                 client = TestClient(m.repair_app)
@@ -729,7 +730,9 @@ class TestDatabricksWorkflowPluginAirflow3:
             assert resp.status_code == 303
             assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["KNOWN_KEY", "LEGACY_KEY"]
             assert mock_clear.call_args.args[2] == ["grp.nb"]
-            assert "Databricks repair returned task keys that could not be mapped to Airflow tasks" in caplog
+            mock_warning.assert_called_once()
+            assert "could not be mapped to Airflow tasks" in mock_warning.call_args.args[0]
+            assert mock_warning.call_args.args[1] == ["LEGACY_KEY"]
         finally:
             m.repair_app.dependency_overrides.clear()
 
@@ -773,10 +776,12 @@ class TestDatabricksWorkflowPluginAirflow3:
         from tests_common.test_utils.mock_plugins import mock_plugin_manager
 
         plugin = DatabricksWorkflowPlugin()
-        with mock_plugin_manager(plugins=[plugin]), dag_maker("repair_roundtrip", serialized=True):
-            with DatabricksWorkflowTaskGroup(group_id="wf", databricks_conn_id="databricks_default"):
-                DatabricksNotebookOperator(task_id="nb", notebook_path="/path/nb", source="WORKSPACE")
+        with mock_plugin_manager(plugins=[plugin]):
+            with dag_maker("repair_roundtrip", serialized=True):
+                with DatabricksWorkflowTaskGroup(group_id="wf", databricks_conn_id="databricks_default"):
+                    DatabricksNotebookOperator(task_id="nb", notebook_path="/path/nb", source="WORKSPACE")
 
+            # Serialization is written on dag_maker exit; create the run from that snapshot.
             dag_run = dag_maker.create_dagrun()
             serialized = SerializedDagModel.get_dag("repair_roundtrip")
             assert serialized is not None

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -428,19 +428,22 @@ class TestDatabricksWorkflowPluginAirflow3:
 
         m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
         dag = Mock()
-        task = Mock(task_id="grp.nb", databricks_task_key="k1")
+        task = Mock(task_id="grp.nb")
         dag.tasks = [task]
         dag.dag_id = "my_dag"
+        # The task uses an EXPLICIT databricks_task_key that does not survive serialization; the
+        # endpoint must recover it from the launch task's trusted task_key_map, not reconstruct md5.
+        metadata = Mock(conn_id="c", run_id=999, task_key_map={"grp.nb": "EXPLICIT_KEY"})
         try:
             with (
                 patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
                 patch("airflow.utils.session.create_session"),
-                patch.object(m, "_read_launch_metadata", return_value=Mock(conn_id="c", run_id=999)),
+                patch.object(m, "_read_launch_metadata", return_value=metadata),
                 patch.object(m, "DatabricksHook") as mock_hook,
                 patch.object(m, "_repair_task") as mock_repair,
                 patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
             ):
-                mock_hook.return_value.get_run_failed_task_keys.return_value = ["k1"]
+                mock_hook.return_value.get_run_failed_task_keys.return_value = ["EXPLICIT_KEY"]
                 client = TestClient(m.repair_app)
                 resp = client.post(
                     "/my_dag/run1",
@@ -449,8 +452,10 @@ class TestDatabricksWorkflowPluginAirflow3:
                 )
             assert resp.status_code == 303
             assert resp.headers["location"] == "/dags/my_dag/runs/run1"
-            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["k1"]
+            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["EXPLICIT_KEY"]
             assert mock_repair.call_args.kwargs["databricks_run_id"] == 999
+            # The explicit key resolved back to the Airflow task_id for clearing.
+            assert mock_clear.call_args.args[2] == ["grp.nb"]
             mock_clear.assert_called_once()
         finally:
             m.repair_app.dependency_overrides.clear()
@@ -481,6 +486,68 @@ class TestDatabricksWorkflowPluginAirflow3:
             assert resp.status_code == 502
             assert "secret token abc" not in resp.text
             mock_clear.assert_not_called()
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    def test_post_single_task_uses_explicit_key_from_map(self):
+        """Single-task repair resolves the task's real Databricks key from the launch task_key_map."""
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        dag = Mock(dag_id="my_dag")
+        dag.has_task.return_value = True
+        metadata = Mock(conn_id="c", run_id=42, task_key_map={"grp.nb": "EXPLICIT_KEY"})
+        try:
+            with (
+                patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
+                patch("airflow.utils.session.create_session"),
+                patch.object(m, "_read_launch_metadata", return_value=metadata),
+                patch.object(m, "_repair_task") as mock_repair,
+                patch.object(m, "_clear_repaired_and_downstream"),
+            ):
+                client = TestClient(m.repair_app)
+                resp = client.post(
+                    "/my_dag/run1",
+                    params={"launch_task_id": "grp.launch", "task_id": "grp.nb"},
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 303
+            # Repairs the explicit key from the map, not a reconstructed md5 hash.
+            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["EXPLICIT_KEY"]
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    def test_post_single_task_falls_back_to_md5_for_legacy_runs(self):
+        """A run launched before task_key_map existed (empty map) falls back to md5(dag_id__task_id)."""
+        import hashlib
+
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        dag = Mock(dag_id="my_dag")
+        dag.has_task.return_value = True
+        metadata = Mock(conn_id="c", run_id=42, task_key_map={})
+        expected = hashlib.md5(b"my_dag__grp.nb").hexdigest()
+        try:
+            with (
+                patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
+                patch("airflow.utils.session.create_session"),
+                patch.object(m, "_read_launch_metadata", return_value=metadata),
+                patch.object(m, "_repair_task") as mock_repair,
+                patch.object(m, "_clear_repaired_and_downstream"),
+            ):
+                client = TestClient(m.repair_app)
+                resp = client.post(
+                    "/my_dag/run1",
+                    params={"launch_task_id": "grp.launch", "task_id": "grp.nb"},
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 303
+            assert mock_repair.call_args.kwargs["tasks_to_repair"] == [expected]
         finally:
             m.repair_app.dependency_overrides.clear()
 

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -274,6 +274,43 @@ def test_workflow_job_repair_single_failed_link_airflow2():
             assert result.startswith("http://localhost/repair_databricks_job")
 
 
+@pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow < 3.0")
+@pytest.mark.skipif(
+    RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES, reason="Web plugin test doesn't work when not against sources"
+)
+@pytest.mark.db_test
+def test_workflow_job_repair_single_failed_link_airflow2_standalone_task_renders_no_url():
+    """A standalone Databricks task (no launch task in its group) renders no URL instead of raising.
+
+    Declaring ``operators`` attaches this link to non-workflow tasks too; on Airflow 2 an unguarded
+    ``get_launch_task_id`` raise surfaces as a 500 behind the button.
+    """
+    from airflow.www.app import create_app
+
+    app = create_app(testing=True)
+    app.config["SERVER_NAME"] = "localhost"
+    with app.app_context():
+        link = WorkflowJobRepairSingleTaskLink()
+        operator = Mock()
+        operator.task_group = Mock(group_id="root")
+        ti_key = Mock(dag_id="dag_id", task_id="standalone_task", run_id="run_id", try_number=1)
+
+        with (
+            patch(
+                "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
+            ) as mock_get_task_instance,
+            patch("airflow.providers.databricks.plugins.databricks_workflow.DagBag.get_dag") as mock_get_dag,
+            patch(
+                "airflow.providers.databricks.plugins.databricks_workflow.get_launch_task_id",
+                side_effect=AirflowException("No launch task can be found in the task group."),
+            ),
+        ):
+            mock_get_task_instance.return_value = Mock(key=ti_key)
+            mock_get_dag.return_value.get_task = Mock(return_value=Mock(task_id="standalone_task"))
+
+            assert link.get_link(operator, ti_key=ti_key) == ""
+
+
 @pytest.fixture
 def plugin():
     return DatabricksWorkflowPlugin()

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
@@ -36,6 +37,7 @@ from airflow.providers.databricks.plugins.databricks_workflow import (
     WorkflowJobRepairSingleTaskLink,
     WorkflowJobRunLink,
     _build_repair_url,
+    _get_launch_task_id_v3,
     _get_launch_task_key,
     _repair_task,
     get_databricks_task_ids,
@@ -209,28 +211,28 @@ def test_workflow_job_run_link_airflow2():
         ti_key.run_id = "run_id"
         ti_key.try_number = 1
 
-        with patch(
-            "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
-        ) as mock_get_task_instance:
-            with patch(
+        with (
+            patch(
+                "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
+            ) as mock_get_task_instance,
+            patch(
                 "airflow.providers.databricks.plugins.databricks_workflow.get_xcom_result"
-            ) as mock_get_xcom_result:
-                with patch(
-                    "airflow.providers.databricks.plugins.databricks_workflow._get_dag"
-                ) as mock_get_dag:
-                    mock_connection = Mock()
-                    mock_connection.extra_dejson = {"host": "mockhost"}
+            ) as mock_get_xcom_result,
+            patch("airflow.providers.databricks.plugins.databricks_workflow._get_dag") as mock_get_dag,
+        ):
+            mock_connection = Mock()
+            mock_connection.extra_dejson = {"host": "mockhost"}
 
-                    with patch(
-                        "airflow.providers.databricks.hooks.databricks.DatabricksHook.get_connection",
-                        return_value=mock_connection,
-                    ):
-                        mock_get_task_instance.return_value = Mock(key=ti_key)
-                        mock_get_xcom_result.return_value = Mock(conn_id="conn_id", run_id=1, job_id=1)
-                        mock_get_dag.return_value.get_task = Mock(return_value=Mock(task_id="task_id"))
+            with patch(
+                "airflow.providers.databricks.hooks.databricks.DatabricksHook.get_connection",
+                return_value=mock_connection,
+            ):
+                mock_get_task_instance.return_value = Mock(key=ti_key)
+                mock_get_xcom_result.return_value = Mock(conn_id="conn_id", run_id=1, job_id=1)
+                mock_get_dag.return_value.get_task = Mock(return_value=Mock(task_id="task_id"))
 
-                        result = link.get_link(operator, ti_key=ti_key)
-                        assert "https://mockhost/#job/1/run/1" in result
+                result = link.get_link(operator, ti_key=ti_key)
+                assert "https://mockhost/#job/1/run/1" in result
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow < 3.0")
@@ -255,21 +257,21 @@ def test_workflow_job_repair_single_failed_link_airflow2():
         ti_key.run_id = "run_id"
         ti_key.try_number = 1
 
-        with patch(
-            "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
-        ) as mock_get_task_instance:
-            with patch(
+        with (
+            patch(
+                "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
+            ) as mock_get_task_instance,
+            patch(
                 "airflow.providers.databricks.plugins.databricks_workflow.get_xcom_result"
-            ) as mock_get_xcom_result:
-                with patch(
-                    "airflow.providers.databricks.plugins.databricks_workflow.DagBag.get_dag"
-                ) as mock_get_dag:
-                    mock_get_task_instance.return_value = Mock(key=ti_key)
-                    mock_get_xcom_result.return_value = Mock(conn_id="conn_id", run_id=1)
-                    mock_get_dag.return_value.get_task = Mock(return_value=Mock(task_id="task_id"))
+            ) as mock_get_xcom_result,
+            patch("airflow.providers.databricks.plugins.databricks_workflow.DagBag.get_dag") as mock_get_dag,
+        ):
+            mock_get_task_instance.return_value = Mock(key=ti_key)
+            mock_get_xcom_result.return_value = Mock(conn_id="conn_id", run_id=1)
+            mock_get_dag.return_value.get_task = Mock(return_value=Mock(task_id="task_id"))
 
-                    result = link.get_link(operator, ti_key=ti_key)
-                    assert result.startswith("http://localhost/repair_databricks_job")
+            result = link.get_link(operator, ti_key=ti_key)
+            assert result.startswith("http://localhost/repair_databricks_job")
 
 
 @pytest.fixture
@@ -341,7 +343,8 @@ class TestDatabricksWorkflowPluginAirflow3:
     def test_build_repair_url_single_task(self):
         """The URL carries only Airflow identifiers — never the Databricks conn/run/task keys."""
         url = _build_repair_url("my_dag", "run 1", "grp.launch", task_id="grp.nb")
-        assert f"{REPAIR_URL_PREFIX}/my_dag/run%201" in url
+        assert url.startswith(f"{REPAIR_URL_PREFIX}/my_dag/run%201")
+        assert "://" not in url
         assert "launch_task_id=grp.launch" in url
         assert "task_id=grp.nb" in url
         assert "repair_all" not in url
@@ -350,9 +353,60 @@ class TestDatabricksWorkflowPluginAirflow3:
 
     def test_build_repair_url_repair_all(self):
         url = _build_repair_url("my_dag", "run1", "grp.launch", repair_all=True)
+        assert url.startswith(f"{REPAIR_URL_PREFIX}/my_dag/run1")
+        assert "://" not in url
         assert "repair_all=true" in url
         assert "launch_task_id=grp.launch" in url
         assert "&task_id=" not in url
+
+    def test_build_repair_url_uses_base_url_path_only(self):
+        from tests_common.test_utils.config import conf_vars
+
+        with conf_vars({("api", "base_url"): "https://host.example/airflow"}):
+            url = _build_repair_url("my_dag", "run1", "grp.launch", repair_all=True)
+        assert url.startswith("/airflow/databricks/workflow/repair/")
+        assert "https://" not in url
+        assert "host.example" not in url
+
+    def test_repair_links_declare_operators(self):
+        from airflow.providers.databricks.operators.databricks import (
+            DatabricksNotebookOperator,
+            DatabricksTaskOperator,
+        )
+        from airflow.providers.databricks.operators.databricks_workflow import (
+            _CreateDatabricksWorkflowOperator,
+        )
+
+        assert _CreateDatabricksWorkflowOperator in WorkflowJobRepairAllFailedLink().operators
+        assert DatabricksNotebookOperator in WorkflowJobRepairSingleTaskLink().operators
+        assert DatabricksTaskOperator in WorkflowJobRepairSingleTaskLink().operators
+
+    def test_get_launch_task_id_v3_uses_upstream_launch(self):
+        group = SimpleNamespace(parent_group=None, children={}, child_id=lambda label: f"wf.{label}")
+        operator = SimpleNamespace(task_id="wf.nb", upstream_task_ids={"wf.launch"}, task_group=group)
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="wf.nb", run_id="run1", try_number=1)
+        assert _get_launch_task_id_v3(operator, ti_key) == "wf.launch"
+
+    def test_get_launch_task_id_v3_walks_group_without_get_child_by_label(self):
+        launch = SimpleNamespace(task_id="wf.launch")
+        group = SimpleNamespace(
+            parent_group=None, children={"wf.launch": launch}, child_id=lambda label: f"wf.{label}"
+        )
+        operator = SimpleNamespace(task_id="wf.nb", upstream_task_ids=set(), task_group=group)
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="wf.nb", run_id="run1", try_number=1)
+        assert not hasattr(operator.task_group, "get_child_by_label")
+        assert _get_launch_task_id_v3(operator, ti_key) == "wf.launch"
+
+    def test_get_launch_task_id_v3_returns_none_when_launch_missing(self):
+        group = SimpleNamespace(parent_group=None, children={}, child_id=lambda label: f"wf.{label}")
+        operator = SimpleNamespace(task_id="wf.nb", upstream_task_ids=set(), task_group=group)
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="wf.nb", run_id="run1", try_number=1)
+        assert _get_launch_task_id_v3(operator, ti_key) is None
+
+    def test_get_launch_task_id_v3_returns_current_task_when_it_is_launch(self):
+        operator = SimpleNamespace(task_id="wf.launch", upstream_task_ids=set(), task_group=None)
+        ti_key = TaskInstanceKey(dag_id="my_dag", task_id="wf.launch", run_id="run1", try_number=1)
+        assert _get_launch_task_id_v3(operator, ti_key) == "wf.launch"
 
     def test_repair_single_task_link_uses_endpoint_url(self):
         """The single-task repair link points at the FastAPI endpoint, naming Airflow ids only."""
@@ -644,6 +698,118 @@ class TestDatabricksWorkflowPluginAirflow3:
             # Verify no XCom was pushed due to the exception
             ti_mock.xcom_push.assert_not_called()
 
+    def test_post_repair_all_warns_on_unmapped_keys(self, caplog):
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        dag = Mock()
+        task = Mock(task_id="grp.nb")
+        dag.tasks = [task]
+        dag.dag_id = "my_dag"
+        metadata = Mock(conn_id="c", run_id=999, task_key_map={"grp.nb": "KNOWN_KEY"})
+        dag_run = Mock(dag_id="my_dag", run_id="run1")
+        try:
+            with (
+                patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
+                patch("airflow.utils.session.create_session", _patched_create_session(dag_run)),
+                patch.object(m, "_read_launch_metadata", return_value=metadata),
+                patch.object(m, "DatabricksHook") as mock_hook,
+                patch.object(m, "_repair_task") as mock_repair,
+                patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
+            ):
+                mock_hook.return_value.get_run_failed_task_keys.return_value = ["KNOWN_KEY", "LEGACY_KEY"]
+                client = TestClient(m.repair_app)
+                resp = client.post(
+                    "/my_dag/run1",
+                    params={"launch_task_id": "grp.launch", "repair_all": "true"},
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 303
+            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["KNOWN_KEY", "LEGACY_KEY"]
+            assert mock_clear.call_args.args[2] == ["grp.nb"]
+            assert "Databricks repair returned task keys that could not be mapped to Airflow tasks" in caplog
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    def test_post_redirect_includes_api_root_path(self):
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        from tests_common.test_utils.config import conf_vars
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        dag = Mock(dag_id="my_dag", tasks=[], has_task=Mock(return_value=True))
+        dag_run = Mock(dag_id="my_dag", run_id="run1")
+        metadata = Mock(conn_id="c", run_id=1, task_key_map={})
+        try:
+            with (
+                conf_vars({("api", "base_url"): "https://host.example/airflow"}),
+                patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
+                patch("airflow.utils.session.create_session", _patched_create_session(dag_run)),
+                patch.object(m, "_read_launch_metadata", return_value=metadata),
+                patch.object(m, "_repair_task"),
+                patch.object(m, "_clear_repaired_and_downstream"),
+            ):
+                client = TestClient(m.repair_app)
+                resp = client.post(
+                    "/my_dag/run1",
+                    params={"launch_task_id": "grp.launch", "task_id": "grp.nb"},
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 303
+            assert resp.headers["location"] == "/airflow/dags/my_dag/runs/run1"
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    @pytest.mark.db_test
+    def test_repair_links_survive_serialized_dag_round_trip(self, dag_maker):
+        from airflow.models.serialized_dag import SerializedDagModel
+        from airflow.providers.databricks.operators.databricks import DatabricksNotebookOperator
+        from airflow.providers.databricks.operators.databricks_workflow import DatabricksWorkflowTaskGroup
+
+        from tests_common.test_utils.mock_plugins import mock_plugin_manager
+
+        plugin = DatabricksWorkflowPlugin()
+        with mock_plugin_manager(plugins=[plugin]), dag_maker("repair_roundtrip", serialized=True):
+            with DatabricksWorkflowTaskGroup(group_id="wf", databricks_conn_id="databricks_default"):
+                DatabricksNotebookOperator(task_id="nb", notebook_path="/path/nb", source="WORKSPACE")
+
+            dag_run = dag_maker.create_dagrun()
+            serialized = SerializedDagModel.get_dag("repair_roundtrip")
+            assert serialized is not None
+
+            member = serialized.get_task("wf.nb")
+            launch = serialized.get_task("wf.launch")
+            member_ti = next(ti for ti in dag_run.task_instances if ti.task_id == "wf.nb")
+            launch_ti = next(ti for ti in dag_run.task_instances if ti.task_id == "wf.launch")
+
+            ti_key = TaskInstanceKey(
+                dag_id=serialized.dag_id, task_id="wf.nb", run_id=dag_run.run_id, try_number=1
+            )
+            assert _get_launch_task_id_v3(member, ti_key) == "wf.launch"
+            assert not hasattr(member.task_group, "get_child_by_label")
+
+            assert any(
+                isinstance(link, WorkflowJobRepairSingleTaskLink) for link in member.operator_extra_links
+            )
+            assert any(
+                isinstance(link, WorkflowJobRepairAllFailedLink) for link in launch.operator_extra_links
+            )
+
+            single_url = member.get_extra_links(member_ti, "Repair a single task")
+            all_url = launch.get_extra_links(launch_ti, "Repair All Failed Tasks")
+            assert single_url
+            assert all_url
+            assert REPAIR_URL_PREFIX in single_url
+            assert "task_id=wf.nb" in single_url
+            assert "launch_task_id=wf.launch" in single_url
+            assert "repair_all=true" in all_url
+            assert "://" not in single_url
+            assert "://" not in all_url
+
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow < 3.0")
 class TestDatabricksWorkflowPluginAirflow2:
@@ -695,28 +861,26 @@ class TestDatabricksWorkflowPluginAirflow2:
 
         ti_key = TaskInstanceKey(dag_id="test_dag", task_id="test_task", run_id="test_run", try_number=1)
 
-        with patch(
-            "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
-        ) as mock_get_ti:
-            with patch(
+        with (
+            patch(
+                "airflow.providers.databricks.plugins.databricks_workflow.get_task_instance"
+            ) as mock_get_ti,
+            patch(
                 "airflow.providers.databricks.plugins.databricks_workflow.get_xcom_result"
-            ) as mock_get_xcom:
-                with patch(
-                    "airflow.providers.databricks.plugins.databricks_workflow._get_dag"
-                ) as mock_get_dag:
-                    with patch(
-                        "airflow.providers.databricks.plugins.databricks_workflow.DatabricksHook"
-                    ) as mock_hook:
-                        mock_get_ti.return_value = Mock(key=ti_key)
-                        mock_get_xcom.return_value = Mock(conn_id="conn_id", run_id=1, job_id=1)
-                        mock_get_dag.return_value.get_task.return_value = Mock(task_id="test_task")
+            ) as mock_get_xcom,
+            patch("airflow.providers.databricks.plugins.databricks_workflow._get_dag") as mock_get_dag,
+            patch("airflow.providers.databricks.plugins.databricks_workflow.DatabricksHook") as mock_hook,
+        ):
+            mock_get_ti.return_value = Mock(key=ti_key)
+            mock_get_xcom.return_value = Mock(conn_id="conn_id", run_id=1, job_id=1)
+            mock_get_dag.return_value.get_task.return_value = Mock(task_id="test_task")
 
-                        mock_hook_instance = Mock()
-                        mock_hook_instance.host = "test-host"
-                        mock_hook.return_value = mock_hook_instance
+            mock_hook_instance = Mock()
+            mock_hook_instance.host = "test-host"
+            mock_hook.return_value = mock_hook_instance
 
-                        result = link.get_link(operator, ti_key=ti_key)
+            result = link.get_link(operator, ti_key=ti_key)
 
-                        # Verify legacy method was used (should contain databricks host)
-                        assert "test-host" in result
-                        assert "#job/1/run/1" in result
+            # Verify legacy method was used (should contain databricks host)
+            assert "test-host" in result
+            assert "#job/1/run/1" in result

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -44,7 +44,7 @@ from airflow.providers.databricks.plugins.databricks_workflow import (
 )
 
 from tests_common import RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
 
 if not AIRFLOW_V_3_0_PLUS:
     from airflow.providers.databricks.plugins.databricks_workflow import (
@@ -296,9 +296,9 @@ def test_appbuilder_views_airflow2(plugin):
     assert repair_view.default_view == "repair"
 
 
-@pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Test only for Airflow 3.0+")
+@pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Airflow-3 repair backend requires 3.1+")
 class TestDatabricksWorkflowPluginAirflow3:
-    """Test Databricks Workflow Plugin functionality specific to Airflow 3.x."""
+    """Test Databricks Workflow Plugin functionality specific to Airflow 3.1+."""
 
     def test_plugin_operator_extra_links_include_repair(self):
         """All three extra links (incl. repair) are registered in Airflow 3.x."""
@@ -312,7 +312,7 @@ class TestDatabricksWorkflowPluginAirflow3:
         }
 
     def test_plugin_registers_fastapi_repair_app(self):
-        """Repair is served by a FastAPI app (not Flask-AppBuilder) in Airflow 3.x."""
+        """Repair is served by a FastAPI app (not Flask-AppBuilder) in Airflow 3.1+."""
         plugin = DatabricksWorkflowPlugin()
 
         assert not getattr(plugin, "appbuilder_views", [])
@@ -322,58 +322,60 @@ class TestDatabricksWorkflowPluginAirflow3:
         assert app["app"] is not None
 
     def test_build_repair_url_single_task(self):
-        url = _build_repair_url("my_dag", "run 1", "databricks_default", 999, tasks_to_repair=["abc", "def"])
-        assert url.startswith(f"{REPAIR_URL_PREFIX}/my_dag/run%201") or REPAIR_URL_PREFIX in url
-        assert "databricks_conn_id=databricks_default" in url
-        assert "databricks_run_id=999" in url
-        assert "tasks_to_repair=abc%2Cdef" in url
+        """The URL carries only Airflow identifiers — never the Databricks conn/run/task keys."""
+        url = _build_repair_url("my_dag", "run 1", "grp.launch", task_id="grp.nb")
+        assert f"{REPAIR_URL_PREFIX}/my_dag/run%201" in url
+        assert "launch_task_id=grp.launch" in url
+        assert "task_id=grp.nb" in url
         assert "repair_all" not in url
+        assert "databricks_conn_id" not in url
+        assert "databricks_run_id" not in url
 
     def test_build_repair_url_repair_all(self):
-        url = _build_repair_url("my_dag", "run1", "databricks_default", 999, repair_all=True)
+        url = _build_repair_url("my_dag", "run1", "grp.launch", repair_all=True)
         assert "repair_all=true" in url
-        assert "tasks_to_repair" not in url
+        assert "launch_task_id=grp.launch" in url
+        assert "&task_id=" not in url
 
     def test_repair_single_task_link_uses_endpoint_url(self):
-        """The single-task repair link points at the FastAPI endpoint, built from XCom only."""
+        """The single-task repair link points at the FastAPI endpoint, naming Airflow ids only."""
         link = WorkflowJobRepairSingleTaskLink()
-        operator = Mock(databricks_task_key="abc123")
+        operator = Mock(task_id="grp.nb")
         ti_key = TaskInstanceKey(dag_id="my_dag", task_id="grp.nb", run_id="run1", try_number=1)
-        metadata = Mock(conn_id="databricks_default", run_id=555)
         with patch(
-            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_metadata_v3",
-            return_value=metadata,
+            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_task_id_v3",
+            return_value="grp.launch",
         ):
             url = link.get_link(operator, ti_key=ti_key)
         assert REPAIR_URL_PREFIX in url
-        assert "tasks_to_repair=abc123" in url
-        assert "databricks_run_id=555" in url
+        assert "launch_task_id=grp.launch" in url
+        assert "task_id=grp.nb" in url
 
     def test_repair_all_link_uses_endpoint_url(self):
         link = WorkflowJobRepairAllFailedLink()
         operator = Mock()
         ti_key = TaskInstanceKey(dag_id="my_dag", task_id="grp.nb", run_id="run1", try_number=1)
-        metadata = Mock(conn_id="databricks_default", run_id=555)
         with patch(
-            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_metadata_v3",
-            return_value=metadata,
+            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_task_id_v3",
+            return_value="grp.launch",
         ):
             url = link.get_link(operator, ti_key=ti_key)
         assert REPAIR_URL_PREFIX in url
         assert "repair_all=true" in url
+        assert "launch_task_id=grp.launch" in url
 
-    def test_repair_link_returns_empty_without_metadata(self):
-        """When the launch XCom isn't available yet, the link renders empty (no crash)."""
+    def test_repair_link_returns_empty_without_launch_task(self):
+        """When the launch task can't be resolved, the link renders empty (no crash)."""
         link = WorkflowJobRepairSingleTaskLink()
         ti_key = TaskInstanceKey(dag_id="my_dag", task_id="grp.nb", run_id="run1", try_number=1)
         with patch(
-            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_metadata_v3",
+            "airflow.providers.databricks.plugins.databricks_workflow._get_launch_task_id_v3",
             return_value=None,
         ):
-            assert link.get_link(Mock(databricks_task_key="x"), ti_key=ti_key) == ""
+            assert link.get_link(Mock(task_id="grp.nb"), ti_key=ti_key) == ""
 
-    def test_repair_endpoint_calls_repair_and_clear(self):
-        """The FastAPI endpoint resolves failed tasks, repairs, clears, and redirects."""
+    def test_get_confirmation_page_does_not_mutate(self):
+        """GET renders a read-only confirmation form and never repairs or clears."""
         from fastapi.testclient import TestClient
 
         from airflow.providers.databricks.plugins import databricks_workflow as m
@@ -381,48 +383,104 @@ class TestDatabricksWorkflowPluginAirflow3:
         m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
         try:
             with (
-                patch.object(m, "DatabricksHook") as mock_hook,
                 patch.object(m, "_repair_task") as mock_repair,
                 patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
             ):
-                mock_hook.return_value.get_run_failed_task_keys.return_value = ["k1", "k2"]
                 client = TestClient(m.repair_app)
                 resp = client.get(
                     "/my_dag/run1",
-                    params={
-                        "databricks_conn_id": "databricks_default",
-                        "databricks_run_id": 999,
-                        "repair_all": "true",
-                    },
+                    params={"launch_task_id": "grp.launch", "repair_all": "true"},
                     follow_redirects=False,
                 )
-            assert resp.status_code == 303
-            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["k1", "k2"]
-            mock_clear.assert_called_once()
+            assert resp.status_code == 200
+            assert "<form" in resp.text
+            assert 'method="post"' in resp.text
+            mock_repair.assert_not_called()
+            mock_clear.assert_not_called()
         finally:
             m.repair_app.dependency_overrides.clear()
 
-    def test_repair_endpoint_returns_502_on_databricks_error(self):
-        """A Databricks/hook failure surfaces as a clean 502, not a bare 500."""
+    def test_confirmation_page_escapes_identifiers(self):
+        """Untrusted path/query identifiers are HTML-escaped on the confirmation page."""
         from fastapi.testclient import TestClient
 
         from airflow.providers.databricks.plugins import databricks_workflow as m
 
         m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
         try:
-            with patch.object(m, "DatabricksHook") as mock_hook:
-                mock_hook.return_value.get_run_failed_task_keys.side_effect = Exception("Invalid Token")
-                client = TestClient(m.repair_app, raise_server_exceptions=False)
-                resp = client.get(
+            client = TestClient(m.repair_app)
+            resp = client.get(
+                "/my_dag/run1",
+                params={"launch_task_id": "grp.launch", "task_id": "<script>x</script>"},
+                follow_redirects=False,
+            )
+            assert resp.status_code == 200
+            assert "<script>x</script>" not in resp.text
+            assert "&lt;script&gt;" in resp.text
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    def test_post_repairs_clears_and_redirects(self):
+        """POST resolves failed tasks from live Databricks state, repairs, clears, and redirects."""
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        dag = Mock()
+        task = Mock(task_id="grp.nb", databricks_task_key="k1")
+        dag.tasks = [task]
+        dag.dag_id = "my_dag"
+        try:
+            with (
+                patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
+                patch("airflow.utils.session.create_session"),
+                patch.object(m, "_read_launch_metadata", return_value=Mock(conn_id="c", run_id=999)),
+                patch.object(m, "DatabricksHook") as mock_hook,
+                patch.object(m, "_repair_task") as mock_repair,
+                patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
+            ):
+                mock_hook.return_value.get_run_failed_task_keys.return_value = ["k1"]
+                client = TestClient(m.repair_app)
+                resp = client.post(
                     "/my_dag/run1",
-                    params={
-                        "databricks_conn_id": "databricks_default",
-                        "databricks_run_id": 1,
-                        "repair_all": "true",
-                    },
+                    params={"launch_task_id": "grp.launch", "repair_all": "true"},
+                    follow_redirects=False,
+                )
+            assert resp.status_code == 303
+            assert resp.headers["location"] == "/dags/my_dag/runs/run1"
+            assert mock_repair.call_args.kwargs["tasks_to_repair"] == ["k1"]
+            assert mock_repair.call_args.kwargs["databricks_run_id"] == 999
+            mock_clear.assert_called_once()
+        finally:
+            m.repair_app.dependency_overrides.clear()
+
+    def test_post_returns_502_on_databricks_error_without_leaking_detail(self):
+        """A Databricks/hook failure surfaces as a clean 502 that does not echo the exception."""
+        from fastapi.testclient import TestClient
+
+        from airflow.providers.databricks.plugins import databricks_workflow as m
+
+        m.repair_app.dependency_overrides[m._require_dag_run_edit] = lambda: Mock()
+        dag = Mock(dag_id="my_dag", tasks=[])
+        try:
+            with (
+                patch("airflow.models.serialized_dag.SerializedDagModel.get_dag", return_value=dag),
+                patch("airflow.utils.session.create_session"),
+                patch.object(m, "_read_launch_metadata", return_value=Mock(conn_id="c", run_id=1)),
+                patch.object(m, "DatabricksHook") as mock_hook,
+                patch.object(m, "_clear_repaired_and_downstream") as mock_clear,
+            ):
+                mock_hook.return_value.get_run_failed_task_keys.side_effect = Exception("secret token abc")
+                client = TestClient(m.repair_app, raise_server_exceptions=False)
+                resp = client.post(
+                    "/my_dag/run1",
+                    params={"launch_task_id": "grp.launch", "repair_all": "true"},
                     follow_redirects=False,
                 )
             assert resp.status_code == 502
+            assert "secret token abc" not in resp.text
+            mock_clear.assert_not_called()
         finally:
             m.repair_app.dependency_overrides.clear()
 

--- a/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
+++ b/providers/databricks/tests/unit/databricks/plugins/test_databricks_workflow.py
@@ -46,7 +46,7 @@ from airflow.providers.databricks.plugins.databricks_workflow import (
 )
 
 from tests_common import RUNNING_TESTS_AGAINST_AIRFLOW_PACKAGES
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_PLUS
+from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_1_1_PLUS
 
 if not AIRFLOW_V_3_0_PLUS:
     from airflow.providers.databricks.plugins.databricks_workflow import (
@@ -352,7 +352,7 @@ def _patched_create_session(dag_run):
     return _factory
 
 
-@pytest.mark.skipif(not AIRFLOW_V_3_1_PLUS, reason="Airflow-3 repair backend requires 3.1+")
+@pytest.mark.skipif(not AIRFLOW_V_3_1_1_PLUS, reason="Airflow-3 repair backend requires 3.1.1+")
 class TestDatabricksWorkflowPluginAirflow3:
     """Test Databricks Workflow Plugin functionality specific to Airflow 3.1+."""
 


### PR DESCRIPTION
On Airflow 3 the "Repair a single task" and "Repair All Failed Tasks" links on DatabricksWorkflowTaskGroup tasks were gated off, so on-call users had to leave Airflow and repair failed runs in the Databricks UI.

This restores repair-from-Airflow on Airflow 3 (3.1+), served by a FastAPI sub-application on the API server since Flask-AppBuilder was dropped:

- A `GET` renders a read-only confirmation page; only a same-site `POST` performs the repair and clears tasks. Because the API server's auth cookie is `SameSite=Lax`, it is not sent on a cross-site `POST`, so moving the mutation off `GET` is what protects the action from cross-site request forgery — matching how Airflow 3's own UI mutations are protected.
- The repair link carries only Airflow identifiers (the run's launch `task_id`, and for a single-task repair the target `task_id`). The Databricks connection and run id are derived server-side from the launch task's trusted `WorkflowRunMetadata` XCom, never from the request, so a crafted link cannot point the repair at an arbitrary connection or Databricks run.
- The set of failed tasks is resolved from the live Databricks run state (hook helper `get_run_failed_task_keys`), and `repair_run` is called with `rerun_dependent_tasks` so downstream tasks resume too.
- The repaired task instances and their downstream instances are cleared — but only after a successful repair call — mapping Databricks task keys to Airflow `task_id`s via the same `md5(dag_id__task_id)` scheme the operators use, resolved from the serialized Dag.
- Databricks failures surface as a generic `502` without reflecting the upstream exception text, and confirmation-page identifiers are HTML-escaped.
- The repair backend and its links are gated to Airflow 3.1+, where the cookie-or-bearer authentication resolver it relies on is available; the redirect target is a same-site relative path, resolving the CodeQL open-redirect findings.

Verified end-to-end against a real Databricks workflow on serverless and job clusters: a failed task plus its `upstream_failed` downstream both return to success after confirming the repair. Unit tests cover the GET-does-not-mutate behaviour, confirmation-page escaping, server-side identifier resolution on the POST, and the generic 502.

related: #52280

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

<!-- pr-triage-fold: triaged=2026-07-28T16:20:09Z head=5f287ab action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @PrakshiGoyal10** · by `@potiuk` · 2026-07-28 16:20 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **294 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
