### PR TITLE
Refactor xcom jwt url

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -27,22 +27,20 @@ from sqlalchemy.sql.selectable import Select
 
 from airflow.api_fastapi.common.db.common import SessionDep
 from airflow.api_fastapi.core_api.base import BaseModel
+from airflow.api_fastapi.execution_api.datamodels.token import TIToken
 from airflow.api_fastapi.execution_api.datamodels.xcom import (
     XComResponse,
     XComSequenceIndexResponse,
     XComSequenceSliceResponse,
 )
 from airflow.api_fastapi.execution_api.security import CurrentTIToken
+from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XComModel
 from airflow.utils.db import get_query_count
 
 
 def has_xcom_access(
-    dag_id: str,
-    run_id: str,
-    task_id: str,
-    xcom_key: Annotated[str, Path(alias="key", min_length=1)],
     request: Request,
     session: SessionDep,
     token=CurrentTIToken,
@@ -68,6 +66,13 @@ def has_xcom_access(
     from airflow.configuration import conf
 
     write = request.method not in {"GET", "HEAD", "OPTIONS"}
+    dag_id = request.path_params.get("dag_id")
+    xcom_key = request.path_params.get("key", "")
+
+    if not dag_id:
+        # If dag_id is not in the URL, the operation is inherently for the
+        # current task (e.g. set_xcom). Access is strictly scoped to the requester's team.
+        return True
 
     log.debug(
         "Checking %s XCom access for task instance '%s' to XCom '%s' on dag '%s'",
@@ -359,15 +364,13 @@ def get_xcom(
 # TODO: once we have JWT tokens, then remove dag_id/run_id/task_id from the URL and just use the info in
 # the token
 @router.post(
-    "/{dag_id}/{run_id}/{task_id}/{key:path}",
+    "/{key:path}",
     status_code=status.HTTP_201_CREATED,
 )
 def set_xcom(
-    dag_id: str,
-    run_id: str,
-    task_id: str,
     key: Annotated[str, Path(min_length=1)],
     session: SessionDep,
+    token: TIToken = CurrentTIToken,
     value: Annotated[
         JsonValue,
         Body(
@@ -407,6 +410,22 @@ def set_xcom(
                 "message": "XCom key must be a non-empty string.",
             },
         )
+
+    ti = session.execute(
+        Select(TaskInstance.dag_id, TaskInstance.run_id, TaskInstance.task_id).where(
+            TaskInstance.id == token.id
+        )
+    ).one_or_none()
+
+    if not ti:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "reason": "not_found",
+                "message": "Task Instance not found",
+            },
+        )
+    dag_id, run_id, task_id = ti
 
     if mapped_length is not None:
         task_map = TaskMap(

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -446,7 +446,10 @@ def set_xcom(
             session=session,
         )
     except ValueError as e:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"reason": "not_found", "message": str(e)},
+        )
     except TypeError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import urllib.parse
+from unittest import mock
 from uuid import uuid4
 
 import pytest
@@ -372,6 +373,26 @@ class TestXComsSetEndpoint:
             select(TaskMap).where(TaskMap.task_id == ti.task_id, TaskMap.dag_id == ti.dag_id)
         ).one_or_none()
         assert task_map is None, "Should not be mapped"
+
+    @mock.patch("airflow.models.xcom.XCom.set")
+    def test_xcom_set_value_error(self, mock_xcom_set, client, create_task_instance, session):
+        ti = create_task_instance()
+        session.commit()
+        
+        mock_xcom_set.side_effect = ValueError("Mocked value error")
+        
+        response = client.post(
+            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            json="value",
+        )
+        
+        assert response.status_code == 404
+        assert response.json() == {
+            "detail": {
+                "reason": "not_found",
+                "message": "Mocked value error",
+            }
+        }
 
     @pytest.mark.parametrize(
         ("orig_value", "ser_value", "deser_value"),

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -62,14 +62,10 @@ def access_denied(client):
 
     def _(
         request: Request,
-        dag_id: str = Path(),
-        run_id: str = Path(),
-        task_id: str = Path(),
-        xcom_key: str = Path(alias="key"),
         token=CurrentTIToken,
     ):
         with create_session() as session:
-            has_xcom_access(dag_id, run_id, task_id, xcom_key, request, session, token)
+            has_xcom_access(request, session, token)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
@@ -110,7 +106,7 @@ class TestXComsGetEndpoint:
         session.add(x)
         session.commit()
 
-        response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1")
+        response = client.get("/execution/xcoms/xcom_1")
 
         assert response.status_code == 200
         assert response.json() == {"key": "xcom_1", "value": db_value}
@@ -129,7 +125,7 @@ class TestXComsGetEndpoint:
     @pytest.mark.usefixtures("access_denied")
     def test_xcom_access_denied(self, client, caplog):
         with caplog.at_level(logging.DEBUG):
-            response = client.get("/execution/xcoms/dag/runid/task/xcom_perms")
+            response = client.get("/execution/xcoms/xcom_perms")
 
         assert response.status_code == 403, response.json()
         assert response.json() == {
@@ -354,7 +350,7 @@ class TestXComsSetEndpoint:
         session.commit()
         value = serialize(value)
         response = client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            "/execution/xcoms/xcom_1",
             json=value,
         )
 
@@ -382,7 +378,7 @@ class TestXComsSetEndpoint:
         mock_xcom_set.side_effect = ValueError("Mocked value error")
         
         response = client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            "/execution/xcoms/xcom_1",
             json="value",
         )
         
@@ -437,7 +433,7 @@ class TestXComsSetEndpoint:
         assert value == ser_value
 
         response = client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            "/execution/xcoms/xcom_1",
             json=value,
         )
 
@@ -465,7 +461,7 @@ class TestXComsSetEndpoint:
         value = serialize("value1")
 
         response = client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            "/execution/xcoms/xcom_1",
             params={"map_index": -1, "mapped_length": 3},
             json=value,
         )
@@ -511,7 +507,7 @@ class TestXComsSetEndpoint:
         session.commit()
 
         response = client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1",
+            "/execution/xcoms/xcom_1",
             json='"valid json"',
             params={"mapped_length": length},
         )
@@ -527,7 +523,7 @@ class TestXComsSetEndpoint:
     def test_xcom_access_denied(self, client, caplog):
         with caplog.at_level(logging.DEBUG):
             response = client.post(
-                "/execution/xcoms/dag/runid/task/xcom_perms",
+                "/execution/xcoms/xcom_perms",
                 json='"value1"',
             )
 
@@ -562,7 +558,7 @@ class TestXComsSetEndpoint:
         value = serialize(value)
         session.commit()
         client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/test_xcom_roundtrip",
+            "/execution/xcoms/test_xcom_roundtrip",
             json=value,
         )
 
@@ -575,7 +571,7 @@ class TestXComsSetEndpoint:
         ).first()
         assert xcom.value == expected_value
 
-        response = client.get(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/test_xcom_roundtrip")
+        response = client.get("/execution/xcoms/test_xcom_roundtrip")
 
         assert response.status_code == 200
         assert XComResponse.model_validate_json(response.read()).value == expected_value
@@ -586,7 +582,7 @@ class TestXComsSetEndpoint:
         """
         ti = create_task_instance()
         client.post(
-            f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/return_value",
+            "/execution/xcoms/return_value",
             params={"dag_result": True},
             json=123,
         )
@@ -615,7 +611,7 @@ class TestXComsDeleteEndpoint:
         assert xcoms is not None
         assert len(xcoms) == 2
 
-        response = client.delete(f"/execution/xcoms/{ti.dag_id}/{ti.run_id}/{ti.task_id}/xcom_1")
+        response = client.delete("/execution/xcoms/xcom_1")
 
         assert response.status_code == 200
         assert response.json() == {"message": "XCom with key: xcom_1 successfully deleted."}
@@ -696,6 +692,10 @@ class TestXComTeamAccess:
     def _url(dag_id, key="k"):
         return f"/execution/xcoms/{dag_id}/run1/task/{key}"
 
+    @staticmethod
+    def _post_url(key="k"):
+        return f"/execution/xcoms/{key}"
+
     def test_multi_team_disabled_allows_cross_team(self, client, exec_app, session, dag_maker):
         """With multi-team disabled, the check is a no-op even across teams."""
         _, requester_ti = self._make_dag(session, dag_maker, f"req_{uuid4().hex}", "team_a")
@@ -719,7 +719,7 @@ class TestXComTeamAccess:
 
         with conf_vars({("core", "multi_team"): "True"}):
             read = client.get(self._url(dag_id, key="existing"))
-            write = client.post(self._url(dag_id, key="newkey"), json="w")
+            write = client.post(self._post_url("newkey"), json="w")
             delete_ = client.delete(self._url(dag_id, key="existing"))
 
         assert read.status_code == 200, read.json()
@@ -766,7 +766,7 @@ class TestXComTeamAccess:
 
         with conf_vars({("core", "multi_team"): "True"}):
             read = client.get(self._url(global_dag, key="k"))
-            write = client.post(self._url(global_dag, key="k2"), json="w")
+            write = client.post(self._post_url("k2"), json="w")
             delete_ = client.delete(self._url(global_dag, key="k"))
 
         assert read.status_code == 200, read.json()

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -609,14 +609,10 @@ class XComOperations:
 
     def set(
         self,
-        dag_id: str,
-        run_id: str,
-        task_id: str,
         key: str,
-        value,
+        value: Any,
         map_index: int | None = None,
-        *,
-        dag_result: bool = False,
+        dag_result: bool | None = None,
         mapped_length: int | None = None,
     ) -> OKResponse:
         """Set a XCom value via the API server."""
@@ -627,7 +623,7 @@ class XComOperations:
             params["map_index"] = map_index
         if mapped_length is not None and mapped_length >= 0:
             params["mapped_length"] = mapped_length
-        self.client.post(f"xcoms/{dag_id}/{run_id}/{task_id}/{key}", params=params, json=value)
+        self.client.post(f"xcoms/{key}", params=params, json=value)
         # Any error from the server will anyway be propagated down to the supervisor,
         # so we choose to send a generic response to the supervisor over the server response to
         # decouple from the server response string

--- a/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
+++ b/task-sdk/src/airflow/sdk/execution_time/request_handlers.py
@@ -180,9 +180,6 @@ def handle_get_previous_ti(client: Client, msg: GetPreviousTI) -> tuple[BaseMode
 def handle_set_xcom(client: Client, msg: SetXCom) -> tuple[BaseModel | None, dict[str, bool]]:
     """Store an XCom value."""
     client.xcoms.set(
-        msg.dag_id,
-        msg.run_id,
-        msg.task_id,
         msg.key,
         msg.value,
         msg.map_index,


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

### Description

The Task Execution API's `set_xcom` endpoint implicitly has access to the current task instance identifiers through the injected JWT token. Removing the task identifiers (`dag_id`, `run_id`, `task_id`) from the URL simplifies routing, prevents clients from providing conflicting or invalid identifiers, and enforces zero-trust security where a task instance can only write its own XComs.

This refactor:
- Updates the `has_xcom_access` dependency to handle write requests gracefully without requiring `dag_id` in the URL path.
- Modifies the `set_xcom` endpoint to query identifiers securely from the database via the token.
- Cleans up `client.xcoms.set` in the Task SDK to use the simplified URL format.

closes: #70080

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: [Gemini] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
