### PR TITLE
Keep Dag run execution API endpoints working for older Task SDK clients

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
@@ -99,6 +99,20 @@ class AddTeamNameField(VersionChange):
         if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
             response.body["dag_run"].pop("team_name", None)
 
+    @convert_response_to_previous_version_for(DagRun)  # type: ignore[arg-type]
+    def remove_team_name_from_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove the ``team_name`` field from responses returning a DagRun directly."""
+        if isinstance(response.body, dict):
+            response.body.pop("team_name", None)
+
+    # Schema-based converters are matched against the route's response model by identity, so a
+    # route annotated ``DagRun | None`` never matches ``DagRun`` and has to be addressed by path.
+    @convert_response_to_previous_version_for("/dag-runs/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_team_name_from_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Remove the ``team_name`` field from the previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("team_name", None)
+
 
 class AddAssetsByAliasEndpoint(VersionChange):
     """Add endpoint to resolve assets from an AssetAlias."""
@@ -141,3 +155,16 @@ class AddPartitionDateField(VersionChange):
         """Strip ``partition_date`` from the nested ``dag_run`` payload for older clients."""
         if "dag_run" in response.body and isinstance(response.body["dag_run"], dict):
             response.body["dag_run"].pop("partition_date", None)
+
+    @convert_response_to_previous_version_for(DagRun)  # type: ignore[arg-type]
+    def remove_partition_date_from_dag_run_response(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Strip ``partition_date`` from responses returning a DagRun directly."""
+        if isinstance(response.body, dict):
+            response.body.pop("partition_date", None)
+
+    # See remove_team_name_from_previous_dag_run: ``DagRun | None`` needs a path-based converter.
+    @convert_response_to_previous_version_for("/dag-runs/previous", ["GET"])  # type: ignore[arg-type]
+    def remove_partition_date_from_previous_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+        """Strip ``partition_date`` from the previous-run response."""
+        if isinstance(response.body, dict):
+            response.body.pop("partition_date", None)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py
@@ -100,7 +100,7 @@ class AddTeamNameField(VersionChange):
             response.body["dag_run"].pop("team_name", None)
 
     @convert_response_to_previous_version_for(DagRun)  # type: ignore[arg-type]
-    def remove_team_name_from_dag_run(response: ResponseInfo) -> None:  # type: ignore[misc]
+    def remove_team_name_from_dag_run_response(response: ResponseInfo) -> None:  # type: ignore[misc]
         """Remove the ``team_name`` field from responses returning a DagRun directly."""
         if isinstance(response.body, dict):
             response.body.pop("team_name", None)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_dag_runs.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow._shared.timezones import timezone
+from airflow.utils.state import DagRunState
+
+pytestmark = pytest.mark.db_test
+
+ADDED_IN_2026_06_30 = frozenset({"team_name", "partition_date"})
+
+
+@pytest.fixture
+def old_ver_client(client):
+    """Last released execution API before ``team_name`` and ``partition_date`` were added."""
+    client.headers["Airflow-API-Version"] = "2026-04-06"
+    return client
+
+
+@pytest.fixture
+def dag_runs(session, dag_maker):
+    with dag_maker(dag_id="test_dag_run_fields", session=session, serialized=True):
+        pass
+    dag_maker.create_dagrun(
+        state=DagRunState.SUCCESS,
+        logical_date=timezone.datetime(2025, 1, 1),
+        run_id="run1",
+    )
+    dag_maker.create_dagrun(
+        state=DagRunState.SUCCESS,
+        logical_date=timezone.datetime(2025, 1, 10),
+        run_id="run2",
+    )
+    session.commit()
+
+
+@pytest.mark.usefixtures("dag_runs")
+def test_get_dag_run_omits_new_fields(old_ver_client):
+    response = old_ver_client.get("/execution/dag-runs/test_dag_run_fields/run1")
+
+    assert response.status_code == 200
+    assert not ADDED_IN_2026_06_30 & response.json().keys()
+
+
+@pytest.mark.usefixtures("dag_runs")
+def test_get_previous_dag_run_omits_new_fields(old_ver_client):
+    response = old_ver_client.get(
+        "/execution/dag-runs/previous",
+        params={
+            "dag_id": "test_dag_run_fields",
+            "logical_date": timezone.datetime(2025, 1, 10).isoformat(),
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["run_id"] == "run1"
+    assert not ADDED_IN_2026_06_30 & response.json().keys()
+
+
+@pytest.mark.usefixtures("dag_runs")
+def test_get_previous_dag_run_without_a_match(old_ver_client):
+    response = old_ver_client.get(
+        "/execution/dag-runs/previous",
+        params={
+            "dag_id": "test_dag_run_fields",
+            "logical_date": timezone.datetime(2024, 1, 1).isoformat(),
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() is None

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_dag_runs.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_dag_runs.py
@@ -38,11 +38,13 @@ def old_ver_client(client):
 def dag_runs(session, dag_maker):
     with dag_maker(dag_id="test_dag_run_fields", session=session, serialized=True):
         pass
-    dag_maker.create_dagrun(
+    run1 = dag_maker.create_dagrun(
         state=DagRunState.SUCCESS,
         logical_date=timezone.datetime(2025, 1, 1),
         run_id="run1",
     )
+    # A populated value proves the converters strip the field, not just drop a null key.
+    run1.partition_date = timezone.datetime(2025, 1, 1)
     dag_maker.create_dagrun(
         state=DagRunState.SUCCESS,
         logical_date=timezone.datetime(2025, 1, 10),


### PR DESCRIPTION
## Why

The `2026-06-30` execution API version added two new fields to the `DagRun` model: `team_name` (`AddTeamNameField`) and `partition_date` (`AddPartitionDateField`). Both version changes only registered response converters for the **nested** `dag_run` payload (e.g. inside `TIRunContext`), but not for endpoints that return a `DagRun` **directly** — `GET /dag-runs/{dag_id}/{run_id}` and `GET /dag-runs/previous`.

As a result, these endpoints break on the **server** side for a Task SDK client pinning `2026-04-06` (the only earlier version they serve — both routes were added in it). Both routes have return annotations, so FastAPI validates the response against the versioned `DagRun` response model, which inherits `StrictBaseModel` (`extra="forbid"`) and, per the version-change declarations, has no `team_name`/`partition_date` in `2026-04-06`. The un-stripped fields make response validation raise `fastapi.exceptions.ResponseValidationError` with `extra_forbidden` errors, and the worker receives a `500 Internal Server Error`. The response never reaches the client, so the symptom to grep for is `extra_forbidden` in api-server logs — not a client-side Task SDK validation error. Either way, calls that worked on `2026-04-06` now fail for pinned older clients — exactly what the versioning layer is supposed to prevent.

## What

- `airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_30.py`: add `@convert_response_to_previous_version_for(DagRun)` converters to both `AddTeamNameField` and `AddPartitionDateField` so the new fields are stripped from direct `DagRun` responses. Because schema-based converters match the route's response model by identity, the `/dag-runs/previous` route (annotated `DagRun | None`) never matches `DagRun`, so it additionally gets path-based converters for `GET /dag-runs/previous`.
- `airflow-core/tests/unit/api_fastapi/execution_api/versions/v2026_06_30/test_dag_runs.py` (new): tests that requests with the previous API version (`2026-04-06`) get responses without `team_name`/`partition_date` from both endpoints, and that the `null` previous-run response still works.

Out of scope: the compat `GET /dag-runs/{dag_id}/previous` route (served only to clients pinning older than `2026-04-06`) has a pre-existing leak of newer `DagRun` fields (`note`, `partition_key`, `triggering_user_name`, and now these two) with a different failure mode — it has no return annotation, so the server responds 200 and the old SDK fails client-side on its own `extra="forbid"` model. That affects a disjoint set of versions and fields and needs its own fix; see the review discussion.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
