### PR TITLE
Add subdomain to worker pods in Deployments

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -123,6 +123,11 @@ spec:
           {{- tpl (toYaml $podAnnotations) . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if not $persistence }}
+      # Fix TaskInstance hostname service resolution for Deployments
+      # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field
+      subdomain: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.celery.name "default" }}-{{ .Values.workers.celery.name }}{{ end }}
+      {{- end }}
       {{- if .Values.workers.celery.runtimeClassName }}
       runtimeClassName: {{ .Values.workers.celery.runtimeClassName }}
       {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -124,8 +124,6 @@ spec:
         {{- end }}
     spec:
       {{- if not $persistence }}
-      # Fix TaskInstance hostname service resolution for Deployments
-      # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field
       subdomain: {{ include "airflow.fullname" . }}-worker{{ if ne .Values.workers.celery.name "default" }}-{{ .Values.workers.celery.name }}{{ end }}
       {{- end }}
       {{- if .Values.workers.celery.runtimeClassName }}

--- a/chart/tests/helm_tests/airflow_core/test_worker.py
+++ b/chart/tests/helm_tests/airflow_core/test_worker.py
@@ -1552,6 +1552,24 @@ class TestWorker:
             {"name": "test-extra-port", "containerPort": 10}
         ]
 
+    def test_worker_service_name_matches_service(self):
+        docs = render_chart(
+            values={"executor": "CeleryExecutor", "workers": {"celery": {"persistence": {"enabled": True}}}},
+            show_only=["templates/workers/worker-deployment.yaml", "templates/workers/worker-service.yaml"],
+        )
+
+        assert jmespath.search("spec.serviceName", docs[0]) == jmespath.search("metadata.name", docs[1])
+
+    def test_worker_subdomain_matches_service(self):
+        docs = render_chart(
+            values={"executor": "CeleryExecutor", "workers": {"celery": {"persistence": {"enabled": False}}}},
+            show_only=["templates/workers/worker-deployment.yaml", "templates/workers/worker-service.yaml"],
+        )
+
+        assert jmespath.search("spec.template.spec.subdomain", docs[0]) == jmespath.search(
+            "metadata.name", docs[1]
+        )
+
 
 class TestWorkerCeleryLogGroomer(LogGroomerTestBase):
     """Worker Celery groomer."""


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Add subdomain to worker pods in Deployments
---
When not using a StatefulSet, setting the `spec.subdomain` property on the pod to the service name will return the fully qualified service address for the pod when calling `airflow.utils.net.getfqdn`, allowing the UI to resolve the worker address and retrieve the logs.

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---


