### PR TITLE
Fix mypy prek hooks skipping all files in dot-directory

### DIFF
--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -178,6 +178,11 @@ def pre_process_mypy_files(files: list[str]) -> list[str]:
     return [file for file in files if not file.startswith("providers")]
 
 
+def is_hidden_within_root(path: Path, root: Path) -> bool:
+    """Whether any path component below ``root`` is dot-prefixed."""
+    return any(part.startswith(".") for part in path.relative_to(root).parts)
+
+
 def insert_documentation(
     file_path: Path,
     content: list[str],

--- a/scripts/ci/prek/mypy_folder.py
+++ b/scripts/ci/prek/mypy_folder.py
@@ -34,6 +34,7 @@ from common_prek_utils import (
     console,
     get_all_provider_ids,
     initialize_breeze_prek,
+    is_hidden_within_root,
     run_command_via_breeze_run,
 )
 
@@ -110,7 +111,7 @@ def get_all_files(folder: str) -> list[str]:
     for file in python_file_paths:
         if (
             (file.name not in ("conftest.py",) and not any(x.match(file.as_posix()) for x in exclude_regexps))
-            and not any(part.startswith(".") for part in file.parts)
+            and not is_hidden_within_root(file, AIRFLOW_ROOT_PATH)
         ) and not file.as_posix().endswith("src/airflow/providers/__init__.py"):
             files_to_check.append(file.relative_to(AIRFLOW_ROOT_PATH).as_posix())
     file_spec = "@/files/mypy_files.txt"

--- a/scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
+++ b/scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from common_prek_utils import (
     AIRFLOW_ROOT_PATH,
     check_uv_version,
+    is_hidden_within_root,
 )
 
 CI = os.environ.get("CI")
@@ -138,7 +139,7 @@ def get_all_files(folder: str) -> list[str]:
         if (
             file.name not in ("conftest.py",)
             and not any(x.match(file.as_posix()) for x in exclude_regexps)
-            and not any(part.startswith(".") for part in file.parts)
+            and not is_hidden_within_root(file, AIRFLOW_ROOT_PATH)
         ):
             files_to_check.append(file.relative_to(AIRFLOW_ROOT_PATH).as_posix())
     return files_to_check

--- a/scripts/tests/ci/prek/test_common_prek_utils.py
+++ b/scripts/tests/ci/prek/test_common_prek_utils.py
@@ -29,6 +29,7 @@ from ci.prek.common_prek_utils import (
     get_provider_id_from_path,
     initialize_breeze_prek,
     insert_documentation,
+    is_hidden_within_root,
     pre_process_mypy_files,
     read_airflow_version,
     read_allowed_kubernetes_versions,
@@ -168,6 +169,21 @@ class TestPreProcessMypyFiles:
         files = [PROVIDERS_AMAZON_S3_PATH]
         result = pre_process_mypy_files(files)
         assert PROVIDERS_AMAZON_S3_PATH in result
+
+
+class TestIsHiddenWithinRoot:
+    @pytest.mark.parametrize(
+        ("relative_path", "expected"),
+        [
+            ("airflow-core/src/airflow/models/dag.py", False),
+            (".build/mypy-venvs/foo.py", True),
+            ("airflow-core/.venv/lib/foo.py", True),
+            (".hidden.py", True),
+        ],
+    )
+    def test_only_components_below_root_count(self, tmp_path, relative_path, expected):
+        root = tmp_path / ".claude" / "worktrees"
+        assert is_hidden_within_root(root / relative_path, root) is expected
 
 
 class TestGetImportsFromFile:


### PR DESCRIPTION
## Why

- Both mypy file collectors filter hidden directories with `any(part.startswith(".") for part in file.parts)`. If any path component starts with `.`, it will be skipped.
- A Claude worktree is in `.claude/worktrees/`, so all files under it are skipped.

## How

- Change the path check to relative path. `any(part.startswith(".") for part in path.relative_to(root).parts)`

## Verification

- `uv run --frozen --project scripts pytest scripts/tests/ci/prek/test_common_prek_utils.py`
- Setup a folder path like claude worktree pattern. The `prek run mypy-airflow-core --all-files --verbose` in this PR shows `Success: no issues found in 1202 source files`. In main branch, it shows `No files to test. Quitting`.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
