### PR TITLE
Reject zero step in mapped XCom slices

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/xcoms.py
@@ -190,6 +190,12 @@ def get_mapped_xcom_by_slice(
     params: Annotated[GetXComSliceFilterParams, Query()],
     session: SessionDep,
 ) -> XComSequenceSliceResponse:
+    if params.step == 0:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"reason": "invalid_step", "message": "XCom slice step cannot be zero."},
+        )
+
     query = XComModel.get_many(
         run_id=run_id,
         key=key,
@@ -199,7 +205,7 @@ def get_mapped_xcom_by_slice(
     )
     query = query.order_by(None)
 
-    step = params.step or 1
+    step = params.step if params.step is not None else 1
 
     # We want to optimize negative slicing (e.g. seq[-10:]) by not doing an
     # additional COUNT query if possible. This is possible unless both start and

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_xcoms.py
@@ -280,6 +280,15 @@ class TestXComsGetEndpoint:
         assert response.status_code == 200
         assert response.json() == ["f", "o", "b"][key]
 
+    def test_xcom_get_with_zero_slice_step(self, client):
+        response = client.get("/execution/xcoms/dag/runid/task/xcom_1/slice?step=0")
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == {
+            "reason": "invalid_step",
+            "message": "XCom slice step cannot be zero.",
+        }
+
     @pytest.mark.parametrize(
         ("include_prior_dates", "expected_xcoms"),
         [[True, ["earlier_value", "later_value"]], [False, ["later_value"]]],


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes #70123 

A mapped XCom slice with `step=0` is invalid, but the endpoint silently treated it as `step=1`, hiding malformed client requests.

This change returns HTTP 422 with an `invalid_step` response for every Execution API version. The default step of `1` is now applied only when the parameter is omitted, preserving positive and negative step behavior.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - GPT-5.6 Sol

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
