### PR TITLE
Harden common.ai SQLToolset allowed_tables against function/COPY bypass

### DIFF
--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -192,10 +192,10 @@ Parameters
   ``check_query`` as well as discovery -- every table a query references must be
   on it. See :ref:`allowed-tables-enforcement` for what this does and does not
   guarantee.
-- ``allowed_functions``: Names of functions that sqlglot does not recognise as
+- ``allowed_functions``: Names of functions that sqlglot does not recognize as
   builtins but are safe to run while ``allowed_tables`` is active (e.g.
   ``["json_build_object"]`` or a project UDF). ``None`` (default) rejects every
-  unrecognised function. Matching is case-insensitive. Only consulted when
+  unrecognized function. Matching is case-insensitive. Only consulted when
   ``allowed_tables`` is set.
 - ``schema``: Default schema/namespace for unqualified table listing and
   introspection. Schema-qualified ``allowed_tables`` entries override it per table.
@@ -654,14 +654,14 @@ When ``allowed_tables`` is set it governs every tool, not just discovery:
   (file/program I/O), and **inline comments** -- because parser-vs-engine differences
   hide in comments (MySQL executes ``/*! ... */`` while sqlglot and other engines
   ignore it).
-- **Any function sqlglot does not recognise is rejected (fail-closed).** A function
+- **Any function sqlglot does not recognize is rejected (fail-closed).** A function
   whose string argument reaches data outside the table graph --
   ``pg_read_file('/etc/passwd')`` (a file), ``query_to_xml('SELECT * FROM other_table', ...)``
   (SQL over another table), a scalar ``dblink`` (a remote database) -- carries no table
   reference for the parser to catch. Rather than maintain a denylist of such functions
   (unbounded, engine-specific, and it would fail *open* on anything missed), the toolset
   rejects every function sqlglot cannot type. Ordinary builtins (``count``, ``lower``,
-  ``sum``) are recognised and pass. A legitimate function sqlglot does not type
+  ``sum``) are recognized and pass. A legitimate function sqlglot does not type
   (``json_build_object``, ``jsonb_agg``) or a project UDF is rejected until you list it
   in ``allowed_functions``:
 

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -192,6 +192,11 @@ Parameters
   ``check_query`` as well as discovery -- every table a query references must be
   on it. See :ref:`allowed-tables-enforcement` for what this does and does not
   guarantee.
+- ``allowed_functions``: Names of functions that sqlglot does not recognise as
+  builtins but are safe to run while ``allowed_tables`` is active (e.g.
+  ``["json_build_object"]`` or a project UDF). ``None`` (default) rejects every
+  unrecognised function. Matching is case-insensitive. Only consulted when
+  ``allowed_tables`` is set.
 - ``schema``: Default schema/namespace for unqualified table listing and
   introspection. Schema-qualified ``allowed_tables`` entries override it per table.
 - ``allow_writes``: Allow data-modifying SQL (INSERT, UPDATE, DELETE, etc.).
@@ -606,9 +611,10 @@ No single layer is sufficient — they work together.
        ``get_schema``, ``query``, and ``check_query``. Queries are parsed and
        every referenced table (including via subqueries, CTEs, JOINs, and
        ``DESCRIBE``) is checked against the list before execution.
-     - Cannot police data reached through side-effecting scalar functions
-       (e.g. ``pg_read_file``), and is only as exact as the SQL parser. Pair it
-       with least-privilege database grants. See
+     - Rejects ``COPY`` and every function sqlglot cannot type (the channel for
+       ``pg_read_file`` / ``query_to_xml`` / ``dblink``) unless named in
+       ``allowed_functions``. Fail-closed, but only as exact as the SQL parser. Not a
+       security boundary -- always pair it with least-privilege database grants. See
        :ref:`allowed-tables-enforcement` below.
    * - **SQLToolset: max_rows**
      - Truncates query results to ``max_rows`` (default 50), preventing the
@@ -644,27 +650,48 @@ When ``allowed_tables`` is set it governs every tool, not just discovery:
   cross-database reference like ``otherdb.public.orders`` is refused.
 - Constructs the list cannot describe are rejected outright while it is active:
   table-valued functions (``dblink``), ``TABLE('name')`` row sources, the
-  ``TABLE <name>`` shorthand, ``SHOW``, dynamic SQL (``EXEC``), and **inline
-  comments** -- the last because parser-vs-engine differences hide in comments
-  (MySQL executes ``/*! ... */`` while sqlglot and other engines ignore it).
+  ``TABLE <name>`` shorthand, ``SHOW``, dynamic SQL (``EXEC``), ``COPY``
+  (file/program I/O), and **inline comments** -- because parser-vs-engine differences
+  hide in comments (MySQL executes ``/*! ... */`` while sqlglot and other engines
+  ignore it).
+- **Any function sqlglot does not recognise is rejected (fail-closed).** A function
+  whose string argument reaches data outside the table graph --
+  ``pg_read_file('/etc/passwd')`` (a file), ``query_to_xml('SELECT * FROM other_table', ...)``
+  (SQL over another table), a scalar ``dblink`` (a remote database) -- carries no table
+  reference for the parser to catch. Rather than maintain a denylist of such functions
+  (unbounded, engine-specific, and it would fail *open* on anything missed), the toolset
+  rejects every function sqlglot cannot type. Ordinary builtins (``count``, ``lower``,
+  ``sum``) are recognised and pass. A legitimate function sqlglot does not type
+  (``json_build_object``, ``jsonb_agg``) or a project UDF is rejected until you list it
+  in ``allowed_functions``:
+
+  .. code-block:: python
+
+      SQLToolset(
+          db_conn_id="analytics_db",
+          allowed_tables=["orders"],
+          allowed_functions=["json_build_object"],  # opt in per function you trust
+      )
 
 So ``SELECT * FROM secrets`` with ``allowed_tables=["orders"]`` is refused, and
 the rejection is handed back to the agent so it can re-target an allowed table.
 
-This is a strong **application-level guardrail**, but it is not a substitute for
-database permissions. It cannot police data reached through a function whose
-argument is itself SQL or a path: ``pg_read_file('/etc/passwd')`` reads a file,
-and ``query_to_xml('SELECT * FROM other_table', ...)`` or a scalar ``dblink``
-reads a table through a string the parser cannot inspect. Any query the engine
-parses differently from sqlglot is also a residual gap. For a hard boundary, also
-run the connection as a least-privilege role:
+.. warning::
 
-.. code-block:: sql
+    This is a strong **application-level guardrail, not a security boundary.** The
+    fail-closed function check raises the bar, but any query the engine parses
+    differently from sqlglot is a residual gap, and ``allowed_functions`` is a trust
+    decision you own. **Always** point the connection at a least-privilege database
+    role -- that is the boundary that holds even when the parser cannot see through a
+    function, and it is what actually keeps an agent (which may be under prompt
+    injection) away from data and files you have not granted it:
 
-    -- Create a read-only role with access to specific tables only
-    CREATE ROLE airflow_agent_reader;
-    GRANT SELECT ON orders, customers TO airflow_agent_reader;
-    -- Use this role's credentials in the Airflow connection
+    .. code-block:: sql
+
+        -- Create a read-only role with access to specific tables only
+        CREATE ROLE airflow_agent_reader;
+        GRANT SELECT ON orders, customers TO airflow_agent_reader;
+        -- Use this role's credentials in the Airflow connection
 
 Defense in depth: the allow-list contains the agent's *intent* (and gives it a
 correctable error), while the database role is the boundary that holds even if

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_agent.py
@@ -65,6 +65,13 @@ if SQLToolset is not None:
                 "the schema and answer the question with data."
             ),
             toolsets=[
+                # ``allowed_tables`` scopes the agent's intent, but it is an
+                # application-level guardrail, not a security boundary. Point
+                # ``postgres_default`` at a least-privilege role whose SELECT grants
+                # are limited to these tables -- that is the boundary that holds even
+                # if the agent (which may be under prompt injection) reaches for data
+                # through a function the parser cannot see. See the "Security" section
+                # of the toolsets docs.
                 SQLToolset(
                     db_conn_id="postgres_default",
                     allowed_tables=["customers", "orders"],

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_agent.py
@@ -75,6 +75,9 @@ if SQLToolset is not None:
                 SQLToolset(
                     db_conn_id="postgres_default",
                     allowed_tables=["customers", "orders"],
+                    # Functions sqlglot cannot type are rejected while allowed_tables is
+                    # set; list any the agent legitimately needs (e.g. to shape output).
+                    allowed_functions=["json_build_object"],
                     max_rows=20,
                 )
             ],

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
@@ -115,20 +115,29 @@ class SQLToolset(AbstractToolset[Any]):
         excluded by lexical scope (a same-named CTE in another scope never hides a real
         table). Constructs the list cannot describe are rejected outright while it is
         active: table-valued functions (``dblink``), ``TABLE('name')`` row sources, the
-        ``TABLE <name>`` shorthand, ``SHOW``, dynamic SQL, and **inline comments**
-        (where parser-vs-engine differences such as MySQL ``/*! ... */`` executable
-        comments hide).
+        ``TABLE <name>`` shorthand, ``SHOW``, dynamic SQL, ``COPY`` (file/program I/O),
+        **inline comments** (where parser-vs-engine differences such as MySQL
+        ``/*! ... */`` executable comments hide), and **any function the parser cannot
+        recognise** -- the channel through which ``pg_read_file`` (a file),
+        ``query_to_xml`` (SQL over another table), or a scalar ``dblink`` (a remote
+        database) reach data with no table node for the walk to catch. Ordinary builtins
+        (``count``, ``lower``) are recognised and pass; a legitimate function sqlglot does
+        not recognise (``json_build_object``, a bespoke UDF) is rejected unless named in
+        ``allowed_functions``.
 
         .. note::
             This is an application-level guardrail, enforced by parsing the SQL with
             sqlglot. It is strong defense-in-depth but not a substitute for database
-            permissions: it cannot police data reached through a function whose
-            argument is itself SQL or a path -- ``pg_read_file('...')`` (a file) or
-            ``query_to_xml('SELECT ... FROM other_table', ...)`` and ``dblink`` in
-            scalar position (a table, read through a string the parser cannot inspect)
-            -- and any query the engine parses differently from sqlglot is a residual
-            gap. For a hard guarantee, also point ``db_conn_id`` at a least-privilege
-            role whose ``SELECT`` grants are limited to the same tables.
+            permissions: an engine or query that sqlglot parses differently is a residual
+            gap. For a hard guarantee, point ``db_conn_id`` at a least-privilege role whose
+            ``SELECT`` grants are limited to the same tables -- the database role is the
+            boundary that holds even when the parser cannot see through a function.
+
+    :param allowed_functions: Names of functions that sqlglot does not recognise as
+        builtins but that are safe to run while ``allowed_tables`` is active -- e.g.
+        ``["json_build_object"]`` or a project UDF. Matching is case-insensitive. Only
+        consulted when ``allowed_tables`` is set; ``None`` (default) rejects every
+        unrecognised function.
 
     :param schema: Default schema/namespace for table listing and introspection,
         used for unqualified ``allowed_tables`` entries and unqualified
@@ -145,12 +154,18 @@ class SQLToolset(AbstractToolset[Any]):
         db_conn_id: str,
         *,
         allowed_tables: list[str] | None = None,
+        allowed_functions: list[str] | None = None,
         schema: str | None = None,
         allow_writes: bool = False,
         max_rows: int = 50,
     ) -> None:
         self._db_conn_id = db_conn_id
         self._allowed_tables: frozenset[str] | None = frozenset(allowed_tables) if allowed_tables else None
+        # Case-folded so matching a query's function names (also case-folded) is
+        # case-insensitive, mirroring how allowed_tables is compared.
+        self._allowed_functions: frozenset[str] = (
+            frozenset(f.casefold() for f in allowed_functions) if allowed_functions else frozenset()
+        )
         self._schema = schema
         self._allow_writes = allow_writes
         self._max_rows = max_rows
@@ -397,14 +412,16 @@ class SQLToolset(AbstractToolset[Any]):
         No-op when ``allowed_tables`` is unset (allow-all). Otherwise every table the
         query references (resolved scope-correctly, including catalog) must be on the
         list, and any construct the list cannot describe -- a table-valued function,
-        ``SHOW``, dynamic SQL, an inline comment, or the ``TABLE <name>`` shorthand --
-        is refused. Raises :class:`SQLSafetyError` -- ``call_tool`` turns it into a
+        ``SHOW``, dynamic SQL, an inline comment, the ``TABLE <name>`` shorthand,
+        ``COPY``, or any function the parser cannot verify (``pg_read_file``,
+        ``query_to_xml``, ``dblink``, or any UDF not in ``allowed_functions``) -- is
+        refused. Raises :class:`SQLSafetyError` -- ``call_tool`` turns it into a
         ``ModelRetry`` so the agent can re-target an allowed table, while
         ``check_query`` reports it invalid.
         """
         if self._allowed_canonical is None:
             return
-        scan = collect_table_references(statements)
+        scan = collect_table_references(statements, allowed_functions=self._allowed_functions)
         if scan.unverifiable_sources:
             raise SQLSafetyError(
                 f"Query uses a data source that cannot be checked against allowed_tables: "

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
@@ -118,11 +118,11 @@ class SQLToolset(AbstractToolset[Any]):
         ``TABLE <name>`` shorthand, ``SHOW``, dynamic SQL, ``COPY`` (file/program I/O),
         **inline comments** (where parser-vs-engine differences such as MySQL
         ``/*! ... */`` executable comments hide), and **any function the parser cannot
-        recognise** -- the channel through which ``pg_read_file`` (a file),
+        recognize** -- the channel through which ``pg_read_file`` (a file),
         ``query_to_xml`` (SQL over another table), or a scalar ``dblink`` (a remote
         database) reach data with no table node for the walk to catch. Ordinary builtins
-        (``count``, ``lower``) are recognised and pass; a legitimate function sqlglot does
-        not recognise (``json_build_object``, a bespoke UDF) is rejected unless named in
+        (``count``, ``lower``) are recognized and pass; a legitimate function sqlglot does
+        not recognize (``json_build_object``, a bespoke UDF) is rejected unless named in
         ``allowed_functions``.
 
         .. note::
@@ -133,11 +133,11 @@ class SQLToolset(AbstractToolset[Any]):
             ``SELECT`` grants are limited to the same tables -- the database role is the
             boundary that holds even when the parser cannot see through a function.
 
-    :param allowed_functions: Names of functions that sqlglot does not recognise as
+    :param allowed_functions: Names of functions that sqlglot does not recognize as
         builtins but that are safe to run while ``allowed_tables`` is active -- e.g.
         ``["json_build_object"]`` or a project UDF. Matching is case-insensitive. Only
         consulted when ``allowed_tables`` is set; ``None`` (default) rejects every
-        unrecognised function.
+        unrecognized function.
 
     :param schema: Default schema/namespace for table listing and introspection,
         used for unqualified ``allowed_tables`` entries and unqualified

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
@@ -161,8 +161,12 @@ class TableScan(NamedTuple):
     #: Human-readable descriptions of constructs that cannot be checked against an
     #: allow-list and so must be rejected while one is active: table-valued functions
     #: (``dblink``), ``TABLE('name')`` row sources, ``SHOW``, dynamic SQL
-    #: (``EXEC``/``Command``), inline comments (a parser-vs-engine differential), and
-    #: the ``TABLE <name>`` shorthand. Empty when every construct is verifiable.
+    #: (``EXEC``/``Command``), inline comments (a parser-vs-engine differential), the
+    #: ``TABLE <name>`` shorthand, a quoted identifier (case-sensitive on the engine but
+    #: matched case-insensitively here), ``COPY`` (file/program I/O), and any function
+    #: sqlglot cannot type (``exp.Anonymous``) that is not in ``allowed_functions`` -- the
+    #: channel through which ``pg_read_file`` / ``query_to_xml`` / scalar ``dblink`` reach
+    #: data with no table node. Empty when every construct is verifiable.
     unverifiable_sources: list[str]
 
 
@@ -244,7 +248,9 @@ def _is_in_scope_cte(table: exp.Table) -> bool:
     return False
 
 
-def collect_table_references(statements: list[exp.Expr]) -> TableScan:
+def collect_table_references(
+    statements: list[exp.Expr], allowed_functions: frozenset[str] = frozenset()
+) -> TableScan:
     """
     Walk parsed statements and report every real table they reach, scope-correctly.
 
@@ -270,11 +276,27 @@ def collect_table_references(statements: list[exp.Expr]) -> TableScan:
       ``TABLE <name>`` shorthand (which sqlglot parses incorrectly, leaking the
       ``TABLE`` keyword as a column), a **quoted identifier** (case-sensitive on the engine but
       matched case-insensitively here, so ``"Orders"`` could otherwise reach a table
-      distinct from the allow-listed ``orders``), and **any inline comment** --
+      distinct from the allow-listed ``orders``), **any inline comment** --
       comments are where parser-vs-engine differentials hide (MySQL executable
-      ``/*! ... */``, ``--`` not followed by whitespace, ``#``).
+      ``/*! ... */``, ``--`` not followed by whitespace, ``#``) -- and **COPY**
+      (file/program I/O whose data channel is not a table).
+    - **Any function sqlglot does not recognise is rejected (fail-closed).** A function
+      whose argument is a file path or a SQL string -- ``pg_read_file`` (a file),
+      ``query_to_xml`` (SQL over another table), a scalar ``dblink`` (a remote database) --
+      reaches data with no ``exp.Table`` node for the walk to catch. Rather than enumerate
+      every such function (a denylist is unbounded, engine-specific, and fails *open* on
+      anything missed), this rejects every unrecognised function: sqlglot models these as
+      ``exp.Anonymous``, while ordinary builtins (``count``, ``lower``) parse to typed
+      ``exp.Func`` subclasses. Legitimate builtins sqlglot does not type
+      (``json_build_object``, ``jsonb_agg``, ``age``) and bespoke UDFs are also
+      ``exp.Anonymous``; pass their names in ``allowed_functions`` to permit them. This is
+      consistent with the module's allowlist philosophy -- an incomplete allow-list refuses
+      a query (recoverable), it never leaks.
 
     :param statements: Parsed sqlglot statements (from :func:`parse_sql`).
+    :param allowed_functions: Case-folded names of otherwise-unrecognised functions to
+        allow (e.g. ``{"json_build_object"}``). Empty by default, so every function
+        sqlglot cannot type is rejected while an allow-list is active.
     :return: A :class:`TableScan` of real table references and unverifiable constructs.
     """
     tables: list[tuple[str, str, str]] = []
@@ -288,6 +310,38 @@ def collect_table_references(statements: list[exp.Expr]) -> TableScan:
         # data through text the parser cannot inspect.
         if isinstance(stmt, (exp.Command, exp.Execute)):
             unverifiable.append(f"a {type(stmt).__name__.lower()} statement")
+            continue
+        # COPY moves data between a table and the server filesystem or a spawned program
+        # (``COPY t FROM/TO PROGRAM '...'``, ``COPY t FROM/TO '<file>'``). The table it
+        # names is real and allow-listed, but the data channel -- a file or a program --
+        # is not a table the allow-list can describe, and ``FROM PROGRAM`` is arbitrary
+        # command execution. Top-level COPY is already blocked in read-only mode by the
+        # statement-type allow-list; this also refuses it under ``allow_writes`` while an
+        # allow-list is active, where only this scan runs.
+        if isinstance(stmt, exp.Copy):
+            unverifiable.append("a COPY statement")
+            continue
+        # A function whose string argument reaches a file, another table, or a program
+        # (``pg_read_file``, ``query_to_xml``, scalar ``dblink``, ...) carries no
+        # ``exp.Table`` node, so the table scan below cannot see it. sqlglot parses any
+        # function it cannot type as ``exp.Anonymous`` (typed builtins like ``count`` are
+        # ``exp.Func`` subclasses), so reject every ``exp.Anonymous`` not explicitly
+        # allow-listed rather than chase an unbounded denylist of dangerous names. A
+        # schema-qualified call (``pg_catalog.pg_read_file(...)``) parses as
+        # ``Dot(this=..., expression=Anonymous)`` with the bare name on the nested
+        # ``Anonymous``, so ``find_all`` still reaches it.
+        unknown = sorted(
+            {
+                name
+                for fn in stmt.find_all(exp.Anonymous)
+                if (name := fn.name.casefold()) not in allowed_functions
+            }
+        )
+        if unknown:
+            unverifiable.append(
+                f"function(s) the parser cannot verify against allowed_tables "
+                f"({', '.join(unknown)}); if safe, permit them via allowed_functions"
+            )
             continue
 
         # A comment is a parser-vs-engine differential vector: sqlglot drops it, but the

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/sql_validation.py
@@ -280,12 +280,12 @@ def collect_table_references(
       comments are where parser-vs-engine differentials hide (MySQL executable
       ``/*! ... */``, ``--`` not followed by whitespace, ``#``) -- and **COPY**
       (file/program I/O whose data channel is not a table).
-    - **Any function sqlglot does not recognise is rejected (fail-closed).** A function
+    - **Any function sqlglot does not recognize is rejected (fail-closed).** A function
       whose argument is a file path or a SQL string -- ``pg_read_file`` (a file),
       ``query_to_xml`` (SQL over another table), a scalar ``dblink`` (a remote database) --
       reaches data with no ``exp.Table`` node for the walk to catch. Rather than enumerate
       every such function (a denylist is unbounded, engine-specific, and fails *open* on
-      anything missed), this rejects every unrecognised function: sqlglot models these as
+      anything missed), this rejects every unrecognized function: sqlglot models these as
       ``exp.Anonymous``, while ordinary builtins (``count``, ``lower``) parse to typed
       ``exp.Func`` subclasses. Legitimate builtins sqlglot does not type
       (``json_build_object``, ``jsonb_agg``, ``age``) and bespoke UDFs are also
@@ -294,7 +294,7 @@ def collect_table_references(
       a query (recoverable), it never leaks.
 
     :param statements: Parsed sqlglot statements (from :func:`parse_sql`).
-    :param allowed_functions: Case-folded names of otherwise-unrecognised functions to
+    :param allowed_functions: Case-folded names of otherwise-unrecognized functions to
         allow (e.g. ``{"json_build_object"}``). Empty by default, so every function
         sqlglot cannot type is rejected while an allow-list is active.
     :return: A :class:`TableScan` of real table references and unverifiable constructs.
@@ -321,6 +321,14 @@ def collect_table_references(
         if isinstance(stmt, exp.Copy):
             unverifiable.append("a COPY statement")
             continue
+        # A bare aliased expression is never a valid top-level statement -- sqlglot only
+        # produces one by mis-parsing input it does not model. Snowflake ``LIST @stage`` /
+        # ``LS @stage`` (list a stage's files) parse this way, as ``Column AS Parameter``.
+        # Read-only mode already rejects it via the statement-type allow-list; this also
+        # refuses it on the ``allow_writes`` path, where only this scan runs.
+        if isinstance(stmt, exp.Alias):
+            unverifiable.append("a statement sqlglot could not parse as a query (e.g. Snowflake LIST @stage)")
+            continue
         # A function whose string argument reaches a file, another table, or a program
         # (``pg_read_file``, ``query_to_xml``, scalar ``dblink``, ...) carries no
         # ``exp.Table`` node, so the table scan below cannot see it. sqlglot parses any
@@ -340,7 +348,7 @@ def collect_table_references(
         if unknown:
             unverifiable.append(
                 f"function(s) the parser cannot verify against allowed_tables "
-                f"({', '.join(unknown)}); if safe, permit them via allowed_functions"
+                f"({', '.join(unknown)}); if these functions are trusted, permit them via allowed_functions"
             )
             continue
 

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
@@ -618,7 +618,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         assert "cannot be checked against allowed_tables" in result["error"]
 
     def test_query_allows_typed_builtins_over_allowed_table(self):
-        """sqlglot-recognised builtins over an allowed table pass without allowed_functions."""
+        """sqlglot-recognized builtins over an allowed table pass without allowed_functions."""
         ts = SQLToolset("pg_default", allowed_tables=["orders"])
         ts._hook = _make_mock_db_hook(records=[(2,)], last_description=[("n",)])
         ts._hook.dialect_name = "postgresql"
@@ -629,7 +629,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         ts._hook.get_records.assert_called_once_with("SELECT count(*), lower(name) FROM orders")
 
     def test_query_blocks_unrecognized_function_by_default(self):
-        """Fail-closed: a legit-but-unrecognised builtin (json_build_object) is refused
+        """Fail-closed: a legit-but-unrecognized builtin (json_build_object) is refused
         until the operator permits it, so an unknown function can never slip through."""
         ts = SQLToolset("pg_default", allowed_tables=["orders"])
         ts._hook = _make_mock_db_hook()
@@ -642,7 +642,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         ts._hook.get_records.assert_not_called()
 
     def test_query_allows_function_named_in_allowed_functions(self):
-        """allowed_functions is the opt-in escape hatch for a safe unrecognised function."""
+        """allowed_functions is the opt-in escape hatch for a safe unrecognized function."""
         ts = SQLToolset("pg_default", allowed_tables=["orders"], allowed_functions=["json_build_object"])
         ts._hook = _make_mock_db_hook(records=[(1,)], last_description=[("obj",)])
         ts._hook.dialect_name = "postgresql"

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
@@ -567,6 +567,103 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         assert "cannot be checked against allowed_tables" in exc_info.value.message
         ts._hook.get_records.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # File read (needs a privileged role) and table exfiltration (needs only a
+            # read role) -- the two headline classes. The full function family is covered
+            # at the unit layer (test_sql_validation.py); here we prove the wiring.
+            "SELECT pg_read_file('/etc/passwd')",
+            "SELECT query_to_xml('SELECT * FROM secret_salaries', true, false, '')",
+        ],
+        ids=["pg_read_file", "query_to_xml"],
+    )
+    def test_query_blocks_data_reaching_functions(self, sql):
+        """A function reaching a file/other table/program carries no table node, so it
+        would otherwise slip past the allow-list. It must be refused before execution,
+        surfaced as a ModelRetry, with the query never handed to the database."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"])
+        ts._hook = _make_mock_db_hook()
+        ts._hook.dialect_name = "postgresql"
+
+        with pytest.raises(ModelRetry) as exc_info:
+            _run_query(ts, sql)
+
+        assert "cannot be checked against allowed_tables" in exc_info.value.message
+        ts._hook.get_records.assert_not_called()
+
+    def test_query_blocks_copy_from_program_under_allow_writes(self):
+        """COPY ... FROM PROGRAM is OS command execution. Even with allow_writes=True (only
+        the table scan runs there), the allow-list must refuse it -- its allow-listed target
+        table does not make the program channel safe."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"], allow_writes=True)
+        ts._hook = _make_mock_db_hook()
+        ts._hook.dialect_name = "postgresql"
+
+        with pytest.raises(ModelRetry) as exc_info:
+            _run_query(ts, "COPY orders FROM PROGRAM 'id > /tmp/x'")
+
+        assert "cannot be checked against allowed_tables" in exc_info.value.message
+        ts._hook.get_records.assert_not_called()
+
+    def test_check_query_reports_data_reaching_function_invalid(self):
+        """check_query surfaces the same rejection so the agent learns before executing."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"])
+        ts._hook = _make_mock_db_hook()
+        ts._hook.dialect_name = "postgresql"
+
+        result = _run_check(ts, "SELECT pg_read_file('/etc/passwd')")
+
+        assert result["valid"] is False
+        assert "cannot be checked against allowed_tables" in result["error"]
+
+    def test_query_allows_typed_builtins_over_allowed_table(self):
+        """sqlglot-recognised builtins over an allowed table pass without allowed_functions."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"])
+        ts._hook = _make_mock_db_hook(records=[(2,)], last_description=[("n",)])
+        ts._hook.dialect_name = "postgresql"
+
+        result = _run_query(ts, "SELECT count(*), lower(name) FROM orders")
+
+        assert "rows" in json.loads(result)
+        ts._hook.get_records.assert_called_once_with("SELECT count(*), lower(name) FROM orders")
+
+    def test_query_blocks_unrecognized_function_by_default(self):
+        """Fail-closed: a legit-but-unrecognised builtin (json_build_object) is refused
+        until the operator permits it, so an unknown function can never slip through."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"])
+        ts._hook = _make_mock_db_hook()
+        ts._hook.dialect_name = "postgresql"
+
+        with pytest.raises(ModelRetry) as exc_info:
+            _run_query(ts, "SELECT json_build_object('id', id) FROM orders")
+
+        assert "cannot be checked against allowed_tables" in exc_info.value.message
+        ts._hook.get_records.assert_not_called()
+
+    def test_query_allows_function_named_in_allowed_functions(self):
+        """allowed_functions is the opt-in escape hatch for a safe unrecognised function."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"], allowed_functions=["json_build_object"])
+        ts._hook = _make_mock_db_hook(records=[(1,)], last_description=[("obj",)])
+        ts._hook.dialect_name = "postgresql"
+
+        result = _run_query(ts, "SELECT json_build_object('id', id) FROM orders")
+
+        assert "rows" in json.loads(result)
+        ts._hook.get_records.assert_called_once_with("SELECT json_build_object('id', id) FROM orders")
+
+    def test_allowed_functions_does_not_permit_a_dangerous_sibling(self):
+        """Permitting one function does not open the door to another unlisted one."""
+        ts = SQLToolset("pg_default", allowed_tables=["orders"], allowed_functions=["json_build_object"])
+        ts._hook = _make_mock_db_hook()
+        ts._hook.dialect_name = "postgresql"
+
+        with pytest.raises(ModelRetry) as exc_info:
+            _run_query(ts, "SELECT json_build_object('x', pg_read_file('/etc/passwd')) FROM orders")
+
+        assert "cannot be checked against allowed_tables" in exc_info.value.message
+        ts._hook.get_records.assert_not_called()
+
     def test_query_blocks_show_when_allowlist_active(self):
         ts = SQLToolset("sf_default", allowed_tables=["orders"])
         ts._hook = _make_mock_db_hook()

--- a/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
@@ -597,6 +597,13 @@ class TestCollectTableReferences:
         scan = collect_table_references(parse_sql(sql, dialect="postgres"))
         assert scan.unverifiable_sources
 
+    @pytest.mark.parametrize("sql", ["LIST @mystage", "LS @mystage"], ids=["list", "ls"])
+    def test_flags_snowflake_stage_listing_as_unverifiable(self, sql):
+        """Snowflake LIST/LS @stage mis-parse to a bare aliased expression (Column AS
+        Parameter); reject it so it cannot list stage files past the allow-list."""
+        scan = collect_table_references(parse_sql(sql, dialect="snowflake"))
+        assert scan.unverifiable_sources
+
     @pytest.mark.parametrize(
         ("sql", "dialect"),
         [("EXEC sp_who", "tsql"), ("EXECUTE my_proc", "tsql")],

--- a/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_sql_validation.py
@@ -488,11 +488,114 @@ class TestCollectTableReferences:
         scan = collect_table_references(parse_sql(sql, dialect=dialect))
         assert scan.unverifiable_sources
 
-    def test_scalar_function_without_table_has_no_references(self):
-        """A scalar function call references no table -- the allow-list does not cover it."""
-        scan = collect_table_references(parse_sql("SELECT pg_read_file('/etc/passwd')", dialect="postgres"))
-        assert scan.tables == []
+    @pytest.mark.parametrize(
+        ("sql", "dialect"),
+        [
+            # File / large-object I/O.
+            ("SELECT pg_read_file('/etc/passwd')", "postgres"),
+            ("SELECT pg_read_binary_file('/etc/passwd')", "postgres"),
+            ("SELECT lo_export(0, '/tmp/x')", "postgres"),
+            ("SELECT lo_import('/etc/passwd')", "postgres"),
+            # Query-carrying function: the string argument reaches another table.
+            ("SELECT query_to_xml('SELECT * FROM secrets', true, false, '')", "postgres"),
+            # table_to_xml names an off-list table directly (only a read role needed).
+            ("SELECT table_to_xml('secrets', true, false, '')", "postgres"),
+            # MySQL server-side file read.
+            ("SELECT load_file('/etc/passwd')", "mysql"),
+            # Scalar dblink: reaches a remote database through a string.
+            ("SELECT dblink_exec('c', 'SELECT 1')", "postgres"),
+            # pg_ls_dir sibling that lists another server directory.
+            ("SELECT pg_ls_logdir()", "postgres"),
+            # Nested inside a projection over an allowed table -- still caught.
+            ("SELECT id, pg_read_file('/etc/passwd') FROM orders", "postgres"),
+            # Case-insensitive: uppercased name is folded before the comparison.
+            ("SELECT PG_READ_FILE('/etc/passwd')", "postgres"),
+            # Schema-qualified call: the bare name sits on the nested Anonymous, still reached.
+            ("SELECT pg_catalog.pg_read_file('/etc/passwd')", "postgres"),
+        ],
+        ids=[
+            "pg_read_file",
+            "pg_read_binary_file",
+            "lo_export",
+            "lo_import",
+            "query_to_xml",
+            "table_to_xml",
+            "load_file_mysql",
+            "dblink_exec",
+            "pg_ls_logdir",
+            "in_projection",
+            "uppercase",
+            "schema_qualified",
+        ],
+    )
+    def test_flags_data_reaching_function_as_unverifiable(self, sql, dialect):
+        """A function reaching a file/other table/program carries no table node and is
+        not a sqlglot-typed builtin, so the fail-closed scan reports it unverifiable."""
+        scan = collect_table_references(parse_sql(sql, dialect=dialect))
+        assert scan.unverifiable_sources
+
+    def test_typed_builtins_are_not_flagged(self):
+        """Built-in scalar functions parse to typed nodes, not Anonymous, so they pass."""
+        scan = collect_table_references(
+            parse_sql("SELECT count(*), lower(name), coalesce(x, 0) FROM orders", dialect="postgres")
+        )
+        assert scan.tables == [("", "", "orders")]
         assert scan.unverifiable_sources == []
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT my_udf(name) FROM orders",  # a bespoke UDF sqlglot cannot type
+            "SELECT json_build_object('id', id) FROM orders",  # a legit builtin sqlglot leaves Anonymous
+        ],
+        ids=["udf", "json_build_object"],
+    )
+    def test_unrecognized_function_flagged_by_default(self, sql):
+        """Fail-closed: any function sqlglot cannot type is rejected unless allow-listed."""
+        scan = collect_table_references(parse_sql(sql, dialect="postgres"))
+        assert scan.unverifiable_sources
+
+    def test_allowed_functions_permits_named_function(self):
+        """A function named in allowed_functions passes, and its table is still checked."""
+        scan = collect_table_references(
+            parse_sql("SELECT json_build_object('id', id) FROM orders", dialect="postgres"),
+            allowed_functions=frozenset({"json_build_object"}),
+        )
+        assert scan.tables == [("", "", "orders")]
+        assert scan.unverifiable_sources == []
+
+    def test_allowed_functions_matched_case_insensitively(self):
+        """allowed_functions entries are compared case-folded, like the query's names."""
+        scan = collect_table_references(
+            parse_sql("SELECT JSON_BUILD_OBJECT('id', id) FROM orders", dialect="postgres"),
+            allowed_functions=frozenset({"json_build_object"}),
+        )
+        assert scan.unverifiable_sources == []
+
+    def test_allowed_functions_does_not_permit_a_different_function(self):
+        """Allow-listing one function does not let a second, unlisted one through."""
+        scan = collect_table_references(
+            parse_sql(
+                "SELECT json_build_object('x', pg_read_file('/etc/passwd')) FROM orders", dialect="postgres"
+            ),
+            allowed_functions=frozenset({"json_build_object"}),
+        )
+        assert scan.unverifiable_sources
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "COPY orders FROM PROGRAM 'id > /tmp/x'",
+            "COPY orders FROM '/tmp/data.csv'",
+            "COPY orders TO '/tmp/orders.csv'",
+            "COPY orders TO PROGRAM 'cat > /tmp/x'",
+        ],
+        ids=["from_program", "from_file", "to_file", "to_program"],
+    )
+    def test_flags_copy_as_unverifiable(self, sql):
+        """COPY moves data through a file/program channel the allow-list cannot describe."""
+        scan = collect_table_references(parse_sql(sql, dialect="postgres"))
+        assert scan.unverifiable_sources
 
     @pytest.mark.parametrize(
         ("sql", "dialect"),


### PR DESCRIPTION
`SQLToolset(allowed_tables=[...])` restricts every table an LLM agent's SQL can reach. The enforcement walks the parsed statement for table references (`exp.Table` nodes) and rejects any that are not on the list. A SQL function whose argument is a file path or a SQL string carries **no table node**, so it was invisible to that scan: with `allowed_tables=["orders"]`, an agent could still run

- `SELECT pg_read_file('/etc/passwd')` — read a server file,
- `SELECT query_to_xml('SELECT * FROM secrets', ...)` — read a table off the list (needs only an ordinary read role),
- `COPY orders FROM PROGRAM 'id'` (under `allow_writes=True`) — run a shell command,

and the guardrail reported the query as allowed.

`collect_table_references` now rejects, before the query runs (handed back to the agent as a correctable error):

- **`COPY`** in any form (`FROM`/`TO`, `PROGRAM` or file). Top-level `COPY` was already blocked in read-only mode by the statement-type allow-list; this also refuses it on the `allow_writes=True` path, where only the table scan runs.
- **Any function sqlglot cannot type** (`exp.Anonymous`) — the channel `pg_read_file` / `query_to_xml` / scalar `dblink` use. Ordinary builtins (`count`, `lower`, `sum`) are recognised and pass.

## Design rationale

- **Fail-closed, not a denylist.** The obvious approach — a list of dangerous function names — is unbounded, engine-specific, and fails *open* on anything missed (it's easy to forget `table_to_xml`, MySQL `load_file`, the next release's new function). Instead, reject *every* function sqlglot doesn't recognise as a typed builtin. An incomplete allow-list refuses a query (recoverable); an incomplete denylist leaks. This also matches the module's own stated philosophy ("an allowlist is safer than a denylist because new/unexpected things are blocked by default").
- **`allowed_functions` escape hatch.** ~10% of common analytics builtins (`json_build_object`, `jsonb_agg`, `age`) and any project UDF also parse to `exp.Anonymous`, so an operator whose agent needs one lists it explicitly: `SQLToolset(allowed_tables=["orders"], allowed_functions=["json_build_object"])`. This inverts the maintenance burden from an unbounded, security-critical denylist we own to a small, local, fail-safe allow-list the operator owns.
- **Best-effort by construction — the DB role is the real boundary.** A query the engine parses differently from sqlglot, or an `allowed_functions` entry that turns out unsafe, is a residual gap. `allowed_tables` encodes the agent's *intent*; the only hard guarantee is pointing `db_conn_id` at a least-privilege database role. The docstrings, the toolset guide (now a `.. warning::`), and the example DAG all say so, and the file-read / RCE payloads additionally require a privileged DB role.

## Notes

- Detection keys on sqlglot modeling unrecognised functions as `exp.Anonymous` (verified at the `>=30.0.0` floor and current 30.12.0); the parametrized tests are the tripwire if that ever changes.
- No behaviour change for typical analytics SQL: recognised builtins over allowed tables still run; only `COPY` and unrecognised functions (absent `allowed_functions`) are refused.
- Docstrings on `SQLToolset` and `collect_table_references`, the toolset guide, and the SQL example DAG are updated to match and to lead with the least-privilege-role guidance.
