### PR TITLE
Fix DocumentLoaderOperator ignoring unknown parser on byte input

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -262,6 +262,9 @@ class DocumentLoaderOperator(BaseOperator):
         if backend == "python-docx":
             return self._parse_docx_stream(io.BytesIO(raw))
 
+        if backend not in ("text", "csv", "json"):
+            raise ValueError(f"No parser found for backend '{backend}'.")
+
         text = self._decode(raw, source_hint=f"<bytes:{ext}>")
         if backend == "csv":
             return self._parse_csv_text(text)

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
@@ -262,9 +262,6 @@ class DocumentLoaderOperator(BaseOperator):
         if backend == "python-docx":
             return self._parse_docx_stream(io.BytesIO(raw))
 
-        if backend not in ("text", "csv", "json"):
-            raise ValueError(f"No parser found for backend '{backend}'.")
-
         text = self._decode(raw, source_hint=f"<bytes:{ext}>")
         if backend == "csv":
             return self._parse_csv_text(text)
@@ -292,6 +289,8 @@ class DocumentLoaderOperator(BaseOperator):
 
     def _resolve_backend(self, ext: str) -> str:
         if self.parser != "auto":
+            if self.parser not in set(self.EXTENSION_BACKEND_MAP.values()):
+                raise ValueError(f"No parser found for backend '{self.parser}'.")
             return self.parser
 
         ext = ext.lower()

--- a/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_document_loader.py
@@ -410,6 +410,11 @@ class TestFileDiscovery:
         with pytest.raises(ValueError, match="No parser registered"):
             op.execute(context=MagicMock())
 
+    def test_unknown_parser_on_source_bytes_raises(self):
+        op = DocumentLoaderOperator(task_id="test", source_bytes=b"a,b\n1,2", file_type=".csv", parser="cvs")
+        with pytest.raises(ValueError, match="No parser found"):
+            op.execute(context=MagicMock())
+
     def test_nonexistent_glob_raises_file_not_found(self, tmp_path):
         op = DocumentLoaderOperator(task_id="test", source_path=str(tmp_path / "*.nope"))
         with pytest.raises(FileNotFoundError, match="No files found"):


### PR DESCRIPTION
## Why

A typo in the parser name silently produced garbage documents instead of an error when loading from bytes, while the same typo with a file path failed loudly.

## How

- Raise the same "No parser found" error for unknown parser backends on byte input, matching file input
- Add a test covering the typo case

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)