### PR TITLE
Fix database connection leaks in resetdb functions

### DIFF
--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -1325,8 +1325,8 @@ def _resetdb_mysql(session: Session) -> None:
 
 def _resetdb_default(session: Session) -> None:
     """Drop all Airflow tables for PostgreSQL/SQLite."""
-    connection = settings.get_engine().connect()
-    with create_global_lock(session=session, lock=DBLocks.MIGRATIONS), connection.begin():
+    engine = settings.get_engine()
+    with create_global_lock(session=session, lock=DBLocks.MIGRATIONS), engine.connect() as connection:
         drop_airflow_models(connection)
         drop_airflow_moved_tables(connection)
         log.info("Dropped all Airflow tables")

--- a/airflow-core/src/airflow/utils/db_manager.py
+++ b/airflow-core/src/airflow/utils/db_manager.py
@@ -186,9 +186,8 @@ class BaseDBManager(LoggingMixin):
 
         self._release_metadata_locks_if_needed()
 
-        connection = settings.engine.connect()
-
-        with create_global_lock(self.session, lock=DBLocks.MIGRATIONS), connection.begin():
+        engine = settings.engine
+        with create_global_lock(self.session, lock=DBLocks.MIGRATIONS), engine.connect() as connection:
             self.log.info("Dropping %s tables", self.__class__.__name__)
             self.drop_tables(connection)
         if not skip_init:


### PR DESCRIPTION
## Summary

Two database connection leaks in the resetdb code path:

### 1. `_resetdb_default` (`airflow-core/src/airflow/utils/db.py:1328`)

```python
connection = settings.get_engine().connect()
with create_global_lock(session=session, lock=DBLocks.MIGRATIONS), connection.begin():
    ...
```

A new database connection is opened but never closed. There is no `try/finally` with `connection.close()`, and the connection is not used as a context manager. Compare with the MySQL variant (`_resetdb_mysql`) at line 1307 which correctly uses `engine.connect() as connection`.

### 2. `BaseDBManager.resetdb` (`airflow-core/src/airflow/utils/db_manager.py:189`)

```python
connection = settings.engine.connect()
with create_global_lock(self.session, lock=DBLocks.MIGRATIONS), connection.begin():
    ...
```

Identical pattern. The `with` statement manages a transaction (via `connection.begin()`) and a lock, but does not close the connection itself. After the `with` block exits, the connection remains open and the reference is lost.

### Fix

Changed both functions to use `engine.connect() as connection` (context manager form), matching the pattern already used in `_resetdb_mysql`. This ensures connections are properly closed after use.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (big-pickle)

Generated-by: Claude Code (big-pickle) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)