### PR TITLE
Fix ZipFile resource leak in open_maybe_zipped

### DIFF
--- a/airflow-core/src/airflow/utils/file.py
+++ b/airflow-core/src/airflow/utils/file.py
@@ -69,7 +69,23 @@ def open_maybe_zipped(fileloc, mode="r"):
     """
     _, archive, filename = ZIP_REGEX.search(fileloc).groups()
     if archive and zipfile.is_zipfile(archive):
-        return TextIOWrapper(zipfile.ZipFile(archive, mode=mode).open(filename))
+        zip_file = zipfile.ZipFile(archive, mode=mode)
+        try:
+            inner_file = zip_file.open(filename)
+        except Exception:
+            zip_file.close()
+            raise
+
+        class _ZipFileWrapper(TextIOWrapper):
+            """Wrapper that closes both the inner file and the ZipFile."""
+
+            def close(self):
+                try:
+                    super().close()
+                finally:
+                    zip_file.close()
+
+        return _ZipFileWrapper(inner_file)
     return open(fileloc, mode=mode)
 
 


### PR DESCRIPTION
## Summary

The `open_maybe_zipped` function (`airflow-core/src/airflow/utils/file.py:72`) creates a `ZipFile` object inline and calls `.open(filename)` on it:

```python
return TextIOWrapper(zipfile.ZipFile(archive, mode=mode).open(filename))
```

The `ZipFile` reference is lost after the return. The `TextIOWrapper` wraps the *inner* file object from `.open()`, but no one retains a reference to the outer `ZipFile`, so it can never be explicitly closed. The `ZipFile` (which holds an open file descriptor to the archive) will only be cleaned up when the garbage collector eventually runs, which is non-deterministic.

Each call to this function with a zipped path leaks one file handle.

**Fix**: Added a `_ZipFileWrapper` subclass of `TextIOWrapper` that closes both the inner file and the `ZipFile` when closed, ensuring proper cleanup of the archive file descriptor.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (big-pickle)

Generated-by: Claude Code (big-pickle) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)