### PR TITLE
Fix output type loss in AgentOperator's human-in-the-loop review

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
@@ -22,8 +22,7 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Protocol
 
-from pydantic import BaseModel, TypeAdapter
-
+from airflow.providers.common.ai.utils.output_type import dump_output_to_json
 from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_3_PLUS
 
 if AIRFLOW_V_3_3_PLUS:
@@ -123,11 +122,8 @@ class LLMApprovalMixin:
         self.validate_approval_prompt()
 
         raw_output = output
-        if isinstance(output, BaseModel):
-            output = output.model_dump_json()
-        elif not isinstance(output, str):
-            # JSON round-trip: execute_complete validates the string back into output_type.
-            output = TypeAdapter(type(output)).dump_json(output).decode()
+        # JSON round-trip: execute_complete validates the string back into output_type.
+        output = dump_output_to_json(output)
 
         ti_id = context["task_instance"].id
 

--- a/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/mixins/approval.py
@@ -21,8 +21,7 @@ import logging
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Protocol
 
-from pydantic import BaseModel, TypeAdapter
-
+from airflow.providers.common.ai.utils.output_type import dump_output_to_json
 from airflow.providers.common.compat.version_compat import AIRFLOW_V_3_3_PLUS
 
 if AIRFLOW_V_3_3_PLUS:
@@ -105,11 +104,8 @@ class LLMApprovalMixin:
                 "require_approval."
             )
 
-        if isinstance(output, BaseModel):
-            output = output.model_dump_json()
-        elif not isinstance(output, str):
-            # JSON round-trip: execute_complete validates the string back into output_type.
-            output = TypeAdapter(type(output)).dump_json(output).decode()
+        # JSON round-trip: execute_complete validates the string back into output_type.
+        output = dump_output_to_json(output)
 
         ti_id = context["task_instance"].id
 

--- a/providers/common/ai/src/airflow/providers/common/ai/mixins/hitl_review.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/mixins/hitl_review.py
@@ -21,8 +21,6 @@ import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Protocol
 
-from pydantic import BaseModel
-
 from airflow.providers.common.ai.exceptions import HITLMaxIterationsError
 from airflow.providers.common.ai.utils.hitl_review import (
     XCOM_AGENT_OUTPUT_PREFIX,
@@ -32,6 +30,7 @@ from airflow.providers.common.ai.utils.hitl_review import (
     HumanActionData,
     SessionStatus,
 )
+from airflow.providers.common.ai.utils.output_type import dump_output_to_json
 
 log = logging.getLogger(__name__)
 
@@ -268,8 +267,4 @@ class HITLReviewMixin:
 
     @staticmethod
     def _to_string(output: Any) -> str:
-        if isinstance(output, BaseModel):
-            return output.model_dump_json()
-        if not isinstance(output, str):
-            return str(output)
-        return output
+        return dump_output_to_json(output)

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from dataclasses import replace
 from datetime import timedelta
@@ -496,16 +495,11 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
                 output,
                 message_history=result.all_messages(),
             )
-            if isinstance(self.output_type, type) and issubclass(self.output_type, BaseModel):
-                return rehydrate_pydantic_output(
-                    self.output_type,
-                    result_str,
-                    serialize_output=self._serialize_model_output,
-                )
-            try:
-                return json.loads(result_str)
-            except (ValueError, TypeError):
-                return result_str
+            return rehydrate_pydantic_output(
+                self.output_type,
+                result_str,
+                serialize_output=self._serialize_model_output,
+            )
 
         if self._serialize_model_output and isinstance(output, BaseModel):
             output = output.model_dump()
@@ -556,7 +550,4 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         result = agent.run_sync(feedback, message_history=messages, usage_limits=self.usage_limits)
         log_run_summary(self.log, result)
 
-        output = result.output
-        if isinstance(output, BaseModel):
-            output = output.model_dump_json()
-        return str(output), result.all_messages()
+        return self._to_string(result.output), result.all_messages()

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from dataclasses import replace
 from datetime import timedelta
@@ -493,16 +492,11 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
                 output,
                 message_history=result.all_messages(),
             )
-            if isinstance(self.output_type, type) and issubclass(self.output_type, BaseModel):
-                return rehydrate_pydantic_output(
-                    self.output_type,
-                    result_str,
-                    serialize_output=self._serialize_model_output,
-                )
-            try:
-                return json.loads(result_str)
-            except (ValueError, TypeError):
-                return result_str
+            return rehydrate_pydantic_output(
+                self.output_type,
+                result_str,
+                serialize_output=self._serialize_model_output,
+            )
 
         if self._serialize_model_output and isinstance(output, BaseModel):
             output = output.model_dump()
@@ -553,7 +547,4 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
         result = agent.run_sync(feedback, message_history=messages, usage_limits=self.usage_limits)
         log_run_summary(self.log, result)
 
-        output = result.output
-        if isinstance(output, BaseModel):
-            output = output.model_dump_json()
-        return str(output), result.all_messages()
+        return self._to_string(result.output), result.all_messages()

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/output_type.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/output_type.py
@@ -19,9 +19,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
+from pydantic_ai import NativeOutput, PromptedOutput, ToolOutput
+
+log = logging.getLogger(__name__)
+
+_OUTPUT_MARKERS = (ToolOutput, NativeOutput, PromptedOutput)
 
 
 def dump_output_to_json(output: Any) -> str:
@@ -38,6 +44,10 @@ def dump_output_to_json(output: Any) -> str:
     try:
         return TypeAdapter(type(output)).dump_json(output).decode()
     except Exception:
+        log.warning(
+            "Could not build a pydantic schema for %s; showing its repr to the reviewer instead.",
+            type(output),
+        )
         return str(output)
 
 
@@ -55,8 +65,13 @@ def rehydrate_pydantic_output(
     reviewer. ``str`` outputs pass through unchanged; any other ``output_type``
     (``BaseModel`` subclass, ``int``, ``list[str]``, ...) is validated with a
     pydantic ``TypeAdapter``. When validation fails (reviewer edited the string
-    into something the type rejects), returns ``raw`` unchanged. An
-    ``output_type`` pydantic cannot build a schema for falls back to plain JSON.
+    into something the type rejects), returns ``raw`` unchanged. A
+    ``ToolOutput``/``NativeOutput``/``PromptedOutput`` marker wrapping a single
+    type is unwrapped first. An ``output_type`` that is a ``[A, B]`` union list,
+    a marker wrapping one, or a pydantic-ai *output function* falls back to
+    plain JSON -- ``TypeAdapter`` builds an *arguments* schema for an output
+    function rather than raising, so validating against it would call the
+    function a second time with reviewer-controlled input.
 
     When ``serialize_output`` is ``True``, returns the model dumped to a
     ``dict`` -- matches the operator's ``serialize_output=True`` opt-in for
@@ -64,18 +79,22 @@ def rehydrate_pydantic_output(
     """
     if output_type is str:
         return raw
-    try:
-        adapter = TypeAdapter(output_type)
-    except Exception:
-        # No pydantic schema for this output_type: a ToolOutput/NativeOutput/
-        # PromptedOutput marker, an output function, or a ``[A, B]`` union list.
-        # These reach us because the operator passes output_type straight to
-        # Agent(...). Schema-build failures are not ValidationError subclasses,
-        # so raising here would lose an already-approved output.
+
+    unwrapped = output_type
+    if isinstance(output_type, _OUTPUT_MARKERS):
+        unwrapped = output_type.output if isinstance(output_type, ToolOutput) else output_type.outputs
+
+    if not isinstance(unwrapped, type):
+        # Not a plain class: an output function, a ``[A, B]`` union list, or a
+        # marker wrapping one. These reach us because the operator passes
+        # output_type straight to Agent(...). Fall back to plain JSON rather
+        # than risk building a schema that re-invokes an output function.
         try:
             return json.loads(raw)
         except (ValueError, TypeError):
             return raw
+
+    adapter: TypeAdapter[Any] = TypeAdapter(unwrapped)
     try:
         rehydrated = adapter.validate_json(raw)
     except (ValidationError, ValueError, TypeError):

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/output_type.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/output_type.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, get_origin
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from pydantic_ai import NativeOutput, PromptedOutput, ToolOutput
@@ -63,19 +63,24 @@ def rehydrate_pydantic_output(
     Used by the HITL/approval paths in ``LLMOperator`` and ``AgentOperator``
     that round-trip the output through a string when deferring to a human
     reviewer. ``str`` outputs pass through unchanged; any other ``output_type``
-    (``BaseModel`` subclass, ``int``, ``list[str]``, ...) is validated with a
-    pydantic ``TypeAdapter``. When validation fails (reviewer edited the string
-    into something the type rejects), returns ``raw`` unchanged. A
+    (``BaseModel`` subclass, ``int``, ``list[str]``, ``list[A]`` for a
+    ``BaseModel`` subclass ``A``, ...) is validated with a pydantic
+    ``TypeAdapter``. When validation fails (reviewer edited the string into
+    something the type rejects), returns ``raw`` unchanged. A
     ``ToolOutput``/``NativeOutput``/``PromptedOutput`` marker wrapping a single
-    type is unwrapped first. An ``output_type`` that is a ``[A, B]`` union list,
-    a marker wrapping one, or a pydantic-ai *output function* falls back to
-    plain JSON -- ``TypeAdapter`` builds an *arguments* schema for an output
-    function rather than raising, so validating against it would call the
-    function a second time with reviewer-controlled input.
+    type is unwrapped first. An ``output_type`` that is a ``[A, B]`` union
+    list, a marker wrapping one, or a pydantic-ai *output function* falls back
+    to plain JSON instead -- none of those are a plain class or a generic
+    alias ``TypeAdapter`` can build a schema for from the type alone, and an
+    output function in particular must never reach ``TypeAdapter``: it builds
+    an *arguments* schema for a callable rather than raising, so validating
+    against it would call the function a second time with reviewer-controlled
+    input.
 
-    When ``serialize_output`` is ``True``, returns the model dumped to a
-    ``dict`` -- matches the operator's ``serialize_output=True`` opt-in for
-    consumers that want the dict shape.
+    When ``serialize_output`` is ``True``, returns the value dumped to plain
+    Python containers (``dict``/``list``/scalars, with any nested
+    ``BaseModel`` dumped too) -- matches the operator's
+    ``serialize_output=True`` opt-in for consumers that want the dict shape.
     """
     if output_type is str:
         return raw
@@ -84,11 +89,12 @@ def rehydrate_pydantic_output(
     if isinstance(output_type, _OUTPUT_MARKERS):
         unwrapped = output_type.output if isinstance(output_type, ToolOutput) else output_type.outputs
 
-    if not isinstance(unwrapped, type):
-        # Not a plain class: an output function, a ``[A, B]`` union list, or a
-        # marker wrapping one. These reach us because the operator passes
-        # output_type straight to Agent(...). Fall back to plain JSON rather
-        # than risk building a schema that re-invokes an output function.
+    if not isinstance(unwrapped, type) and get_origin(unwrapped) is None:
+        # Not a plain class or generic alias: an output function, a ``[A, B]``
+        # union list, or a marker wrapping one. These reach us because the
+        # operator passes output_type straight to Agent(...). Fall back to
+        # plain JSON rather than risk building a schema that re-invokes an
+        # output function.
         try:
             return json.loads(raw)
         except (ValueError, TypeError):
@@ -99,6 +105,6 @@ def rehydrate_pydantic_output(
         rehydrated = adapter.validate_json(raw)
     except (ValidationError, ValueError, TypeError):
         return raw
-    if serialize_output and isinstance(rehydrated, BaseModel):
-        return rehydrated.model_dump()
+    if serialize_output:
+        return adapter.dump_python(rehydrated, mode="python")
     return rehydrated

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/output_type.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/output_type.py
@@ -18,9 +18,27 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
+
+
+def dump_output_to_json(output: Any) -> str:
+    """
+    Serialize an LLM output into the string carried through human review.
+
+    The inverse of :func:`rehydrate_pydantic_output`: both sides of the review
+    round-trip live here so they cannot drift apart.
+    """
+    if isinstance(output, BaseModel):
+        return output.model_dump_json()
+    if isinstance(output, str):
+        return output
+    try:
+        return TypeAdapter(type(output)).dump_json(output).decode()
+    except Exception:
+        return str(output)
 
 
 def rehydrate_pydantic_output(
@@ -37,7 +55,8 @@ def rehydrate_pydantic_output(
     reviewer. ``str`` outputs pass through unchanged; any other ``output_type``
     (``BaseModel`` subclass, ``int``, ``list[str]``, ...) is validated with a
     pydantic ``TypeAdapter``. When validation fails (reviewer edited the string
-    into something the type rejects), returns ``raw`` unchanged.
+    into something the type rejects), returns ``raw`` unchanged. An
+    ``output_type`` pydantic cannot build a schema for falls back to plain JSON.
 
     When ``serialize_output`` is ``True``, returns the model dumped to a
     ``dict`` -- matches the operator's ``serialize_output=True`` opt-in for
@@ -46,7 +65,19 @@ def rehydrate_pydantic_output(
     if output_type is str:
         return raw
     try:
-        rehydrated = TypeAdapter(output_type).validate_json(raw)
+        adapter = TypeAdapter(output_type)
+    except Exception:
+        # No pydantic schema for this output_type: a ToolOutput/NativeOutput/
+        # PromptedOutput marker, an output function, or a ``[A, B]`` union list.
+        # These reach us because the operator passes output_type straight to
+        # Agent(...). Schema-build failures are not ValidationError subclasses,
+        # so raising here would lose an already-approved output.
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return raw
+    try:
+        rehydrated = adapter.validate_json(raw)
     except (ValidationError, ValueError, TypeError):
         return raw
     if serialize_output and isinstance(rehydrated, BaseModel):

--- a/providers/common/ai/tests/unit/common/ai/mixins/test_hitl_review.py
+++ b/providers/common/ai/tests/unit/common/ai/mixins/test_hitl_review.py
@@ -107,6 +107,18 @@ def context(mock_ti):
     return {"task_instance": mock_ti}
 
 
+class TestToString:
+    """Serialization itself is covered by ``dump_output_to_json``'s own tests."""
+
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [("plain text", "plain text"), (["tag-a", "tag-b"], '["tag-a","tag-b"]'), (True, "true")],
+        ids=["str", "list", "bool"],
+    )
+    def test_delegates_to_dump_output_to_json(self, output, expected):
+        assert HITLReviewMixin._to_string(output) == expected
+
+
 class TestHITLReviewMixin:
     @patch("airflow.providers.common.ai.mixins.hitl_review.time.sleep", autospec=True)
     def test_pushes_session_and_output_on_start(

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -437,6 +437,31 @@ class TestAgentOperatorExecute:
     )
     @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
     @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_with_hitl_rehydrates_non_base_model_output(self, mock_hook_cls, mock_run_hitl):
+        mock_result = _make_mock_run_result(["tag-a", "tag-b"])
+        mock_agent = MagicMock(spec=["run_sync"])
+        mock_agent.run_sync.return_value = mock_result
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_run_hitl.return_value = '["tag-a", "tag-b"]'
+
+        op = AgentOperator(
+            task_id="test",
+            prompt="Summarize",
+            llm_conn_id="my_llm",
+            output_type=list[str],
+            enable_hitl_review=True,
+            hitl_timeout=timedelta(minutes=5),
+        )
+        context = MagicMock()
+        result = op.execute(context=context)
+
+        assert result == ["tag-a", "tag-b"]
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
+    )
+    @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
     def test_execute_with_hitl_returns_string_unchanged(self, mock_hook_cls, mock_run_hitl):
         """When enable_hitl_review=True and output_type is str, execute returns string as-is."""
         mock_result = _make_mock_run_result("Initial output")
@@ -457,6 +482,33 @@ class TestAgentOperatorExecute:
         result = op.execute(context=context)
 
         assert result == "Approved output"
+
+    @pytest.mark.skipif(
+        not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
+    )
+    @pytest.mark.parametrize("approved", ["42", '{"text": "hi"}', "true", "null"])
+    @patch("airflow.providers.common.ai.operators.agent.AgentOperator.run_hitl_review", autospec=True)
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_execute_with_hitl_does_not_parse_json_for_str_output_type(
+        self, mock_hook_cls, mock_run_hitl, approved
+    ):
+        """A JSON-parseable approved string stays a string, matching the non-HITL path."""
+        mock_agent = MagicMock(spec=["run_sync"])
+        mock_agent.run_sync.return_value = _make_mock_run_result("Initial output")
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+        mock_run_hitl.return_value = approved
+
+        op = AgentOperator(
+            task_id="test",
+            prompt="Summarize",
+            llm_conn_id="my_llm",
+            output_type=str,
+            enable_hitl_review=True,
+            hitl_timeout=timedelta(minutes=5),
+        )
+        result = op.execute(context=MagicMock())
+
+        assert result == approved
 
     @pytest.mark.skipif(
         not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"
@@ -583,6 +635,27 @@ class TestAgentOperatorRegenerateWithFeedback:
         )
 
         assert output == '{"text":"Revised","score":0.0}'
+
+    @patch("airflow.providers.common.ai.operators.agent.PydanticAIHook", autospec=True)
+    def test_regenerate_with_feedback_serializes_non_base_model_output(self, mock_hook_cls):
+        mock_result = _make_mock_run_result(["tag-a", "tag-b"])
+        mock_result.all_messages.return_value = []
+        mock_agent = MagicMock(spec=["run_sync"])
+        mock_agent.run_sync.return_value = mock_result
+        mock_hook_cls.get_hook.return_value.create_agent.return_value = mock_agent
+
+        op = AgentOperator(
+            task_id="test",
+            prompt="test",
+            llm_conn_id="my_llm",
+            output_type=list[str],
+        )
+        output, _ = op.regenerate_with_feedback(
+            feedback="Expand",
+            message_history=[],
+        )
+
+        assert output == '["tag-a","tag-b"]'
 
 
 class TestAgentOperatorDurable:

--- a/providers/common/ai/tests/unit/common/ai/utils/test_output_type.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_output_type.py
@@ -16,14 +16,37 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import BaseModel
+from pydantic_ai import ToolOutput
 
-from airflow.providers.common.ai.utils.output_type import rehydrate_pydantic_output
+from airflow.providers.common.ai.utils.output_type import (
+    dump_output_to_json,
+    rehydrate_pydantic_output,
+)
 
 
 class A(BaseModel):
     x: int
+
+
+class B(BaseModel):
+    y: int
+
+
+UNION_OUTPUT_TYPE: list[Any] = [A, B]
+
+
+class Widget:
+    """Plain class pydantic cannot build a schema for."""
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+
+    def __str__(self) -> str:
+        return f"Widget({self.n})"
 
 
 class TestRehydratePydanticOutput:
@@ -60,3 +83,39 @@ class TestRehydratePydanticOutput:
         # ``A`` requires ``x: int`` -- this payload should fail validation
         result = rehydrate_pydantic_output(A, '{"y": "no-x-field"}', serialize_output=False)
         assert result == '{"y": "no-x-field"}'
+
+    @pytest.mark.parametrize(
+        "output_type",
+        [UNION_OUTPUT_TYPE, ToolOutput(A)],
+        ids=["union-list", "tool-output-marker"],
+    )
+    def test_falls_back_to_json_when_output_type_has_no_schema(self, output_type):
+        # pydantic-ai accepts these shapes, but TypeAdapter cannot build a schema for
+        # them and the failure is not a ValidationError, so it must not escape.
+        result = rehydrate_pydantic_output(output_type, '{"x": 7}', serialize_output=False)
+        assert result == {"x": 7}
+
+    def test_returns_raw_when_output_type_has_no_schema_and_raw_is_not_json(self):
+        result = rehydrate_pydantic_output(UNION_OUTPUT_TYPE, "not-json", serialize_output=False)
+        assert result == "not-json"
+
+
+class TestDumpOutputToJson:
+    def test_returns_str_unchanged(self):
+        assert dump_output_to_json("plain text") == "plain text"
+
+    def test_uses_model_dump_json_for_base_model(self):
+        assert dump_output_to_json(A(x=7)) == '{"x":7}'
+
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [(["tag-a", "tag-b"], '["tag-a","tag-b"]'), (True, "true"), ({"k": 1}, '{"k":1}')],
+        ids=["list", "bool", "dict"],
+    )
+    def test_dumps_other_types_as_json(self, output, expected):
+        assert dump_output_to_json(output) == expected
+
+    def test_falls_back_to_str_when_type_has_no_schema(self):
+        # Reachable via a pydantic-ai output function: a non-schema-able return type
+        # only warns at agent-build time, so serialization must not raise here.
+        assert dump_output_to_json(Widget(3)) == "Widget(3)"

--- a/providers/common/ai/tests/unit/common/ai/utils/test_output_type.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_output_type.py
@@ -69,6 +69,18 @@ class TestRehydratePydanticOutput:
         result = rehydrate_pydantic_output(A, '{"x": 7}', serialize_output=True)
         assert result == {"x": 7}
 
+    def test_returns_model_instances_for_generic_alias_of_base_model(self):
+        # ``list[A]`` is not ``isinstance(..., type)`` -- it must still reach TypeAdapter
+        # rather than fall back to plain json.loads and hand back a list of dicts.
+        result = rehydrate_pydantic_output(list[A], '[{"x": 7}]', serialize_output=False)
+        assert result == [A(x=7)]
+        assert isinstance(result[0], A)
+
+    def test_returns_dicts_for_generic_alias_of_base_model_when_serialize_output(self):
+        result = rehydrate_pydantic_output(list[A], '[{"x": 7}]', serialize_output=True)
+        assert result == [{"x": 7}]
+        assert not isinstance(result[0], BaseModel)
+
     def test_returns_raw_for_str_output_type(self):
         result = rehydrate_pydantic_output(str, "anything", serialize_output=False)
         assert result == "anything"

--- a/providers/common/ai/tests/unit/common/ai/utils/test_output_type.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_output_type.py
@@ -16,11 +16,12 @@
 # under the License.
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pytest
 from pydantic import BaseModel
-from pydantic_ai import ToolOutput
+from pydantic_ai import NativeOutput, PromptedOutput, ToolOutput
 
 from airflow.providers.common.ai.utils.output_type import (
     dump_output_to_json,
@@ -47,6 +48,15 @@ class Widget:
 
     def __str__(self) -> str:
         return f"Widget({self.n})"
+
+
+CALLS: list[int] = []
+
+
+def make_widget(n: int) -> Widget:
+    """A pydantic-ai output function: called with validated *arguments*, not a schema for its return value."""
+    CALLS.append(n)
+    return Widget(n)
 
 
 class TestRehydratePydanticOutput:
@@ -84,20 +94,44 @@ class TestRehydratePydanticOutput:
         result = rehydrate_pydantic_output(A, '{"y": "no-x-field"}', serialize_output=False)
         assert result == '{"y": "no-x-field"}'
 
-    @pytest.mark.parametrize(
-        "output_type",
-        [UNION_OUTPUT_TYPE, ToolOutput(A)],
-        ids=["union-list", "tool-output-marker"],
-    )
-    def test_falls_back_to_json_when_output_type_has_no_schema(self, output_type):
-        # pydantic-ai accepts these shapes, but TypeAdapter cannot build a schema for
-        # them and the failure is not a ValidationError, so it must not escape.
-        result = rehydrate_pydantic_output(output_type, '{"x": 7}', serialize_output=False)
+    def test_falls_back_to_json_when_output_type_has_no_schema(self):
+        # pydantic-ai accepts a ``[A, B]`` union list, but TypeAdapter cannot build a
+        # schema for it and the failure is not a ValidationError, so it must not escape.
+        result = rehydrate_pydantic_output(UNION_OUTPUT_TYPE, '{"x": 7}', serialize_output=False)
         assert result == {"x": 7}
 
     def test_returns_raw_when_output_type_has_no_schema_and_raw_is_not_json(self):
         result = rehydrate_pydantic_output(UNION_OUTPUT_TYPE, "not-json", serialize_output=False)
         assert result == "not-json"
+
+    @pytest.mark.parametrize(
+        "marker",
+        [ToolOutput(A), NativeOutput(A), PromptedOutput(A)],
+        ids=["tool-output", "native-output", "prompted-output"],
+    )
+    def test_unwraps_output_marker_wrapping_a_single_type(self, marker):
+        # A marker wrapping one type unwraps to that type and validates normally --
+        # it must not fall back to json.loads and hand back a bare dict.
+        result = rehydrate_pydantic_output(marker, '{"x": 7}', serialize_output=False)
+        assert result == A(x=7)
+
+    @pytest.mark.parametrize(
+        "marker",
+        [NativeOutput([A, B]), PromptedOutput([A, B])],
+        ids=["native-output", "prompted-output"],
+    )
+    def test_falls_back_when_marker_wraps_a_sequence(self, marker):
+        result = rehydrate_pydantic_output(marker, '{"x": 7}', serialize_output=False)
+        assert result == {"x": 7}
+
+    def test_output_function_falls_back_without_invoking_it(self):
+        # TypeAdapter(make_widget) builds a schema for its *arguments*, not its return
+        # value, and does not raise -- validating against it would call make_widget a
+        # second time with reviewer-controlled input instead of falling back to JSON.
+        CALLS.clear()
+        result = rehydrate_pydantic_output(make_widget, '{"n": 3}', serialize_output=False)
+        assert result == {"n": 3}
+        assert CALLS == []
 
 
 class TestDumpOutputToJson:
@@ -119,3 +153,8 @@ class TestDumpOutputToJson:
         # Reachable via a pydantic-ai output function: a non-schema-able return type
         # only warns at agent-build time, so serialization must not raise here.
         assert dump_output_to_json(Widget(3)) == "Widget(3)"
+
+    def test_logs_warning_when_falling_back_to_str(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            dump_output_to_json(Widget(3))
+        assert any(r.levelno == logging.WARNING and "Widget" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

`AgentOperator`'s human-in-the-loop review path (`enable_hitl_review=True`) loses the original output type for any `output_type` that is neither `str` nor a Pydantic `BaseModel` (e.g. `list[str]`, `bool`, `dict`).

The output is round-tripped through a string while it's shown to a human reviewer: `HITLReviewMixin._to_string` serializes it before review, and `AgentOperator.execute()` deserializes it back into `output_type` after approval. The serialization side used `str(output)`, which produces a Python repr (e.g. `"['tag-a', 'tag-b']"`), not valid JSON.

The deserialization side then tried `json.loads()` on that repr, which always raised, and silently fell back to returning the raw repr *string* instead of the original list/bool/dict — a type change downstream tasks don't expect.

`regenerate_with_feedback()` (used when a reviewer requests changes) had the identical `str(output)` bug.

This is the same defect class already fixed for the `require_approval=True` path in #70075, which switched to `TypeAdapter(...).dump_json(...)`. That fix wasn't applied to the separate `enable_hitl_review=True` path, so it regressed here.

## Changes

- Both directions of the review round-trip now live next to each other in
  `utils/output_type.py`: the existing `rehydrate_pydantic_output()` and a new
  `dump_output_to_json()`.
- `dump_output_to_json()` replaces the three copies of the serialization block
  that had drifted apart — `HITLReviewMixin._to_string`,
  `AgentOperator.regenerate_with_feedback` and `LLMApprovalMixin.defer_for_approval`.
  That drift is how the original bug survived #70075.
- `AgentOperator.execute()`'s HITL-review branch reuses `rehydrate_pydantic_output`
  instead of a bespoke `json.loads`/`except` fallback, so both review paths behave
  consistently.

## Guarding an `output_type` pydantic cannot build a schema for

`AgentOperator` passes `output_type` straight through to `Agent(...)`, so pydantic-ai's
`[A, B]` multi-output lists, `ToolOutput`/`NativeOutput`/`PromptedOutput` markers and
output functions all reach these helpers. `TypeAdapter` raises
`PydanticSchemaGenerationError` (a `RuntimeError`, not a `ValidationError`) or
`AttributeError` on those, which neither side's `except` clause caught:

- `rehydrate_pydantic_output` now separates schema build from validation and falls
  back to plain `json.loads`. Without this an already-approved output is lost, after
  the model call and after the reviewer has signed off.
- `dump_output_to_json` falls back to `str(output)`. This one fires before the session
  XCom push, so without it the task dies before the reviewer is ever shown a review
  session. It is reachable through output functions, which only warn
  ("Falling back to unconstrained schema") for a non-schema-able return type and then
  run fine.

## Behaviour change

With the default `output_type=str`, the approved string is no longer parsed as JSON:

| Approved string | Before | After |
| --- | --- | --- |
| `'42'` | `42` | `'42'` |
| `'{"text": "hi"}'` | `{'text': 'hi'}` | `'{"text": "hi"}'` |
| `'true'` | `True` | `'true'` |
| `'null'` | `None` | `'null'` |

This matches the non-HITL path (which returns `result.output` unparsed) and the
`require_approval` path. `str` is the default `output_type` and `enable_hitl_review`
has shipped since 0.1.0, so a Dag relying on the implicit parse needs an explicit
`output_type` (e.g. `output_type=int`) or its own `json.loads()` downstream.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5, Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
