### PR TITLE
Fix flaky static checks caused by migration-reference hook race

### DIFF
--- a/airflow-core/.pre-commit-config.yaml
+++ b/airflow-core/.pre-commit-config.yaml
@@ -262,6 +262,7 @@ repos:
         name: Update migration ref doc
         language: python
         entry: ../scripts/ci/prek/migration_reference.py
+        args: ["--app", "airflow"]
         pass_filenames: false
         files:
           (?x)

--- a/providers/edge3/.pre-commit-config.yaml
+++ b/providers/edge3/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
         name: Update migration ref doc for Edge3
         language: python
         entry: ../../scripts/ci/prek/migration_reference.py
+        args: ["--app", "edge3"]
         pass_filenames: false
         files: >
           (?x)

--- a/providers/fab/.pre-commit-config.yaml
+++ b/providers/fab/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
         name: Update migration ref doc for FAB
         language: python
         entry: ../../scripts/ci/prek/migration_reference.py
+        args: ["--app", "fab"]
         pass_filenames: false
         files: >
           (?x)

--- a/scripts/ci/prek/migration_reference.py
+++ b/scripts/ci/prek/migration_reference.py
@@ -23,6 +23,8 @@
 # ///
 from __future__ import annotations
 
+import sys
+
 from common_prek_utils import (
     initialize_breeze_prek,
     run_command_via_breeze_run,
@@ -32,7 +34,7 @@ from common_prek_utils import (
 initialize_breeze_prek(__name__, __file__)
 
 cmd_result = run_command_via_breeze_run(
-    ["python3", "/opt/airflow/scripts/in_container/run_migration_reference.py"],
+    ["python3", "/opt/airflow/scripts/in_container/run_migration_reference.py", *sys.argv[1:]],
     backend="sqlite",
 )
 

--- a/scripts/in_container/run_migration_reference.py
+++ b/scripts/in_container/run_migration_reference.py
@@ -22,6 +22,7 @@ Module to update db migration information in Airflow
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import textwrap
@@ -53,7 +54,9 @@ def replace_text_between(file: Path, start: str, end: str, replacement_text: str
     original_text = file.read_text()
     leading_text = original_text.split(start)[0]
     trailing_text = original_text.split(end)[1]
-    file.write_text(leading_text + start + replacement_text + end + trailing_text)
+    new_text = leading_text + start + replacement_text + end + trailing_text
+    if new_text != original_text:
+        file.write_text(new_text)
 
 
 def wrap_backticks(val):
@@ -275,11 +278,21 @@ def correct_mismatching_revision_nums(revisions: Iterable[Script]):
             if revises_id_match is None:
                 raise RuntimeError(f"Revises: not found in {file}")
             new_content = new_content.replace(revises_id_match.group(1), down_revision_match.group(1), 1)
-        file.write_text(new_content)
+        if new_content != content:
+            file.write_text(new_content)
 
 
 if __name__ == "__main__":
-    apps = ["airflow", "fab", "edge3"]
+    all_apps = ["airflow", "fab", "edge3"]
+    parser = argparse.ArgumentParser(description="Update migration references and docs.")
+    parser.add_argument(
+        "--app",
+        choices=all_apps,
+        default=None,
+        help="Only process this app (default: all apps).",
+    )
+    args = parser.parse_args()
+    apps = [args.app] if args.app else all_apps
     for app in apps:
         console.print(f"[bright_blue]Updating migration reference for {app}")
         revisions = list(reversed(list(get_revisions(app))))


### PR DESCRIPTION
- related: #70155 (docs-only PR whose Static checks hit this flake)
- failed run: https://github.com/apache/airflow/actions/runs/29797370113/job/88533337550

## Why

The "CI image checks / Static checks" job fails intermittently with `RuntimeError: revision = not found in .../fab/migrations/versions/0000_1_4_0_create_ab_tables_if_missing.py`

The three `update-migration-references*` hooks live in three prek workspaces that run **in parallel**, yet each invocation of the shared `scripts/ci/prek/migration_reference.py` processed **all three apps** (`airflow`, `fab`, `edge3`) and rewrote every migration file and `migrations-ref.rst` even when nothing changed — so concurrent containers race on the same files, and a reader catching a file mid-write sees truncated content and fails.

## What

- Each hook's `files:` filter already scopes it to its own app's migration files/docs, so the all-apps loop was pure overlap: scope each hook invocation to its own app and the hooks no longer share any files — the race is structurally gone.
- Reproduced before the fix with CI's exact invocation (`prek --all-files` with the same `SKIP` list): the fab hook failed with the same `revision = not found` error while passing in isolation.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
