### PR TITLE
Update documented tested database versions for Airflow 3.3

### DIFF
--- a/airflow-core/docs/installation/prerequisites.rst
+++ b/airflow-core/docs/installation/prerequisites.rst
@@ -26,8 +26,8 @@ Airflow® is tested with:
 
 * Databases:
 
-  * PostgreSQL: 13, 14, 15, 16, 17
-  * MySQL: 8.0, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
+  * PostgreSQL: 14, 15, 16, 17, 18
+  * MySQL: 8.0, 8.4, `Innovation <https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions>`_
   * SQLite: 3.15.0+
 
 * Kubernetes: 1.30, 1.31, 1.32, 1.33, 1.34, 1.35


### PR DESCRIPTION
The `update-tested-versions` hook (added in #70109) landed on `v3-3-test` and immediately caught pre-existing drift: `prerequisites.rst` still listed PostgreSQL 13-17 and omitted MySQL 8.4, while `global_constants.py` and `README.md` had already moved to PostgreSQL 14-18 and MySQL 8.0/8.4.

Users reading the prerequisites were told Airflow is tested against a Postgres version it no longer covers, and not told about one it does.

This fixes both failing jobs on [run 29706531222](https://github.com/apache/airflow/actions/runs/29706531222) — `Basic tests / Scripts tests` (`test_prerequisites_in_sync`) and `CI image checks / Static checks` — which were the same tripwire seen from two angles. The diff is exactly what `prek run update-tested-versions --all-files` generates.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)