### PR TITLE
Go SDK: Propagate OTel context to Go SDK tasks

### DIFF
--- a/go-sdk/bundle/bundlev1/bundlev1client/grpc.go
+++ b/go-sdk/bundle/bundlev1/bundlev1client/grpc.go
@@ -64,6 +64,20 @@ func (p *BundleGRPCPlugin) GRPCClient(
 // GRPCClient is an implementation of DagBundle that talks over RPC.
 type GRPCClient struct{ client proto.DagBundleClient }
 
+func buildOTelContext(contextCarrier *map[string]any) map[string]string {
+	if contextCarrier == nil {
+		return nil
+	}
+
+	otelContext := make(map[string]string, len(*contextCarrier))
+	for key, value := range *contextCarrier {
+		if stringValue, ok := value.(string); ok {
+			otelContext[key] = stringValue
+		}
+	}
+	return otelContext
+}
+
 func (c *GRPCClient) GetMetadata(ctx context.Context) (bundlev1.GetMetadataResponse, error) {
 	ret := bundlev1.GetMetadataResponse{}
 	rpcResp, err := c.client.GetMetadata(ctx, proto.GetMetadata_Request_builder{}.Build())
@@ -90,14 +104,13 @@ func (c *GRPCClient) ExecuteTaskWorkload(
 	workload bundlev1.ExecuteTaskWorkload,
 ) error {
 	tiBuilder := proto.TaskInstance_builder{
-		Id:        proto.UUID_builder{Value: ptr(workload.TI.Id.String())}.Build(),
-		DagId:     &workload.TI.DagId,
-		RunId:     &workload.TI.RunId,
-		TaskId:    &workload.TI.TaskId,
-		Hostname:  workload.TI.Hostname,
-		TryNumber: ptr((int32)(workload.TI.TryNumber)),
-		// TODO: OtelContext support!
-		// OtelContext: map[string]string{},
+		Id:          proto.UUID_builder{Value: ptr(workload.TI.Id.String())}.Build(),
+		DagId:       &workload.TI.DagId,
+		RunId:       &workload.TI.RunId,
+		TaskId:      &workload.TI.TaskId,
+		Hostname:    workload.TI.Hostname,
+		TryNumber:   ptr((int32)(workload.TI.TryNumber)),
+		OtelContext: buildOTelContext(workload.TI.ContextCarrier),
 	}
 
 	if workload.TI.MapIndex != nil {

--- a/go-sdk/bundle/bundlev1/bundlev1client/grpc_test.go
+++ b/go-sdk/bundle/bundlev1/bundlev1client/grpc_test.go
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package bundlev1client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+	proto "github.com/apache/airflow/go-sdk/internal/protov1"
+	"github.com/apache/airflow/go-sdk/pkg/api"
+)
+
+type recordingDagBundleClient struct {
+	request *proto.Execute_Request
+}
+
+func (*recordingDagBundleClient) GetMetadata(
+	context.Context,
+	*proto.GetMetadata_Request,
+	...grpc.CallOption,
+) (*proto.GetMetadata_Response, error) {
+	return proto.GetMetadata_Response_builder{}.Build(), nil
+}
+
+func (c *recordingDagBundleClient) Execute(
+	_ context.Context,
+	request *proto.Execute_Request,
+	_ ...grpc.CallOption,
+) (*proto.Execute_Response, error) {
+	c.request = request
+	return proto.Execute_Response_builder{}.Build(), nil
+}
+
+func TestExecuteTaskWorkloadPropagatesOTelContext(t *testing.T) {
+	contextCarrier := map[string]any{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+		"non-string":  42,
+	}
+	recorder := &recordingDagBundleClient{}
+	client := &GRPCClient{client: recorder}
+
+	err := client.ExecuteTaskWorkload(t.Context(), bundlev1.ExecuteTaskWorkload{
+		TI: api.TaskInstance{
+			Id:             uuid.New(),
+			ContextCarrier: &contextCarrier,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, recorder.request)
+	assert.Equal(t, map[string]string{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+	}, recorder.request.GetTask().GetTi().GetOtelContext())
+}

--- a/go-sdk/bundle/bundlev1/bundlev1server/impl/plugin.go
+++ b/go-sdk/bundle/bundlev1/bundlev1server/impl/plugin.go
@@ -81,6 +81,18 @@ type server struct {
 	bundle bundlev1.Bundle
 }
 
+func buildContextCarrier(otelContext map[string]string) *map[string]any {
+	if len(otelContext) == 0 {
+		return nil
+	}
+
+	contextCarrier := make(map[string]any, len(otelContext))
+	for key, value := range otelContext {
+		contextCarrier[key] = value
+	}
+	return &contextCarrier
+}
+
 func (g *server) GetMetadata(
 	ctx context.Context,
 	_ *proto.GetMetadata_Request,
@@ -142,13 +154,12 @@ func (g *server) executeTask(ctx context.Context, executeTask *proto.ExecuteTask
 	workload := api.ExecuteTaskWorkload{
 		Token: executeTask.GetToken(),
 		TI: bundlev1.TaskInstance{
-			DagId:     ti.GetDagId(),
-			Id:        id,
-			RunId:     ti.GetRunId(),
-			TaskId:    ti.GetTaskId(),
-			TryNumber: int(ti.GetTryNumber()),
-			// TODO: support otel context carrier
-			// ContextCarrier: (map[string]any)(ti.GetOtelContext()),
+			ContextCarrier: buildContextCarrier(ti.GetOtelContext()),
+			DagId:          ti.GetDagId(),
+			Id:             id,
+			RunId:          ti.GetRunId(),
+			TaskId:         ti.GetTaskId(),
+			TryNumber:      int(ti.GetTryNumber()),
 		},
 		BundleInfo: bundlev1.BundleInfo{
 			Name: bundle.GetName(),

--- a/go-sdk/bundle/bundlev1/bundlev1server/impl/plugin_test.go
+++ b/go-sdk/bundle/bundlev1/bundlev1server/impl/plugin_test.go
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package impl
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+	proto "github.com/apache/airflow/go-sdk/internal/protov1"
+	"github.com/apache/airflow/go-sdk/pkg/api"
+	"github.com/apache/airflow/go-sdk/pkg/sdkcontext"
+)
+
+type testBundleProvider struct {
+	task func(context.Context) error
+}
+
+func (*testBundleProvider) GetBundleVersion() bundlev1.BundleInfo {
+	return bundlev1.BundleInfo{Name: "test-bundle"}
+}
+
+func (p *testBundleProvider) RegisterDags(registry bundlev1.Registry) error {
+	registry.AddDag("test-dag").AddTaskWithName("test-task", p.task)
+	return nil
+}
+
+func TestBuildContextCarrier(t *testing.T) {
+	actual := buildContextCarrier(map[string]string{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+	})
+
+	require.NotNil(t, actual)
+	assert.Equal(t, map[string]any{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+	}, *actual)
+}
+
+func TestExecutePropagatesOTelContextToWorkload(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch && r.URL.Path == "/task-instances/00000000-0000-0000-0000-000000000001/run":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{}"))
+		case r.Method == http.MethodPatch && r.URL.Path == "/task-instances/00000000-0000-0000-0000-000000000001/state":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(apiServer.Close)
+	viper.Set("execution.api_url", apiServer.URL)
+	t.Cleanup(func() { viper.Set("execution.api_url", "") })
+
+	otelContext := map[string]string{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+	}
+	var observedCarrier *map[string]any
+	provider := &testBundleProvider{task: func(ctx context.Context) error {
+		workload := ctx.Value(sdkcontext.WorkloadContextKey).(api.ExecuteTaskWorkload)
+		observedCarrier = workload.TI.ContextCarrier
+		return nil
+	}}
+	taskInstanceID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	taskInstanceIDString := taskInstanceID.String()
+	dagID := "test-dag"
+	runID := "test-run"
+	taskID := "test-task"
+	tryNumber := int32(1)
+	bundleName := "test-bundle"
+	token := "test-token"
+	request := proto.Execute_Request_builder{
+		Task: proto.ExecuteTaskWorkload_builder{
+			BundleInfo: proto.BundleInfo_builder{Name: &bundleName}.Build(),
+			Ti: proto.TaskInstance_builder{
+				Id:          proto.UUID_builder{Value: &taskInstanceIDString}.Build(),
+				DagId:       &dagID,
+				RunId:       &runID,
+				TaskId:      &taskID,
+				TryNumber:   &tryNumber,
+				OtelContext: otelContext,
+			}.Build(),
+			Token: &token,
+		}.Build(),
+	}.Build()
+
+	_, err := (&server{Impl: provider}).Execute(t.Context(), request)
+
+	require.NoError(t, err)
+	require.NotNil(t, observedCarrier)
+	assert.Equal(t, map[string]any{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+	}, *observedCarrier)
+}

--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -17,6 +17,8 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
 	github.com/vmihailenco/msgpack/v5 v5.4.1
+	go.opentelemetry.io/otel v1.41.0
+	go.opentelemetry.io/otel/trace v1.41.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.10
 	resty.dev/v3 v3.0.0-beta.2
@@ -40,8 +42,6 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	go.opentelemetry.io/otel v1.41.0 // indirect
-	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/go-sdk/pkg/worker/runner.go
+++ b/go-sdk/pkg/worker/runner.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel/propagation"
 
 	"github.com/apache/airflow/go-sdk/pkg/api"
 	"github.com/apache/airflow/go-sdk/pkg/logging"
@@ -111,6 +112,20 @@ func (w *worker) WithServer(server string) (Worker, error) {
 	return &newWorker, nil
 }
 
+func extractTraceContext(ctx context.Context, contextCarrier *map[string]any) context.Context {
+	if contextCarrier == nil {
+		return ctx
+	}
+
+	carrier := make(propagation.MapCarrier, len(*contextCarrier))
+	for key, value := range *contextCarrier {
+		if stringValue, ok := value.(string); ok {
+			carrier[key] = stringValue
+		}
+	}
+	return propagation.TraceContext{}.Extract(ctx, carrier)
+}
+
 type heartbeater struct {
 	heartbeatInterval time.Duration
 	logger            *slog.Logger
@@ -184,6 +199,7 @@ func (w *worker) ExecuteTaskWorkload(ctx context.Context, workload api.ExecuteTa
 	}
 
 	// Store the workload in the context so we can get at task id, etc, variables
+	ctx = extractTraceContext(ctx, workload.TI.ContextCarrier)
 	taskContext, cancelTaskCtx := context.WithCancelCause(
 		context.WithValue(ctx, sdkcontext.WorkloadContextKey, workload),
 	)

--- a/go-sdk/pkg/worker/runner_test.go
+++ b/go-sdk/pkg/worker/runner_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+	"go.opentelemetry.io/otel/trace"
 	"resty.dev/v3"
 
 	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
@@ -115,8 +116,17 @@ func (s *WorkerSuite) ExpectTaskRun(taskId string) {
 // ExpectTaskState sets up a matcher for the "/task-instances/{id}/state" with the given state end point
 func (s *WorkerSuite) ExpectTaskState(taskId string, state api.TerminalTIState) {
 	s.T().Helper()
+	s.expectTaskState(taskId, state, mock.AnythingOfType("context.backgroundCtx"))
+}
+
+func (s *WorkerSuite) expectTaskState(
+	taskId string,
+	state api.TerminalTIState,
+	contextMatcher any,
+) {
+	s.T().Helper()
 	s.ti.EXPECT().
-		UpdateState(mock.AnythingOfType("context.backgroundCtx"), uuid.MustParse(taskId), mock.AnythingOfType("*api.TIUpdateStatePayload")).
+		UpdateState(contextMatcher, uuid.MustParse(taskId), mock.AnythingOfType("*api.TIUpdateStatePayload")).
 		RunAndReturn(func(ctx context.Context, taskInstanceId uuid.UUID, body *api.TIUpdateStatePayload) error {
 			if payload, err := body.AsTITerminalStatePayload(); err == nil {
 				if payload.State == api.TerminalStateNonSuccess(state) {
@@ -148,6 +158,36 @@ func (s *WorkerSuite) TestTaskNotRegisteredErrors() {
 		"ExecuteTaskWorkload should not report an error %#v",
 		s.transport.GetCallCountInfo(),
 	)
+}
+
+func (s *WorkerSuite) TestTaskReceivesTraceContext() {
+	id := uuid.New().String()
+	testWorkload := newTestWorkLoad(id, id[:8])
+	contextCarrier := map[string]any{
+		"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		"tracestate":  "vendor=value",
+	}
+	testWorkload.TI.ContextCarrier = &contextCarrier
+
+	var spanContext trace.SpanContext
+	s.registry.AddDag(testWorkload.TI.DagId).
+		AddTaskWithName(testWorkload.TI.TaskId, func(ctx context.Context) error {
+			spanContext = trace.SpanContextFromContext(ctx)
+			return nil
+		})
+
+	s.ExpectTaskRun(id)
+	s.expectTaskState(id, api.TerminalTIStateSuccess, mock.Anything)
+
+	err := s.worker.ExecuteTaskWorkload(context.Background(), testWorkload)
+
+	s.NoError(err)
+	s.True(spanContext.IsValid())
+	s.True(spanContext.IsRemote())
+	s.Equal("4bf92f3577b34da6a3ce929d0e0e4736", spanContext.TraceID().String())
+	s.Equal("00f067aa0ba902b7", spanContext.SpanID().String())
+	s.True(spanContext.IsSampled())
+	s.Equal("vendor=value", spanContext.TraceState().String())
 }
 
 // TestStartContextErrorTaskDoesntStart checks that if the /run endpoint returns an error that task doesn't


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Closes #70165.

Go SDK tasks executed through the bundle gRPC path currently don't have the task instance's OpenTelemetry context carrier. This breaks trace continuity at the Go task boundary even though the protobuf schema already provides an `otel_context` field.

This change:
- forwards string-valued context-carrier entries through the existing bundle protobuf field.
- reconstructs the carrier when the bundle server receives the workload.
- extracts the W3C Trace Context into the task's `context.Context`, allowing task instrumentation and downstream API calls to inherit the remote parent.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes - GPT-5.6 Sol

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=924c8cf action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @viiccwen** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
