### PR TITLE
Fix execution API set_xcom returning non-RFC 9457 error for invalid v…

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -446,7 +446,10 @@ def set_xcom(
             session=session,
         )
     except ValueError as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"reason": "not_found", "message": str(e)},
+        )
     except TypeError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import urllib.parse
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -372,6 +373,26 @@ class TestXComsSetEndpoint:
             select(TaskMap).where(TaskMap.task_id == ti.task_id, TaskMap.dag_id == ti.dag_id)
         ).one_or_none()
         assert task_map is None, "Should not be mapped"
+
+    @mock.patch("airflow.models.xcom.XCom.set")
+    def test_xcom_set_value_error(self, mock_xcom_set, client, create_task_instance, session):
+        ti = create_task_instance()
+        session.commit()
+        
+        mock_xcom_set.side_effect = ValueError("Mocked value error")
+        
+        response = client.post(
+            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            json="value",
+        )
+        
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": {
+                "reason": "not_found",
+                "message": "Mocked value error",
+            }
+        }
 
     @pytest.mark.parametrize(
         ("orig_value", "ser_value", "deser_value"),


### PR DESCRIPTION
The Task Execution API in Apache Airflow handles requests from workers and other components. In `airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py`, if the client attempts to set an XCom with a value that raises a `ValueError` from `XComModel.set`, the API correctly rejected the request with a 404 Not Found. However, the detail object returned was just a string. This PR resolves the issue by refactoring the detail dictionary to strictly conform to the RFC 9457 schema.

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:
-->
closes: #70044

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (Gemini AI Agent)

<!-- pr-triage-fold: triaged=2026-07-28T16:20:03Z head=34bf2d8 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @KushagraB424** · by `@potiuk` · 2026-07-28 16:20 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Unit tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **318 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
