### PR TITLE
Go SDK: fix operator-precedence bug that could crash the worker process

### DIFF
--- a/go-sdk/pkg/worker/runner.go
+++ b/go-sdk/pkg/worker/runner.go
@@ -149,7 +149,7 @@ func (h *heartbeater) Run(
 			var httpError *api.GeneralHTTPError
 			if errors.As(err, &httpError) {
 				resp := httpError.Response
-				if resp != nil && resp.StatusCode() == 404 || resp.StatusCode() == 409 {
+				if resp != nil && (resp.StatusCode() == 404 || resp.StatusCode() == 409) {
 					h.logger.ErrorContext(
 						ctx,
 						"Server indicated the task shouldn't be running anymore",

--- a/go-sdk/pkg/worker/runner_test.go
+++ b/go-sdk/pkg/worker/runner_test.go
@@ -256,17 +256,29 @@ func (s *WorkerSuite) TestTaskHeartbeatNilResponseDoesNotPanic() {
 	id := uuid.New().String()
 	testWorkload := newTestWorkLoad(id, id[:8])
 
+	var callCount atomic.Int32
+	secondHeartbeat := make(chan struct{})
+
 	s.registry.AddDag(testWorkload.TI.DagId).
 		AddTaskWithName(testWorkload.TI.TaskId, func() error {
-			time.Sleep(250 * time.Millisecond)
-			return nil
+			select {
+			case <-secondHeartbeat:
+				return nil
+			case <-time.After(2 * time.Second):
+				return fmt.Errorf("second heartbeat was never observed")
+			}
 		})
 
 	s.ExpectTaskRun(id)
 	s.ExpectTaskState(id, api.TerminalTIStateSuccess)
 	s.ti.EXPECT().
 		Heartbeat(mock.Anything, uuid.MustParse(id), mock.Anything).
-		Return(&api.GeneralHTTPError{Response: nil})
+		RunAndReturn(func(ctx context.Context, taskInstanceId uuid.UUID, body *api.TIHeartbeatInfo) error {
+			if callCount.Add(1) == 2 {
+				close(secondHeartbeat)
+			}
+			return &api.GeneralHTTPError{Response: nil}
+		})
 	s.client.EXPECT().TaskInstances().Return(s.ti)
 
 	err := s.worker.ExecuteTaskWorkload(context.Background(), testWorkload)

--- a/go-sdk/pkg/worker/runner_test.go
+++ b/go-sdk/pkg/worker/runner_test.go
@@ -252,6 +252,27 @@ func (s *WorkerSuite) TestTaskHeartbeatConflictStopsTask() {
 	s.NoError(err)
 }
 
+func (s *WorkerSuite) TestTaskHeartbeatNilResponseDoesNotPanic() {
+	id := uuid.New().String()
+	testWorkload := newTestWorkLoad(id, id[:8])
+
+	s.registry.AddDag(testWorkload.TI.DagId).
+		AddTaskWithName(testWorkload.TI.TaskId, func() error {
+			time.Sleep(250 * time.Millisecond)
+			return nil
+		})
+
+	s.ExpectTaskRun(id)
+	s.ExpectTaskState(id, api.TerminalTIStateSuccess)
+	s.ti.EXPECT().
+		Heartbeat(mock.Anything, uuid.MustParse(id), mock.Anything).
+		Return(&api.GeneralHTTPError{Response: nil})
+	s.client.EXPECT().TaskInstances().Return(s.ti)
+
+	err := s.worker.ExecuteTaskWorkload(context.Background(), testWorkload)
+	s.NoError(err, "ExecuteTaskWorkload should not report an error")
+}
+
 func (s *WorkerSuite) TestTaskHeartbeatErrorStopsTaskAndLogs() {
 	s.T().Skip("TODO: Not implemented yet")
 }


### PR DESCRIPTION
## Summary

`heartbeater.Run` in the Go SDK worker checks whether a heartbeat error indicates the server no longer wants the task running (404/409), so it can cancel the task instead of retrying forever:

```go
if resp != nil && resp.StatusCode() == 404 || resp.StatusCode() == 409 {
```
`&&` binds tighter than `||` in Go, so this actually parses as `(resp != nil && resp.StatusCode() == 404) || resp.StatusCode() == 409` -- the second disjunct calls `resp.StatusCode()` unconditionally, bypassing the nil check the `resp != nil &&` clearly intended to guard.

`resp` here is `*api.GeneralHTTPError.Response` (`*resty.Response`), which can be nil for transport-level failures that never got as far as an actual HTTP response (e.g. connection reset, TLS failure). When that happens, `resp.StatusCode()` panics on a nil pointer -- and this happens inside the heartbeater's own goroutine (`go heartbeater.Run(heartbeatCtx)` in `ExecuteTaskWorkload`), which has no `recover()` of its own. Go's `recover()` only catches panics in the same goroutine's call stack, so this crashes the entire worker process, not just the one task.

Confirmed by temporarily reverting the fix and running the new test: it panics with `SIGSEGV` at exactly this line, unrecovered, exactly as described above.

## Changes

- Add parentheses so the nil guard covers both status checks:
  `resp != nil && (resp.StatusCode() == 404 || resp.StatusCode() == 409)`.
- Add `TestTaskHeartbeatNilResponseDoesNotPanic`, which returns a
  `GeneralHTTPError{Response: nil}` from the mocked heartbeat call and
  asserts the task completes normally instead of crashing.
