### PR TITLE
Fix ClickHouse test_connection unit test failing with newer clickhouse-connect

### DIFF
--- a/providers/clickhousedb/tests/unit/clickhousedb/hooks/test_clickhouse.py
+++ b/providers/clickhousedb/tests/unit/clickhousedb/hooks/test_clickhouse.py
@@ -1147,10 +1147,13 @@ class TestClickHouseHookTestConnection:
         hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
         hook.test_connection()
 
-        # Assert only on the SQL: the extra arguments clickhouse_connect's Cursor
-        # passes through vary between releases.
+        # Assert on the statement and the bound parameters only. Anything the
+        # driver appends beyond those (e.g. a settings kwarg) is its own concern
+        # and varies between releases.
         mock_client.query.assert_called_once()
-        assert mock_client.query.call_args.args[0] == "SELECT 1"
+        sql, parameters = mock_client.query.call_args.args[:2]
+        assert sql == "SELECT 1"
+        assert not parameters
 
 
 # ---------------------------------------------------------------------------

--- a/providers/clickhousedb/tests/unit/clickhousedb/hooks/test_clickhouse.py
+++ b/providers/clickhousedb/tests/unit/clickhousedb/hooks/test_clickhouse.py
@@ -1147,8 +1147,10 @@ class TestClickHouseHookTestConnection:
         hook = ClickHouseHook(clickhouse_conn_id="clickhouse_test")
         hook.test_connection()
 
-        # clickhouse_connect.dbapi.Cursor passes parameters positionally; None when not provided.
-        mock_client.query.assert_called_once_with("SELECT 1", None)
+        # Assert only on the SQL: the extra arguments clickhouse_connect's Cursor
+        # passes through vary between releases.
+        mock_client.query.assert_called_once()
+        assert mock_client.query.call_args.args[0] == "SELECT 1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CI error : https://github.com/apache/airflow/actions/runs/29713514873

The assertion now checks only the SQL that gets sent, which is what the test is actually about, so it passes across the whole supported clickhouse-connect range.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)