### PR TITLE
Document that Code view shows only Python source for stub tasks

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/language-sdks/index.rst
+++ b/airflow-core/docs/authoring-and-scheduling/language-sdks/index.rst
@@ -122,6 +122,13 @@ XCom references should be defined inside the Python Dag (they are task dependenc
 actually read the values out in the language implementation, and vice versa. See specific language SDK
 documentation on how to do this correctly.
 
+.. note::
+
+    For a Dag containing stub tasks, the **Code** view in the Airflow UI shows only the Python Dag
+    file — including the stub declarations — as the Dag's source. The non-Python implementation source
+    is not displayed anywhere in the UI; consult your project repository or the build artifact shipped
+    in the bundle to inspect it. This is an intentional architecture decision, not a bug.
+
 .. _language-sdks/coordinator-config:
 
 Coordinator configuration


### PR DESCRIPTION
- related: #70059

## Why

[ADR-0006](https://github.com/apache/airflow/pull/70059) records that the Code view shows only the Python Dag file for mixed-language (`@task.stub`) Dags, and its Consequences section relies on the user documentation stating this explicitly so the behavior is expected rather than reported as a bug.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
