### PR TITLE
Reject unsupported require_approval in common.ai operators

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_branch.py
@@ -60,6 +60,8 @@ class LLMBranchOperator(LLMOperator, BranchMixIn):
         **kwargs: Any,
     ) -> None:
         kwargs.pop("output_type", None)
+        if kwargs.get("require_approval"):
+            raise ValueError("require_approval=True is not supported by LLMBranchOperator.")
         super().__init__(**kwargs)
         self.allow_multiple_branches = allow_multiple_branches
 

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_schema_compare.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_schema_compare.py
@@ -127,6 +127,8 @@ class LLMSchemaCompareOperator(LLMOperator):
         **kwargs: Any,
     ) -> None:
         kwargs.pop("output_type", None)
+        if kwargs.get("require_approval"):
+            raise ValueError("require_approval=True is not supported by LLMSchemaCompareOperator.")
         super().__init__(**kwargs)
         self.data_sources = data_sources or []
         self.db_conn_ids = db_conn_ids or []

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_branch.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_branch.py
@@ -54,6 +54,15 @@ class TestLLMBranchOperator:
         # the real output_type is built dynamically from downstream_task_ids
         assert op.output_type is str
 
+    def test_require_approval_rejected(self):
+        with pytest.raises(ValueError, match="require_approval=True is not supported"):
+            LLMBranchOperator(
+                task_id="test",
+                prompt="pick a branch",
+                llm_conn_id="my_llm",
+                require_approval=True,
+            )
+
     @patch.object(LLMBranchOperator, "do_branch")
     @patch("airflow.providers.common.ai.operators.llm.PydanticAIHook", autospec=True)
     def test_execute_single_branch(self, mock_hook_cls, mock_do_branch):

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_schema_compare.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_schema_compare.py
@@ -97,6 +97,11 @@ class TestLLMSchemaCompareOperator:
                 "at-least two combinations",
                 id="one_datasource_only",
             ),
+            pytest.param(
+                {"require_approval": True},
+                "require_approval=True is not supported",
+                id="require_approval",
+            ),
         ],
     )
     def test_init_validation(self, kwargs, expected_error):


### PR DESCRIPTION
## Why

Asking for human approval on these two operators did nothing: the task ran straight through without review, silently.

## How

- Raise ValueError when require_approval=True is passed to LLMBranchOperator or LLMSchemaCompareOperator
- Add init-validation tests for both operators

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)