### PR TITLE
[v3-3-test] Skip stored credentials when a connection test overrides host or port

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/connections.py
@@ -307,11 +307,30 @@ def test_connection(test_body: ConnectionBody) -> ConnectionTestResponse:
     try:
         # Try to get existing connection and merge with provided values
         try:
-            existing_conn = Connection.get_connection_from_secrets(test_body.connection_id)
+            existing_conn: Connection | None = Connection.get_connection_from_secrets(test_body.connection_id)
+        except AirflowNotFoundException:
+            existing_conn = None
+
+        if existing_conn is not None:
+            # Stored credentials are only reused to test the connection's own
+            # host/port; testing a different destination must supply its own.
+            fields_set = test_body.model_fields_set
+            if ("host" in fields_set and test_body.host != existing_conn.host) or (
+                "port" in fields_set and test_body.port != existing_conn.port
+            ):
+                if "password" not in fields_set:
+                    raise HTTPException(
+                        status.HTTP_400_BAD_REQUEST,
+                        "The host or port to test differs from the stored connection. "
+                        "Include the credentials to test in the request body.",
+                    )
+                existing_conn = None
+
+        if existing_conn is not None:
             existing_conn.conn_id = transient_conn_id
             update_orm_from_pydantic(existing_conn, test_body)
             conn = existing_conn
-        except AirflowNotFoundException:
+        else:
             data = test_body.model_dump(by_alias=True)
             data["conn_id"] = transient_conn_id
             conn = Connection(**data)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_connections.py
@@ -1222,6 +1222,71 @@ class TestConnection(TestConnectionEndpoint):
         assert session.scalar(select(func.count()).select_from(Connection)) == initial_count
 
     @mock.patch.dict(os.environ, {"AIRFLOW__CORE__TEST_CONNECTION": "Enabled"})
+    @pytest.mark.parametrize(
+        "override",
+        [
+            pytest.param({"host": "other_host"}, id="host-changed"),
+            pytest.param({"host": "stored_host", "port": 9999}, id="port-changed"),
+        ],
+    )
+    def test_should_reject_test_when_target_overridden_without_credentials(
+        self, test_client, session, override
+    ):
+        session.add(
+            Connection(
+                conn_id=TEST_CONN_ID,
+                conn_type="sqlite",
+                host="stored_host",
+                port=1234,
+                password="existing_password",
+            )
+        )
+        session.commit()
+
+        body = {"connection_id": TEST_CONN_ID, "conn_type": "sqlite", **override}
+        response = test_client.post("/connections/test", json=body)
+
+        assert response.status_code == 400
+
+    @mock.patch.dict(os.environ, {"AIRFLOW__CORE__TEST_CONNECTION": "Enabled"})
+    @pytest.mark.parametrize(
+        ("override", "expected_password"),
+        [
+            pytest.param(
+                {"host": "stored_host", "port": 1234}, "existing_password", id="same-target-reuses-stored"
+            ),
+            pytest.param(
+                {"host": "other_host", "password": "supplied_password"},
+                "supplied_password",
+                id="overridden-target-uses-supplied-creds",
+            ),
+        ],
+    )
+    def test_stored_secret_reused_only_for_same_target(
+        self, test_client, session, override, expected_password
+    ):
+        session.add(
+            Connection(
+                conn_id=TEST_CONN_ID,
+                conn_type="sqlite",
+                host="stored_host",
+                port=1234,
+                password="existing_password",
+            )
+        )
+        session.commit()
+
+        body = {"connection_id": TEST_CONN_ID, "conn_type": "sqlite", **override}
+
+        with mock.patch.object(Connection, "test_connection", autospec=True) as mock_test:
+            mock_test.return_value = (True, "mocked")
+            response = test_client.post("/connections/test", json=body)
+
+        assert response.status_code == 200
+        tested_connection = mock_test.call_args.args[0]
+        assert tested_connection.password == expected_password
+
+    @mock.patch.dict(os.environ, {"AIRFLOW__CORE__TEST_CONNECTION": "Enabled"})
     def test_should_test_new_connection_without_existing(self, test_client):
         body = {
             "connection_id": "non_existent_conn",


### PR DESCRIPTION
Backport of #69957 to `v3-3-test`.

Cherry-picked from a6d87ba5b0157baf744995d47dd5d6a47e798edb.

**Conflict resolution (`connections.py`):** the cherry-pick pulled in the `get_team_name` / `is_authorized_connection(GET)` authorization scaffolding from #67620, which is not on `v3-3-test`. Only #69957's own change was applied — skipping stored credentials when the request overrides the stored connection's host or port — adapted to the `v3-3-test` code structure (the inline `try/except` was converted to `existing_conn: Connection | None` + `if/else`, mirroring the post-#69957 shape on `main` minus the #67620 dependency). The test file applied cleanly, and all connection-test unit tests pass.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)