### PR TITLE
docs: fix broken BaseOperator link in templates-ref (#60477)

### DIFF
--- a/airflow-core/docs/templates-ref.rst
+++ b/airflow-core/docs/templates-ref.rst
@@ -77,7 +77,7 @@ Variable                                    Type                  Description
 ``{{ outlet_events }}``                     dict[str, ...]        | Accessors to attach information to asset events that will be emitted by the current task.
                                                                   | See :doc:`Assets <authoring-and-scheduling/asset-scheduling>`. Added in version 2.10.
 ``{{ dag }}``                               DAG                   The currently running :class:`~airflow.models.dag.DAG`. You can read more about Dags in :doc:`Dags <core-concepts/dags>`.
-``{{ task }}``                              BaseOperator          | The currently running :class:`~airflow.models.baseoperator.BaseOperator`. You can read more about Tasks in :doc:`core-concepts/operators`
+``{{ task }}``                              BaseOperator          | The currently running :class:`~airflow.sdk.BaseOperator`. You can read more about Tasks in :doc:`core-concepts/operators`
 ``{{ task_reschedule_count }}``             int                   How many times current task has been rescheduled. Relevant to ``mode="reschedule"`` sensors.
 ``{{ macros }}``                                                  | A reference to the macros package. See Macros_ below.
 ``{{ task_instance }}``                     TaskInstance          The currently running :class:`~airflow.models.taskinstance.TaskInstance`.


### PR DESCRIPTION
Closes #60477

## Fixes broken `BaseOperator` link in `templates-ref`

The template variable reference table in `airflow-core/docs/templates-ref.rst`
linked the `{{ task }}` variable to
`:class:`~airflow.models.baseoperator.BaseOperator``. That module no longer
exists on `main` — `BaseOperator` now lives in the Task SDK — so the link is
dead and renders as an unresolvable reference.

This updates the reference to the canonical public path
`:class:`~airflow.sdk.BaseOperator``, which is the form already used throughout
the rest of the core docs (e.g. `howto/custom-operator.rst`,
`authoring-and-scheduling/deferring.rst`, `tutorial/fundamentals.rst`).

Doc-only change — no behavior change, no newsfragment required.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.
-->

---

**^ Add meaningful description above**

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes are not needed (docs-only change)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](https://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as reviewers and add my changes to a public repo

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=8fea884 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @Sanjays2402** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
