### PR TITLE
Guard the backfill dag-runs list query count and tidy test params

### DIFF
--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -251,7 +251,8 @@ class TestListBackfillDagRuns(TestBackfillEndpoint):
         session.add_all([bdr1, bdr2])
         session.commit()
 
-        response = test_client.get(f"/backfills/{b.id}/dag_runs")
+        with assert_queries_count(5):
+            response = test_client.get(f"/backfills/{b.id}/dag_runs")
         assert response.status_code == 200
         data = response.json()
         assert data["total_entries"] == 2
@@ -321,13 +322,13 @@ class TestListBackfillDagRuns(TestBackfillEndpoint):
             )
         session.commit()
 
-        response = test_client.get(f"/backfills/{b.id}/dag_runs?limit=2&offset=0")
+        response = test_client.get(f"/backfills/{b.id}/dag_runs", params={"limit": 2, "offset": 0})
         assert response.status_code == 200
         data = response.json()
         assert data["total_entries"] == 3
         assert len(data["backfill_dag_runs"]) == 2
 
-        response = test_client.get(f"/backfills/{b.id}/dag_runs?limit=2&offset=2")
+        response = test_client.get(f"/backfills/{b.id}/dag_runs", params={"limit": 2, "offset": 2})
         assert response.status_code == 200
         data = response.json()
         assert len(data["backfill_dag_runs"]) == 1
@@ -376,7 +377,7 @@ class TestListBackfillDagRuns(TestBackfillEndpoint):
             )
         session.commit()
 
-        response = test_client.get(f"/backfills/{b.id}/dag_runs?order_by={order_by}")
+        response = test_client.get(f"/backfills/{b.id}/dag_runs", params={"order_by": order_by})
         assert response.status_code == 200
         data = response.json()
         assert data["backfill_dag_runs"][0]["sort_ordinal"] == expected_first_ordinal


### PR DESCRIPTION
Follow-up to #67381.

The `GET /backfills/{backfill_id}/dag_runs` endpoint added in #67381 relies on `joinedload` to keep its query count constant, but its tests didn't assert that — so a change that drops the eager-load could silently reintroduce an N+1.

- Add an `assert_queries_count(5)` guard on the happy-path test. Verified the count is constant: 2 dag runs and 6 dag runs both issue 5 queries, so nothing scales with the number of rows.
- Let the test client encode the query parameters from a native `dict` (`params={...}`) instead of hand-building `?limit=...&offset=...` / `?order_by=...` strings, so the client handles the encoding.

Test-only change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)