### PR TITLE
Fix mapped tasks does not validate task_id

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/decorator.py
+++ b/task-sdk/src/airflow/sdk/bases/decorator.py
@@ -45,6 +45,7 @@ from airflow.sdk.definitions._internal.expandinput import (
     ListOfDictsExpandInput,
     is_mappable,
 )
+from airflow.sdk.definitions._internal.node import validate_key
 from airflow.sdk.definitions._internal.types import NOTSET
 from airflow.sdk.definitions.asset import Asset
 from airflow.sdk.definitions.context import KNOWN_CONTEXT_KEYS
@@ -621,6 +622,7 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
         task_id = get_unique_task_id(partial_kwargs.pop("task_id"), dag, task_group)
         if task_group:
             task_id = task_group.child_id(task_id)
+        validate_key(task_id)
 
         # Logic here should be kept in sync with BaseOperatorMeta.partial().
         if partial_kwargs.get("wait_for_downstream"):

--- a/task-sdk/src/airflow/sdk/bases/operator.py
+++ b/task-sdk/src/airflow/sdk/bases/operator.py
@@ -345,6 +345,7 @@ else:
             task_group = task_group or TaskGroupContext.get_current(dag)
         if task_group:
             task_id = task_group.child_id(task_id)
+        validate_key(task_id)
 
         # Merge Dag and task group level defaults into user-supplied values.
         dag_default_args, partial_params = get_merged_defaults(

--- a/task-sdk/tests/task_sdk/definitions/decorators/test_mapped.py
+++ b/task-sdk/tests/task_sdk/definitions/decorators/test_mapped.py
@@ -17,7 +17,30 @@
 # under the License.
 from __future__ import annotations
 
+import pytest
+
 from airflow.sdk import DAG, TaskGroup
+
+
+def test_mapped_taskflow_task_id_is_validated():
+    def f(z):
+        pass
+
+    with DAG(dag_id="d", schedule=None) as dag:
+        with pytest.raises(ValueError, match="has to be made of alphanumeric"):
+            dag.task(task_id="bad*id")(f).expand(z=[])
+
+
+def test_mapped_taskflow_task_id_validated_after_unique_suffix():
+    # A 250-char id is valid the first time; the auto-added "__1" dedup suffix on the second
+    # use makes it 253 chars, so this only fails if the id is validated after deduplication.
+    def f(z):
+        pass
+
+    with DAG(dag_id="d", schedule=None) as dag:
+        dag.task(task_id="t" * 250)(f).expand(z=[])
+        with pytest.raises(ValueError, match="has to be less than 250 characters"):
+            dag.task(task_id="t" * 250)(f).expand(z=[])
 
 
 def test_mapped_task_group_id_prefix_task_id():

--- a/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
+++ b/task-sdk/tests/task_sdk/definitions/test_mappedoperator.py
@@ -75,6 +75,31 @@ def test_task_mapping_with_dag():
 # test_task_mapping_with_dag_and_list_of_pandas_dataframe
 
 
+@pytest.mark.parametrize(
+    ("bad_task_id", "match"),
+    [
+        ("bad*id", "has to be made of alphanumeric"),
+        ("with space", "has to be made of alphanumeric"),
+        ("a" * 251, "has to be less than 250 characters"),
+    ],
+)
+def test_mapped_task_id_is_validated(bad_task_id, match):
+    with DAG("test-dag"):
+        with pytest.raises(ValueError, match=match):
+            MockOperator.partial(task_id=bad_task_id).expand(arg2=["a"])
+
+
+def test_mapped_task_id_validated_after_group_prefix():
+    # A 50-char task id is valid on its own but is 251 chars once prefixed with the 200-char
+    # group id, so this only fails if the *final* prefixed id is what gets validated.
+    from airflow.sdk.definitions.taskgroup import TaskGroup
+
+    with DAG("test-dag"):
+        with TaskGroup("g" * 200):
+            with pytest.raises(ValueError, match="has to be less than 250 characters"):
+                MockOperator.partial(task_id="t" * 50).expand(arg2=["a"])
+
+
 def test_task_mapping_without_dag_context():
     with DAG("test-dag") as dag:
         task1 = BaseOperator(task_id="op1")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Validate task_id for mapped tasks
---
### Why

A regular task validates its `task_id` in `BaseOperator.__init__`. A mapped task is built on a path that skips `__init__`, so its id was never validated. A regular task and a mapped task then accept different sets of ids, breaking the invariant that every `task_id` is validated:

```python
MyOperator(task_id="bad*id")                      # raises
MyOperator.partial(task_id="bad*id").expand(...)  # passed silently
```
The taskflow `@task` mapped form had the same gap.

### What
Validate the id in both mapped paths, at the point where the final id is known (after the task-group prefix and unique-suffix), matching `BaseOperator.__init__`. Valid ids are unaffected. Tests lock that the final id is validated, not the raw one.

related: #69965, #69937
##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
