### PR TITLE
Fix toolsets python-modules check for common.ai provider

### DIFF
--- a/providers/common/ai/provider.yaml
+++ b/providers/common/ai/provider.yaml
@@ -454,6 +454,7 @@ operators:
 toolsets:
   - integration-name: Common AI
     python-modules:
+      - airflow.providers.common.ai.toolsets.aws
       - airflow.providers.common.ai.toolsets.hook
       - airflow.providers.common.ai.toolsets.sql
       - airflow.providers.common.ai.toolsets.datafusion


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Main is broken with this error:
```shell
    suspended_providers  {'apache-airflow-providers-apache-beam'}
    Found 2 errors in providers
    Error: Incorrect content of key 'toolsets/python-modules' in file: providers/common/ai/provider.yaml
       Left set:Found list of toolsets modules in provider package: airflow.providers.common.ai
       Right set:Currently configured list of toolsets modules in providers/common/ai/provider.yaml
          Items in the left set but not the right:
             'airflow.providers.common.ai.toolsets.aws'
      Additional check: If there are deprecated modules in the list,please add them to DEPRECATED_MODULES in scripts/in_container/run_provider_yaml_files_check.py
    Error: Module `airflow.providers.common.ai.toolsets.aws` contains toolsets class(es) (`AWSToolset`) but is not registered in any resource section of providers/common/ai/provider.yaml.
    How to fix it: Add `airflow.providers.common.ai.toolsets.aws` to the python-modules list in the toolsets section of providers/common/ai/provider.yaml, or to the transfers section if it is a transfer operator.
```

Likely caused due to https://github.com/apache/airflow/pull/70122.

Seen in https://github.com/apache/airflow/actions/runs/29822835809/job/88611957851

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
