### PR TITLE
Include spark submit canonical logs in failure exceptions

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -27,6 +27,7 @@ import subprocess
 import tempfile
 import time
 import uuid
+from collections import deque
 from collections.abc import Iterator
 from functools import cached_property
 from pathlib import Path
@@ -318,6 +319,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         self._driver_id: str | None = None
         self._driver_status: str | None = None
         self._spark_exit_code: int | None = None
+        # Last few lines of the spark-submit process's own stdout/stderr, so failure
+        # exceptions can include the actual root cause instead of just an exit code.
+        self._last_submit_log_lines: deque[str] = deque(maxlen=20)
         self._env: dict[str, Any] | None = None
         self._post_submit_commands: list[str] = list(post_submit_commands) if post_submit_commands else []
         self._post_submit_commands_done: bool = False
@@ -529,6 +533,17 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         )
 
         return connection_cmd_masked
+
+    def _format_submit_log_tail(self) -> str:
+        """
+        Capture the last few lines of the spark-submit process's own output.
+
+        Appended to submit-failure exceptions so the real root cause is visible instead of just an exit code.
+        """
+        if not self._last_submit_log_lines:
+            return ""
+        tail = "\n".join(self._mask_cmd([line]) for line in self._last_submit_log_lines)
+        return f"\nLast spark-submit output:\n{tail}"
 
     def _build_spark_common_args(self) -> list[str]:
         """
@@ -781,9 +796,11 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     raise AirflowException(
                         f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}. "
                         f"Kubernetes spark exit code is: {self._spark_exit_code}"
+                        f"{self._format_submit_log_tail()}"
                     )
                 raise AirflowException(
                     f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}."
+                    f"{self._format_submit_log_tail()}"
                 )
 
             if self._should_track_yarn_application_via_rm_api():
@@ -794,6 +811,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             if self._should_track_driver_status and self._driver_id is None:
                 raise AirflowException(
                     "No driver id is known: something went wrong when executing the spark submit command"
+                    f"{self._format_submit_log_tail()}"
                 )
         finally:
             # K8s-API tracking defers post-submit commands to _poll_k8s_driver_via_api's finally
@@ -866,6 +884,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     self._driver_id = match_driver_id.group(0)
                     self.log.info("identified spark driver id: %s", self._driver_id)
 
+            self._last_submit_log_lines.append(line)
             self.log.info(line)
 
     def _start_yarn_application_status_tracking(self, application_id: str) -> None:

--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -534,9 +534,10 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         return connection_cmd_masked
 
-    def _format_submit_log_tail(self) -> str:
+    @property
+    def _submit_log_tail(self) -> str:
         """
-        Capture the last few lines of the spark-submit process's own output.
+        The last few lines of the spark-submit process's own output.
 
         Appended to submit-failure exceptions so the real root cause is visible instead of just an exit code.
         """
@@ -796,11 +797,11 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     raise AirflowException(
                         f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}. "
                         f"Kubernetes spark exit code is: {self._spark_exit_code}"
-                        f"{self._format_submit_log_tail()}"
+                        f"{self._submit_log_tail}"
                     )
                 raise AirflowException(
                     f"Cannot execute: {self._mask_cmd(spark_submit_cmd)}. Error code is: {returncode}."
-                    f"{self._format_submit_log_tail()}"
+                    f"{self._submit_log_tail}"
                 )
 
             if self._should_track_yarn_application_via_rm_api():
@@ -811,7 +812,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             if self._should_track_driver_status and self._driver_id is None:
                 raise AirflowException(
                     "No driver id is known: something went wrong when executing the spark submit command"
-                    f"{self._format_submit_log_tail()}"
+                    f"{self._submit_log_tail}"
                 )
         finally:
             # K8s-API tracking defers post-submit commands to _poll_k8s_driver_via_api's finally

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -1286,12 +1286,18 @@ class TestSparkSubmitHook:
         assert command_masked == expected
 
     @pytest.mark.db_test
-    def test_format_submit_log_tail_formats_and_masks_captured_lines(self) -> None:
+    def test_submit_log_tail_empty_when_no_lines_captured(self) -> None:
+        hook = SparkSubmitHook()
+
+        assert hook._submit_log_tail == ""
+
+    @pytest.mark.db_test
+    def test_submit_log_tail_formats_and_masks_captured_lines(self) -> None:
         hook = SparkSubmitHook()
         hook._last_submit_log_lines.append("Exception in thread main: SparkException: bad jar")
         hook._last_submit_log_lines.append("--password='secret'")
 
-        tail = hook._format_submit_log_tail()
+        tail = hook._submit_log_tail
 
         assert tail == (
             "\nLast spark-submit output:\n"

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -379,6 +379,33 @@ class TestSparkSubmitHook:
         )
 
     @pytest.mark.db_test
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")
+    def test_submit_failure_includes_captured_log_tail(self, mock_popen, sdk_connection_not_found):
+        mock_popen.return_value.stdout = StringIO(
+            "Exception in thread main: SparkException: bad jar\nsome other line"
+        )
+        mock_popen.return_value.stderr = StringIO("")
+        mock_popen.return_value.wait.return_value = 1
+
+        hook = SparkSubmitHook(conn_id="")
+
+        with pytest.raises(AirflowException, match="Last spark-submit output:") as exc_info:
+            hook.submit()
+        assert "Exception in thread main: SparkException: bad jar" in str(exc_info.value)
+
+    @pytest.mark.db_test
+    @patch("airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen")
+    def test_submit_no_driver_id_includes_captured_log_tail(self, mock_popen, sdk_connection_not_found):
+        mock_popen.return_value.stdout = StringIO("some unrelated spark-submit output")
+        mock_popen.return_value.stderr = StringIO("")
+        mock_popen.return_value.wait.return_value = 0
+
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster")
+        with pytest.raises(AirflowException, match="No driver id is known") as exc_info:
+            hook.submit()
+        assert "Last spark-submit output:\nsome unrelated spark-submit output" in str(exc_info.value)
+
+    @pytest.mark.db_test
     def test_resolve_should_track_driver_status(self, sdk_connection_not_found):
         # Given
         hook_default = SparkSubmitHook(conn_id="")
@@ -986,6 +1013,24 @@ class TestSparkSubmitHook:
 
         assert hook._driver_id == "driver-20171128111415-0001"
 
+    def test_process_spark_submit_log_populates_last_submit_log_lines(self):
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster")
+        log_lines = [
+            "Running Spark using the REST application submission protocol.",
+            "17/11/28 11:14:15 INFO RestSubmissionClient: Submitting a request "
+            "to launch an application in spark://spark-standalone-master:6066",
+        ]
+
+        hook._process_spark_submit_log(log_lines)
+
+        assert list(hook._last_submit_log_lines) == log_lines
+
+    def test_process_spark_submit_log_last_submit_log_lines_truncates_to_maxlen(self):
+        hook = SparkSubmitHook(conn_id="spark_standalone_cluster")
+        log_lines = [f"line {i}" for i in range(25)]
+        hook._process_spark_submit_log(log_lines)
+        assert list(hook._last_submit_log_lines) == log_lines[-20:]
+
     def test_process_spark_driver_status_log(self):
         # Given
         hook = SparkSubmitHook(conn_id="spark_standalone_cluster")
@@ -1239,6 +1284,20 @@ class TestSparkSubmitHook:
 
         # Then
         assert command_masked == expected
+
+    @pytest.mark.db_test
+    def test_format_submit_log_tail_formats_and_masks_captured_lines(self) -> None:
+        hook = SparkSubmitHook()
+        hook._last_submit_log_lines.append("Exception in thread main: SparkException: bad jar")
+        hook._last_submit_log_lines.append("--password='secret'")
+
+        tail = hook._format_submit_log_tail()
+
+        assert tail == (
+            "\nLast spark-submit output:\n"
+            "Exception in thread main: SparkException: bad jar\n"
+            "--password='******'"
+        )
 
     @pytest.mark.db_test
     def test_create_keytab_path_from_base64_keytab_with_decode_exception(self):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

### Why?

Airflow only surfaced spark-submit's exit code when the process failed, discarding the JVM's actual stdout/stderr (missing jar, bad main class, Kerberos errors, etc.). Humans and Retry policies evaluating these exceptions had nothing but an exit code to reason from. 

Some cases I encountered are when Spark's `SparkSubmitHook.submit()` raises `AirflowException` on three
failure paths: 

- a nonzero spark-submit exit code, 
- a Kubernetes exit-code mismatch, and 
- a standalone-cluster submit that produced no driver id.

In all three cases the exception message contained only the masked command line and an exit code -- never the spark-submit process's own stdout/stderr, even though that output already streams through `_process_spark_submit_log()` line by line and often contains the real cause (missing jar, bad main class, Kerberos failure, etc.).

This makes root-causing failures harder for humans, and gives automated/LLM-based retry policies nothing to work with beyond an exit code cos they can't distinguish a transient submit infra hiccup from a permanent misconfiguration.


### What

This PR adds a small rolling buffer of the last 20 lines of spark-submit's own output (`_last_submit_log_lines`, populated in
`_process_spark_submit_log`) and appends it, masked the same way the command line already is, to all three submit-failure exceptions via a new `_format_submit_log_tail()` helper. Example:

```shell
            "Cannot execute: spark-submit --master spark://spark-master:7077 --deploy-mode cluster "
            "/opt/spark/apps/does-not-exist.jar. Error code is: 1.\n"
            "Last spark-submit output:\n"
            "WARNING: Using incubator modules: jdk.incubator.vector\n"
            "26/07/21 07:03:03 WARN NativeCodeLoader: Unable to load native-hadoop library for your "
            "platform... using builtin-java classes where applicable\n"
            'Exception in thread "main" org.apache.spark.SparkException: Failed to get main class in '
            "JAR with error 'File file:/opt/spark/apps/does-not-exist.jar does not exist'.  Please "
            "specify one with --class.\n"
            "\tat org.apache.spark.deploy.SparkSubmit.error(SparkSubmit.scala:1065)\n"
            "\tat org.apache.spark.deploy.SparkSubmit.prepareSubmitEnvironment(SparkSubmit.scala:547)\n"
            "\tat org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:95)"
```




---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
