### PR TITLE
Fail queued DagRuns with unresolvable pinned versions

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2768,6 +2768,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             backfill_id = dag_run.backfill_id
             dag = dag_run.dag = cached_get_dag(dag_run)
             if not dag:
+                if dag_run.bundle_version is not None and dag_run.created_dag_version_id is None:
+                    self.log.error(
+                        "Queued DagRun '%s' for DAG '%s' has an unresolvable pinned version "
+                        "(bundle_version=%s, created_dag_version_id=None); marking run as failed",
+                        dag_run.run_id,
+                        dag_run.dag_id,
+                        dag_run.bundle_version,
+                    )
+                    dag_run.state = DagRunState.FAILED
+                    dag_run.notify_dagrun_state_changed(msg="unresolvable_pinned_version")
+                    continue
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
                 continue
             active_runs = active_runs_of_dags[(dag_id, backfill_id)]

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2776,7 +2776,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         dag_run.dag_id,
                         dag_run.bundle_version,
                     )
-                    dag_run.state = DagRunState.FAILED
+                    dag_run.set_state(DagRunState.FAILED)
                     dag_run.notify_dagrun_state_changed(msg="unresolvable_pinned_version")
                     continue
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10037,6 +10037,31 @@ def test_schedule_dag_run_with_upstream_skip(dag_maker, session):
         )
         assert running_count == 2
 
+    def test_start_queued_dagrun_with_unresolvable_pinned_version_is_marked_failed(self, dag_maker, session):
+        with dag_maker(dag_id="test_unresolvable_pinned_dagrun_version", max_active_runs=1):
+            EmptyOperator(task_id="dummy_task")
+
+        dag_run = dag_maker.create_dagrun(
+            run_id="queued_unresolvable_version",
+            state=DagRunState.QUEUED,
+            run_type=DagRunType.MANUAL,
+            session=session,
+        )
+        dag_run.bundle_version = "0123456789abcdef"
+        dag_run.created_dag_version_id = None
+        session.merge(dag_run)
+        session.flush()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        self.job_runner._start_queued_dagruns(session)
+        session.flush()
+
+        dag_run = session.get(DagRun, dag_run.id)
+        assert dag_run is not None
+        assert dag_run.state == DagRunState.FAILED
+
 
 class TestSchedulerJobQueriesCount:
     """


### PR DESCRIPTION
 

Closes #70056

This PR fixes a scheduler bug where a queued DagRun can remain stuck forever when its pinned dag version becomes unresolvable.

Problem
- Some queued DagRuns are created with version pinning metadata.
- If the pinned dag version row is later removed, the run may no longer resolve to a serialized DAG.
- The scheduler previously logged and skipped these runs on every loop, leaving them permanently queued with no terminal outcome.

Fix
- In the queued DagRun start path, when a run has pinned version metadata but the pinned version is unresolvable, the scheduler now marks the DagRun as failed.
- The scheduler also emits a specific state-change notification reason for this condition.
- Existing behavior for other missing-DAG cases is unchanged.

Tests
- Added a regression test covering the unresolvable pinned-version scenario and asserting the DagRun transitions to failed.
- Kept an existing related max_active_runs scheduler test alongside this change for local targeted verification.

Validation run notes
- Ruff format/check passed on changed files.
- Local targeted pytest invocation was attempted multiple ways in this environment.
- One explicit failure captured: ModuleNotFoundError for tests_common during local conftest import.
- No changes were made to unrelated workspace files.

 