### PR TITLE
Add Google API toolset for agents to access 1000+ APIs

### DIFF
--- a/providers/common/ai/docs/index.rst
+++ b/providers/common/ai/docs/index.rst
@@ -254,6 +254,7 @@ Extra           Dependencies
 ``parquet``     ``pyarrow>=18.0.0; python_version < '3.14'``, ``pyarrow>=22.0.0; python_version >= '3.14'``
 ``sql``         ``apache-airflow-providers-common-sql>=1.33.0``, ``sqlglot>=30.0.0``
 ``aws``         ``apache-airflow-providers-amazon>=9.0.0``
+``gcp``         ``apache-airflow-providers-google>=22.0.0``
 ``common.sql``  ``apache-airflow-providers-common-sql>=1.33.0``
 ``langchain``   ``langchain>=1.0.0``
 ``llamaindex``  ``dataclasses-json>=0.6.7``, ``llama-index-core>=0.13.0``, ``llama-index-embeddings-openai>=0.6.0``, ``llama-index-llms-openai>=0.6.0``

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -260,6 +260,14 @@ published through Google's Discovery REST surface. Requires the ``gcp`` extra:
     :start-after: [START howto_operator_agent_gcp]
     :end-before: [END howto_operator_agent_gcp]
 
+For a multi-service troubleshooting example, use a small read-only allow-list
+across Cloud Storage, BigQuery, and Cloud Monitoring:
+
+.. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_gcp_troubleshooting_agent.py
+    :language: python
+    :start-after: [START howto_operator_agent_gcp_troubleshooting]
+    :end-before: [END howto_operator_agent_gcp_troubleshooting]
+
 ``GoogleCloudToolset`` exposes ``list_gcp_methods``,
 ``describe_gcp_method``, and ``call_gcp``. The allow-list is required and
 deny-by-default. Entries use ``"<api>/<version>:<resource.method>"`` form:

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -54,6 +54,44 @@ passed to any pydantic-ai ``Agent``, including via
     integration, and the connection UI, but you are not locked in.
 
 
+Choosing between HookToolset and provider API toolsets
+------------------------------------------------------
+
+For provider-backed actions, Airflow supports two complementary approaches.
+
+Use ``HookToolset`` when the task maps to methods that already exist on an
+Airflow Hook. Its allow-list contains Python method names on that hook, such as
+``list`` or ``get_records``. This is a good fit when the provider already wraps
+the operation in a stable, workflow-oriented hook method.
+
+Use provider API toolsets, such as ``AWSToolset`` and ``GoogleCloudToolset``,
+when the task needs selected operations from the cloud provider API surface
+itself. Their allow-lists use the provider's operation language, such as AWS
+actions or Google Discovery REST methods. This is useful when the provider API
+has operations that are not wrapped by Airflow Hooks, or when one agent task
+needs to inspect several low-level services during troubleshooting.
+
+For example, use ``HookToolset`` when an agent should call an existing storage
+hook to list objects, an existing database hook to run a query, or an existing
+HTTP hook to call an internal API.
+
+Use a provider API toolset when an agent should compare signals across services,
+such as storage object arrivals, query job status, and monitoring time series,
+or inspect cloud resources and configuration where Airflow does not provide a
+dedicated hook method.
+
+The distinction is the allow-list contract:
+
+- ``HookToolset`` allow-lists Airflow Hook method names.
+- ``AWSToolset`` allow-lists AWS service/API actions.
+- ``GoogleCloudToolset`` allow-lists Google Discovery REST methods.
+
+Toolset allow-lists are application-level guardrails: they limit what the agent
+can ask the toolset to call. They are not a replacement for least-privilege
+cloud credentials. The connection used by the toolset should still be scoped to
+the minimum permissions needed for the agent's task.
+
+
 Using Toolsets Directly with PydanticAI
 ---------------------------------------
 

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -24,20 +24,23 @@ Airflow's 350+ provider hooks already have typed methods, rich docstrings,
 and managed credentials. Toolsets expose them as pydantic-ai tools so that
 LLM agents can call them during multi-turn reasoning.
 
-Four toolsets are included:
+Five core toolsets are included:
 
 - :class:`~airflow.providers.common.ai.toolsets.aws.AWSToolset` — configured
   AWS services toolset for agent access to AWS APIs through Airflow-managed
   AWS connections.
 - :class:`~airflow.providers.common.ai.toolsets.hook.HookToolset` — generic
   adapter for any Airflow Hook.
+- :class:`~airflow.providers.common.ai.toolsets.google.GoogleCloudToolset` —
+  allow-listed access to Google APIs published through Google's Discovery
+  service.
 - :class:`~airflow.providers.common.ai.toolsets.mcp.MCPToolset` — connect to
   `MCP servers <https://modelcontextprotocol.io/>`__ configured via Airflow
   connections.
 - :class:`~airflow.providers.common.ai.toolsets.sql.SQLToolset` — curated
   4-tool database toolset.
 
-All four implement pydantic-ai's
+All five implement pydantic-ai's
 `AbstractToolset <https://ai.pydantic.dev/toolsets/>`__ interface and can be
 passed to any pydantic-ai ``Agent``, including via
 :class:`~airflow.providers.common.ai.operators.agent.AgentOperator`.
@@ -206,6 +209,70 @@ Parameters
   Default ``False`` -- only SELECT-family and read-only metadata
   (``DESCRIBE``/``SHOW``) statements are permitted.
 - ``max_rows``: Maximum rows returned from the ``query`` tool. Default ``50``.
+
+``GoogleCloudToolset``
+----------------------
+
+Curated toolset that gives an agent allow-listed access to Google APIs
+published through Google's Discovery REST surface. Requires the ``gcp`` extra:
+``pip install "apache-airflow-providers-common-ai[gcp]"``.
+
+.. exampleinclude:: /../../ai/src/airflow/providers/common/ai/example_dags/example_gcp_toolset.py
+    :language: python
+    :start-after: [START howto_operator_agent_gcp]
+    :end-before: [END howto_operator_agent_gcp]
+
+``GoogleCloudToolset`` exposes ``list_gcp_methods``,
+``describe_gcp_method``, and ``call_gcp``. The allow-list is required and
+deny-by-default. Entries use ``"<api>/<version>:<resource.method>"`` form:
+
+.. code-block:: python
+
+    GoogleCloudToolset(
+        gcp_conn_id="google_cloud_default",
+        allowed_methods=[
+            "storage/v1:buckets.list",
+            "storage/v1:objects.list",
+            "pubsub/v1:projects.topics.list",
+            "bigquery/v2:jobs.query",
+        ],
+    )
+
+The API and version must be explicit, for example ``pubsub/v1`` rather than
+``pubsub``. The method part accepts ``*``/``?`` wildcards, but methods that
+return credentials or decrypted secrets are never matched by a wildcard; each
+must be listed verbatim.
+
+The toolset covers APIs present in the bundled Discovery documents shipped
+with ``google-api-python-client``. This includes many Google Cloud control and
+metadata APIs such as Cloud Storage, Pub/Sub, BigQuery REST methods, Compute
+Engine, Cloud SQL Admin, and Workspace APIs that publish Discovery documents.
+It does not cover APIs outside that Discovery REST surface, and credentials
+still need IAM permissions for the requested call.
+
+Credentials, impersonation, and the project come from ``gcp_conn_id`` via the
+Google provider. With ``enforce_project=True`` (the default), missing
+``project``/``projectId`` parameters are filled from the connection, and
+model-supplied values for another project are rejected.
+
+Parameters
+^^^^^^^^^^
+
+- ``gcp_conn_id``: Airflow Google connection ID. Default
+  ``"google_cloud_default"``.
+- ``allowed_methods``: Required list of allowed methods in
+  ``"<api>/<version>:<resource.method>"`` form. The method part accepts
+  wildcards; the API and version do not.
+- ``impersonation_chain``: Optional service account or chain passed through to
+  ``GoogleBaseHook``.
+- ``enforce_project``: Fill or reject project parameters based on the
+  connection's project. Default ``True``.
+- ``allow_remote_discovery``: Allow APIs missing from the bundled Discovery
+  documents and fetch their documents lazily. Default ``False``.
+- ``max_pages``: Maximum number of pages followed for paginated methods.
+  Default ``5``.
+- ``max_output_bytes``: Maximum serialized response size returned to the
+  agent. Larger responses are truncated and marked as such. Default ``65536``.
 
 ``DataFusionToolset``
 ---------------------

--- a/providers/common/ai/provider.yaml
+++ b/providers/common/ai/provider.yaml
@@ -455,6 +455,7 @@ toolsets:
   - integration-name: Common AI
     python-modules:
       - airflow.providers.common.ai.toolsets.aws
+      - airflow.providers.common.ai.toolsets.google
       - airflow.providers.common.ai.toolsets.hook
       - airflow.providers.common.ai.toolsets.sql
       - airflow.providers.common.ai.toolsets.datafusion

--- a/providers/common/ai/pyproject.toml
+++ b/providers/common/ai/pyproject.toml
@@ -113,6 +113,12 @@ dependencies = [
 "aws" = [
     "apache-airflow-providers-amazon>=9.0.0",
 ]
+# GoogleCloudToolset: allow-listed Google API access for agents. The google
+# provider supplies credential resolution (GoogleBaseHook) and brings
+# google-api-python-client with the bundled discovery documents.
+"gcp" = [
+    "apache-airflow-providers-google>=22.0.0",
+]
 "common.sql" = [
     "apache-airflow-providers-common-sql>=1.33.0"
 ]

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_gcp_toolset.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_gcp_toolset.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Example Dag: agent with allow-listed Google API access via GoogleCloudToolset."""
+
+from __future__ import annotations
+
+from airflow.providers.common.ai.operators.agent import AgentOperator
+from airflow.providers.common.ai.toolsets.google import GoogleCloudToolset
+from airflow.providers.common.compat.sdk import dag
+
+
+# [START howto_operator_agent_gcp]
+@dag(tags=["example"])
+def example_agent_gcp_toolset():
+    AgentOperator(
+        task_id="gcs_auditor",
+        prompt="Which buckets exist, and roughly how many objects are in 'data-lake-raw'?",
+        llm_conn_id="pydanticai_default",
+        system_prompt=(
+            "You are a Google Cloud operations assistant. Discover what you "
+            "are allowed to call, check parameter shapes before calling, and "
+            "answer with concrete numbers."
+        ),
+        toolsets=[
+            GoogleCloudToolset(
+                gcp_conn_id="google_cloud_default",
+                allowed_methods=[
+                    "storage/v1:buckets.list",
+                    "storage/v1:buckets.get",
+                    "storage/v1:objects.list",
+                ],
+            )
+        ],
+    )
+
+
+# [END howto_operator_agent_gcp]
+
+example_agent_gcp_toolset()

--- a/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_gcp_troubleshooting_agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/example_dags/example_gcp_troubleshooting_agent.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Dag: troubleshoot a Google Cloud data pipeline with GoogleCloudToolset.
+
+Required Airflow Variables:
+- ``common_ai_gcp_project_id``
+- ``common_ai_gcp_bucket``
+
+Optional Airflow Variables:
+- ``common_ai_gcp_dataset``; default: ``pipeline_observability``
+- ``common_ai_gcp_pipeline_table``; default: ``pipeline_runs``
+- ``common_ai_gcp_raw_prefix``; default: ``raw/``
+
+For a useful demo, point the variables at a project with:
+- GCS objects under ``gs://<bucket>/<raw_prefix>``
+- a BigQuery table with recent pipeline status rows
+- Cloud Monitoring metrics from recent BigQuery and GCS activity
+"""
+
+from __future__ import annotations
+
+from airflow.providers.common.ai.operators.agent import AgentOperator
+from airflow.providers.common.ai.toolsets.google import GoogleCloudToolset
+from airflow.providers.common.compat.sdk import Variable, dag, task
+
+
+# [START howto_operator_agent_gcp_troubleshooting]
+@dag(tags=["example"])
+def example_gcp_troubleshooting_agent():
+    @task
+    def build_triage_prompt() -> str:
+        project_id = Variable.get("common_ai_gcp_project_id")
+        bucket_name = Variable.get("common_ai_gcp_bucket")
+        dataset_id = Variable.get("common_ai_gcp_dataset", default="pipeline_observability")
+        pipeline_table = Variable.get("common_ai_gcp_pipeline_table", default="pipeline_runs")
+        raw_prefix = Variable.get("common_ai_gcp_raw_prefix", default="raw/")
+
+        return (
+            f"Pipeline is slow today in project {project_id}. "
+            f"Check whether raw files arrived in gs://{bucket_name}/{raw_prefix}, "
+            "inspect recent BigQuery jobs and rows from "
+            f"{dataset_id}.{pipeline_table}, check active Cloud Monitoring alert policies, "
+            "and compare BigQuery query count and GCS request count metrics for today versus yesterday. "
+            "Summarize the likely cause and the next action."
+        )
+
+    AgentOperator(
+        task_id="triage_pipeline",
+        prompt=build_triage_prompt(),
+        llm_conn_id="pydanticai_default",
+        system_prompt="Use the available Google tools to investigate the pipeline. Do not invent missing values.",
+        toolsets=[
+            GoogleCloudToolset(
+                gcp_conn_id="google_cloud_default",
+                allowed_methods=[
+                    "storage/v1:objects.list",
+                    "bigquery/v2:jobs.list",
+                    "bigquery/v2:jobs.get",
+                    "bigquery/v2:jobs.query",
+                    "monitoring/v3:projects.alertPolicies.list",
+                    "monitoring/v3:projects.timeSeries.list",
+                ],
+                max_pages=2,
+                max_output_bytes=20000,
+            )
+        ],
+    )
+
+
+# [END howto_operator_agent_gcp_troubleshooting]
+
+example_gcp_troubleshooting_agent()

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/__init__.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/__init__.py
@@ -67,6 +67,6 @@ def __getattr__(name: str):
         except ImportError as e:
             from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 
-            raise AirflowOptionalProviderFeatureException(e)
+            raise AirflowOptionalProviderFeatureException() from e
         return GoogleCloudToolset
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/__init__.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/__init__.py
@@ -20,7 +20,14 @@ from __future__ import annotations
 
 from airflow.providers.common.ai.toolsets.hook import HookToolset
 
-__all__ = ["AWSToolset", "HookToolset", "MCPToolset", "SQLToolset", "airflow_toolset_to_langchain_tools"]
+__all__ = [
+    "AWSToolset",
+    "GoogleCloudToolset",
+    "HookToolset",
+    "MCPToolset",
+    "SQLToolset",
+    "airflow_toolset_to_langchain_tools",
+]
 
 
 def __getattr__(name: str):
@@ -54,4 +61,12 @@ def __getattr__(name: str):
 
             raise AirflowOptionalProviderFeatureException() from e
         return AWSToolset
+    if name == "GoogleCloudToolset":
+        try:
+            from airflow.providers.common.ai.toolsets.google import GoogleCloudToolset
+        except ImportError as e:
+            from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+            raise AirflowOptionalProviderFeatureException(e)
+        return GoogleCloudToolset
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
@@ -1,0 +1,784 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Curated Google toolset exposing allow-listed Discovery API methods as pydantic-ai tools."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from fnmatch import fnmatchcase
+from functools import cache
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+try:
+    import googleapiclient.discovery_cache
+    from googleapiclient.discovery import build
+except ImportError as e:
+    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+    raise AirflowOptionalProviderFeatureException(e)
+
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
+from pydantic_core import SchemaValidator, core_schema
+
+from airflow.providers.common.ai.utils.tool_definition import return_schema_kwargs
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pydantic_ai._run_context import RunContext
+
+_PASSTHROUGH_VALIDATOR = SchemaValidator(core_schema.any_schema())
+
+log = logging.getLogger(__name__)
+
+_DISCOVERY_DOC_URL = "https://www.googleapis.com/discovery/v1/apis/{api}/{version}/rest"
+
+
+def _normalize_method(method: str) -> str:
+    """Comparison key for method entries: case- and underscore-insensitive."""
+    return method.replace("_", "").casefold()
+
+
+def _require_string_arg(*, tool_args: dict[str, Any], key: str) -> str:
+    value = tool_args.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"The {key!r} argument is required and must be a non-empty string.")
+    return value
+
+
+def _format_project_parameter(*, project: str, param_def: dict[str, Any]) -> str:
+    pattern = param_def.get("pattern")
+    if not isinstance(pattern, str):
+        return project
+    try:
+        if re.fullmatch(pattern, project):
+            return project
+        resource_project = f"projects/{project}"
+        if re.fullmatch(pattern, resource_project):
+            return resource_project
+    except re.error:
+        return project
+    return project
+
+
+def _get_google_base_hook_class() -> type[Any]:
+    try:
+        return import_module("airflow.providers.google.common.hooks.base_google").GoogleBaseHook
+    except ImportError as e:
+        raise AirflowOptionalProviderFeatureException(e)
+
+
+# Methods that put credentials or decrypted secrets into the agent's context.
+# Keys are version-agnostic (``api:resource.method``) so v1/v1beta variants are
+# equally protected. A wildcard in ``allowed_methods`` never matches these --
+# each must be listed verbatim (with its version) to be callable. Defense in
+# depth, not exhaustive: least-privilege IAM on the connection's service
+# account remains the real boundary.
+_CREDENTIAL_RETURNING_METHODS = frozenset(
+    _normalize_method(method)
+    for method in (
+        "secretmanager:projects.secrets.versions.access",
+        "iamcredentials:projects.serviceAccounts.generateAccessToken",
+        "iamcredentials:projects.serviceAccounts.generateIdToken",
+        "iamcredentials:projects.serviceAccounts.signBlob",
+        "iamcredentials:projects.serviceAccounts.signJwt",
+        "iam:projects.serviceAccounts.keys.create",
+        "cloudkms:projects.locations.keyRings.cryptoKeys.decrypt",
+        "cloudkms:projects.locations.keyRings.cryptoKeys.rawDecrypt",
+        "cloudkms:projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.asymmetricDecrypt",
+        "cloudkms:projects.locations.keyRings.cryptoKeys.cryptoKeyVersions.rawDecrypt",
+        "sqladmin:users.insert",
+        "sqladmin:users.update",
+    )
+)
+
+_SCHEMA_DEPTH = 3
+
+# JSON Schemas for the three Google tools.
+_LIST_METHODS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "api": {
+            "type": "string",
+            "description": "Optional API filter as '<api>/<version>', e.g. 'storage/v1'.",
+        },
+    },
+}
+
+_DESCRIBE_METHOD_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "api": {"type": "string", "description": "API and version, e.g. 'storage/v1'."},
+        "method": {
+            "type": "string",
+            "description": "Method path within the API, e.g. 'objects.list'.",
+        },
+    },
+    "required": ["api", "method"],
+}
+
+_CALL_GCP_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "api": {"type": "string", "description": "API and version, e.g. 'storage/v1'."},
+        "method": {
+            "type": "string",
+            "description": "Method path within the API, e.g. 'objects.list'.",
+        },
+        "parameters": {
+            "type": "object",
+            "description": (
+                "Flat path/query parameters exactly as the API expects them (see describe_gcp_method)."
+            ),
+        },
+        "body": {
+            "type": "object",
+            "description": "Request body for methods that take one (see describe_gcp_method).",
+        },
+    },
+    "required": ["api", "method"],
+}
+
+
+class GoogleCloudToolset(AbstractToolset[Any]):
+    """
+    Curated toolset that gives an LLM agent allow-listed access to Google APIs.
+
+    Covers every API published through Google's Discovery Service -- the
+    bundled discovery documents in ``google-api-python-client`` (Cloud control
+    and admin planes, BigQuery/Firestore/Datastore query methods, Workspace
+    APIs such as Drive and Sheets, and more). Exposes three tools:
+
+    - ``list_gcp_methods`` -- the methods this toolset allows, grouped by
+      ``api/version`` (the allow-list intersected with the discovery documents).
+    - ``describe_gcp_method`` -- a method's parameters and request/response
+      schemas, read from the discovery document, so the agent can check what a
+      call expects *before* making it.
+    - ``call_gcp`` -- execute an allowed method and return the response as
+      JSON, following ``nextPageToken`` pagination up to ``max_pages``.
+
+    Credentials, impersonation, and the target project come exclusively from
+    the Airflow connection (resolved lazily through the google provider's
+    ``GoogleBaseHook``); none of them are tool arguments, so the model cannot
+    steer them.
+
+    Not covered: gRPC-only data planes absent from the Discovery surface (for
+    example the Bigtable data API and BigQuery Storage streams), streaming
+    methods, media upload/download (``alt=media`` is rejected; metadata calls
+    on the same resources work), and batch HTTP endpoints. For those, use the
+    dedicated Google hook with
+    :class:`~airflow.providers.common.ai.toolsets.hook.HookToolset`. A bundled
+    discovery document also does not guarantee Google still operates the API --
+    a handful of bundled documents describe shut-down services, and calls to
+    them fail with Google's own error.
+
+    When a call fails, Google's error message is returned to the agent as a
+    retry (:class:`pydantic_ai.ModelRetry`) so the model can correct its
+    parameters within the run. pydantic-ai bounds this by the tool's
+    ``max_retries``, so an unrecoverable error -- bad credentials, missing IAM
+    permissions -- exhausts the retries and fails the task for Airflow to retry.
+
+    :param gcp_conn_id: Airflow connection ID for Google Cloud credentials.
+    :param allowed_methods: Methods the agent may call, in
+        ``"<api>/<version>:<resource.method>"`` form -- e.g.
+        ``["storage/v1:objects.list", "bigquery/v2:jobs.query",
+        "compute/v1:instances.*"]``. Required -- access is deny-by-default and
+        there is deliberately no auto-discovery. The method part accepts
+        ``*``/``?`` wildcards; the API and version must be explicit, so an
+        agent can never roam onto ``alpha``/``beta`` surfaces that were not
+        deliberately listed. Matching is case- and underscore-insensitive.
+
+        Method names are the method IDs from Google's REST reference docs and
+        the `APIs Explorer <https://developers.google.com/apis-explorer>`__ --
+        both the path form (``objects.list``) and the doc-style prefixed form
+        (``storage.objects.list``) are accepted. Enumerate an API's entries at
+        authoring time with :meth:`get_available_methods`.
+
+        Methods that return credentials or decrypted secrets (for example
+        ``secretmanager/v1:projects.secrets.versions.access``,
+        ``iamcredentials/v1:projects.serviceAccounts.generateAccessToken``)
+        are never matched by a wildcard -- each must be listed verbatim to be
+        callable.
+
+        .. note::
+            This is an application-level guardrail: it bounds what the agent
+            can *ask for*, not what the credentials can *do*. Pair it with a
+            least-privilege service account on ``gcp_conn_id`` for a hard
+            guarantee.
+
+    :param impersonation_chain: Optional service account (or chain) to
+        impersonate, passed through to ``GoogleBaseHook``.
+    :param enforce_project: Pin API calls to the connection's project. Missing
+        ``project``/``projectId`` parameters are filled from the connection; a
+        model-supplied value that differs is rejected, including a best-effort
+        check on ``projects/<id>/...`` path parameters. Set ``False`` only for
+        deliberate cross-project access (the service account's IAM still
+        applies). No-op when the connection defines no project. Default
+        ``True``.
+    :param allow_remote_discovery: Permit ``allowed_methods`` entries for APIs
+        missing from the locally bundled discovery documents. Their documents
+        are fetched lazily from ``googleapis.com`` at first tool use -- never
+        at Dag parse time. Default ``False`` (local metadata only).
+    :param max_pages: Upper bound on pages followed via ``nextPageToken`` for
+        paginated methods. Default ``5``.
+    :param max_output_bytes: Upper bound on the serialized response returned to
+        the agent. Larger payloads are clipped and flagged with
+        ``"truncated": true``. Default ``65536``.
+    """
+
+    def __init__(
+        self,
+        gcp_conn_id: str = "google_cloud_default",
+        *,
+        allowed_methods: list[str],
+        impersonation_chain: str | Sequence[str] | None = None,
+        enforce_project: bool = True,
+        allow_remote_discovery: bool = False,
+        max_pages: int = 5,
+        max_output_bytes: int = 65536,
+    ) -> None:
+        if not allowed_methods:
+            raise ValueError("allowed_methods must be a non-empty list.")
+        if max_pages < 1:
+            raise ValueError("max_pages must be at least 1.")
+        if max_output_bytes < 1:
+            raise ValueError("max_output_bytes must be a positive number of bytes.")
+
+        # Validation below reads google-api-python-client's bundled discovery
+        # documents only -- local files, no credentials, no network
+        patterns: dict[tuple[str, str], list[str]] = {}
+        literal_methods: set[str] = set()
+        for entry in allowed_methods:
+            api_version, sep, method_path = entry.partition(":")
+            api, vsep, version = api_version.partition("/")
+            if not sep or not vsep or not api or not version or not method_path:
+                raise ValueError(
+                    f"Invalid method {entry!r}: expected '<api>/<version>:<resource.method>', "
+                    "e.g. 'storage/v1:objects.list'."
+                )
+            if any(ch in api_version for ch in "*?["):
+                raise ValueError(f"Invalid method {entry!r}: wildcards are only allowed in the method part.")
+            key = (api, version)
+            bundled = key in _bundled_apis()
+            if not bundled and not allow_remote_discovery:
+                raise ValueError(
+                    f"API {api!r} version {version!r} is not in the bundled discovery documents. "
+                    "Upgrade google-api-python-client, or pass allow_remote_discovery=True to "
+                    "fetch the document at call time. gRPC-only services are not available via "
+                    "the Discovery surface -- use the dedicated Google hook with HookToolset."
+                )
+            has_wildcard = any(ch in method_path for ch in "*?[")
+            if bundled and not has_wildcard:
+                doc = _load_bundled_doc(api, version)
+                canonical = _collect_method_paths(doc).get(_normalize_method(method_path))
+                if canonical is None:
+                    raise ValueError(
+                        f"Unknown method {method_path!r} for {api}/{version} in {entry!r}. "
+                        "Use the method ID from Google's REST reference, e.g. 'objects.list' "
+                        "or 'storage.objects.list'."
+                    )
+                # Store the canonical path so doc-style IDs ("storage.objects.list")
+                # and path-style entries ("objects.list") authorize identically.
+                method_path = canonical
+            elif bundled:
+                doc = _load_bundled_doc(api, version)
+                pattern = _normalize_method(f"{api}/{version}:{method_path}")
+                if not any(
+                    fnmatchcase(_normalize_method(f"{api}/{version}:{path}"), pattern)
+                    and _normalize_method(f"{api}:{path}") not in _CREDENTIAL_RETURNING_METHODS
+                    for path in set(_collect_method_paths(doc).values())
+                ):
+                    raise ValueError(
+                        f"Pattern {method_path!r} matches no methods of {api}/{version} in {entry!r}. "
+                        "Wildcards never match credential-returning methods; list those verbatim."
+                    )
+            normalized = _normalize_method(f"{api}/{version}:{method_path}")
+            patterns.setdefault(key, []).append(normalized)
+            if not has_wildcard:
+                literal_methods.add(normalized)
+
+        self._gcp_conn_id = gcp_conn_id
+        self._impersonation_chain = impersonation_chain
+        self._enforce_project = enforce_project
+        self._allow_remote_discovery = allow_remote_discovery
+        self._max_pages = max_pages
+        self._max_output_bytes = max_output_bytes
+        self._patterns = patterns
+        self._literal_methods = frozenset(literal_methods)
+        # Populated lazily at call time, so Dag parsing never touches network
+        # or credentials.
+        self._hook: Any | None = None
+        self._services: dict[tuple[str, str], Any] = {}
+        self._remote_docs: dict[tuple[str, str], dict[str, Any]] = {}
+
+    @property
+    def id(self) -> str:
+        return f"gcp-{self._gcp_conn_id}"
+
+    @staticmethod
+    def get_available_methods(api_version: str) -> list[str]:
+        """
+        Return ready-to-use ``allowed_methods`` entries for every method of a bundled API.
+
+        Authoring-time discovery helper -- reads only the locally bundled
+        discovery document (no network, no credentials)::
+
+            GoogleCloudToolset.get_available_methods("storage/v1")
+            # ['storage/v1:bucketAccessControls.delete', ..., 'storage/v1:objects.list', ...]
+
+        :param api_version: API and version, e.g. ``"storage/v1"``.
+        """
+        api, _, version = api_version.partition("/")
+        if not version or (api, version) not in _bundled_apis():
+            raise ValueError(
+                f"API {api_version!r} is not in the bundled discovery documents. "
+                "Expected '<api>/<version>', e.g. 'storage/v1'."
+            )
+        doc = _load_bundled_doc(api, version)
+        return sorted(f"{api}/{version}:{path}" for path in set(_collect_method_paths(doc).values()))
+
+    # ------------------------------------------------------------------
+    # AbstractToolset interface
+    # ------------------------------------------------------------------
+
+    async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
+        tools: dict[str, ToolsetTool[Any]] = {}
+
+        for name, description, schema in (
+            (
+                "list_gcp_methods",
+                "List the Google API methods this toolset allows, grouped by api/version.",
+                _LIST_METHODS_SCHEMA,
+            ),
+            (
+                "describe_gcp_method",
+                "Show a method's parameters and request/response schemas before calling it.",
+                _DESCRIBE_METHOD_SCHEMA,
+            ),
+            (
+                "call_gcp",
+                "Execute an allowed Google API method and return the response as JSON.",
+                _CALL_GCP_SCHEMA,
+            ),
+        ):
+            # sequential=True because all tools share per-API service clients
+            # with synchronous I/O -- they must not run concurrently.
+            # return_schema is "string": every tool returns a JSON-encoded string,
+            # so code mode renders `-> str` instead of `-> Any`.
+            tool_def = ToolDefinition(
+                name=name,
+                description=description,
+                parameters_json_schema=schema,
+                sequential=True,
+                **return_schema_kwargs({"type": "string"}),
+            )
+            tools[name] = ToolsetTool(
+                toolset=self,
+                tool_def=tool_def,
+                max_retries=1,
+                args_validator=_PASSTHROUGH_VALIDATOR,
+            )
+        return tools
+
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[Any],
+        tool: ToolsetTool[Any],
+    ) -> Any:
+        if name not in ("list_gcp_methods", "describe_gcp_method", "call_gcp"):
+            raise ValueError(f"Unknown tool: {name!r}")
+        try:
+            if name == "list_gcp_methods":
+                api_filter = tool_args.get("api")
+                if api_filter is not None and not isinstance(api_filter, str):
+                    raise ValueError("The 'api' argument must be a string, e.g. 'storage/v1'.")
+                return self._list_methods(api_filter=api_filter)
+            api = _require_string_arg(tool_args=tool_args, key="api")
+            method = _require_string_arg(tool_args=tool_args, key="method")
+            if name == "describe_gcp_method":
+                return self._describe_method(api_version=api, method=method)
+            parameters = tool_args.get("parameters") or {}
+            if not isinstance(parameters, dict):
+                raise ValueError("The 'parameters' argument must be a JSON object.")
+            body = tool_args.get("body")
+            if body is not None and not isinstance(body, dict):
+                raise ValueError("The 'body' argument must be a JSON object.")
+            return self._call_gcp(api_version=api, method=method, parameters=parameters, body=body)
+        except Exception as e:
+            # Hand Google's own error back to the agent as a retry so it can
+            # correct its parameters within the run. pydantic-ai bounds this by
+            # the tool's max_retries, so an unrecoverable error (bad
+            # credentials, missing IAM permissions) exhausts the budget and
+            # fails the task for Airflow to retry.
+            raise ModelRetry(
+                f"The {name} tool failed: {e}\n"
+                "Use list_gcp_methods to see what you may call and "
+                "describe_gcp_method to check the expected parameters, then try again."
+            ) from e
+
+    # ------------------------------------------------------------------
+    # Authorization
+    # ------------------------------------------------------------------
+
+    def _is_method_allowed(self, *, api: str, version: str, method_path: str) -> bool:
+        key = _normalize_method(f"{api}/{version}:{method_path}")
+        if _normalize_method(f"{api}:{method_path}") in _CREDENTIAL_RETURNING_METHODS:
+            return key in self._literal_methods
+        return any(fnmatchcase(key, pattern) for pattern in self._patterns.get((api, version), ()))
+
+    def _get_allowed_api(self, *, api_version: str) -> tuple[str, str]:
+        """Validate a tool-supplied ``api/version`` against the allow-list."""
+        api, _, version = api_version.partition("/")
+        key = (api, version)
+        if not version or key not in self._patterns:
+            allowed = ", ".join(sorted(f"{a}/{v}" for a, v in self._patterns))
+            raise ValueError(
+                f"API {api_version!r} is not in this toolset's allowed methods. Allowed APIs: {allowed}."
+            )
+        return key
+
+    # ------------------------------------------------------------------
+    # Tool implementations
+    # ------------------------------------------------------------------
+
+    def _list_methods(self, *, api_filter: str | None) -> str:
+        keys = [self._get_allowed_api(api_version=api_filter)] if api_filter else sorted(self._patterns)
+        listing = {}
+        for api, version in keys:
+            doc = self._get_doc(api=api, version=version)
+            listing[f"{api}/{version}"] = sorted(
+                canonical
+                for canonical in set(_collect_method_paths(doc).values())
+                if self._is_method_allowed(api=api, version=version, method_path=canonical)
+            )
+        return json.dumps(listing)
+
+    def _describe_method(self, *, api_version: str, method: str) -> str:
+        api, version = self._get_allowed_api(api_version=api_version)
+        doc = self._get_doc(api=api, version=version)
+        canonical = _collect_method_paths(doc).get(_normalize_method(method))
+        if canonical is None:
+            raise ValueError(f"Unknown method {method!r} for {api}/{version}.")
+        if not self._is_method_allowed(api=api, version=version, method_path=canonical):
+            raise ValueError(f"Method {api}/{version}:{canonical} is not in this toolset's allowed methods.")
+        log.info("Describing Google Cloud API method %s/%s:%s", api, version, canonical)
+        method_doc = _get_method_doc(doc, canonical)
+        request_ref = method_doc.get("request")
+        response_ref = method_doc.get("response")
+        return json.dumps(
+            {
+                "api": f"{api}/{version}",
+                "method": canonical,
+                "http_method": method_doc.get("httpMethod"),
+                "description": (method_doc.get("description") or "")[:600],
+                "parameters": _describe_parameters(method_doc),
+                "request_body": _describe_schema(doc, request_ref) if request_ref else None,
+                "response": _describe_schema(doc, response_ref) if response_ref else None,
+                "scopes": method_doc.get("scopes", []),
+            }
+        )
+
+    def _call_gcp(
+        self,
+        *,
+        api_version: str,
+        method: str,
+        parameters: dict[str, Any],
+        body: dict[str, Any] | None,
+    ) -> str:
+        api, version = self._get_allowed_api(api_version=api_version)
+        doc = self._get_doc(api=api, version=version)
+        canonical = _collect_method_paths(doc).get(_normalize_method(method))
+        if canonical is None:
+            raise ValueError(f"Unknown method {method!r} for {api}/{version}.")
+        if not self._is_method_allowed(api=api, version=version, method_path=canonical):
+            raise ValueError(
+                f"Method {api}/{version}:{canonical} is not in this toolset's allowed methods. "
+                "Use list_gcp_methods to see what you may call."
+            )
+        log.info("Calling Google Cloud API method %s/%s:%s", api, version, canonical)
+        method_doc = _get_method_doc(doc, canonical)
+
+        params = dict(parameters)
+        if str(params.get("alt", "")).casefold() == "media":
+            raise ValueError(
+                "Media download (alt=media) is not supported by this toolset; "
+                "metadata calls on the same resource work."
+            )
+        # media_body/media_mime_type are googleapiclient upload kwargs, not API
+        # parameters -- a string media_body would make the client read a local
+        # file from the worker. Media transfer is unsupported here.
+        for media_param in ("media_body", "media_mime_type"):
+            if media_param in params:
+                raise ValueError(
+                    f"Media upload ({media_param}) is not supported by this toolset; "
+                    "metadata calls on the same resource work."
+                )
+        for param_name in list(params):
+            if "." in param_name:
+                client_param_name = param_name.replace(".", "_")
+                params.setdefault(client_param_name, params[param_name])
+                del params[param_name]
+        self._apply_project_guard(method_doc=method_doc, params=params)
+
+        service = self._get_service(api=api, version=version)
+        *resource_path, method_name = canonical.split(".")
+        node: Any = service
+        for resource in resource_path:
+            node = getattr(node, resource)()
+        bound = getattr(node, method_name)
+        request = bound(**params, body=body) if body is not None else bound(**params)
+        response = request.execute()
+
+        pages = [response]
+        next_method = getattr(node, f"{method_name}_next", None)
+        while next_method is not None and isinstance(pages[-1], dict) and len(pages) < self._max_pages:
+            request = next_method(previous_request=request, previous_response=pages[-1])
+            if request is None:
+                break
+            pages.append(request.execute())
+
+        if len(pages) == 1:
+            return self._serialize_response(response)
+        payload: dict[str, Any] = {"pages": pages, "page_count": len(pages)}
+        if isinstance(pages[-1], dict) and pages[-1].get("nextPageToken"):
+            payload["more_pages_available"] = True
+        return self._serialize_response(payload)
+
+    # ------------------------------------------------------------------
+    # Project pinning
+    # ------------------------------------------------------------------
+
+    def _apply_project_guard(self, *, method_doc: dict[str, Any], params: dict[str, Any]) -> None:
+        project = self._get_hook().project_id
+        if not project:
+            return
+        param_defs = method_doc.get("parameters", {})
+        for param_name in ("project", "projectId"):
+            if param_name in param_defs:
+                expected = _format_project_parameter(project=project, param_def=param_defs[param_name])
+                supplied = params.get(param_name)
+                if supplied is None:
+                    params[param_name] = expected
+                elif supplied == project and expected != project:
+                    params[param_name] = expected
+                elif self._enforce_project and supplied != expected:
+                    raise ValueError(f"{param_name} must be {expected!r} (the connection's project).")
+        if not self._enforce_project:
+            return
+        # Best-effort guard on path-style parameters ("projects/<id>/...").
+        for param_name, param_def in param_defs.items():
+            value = params.get(param_name)
+            if (
+                param_def.get("location") == "path"
+                and isinstance(value, str)
+                and value.startswith("projects/")
+            ):
+                segments = value.split("/")
+                if len(segments) >= 2 and segments[1] != project:
+                    raise ValueError(
+                        f"{param_name} references project {segments[1]!r}; this toolset is "
+                        f"pinned to {project!r}."
+                    )
+
+    # ------------------------------------------------------------------
+    # Lazy hook/service/document resolution and serialization
+    # ------------------------------------------------------------------
+
+    def _get_hook(self) -> Any:
+        if self._hook is None:
+            self._hook = _get_google_base_hook_class()(
+                gcp_conn_id=self._gcp_conn_id, impersonation_chain=self._impersonation_chain
+            )
+        return self._hook
+
+    def _get_service(self, *, api: str, version: str) -> Any:
+        key = (api, version)
+        if key not in self._services:
+            self._services[key] = build(
+                api,
+                version,
+                credentials=self._get_hook().get_credentials(),
+                cache_discovery=False,
+                static_discovery=key in _bundled_apis(),
+            )
+        return self._services[key]
+
+    def _get_doc(self, *, api: str, version: str) -> dict[str, Any]:
+        key = (api, version)
+        if key in _bundled_apis():
+            return _load_bundled_doc(api, version)
+        # Normally only reachable when allow_remote_discovery=True let the entry
+        # through construction; re-checked here in case the bundle differs between
+        # the parsing and execution environments. Fetched lazily at call time,
+        # never at Dag parse time.
+        if not self._allow_remote_discovery:
+            raise ValueError(
+                f"API {api}/{version} has no bundled discovery document and "
+                "allow_remote_discovery is disabled."
+            )
+        if key not in self._remote_docs:
+            import requests
+
+            response = requests.get(_DISCOVERY_DOC_URL.format(api=api, version=version), timeout=30)
+            response.raise_for_status()
+            self._remote_docs[key] = response.json()
+        return self._remote_docs[key]
+
+    def _serialize_response(self, response: Any) -> str:
+        payload = json.dumps(response, default=str)
+        if len(payload) > self._max_output_bytes:
+            return json.dumps(
+                {
+                    "truncated": True,
+                    "max_output_bytes": self._max_output_bytes,
+                    "data": payload[: self._max_output_bytes],
+                }
+            )
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Private discovery-document helpers
+# ---------------------------------------------------------------------------
+
+
+@cache
+def _bundled_docs_dir() -> str:
+    return os.path.join(os.path.dirname(googleapiclient.discovery_cache.__file__), "documents")
+
+
+@cache
+def _bundled_apis() -> frozenset[tuple[str, str]]:
+    pairs = set()
+    for filename in os.listdir(_bundled_docs_dir()):
+        if filename.endswith(".json"):
+            api, _, version = filename[:-5].partition(".")
+            if version:
+                pairs.add((api, version))
+    return frozenset(pairs)
+
+
+@cache
+def _load_bundled_doc(api: str, version: str) -> dict[str, Any]:
+    path = os.path.join(_bundled_docs_dir(), f"{api}.{version}.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+def _collect_method_paths(doc: dict[str, Any]) -> dict[str, str]:
+    """
+    Map normalized method paths to their canonical form for one discovery document.
+
+    Google's reference docs display method IDs with the API name prefixed
+    (``storage.buckets.list``), so each path is also registered under that
+    alias -- users can paste either form.
+    """
+    paths: dict[str, str] = {}
+    for method_name in doc.get("methods", {}):
+        paths[_normalize_method(method_name)] = method_name
+
+    def walk(resources: dict[str, Any], prefix: str) -> None:
+        for resource_name, resource in resources.items():
+            for method_name in resource.get("methods", {}):
+                canonical = f"{prefix}{resource_name}.{method_name}"
+                paths[_normalize_method(canonical)] = canonical
+            if "resources" in resource:
+                walk(resource["resources"], f"{prefix}{resource_name}.")
+
+    walk(doc.get("resources", {}), "")
+
+    api_name = doc.get("name")
+    if api_name:
+        for canonical in list(paths.values()):
+            paths.setdefault(_normalize_method(f"{api_name}.{canonical}"), canonical)
+    return paths
+
+
+def _get_method_doc(doc: dict[str, Any], method_path: str) -> dict[str, Any]:
+    """Return the discovery entry for a canonical method path."""
+    *resource_path, method_name = method_path.split(".")
+    node = doc
+    for resource in resource_path:
+        node = node["resources"][resource]
+    return node["methods"][method_name]
+
+
+def _describe_parameters(method_doc: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name, param in method_doc.get("parameters", {}).items():
+        entry: dict[str, Any] = {
+            "type": param.get("type", "string"),
+            "location": param.get("location", "query"),
+        }
+        if param.get("required"):
+            entry["required"] = True
+        if param.get("description"):
+            entry["description"] = param["description"][:200]
+        out[name] = entry
+    return out
+
+
+def _describe_schema(
+    doc: dict[str, Any],
+    node: dict[str, Any],
+    depth: int = _SCHEMA_DEPTH,
+    seen: frozenset[str] = frozenset(),
+) -> Any:
+    """
+    Render a discovery schema as a compact JSON-friendly summary.
+
+    Discovery schemas are ``$ref``-based and recursive, so resolution carries a
+    visited set: a schema already on the current path is cut to its name.
+    """
+    if "$ref" in node:
+        ref = node["$ref"]
+        if ref in seen or depth <= 0:
+            return ref
+        return _describe_schema(doc, doc.get("schemas", {}).get(ref, {}), depth - 1, seen | {ref})
+    type_name = node.get("type", "any")
+    if type_name == "object":
+        properties = node.get("properties")
+        if properties and depth > 0:
+            out = {}
+            for name, member in properties.items():
+                summary = _describe_schema(doc, member, depth - 1, seen)
+                if member.get("required"):
+                    out[name] = {"type": summary, "required": True}
+                else:
+                    out[name] = {"type": summary}
+            return out
+        if "additionalProperties" in node and depth > 0:
+            return {"<key>": _describe_schema(doc, node["additionalProperties"], depth - 1, seen)}
+        return type_name
+    if type_name == "array":
+        if depth > 0:
+            return [_describe_schema(doc, node.get("items", {}), depth - 1, seen)]
+        return type_name
+    enum = node.get("enum")
+    if enum:
+        return f"{type_name} (one of: {', '.join(enum[:20])})"
+    return type_name

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
@@ -355,10 +355,6 @@ class GoogleCloudToolset(AbstractToolset[Any]):
             f"{api}/{version}:{path}" for path in set(_get_bundled_method_paths(api, version).values())
         )
 
-    # ------------------------------------------------------------------
-    # AbstractToolset interface
-    # ------------------------------------------------------------------
-
     async def get_tools(self, ctx: RunContext[Any]) -> dict[str, ToolsetTool[Any]]:
         tools: dict[str, ToolsetTool[Any]] = {}
 
@@ -436,10 +432,6 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 "describe_gcp_method to check the expected parameters, then try again."
             ) from e
 
-    # ------------------------------------------------------------------
-    # Authorization
-    # ------------------------------------------------------------------
-
     def _is_method_allowed(self, *, api: str, version: str, method_path: str) -> bool:
         key = _normalize_method(f"{api}/{version}:{method_path}")
         if _normalize_method(f"{api}:{method_path}") in _CREDENTIAL_RETURNING_METHODS:
@@ -456,10 +448,6 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 f"API {api_version!r} is not in this toolset's allowed methods. Allowed APIs: {allowed}."
             )
         return key
-
-    # ------------------------------------------------------------------
-    # Tool implementations
-    # ------------------------------------------------------------------
 
     def _list_methods(self, *, api_filter: str | None) -> str:
         keys = [self._get_allowed_api(api_version=api_filter)] if api_filter else sorted(self._patterns)
@@ -561,10 +549,6 @@ class GoogleCloudToolset(AbstractToolset[Any]):
             payload["more_pages_available"] = True
         return self._serialize_response(payload)
 
-    # ------------------------------------------------------------------
-    # Project pinning
-    # ------------------------------------------------------------------
-
     def _apply_project_guard(self, *, method_doc: dict[str, Any], params: dict[str, Any]) -> None:
         if not (project := self._get_hook().project_id):
             return
@@ -595,10 +579,6 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                         f"{param_name} references project {segments[1]!r}; this toolset is "
                         f"pinned to {project!r}."
                     )
-
-    # ------------------------------------------------------------------
-    # Lazy hook/service/document resolution and serialization
-    # ------------------------------------------------------------------
 
     def _get_hook(self) -> Any:
         if self._hook is None:

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 try:
     import googleapiclient.discovery_cache
-    from googleapiclient.discovery import build
+    from googleapiclient.discovery import ResourceMethodParameters, build
 except ImportError as e:
     from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 
@@ -537,12 +537,8 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                     f"Media upload ({media_param}) is not supported by this toolset; "
                     "metadata calls on the same resource work."
                 )
-        for param_name in list(params):
-            if "." in param_name:
-                client_param_name = param_name.replace(".", "_")
-                params.setdefault(client_param_name, params[param_name])
-                del params[param_name]
         self._apply_project_guard(method_doc=method_doc, params=params)
+        params = _normalize_parameters_for_google_client(method_doc=method_doc, parameters=params)
 
         service = self._get_service(api=api, version=version)
         *resource_path, method_name = canonical.split(".")
@@ -725,6 +721,40 @@ def _get_method_doc(doc: dict[str, Any], method_path: str) -> dict[str, Any]:
     for resource in resource_path:
         node = node["resources"][resource]
     return node["methods"][method_name]
+
+
+def _normalize_parameters_for_google_client(
+    *,
+    method_doc: dict[str, Any],
+    parameters: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Convert documented Google REST parameter names to googleapiclient keyword names.
+
+    Discovery documents describe parameters using the public REST names shown in
+    Google docs and APIs Explorer, for example ``interval.startTime`` or
+    ``options.requestedPolicyVersion``. The generated ``googleapiclient`` Python
+    methods cannot accept those names directly as keyword arguments, so the
+    client converts them to safe Python names such as ``interval_startTime`` and
+    ``options_requestedPolicyVersion``.
+
+    Keep the tool contract model-facing and doc-facing by accepting the REST
+    names from ``describe_gcp_method``, then translate only at the final
+    ``googleapiclient`` call boundary using the same per-method mapping the
+    client uses internally.
+    """
+    method_params = ResourceMethodParameters(method_doc)
+    rest_to_client = {rest_name: client_name for client_name, rest_name in method_params.argmap.items()}
+
+    normalized: dict[str, Any] = {}
+    for name, value in parameters.items():
+        client_name = rest_to_client.get(name, name)
+        if client_name in normalized and normalized[client_name] != value:
+            raise ValueError(
+                f"Parameter {name!r} conflicts with another parameter mapped to {client_name!r}."
+            )
+        normalized[client_name] = value
+    return normalized
 
 
 def _describe_parameters(method_doc: dict[str, Any]) -> dict[str, Any]:

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/google.py
@@ -27,14 +27,7 @@ from functools import cache
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-try:
-    import googleapiclient.discovery_cache
-    from googleapiclient.discovery import ResourceMethodParameters, build
-except ImportError as e:
-    from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
-
-    raise AirflowOptionalProviderFeatureException(e)
-
+import requests
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
@@ -42,6 +35,12 @@ from pydantic_core import SchemaValidator, core_schema
 
 from airflow.providers.common.ai.utils.tool_definition import return_schema_kwargs
 from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
+
+try:
+    import googleapiclient.discovery_cache
+    from googleapiclient.discovery import ResourceMethodParameters, build
+except ImportError as e:
+    raise AirflowOptionalProviderFeatureException() from e
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -86,7 +85,7 @@ def _get_google_base_hook_class() -> type[Any]:
     try:
         return import_module("airflow.providers.google.common.hooks.base_google").GoogleBaseHook
     except ImportError as e:
-        raise AirflowOptionalProviderFeatureException(e)
+        raise AirflowOptionalProviderFeatureException() from e
 
 
 # Methods that put credentials or decrypted secrets into the agent's context.
@@ -290,8 +289,7 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 )
             has_wildcard = any(ch in method_path for ch in "*?[")
             if bundled and not has_wildcard:
-                doc = _load_bundled_doc(api, version)
-                canonical = _collect_method_paths(doc).get(_normalize_method(method_path))
+                canonical = _get_bundled_method_paths(api, version).get(_normalize_method(method_path))
                 if canonical is None:
                     raise ValueError(
                         f"Unknown method {method_path!r} for {api}/{version} in {entry!r}. "
@@ -302,12 +300,11 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 # and path-style entries ("objects.list") authorize identically.
                 method_path = canonical
             elif bundled:
-                doc = _load_bundled_doc(api, version)
                 pattern = _normalize_method(f"{api}/{version}:{method_path}")
                 if not any(
                     fnmatchcase(_normalize_method(f"{api}/{version}:{path}"), pattern)
                     and _normalize_method(f"{api}:{path}") not in _CREDENTIAL_RETURNING_METHODS
-                    for path in set(_collect_method_paths(doc).values())
+                    for path in set(_get_bundled_method_paths(api, version).values())
                 ):
                     raise ValueError(
                         f"Pattern {method_path!r} matches no methods of {api}/{version} in {entry!r}. "
@@ -326,8 +323,7 @@ class GoogleCloudToolset(AbstractToolset[Any]):
         self._max_output_bytes = max_output_bytes
         self._patterns = patterns
         self._literal_methods = frozenset(literal_methods)
-        # Populated lazily at call time, so Dag parsing never touches network
-        # or credentials.
+        # Populated lazily at call time, so Dag parsing never touches network or credentials.
         self._hook: Any | None = None
         self._services: dict[tuple[str, str], Any] = {}
         self._remote_docs: dict[tuple[str, str], dict[str, Any]] = {}
@@ -355,8 +351,9 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 f"API {api_version!r} is not in the bundled discovery documents. "
                 "Expected '<api>/<version>', e.g. 'storage/v1'."
             )
-        doc = _load_bundled_doc(api, version)
-        return sorted(f"{api}/{version}:{path}" for path in set(_collect_method_paths(doc).values()))
+        return sorted(
+            f"{api}/{version}:{path}" for path in set(_get_bundled_method_paths(api, version).values())
+        )
 
     # ------------------------------------------------------------------
     # AbstractToolset interface
@@ -468,10 +465,10 @@ class GoogleCloudToolset(AbstractToolset[Any]):
         keys = [self._get_allowed_api(api_version=api_filter)] if api_filter else sorted(self._patterns)
         listing = {}
         for api, version in keys:
-            doc = self._get_doc(api=api, version=version)
+            method_paths = self._get_method_paths(api=api, version=version)
             listing[f"{api}/{version}"] = sorted(
                 canonical
-                for canonical in set(_collect_method_paths(doc).values())
+                for canonical in set(method_paths.values())
                 if self._is_method_allowed(api=api, version=version, method_path=canonical)
             )
         return json.dumps(listing)
@@ -479,7 +476,7 @@ class GoogleCloudToolset(AbstractToolset[Any]):
     def _describe_method(self, *, api_version: str, method: str) -> str:
         api, version = self._get_allowed_api(api_version=api_version)
         doc = self._get_doc(api=api, version=version)
-        canonical = _collect_method_paths(doc).get(_normalize_method(method))
+        canonical = self._get_method_paths(api=api, version=version).get(_normalize_method(method))
         if canonical is None:
             raise ValueError(f"Unknown method {method!r} for {api}/{version}.")
         if not self._is_method_allowed(api=api, version=version, method_path=canonical):
@@ -511,7 +508,7 @@ class GoogleCloudToolset(AbstractToolset[Any]):
     ) -> str:
         api, version = self._get_allowed_api(api_version=api_version)
         doc = self._get_doc(api=api, version=version)
-        canonical = _collect_method_paths(doc).get(_normalize_method(method))
+        canonical = self._get_method_paths(api=api, version=version).get(_normalize_method(method))
         if canonical is None:
             raise ValueError(f"Unknown method {method!r} for {api}/{version}.")
         if not self._is_method_allowed(api=api, version=version, method_path=canonical):
@@ -569,8 +566,7 @@ class GoogleCloudToolset(AbstractToolset[Any]):
     # ------------------------------------------------------------------
 
     def _apply_project_guard(self, *, method_doc: dict[str, Any], params: dict[str, Any]) -> None:
-        project = self._get_hook().project_id
-        if not project:
+        if not (project := self._get_hook().project_id):
             return
         param_defs = method_doc.get("parameters", {})
         for param_name in ("project", "projectId"):
@@ -637,12 +633,16 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 "allow_remote_discovery is disabled."
             )
         if key not in self._remote_docs:
-            import requests
-
             response = requests.get(_DISCOVERY_DOC_URL.format(api=api, version=version), timeout=30)
             response.raise_for_status()
             self._remote_docs[key] = response.json()
         return self._remote_docs[key]
+
+    def _get_method_paths(self, *, api: str, version: str) -> dict[str, str]:
+        key = (api, version)
+        if key in _bundled_apis():
+            return _get_bundled_method_paths(api, version)
+        return _collect_method_paths(self._get_doc(api=api, version=version))
 
     def _serialize_response(self, response: Any) -> str:
         payload = json.dumps(response, default=str)
@@ -655,11 +655,6 @@ class GoogleCloudToolset(AbstractToolset[Any]):
                 }
             )
         return payload
-
-
-# ---------------------------------------------------------------------------
-# Private discovery-document helpers
-# ---------------------------------------------------------------------------
 
 
 @cache
@@ -678,11 +673,15 @@ def _bundled_apis() -> frozenset[tuple[str, str]]:
     return frozenset(pairs)
 
 
-@cache
 def _load_bundled_doc(api: str, version: str) -> dict[str, Any]:
     path = os.path.join(_bundled_docs_dir(), f"{api}.{version}.json")
     with open(path) as f:
         return json.load(f)
+
+
+@cache
+def _get_bundled_method_paths(api: str, version: str) -> dict[str, str]:
+    return _collect_method_paths(_load_bundled_doc(api, version))
 
 
 def _collect_method_paths(doc: dict[str, Any]) -> dict[str, str]:
@@ -707,8 +706,7 @@ def _collect_method_paths(doc: dict[str, Any]) -> dict[str, str]:
 
     walk(doc.get("resources", {}), "")
 
-    api_name = doc.get("name")
-    if api_name:
+    if api_name := doc.get("name"):
         for canonical in list(paths.values()):
             paths.setdefault(_normalize_method(f"{api_name}.{canonical}"), canonical)
     return paths
@@ -808,7 +806,6 @@ def _describe_schema(
         if depth > 0:
             return [_describe_schema(doc, node.get("items", {}), depth - 1, seen)]
         return type_name
-    enum = node.get("enum")
-    if enum:
+    if enum := node.get("enum"):
         return f"{type_name} (one of: {', '.join(enum[:20])})"
     return type_name

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
@@ -357,6 +357,64 @@ class TestGoogleCloudToolsetCallGcp:
             interval_endTime="2026-07-20T01:00:00Z",
         )
 
+    def test_leading_underscore_parameters_are_passed_as_client_keyword_names(self):
+        ts = GoogleCloudToolset(
+            "gcp_test", allowed_methods=["healthcare/v1:projects.locations.datasets.fhirStores.fhir.history"]
+        )
+        _install_mock_hook(ts, project_id=None)
+        _, bound, _ = _install_mock_service(
+            ts,
+            "healthcare",
+            "v1",
+            ["projects", "locations", "datasets", "fhirStores", "fhir"],
+            "history",
+            response={"entry": []},
+        )
+
+        _call(
+            ts,
+            "call_gcp",
+            {
+                "api": "healthcare/v1",
+                "method": "projects.locations.datasets.fhirStores.fhir.history",
+                "parameters": {
+                    "name": "projects/p/locations/us/datasets/d/fhirStores/s/fhir/Patient/123",
+                    "_count": 10,
+                    "_page_token": "next",
+                },
+            },
+        )
+
+        bound.assert_called_once_with(
+            name="projects/p/locations/us/datasets/d/fhirStores/s/fhir/Patient/123",
+            x_count=10,
+            x_page_token="next",
+        )
+
+    def test_rejects_conflicting_rest_and_client_parameter_names(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["monitoring/v3:projects.timeSeries.list"])
+        _install_mock_hook(ts, project_id=None)
+        _, bound, _ = _install_mock_service(
+            ts, "monitoring", "v3", ["projects", "timeSeries"], "list", response={"timeSeries": []}
+        )
+
+        with pytest.raises(ModelRetry, match="conflicts with another parameter"):
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "monitoring/v3",
+                    "method": "projects.timeSeries.list",
+                    "parameters": {
+                        "name": "projects/p",
+                        "interval.startTime": "2026-07-20T00:00:00Z",
+                        "interval_startTime": "2026-07-20T01:00:00Z",
+                    },
+                },
+            )
+
+        bound.assert_not_called()
+
     def test_follows_pagination_up_to_max_pages(self):
         ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"], max_pages=2)
         _install_mock_hook(ts, project_id=None)

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic_ai.exceptions import ModelRetry
 
+from airflow.providers.common.ai.toolsets import google as google_toolset
 from airflow.providers.common.ai.toolsets.google import GoogleCloudToolset
 from airflow.providers.common.ai.utils.tool_definition import _SUPPORTS_RETURN_SCHEMA
 
@@ -103,6 +104,20 @@ class TestGoogleCloudToolsetInit:
 
     def test_unbundled_api_allowed_with_remote_discovery(self):
         GoogleCloudToolset("gcp_test", allowed_methods=["nosuchapi/v1:foo.bar"], allow_remote_discovery=True)
+
+    def test_reuses_cached_method_path_map_during_init_validation(self):
+        google_toolset._get_bundled_method_paths.cache_clear()
+
+        with patch.object(
+            google_toolset, "_load_bundled_doc", wraps=google_toolset._load_bundled_doc
+        ) as load_bundled_doc:
+            GoogleCloudToolset(
+                "gcp_test",
+                allowed_methods=["storage/v1:objects.list", "storage/v1:buckets.*"],
+            )
+            GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:buckets.list"])
+
+        load_bundled_doc.assert_called_once_with("storage", "v1")
 
 
 class TestGoogleCloudToolsetGetTools:

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -223,17 +222,6 @@ class TestGoogleCloudToolsetDescribeMethod:
         )
         assert described["method"] == "objects.list"
 
-    def test_logs_canonical_method(self, caplog):
-        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
-
-        with caplog.at_level(logging.INFO, logger="airflow.providers.common.ai.toolsets.google"):
-            _call(ts, "describe_gcp_method", {"api": "storage/v1", "method": "storage.objects.list"})
-
-        assert {
-            "event": "Describing Google Cloud API method storage/v1:objects.list",
-            "level": "info",
-        } in caplog
-
     def test_disallowed_method_raises_model_retry(self):
         ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
         with pytest.raises(ModelRetry, match="not in this toolset's allowed methods"):
@@ -263,30 +251,6 @@ class TestGoogleCloudToolsetCallGcp:
         bound.assert_called_once_with(bucket="b")
         request.execute.assert_called_once_with()
         assert result["items"] == [{"name": "a.parquet"}]
-
-    def test_logs_canonical_method(self, caplog):
-        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
-        _install_mock_hook(ts, project_id=None)
-        _install_mock_service(
-            ts,
-            "storage",
-            "v1",
-            ["objects"],
-            "list",
-            response={"items": []},
-        )
-
-        with caplog.at_level(logging.INFO, logger="airflow.providers.common.ai.toolsets.google"):
-            _call(
-                ts,
-                "call_gcp",
-                {"api": "storage/v1", "method": "storage.objects.list", "parameters": {"bucket": "b"}},
-            )
-
-        assert {
-            "event": "Calling Google Cloud API method storage/v1:objects.list",
-            "level": "info",
-        } in caplog
 
     def test_body_is_passed_as_keyword(self):
         ts = GoogleCloudToolset("gcp_test", allowed_methods=["bigquery/v2:jobs.insert"])

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_google.py
@@ -1,0 +1,638 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic_ai.exceptions import ModelRetry
+
+from airflow.providers.common.ai.toolsets.google import GoogleCloudToolset
+from airflow.providers.common.ai.utils.tool_definition import _SUPPORTS_RETURN_SCHEMA
+
+
+def _make_toolset(**kwargs):
+    kwargs.setdefault("allowed_methods", ["storage/v1:objects.list", "storage/v1:buckets.*"])
+    return GoogleCloudToolset("gcp_test", **kwargs)
+
+
+def _call(ts, name, args):
+    return asyncio.run(ts.call_tool(name, args, ctx=MagicMock(), tool=MagicMock()))
+
+
+def _install_mock_service(ts, api, version, resource_path, method, response=None):
+    """Wire a MagicMock service into the toolset and return (node, bound_method, request)."""
+    service = MagicMock()
+    node = service
+    for resource in resource_path:
+        node = getattr(node, resource).return_value
+    bound = getattr(node, method)
+    request = bound.return_value
+    request.execute.return_value = response if response is not None else {}
+    getattr(node, f"{method}_next").return_value = None
+    ts._services[(api, version)] = service
+    return node, bound, request
+
+
+def _install_mock_hook(ts, project_id="my-proj"):
+    hook = MagicMock()
+    hook.project_id = project_id
+    ts._hook = hook
+    return hook
+
+
+class TestGoogleCloudToolsetInit:
+    def test_id_includes_conn_id(self):
+        ts = _make_toolset()
+        assert ts.id == "gcp-gcp_test"
+
+    def test_rejects_empty_allowed_methods(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            GoogleCloudToolset("gcp_test", allowed_methods=[])
+
+    @pytest.mark.parametrize(
+        ("entry", "match"),
+        [
+            ("storage:objects.list", "expected"),
+            ("storage/v1", "expected"),
+            (":objects.list", "expected"),
+            ("*/v1:foo", "wildcards are only allowed in the method part"),
+            ("storage/*:foo", "wildcards are only allowed in the method part"),
+            ("nosuchapi/v1:foo", "not in the bundled discovery documents"),
+            ("storage/v1:no.such.method", "Unknown method"),
+            ("storage/v1:no.such.*", "matches no methods"),
+            ("secretmanager/v1:projects.secrets.versions.acc*", "matches no methods"),
+        ],
+    )
+    def test_rejects_invalid_entry(self, entry, match):
+        with pytest.raises(ValueError, match=match):
+            GoogleCloudToolset("gcp_test", allowed_methods=[entry])
+
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"max_pages": 0}, "max_pages"),
+            ({"max_output_bytes": 0}, "max_output_bytes"),
+        ],
+    )
+    def test_rejects_non_positive_bounds(self, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            _make_toolset(**kwargs)
+
+    def test_accepts_case_and_doc_style_variants(self):
+        GoogleCloudToolset(
+            "gcp_test",
+            allowed_methods=["storage/v1:OBJECTS.LIST", "storage/v1:storage.buckets.list"],
+        )
+
+    def test_unbundled_api_allowed_with_remote_discovery(self):
+        GoogleCloudToolset("gcp_test", allowed_methods=["nosuchapi/v1:foo.bar"], allow_remote_discovery=True)
+
+
+class TestGoogleCloudToolsetGetTools:
+    def test_returns_three_tools(self):
+        ts = _make_toolset()
+        tools = asyncio.run(ts.get_tools(ctx=MagicMock()))
+        assert set(tools.keys()) == {"list_gcp_methods", "describe_gcp_method", "call_gcp"}
+
+    def test_tool_definitions_have_descriptions(self):
+        ts = _make_toolset()
+        tools = asyncio.run(ts.get_tools(ctx=MagicMock()))
+        for tool in tools.values():
+            assert tool.tool_def.description
+
+    @pytest.mark.skipif(
+        not _SUPPORTS_RETURN_SCHEMA, reason="pydantic-ai too old for ToolDefinition.return_schema"
+    )
+    def test_tools_declare_string_return_schema(self):
+        ts = _make_toolset()
+        tools = asyncio.run(ts.get_tools(ctx=MagicMock()))
+        for tool in tools.values():
+            assert tool.tool_def.return_schema == {"type": "string"}
+
+
+class TestGoogleCloudToolsetMethodMatching:
+    @pytest.mark.parametrize(
+        ("methods", "api", "version", "path", "allowed"),
+        [
+            (["storage/v1:objects.list"], "storage", "v1", "objects.list", True),
+            (["storage/v1:storage.objects.list"], "storage", "v1", "objects.list", True),
+            (["storage/v1:buckets.get_iam_policy"], "storage", "v1", "buckets.getIamPolicy", True),
+            (["storage/v1:buckets.*"], "storage", "v1", "buckets.getIamPolicy", True),
+            (["storage/v1:buckets.*"], "storage", "v1", "objects.list", False),
+            (["storage/v1:*"], "bigquery", "v2", "jobs.query", False),
+            (["compute/v1:instances.*"], "compute", "beta", "instances.list", False),
+            (["secretmanager/v1:*"], "secretmanager", "v1", "projects.secrets.versions.access", False),
+            (
+                ["secretmanager/v1:projects.secrets.versions.access"],
+                "secretmanager",
+                "v1",
+                "projects.secrets.versions.access",
+                True,
+            ),
+            (
+                ["secretmanager/v1beta1:*"],
+                "secretmanager",
+                "v1beta1",
+                "projects.secrets.versions.access",
+                False,
+            ),
+        ],
+    )
+    def test_allow_list_matching(self, methods, api, version, path, allowed):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=methods)
+        assert ts._is_method_allowed(api=api, version=version, method_path=path) is allowed
+
+
+class TestGoogleCloudToolsetListMethods:
+    def test_lists_only_allowed_methods(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:buckets.*"])
+        listing = json.loads(_call(ts, "list_gcp_methods", {}))
+        assert "buckets.list" in listing["storage/v1"]
+        assert "objects.list" not in listing["storage/v1"]
+
+    def test_listing_has_no_duplicates_from_aliases(self):
+        ts = GoogleCloudToolset(
+            "gcp_test",
+            allowed_methods=["storage/v1:storage.buckets.list", "storage/v1:objects.list"],
+        )
+        listing = json.loads(_call(ts, "list_gcp_methods", {}))
+        assert listing["storage/v1"] == ["buckets.list", "objects.list"]
+
+    def test_sensitive_methods_hidden_behind_wildcard(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["secretmanager/v1:*"])
+        listing = json.loads(_call(ts, "list_gcp_methods", {}))
+        assert "projects.secrets.list" in listing["secretmanager/v1"]
+        assert "projects.secrets.versions.access" not in listing["secretmanager/v1"]
+
+    def test_verbatim_sensitive_method_is_listed(self):
+        ts = GoogleCloudToolset(
+            "gcp_test",
+            allowed_methods=["secretmanager/v1:*", "secretmanager/v1:projects.secrets.versions.access"],
+        )
+        listing = json.loads(_call(ts, "list_gcp_methods", {}))
+        assert "projects.secrets.versions.access" in listing["secretmanager/v1"]
+
+    def test_api_outside_allow_list_raises_model_retry(self):
+        ts = _make_toolset()
+        with pytest.raises(ModelRetry, match="not in this toolset's allowed methods"):
+            _call(ts, "list_gcp_methods", {"api": "bigquery/v2"})
+
+
+class TestGoogleCloudToolsetDescribeMethod:
+    def test_returns_parameters_with_required_members(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        described = json.loads(
+            _call(ts, "describe_gcp_method", {"api": "storage/v1", "method": "objects.list"})
+        )
+        assert described["method"] == "objects.list"
+        assert described["http_method"] == "GET"
+        assert described["parameters"]["bucket"]["required"] is True
+        assert described["parameters"]["prefix"]["location"] == "query"
+        assert described["scopes"]
+
+    def test_request_body_schema_for_insert_method(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["bigquery/v2:jobs.insert"])
+        described = json.loads(
+            _call(ts, "describe_gcp_method", {"api": "bigquery/v2", "method": "jobs.insert"})
+        )
+        assert described["request_body"] is not None
+        assert described["response"] is not None
+
+    def test_resolves_doc_style_method_id(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        described = json.loads(
+            _call(ts, "describe_gcp_method", {"api": "storage/v1", "method": "storage.objects.list"})
+        )
+        assert described["method"] == "objects.list"
+
+    def test_logs_canonical_method(self, caplog):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+
+        with caplog.at_level(logging.INFO, logger="airflow.providers.common.ai.toolsets.google"):
+            _call(ts, "describe_gcp_method", {"api": "storage/v1", "method": "storage.objects.list"})
+
+        assert {
+            "event": "Describing Google Cloud API method storage/v1:objects.list",
+            "level": "info",
+        } in caplog
+
+    def test_disallowed_method_raises_model_retry(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        with pytest.raises(ModelRetry, match="not in this toolset's allowed methods"):
+            _call(ts, "describe_gcp_method", {"api": "storage/v1", "method": "buckets.delete"})
+
+
+class TestGoogleCloudToolsetCallGcp:
+    def test_executes_method_and_returns_json(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        _install_mock_hook(ts, project_id=None)
+        _, bound, request = _install_mock_service(
+            ts,
+            "storage",
+            "v1",
+            ["objects"],
+            "list",
+            response={"kind": "storage#objects", "items": [{"name": "a.parquet"}]},
+        )
+
+        result = json.loads(
+            _call(
+                ts,
+                "call_gcp",
+                {"api": "storage/v1", "method": "objects.list", "parameters": {"bucket": "b"}},
+            )
+        )
+        bound.assert_called_once_with(bucket="b")
+        request.execute.assert_called_once_with()
+        assert result["items"] == [{"name": "a.parquet"}]
+
+    def test_logs_canonical_method(self, caplog):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        _install_mock_hook(ts, project_id=None)
+        _install_mock_service(
+            ts,
+            "storage",
+            "v1",
+            ["objects"],
+            "list",
+            response={"items": []},
+        )
+
+        with caplog.at_level(logging.INFO, logger="airflow.providers.common.ai.toolsets.google"):
+            _call(
+                ts,
+                "call_gcp",
+                {"api": "storage/v1", "method": "storage.objects.list", "parameters": {"bucket": "b"}},
+            )
+
+        assert {
+            "event": "Calling Google Cloud API method storage/v1:objects.list",
+            "level": "info",
+        } in caplog
+
+    def test_body_is_passed_as_keyword(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["bigquery/v2:jobs.insert"])
+        _install_mock_hook(ts, project_id=None)
+        _, bound, _ = _install_mock_service(
+            ts, "bigquery", "v2", ["jobs"], "insert", response={"jobReference": {}}
+        )
+
+        _call(
+            ts,
+            "call_gcp",
+            {
+                "api": "bigquery/v2",
+                "method": "jobs.insert",
+                "parameters": {"projectId": "p"},
+                "body": {"configuration": {"query": {}}},
+            },
+        )
+        bound.assert_called_once_with(projectId="p", body={"configuration": {"query": {}}})
+
+    def test_traverses_nested_resource_path(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["secretmanager/v1:projects.secrets.list"])
+        _install_mock_hook(ts, project_id=None)
+        _, bound, _ = _install_mock_service(
+            ts, "secretmanager", "v1", ["projects", "secrets"], "list", response={"secrets": []}
+        )
+
+        result = json.loads(
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "secretmanager/v1",
+                    "method": "projects.secrets.list",
+                    "parameters": {"parent": "projects/p"},
+                },
+            )
+        )
+        bound.assert_called_once_with(parent="projects/p")
+        assert result == {"secrets": []}
+
+    def test_dotted_query_parameters_are_passed_as_client_keyword_names(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["monitoring/v3:projects.timeSeries.list"])
+        _install_mock_hook(ts, project_id=None)
+        _, bound, _ = _install_mock_service(
+            ts, "monitoring", "v3", ["projects", "timeSeries"], "list", response={"timeSeries": []}
+        )
+
+        _call(
+            ts,
+            "call_gcp",
+            {
+                "api": "monitoring/v3",
+                "method": "projects.timeSeries.list",
+                "parameters": {
+                    "name": "projects/p",
+                    "filter": 'metric.type = "bigquery.googleapis.com/query/count"',
+                    "interval.startTime": "2026-07-20T00:00:00Z",
+                    "interval.endTime": "2026-07-20T01:00:00Z",
+                },
+            },
+        )
+
+        bound.assert_called_once_with(
+            name="projects/p",
+            filter='metric.type = "bigquery.googleapis.com/query/count"',
+            interval_startTime="2026-07-20T00:00:00Z",
+            interval_endTime="2026-07-20T01:00:00Z",
+        )
+
+    def test_follows_pagination_up_to_max_pages(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"], max_pages=2)
+        _install_mock_hook(ts, project_id=None)
+        node, _, _ = _install_mock_service(
+            ts,
+            "storage",
+            "v1",
+            ["objects"],
+            "list",
+            response={"items": [{"name": "page1"}], "nextPageToken": "t1"},
+        )
+        page2_request = MagicMock()
+        page2_request.execute.return_value = {"items": [{"name": "page2"}], "nextPageToken": "t2"}
+        node.list_next.side_effect = [page2_request, MagicMock()]
+
+        result = json.loads(
+            _call(
+                ts,
+                "call_gcp",
+                {"api": "storage/v1", "method": "objects.list", "parameters": {"bucket": "b"}},
+            )
+        )
+        assert result["page_count"] == 2
+        assert result["more_pages_available"] is True
+        assert [p["items"][0]["name"] for p in result["pages"]] == ["page1", "page2"]
+        assert node.list_next.call_count == 1
+
+    @pytest.mark.parametrize("media_param", ["media_body", "media_mime_type"])
+    def test_rejects_media_upload_kwargs(self, media_param):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.insert"])
+        with pytest.raises(ModelRetry, match="Media upload"):
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "storage/v1",
+                    "method": "objects.insert",
+                    "parameters": {"bucket": "b", media_param: "/etc/passwd"},
+                },
+            )
+        assert ts._services == {}
+
+    @pytest.mark.parametrize(
+        ("args", "match"),
+        [
+            ({"method": "objects.list"}, "'api' argument is required"),
+            ({"api": "storage/v1"}, "'method' argument is required"),
+            ({"api": 42, "method": "objects.list"}, "'api' argument is required"),
+            (
+                {"api": "storage/v1", "method": "objects.list", "parameters": ["bucket"]},
+                "'parameters' argument must be a JSON object",
+            ),
+            (
+                {"api": "storage/v1", "method": "objects.list", "body": "not-a-dict"},
+                "'body' argument must be a JSON object",
+            ),
+        ],
+    )
+    def test_invalid_tool_args_raise_clear_model_retry(self, args, match):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        with pytest.raises(ModelRetry, match=match):
+            _call(ts, "call_gcp", args)
+
+    def test_rejects_media_download(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.get"])
+        with pytest.raises(ModelRetry, match="alt=media"):
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "storage/v1",
+                    "method": "objects.get",
+                    "parameters": {"bucket": "b", "object": "o", "alt": "media"},
+                },
+            )
+        assert ts._services == {}
+
+    def test_disallowed_method_raises_model_retry_without_client(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        with pytest.raises(ModelRetry, match="not in this toolset's allowed methods"):
+            _call(ts, "call_gcp", {"api": "storage/v1", "method": "buckets.delete"})
+        assert ts._services == {}
+
+    def test_api_error_raises_model_retry(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"])
+        _install_mock_hook(ts, project_id=None)
+        _, _, request = _install_mock_service(ts, "storage", "v1", ["objects"], "list")
+        request.execute.side_effect = Exception("403 storage.objects.list access denied")
+
+        with pytest.raises(ModelRetry, match="access denied"):
+            _call(
+                ts,
+                "call_gcp",
+                {"api": "storage/v1", "method": "objects.list", "parameters": {"bucket": "b"}},
+            )
+
+    def test_large_response_is_truncated(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["storage/v1:objects.list"], max_output_bytes=200)
+        _install_mock_hook(ts, project_id=None)
+        _install_mock_service(
+            ts, "storage", "v1", ["objects"], "list", response={"items": [{"name": "x" * 50}] * 50}
+        )
+
+        result = json.loads(
+            _call(
+                ts,
+                "call_gcp",
+                {"api": "storage/v1", "method": "objects.list", "parameters": {"bucket": "b"}},
+            )
+        )
+        assert result["truncated"] is True
+        assert len(result["data"]) == 200
+
+    def test_unknown_tool_raises_value_error(self):
+        ts = _make_toolset()
+        with pytest.raises(ValueError, match="Unknown tool"):
+            _call(ts, "use_gcp", {})
+
+    @patch("airflow.providers.common.ai.toolsets.google.build", autospec=True)
+    @patch("airflow.providers.common.ai.toolsets.google._get_google_base_hook_class", autospec=True)
+    def test_service_built_with_hook_credentials(self, mock_get_hook_cls, mock_build):
+        mock_hook_cls = mock_get_hook_cls.return_value
+        hook = mock_hook_cls.return_value
+        hook.project_id = None
+        service = MagicMock()
+        node = service.objects.return_value
+        node.list.return_value.execute.return_value = {"items": []}
+        node.list_next.return_value = None
+        mock_build.return_value = service
+
+        ts = GoogleCloudToolset(
+            "gcp_prod",
+            allowed_methods=["storage/v1:objects.list"],
+            impersonation_chain="sa@proj.iam.gserviceaccount.com",
+        )
+        _call(
+            ts,
+            "call_gcp",
+            {"api": "storage/v1", "method": "objects.list", "parameters": {"bucket": "b"}},
+        )
+        mock_hook_cls.assert_called_once_with(
+            gcp_conn_id="gcp_prod", impersonation_chain="sa@proj.iam.gserviceaccount.com"
+        )
+        mock_build.assert_called_once_with(
+            "storage",
+            "v1",
+            credentials=hook.get_credentials.return_value,
+            cache_discovery=False,
+            static_discovery=True,
+        )
+
+
+class TestGoogleCloudToolsetProjectGuard:
+    def _make_compute_toolset(self, **kwargs):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["compute/v1:instances.list"], **kwargs)
+        _install_mock_hook(ts, project_id="my-proj")
+        _install_mock_service(ts, "compute", "v1", ["instances"], "list", response={"items": []})
+        return ts
+
+    def _make_pubsub_toolset(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["pubsub/v1:projects.topics.list"])
+        _install_mock_hook(ts, project_id="my-proj")
+        _install_mock_service(ts, "pubsub", "v1", ["projects", "topics"], "list", response={"topics": []})
+        return ts
+
+    def test_fills_missing_project_from_connection(self):
+        ts = self._make_compute_toolset()
+        _call(
+            ts,
+            "call_gcp",
+            {"api": "compute/v1", "method": "instances.list", "parameters": {"zone": "z"}},
+        )
+        node = ts._services[("compute", "v1")].instances.return_value
+        node.list.assert_called_once_with(zone="z", project="my-proj")
+
+    def test_rejects_mismatched_project(self):
+        ts = self._make_compute_toolset()
+        with pytest.raises(ModelRetry, match="must be 'my-proj'"):
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "compute/v1",
+                    "method": "instances.list",
+                    "parameters": {"zone": "z", "project": "other-proj"},
+                },
+            )
+
+    def test_enforce_project_false_allows_mismatch(self):
+        ts = self._make_compute_toolset(enforce_project=False)
+        _call(
+            ts,
+            "call_gcp",
+            {
+                "api": "compute/v1",
+                "method": "instances.list",
+                "parameters": {"zone": "z", "project": "other-proj"},
+            },
+        )
+        node = ts._services[("compute", "v1")].instances.return_value
+        node.list.assert_called_once_with(zone="z", project="other-proj")
+
+    def test_fills_project_path_parameter_from_connection(self):
+        ts = self._make_pubsub_toolset()
+        _call(ts, "call_gcp", {"api": "pubsub/v1", "method": "projects.topics.list"})
+        node = ts._services[("pubsub", "v1")].projects.return_value.topics.return_value
+        node.list.assert_called_once_with(project="projects/my-proj")
+
+    def test_normalizes_bare_project_path_parameter(self):
+        ts = self._make_pubsub_toolset()
+        _call(
+            ts,
+            "call_gcp",
+            {
+                "api": "pubsub/v1",
+                "method": "projects.topics.list",
+                "parameters": {"project": "my-proj"},
+            },
+        )
+        node = ts._services[("pubsub", "v1")].projects.return_value.topics.return_value
+        node.list.assert_called_once_with(project="projects/my-proj")
+
+    def test_rejects_mismatched_project_path_parameter(self):
+        ts = self._make_pubsub_toolset()
+        with pytest.raises(ModelRetry, match="must be 'projects/my-proj'"):
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "pubsub/v1",
+                    "method": "projects.topics.list",
+                    "parameters": {"project": "projects/other-proj"},
+                },
+            )
+
+    def test_rejects_mismatched_project_in_path_parameter(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["secretmanager/v1:projects.secrets.list"])
+        _install_mock_hook(ts, project_id="my-proj")
+        _install_mock_service(ts, "secretmanager", "v1", ["projects", "secrets"], "list")
+
+        with pytest.raises(ModelRetry, match="pinned to 'my-proj'"):
+            _call(
+                ts,
+                "call_gcp",
+                {
+                    "api": "secretmanager/v1",
+                    "method": "projects.secrets.list",
+                    "parameters": {"parent": "projects/other-proj"},
+                },
+            )
+
+    def test_no_project_on_connection_skips_guard(self):
+        ts = GoogleCloudToolset("gcp_test", allowed_methods=["compute/v1:instances.list"])
+        _install_mock_hook(ts, project_id=None)
+        _install_mock_service(ts, "compute", "v1", ["instances"], "list", response={"items": []})
+        _call(
+            ts,
+            "call_gcp",
+            {
+                "api": "compute/v1",
+                "method": "instances.list",
+                "parameters": {"zone": "z", "project": "any-proj"},
+            },
+        )
+        node = ts._services[("compute", "v1")].instances.return_value
+        node.list.assert_called_once_with(zone="z", project="any-proj")
+
+
+class TestGetAvailableMethods:
+    def test_returns_ready_to_use_entries(self):
+        methods = GoogleCloudToolset.get_available_methods("storage/v1")
+        assert "storage/v1:objects.list" in methods
+        assert "storage/v1:buckets.list" in methods
+        assert methods == sorted(methods)
+
+    @pytest.mark.parametrize("bad", ["storage", "nosuchapi/v1"])
+    def test_rejects_invalid_api(self, bad):
+        with pytest.raises(ValueError, match="not in the bundled discovery documents"):
+            GoogleCloudToolset.get_available_methods(bad)

--- a/uv.lock
+++ b/uv.lock
@@ -64,9 +64,9 @@ apache-airflow-providers-apache-cassandra = false
 apache-airflow-providers-asana = false
 apache-airflow-providers-oracle = false
 apache-airflow-providers-mysql = false
+apache-airflow-providers-teradata = false
 apache-airflow-providers-alibaba = false
 apache-airflow-providers-microsoft-mssql = false
-apache-airflow-providers-teradata = false
 apache-airflow-providers-jdbc = false
 apache-airflow-helm-chart = false
 apache-airflow-providers-anthropic = false
@@ -647,7 +647,7 @@ name = "aiohttp-cors"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", hash = "sha256:ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403", size = 38626, upload-time = "2025-03-31T14:16:20.048Z" }
 wheels = [
@@ -4420,6 +4420,9 @@ common-sql = [
 docx = [
     { name = "python-docx" },
 ]
+gcp = [
+    { name = "apache-airflow-providers-google" },
+]
 git = [
     { name = "apache-airflow-providers-git" },
 ]
@@ -4491,6 +4494,7 @@ requires-dist = [
     { name = "apache-airflow-providers-common-sql", marker = "extra == 'sql'", editable = "providers/common/sql" },
     { name = "apache-airflow-providers-git", marker = "extra == 'git'", editable = "providers/git" },
     { name = "apache-airflow-providers-git", marker = "extra == 'skills'", editable = "providers/git" },
+    { name = "apache-airflow-providers-google", marker = "extra == 'gcp'", editable = "providers/google" },
     { name = "apache-airflow-providers-standard", editable = "providers/standard" },
     { name = "dataclasses-json", marker = "extra == 'llamaindex'", specifier = ">=0.6.7" },
     { name = "fastavro", marker = "python_full_version >= '3.14' and extra == 'avro'", specifier = ">=1.12.1" },
@@ -4514,7 +4518,7 @@ requires-dist = [
     { name = "python-docx", marker = "extra == 'docx'", specifier = ">=1.0.0" },
     { name = "sqlglot", marker = "extra == 'sql'", specifier = ">=30.0.0" },
 ]
-provides-extras = ["anthropic", "bedrock", "google", "openai", "mcp", "code-mode", "shields", "skills", "avro", "parquet", "sql", "aws", "common-sql", "langchain", "llamaindex", "pdf", "docx", "git", "amazon"]
+provides-extras = ["anthropic", "bedrock", "google", "openai", "mcp", "code-mode", "shields", "skills", "avro", "parquet", "sql", "aws", "gcp", "common-sql", "langchain", "llamaindex", "pdf", "docx", "git", "amazon"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -11012,7 +11016,7 @@ name = "colorful"
 version = "0.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.15' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/31/109ef4bedeb32b4202e02ddb133162457adc4eb890a9ed9c05c9dd126ed0/colorful-0.5.8.tar.gz", hash = "sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445", size = 209361, upload-time = "2025-10-29T11:53:21.663Z" }
 wheels = [
@@ -17515,9 +17519,9 @@ name = "opencensus"
 version = "0.11.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core" },
-    { name = "opencensus-context" },
-    { name = "six" },
+    { name = "google-api-core", marker = "python_full_version < '3.15'" },
+    { name = "opencensus-context", marker = "python_full_version < '3.15'" },
+    { name = "six", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2", size = 64966, upload-time = "2024-01-03T18:04:07.085Z" }
 wheels = [
@@ -20815,14 +20819,14 @@ name = "ray"
 version = "2.56.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
+    { name = "click", marker = "python_full_version < '3.15'" },
+    { name = "filelock", marker = "python_full_version < '3.15'" },
+    { name = "jsonschema", marker = "python_full_version < '3.15'" },
+    { name = "msgpack", marker = "python_full_version < '3.15'" },
+    { name = "packaging", marker = "python_full_version < '3.15'" },
+    { name = "protobuf", marker = "python_full_version < '3.15'" },
+    { name = "pyyaml", marker = "python_full_version < '3.15'" },
+    { name = "requests", marker = "python_full_version < '3.15'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/f5/89dc8571f35355a7f889cd4709b440abf6db2c5fc8b5427b614d5084e9cb/ray-2.56.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:58b8c037a9f2b7b7866439cb6fe19d452ba3961f2b62d0a247dc3adf2ca45265", size = 66364186, upload-time = "2026-07-17T21:27:58.09Z" },
@@ -20847,20 +20851,20 @@ wheels = [
 
 [package.optional-dependencies]
 default = [
-    { name = "aiohttp" },
-    { name = "aiohttp-cors" },
-    { name = "colorful" },
-    { name = "grpcio" },
-    { name = "opencensus" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-    { name = "py-spy" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "smart-open" },
-    { name = "virtualenv" },
+    { name = "aiohttp", marker = "python_full_version < '3.15'" },
+    { name = "aiohttp-cors", marker = "python_full_version < '3.15'" },
+    { name = "colorful", marker = "python_full_version < '3.15'" },
+    { name = "grpcio", marker = "python_full_version < '3.15'" },
+    { name = "opencensus", marker = "python_full_version < '3.15'" },
+    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version < '3.15'" },
+    { name = "opentelemetry-proto", marker = "python_full_version < '3.15'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version < '3.15'" },
+    { name = "prometheus-client", marker = "python_full_version < '3.15'" },
+    { name = "py-spy", marker = "python_full_version < '3.15'" },
+    { name = "pydantic", marker = "python_full_version < '3.15'" },
+    { name = "requests", marker = "python_full_version < '3.15'" },
+    { name = "smart-open", marker = "python_full_version < '3.15'" },
+    { name = "virtualenv", marker = "python_full_version < '3.15'" },
 ]
 
 [[package]]
@@ -22157,7 +22161,7 @@ name = "smart-open"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/53/9c513747547fd595d5c143259129ea8b9c3ea2f6b7bb9dcea2b1966ded3c/smart_open-8.0.1.tar.gz", hash = "sha256:18b1c4496003c6902be17c15f032b5c319f307c89c6ae9e6b028b508bed8b2cf", size = 61882, upload-time = "2026-07-15T13:56:10.492Z" }
 wheels = [


### PR DESCRIPTION
Add GoogleCloudToolset to the common.ai provider so agents can call explicitly allow-listed Google APIs through pydantic-ai tools.

The toolset exposes three tools for agents:

- `list_gcp_methods` to show the allowed Google API methods
- `describe_gcp_method` to inspect parameters and schemas before calling
- `call_gcp` to execute an allowed method and return JSON

## Design

The toolset is intentionally generic rather than service-specific. Instead of implementing separate wrappers for GCS, BigQuery, Pub/Sub, Cloud Run, and other Google services, it uses Google Discovery REST metadata to resolve method names, parameters, request schemas, and response schemas at runtime. This keeps the provider small while still allowing agents to work with the Google APIs that publish Discovery documents.

Access is deny-by-default. Dag authors must pass `allowed_methods`, for example `storage/v1:objects.list` or `bigquery/v2:jobs.query`. Method-level wildcards are supported, but the API and version must be explicit so an agent cannot move from an approved stable API to an alpha or beta surface by changing tool input.

Credentials, impersonation, and project selection come from the Airflow Google connection through `GoogleBaseHook`. They are not exposed as tool arguments, so the model can choose only the allowed API method and request parameters, not which credentials or project to use.

The toolset also adds guardrails around high-risk behavior:

- Credential-returning methods are not matched by wildcards and must be allow-listed verbatim.
- Media upload/download is rejected.
- Pagination is bounded with `max_pages`.
- Returned payload size is bounded with `max_output_bytes`.
- Project parameters can be pinned to the connection project by default.


<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
