### PR TITLE
Mark dags list-jobs as migrated to airflowctl #68402

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -732,6 +732,7 @@ def dag_report(args) -> None:
     )
 
 
+@deprecated_for_airflowctl("airflowctl jobs list")
 @cli_utils.action_cli
 @suppress_logs_and_warning
 @providers_configuration_loaded

--- a/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
+++ b/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
@@ -57,6 +57,7 @@ MIGRATED_CLI_COMMANDS = [
     (dag_command.dag_pause, "airflowctl dags pause"),
     (dag_command.dag_unpause, "airflowctl dags unpause"),
     (dag_command.dag_list_dag_runs, "airflowctl dagrun list"),
+    (dag_command.dag_list_jobs, "airflowctl jobs list"),
     (dag_command.dag_state, "airflowctl dags state"),
     (dag_command.dag_next_execution, "airflowctl dags next-execution"),
     (pool_command.pool_list, "airflowctl pools list"),


### PR DESCRIPTION
Mark `airflow dags list-jobs` as migrated to `airflowctl jobs list` via the`deprecated_for_airflowctl` marker. Deferred until #68616 added `dag_id` filtering to `airflowctl jobs list`, making it a true equivalent.

related: #68402