### PR TITLE
Skip ts-sdk supervisor schema check for doc-only changes

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -459,7 +459,8 @@ CI_FILE_GROUP_MATCHES: HashableDict[FileGroupForCi] = HashableDict(
             r"^java-sdk/(?!.*\.md$).*",
         ],
         FileGroupForCi.TS_SDK_FILES: [
-            r"^ts-sdk/",
+            # `.md` excluded — doc-only edits do not affect the generated supervisor schema.
+            r"^ts-sdk/(?!.*\.md$).*",
         ],
         FileGroupForCi.ASSET_FILES: [
             r"^airflow-core/src/airflow/assets/",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -1761,6 +1761,16 @@ def test_ktlint_hook_only_runs_for_java_sdk_changes(files: tuple[str, ...], ktli
             True,
             id="skipped when no ts-sdk files change",
         ),
+        pytest.param(
+            ("ts-sdk/README.md",),
+            True,
+            id="skipped when only ts-sdk docs change",
+        ),
+        pytest.param(
+            ("ts-sdk/example/README.md",),
+            True,
+            id="skipped when only nested ts-sdk docs change",
+        ),
     ],
 )
 def test_check_ts_sdk_supervisor_schema_hook_only_runs_for_relevant_changes(


### PR DESCRIPTION
### Why
Editing a `.md` file under `ts-sdk/` (like README) currently matches `TS_SDK_FILES`. That keeps the `check-ts-sdk-supervisor-schema` prek hook from being skipped, so a docs-only change re-runs the schema regen and diff for no reason. 

### What
This PR excludes `.md` from `TS_SDK_FILES` so doc-only changes skip that hook. It follows the same pattern as the java-sdk fix in #69674.

related: #69674

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)