### PR TITLE
Add Cloud Run job links during execution

### DIFF
--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -1382,6 +1382,7 @@ extra-links:
   - airflow.providers.google.cloud.links.compute.ComputeInstanceTemplateDetailsLink
   - airflow.providers.google.cloud.links.compute.ComputeInstanceGroupManagerDetailsLink
   - airflow.providers.google.cloud.links.cloud_run.CloudRunJobLoggingLink
+  - airflow.providers.google.cloud.links.cloud_run.CloudRunJobExecutionDetailsLink
   - airflow.providers.google.cloud.links.cloud_tasks.CloudTasksQueueLink
   - airflow.providers.google.cloud.links.cloud_tasks.CloudTasksLink
   - airflow.providers.google.cloud.links.dataproc.DataprocLink

--- a/providers/google/src/airflow/providers/google/cloud/links/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/links/cloud_run.py
@@ -16,7 +16,18 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.google.cloud.links.base import BaseGoogleLink
+from typing import TYPE_CHECKING, Any
+
+from airflow.providers.google.cloud.links.base import BASE_LINK, BaseGoogleLink
+
+if TYPE_CHECKING:
+    from airflow.providers.common.compat.sdk import Context
+
+
+CLOUD_RUN_BASE_LINK = "/run"
+CLOUD_RUN_JOB_EXECUTION_DETAILS_LINK = (
+    CLOUD_RUN_BASE_LINK + "/jobs/details/{region}/{job_name}/executions?project={project_id}"
+)
 
 
 class CloudRunJobLoggingLink(BaseGoogleLink):
@@ -25,3 +36,24 @@ class CloudRunJobLoggingLink(BaseGoogleLink):
     name = "Cloud Run Job Logging"
     key = "log_uri"
     format_str = "{log_uri}"
+
+    @classmethod
+    def persist(cls, context: Context, **value: Any) -> None:
+        """Persist the complete URL expected by serialized operator links."""
+        context["ti"].xcom_push(key=cls.key, value=value["log_uri"])
+
+
+class CloudRunJobExecutionDetailsLink(BaseGoogleLink):
+    """Helper class for constructing a Cloud Run Job execution details link."""
+
+    name = "Cloud Run Job Execution Details"
+    key = "cloud_run_job_execution_details"
+    format_str = CLOUD_RUN_JOB_EXECUTION_DETAILS_LINK
+
+    @classmethod
+    def persist(cls, context: Context, **value: Any) -> None:
+        """Persist the complete URL so it is usable while the execution is running."""
+        context["ti"].xcom_push(
+            key=cls.key,
+            value=BASE_LINK + cls.format_str.format(**value),
+        )

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_run.py
@@ -29,7 +29,10 @@ from google.cloud.run_v2 import Job, Service
 
 from airflow.providers.common.compat.sdk import AirflowException, conf
 from airflow.providers.google.cloud.hooks.cloud_run import CloudRunHook, CloudRunServiceHook
-from airflow.providers.google.cloud.links.cloud_run import CloudRunJobLoggingLink
+from airflow.providers.google.cloud.links.cloud_run import (
+    CloudRunJobExecutionDetailsLink,
+    CloudRunJobLoggingLink,
+)
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
 from airflow.providers.google.cloud.triggers.cloud_run import CloudRunJobFinishedTrigger, RunJobStatus
 
@@ -319,7 +322,10 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
         Default: ``False``.
     """
 
-    operator_extra_links = (CloudRunJobLoggingLink(),)
+    operator_extra_links = (
+        CloudRunJobLoggingLink(),
+        CloudRunJobExecutionDetailsLink(),
+    )
     template_fields = (
         "project_id",
         "region",
@@ -380,6 +386,13 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
                 context=context,
                 log_uri=self.operation.metadata.log_uri,
             )
+
+        CloudRunJobExecutionDetailsLink.persist(
+            context=context,
+            region=self.region,
+            job_name=self.job_name,
+            project_id=self.project_id,
+        )
 
         if not self.deferrable:
             result: Execution = self._wait_for_operation(self.operation)

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1600,6 +1600,7 @@ def get_provider_info():
             "airflow.providers.google.cloud.links.compute.ComputeInstanceTemplateDetailsLink",
             "airflow.providers.google.cloud.links.compute.ComputeInstanceGroupManagerDetailsLink",
             "airflow.providers.google.cloud.links.cloud_run.CloudRunJobLoggingLink",
+            "airflow.providers.google.cloud.links.cloud_run.CloudRunJobExecutionDetailsLink",
             "airflow.providers.google.cloud.links.cloud_tasks.CloudTasksQueueLink",
             "airflow.providers.google.cloud.links.cloud_tasks.CloudTasksLink",
             "airflow.providers.google.cloud.links.dataproc.DataprocLink",

--- a/providers/google/tests/unit/google/cloud/links/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/links/test_cloud_run.py
@@ -21,7 +21,11 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.google.cloud.links.cloud_run import CloudRunJobLoggingLink
+from airflow.providers.google.cloud.links.cloud_run import (
+    CLOUD_RUN_JOB_EXECUTION_DETAILS_LINK,
+    CloudRunJobExecutionDetailsLink,
+    CloudRunJobLoggingLink,
+)
 from airflow.providers.google.cloud.operators.cloud_run import CloudRunExecuteJobOperator
 
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
@@ -31,6 +35,9 @@ if AIRFLOW_V_3_0_PLUS:
 
 TEST_LOG_URI = (
     "https://console.cloud.google.com/run/jobs/logs?project=test-project&region=test-region&job=test-job"
+)
+TEST_EXECUTION_DETAILS_URI = (
+    "https://console.cloud.google.com/run/jobs/details/test-region/test-job/executions?project=test-project"
 )
 
 
@@ -52,7 +59,7 @@ class TestCloudRunJobLoggingLink:
 
         mock_context["ti"].xcom_push.assert_called_once_with(
             key=CloudRunJobLoggingLink.key,
-            value={"log_uri": TEST_LOG_URI},
+            value=TEST_LOG_URI,
         )
 
     @pytest.mark.db_test
@@ -74,7 +81,30 @@ class TestCloudRunJobLoggingLink:
         if mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
                 key="key",
-                value={"log_uri": TEST_LOG_URI},
+                value=TEST_LOG_URI,
             )
         actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
         assert actual_url == TEST_LOG_URI
+
+
+class TestCloudRunJobExecutionDetailsLink:
+    def test_class_attributes(self):
+        assert CloudRunJobExecutionDetailsLink.key == "cloud_run_job_execution_details"
+        assert CloudRunJobExecutionDetailsLink.name == "Cloud Run Job Execution Details"
+        assert CloudRunJobExecutionDetailsLink.format_str == CLOUD_RUN_JOB_EXECUTION_DETAILS_LINK
+
+    def test_persist(self):
+        mock_context = mock.MagicMock()
+        mock_context["ti"] = mock.MagicMock()
+
+        CloudRunJobExecutionDetailsLink.persist(
+            context=mock_context,
+            region="test-region",
+            job_name="test-job",
+            project_id="test-project",
+        )
+
+        mock_context["ti"].xcom_push.assert_called_once_with(
+            key=CloudRunJobExecutionDetailsLink.key,
+            value=TEST_EXECUTION_DETAILS_URI,
+        )

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_run.py
@@ -43,6 +43,9 @@ from airflow.providers.google.cloud.triggers.cloud_run import RunJobStatus
 CLOUD_RUN_HOOK_PATH = "airflow.providers.google.cloud.operators.cloud_run.CloudRunHook"
 CLOUD_RUN_SERVICE_HOOK_PATH = "airflow.providers.google.cloud.operators.cloud_run.CloudRunServiceHook"
 GCP_LOGGING_PATH = "airflow.providers.google.cloud.operators.cloud_run.gcp_logging"
+CLOUD_RUN_EXECUTION_DETAILS_LINK_PATH = (
+    "airflow.providers.google.cloud.operators.cloud_run.CloudRunJobExecutionDetailsLink"
+)
 TASK_ID = "test"
 PROJECT_ID = "testproject"
 REGION = "us-central1"
@@ -218,6 +221,31 @@ class TestCloudRunExecuteJobOperator:
 
         with pytest.raises(TaskDeferred):
             operator.execute(mock.MagicMock())
+
+    @mock.patch(f"{CLOUD_RUN_EXECUTION_DETAILS_LINK_PATH}.persist")
+    @mock.patch(CLOUD_RUN_HOOK_PATH)
+    def test_execute_persists_job_execution_details_link(self, hook_mock, persist_mock):
+        operation = mock.MagicMock()
+        operation.metadata.log_uri = None
+        hook_mock.return_value.execute_job.return_value = operation
+        context = mock.MagicMock()
+        operator = CloudRunExecuteJobOperator(
+            task_id=TASK_ID,
+            project_id=PROJECT_ID,
+            region=REGION,
+            job_name=JOB_NAME,
+            deferrable=True,
+        )
+
+        with pytest.raises(TaskDeferred):
+            operator.execute(context)
+
+        persist_mock.assert_called_once_with(
+            context=context,
+            region=REGION,
+            job_name=JOB_NAME,
+            project_id=PROJECT_ID,
+        )
 
     @mock.patch(CLOUD_RUN_HOOK_PATH)
     def test_execute_deferrable_execute_complete_method_timeout(self, hook_mock):


### PR DESCRIPTION
Add Cloud Run links to the job’s Executions tab as soon as CloudRunExecuteJobOperator starts the job. 
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-07-28T16:21:47Z head=f5956c5 action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @VladaZakharova** · by `@potiuk` · 2026-07-28 16:21 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> See the [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria) for how to fix each item. There is no rush.
>
> **Note:** your branch is **359 commits behind `main`** — please rebase and push again to get up-to-date CI results.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look. We use this [two-stage triage process](https://github.com/apache/airflow/blob/main/contributing-docs/25_maintainer_pr_triage.md#why-the-first-pass-is-automated) so maintainers' limited time goes to the conversation with you._</sub>

<!-- /pr-triage-fold -->
