### PR TITLE
Format Dataflow wordcount system-test resource with gofmt

### DIFF
--- a/providers/google/tests/system/google/cloud/dataflow/resources/wordcount.go
+++ b/providers/google/tests/system/google/cloud/dataflow/resources/wordcount.go
@@ -25,7 +25,7 @@
 //
 // For a detailed walkthrough of this example, see
 //
-//    https://beam.apache.org/get-started/wordcount-example/
+//	https://beam.apache.org/get-started/wordcount-example/
 //
 // Basic concepts, also in the minimal_wordcount example: reading text files;
 // counting a PCollection; writing to text files.
@@ -45,12 +45,12 @@
 //
 // To change the runner, specify:
 //
-//    --runner=YOUR_SELECTED_RUNNER
+//	--runner=YOUR_SELECTED_RUNNER
 //
 // To execute this pipeline, specify a local output file (if using the
 // 'direct' runner) or a remote file on a supported distributed file system.
 //
-//    --output=[YOUR_LOCAL_FILE | YOUR_REMOTE_FILE]
+//	--output=[YOUR_LOCAL_FILE | YOUR_REMOTE_FILE]
 //
 // The input file defaults to a public data set containing the text of King
 // Lear by William Shakespeare. You can override it and choose your own input
@@ -74,30 +74,34 @@ package main
 //     - strings
 
 import (
-    "context"
-    "flag"
-    "fmt"
-    "log"
-    "regexp"
-    "strings"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
 
-    "github.com/apache/beam/sdks/v2/go/pkg/beam"
-    "github.com/apache/beam/sdks/v2/go/pkg/beam/io/textio"
-    "github.com/apache/beam/sdks/v2/go/pkg/beam/register"
-    "github.com/apache/beam/sdks/v2/go/pkg/beam/transforms/stats"
-    "github.com/apache/beam/sdks/v2/go/pkg/beam/x/beamx"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/textio"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/transforms/stats"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/x/beamx"
 )
 
 // Concept #2: Defining your own configuration options. Pipeline options can
 // be standard Go flags, or they can be obtained any other way. Defining and
 // configuring the pipeline is normal Go code.
 var (
-    // By default, this example reads from a public dataset containing the text of
-    // King Lear. Set this option to choose a different input file or glob.
-    input = flag.String("input", "gs://apache-beam-samples/shakespeare/kinglear.txt", "File(s) to read.")
+	// By default, this example reads from a public dataset containing the text of
+	// King Lear. Set this option to choose a different input file or glob.
+	input = flag.String(
+		"input",
+		"gs://apache-beam-samples/shakespeare/kinglear.txt",
+		"File(s) to read.",
+	)
 
-    // Set this required option to specify where to write the output.
-    output = flag.String("output", "", "Output file (required).")
+	// Set this required option to specify where to write the output.
+	output = flag.String("output", "", "Output file (required).")
 )
 
 // Concept #3: You can make your pipeline assembly code less verbose by
@@ -107,7 +111,7 @@ var (
 // experience. The argument and return types of a function dictate the pipeline
 // shape when used in a ParDo. For example,
 //
-//    func formatFn(w string, c int) string
+//	func formatFn(w string, c int) string
 //
 // indicates that the function operates on a PCollection of type KV<string,int>,
 // representing key value pairs of strings and ints, and outputs a PCollection
@@ -116,7 +120,7 @@ var (
 // DoFns that potentially output zero or multiple elements can also be Go
 // functions, but have a different signature. For example,
 //
-//    func extractFn(w string, emit func(string))
+//	func extractFn(w string, emit func(string))
 //
 // uses an "emit" function argument instead of a string return type to allow it
 // to output any number of elements. It operates on a PCollection of type string
@@ -126,57 +130,57 @@ var (
 // done automatically by the starcgen code generator, or it can be done manually
 // by calling beam.RegisterFunction in an init() call.
 func init() {
-    // register.DoFnXxY registers a struct DoFn so that it can be correctly
-    // serialized and does some optimization to avoid runtime reflection. Since
-    // extractFn has 3 inputs and 0 outputs, we use register.DoFn3x0 and provide
-    // its input types as its constraints (if it had any outputs, we would add
-    // those as constraints as well). Struct DoFns must be registered for a
-    // pipeline to run.
-    register.DoFn3x0[context.Context, string, func(string)](&extractFn{})
-    // register.FunctionXxY registers a functional DoFn to optimize execution at
-    // runtime. formatFn has 2 inputs and 1 output, so we use
-    // register.Function2x1.
-    register.Function2x1(formatFn)
-    // register.EmitterX is optional and will provide some optimization to make
-    // things run faster. Any emitters (functions that produce output for the next
-    // step) should be registered. Here we register all emitters with the
-    // signature func(string).
-    register.Emitter1[string]()
+	// register.DoFnXxY registers a struct DoFn so that it can be correctly
+	// serialized and does some optimization to avoid runtime reflection. Since
+	// extractFn has 3 inputs and 0 outputs, we use register.DoFn3x0 and provide
+	// its input types as its constraints (if it had any outputs, we would add
+	// those as constraints as well). Struct DoFns must be registered for a
+	// pipeline to run.
+	register.DoFn3x0[context.Context, string, func(string)](&extractFn{})
+	// register.FunctionXxY registers a functional DoFn to optimize execution at
+	// runtime. formatFn has 2 inputs and 1 output, so we use
+	// register.Function2x1.
+	register.Function2x1(formatFn)
+	// register.EmitterX is optional and will provide some optimization to make
+	// things run faster. Any emitters (functions that produce output for the next
+	// step) should be registered. Here we register all emitters with the
+	// signature func(string).
+	register.Emitter1[string]()
 }
 
 var (
-    wordRE          = regexp.MustCompile(`[a-zA-Z]+('[a-z])?`)
-    empty           = beam.NewCounter("extract", "emptyLines")
-    smallWordLength = flag.Int("small_word_length", 9, "length of small words (default: 9)")
-    smallWords      = beam.NewCounter("extract", "smallWords")
-    lineLen         = beam.NewDistribution("extract", "lineLenDistro")
+	wordRE          = regexp.MustCompile(`[a-zA-Z]+('[a-z])?`)
+	empty           = beam.NewCounter("extract", "emptyLines")
+	smallWordLength = flag.Int("small_word_length", 9, "length of small words (default: 9)")
+	smallWords      = beam.NewCounter("extract", "smallWords")
+	lineLen         = beam.NewDistribution("extract", "lineLenDistro")
 )
 
 // extractFn is a structural DoFn that emits the words in a given line and keeps
 // a count for small words. Its ProcessElement function will be invoked on each
 // element in the input PCollection.
 type extractFn struct {
-    SmallWordLength int `json:"smallWordLength"`
+	SmallWordLength int `json:"smallWordLength"`
 }
 
 func (f *extractFn) ProcessElement(ctx context.Context, line string, emit func(string)) {
-    lineLen.Update(ctx, int64(len(line)))
-    if len(strings.TrimSpace(line)) == 0 {
-        empty.Inc(ctx, 1)
-    }
-    for _, word := range wordRE.FindAllString(line, -1) {
-        // increment the counter for small words if length of words is
-        // less than small_word_length
-        if len(word) < f.SmallWordLength {
-            smallWords.Inc(ctx, 1)
-        }
-        emit(word)
-    }
+	lineLen.Update(ctx, int64(len(line)))
+	if len(strings.TrimSpace(line)) == 0 {
+		empty.Inc(ctx, 1)
+	}
+	for _, word := range wordRE.FindAllString(line, -1) {
+		// increment the counter for small words if length of words is
+		// less than small_word_length
+		if len(word) < f.SmallWordLength {
+			smallWords.Inc(ctx, 1)
+		}
+		emit(word)
+	}
 }
 
 // formatFn is a functional DoFn that formats a word and its count as a string.
 func formatFn(w string, c int) string {
-    return fmt.Sprintf("%s: %v", w, c)
+	return fmt.Sprintf("%s: %v", w, c)
 }
 
 // Concept #4: A composite PTransform is a Go function that adds
@@ -194,39 +198,39 @@ func formatFn(w string, c int) string {
 // of type KV<string,int>. The Beam type checker enforces these constraints
 // during pipeline construction.
 func CountWords(s beam.Scope, lines beam.PCollection) beam.PCollection {
-    s = s.Scope("CountWords")
+	s = s.Scope("CountWords")
 
-    // Convert lines of text into individual words.
-    col := beam.ParDo(s, &extractFn{SmallWordLength: *smallWordLength}, lines)
+	// Convert lines of text into individual words.
+	col := beam.ParDo(s, &extractFn{SmallWordLength: *smallWordLength}, lines)
 
-    // Count the number of times each word occurs.
-    return stats.Count(s, col)
+	// Count the number of times each word occurs.
+	return stats.Count(s, col)
 }
 
 func main() {
-    // If beamx or Go flags are used, flags must be parsed first.
-    flag.Parse()
-    // beam.Init() is an initialization hook that must be called on startup. On
-    // distributed runners, it is used to intercept control.
-    beam.Init()
+	// If beamx or Go flags are used, flags must be parsed first.
+	flag.Parse()
+	// beam.Init() is an initialization hook that must be called on startup. On
+	// distributed runners, it is used to intercept control.
+	beam.Init()
 
-    // Input validation is done as usual. Note that it must be after Init().
-    if *output == "" {
-        log.Fatal("No output provided")
-    }
+	// Input validation is done as usual. Note that it must be after Init().
+	if *output == "" {
+		log.Fatal("No output provided")
+	}
 
-    // Concepts #3 and #4: The pipeline uses the named transform and DoFn.
-    p := beam.NewPipeline()
-    s := p.Root()
+	// Concepts #3 and #4: The pipeline uses the named transform and DoFn.
+	p := beam.NewPipeline()
+	s := p.Root()
 
-    lines := textio.Read(s, *input)
-    counted := CountWords(s, lines)
-    formatted := beam.ParDo(s, formatFn, counted)
-    textio.Write(s, *output, formatted)
+	lines := textio.Read(s, *input)
+	counted := CountWords(s, lines)
+	formatted := beam.ParDo(s, formatFn, counted)
+	textio.Write(s, *output, formatted)
 
-    // Concept #1: The beamx.Run convenience wrapper allows a number of
-    // pre-defined runners to be used via the --runner flag.
-    if err := beamx.Run(context.Background(), p); err != nil {
-        log.Fatalf("Failed to execute job: %v", err)
-    }
+	// Concept #1: The beamx.Run convenience wrapper allows a number of
+	// pre-defined runners to be used via the --runner flag.
+	if err := beamx.Run(context.Background(), p); err != nil {
+		log.Fatalf("Failed to execute job: %v", err)
+	}
 }


### PR DESCRIPTION
The Dataflow system-test resource `wordcount.go` is indented with spaces, so the Go SDK's gofmt prek hook (`golines` + `gofumpt`) rewrites it on every repo-wide run (`prek run -c go-sdk/.pre-commit-config.yaml gofmt --all-files`), leaving contributors with an unrelated dirty file. Tab indentation also matches standard Go formatting and the upstream Apache Beam example this resource copies.

Whitespace-only change: the Dataflow system test compiles the pipeline from source, so behaviour is unchanged.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)  following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)