### PR TITLE
Fix LLMSQLQueryOperator not stripping single-line markdown code fences

### DIFF
--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
@@ -177,10 +177,13 @@ class LLMSQLQueryOperator(LLMOperator):
         text = raw.strip()
         if text.startswith("```"):
             lines = text.split("\n")
-            # Remove opening fence (```sql, ```, etc.) and closing fence
             if len(lines) >= 2:
+                # Remove opening fence (```sql, ```, etc.) and closing fence
                 end = -1 if lines[-1].strip().startswith("```") else len(lines)
                 text = "\n".join(lines[1:end]).strip()
+            elif text.endswith("```") and len(text) > 6:
+                # Whole fenced block on one line, e.g. "```SELECT 1```" -> "SELECT 1"
+                text = text[3:-3].strip()
         return text
 
     def _get_schema_context(self) -> str:

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/llm_sql.py
@@ -152,7 +152,7 @@ class LLMSQLQueryOperator(LLMOperator):
         )
         result = agent.run_sync(self.prompt, usage_limits=self.usage_limits)
         log_run_summary(self.log, result)
-        sql = self._strip_llm_output(result.output)
+        sql = self._strip_llm_output(result.output, dialect=self._resolved_dialect)
 
         if self.validate_sql:
             _validate_sql(sql, allowed_types=self.allowed_sql_types, dialect=self._resolved_dialect)
@@ -172,7 +172,7 @@ class LLMSQLQueryOperator(LLMOperator):
         return output
 
     @staticmethod
-    def _strip_llm_output(raw: str) -> str:
+    def _strip_llm_output(raw: str, *, dialect: str | None = None) -> str:
         """Strip whitespace and markdown code fences from LLM output."""
         text = raw.strip()
         if text.startswith("```"):
@@ -182,8 +182,15 @@ class LLMSQLQueryOperator(LLMOperator):
                 end = -1 if lines[-1].strip().startswith("```") else len(lines)
                 text = "\n".join(lines[1:end]).strip()
             elif text.endswith("```") and len(text) > 6:
-                # Whole fenced block on one line, e.g. "```SELECT 1```" -> "SELECT 1"
-                text = text[3:-3].strip()
+                # Whole fenced block on one line, e.g. "```sql SELECT 1```" -> "SELECT 1".
+                # Only drop the leading word if it's a known tag, so a real keyword
+                # like "SELECT" is never mistaken for one.
+                inner = text[3:-3].strip()
+                tags = {"sql", *([dialect.lower()] if dialect else [])}
+                first_word, sep, rest = inner.partition(" ")
+                if sep and first_word.lower() in tags:
+                    inner = rest.strip()
+                text = inner
         return text
 
     def _get_schema_context(self) -> str:

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_sql.py
@@ -77,6 +77,16 @@ class TestStripLLMOutput:
                 "SELECT 1",
                 id="missing_closing_fence",
             ),
+            pytest.param(
+                "```SELECT 1```",
+                "SELECT 1",
+                id="single_line_fence_no_language_tag",
+            ),
+            pytest.param(
+                "```SELECT * FROM users LIMIT 10```",
+                "SELECT * FROM users LIMIT 10",
+                id="single_line_fence_with_query",
+            ),
         ),
     )
     def test_strip_llm_output(self, raw, expected):

--- a/providers/common/ai/tests/unit/common/ai/operators/test_llm_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_llm_sql.py
@@ -87,10 +87,38 @@ class TestStripLLMOutput:
                 "SELECT * FROM users LIMIT 10",
                 id="single_line_fence_with_query",
             ),
+            pytest.param(
+                "```sql SELECT 1```",
+                "SELECT 1",
+                id="single_line_fence_with_language_tag",
+            ),
+            pytest.param(
+                "```SQL SELECT 1```",
+                "SELECT 1",
+                id="single_line_fence_with_uppercase_language_tag",
+            ),
         ),
     )
     def test_strip_llm_output(self, raw, expected):
         assert LLMSQLQueryOperator._strip_llm_output(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "dialect", "expected"),
+        (
+            pytest.param("```postgres SELECT 1```", "postgres", "SELECT 1", id="dialect_tag_matches"),
+            pytest.param(
+                "```POSTGRES SELECT 1```", "postgres", "SELECT 1", id="dialect_tag_case_insensitive"
+            ),
+            pytest.param(
+                "```mysql SELECT 1```",
+                "postgres",
+                "mysql SELECT 1",
+                id="dialect_tag_mismatch_left_alone",
+            ),
+        ),
+    )
+    def test_strip_llm_output_with_dialect(self, raw, dialect, expected):
+        assert LLMSQLQueryOperator._strip_llm_output(raw, dialect=dialect) == expected
 
 
 class TestLLMSQLQueryOperator:


### PR DESCRIPTION
## Summary

`LLMSQLQueryOperator._strip_llm_output` strips markdown code fences from LLM output before the generated SQL is validated/executed. The existing logic only handles fences where the LLM's response spans multiple lines
(e.g. ` ```sql\nSELECT 1\n``` `) — it splits on `"\n"` and requires at least 2 lines before attempting to drop the opening/closing fence.

When the whole fenced response is on a single line (e.g. ` ```SELECT 1``` `, no internal newline), `text.split("\n")` yields a
single element, the `len(lines) >= 2` guard is never satisfied, and the fence-stripping is skipped entirely — the backticks stay attached and the value is passed straight into `_validate_sql` (and potentially execution) as-is.

The operator's system prompt already asks the LLM not to use markdown at all (`"Return ONLY the SQL query, no explanation or markdown."`), but the existing multi-line fence-handling logic (and its test coverage) already assumes LLMs commonly ignore that instruction and wrap output in a fence anyway. 

This change extends the same defensive handling to the single-line variant of that same behavior, which the multi-line path doesn't cover.

## Changes

- `_strip_llm_output` gains an `elif` branch for the case where the fenced
  text has no internal newline: strip the leading/trailing ` ``` ` directly
  instead of relying on line-splitting. The existing multi-line branch is
  untouched, so behavior for every previously-tested case is unchanged.

## Test plan

- Added two regression cases to `TestStripLLMOutput`: a single-line fence
  with no language tag, and one wrapping a longer query.
- Full `test_llm_sql.py` suite passes (44 passed), including all
  pre-existing multi-line fence cases unchanged.
- `ruff format` / `ruff check`, `prek --stage pre-commit`, and
  `breeze run mypy` all clean on the changed file.


