### PR TITLE
Register asset events before taking the task_instance row lock

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -358,6 +358,33 @@ def ti_update_state(
     bind_contextvars(ti_id=str(task_instance_id))
     log.debug("Updating task instance state", new_state=ti_patch_payload.state)
 
+    # For a success payload, register outlet asset events *before* acquiring the task_instance
+    # row lock below, so the registration work (asset lookups, event inserts, dag-run queueing)
+    # never runs while holding that lock and concurrent completions do not pile up behind it.
+    # The locked SELECT below re-checks the state: if the transaction does not commit (duplicate
+    # or invalid transition), these writes roll back with it, so the registered events are only
+    # ever observable together with the committed SUCCESS state.
+    assets_registered = False
+    if isinstance(ti_patch_payload, TISuccessStatePayload) and (
+        ti_patch_payload.task_outlets or ti_patch_payload.outlet_events
+    ):
+        ti = session.get(TI, task_instance_id)
+        if ti is not None and ti.state == TaskInstanceState.RUNNING:
+            try:
+                _validate_outlet_event_partition_keys(ti_patch_payload.outlet_events)
+            except InvalidPartitionKeyError as e:
+                raise HTTPException(
+                    status_code=HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail={"reason": "invalid_partition_key", "message": str(e)},
+                ) from e
+            TI.register_asset_changes_in_db(
+                ti,
+                ti_patch_payload.task_outlets,
+                ti_patch_payload.outlet_events,
+                session=session,
+            )
+            assets_registered = True
+
     old = (
         select(
             TI.state,
@@ -411,6 +438,10 @@ def ti_update_state(
     # SUCCESS or DEFERRED -> DEFERRED), including duplicates that would not pass the RUNNING
     # transition check below.
     if ti_patch_payload.state.value == previous_state:
+        if assets_registered:
+            # A concurrent completion won the race and committed its own registration;
+            # discard ours so the events are not recorded twice.
+            session.rollback()
         log.info(
             "Duplicate state update request received; state already set",
             requested_state=ti_patch_payload.state.value,
@@ -460,6 +491,7 @@ def ti_update_state(
             query=query,
             dag_id=dag_id,
             dag_bag=dag_bag,
+            assets_registered=assets_registered,
         )
     except DataError:
         # Let DataErrorHandler return a 422 instead of silently marking the TI FAILED below.
@@ -630,6 +662,7 @@ def _create_ti_state_update_query_and_update_state(
     session: SessionDep,
     dag_bag: DagBagDep,
     dag_id: str,
+    assets_registered: bool = False,
 ) -> tuple[Update, TaskInstanceState]:
     if isinstance(ti_patch_payload, (TITerminalStatePayload, TIRetryStatePayload, TISuccessStatePayload)):
         ti = session.get(TI, task_instance_id, with_for_update={"of": TI})
@@ -660,7 +693,11 @@ def _create_ti_state_update_query_and_update_state(
             # These are cleared when the task enters RUNNING (ti_run).
             query = query.values(retry_delay_override=retry_delay_override, retry_reason=retry_reason)
         elif isinstance(ti_patch_payload, TISuccessStatePayload):
-            if ti is not None:
+            # Normally the events were registered before the row lock was taken (see
+            # ti_update_state). Falling in here means the state was not RUNNING at the
+            # unlocked pre-read but is now: a new try started in between. Register under
+            # the lock, preserving the previous behaviour for that race.
+            if ti is not None and not assets_registered:
                 TI.register_asset_changes_in_db(
                     ti,
                     ti_patch_payload.task_outlets,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1294,6 +1294,139 @@ class TestTIUpdateState:
         assert event[0].asset == AssetModel(name="my-task", uri="s3://bucket/my-task", extra={})
         assert event[0].extra == expected_extra
 
+    def test_ti_update_state_success_registers_assets_before_taking_ti_row_lock(
+        self, client, session, create_task_instance
+    ):
+        import sqlalchemy.event
+
+        asset = AssetModel(id=1, name="my-task", uri="s3://bucket/my-task", group="asset", extra={})
+        session.add_all([asset, AssetActive.for_asset(asset)])
+        ti = create_task_instance(
+            task_id="test_register_assets_before_ti_row_lock",
+            start_date=DEFAULT_START_DATE,
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        statement_order: list[str] = []
+
+        def _before_execute(conn, clauseelement, multiparams, params, execution_options):
+            if getattr(clauseelement, "_for_update_arg", None) is not None:
+                statement_order.append("locked_select")
+            elif getattr(getattr(clauseelement, "table", None), "name", None) == "asset_event":
+                statement_order.append("asset_event_insert")
+
+        engine = session.get_bind()
+        sqlalchemy.event.listen(engine, "before_execute", _before_execute)
+        try:
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/state",
+                json={
+                    "state": "success",
+                    "end_date": DEFAULT_END_DATE.isoformat(),
+                    "task_outlets": [{"name": "my-task", "uri": "s3://bucket/my-task", "type": "Asset"}],
+                    "outlet_events": [],
+                },
+            )
+        finally:
+            sqlalchemy.event.remove(engine, "before_execute", _before_execute)
+
+        assert response.status_code == 204
+        assert "asset_event_insert" in statement_order
+        assert "locked_select" in statement_order
+        assert statement_order.index("asset_event_insert") < statement_order.index("locked_select")
+
+    @pytest.mark.parametrize(
+        ("concurrent_state", "expected_status"),
+        [
+            pytest.param(TaskInstanceState.SUCCESS, 200, id="duplicate-success"),
+            pytest.param(TaskInstanceState.FAILED, 409, id="failed-during-registration"),
+        ],
+    )
+    @mock.patch.object(TaskInstance, "register_asset_changes_in_db")
+    def test_ti_update_state_success_rolls_back_asset_events_when_state_changes_during_registration(
+        self,
+        mock_register,
+        client,
+        session,
+        create_task_instance,
+        concurrent_state,
+        expected_status,
+    ):
+        real_register = mock_register.get_original()[0]
+
+        asset = AssetModel(id=1, name="my-task", uri="s3://bucket/my-task", group="asset", extra={})
+        session.add_all([asset, AssetActive.for_asset(asset)])
+        ti = create_task_instance(
+            task_id="test_rollback_asset_events_on_concurrent_state_change",
+            start_date=DEFAULT_START_DATE,
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        def _register_then_concurrent_transition(ti_arg, task_outlets, outlet_events, *, session):
+            real_register(ti_arg, task_outlets, outlet_events, session=session)
+            # Simulate a concurrent transition landing between the unlocked registration
+            # and the locked state re-check.
+            session.execute(
+                update(TaskInstance).where(TaskInstance.id == ti_arg.id).values(state=concurrent_state)
+            )
+
+        mock_register.side_effect = _register_then_concurrent_transition
+
+        response = client.patch(
+            f"/execution/task-instances/{ti.id}/state",
+            json={
+                "state": "success",
+                "end_date": DEFAULT_END_DATE.isoformat(),
+                "task_outlets": [{"name": "my-task", "uri": "s3://bucket/my-task", "type": "Asset"}],
+                "outlet_events": [],
+            },
+        )
+
+        assert response.status_code == expected_status
+        session.expire_all()
+        assert session.scalars(select(AssetEvent)).all() == []
+
+    def test_ti_update_state_success_registers_assets_under_lock_when_pre_read_skips(
+        self, client, session, create_task_instance
+    ):
+        """A success whose unlocked pre-read cannot confirm RUNNING must still register its events."""
+        asset = AssetModel(id=1, name="my-task", uri="s3://bucket/my-task", group="asset", extra={})
+        session.add_all([asset, AssetActive.for_asset(asset)])
+        ti = create_task_instance(
+            task_id="test_fallback_registration_under_lock",
+            start_date=DEFAULT_START_DATE,
+            state=State.RUNNING,
+        )
+        session.commit()
+
+        real_get = Session.get
+        pre_read_skipped = False
+
+        def _none_on_first_ti_get(session_self, entity, *args, **kwargs):
+            nonlocal pre_read_skipped
+            if not pre_read_skipped and entity is TaskInstance:
+                pre_read_skipped = True
+                return None
+            return real_get(session_self, entity, *args, **kwargs)
+
+        with mock.patch.object(Session, "get", autospec=True, side_effect=_none_on_first_ti_get):
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/state",
+                json={
+                    "state": "success",
+                    "end_date": DEFAULT_END_DATE.isoformat(),
+                    "task_outlets": [{"name": "my-task", "uri": "s3://bucket/my-task", "type": "Asset"}],
+                    "outlet_events": [],
+                },
+            )
+
+        assert pre_read_skipped
+        assert response.status_code == 204
+        session.expire_all()
+        assert len(session.scalars(select(AssetEvent)).all()) == 1
+
     @pytest.mark.parametrize(
         ("outlet_events", "expected_extra"),
         [


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Register asset events before taking the task_instance row lock
---
## Why

When a task succeeds, `ti_update_state` currently takes the `task_instance` row lock and then registers asset events while holding the lock.

Asset registration can be slow because it performs asset lookups, event inserts, and Dag-run queueing. When many tasks finish at the same time, concurrent requests can wait for the row lock while each request continues to use an API-server thread. In the case reported in #66853, this caused the API server to run out of memory and get OOMKilled.

## What

This change registers the asset events before taking the `task_instance` row lock:
<img width="1688" height="882" alt="image" src="https://github.com/user-attachments/assets/0420c4fa-7a7d-4f5e-9835-731812f70906" />
The asset events and the task state are still written in the same database transaction.

In this PR, we first read the state without the row lock, then perform the asset registration. This can hit a TOCTOU problem: the state may change in between, for example, when the worker retries. So before we actually change the state, we take the row lock and read the state one more time. The lock makes sure no one else can change it after this point. Then we decide what to do.

There are three cases:

1. The state is still `RUNNING`: the normal path. We change the state to `SUCCESS` and commit. The state and the events are saved together in one transaction.

2. The state is already `SUCCESS`: another request won the race and already saved its own events. We roll back so the events are not saved twice, and return 200.

3. The state is something else, such as `FAILED`: the task is no longer running, so the update is rejected with 409 and the transaction is rolled back. No events from this request are saved.

This locked re-check keeps the task state and asset events atomic: the events are committed only together with the `SUCCESS` state.

## Benchmark
The `task_instance` row lock is held during one successful task completion, on Postgres. The task emits to N assets to make the registration slow. Median of 14 runs (lock holding time):
outlets | before | after
-- | -- | --
300 | 426 ms | 2.0 ms
600 | 974 ms | 2.1 ms

Before, the lock is held for the whole registration, so it grows with the number of outlets. After, the registration runs before the lock, so the lock is held only for the state update and stays flat.

This is an alternative to #66854.

related: #66853

---

##### Was generative AI tooling used to co-author this PR?



<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
