### PR TITLE
Fix task supervisor hang by resetting SIGCHLD in CeleryExecutor

### DIFF
--- a/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
+++ b/providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py
@@ -239,6 +239,13 @@ def execute_workload(input: str) -> None:
 
     log.info("[%s] Executing workload in Celery: %s", celery_task_id, workload)
 
+    # Reset SIGCHLD to default to prevent billiard's inherited handler from stealing
+    # the exit status of child processes spawned by the Task SDK supervisor.
+    import signal
+
+    if hasattr(signal, "SIGCHLD"):
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
+
     try:
         BaseExecutor.run_workload(workload)
     except Exception as e:

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1141,7 +1141,14 @@ class WatchedSubprocess:
             if raise_on_timeout:
                 raise
         else:
-            self._process_exit_monotonic = time.monotonic()
+            if self._exit_code is None:
+                self.process_log.warning(
+                    "Process has already exited but its exit status was consumed by an external process. "
+                    "Setting exit code to -1."
+                )
+                self._exit_code = -1
+                self._process_exit_monotonic = time.monotonic()
+                return self._exit_code
 
             if expect_signal is not None and self._exit_code == -expect_signal:
                 # Bypass logging, the caller expected us to exit with this

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -4465,3 +4465,31 @@ class TestMakeBufferedSocketReader:
         finally:
             r.close()
             w.close()
+
+
+class TestCheckSubprocessExit:
+    @mock.patch("airflow.sdk.execution_time.supervisor.time.monotonic", return_value=123.456)
+    def test_subprocess_exit_status_consumed_by_init(self, mock_time):
+        """
+        Test that if wait() returns None (e.g., child process was already reaped by an init process like dumb-init),
+        the exit code is set to -1 to prevent an infinite loop, and _process_exit_monotonic is recorded.
+        """
+        from airflow.sdk.execution_time.supervisor import WatchedSubprocess
+        from unittest.mock import MagicMock
+        import uuid
+        
+        watched_subprocess = WatchedSubprocess(
+            process_log=MagicMock(),
+            id=uuid.uuid4(),
+            pid=12345,
+            stdin=MagicMock(),
+            client=MagicMock(),
+            process=MagicMock(),
+        )
+        watched_subprocess._process.wait.return_value = None
+
+        exit_code = watched_subprocess._check_subprocess_exit()
+
+        assert exit_code == -1
+        assert watched_subprocess._exit_code == -1
+        assert watched_subprocess._process_exit_monotonic == 123.456


### PR DESCRIPTION
## Description
This PR resolves the memory leak and infinite hang observed in Airflow 3 Task SDK supervisors running on Celery workers. 
### Root Cause
When Airflow 3 runs a task via the `CeleryExecutor`, the `execute_workload` task is executed inside a Celery/billiard worker process. 
Because `billiard` workers are spawned via `fork()`, they inherit the global `SIGCHLD` signal handler installed by the Celery main pool manager. This inherited handler uses a non-blocking `waitpid(-1, WNOHANG)` loop.
When the Airflow supervisor (`WatchedSubprocess`) forks a child process to execute the actual task SDK payload, that child is a direct descendant of the Celery worker. When the task finishes, the child sends `SIGCHLD` to the worker, triggering the inherited `billiard` signal handler. The handler reaps the child process and discards the exit status.
When the Airflow supervisor subsequently attempts to retrieve the exit status via `psutil.Process.wait(timeout=0)`, it receives an `ECHILD` (No child processes) error. `psutil` catches this and returns `None`. The supervisor's polling loop did not expect a `None` return value, leaving `_exit_code` unset, which prevented the `socket_cleanup_timeout` from ever triggering. The supervisor hung indefinitely in `epoll_wait()`.
### The Fix
This PR introduces  fix:
1. **(Celery Executor):** Added a `SIGCHLD` reset in `celery_executor_utils.py::execute_workload`. By resetting `SIGCHLD` to `SIG_DFL` before invoking `supervise()`, we prevent the inherited billiard handler from stealing the exit status of the Task SDK subprocess.
2. **(Task SDK Supervisor):** Updated `_check_subprocess_exit` in `supervisor.py` to handle cases where `psutil.wait(timeout=0)` returns `None`. It now logs a warning, gracefully assigns an exit code of `-1`, and returns immediately, preventing the supervisor from hanging if an exit status is ever consumed externally (e.g. reparenting to `dumb-init`).
### Testing
- Added a dedicated unit test in `test_supervisor.py` to ensure `None` is mapped to `-1` and the loop exits cleanly.
