### PR TITLE
Fix OpenLineage DeprecationWarning about fork() on Python 3.12+

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -17,15 +17,13 @@
 from __future__ import annotations
 
 import logging
-import os
-import sys
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
 from datetime import datetime
 from functools import cache
 from typing import TYPE_CHECKING
 
-import psutil
 from openlineage.client.serde import Serde
 
 from airflow import settings
@@ -57,7 +55,6 @@ from airflow.providers.openlineage.utils.utils import (
     is_dag_run_asset_triggered,
     print_warning,
 )
-from airflow.settings import configure_orm
 from airflow.utils.helpers import prune_dict
 from airflow.utils.state import TaskInstanceState
 
@@ -65,14 +62,6 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
-
-if sys.platform == "darwin":
-    from setproctitle import getproctitle
-
-    setproctitle = lambda title: logging.getLogger(__name__).debug("Mac OS detected, skipping setproctitle")
-else:
-    from setproctitle import getproctitle, setproctitle
-
 
 def _executor_initializer():
     """
@@ -343,7 +332,7 @@ class OpenLineageListener:
                 ),
             )
 
-        self._execute(on_running, "on_running", use_fork=True)
+        on_running()
 
     if AIRFLOW_V_3_0_PLUS:
 
@@ -504,7 +493,7 @@ class OpenLineageListener:
                 ),
             )
 
-        self._execute(on_success, "on_success", use_fork=True)
+        on_success()
 
     if AIRFLOW_V_3_0_PLUS:
 
@@ -680,7 +669,7 @@ class OpenLineageListener:
                 ),
             )
 
-        self._execute(on_failure, "on_failure", use_fork=True)
+        on_failure()
 
     if AIRFLOW_V_3_0_PLUS:
 
@@ -831,7 +820,7 @@ class OpenLineageListener:
                 ),
             )
 
-        self._execute(on_skipped, "on_skipped", use_fork=True)
+        on_skipped()
 
     def _on_task_instance_manual_state_change(
         self,
@@ -845,11 +834,9 @@ class OpenLineageListener:
 
         This path is only reached on the scheduler (``process_executor_events ->
         handle_failure``, or manual UI/API state changes). Emission is routed through
-        the same ``ProcessPoolExecutor`` the DAG-run listeners use rather than through
-        ``_fork_execute``: the pool's ``_executor_initializer`` rebuilds the ORM once
-        per worker, so the child never shares a pooled Postgres SSL connection with
-        the scheduler, and bursts of external-state-change events no longer produce a
-        fork-per-event.
+        the same ``ProcessPoolExecutor`` the DAG-run listeners use: the pool's
+        ``_executor_initializer`` rebuilds the ORM once per worker, so the child never
+        shares a pooled Postgres SSL connection with the scheduler.
         """
         self.log.debug("`_on_task_instance_manual_state_change` was called with state: `%s`.", ti_state)
         end_date = timezone.utcnow()
@@ -972,68 +959,13 @@ class OpenLineageListener:
                 exc_info=e,
             )
 
-    def _execute(self, callable, callable_name: str, use_fork: bool = False):
-        if use_fork:
-            self._fork_execute(callable, callable_name)
-        else:
-            callable()
-
-    def _terminate_with_wait(self, process: psutil.Process):
-        process.terminate()
-        try:
-            # Waiting for max 3 seconds to make sure process can clean up before being killed.
-            process.wait(timeout=3)
-        except psutil.TimeoutExpired:
-            # If it's not dead by then, then force kill.
-            process.kill()
-
-    def _fork_execute(self, callable, callable_name: str):
-        self.log.debug("Will fork to execute OpenLineage process.")
-        pid = os.fork()
-        if pid:
-            process = psutil.Process(pid)
-            try:
-                self.log.debug("Waiting for process %s", pid)
-                process.wait(conf.execution_timeout())
-            except psutil.TimeoutExpired:
-                self.log.warning(
-                    "OpenLineage process with pid `%s` expired and will be terminated by listener. "
-                    "This has no impact on actual task execution status.",
-                    pid,
-                )
-                self._terminate_with_wait(process)
-            except BaseException:
-                # Kill the process directly.
-                self._terminate_with_wait(process)
-            self.log.debug("Process with pid %s finished - parent", pid)
-        else:
-            setproctitle(getproctitle() + " - OpenLineage - " + callable_name)
-            if not AIRFLOW_V_3_0_PLUS:
-                configure_orm(disable_connection_pool=True)
-            self.log.debug("Executing OpenLineage process - %s - pid %s", callable_name, os.getpid())
-            try:
-                callable()
-                self.log.debug("Process with current pid finishes after %s", callable_name)
-            except Exception:
-                self.log.warning(
-                    "OpenLineage %s process failed. This has no impact on actual task execution status.",
-                    callable_name,
-                    exc_info=True,
-                )
-            finally:
-                # os._exit(0) bypasses Python's atexit/stdio flush. Explicitly shut down
-                # logging so buffered records (including any warnings above) are flushed
-                # before the process exits. Without this, the final log lines are silently
-                # dropped, making failures invisible.
-                logging.shutdown()
-            os._exit(0)
-
     @property
     def executor(self) -> ProcessPoolExecutor:
         if not self._executor:
             self._executor = ProcessPoolExecutor(
                 max_workers=conf.dag_state_change_process_pool_size(),
                 initializer=_executor_initializer,
+                mp_context=multiprocessing.get_context("forkserver"),
             )
         return self._executor
 

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -144,6 +144,35 @@ def _emit_manual_state_change_event(adapter_method_name: str, stats_key: str, **
     return event
 
 
+def _emit_task_instance_event(
+    adapter_method_name: str,
+    event_type: str,
+    operator_name: str,
+    team_name: str | None,
+    **kwargs,
+):
+    """
+    Emit an OL event for a task instance lifecycle transition.
+
+    Module-level so it is picklable across the ProcessPoolExecutor boundary.
+    Metadata extraction runs in the parent listener process; only adapter emission
+    and metrics recording run in a forkserver-backed pool worker.
+    """
+    event = getattr(_get_process_adapter(), adapter_method_name)(**kwargs)
+    Stats.gauge(
+        "ol.event.size",
+        len(Serde.to_json(event).encode("utf-8")),
+        tags=prune_dict(
+            {
+                "event_type": event_type,
+                "operator_name": operator_name,
+                "team_name": team_name,
+            }
+        ),
+    )
+    return event
+
+
 class OpenLineageListener:
     """OpenLineage listener sends events on task instance and dag run starts, completes and failures."""
 
@@ -214,7 +243,6 @@ class OpenLineageListener:
             )
             return
 
-        # Needs to be calculated outside of inner method so that it gets cached for usage in fork processes
         debug_facet = get_airflow_debug_facet()
 
         @print_warning(self.log)
@@ -287,7 +315,12 @@ class OpenLineageListener:
 
                 task_metadata = OperatorLineage()
 
-            redacted_event = self.adapter.start_task(
+            self.submit_callable(
+                _emit_task_instance_event,
+                "start_task",
+                event_type,
+                operator_name,
+                team_name,
                 run_id=task_uuid,
                 job_name=get_job_name(task_instance),
                 job_description=doc,
@@ -317,19 +350,6 @@ class OpenLineageListener:
                     ),
                     **debug_facet,
                 },
-            )
-            event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
-
-            Stats.gauge(
-                "ol.event.size",
-                event_size,
-                tags=prune_dict(
-                    {
-                        "event_type": event_type,
-                        "operator_name": operator_name,
-                        "team_name": team_name,
-                    }
-                ),
             )
 
         on_running()
@@ -449,7 +469,12 @@ class OpenLineageListener:
 
                 task_metadata = OperatorLineage()
 
-            redacted_event = self.adapter.complete_task(
+            self.submit_callable(
+                _emit_task_instance_event,
+                "complete_task",
+                event_type,
+                operator_name,
+                team_name,
                 run_id=task_uuid,
                 job_name=get_job_name(task_instance),
                 end_time=end_date.isoformat(),
@@ -478,19 +503,6 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
-            )
-            event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
-
-            Stats.gauge(
-                "ol.event.size",
-                event_size,
-                tags=prune_dict(
-                    {
-                        "event_type": event_type,
-                        "operator_name": operator_name,
-                        "team_name": team_name,
-                    }
-                ),
             )
 
         on_success()
@@ -624,7 +636,12 @@ class OpenLineageListener:
                 )
                 task_metadata = OperatorLineage()
 
-            redacted_event = self.adapter.fail_task(
+            self.submit_callable(
+                _emit_task_instance_event,
+                "fail_task",
+                event_type,
+                operator_name,
+                team_name,
                 run_id=task_uuid,
                 job_name=get_job_name(task_instance),
                 end_time=end_date.isoformat(),
@@ -654,19 +671,6 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
-            )
-            event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
-
-            Stats.gauge(
-                "ol.event.size",
-                event_size,
-                tags=prune_dict(
-                    {
-                        "event_type": event_type,
-                        "operator_name": operator_name,
-                        "team_name": team_name,
-                    }
-                ),
             )
 
         on_failure()
@@ -776,7 +780,12 @@ class OpenLineageListener:
                 )
                 task_metadata = OperatorLineage()
 
-            redacted_event = self.adapter.complete_task(
+            self.submit_callable(
+                _emit_task_instance_event,
+                "complete_task",
+                event_type,
+                operator_name,
+                team_name,
                 run_id=task_uuid,
                 job_name=get_job_name(task_instance),
                 end_time=end_date.isoformat(),
@@ -805,19 +814,6 @@ class OpenLineageListener:
                     ),
                     **get_airflow_debug_facet(),
                 },
-            )
-            event_size = len(Serde.to_json(redacted_event).encode("utf-8"))
-
-            Stats.gauge(
-                "ol.event.size",
-                event_size,
-                tags=prune_dict(
-                    {
-                        "event_type": event_type,
-                        "operator_name": operator_name,
-                        "team_name": team_name,
-                    }
-                ),
             )
 
         on_skipped()

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -89,10 +89,6 @@ def render_df():
     return pd.DataFrame({"col": [1, 2]})
 
 
-def regular_call(self, callable, callable_name, use_fork):
-    callable()
-
-
 def direct_submit_call(self, callable, *args, **kwargs):
     """Synchronous stand-in for ``OpenLineageListener.submit_callable``.
 
@@ -106,12 +102,19 @@ def direct_submit_call(self, callable, *args, **kwargs):
     """
     from airflow.providers.openlineage.plugins.listener import (
         _emit_manual_state_change_event,
+        _emit_task_instance_event,
         _run_adapter_method,
     )
 
     if callable is _emit_manual_state_change_event:
         adapter_method_name, _stats_key, *_ = args
         return getattr(self.adapter, adapter_method_name)(**kwargs)
+    if callable is _emit_task_instance_event:
+        with mock.patch(
+            "airflow.providers.openlineage.plugins.listener._get_process_adapter",
+            return_value=self.adapter,
+        ):
+            return _emit_task_instance_event(*args, **kwargs)
     if callable is _run_adapter_method:
         adapter_method_name, *rest = args
         return getattr(self.adapter, adapter_method_name)(*rest, **kwargs)
@@ -472,7 +475,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_start_task_is_called_with_proper_arguments(
         self,
@@ -529,7 +533,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_start_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
@@ -562,7 +567,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_start_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
@@ -596,7 +602,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_fail_task_is_called_with_proper_arguments(
         self,
@@ -657,7 +664,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_fail_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
@@ -692,7 +700,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_fail_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
@@ -727,7 +736,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_proper_arguments(
         self,
@@ -788,7 +798,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
@@ -820,7 +831,8 @@ class TestOpenLineageListenerAirflow2:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
@@ -846,7 +858,8 @@ class TestOpenLineageListenerAirflow2:
         assert listener.adapter.complete_task.call_args.kwargs["job_description_type"] == "text/plain"
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_running_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is in the running state.
@@ -866,7 +879,8 @@ class TestOpenLineageListenerAirflow2:
         )
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_failed_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is in the failed state.
@@ -890,7 +904,8 @@ class TestOpenLineageListenerAirflow2:
         )
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_success_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is in the success state.
@@ -1423,7 +1438,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_start_task_is_called_with_proper_arguments(
         self,
@@ -1516,7 +1532,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_task_hook_emits_with_defaults_when_emission_policy_misconfigured(
         self,
@@ -1552,7 +1569,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_task_hook_failed_emits_with_defaults_when_emission_policy_misconfigured(
         self,
@@ -1585,7 +1603,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_task_hook_success_emits_with_defaults_when_emission_policy_misconfigured(
         self,
@@ -1615,7 +1634,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_extract_operator_metadata_false_skips_extraction(
         self,
@@ -1652,7 +1672,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_include_full_task_info_true_forwarded_to_get_airflow_run_facet(
         self,
@@ -1690,7 +1711,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_start_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
@@ -1724,7 +1746,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_job_name")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_start_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
@@ -1787,7 +1810,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_fail_task_is_called_with_proper_arguments(
         self,
@@ -1883,7 +1907,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_fail_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
@@ -1918,7 +1943,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_fail_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
@@ -2043,7 +2069,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_proper_arguments(
         self,
@@ -2138,7 +2165,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_dag_owners_when_task_owner_is_default(
         self,
@@ -2172,7 +2200,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_mapped_task_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_dag_description_when_task_doc_is_empty(
         self,
@@ -2257,7 +2286,8 @@ class TestOpenLineageListenerAirflow3:
         assert mock_emit.assert_called_once
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_running_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is in the running state.
@@ -2277,7 +2307,8 @@ class TestOpenLineageListenerAirflow3:
         )
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_failed_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is in the failed state.
@@ -2301,7 +2332,8 @@ class TestOpenLineageListenerAirflow3:
         )
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_success_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is in the success state.
@@ -2393,7 +2425,8 @@ class TestOpenLineageListenerAirflow3:
         listener.adapter.complete_task.assert_not_called()
 
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_on_task_instance_skipped_correctly_calls_openlineage_adapter_run_id_method(self):
         """Tests the OpenLineageListener's response when a task instance is skipped.
@@ -2470,8 +2503,8 @@ class TestOpenLineageListenerAirflow3:
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_run_facet")
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_user_provided_run_facets")
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute",
-        new=regular_call,
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_adapter_complete_task_is_called_with_proper_arguments_on_skip(
         self,
@@ -2785,7 +2818,8 @@ class TestOpenLineageSelectiveEnableAirflow2:
         ],
     )
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_listener_with_task_enabled(
         self, selective_enable, enable_task, expected_dag_call_count, expected_task_call_count
@@ -2842,7 +2876,8 @@ class TestOpenLineageSelectiveEnableAirflow2:
         ],
     )
     @mock.patch(
-        "airflow.providers.openlineage.plugins.listener.OpenLineageListener._execute", new=regular_call
+        "airflow.providers.openlineage.plugins.listener.OpenLineageListener.submit_callable",
+        new=direct_submit_call,
     )
     def test_listener_with_dag_disabled_task_enabled(
         self, selective_enable, enable_task, expected_call_count, expected_task_call_count

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -1944,7 +1944,6 @@ class TestOpenLineageListenerAirflow3:
         assert listener.adapter.fail_task.call_args.kwargs["job_description"] == "Test DAG Description"
         assert listener.adapter.fail_task.call_args.kwargs["job_description_type"] == "text/plain"
 
-    @mock.patch("airflow.providers.openlineage.plugins.listener.OpenLineageListener._fork_execute")
     @mock.patch("airflow.providers.openlineage.plugins.adapter.OpenLineageAdapter.emit")
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
@@ -1961,7 +1960,6 @@ class TestOpenLineageListenerAirflow3:
         mock_debug_facet,
         mock_debug_mode,
         mock_emit,
-        mock_fork_execute,
         time_machine,
     ):
         """Tests that the 'fail_task' method of the OpenLineageAdapter is invoked with the correct arguments.
@@ -2004,9 +2002,6 @@ class TestOpenLineageListenerAirflow3:
             error=err,
         )
         listener.adapter.fail_task.assert_called_once_with(**expected_args)
-        # Regression guard: manual state-change emission must not go through _fork_execute.
-        mock_fork_execute.assert_not_called()
-
         expected_args["run_id"] = "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
         adapter = OpenLineageAdapter()
         adapter.fail_task(**expected_args)
@@ -2202,7 +2197,6 @@ class TestOpenLineageListenerAirflow3:
         assert listener.adapter.complete_task.call_args.kwargs["job_description"] == "Test DAG Description"
         assert listener.adapter.complete_task.call_args.kwargs["job_description_type"] == "text/plain"
 
-    @mock.patch("airflow.providers.openlineage.plugins.listener.OpenLineageListener._fork_execute")
     @mock.patch("airflow.providers.openlineage.plugins.adapter.OpenLineageAdapter.emit")
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
@@ -2217,7 +2211,6 @@ class TestOpenLineageListenerAirflow3:
         mock_debug_facet,
         mock_debug_mode,
         mock_emit,
-        mock_fork_execute,
         time_machine,
     ):
         """Tests that the 'complete_task' method of the OpenLineageAdapter is called with the correct arguments.
@@ -2258,9 +2251,6 @@ class TestOpenLineageListenerAirflow3:
             },
         )
         assert calls[0][1] == expected_args
-        # Regression guard: manual state-change emission must not go through _fork_execute.
-        mock_fork_execute.assert_not_called()
-
         expected_args["run_id"] = "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
         adapter = OpenLineageAdapter()
         adapter.complete_task(**expected_args)
@@ -2559,7 +2549,6 @@ class TestOpenLineageListenerAirflow3:
             tags=expected_tags,
         )
 
-    @mock.patch("airflow.providers.openlineage.plugins.listener.OpenLineageListener._fork_execute")
     @mock.patch("airflow.providers.openlineage.plugins.adapter.OpenLineageAdapter.emit")
     @mock.patch("airflow.providers.openlineage.conf.debug_mode", return_value=True)
     @mock.patch("airflow.providers.openlineage.plugins.listener.get_airflow_debug_facet")
@@ -2574,7 +2563,6 @@ class TestOpenLineageListenerAirflow3:
         mock_debug_facet,
         mock_debug_mode,
         mock_emit,
-        mock_fork_execute,
         time_machine,
     ):
         """Tests that the 'complete_task' method of the OpenLineageAdapter is called with the correct arguments.
@@ -2615,9 +2603,6 @@ class TestOpenLineageListenerAirflow3:
             },
         )
         assert calls[0][1] == expected_args
-        # Regression guard: manual state-change emission must not go through _fork_execute.
-        mock_fork_execute.assert_not_called()
-
         expected_args["run_id"] = "9d3b14f7-de91-40b6-aeef-e887e2c7673e"
         adapter = OpenLineageAdapter()
         adapter.complete_task(**expected_args)


### PR DESCRIPTION
## Summary

- Remove \os.fork()\-based task event emission in the OpenLineage listener
- Extract operator metadata in the parent process; emit lifecycle events via picklable \_emit_task_instance_event()\ and \ProcessPoolExecutor\ with \orkserver\ context
- Use \orkserver\ multiprocessing context for scheduler-side DAG-run and manual state-change emissions

## Problem

On Python 3.12+, the OpenLineage listener emits:

\\\
DeprecationWarning: This process is multi-threaded, use of fork() may lead to deadlocks in the child.
\\\

This came from \_fork_execute()\ calling \os.fork()\ during task lifecycle events, and from \ProcessPoolExecutor\ defaulting to the \ork\ start method on Linux.

## Approach

Task lifecycle handlers (\on_running\, \on_success\, \on_failure\, \on_skipped\) follow the same two-phase pattern as DAG-run listeners:

1. **Parent process:** metadata extraction while ORM/task objects are available
2. **Pool worker (forkserver):** adapter emission + metrics via \submit_callable(_emit_task_instance_event, ...)\

This preserves process isolation for OL transport code without \os.fork()\ in multi-threaded worker/scheduler processes.

## Test plan

- [x] \pytest providers/openlineage/tests/unit/openlineage/plugins/test_listener.py\
- [ ] CI provider tests for \openlineage\ pass
- [ ] \prek run --all-files\

Closes #47160