### PR TITLE
Fix deadlock when concurrent tasks queue the same asset's downstream dags

### DIFF
--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -65,6 +65,18 @@ if TYPE_CHECKING:
 log = structlog.get_logger(__name__)
 
 
+def _sorted_by_dag_id(dags: Collection[DagModel]) -> list[DagModel]:
+    """
+    Order dags deterministically before queueing their AssetDagRunQueue rows.
+
+    ``dags_to_queue`` is a set, whose iteration order varies between processes. If two
+    concurrent transactions queue the same dags for one asset in different orders, they take
+    the per-row locks (from ON CONFLICT / ON DUPLICATE KEY / the SAVEPOINT merge) in opposite
+    orders and can deadlock. Inserting in a fixed order removes that lock-ordering cycle.
+    """
+    return sorted(dags, key=lambda dag: dag.dag_id)
+
+
 @contextmanager
 def _lock_asset_model(
     *,
@@ -808,7 +820,7 @@ class AssetManager(LoggingMixin):
                 cls.logger().debug("Skipping record %s", item, exc_info=True)
             return dag.dag_id
 
-        queued_results = (_queue_dagrun_if_needed(dag) for dag in dags_to_queue)
+        queued_results = (_queue_dagrun_if_needed(dag) for dag in _sorted_by_dag_id(dags_to_queue))
         if queued_dag_ids := [r for r in queued_results if r is not None]:
             cls.logger().debug("consuming dag ids %s", queued_dag_ids)
 
@@ -818,7 +830,7 @@ class AssetManager(LoggingMixin):
     ) -> None:
         from sqlalchemy.dialects.postgresql import insert
 
-        values = [{"target_dag_id": dag.dag_id} for dag in dags_to_queue]
+        values = [{"target_dag_id": dag.dag_id} for dag in _sorted_by_dag_id(dags_to_queue)]
         stmt = insert(AssetDagRunQueue).values(asset_id=asset_id).on_conflict_do_nothing()
         session.execute(stmt, values)
 
@@ -828,7 +840,7 @@ class AssetManager(LoggingMixin):
     ) -> None:
         from sqlalchemy.dialects.mysql import insert
 
-        values = [{"target_dag_id": dag.dag_id} for dag in dags_to_queue]
+        values = [{"target_dag_id": dag.dag_id} for dag in _sorted_by_dag_id(dags_to_queue)]
         stmt = insert(AssetDagRunQueue).values(asset_id=asset_id)
         # MySQL has no "ON CONFLICT DO NOTHING"; a no-op ON DUPLICATE KEY UPDATE turns a
         # conflicting (asset_id, target_dag_id) row into a no-op rather than an error,

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -65,7 +65,7 @@ if TYPE_CHECKING:
 log = structlog.get_logger(__name__)
 
 
-def _sorted_by_dag_id(dags: Collection[DagModel]) -> list[DagModel]:
+def _sorted_by_dag_id(dags: set[DagModel]) -> list[DagModel]:
     """
     Order dags deterministically before queueing their AssetDagRunQueue rows.
 

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import Session
 from airflow import settings
 from airflow._shared.observability.metrics.base_stats_logger import StatsLogger
 from airflow._shared.timezones import timezone
-from airflow.assets.manager import AssetManager
+from airflow.assets.manager import AssetManager, _sorted_by_dag_id
 from airflow.models.asset import (
     AssetAliasModel,
     AssetDagRunQueue,
@@ -251,6 +251,43 @@ class TestAssetManager:
         compiled = str(stmt.compile(dialect=mysql.dialect())).upper()
         assert "ON DUPLICATE KEY UPDATE" in compiled
         assert values == [{"target_dag_id": "dag1"}]
+
+    def test_sorted_by_dag_id_orders_deterministically(self):
+        dags = [DagModel(dag_id="dag_c"), DagModel(dag_id="dag_a"), DagModel(dag_id="dag_b")]
+        assert [d.dag_id for d in _sorted_by_dag_id(dags)] == ["dag_a", "dag_b", "dag_c"]
+
+    @pytest.mark.parametrize(
+        "helper", ["_queue_dagruns_nonpartitioned_postgres", "_queue_dagruns_nonpartitioned_mysql"]
+    )
+    def test_queue_dagruns_single_statement_inserts_in_helper_order(self, helper):
+        """Both single-statement paths must build the insert from _sorted_by_dag_id, not set order."""
+        dags = {DagModel(dag_id="dag_a"), DagModel(dag_id="dag_b"), DagModel(dag_id="dag_c")}
+        ordered = [DagModel(dag_id="dag_c"), DagModel(dag_id="dag_b"), DagModel(dag_id="dag_a")]
+        session = mock.MagicMock(spec=Session)
+
+        with mock.patch("airflow.assets.manager._sorted_by_dag_id", return_value=ordered) as sorter:
+            getattr(AssetManager, helper)(asset_id=1, dags_to_queue=dags, session=session)
+
+        sorter.assert_called_once_with(dags)
+        # The insert order must follow the helper's return, not the set's iteration order.
+        _, values = session.execute.call_args.args
+        assert values == [{"target_dag_id": d.dag_id} for d in ordered]
+
+    def test_queue_dagruns_slow_path_merges_in_helper_order(self):
+        """The per-row SAVEPOINT path must merge from _sorted_by_dag_id, not set order."""
+        dags = {DagModel(dag_id="dag_a"), DagModel(dag_id="dag_b"), DagModel(dag_id="dag_c")}
+        ordered = [DagModel(dag_id="dag_c"), DagModel(dag_id="dag_b"), DagModel(dag_id="dag_a")]
+        session = mock.MagicMock(spec=Session)
+
+        with mock.patch("airflow.assets.manager._sorted_by_dag_id", return_value=ordered) as sorter:
+            AssetManager._queue_dagruns_nonpartitioned_slow_path(
+                asset_id=1, dags_to_queue=dags, session=session
+            )
+
+        sorter.assert_called_once_with(dags)
+        # The merge order must follow the helper's return, not the set's iteration order.
+        merged = [call.args[0].target_dag_id for call in session.merge.call_args_list]
+        assert merged == [d.dag_id for d in ordered]
 
     def test_register_asset_change_notifies_asset_listener(
         self, session, mock_task_instance, testing_dag_bundle, listener_manager


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Fix deadlock when concurrent tasks queue the same asset's downstream dags
---
### Background
When a task produces an asset, the downstream Dags scheduled on that asset need to run. Airflow records this in the `asset_dag_run_queue` (ADRQ) table, one row per `(asset_id, target_dag_id)`. So when a task succeeds and updates asset `S`, `register_asset_change` inserts one ADRQ row for every Dag scheduled on `S`. Those Dags are collected into a Python `set` (`dags_to_queue`), and the rows are inserted by looping over that set.

### Why
A Python `set` has no stable order (The essence of `set` is a hash table). Here, the elements are `DagModel` objects, freshly loaded at different memory addresses in each process, so two processes can loop over the same Dags in opposite orders.

When two tasks finish at the same time and both emit to the same asset, they insert the same ADRQ rows, but maybe in opposite orders. Each insert holds a row lock until commit. So transaction A can hold row `(S, dag_a)` and wait for `(S, dag_b)`, while transaction B holds `(S, dag_b)` and waits for `(S, dag_a)`. **That is a deadlock.** Postgres aborts one side and it retries, which adds latency and error noise under high asset fan-out.

### What
Insert the rows in a fixed order, sorted by `dag_id`, so every process takes the row locks in the same order and the cycle cannot form. A small shared helper `_sorted_by_dag_id` is used in all three insert paths (postgres `ON CONFLICT`, mysql `ON DUPLICATE KEY`, and the per-row `SAVEPOINT` fallback), because all three loop over the same set.


I was running the concurrent test for #70078 and found that this problem exists on `main`.
Then I reproduced it on Postgres with a script that has 8 concurrent transactions insert one asset's downstream rows in opposite orders (what two processes' set iteration can produce). Over 20 rounds it hit 658 deadlocks with the old order and 0 after sorting. I only benchmarked Postgres. MySQL uses InnoDB row locks with the same inversion, so sorting fixes it there too. The SQLite path cannot deadlock this way and is sorted only for consistency.
<details>
  <summary>The script for reproduce:</summary>

```python

from __future__ import annotations

import threading
import time

from sqlalchemy import delete
from sqlalchemy.dialects.postgresql import insert
from sqlalchemy.exc import OperationalError

from airflow import settings
from airflow.models.asset import AssetActive, AssetDagRunQueue, AssetModel, DagScheduleAssetReference
from airflow.models.dag import DagModel
from airflow.models.dagbundle import DagBundleModel
from airflow.utils.session import create_session

ASSET_ID = 1
DOWNSTREAM_DAGS = ["dag_a", "dag_b", "dag_c", "dag_d"]
N_THREADS = 8
N_ROUNDS = 20
ROW_GAP = 0.004  # small pause between rows to widen the lock window


def _seed():
    with create_session() as s:
        s.execute(delete(AssetDagRunQueue))
        s.execute(delete(DagScheduleAssetReference))
        s.query(AssetActive).delete()
        s.query(AssetModel).delete()
        s.query(DagModel).filter(DagModel.dag_id.in_(DOWNSTREAM_DAGS)).delete(synchronize_session=False)
        s.merge(DagBundleModel(name="repro"))
        s.flush()  # bundle must exist before dags reference it (FK)
        asset = AssetModel(id=ASSET_ID, name="S", uri="s3://bucket/S", group="asset", extra={})
        s.add_all([asset, AssetActive.for_asset(asset)])
        for d in DOWNSTREAM_DAGS:
            s.add(DagModel(dag_id=d, bundle_name="repro", is_stale=False, fileloc=f"{d}.py"))
        s.flush()
        asset.scheduled_dags = [DagScheduleAssetReference(dag_id=d) for d in DOWNSTREAM_DAGS]


def _insert_rows(order, sort_fix, counters, barrier):
    dag_ids = sorted(order) if sort_fix else order  # the fix: always sort first
    barrier.wait()
    while True:
        try:
            with create_session() as session:
                for dag_id in dag_ids:
                    stmt = (
                        insert(AssetDagRunQueue)
                        .values(asset_id=ASSET_ID, target_dag_id=dag_id)
                        .on_conflict_do_nothing()
                    )
                    session.execute(stmt)
                    time.sleep(ROW_GAP)
            return
        except OperationalError as e:
            if "deadlock detected" in str(e).lower():
                counters["deadlocks"] += 1
                continue  # retry: the losing side re-runs and eventually wins
            raise


def _run(sort_fix):
    counters = {"deadlocks": 0}
    forward = DOWNSTREAM_DAGS
    reverse = list(reversed(DOWNSTREAM_DAGS))
    for _ in range(N_ROUNDS):
        with create_session() as s:  # fresh rows each round so ON CONFLICT actually inserts
            s.execute(delete(AssetDagRunQueue))
        barrier = threading.Barrier(N_THREADS)
        threads = [
            threading.Thread(
                target=_insert_rows,
                args=(forward if i % 2 == 0 else reverse, sort_fix, counters, barrier),
            )
            for i in range(N_THREADS)
        ]
        for t in threads:
            t.start()
        for t in threads:
            t.join()
    return counters["deadlocks"]


def main():
    if settings.engine.dialect.name != "postgresql":
        raise SystemExit("Run under --backend postgres (row locks are needed to reproduce).")
    _seed()
    unsorted_deadlocks = _run(sort_fix=False)
    sorted_deadlocks = _run(sort_fix=True)
    print(
        f"\n=== ADRQ insert-order deadlock — {N_THREADS} threads x {N_ROUNDS} rounds, "
        f"{len(DOWNSTREAM_DAGS)} downstream dags ===\n"
        f"  UNSORTED (insert in set order, forward vs reversed): {unsorted_deadlocks} deadlocks\n"
        f"  SORTED   (sort by dag_id first, the fix)           : {sorted_deadlocks} deadlocks\n"
    )


if __name__ == "__main__":
    main()

```
</details>

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
