### PR TITLE
Add Cortex Agent management methods to SnowflakeCortexAgentHook

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_cortex_agent.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/hooks/snowflake_cortex_agent.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -54,8 +54,9 @@ class SnowflakeCortexAgentHook(SnowflakeHook):
         method: str,
         endpoint: str,
         payload: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
         timeout: int | None = None,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | list[dict[str, Any]]:
 
         response = requests.request(
             method=method,
@@ -65,6 +66,7 @@ class SnowflakeCortexAgentHook(SnowflakeHook):
                 "Content-Type": "application/json",
             },
             json=payload,
+            params=params,
             timeout=timeout,
         )
 
@@ -159,11 +161,124 @@ class SnowflakeCortexAgentHook(SnowflakeHook):
 
         endpoint = f"/api/v2/databases/{database}/schemas/{schema}/agents/{agent_name}:run"
 
-        return self._request(
-            method="POST",
-            endpoint=endpoint,
-            payload=payload,
-            timeout=timeout,
+        return cast(
+            "dict[str, Any]",
+            self._request(
+                method="POST",
+                endpoint=endpoint,
+                payload=payload,
+                timeout=timeout,
+            ),
+        )
+
+    def describe_agent(
+        self,
+        *,
+        database: str,
+        schema: str,
+        agent_name: str,
+        timeout: int | None = 600,
+    ) -> dict[str, Any]:
+        """
+        Describe a Snowflake Cortex Agent.
+
+        :param database: Database containing the Cortex Agent.
+        :param schema: Schema containing the Cortex Agent.
+        :param agent_name: Name of the Cortex Agent.
+        :param timeout: Maximum time in seconds to wait for the Cortex Agent
+            request to complete. Defaults to ``600``.
+        :return: JSON description of the Cortex Agent.
+        """
+        endpoint = f"/api/v2/databases/{database}/schemas/{schema}/agents/{agent_name}"
+
+        return cast(
+            "dict[str, Any]",
+            self._request(
+                method="GET",
+                endpoint=endpoint,
+                timeout=timeout,
+            ),
+        )
+
+    def list_agents(
+        self,
+        *,
+        database: str,
+        schema: str,
+        like: str | None = None,
+        from_name: str | None = None,
+        show_limit: int | None = None,
+        timeout: int | None = 600,
+    ) -> list[dict[str, Any]]:
+        """
+        List Snowflake Cortex Agents.
+
+        :param database: Database containing the Cortex Agents.
+        :param schema: Schema containing the Cortex Agents.
+        :param like: Optional case-insensitive name filter. Optional.
+            Defaults to ``None``.
+        :param from_name: Optional pagination starting point. Optional.
+            Defaults to ``None``.
+        :param show_limit: Maximum number of agents to return. Optional.
+            Defaults to ``None``.
+        :param timeout: Maximum time in seconds to wait for the Cortex Agent
+            request to complete. Defaults to ``600``.
+        :return: List of Cortex Agents.
+        """
+        endpoint = f"/api/v2/databases/{database}/schemas/{schema}/agents"
+
+        params: dict[str, Any] = {}
+
+        if like is not None:
+            params["like"] = like
+
+        if from_name is not None:
+            params["fromName"] = from_name
+
+        if show_limit is not None:
+            params["showLimit"] = show_limit
+
+        return cast(
+            "list[dict[str, Any]]",
+            self._request(
+                method="GET",
+                endpoint=endpoint,
+                params=params or None,
+                timeout=timeout,
+            ),
+        )
+
+    def delete_agent(
+        self,
+        *,
+        database: str,
+        schema: str,
+        agent_name: str,
+        if_exists: bool = False,
+        timeout: int | None = 600,
+    ) -> dict[str, Any]:
+        """
+        Delete a Snowflake Cortex Agent.
+
+        :param database: Database containing the Cortex Agent.
+        :param schema: Schema containing the Cortex Agent.
+        :param agent_name: Name of the Cortex Agent.
+        :param if_exists: If ``True``, do not fail when the agent does not exist.
+            Defaults to ``False``.
+        :param timeout: Maximum time in seconds to wait for the Cortex Agent request
+            to complete. Defaults to ``600``.
+        :return: JSON response confirming deletion.
+        """
+        endpoint = f"/api/v2/databases/{database}/schemas/{schema}/agents/{agent_name}"
+
+        return cast(
+            "dict[str, Any]",
+            self._request(
+                method="DELETE",
+                endpoint=endpoint,
+                params={"ifExists": str(if_exists).lower()},
+                timeout=timeout,
+            ),
         )
 
     @staticmethod

--- a/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_cortex_agent.py
+++ b/providers/snowflake/tests/unit/snowflake/hooks/test_snowflake_cortex_agent.py
@@ -127,6 +127,7 @@ class TestSnowflakeCortexAgentHook:
                 ],
                 "stream": False,
             },
+            params=None,
             timeout=REQUEST_TIMEOUT,
         )
 
@@ -316,3 +317,160 @@ class TestSnowflakeCortexAgentHook:
         expected,
     ):
         assert SnowflakeCortexAgentHook.get_text_response(response) == expected
+
+    @mock.patch(f"{MODULE_PATH}.requests.request")
+    @mock.patch(f"{HOOK_PATH}._get_conn_params")
+    @mock.patch(
+        f"{HOOK_PATH}._get_static_conn_params",
+        new_callable=mock.PropertyMock,
+    )
+    def test_describe_agent(
+        self,
+        mock_static_conn_params,
+        mock_conn_params,
+        mock_request,
+    ):
+        mock_conn_params.return_value = CONN_PARAMS
+        mock_static_conn_params.return_value = STATIC_CONN_PARAMS
+        mock_request.return_value = create_response(
+            json_body={"name": AGENT_NAME},
+        )
+
+        hook = SnowflakeCortexAgentHook(
+            snowflake_conn_id="mock_conn_id",
+        )
+
+        result = hook.describe_agent(
+            database=DATABASE,
+            schema=SCHEMA,
+            agent_name=AGENT_NAME,
+        )
+
+        assert result == {"name": AGENT_NAME}
+
+        mock_request.assert_called_once_with(
+            method="GET",
+            url=(
+                f"https://{ACCOUNT}.snowflakecomputing.com"
+                f"/api/v2/databases/{DATABASE}"
+                f"/schemas/{SCHEMA}"
+                f"/agents/{AGENT_NAME}"
+            ),
+            headers={
+                "Authorization": f"Bearer {ACCESS_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            json=None,
+            params=None,
+            timeout=REQUEST_TIMEOUT,
+        )
+
+    @mock.patch(f"{MODULE_PATH}.requests.request")
+    @mock.patch(f"{HOOK_PATH}._get_conn_params")
+    @mock.patch(
+        f"{HOOK_PATH}._get_static_conn_params",
+        new_callable=mock.PropertyMock,
+    )
+    def test_list_agents(
+        self,
+        mock_static_conn_params,
+        mock_conn_params,
+        mock_request,
+    ):
+        mock_conn_params.return_value = CONN_PARAMS
+        mock_static_conn_params.return_value = STATIC_CONN_PARAMS
+        mock_request.return_value = create_response(
+            json_body=[{"name": AGENT_NAME}],
+        )
+
+        hook = SnowflakeCortexAgentHook(
+            snowflake_conn_id="mock_conn_id",
+        )
+
+        result = hook.list_agents(
+            database=DATABASE,
+            schema=SCHEMA,
+            like="AIRFLOW%",
+            from_name="AIRFLOW_TEST",
+            show_limit=10,
+        )
+
+        assert result == [{"name": AGENT_NAME}]
+
+        mock_request.assert_called_once_with(
+            method="GET",
+            url=(
+                f"https://{ACCOUNT}.snowflakecomputing.com"
+                f"/api/v2/databases/{DATABASE}"
+                f"/schemas/{SCHEMA}"
+                f"/agents"
+            ),
+            headers={
+                "Authorization": f"Bearer {ACCESS_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            json=None,
+            params={
+                "like": "AIRFLOW%",
+                "fromName": "AIRFLOW_TEST",
+                "showLimit": 10,
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+
+    @pytest.mark.parametrize(
+        ("if_exists", "expected"),
+        [
+            pytest.param(True, "true", id="if_exists"),
+            pytest.param(False, "false", id="error_if_missing"),
+        ],
+    )
+    @mock.patch(f"{MODULE_PATH}.requests.request")
+    @mock.patch(f"{HOOK_PATH}._get_conn_params")
+    @mock.patch(
+        f"{HOOK_PATH}._get_static_conn_params",
+        new_callable=mock.PropertyMock,
+    )
+    def test_delete_agent(
+        self,
+        mock_static_conn_params,
+        mock_conn_params,
+        mock_request,
+        if_exists,
+        expected,
+    ):
+        mock_conn_params.return_value = CONN_PARAMS
+        mock_static_conn_params.return_value = STATIC_CONN_PARAMS
+        mock_request.return_value = create_response(
+            json_body={"status": "deleted"},
+        )
+
+        hook = SnowflakeCortexAgentHook(
+            snowflake_conn_id="mock_conn_id",
+        )
+
+        result = hook.delete_agent(
+            database=DATABASE,
+            schema=SCHEMA,
+            agent_name=AGENT_NAME,
+            if_exists=if_exists,
+        )
+
+        assert result == {"status": "deleted"}
+
+        mock_request.assert_called_once_with(
+            method="DELETE",
+            url=(
+                f"https://{ACCOUNT}.snowflakecomputing.com"
+                f"/api/v2/databases/{DATABASE}"
+                f"/schemas/{SCHEMA}"
+                f"/agents/{AGENT_NAME}"
+            ),
+            headers={
+                "Authorization": f"Bearer {ACCESS_TOKEN}",
+                "Content-Type": "application/json",
+            },
+            json=None,
+            params={"ifExists": expected},
+            timeout=REQUEST_TIMEOUT,
+        )


### PR DESCRIPTION
**Description**

This change extends `SnowflakeCortexAgentHook` with support for managing Snowflake Cortex Agent Objects.

The hook now exposes methods to describe, list and delete Cortex Agents using the Snowflake Cortex Agent REST API. To support these endpoints, the internal request helper has been updated to accept optional query parameters while continuing to centralize authentication, request execution and error handling.

**Rationale**

The existing hook supports executing Cortex Agents through `run_agent()`, but the Snowflake Cortex Agent REST API also provides endpoints for managing Cortex Agent Objects. Exposing these operations through the hook allows users to inspect and manage agents without needing to invoke the REST API directly.

Adding query parameter support to the shared request helper also provides a reusable foundation for additional Cortex Agent management operations in future enhancements.

**Tests**

Added unit tests verifying that:

* `describe_agent()` sends the expected request and returns the API response.
* `list_agents()` correctly forwards optional query parameters and returns the list of agents.
* `delete_agent()` issues the expected DELETE request, including both values of the `if_exists` parameter.
* `_request()` returns `{}` for successful empty dict responses.
* Cortex Agent methods raise when Snowflake returns an unexpected top-level response shape.