### PR TITLE
Document task subprocess lifecycle and pre-connect log buffer

### DIFF
--- a/contributing-docs/30_new_language_sdk.rst
+++ b/contributing-docs/30_new_language_sdk.rst
@@ -245,7 +245,7 @@ subprocess relative to the ``--logs`` socket:
 
 .. code-block:: text
 
-    1. Coordinator forks the subprocess with
+    1. Coordinator launches the subprocess with
        --comm=<host>:<port> --logs=<host>:<port>
       │
       └─► 2. Subprocess starts. Its logger is already active, but the
@@ -253,7 +253,7 @@ subprocess relative to the ``--logs`` socket:
              │
              └─► 3. Subprocess connects to --comm and --logs.
                     │
-                    └─► 4. Every later record is streamed straight to the
+                    └─► 4. Each subsequent record is sent over the
                             --logs socket.
 
 The gap is stage 2: the SDK's own startup code (argument parsing, the connect

--- a/contributing-docs/30_new_language_sdk.rst
+++ b/contributing-docs/30_new_language_sdk.rst
@@ -237,6 +237,30 @@ match responses to requests. The SDK MUST correlate by ``id`` whenever multiple
 requests can be outstanding simultaneously (e.g. when tasks are executed
 concurrently, or when a single task issues multiple requests).
 
+Task subprocess lifecycle
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before implementing logging, it helps to see the full lifecycle of the
+subprocess relative to the ``--logs`` socket:
+
+.. code-block:: text
+
+    1. Coordinator forks the subprocess with
+       --comm=<host>:<port> --logs=<host>:<port>
+      │
+      └─► 2. Subprocess starts. Its logger is already active, but the
+              --logs socket is not connected yet.
+             │
+             └─► 3. Subprocess connects to --comm and --logs.
+                    │
+                    └─► 4. Every later record is streamed straight to the
+                            --logs socket.
+
+The gap is stage 2: the SDK's own startup code (argument parsing, the connect
+calls themselves) can already produce log records before the ``--logs`` socket
+in stage 3 exists to carry them. See `Logging`_ below for how to handle that
+gap.
+
 Logging
 ~~~~~~~
 
@@ -245,6 +269,11 @@ The SDK should wire the native logging mechanism (the equivalent of Python's
 during execution to Airflow's task log store, so they appear in the UI with the
 rest of the output. Records travel over the ``--logs`` socket introduced in
 `Startup`_.
+
+Records produced during stage 2 of the `Task subprocess lifecycle`_ — before
+the ``--logs`` socket connects — MUST NOT be dropped. Buffer them in memory and
+flush the buffer, in order, as soon as the socket connects, before sending any
+later record. Both the Go SDK and Java SDK already implement this buffer.
 
 Log messages should be **newline-delimited JSON**. Each log is a UTF-8 encoded
 JSON object in one line, terminated by a newline character (``\n``). Each object

--- a/contributing-docs/30_new_language_sdk.rst
+++ b/contributing-docs/30_new_language_sdk.rst
@@ -245,7 +245,7 @@ subprocess relative to the ``--logs`` socket:
 
 .. code-block:: text
 
-    1. Coordinator launches the subprocess with
+    1. Supervisor launches the subprocess with
        --comm=<host>:<port> --logs=<host>:<port>
       │
       └─► 2. Subprocess starts. Its logger is already active, but the


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/69302#discussion_r3608252730

## Why

The Lang-SDK contributor doc describes the `--comm`/`--logs` socket handshake but never explains
that a subprocess's logger can already be active before the `--logs` socket connects, so new
Language SDK implementers have no guidance that early records need to be buffered rather than
dropped.

## What

- Add a "Task subprocess lifecycle" subsection to `contributing-docs/30_new_language_sdk.rst`,
  with a diagram of the four lifecycle stages from subprocess start to log forwarding.
- Add a paragraph to the existing "Logging" subsection requiring implementers to buffer log
  records produced before the `--logs` socket connects and flush them once it does, matching what
  the Go SDK and Java SDK already do.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
