### PR TITLE
Add worker-name filter to `airflow edge list-workers`

### DIFF
--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -248,7 +248,9 @@ on all workers in the cluster or to check the status of all workers in the clust
 These set of commands need database access, and can only be called on the central Airflow
 instance. The commands are:
 
-- ``airflow edge list-workers``: List all workers in the cluster
+- ``airflow edge list-workers``: List all workers in the cluster. Accepts an optional
+  ``--name-pattern`` glob (e.g. ``'prod-*'``) to filter workers by name,
+  and ``-s``/``--state`` to filter by worker state.
 - ``airflow edge remote-edge-worker-request-maintenance``: Request a remote edge worker to enter maintenance mode
 - ``airflow edge remote-edge-worker-update-maintenance-comment``: Updates the maintenance comment for a remote edge worker
 - ``airflow edge remote-edge-worker-exit-maintenance``: Request a remote edge worker to exit maintenance mode

--- a/providers/edge3/docs/deployment.rst
+++ b/providers/edge3/docs/deployment.rst
@@ -249,7 +249,7 @@ These set of commands need database access, and can only be called on the centra
 instance. The commands are:
 
 - ``airflow edge list-workers``: List all workers in the cluster. Accepts an optional
-  ``--name-pattern`` glob (e.g. ``'prod-*'``) to filter workers by name,
+  ``--worker-name-pattern`` glob (e.g. ``'prod-*'``) to filter workers by name,
   and ``-s``/``--state`` to filter by worker state.
 - ``airflow edge remote-edge-worker-request-maintenance``: Request a remote edge worker to enter maintenance mode
 - ``airflow edge remote-edge-worker-update-maintenance-comment``: Updates the maintenance comment for a remote edge worker

--- a/providers/edge3/src/airflow/providers/edge3/cli/definition.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/definition.py
@@ -53,7 +53,7 @@ ARG_EDGE_HOSTNAME = Arg(
     help="Set the hostname of worker if you have multiple workers on a single machine",
 )
 ARG_WORKER_NAME_PATTERN = Arg(
-    ("--name-pattern",),
+    ("--worker-name-pattern",),
     metavar="PATTERN",
     help="Optional glob pattern to filter workers by name, e.g. 'prod-*'. Lists all workers if omitted.",
 )

--- a/providers/edge3/src/airflow/providers/edge3/cli/definition.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/definition.py
@@ -52,6 +52,11 @@ ARG_EDGE_HOSTNAME = Arg(
     ("-H", "--edge-hostname"),
     help="Set the hostname of worker if you have multiple workers on a single machine",
 )
+ARG_WORKER_NAME_PATTERN = Arg(
+    ("--name-pattern",),
+    metavar="PATTERN",
+    help="Optional glob pattern to filter workers by name, e.g. 'prod-*'. Lists all workers if omitted.",
+)
 ARG_REQUIRED_EDGE_HOSTNAME = Arg(
     ("-H", "--edge-hostname"),
     help="Set the hostname of worker if you have multiple workers on a single machine",
@@ -183,6 +188,7 @@ EDGE_COMMANDS: list[ActionCommand] = [
         args=(
             ARG_OUTPUT,
             ARG_STATE,
+            ARG_WORKER_NAME_PATTERN,
         ),
     ),
     ActionCommand(

--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -260,7 +260,7 @@ def list_edge_workers(args) -> None:
     _check_valid_db_connection()
     from airflow.providers.edge3.models.edge_worker import get_registered_edge_hosts
 
-    all_hosts_iter = get_registered_edge_hosts(states=args.state)
+    all_hosts_iter = get_registered_edge_hosts(states=args.state, worker_name_pattern=args.name_pattern)
     # Format and print worker info on the screen
     fields = [
         "worker_name",

--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -260,7 +260,9 @@ def list_edge_workers(args) -> None:
     _check_valid_db_connection()
     from airflow.providers.edge3.models.edge_worker import get_registered_edge_hosts
 
-    all_hosts_iter = get_registered_edge_hosts(states=args.state, worker_name_pattern=args.name_pattern)
+    all_hosts_iter = get_registered_edge_hosts(
+        states=args.state, worker_name_pattern=args.worker_name_pattern
+    )
     # Format and print worker info on the screen
     fields = [
         "worker_name",

--- a/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
+++ b/providers/edge3/src/airflow/providers/edge3/models/edge_worker.py
@@ -239,11 +239,23 @@ def get_query_filter_by_worker_name(worker_name: str):
     return select(EdgeWorkerModel).where(EdgeWorkerModel.worker_name == worker_name)
 
 
+def _glob_to_like_pattern(pattern: str) -> str:
+    r"""
+    Convert a shell-style glob (``*``, ``?``) to a SQL ``LIKE`` pattern.
+
+    Literal ``LIKE`` metacharacters in the input are escaped with a backslash so
+    only glob wildcards are treated as special; the caller must pass ``escape="\"``.
+    """
+    escaped = pattern.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return escaped.replace("*", "%").replace("?", "_")
+
+
 @providers_configuration_loaded
 @provide_session
 def _fetch_edge_hosts_from_db(
     hostname: str | None = None,
     states: list | None = None,
+    worker_name_pattern: str | None = None,
     *,
     session: Session = NEW_SESSION,
 ) -> Sequence[EdgeWorkerModel]:
@@ -252,14 +264,20 @@ def _fetch_edge_hosts_from_db(
         query = query.where(EdgeWorkerModel.state.in_(states))
     if hostname:
         query = query.where(EdgeWorkerModel.worker_name == hostname)
+    if worker_name_pattern:
+        query = query.where(
+            EdgeWorkerModel.worker_name.like(_glob_to_like_pattern(worker_name_pattern), escape="\\")
+        )
     query = query.order_by(EdgeWorkerModel.worker_name)
     return session.scalars(query).all()
 
 
 @providers_configuration_loaded
 @provide_session
-def get_registered_edge_hosts(*, states: list | None = None, session: Session = NEW_SESSION):
-    return _fetch_edge_hosts_from_db(states=states, session=session)
+def get_registered_edge_hosts(
+    *, states: list | None = None, worker_name_pattern: str | None = None, session: Session = NEW_SESSION
+):
+    return _fetch_edge_hosts_from_db(states=states, worker_name_pattern=worker_name_pattern, session=session)
 
 
 @provide_session

--- a/providers/edge3/tests/unit/edge3/cli/test_definition.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_definition.py
@@ -152,13 +152,13 @@ class TestEdgeCliDefinition:
             "--state",
             "running",
             "maintenance",
-            "--name-pattern",
+            "--worker-name-pattern",
             "prod-*",
         ]
         args = self.arg_parser.parse_args(params)
         assert args.output == "json"
         assert args.state == ["running", "maintenance"]
-        assert args.name_pattern == "prod-*"
+        assert args.worker_name_pattern == "prod-*"
 
     def test_remote_edge_worker_request_maintenance_args(self):
         """Test remote-edge-worker-request-maintenance command with required arguments."""

--- a/providers/edge3/tests/unit/edge3/cli/test_definition.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_definition.py
@@ -143,7 +143,7 @@ class TestEdgeCliDefinition:
         assert args.pid == "/path/to/pid"
 
     def test_list_workers_command_args(self):
-        """Test list-workers command with output format and state filter."""
+        """Test list-workers command with output format, state, and name-pattern filters."""
         params = [
             "edge",
             "list-workers",
@@ -152,10 +152,13 @@ class TestEdgeCliDefinition:
             "--state",
             "running",
             "maintenance",
+            "--name-pattern",
+            "prod-*",
         ]
         args = self.arg_parser.parse_args(params)
         assert args.output == "json"
         assert args.state == ["running", "maintenance"]
+        assert args.name_pattern == "prod-*"
 
     def test_remote_edge_worker_request_maintenance_args(self):
         """Test remote-edge-worker-request-maintenance command with required arguments."""

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -1114,6 +1114,24 @@ class TestEdgeWorker:
             assert key in edge_workers[0]
         assert any("test_edge_worker" in h["worker_name"] for h in edge_workers)
 
+    @pytest.mark.db_test
+    def test_list_edge_workers_passes_name_pattern(self, mock_edgeworker: EdgeWorkerModel):
+        args = self.parser.parse_args(
+            ["edge", "list-workers", "--output", "json", "--name-pattern", "prod-*"]
+        )
+        with contextlib.redirect_stdout(StringIO()):
+            with (
+                patch(
+                    "airflow.providers.edge3.cli.edge_command._check_valid_db_connection",
+                ),
+                patch(
+                    "airflow.providers.edge3.models.edge_worker.get_registered_edge_hosts",
+                    return_value=[mock_edgeworker],
+                ) as mock_get_hosts,
+            ):
+                edge_command.list_edge_workers(args)
+        mock_get_hosts.assert_called_once_with(states=None, worker_name_pattern="prod-*")
+
 
 class TestSignalHandling:
     """Regression tests for the SIGTERM-storm fix (Bug B)."""

--- a/providers/edge3/tests/unit/edge3/cli/test_worker.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_worker.py
@@ -1117,7 +1117,7 @@ class TestEdgeWorker:
     @pytest.mark.db_test
     def test_list_edge_workers_passes_name_pattern(self, mock_edgeworker: EdgeWorkerModel):
         args = self.parser.parse_args(
-            ["edge", "list-workers", "--output", "json", "--name-pattern", "prod-*"]
+            ["edge", "list-workers", "--output", "json", "--worker-name-pattern", "prod-*"]
         )
         with contextlib.redirect_stdout(StringIO()):
             with (

--- a/providers/edge3/tests/unit/edge3/models/test_edge_worker.py
+++ b/providers/edge3/tests/unit/edge3/models/test_edge_worker.py
@@ -16,12 +16,25 @@
 # under the License.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest import mock
 
+import pytest
+from sqlalchemy import delete
+
 from airflow.providers.common.compat.sdk import Stats
-from airflow.providers.edge3.models.edge_worker import EdgeWorkerState, set_metrics
+from airflow.providers.edge3.models.edge_worker import (
+    EdgeWorkerModel,
+    EdgeWorkerState,
+    _glob_to_like_pattern,
+    get_registered_edge_hosts,
+    set_metrics,
+)
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_3_PLUS
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 stats_reference = f"{Stats.__module__}.Stats"
 
@@ -62,3 +75,48 @@ def test_set_metrics():
 
     legacy_metric_name = f"edge_worker.status.{worker_name}"
     assert legacy_metric_name in metric_names
+
+
+@pytest.mark.parametrize(
+    ("glob", "expected"),
+    [
+        ("prod-*", "prod-%"),
+        ("worker-?", "worker-_"),
+        ("*gpu*", "%gpu%"),
+        # Literal LIKE metacharacters are escaped so they are not treated as wildcards.
+        ("50%_worker", "50\\%\\_worker"),
+        ("back\\slash", "back\\\\slash"),
+    ],
+)
+def test_glob_to_like_pattern(glob, expected):
+    assert _glob_to_like_pattern(glob) == expected
+
+
+@pytest.mark.db_test
+class TestGetRegisteredEdgeHosts:
+    @pytest.fixture(autouse=True)
+    def setup_test_cases(self, session: Session):
+        session.execute(delete(EdgeWorkerModel))
+        for name in ("prod-worker-1", "prod-worker-2", "dev-worker-1"):
+            session.add(EdgeWorkerModel(worker_name=name, queues=["default"], state=EdgeWorkerState.RUNNING))
+        session.commit()
+
+    def test_no_pattern_returns_all(self, session: Session):
+        hosts = get_registered_edge_hosts(session=session)
+        assert {h.worker_name for h in hosts} == {
+            "prod-worker-1",
+            "prod-worker-2",
+            "dev-worker-1",
+        }
+
+    def test_star_glob_filters_by_prefix(self, session: Session):
+        hosts = get_registered_edge_hosts(worker_name_pattern="prod-*", session=session)
+        assert {h.worker_name for h in hosts} == {"prod-worker-1", "prod-worker-2"}
+
+    def test_question_mark_glob_matches_single_char(self, session: Session):
+        hosts = get_registered_edge_hosts(worker_name_pattern="prod-worker-?", session=session)
+        assert {h.worker_name for h in hosts} == {"prod-worker-1", "prod-worker-2"}
+
+    def test_no_match_returns_empty(self, session: Session):
+        hosts = get_registered_edge_hosts(worker_name_pattern="nonexistent-*", session=session)
+        assert list(hosts) == []


### PR DESCRIPTION
In clusters with many edge workers, `list-workers` could only be narrowed by `--state`. This adds an optional `--worker-name-pattern` glob (e.g. `'prod-*'`, `'*gpu*'`) that filters workers by name DB-side, composable with `--state`. This brings the CLI to parity with the edge UI/REST route, which already supports `worker_name_pattern`.

Usage:
    airflow edge list-workers --worker-name-pattern 'bree-*'

<img width="1174" height="120" alt="image" src="https://github.com/user-attachments/assets/a5139aa2-d482-4578-9941-827cba00f617" />




##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (Opus 4.8)