### PR TITLE
edge3: Exit non-zero when worker admin CLI commands fail

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
+++ b/providers/edge3/src/airflow/providers/edge3/cli/edge_command.py
@@ -326,8 +326,8 @@ def remote_worker_update_maintenance_comment(args) -> None:
     try:
         change_maintenance_comment(args.edge_hostname, args.comments)
         logger.info("Maintenance comments updated for %s by %s.", args.edge_hostname, getuser())
-    except TypeError:
-        raise SystemExit
+    except TypeError as e:
+        raise SystemExit(str(e))
 
 
 @cli_utils.action_cli(check_db=False)
@@ -341,8 +341,8 @@ def remove_remote_worker(args) -> None:
     try:
         remove_worker(args.edge_hostname)
         logger.info("Edge Worker host %s removed by %s.", args.edge_hostname, getuser())
-    except TypeError:
-        raise SystemExit
+    except TypeError as e:
+        raise SystemExit(str(e))
 
 
 @cli_utils.action_cli(check_db=False)
@@ -404,8 +404,7 @@ def add_worker_queues(args) -> None:
         add_worker_queues(args.edge_hostname, queues)
         logger.info("Added queues %s to Edge Worker host %s by %s.", queues, args.edge_hostname, getuser())
     except TypeError as e:
-        logger.error(str(e))
-        raise SystemExit
+        raise SystemExit(str(e))
 
 
 @cli_utils.action_cli(check_db=False)
@@ -426,8 +425,7 @@ def remove_worker_queues(args) -> None:
             "Removed queues %s from Edge Worker host %s by %s.", queues, args.edge_hostname, getuser()
         )
     except TypeError as e:
-        logger.error(str(e))
-        raise SystemExit
+        raise SystemExit(str(e))
 
 
 @cli_utils.action_cli(check_db=False)
@@ -450,5 +448,4 @@ def set_remote_worker_concurrency(args) -> None:
             getuser(),
         )
     except TypeError as e:
-        logger.error(str(e))
-        raise SystemExit
+        raise SystemExit(str(e))

--- a/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
+++ b/providers/edge3/tests/unit/edge3/cli/test_edge_command.py
@@ -14,5 +14,80 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-# here is nothing to test, all is CLI wrapper only
+from argparse import Namespace
+from unittest import mock
+
+import pytest
+
+from airflow.providers.edge3.cli import edge_command
+
+# ``@cli_utils.action_cli`` writes a Log row via ``cli_action_loggers`` on
+# every invocation, which touches the metadata DB even with ``check_db=False``.
+# Same reason ``airflow-core/tests/unit/utils/test_cli_util.py`` marks its
+# module ``db_test``.
+pytestmark = pytest.mark.db_test
+
+
+class TestWorkerAdminExitCodes:
+    """CLI worker-admin subcommands must exit non-zero when the model raises."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_db_checks(self):
+        with (
+            mock.patch.object(edge_command, "_check_valid_db_connection"),
+            mock.patch.object(edge_command, "_check_if_registered_edge_host"),
+        ):
+            yield
+
+    @pytest.mark.parametrize(
+        ("cli_func", "model_attr", "args"),
+        [
+            (
+                edge_command.add_worker_queues,
+                "add_worker_queues",
+                Namespace(edge_hostname="worker-1", queues="q1,q2"),
+            ),
+            (
+                edge_command.remove_worker_queues,
+                "remove_worker_queues",
+                Namespace(edge_hostname="worker-1", queues="q1"),
+            ),
+            (
+                edge_command.set_remote_worker_concurrency,
+                "set_worker_concurrency",
+                Namespace(edge_hostname="worker-1", concurrency=8),
+            ),
+            (
+                edge_command.remote_worker_update_maintenance_comment,
+                "change_maintenance_comment",
+                Namespace(edge_hostname="worker-1", comments="short break"),
+            ),
+            (
+                edge_command.remove_remote_worker,
+                "remove_worker",
+                Namespace(edge_hostname="worker-1"),
+            ),
+        ],
+        ids=[
+            "add_worker_queues",
+            "remove_worker_queues",
+            "set_remote_worker_concurrency",
+            "remote_worker_update_maintenance_comment",
+            "remove_remote_worker",
+        ],
+    )
+    def test_exits_non_zero_when_model_raises_type_error(self, cli_func, model_attr, args):
+        message = "Cannot mutate worker in OFFLINE state!"
+        with mock.patch(
+            f"airflow.providers.edge3.models.edge_worker.{model_attr}",
+            side_effect=TypeError(message),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cli_func(args)
+        # SystemExit carries the model's error message as its `code`, which the
+        # interpreter prints to stderr and translates to exit status 1. A bare
+        # `raise SystemExit` would leave code=None (exit 0), which is the bug
+        # this test guards against.
+        assert exc_info.value.code == message


### PR DESCRIPTION
`add-worker-queues`, `remove-worker-queues`, and `set-worker-concurrency` raised bare `SystemExit` after catching a `TypeError` from the model layer (raised when the target worker is in `OFFLINE`, `OFFLINE_MAINTENANCE`, or `UNKNOWN` state). `SystemExit()` with no argument yields exit code `0`, so shell scripts wrapping these commands saw success and continued as if the queue or concurrency change had been applied, when in fact it had been silently rejected.

Pass the exception message to `SystemExit(str(e))` so the process exits with status `1` and writes the failure to stderr. Matches this file's own convention for validation-error paths (e.g. `raise SystemExit("Error: No queues specified to add.")` a few lines above each fix site) and the `raise SystemExit(str(e))` pattern already used in `providers/edge3/src/airflow/providers/edge3/cli/worker.py`.

The model layer at `providers/edge3/src/airflow/providers/edge3/models/edge_worker.py` already calls `logger.error(error_message)` before raising, so the CLI-side `logger.error(str(e))` was strictly duplicative and is removed.

Adds parametrized tests over all three subcommands asserting that `SystemExit.code` carries the error message (i.e. exit status is `1`, not `0`).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Cursor 
