### PR TITLE
Fall back for empty console domain

### DIFF
--- a/providers/google/src/airflow/providers/google/common/hooks/base_google.py
+++ b/providers/google/src/airflow/providers/google/common/hooks/base_google.py
@@ -436,7 +436,8 @@ class GoogleBaseHook(BaseHook):
 
     @staticmethod
     def get_high_value_cookie_domain() -> str:
-        return os.getenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN") or "google.com"
+        domain = os.getenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN")
+        return "google.com" if domain in (None, "") else domain
 
     def get_client_options(
         self,

--- a/providers/google/src/airflow/providers/google/common/hooks/base_google.py
+++ b/providers/google/src/airflow/providers/google/common/hooks/base_google.py
@@ -436,7 +436,7 @@ class GoogleBaseHook(BaseHook):
 
     @staticmethod
     def get_high_value_cookie_domain() -> str:
-        return os.getenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN", "google.com")
+        return os.getenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN") or "google.com"
 
     def get_client_options(
         self,

--- a/providers/google/tests/unit/google/common/hooks/test_base_google.py
+++ b/providers/google/tests/unit/google/common/hooks/test_base_google.py
@@ -865,6 +865,22 @@ class TestGoogleBaseHook:
 
             assert is_default_universe
 
+    @pytest.mark.parametrize(
+        ("high_value_cookie_domain", "expected_result"),
+        [
+            pytest.param(None, "google.com", id="unset_value"),
+            pytest.param("", "google.com", id="empty_value"),
+            pytest.param("googleapis.cn", "googleapis.cn", id="custom_value"),
+        ],
+    )
+    def test_get_high_value_cookie_domain(self, high_value_cookie_domain, expected_result):
+        env = {}
+        if high_value_cookie_domain is not None:
+            env["GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN"] = high_value_cookie_domain
+
+        with patch.dict(os.environ, env, clear=True):
+            assert self.instance.get_high_value_cookie_domain() == expected_result
+
     def test_get_client_options_default(self):
         with patch.dict(os.environ, {}, clear=True):
             client_options = self.instance.get_client_options()


### PR DESCRIPTION
## What changed

Treat an empty `GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN` value as the default `google.com` domain. This prevents the Google provider's sovereign-console link helpers from emitting `https://console.cloud.` when the variable is present but empty.

The change adds direct coverage for unset, empty, and custom values.

## Tests

- `ruff format --check` (changed files)
- `ruff check` (changed files)
- `python3 -m compileall` (changed files)
- Targeted pytest was attempted with the repository-required `uv 0.11.8`, but dependency resolution could not build `pykerberos` because this machine's `xcrun` Command Line Tools library has an architecture mismatch. GitHub CI should run the added test in the project toolchain.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Codex)

<!-- pr-triage-fold: triaged=2026-07-28T16:11:01Z head=12c8f3e action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @suyua9** · by `@potiuk` · 2026-07-28 16:11 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **199 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
