### PR TITLE
Support sovereign console links for Google providers

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/bundles/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/bundles/gcs.py
@@ -154,7 +154,7 @@ class GCSDagBundle(BaseDagBundle):
             # _view_url_template attribute. Should be removed when we drop support for Airflow 3.0
             return self._view_url_template
         # https://console.cloud.google.com/storage/browser/<bucket-name>/<prefix>
-        url = f"https://console.cloud.google.com/storage/browser/{self.bucket_name}"
+        url = f"https://console.cloud.{GoogleBaseHook.get_high_value_cookie_domain()}/storage/browser/{self.bucket_name}"
         if self.prefix:
             url += f"/{self.prefix}"
 

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -43,6 +43,7 @@ from google.cloud.logging_v2.types import ListLogEntriesRequest, ListLogEntriesR
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.google.cloud.utils.credentials_provider import get_credentials_and_project_id
 from airflow.providers.google.common.consts import CLIENT_INFO
+from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.providers.google.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -326,7 +327,7 @@ class StackdriverTaskHandler(logging.Handler):
     LABEL_DAG_ID = LABEL_DAG_ID
     LABEL_LOGICAL_DATE = LABEL_LOGICAL_DATE
     LABEL_TRY_NUMBER = LABEL_TRY_NUMBER
-    LOG_VIEWER_BASE_URL = "https://console.cloud.google.com/logs/viewer"
+    LOG_VIEWER_BASE_URL = "https://console.cloud.{domain}/logs/viewer"
     LOG_NAME = "Google Stackdriver"
 
     trigger_supported = True
@@ -509,7 +510,8 @@ class StackdriverTaskHandler(logging.Handler):
             "advancedFilter": log_filter,
         }
 
-        url = f"{self.LOG_VIEWER_BASE_URL}?{urlencode(url_query_string)}"
+        log_viewer_url = self.LOG_VIEWER_BASE_URL.format(domain=GoogleBaseHook.get_high_value_cookie_domain())
+        url = f"{log_viewer_url}?{urlencode(url_query_string)}"
         return url
 
     def close(self) -> None:

--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -45,6 +45,7 @@ from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.google.cloud.utils.credentials_provider import get_credentials_and_project_id
 from airflow.providers.google.common.consts import CLIENT_INFO
+from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.providers.google.version_compat import AIRFLOW_V_3_0_PLUS
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -362,7 +363,7 @@ class StackdriverTaskHandler(logging.Handler):
     LABEL_DAG_ID = LABEL_DAG_ID
     LABEL_LOGICAL_DATE = LABEL_LOGICAL_DATE
     LABEL_TRY_NUMBER = LABEL_TRY_NUMBER
-    LOG_VIEWER_BASE_URL = "https://console.cloud.google.com/logs/viewer"
+    LOG_VIEWER_BASE_URL = "https://console.cloud.{domain}/logs/viewer"
     LOG_NAME = "Google Stackdriver"
 
     trigger_supported = True
@@ -545,7 +546,8 @@ class StackdriverTaskHandler(logging.Handler):
             "advancedFilter": log_filter,
         }
 
-        url = f"{self.LOG_VIEWER_BASE_URL}?{urlencode(url_query_string)}"
+        log_viewer_url = self.LOG_VIEWER_BASE_URL.format(domain=GoogleBaseHook.get_high_value_cookie_domain())
+        url = f"{log_viewer_url}?{urlencode(url_query_string)}"
         return url
 
     def close(self) -> None:

--- a/providers/google/tests/unit/google/cloud/bundles/test_gcs.py
+++ b/providers/google/tests/unit/google/cloud/bundles/test_gcs.py
@@ -70,6 +70,17 @@ class TestGCSDagBundle:
             url == f"https://console.cloud.google.com/storage/browser/{GCS_BUCKET_NAME}/{GCS_BUCKET_PREFIX}"
         )
 
+    def test_view_url_template_uses_high_value_cookie_domain(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN", "googleapis.cn")
+        bundle = GCSDagBundle(
+            name="test", gcp_conn_id=GCP_CONN_ID, prefix=GCS_BUCKET_PREFIX, bucket_name=GCS_BUCKET_NAME
+        )
+
+        assert (
+            bundle.view_url_template()
+            == f"https://console.cloud.googleapis.cn/storage/browser/{GCS_BUCKET_NAME}/{GCS_BUCKET_PREFIX}"
+        )
+
     def test_supports_versioning(self):
         bundle = GCSDagBundle(
             name="test", gcp_conn_id=GCP_CONN_ID, prefix=GCS_BUCKET_PREFIX, bucket_name=GCS_BUCKET_NAME

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -692,8 +692,9 @@ class TestStackdriverLoggingHandlerTask:
 
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.LoggingServiceV2Client")
-    def test_should_return_valid_external_url(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_return_valid_external_url(self, mock_client, mock_get_creds_and_project_id, monkeypatch):
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+        monkeypatch.setenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN", "googleapis.cn")
 
         stackdriver_task_handler = StackdriverTaskHandler(gcp_key_path="KEY_PATH")
         url = stackdriver_task_handler.get_external_log_url(self.ti, self.ti.try_number)
@@ -701,7 +702,7 @@ class TestStackdriverLoggingHandlerTask:
         parsed_url = urlsplit(url)
         parsed_qs = parse_qs(parsed_url.query)
         assert parsed_url.scheme == "https"
-        assert parsed_url.netloc == "console.cloud.google.com"
+        assert parsed_url.netloc == "console.cloud.googleapis.cn"
         assert parsed_url.path == "/logs/viewer"
         assert {"project", "interval", "resource", "advancedFilter"} == set(parsed_qs.keys())
         assert "global" in parsed_qs["resource"]

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -755,8 +755,9 @@ class TestStackdriverLoggingHandlerTask:
 
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.LoggingServiceV2Client")
-    def test_should_return_valid_external_url(self, mock_client, mock_get_creds_and_project_id):
+    def test_should_return_valid_external_url(self, mock_client, mock_get_creds_and_project_id, monkeypatch):
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+        monkeypatch.setenv("GOOGLE_CLOUD_HIGH_VALUE_COOKIE_DOMAIN", "googleapis.cn")
 
         stackdriver_task_handler = StackdriverTaskHandler(gcp_key_path="KEY_PATH")
         url = stackdriver_task_handler.get_external_log_url(self.ti, self.ti.try_number)
@@ -764,7 +765,7 @@ class TestStackdriverLoggingHandlerTask:
         parsed_url = urlsplit(url)
         parsed_qs = parse_qs(parsed_url.query)
         assert parsed_url.scheme == "https"
-        assert parsed_url.netloc == "console.cloud.google.com"
+        assert parsed_url.netloc == "console.cloud.googleapis.cn"
         assert parsed_url.path == "/logs/viewer"
         assert {"project", "interval", "resource", "advancedFilter"} == set(parsed_qs.keys())
         assert "global" in parsed_qs["resource"]


### PR DESCRIPTION
## What changed

Completes the Trusted Partner Cloud console-link handling for two remaining user-visible URLs:

- Stackdriver task-log viewer links
- GCS DAG bundle browser links

Both now use `GoogleBaseHook.get_high_value_cookie_domain()` while preserving the default `google.com` domain.

## Tests

- `uv run --package apache-airflow-providers-google pytest providers/google/tests/unit/google/cloud/bundles/test_gcs.py -q`
- `uv run --package apache-airflow-providers-google pytest providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py::TestStackdriverLoggingHandlerTask::test_should_return_valid_external_url -q`
- `ruff check` on the four changed files

<!-- pr-triage-fold: triaged=2026-07-28T16:22:13Z head=09be1e1 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @auyua9** · by `@potiuk` · 2026-07-28 16:22 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **199 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
