### PR TITLE
Fix `@task.llm_branch` import failure on Task SDK-only workers

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/decorators/llm_branch.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/decorators/llm_branch.py
@@ -33,10 +33,10 @@ from airflow.providers.common.compat.sdk import (
     DecoratedOperator,
     TaskDecorator,
     context_merge,
+    determine_kwargs,
     task_decorator_factory,
 )
 from airflow.sdk.definitions._internal.types import SET_DURING_EXECUTION
-from airflow.utils.operator_helpers import determine_kwargs
 
 if TYPE_CHECKING:
     from airflow.sdk import Context


### PR DESCRIPTION
## Why

Dags using `@task.llm_branch` failed to load on workers that only have the Task SDK installed.

## How

- Import `determine_kwargs` from `airflow.providers.common.compat.sdk`, matching every sibling decorator in the package

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)