### PR TITLE
Fail fast on permanent batch poll errors in AnthropicBatchTrigger

### DIFF
--- a/providers/anthropic/src/airflow/providers/anthropic/triggers/batch.py
+++ b/providers/anthropic/src/airflow/providers/anthropic/triggers/batch.py
@@ -21,12 +21,19 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any
 
+from anthropic import APIStatusError
+
 from airflow.providers.anthropic.hooks.anthropic import (
     MAX_CONSECUTIVE_POLL_FAILURES,
     AnthropicHook,
     BatchStatus,
 )
 from airflow.triggers.base import BaseTrigger, TriggerEvent
+
+
+def _is_permanent_poll_error(error: Exception) -> bool:
+    """Return whether an Anthropic batch polling error cannot succeed on a retry."""
+    return isinstance(error, APIStatusError) and 400 <= error.status_code < 500 and error.status_code != 429
 
 
 class AnthropicBatchTrigger(BaseTrigger):
@@ -86,7 +93,11 @@ class AnthropicBatchTrigger(BaseTrigger):
                 # single poll does not stall every other trigger on this triggerer.
                 batch = await asyncio.to_thread(hook.get_batch, self.batch_id)
             except Exception as e:
-                # Tolerate transient polling errors rather than failing a (up to 24h) wait.
+                if _is_permanent_poll_error(e):
+                    yield TriggerEvent({"status": "error", "batch_id": self.batch_id, "message": str(e)})
+                    return
+                # Tolerate retryable network, rate-limit, and server errors rather than
+                # failing a (up to 24h) wait on a single transient polling failure.
                 consecutive_failures += 1
                 if consecutive_failures >= MAX_CONSECUTIVE_POLL_FAILURES or time.time() > self.end_time:
                     yield TriggerEvent({"status": "error", "batch_id": self.batch_id, "message": str(e)})

--- a/providers/anthropic/tests/unit/anthropic/triggers/test_batch.py
+++ b/providers/anthropic/tests/unit/anthropic/triggers/test_batch.py
@@ -20,6 +20,8 @@ import time
 from unittest import mock
 
 import pytest
+from anthropic import APIStatusError
+from httpx import Request, Response
 
 from airflow.providers.anthropic.triggers.batch import AnthropicBatchTrigger
 from airflow.triggers.base import TriggerEvent
@@ -28,6 +30,12 @@ pytest.importorskip("anthropic")
 
 TRIGGER_PATH = "airflow.providers.anthropic.triggers.batch"
 HOOK_PATH = "airflow.providers.anthropic.hooks.anthropic.AnthropicHook.get_batch"
+
+
+def _api_status_error(status_code: int) -> APIStatusError:
+    request = Request("GET", "https://api.anthropic.com/v1/messages/batches/batch_1")
+    response = Response(status_code, request=request)
+    return APIStatusError(f"HTTP {status_code}", response=response, body=None)
 
 
 def _batch(status, succeeded=0, errored=0, canceled=0, expired=0, processing=0):
@@ -103,11 +111,22 @@ class TestAnthropicBatchTrigger:
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.asyncio.sleep")
     @mock.patch(HOOK_PATH)
-    async def test_persistent_error_yields_error_after_retries(self, mock_get_batch, mock_sleep):
-        mock_get_batch.side_effect = RuntimeError("kaboom")
+    async def test_permanent_api_error_yields_error_without_retry(self, mock_get_batch, mock_sleep):
+        mock_get_batch.side_effect = _api_status_error(404)
         event = await self._trigger().run().__anext__()
-        assert event == TriggerEvent({"status": "error", "batch_id": self.BATCH_ID, "message": "kaboom"})
-        assert mock_get_batch.call_count == 5
+        assert event.payload["status"] == "error"
+        assert mock_get_batch.call_count == 1
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @mock.patch(f"{TRIGGER_PATH}.asyncio.sleep")
+    @mock.patch(HOOK_PATH)
+    async def test_transient_server_error_then_success(self, mock_get_batch, mock_sleep):
+        mock_get_batch.side_effect = [_api_status_error(503), _batch("ended", succeeded=1)]
+        event = await self._trigger().run().__anext__()
+        assert event.payload["status"] == "success"
+        assert mock_get_batch.call_count == 2
+        mock_sleep.assert_awaited_once_with(self.POLL)
 
     @pytest.mark.asyncio
     @mock.patch(f"{TRIGGER_PATH}.asyncio.sleep")


### PR DESCRIPTION
## What changed

Fail fast when deferred Anthropic batch polling receives a known permanent API error (non-rate-limit 4xx), instead of retrying until the transient-failure limit.

Retries remain unchanged for rate limits, server errors, network failures, and unknown exceptions.

## Tests

- `uv run --package apache-airflow-providers-anthropic pytest providers/anthropic/tests/unit/anthropic/triggers/test_batch.py -q`
- `ruff check` on the changed source and test files

<!-- pr-triage-fold: triaged=2026-07-28T16:11:19Z head=ccfe5e6 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @suyua9** · by `@potiuk` · 2026-07-28 16:11 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Unresolved review comments**: 1 thread(s). See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **199 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
