### PR TITLE
Attach dbt Cloud job metadata to Airflow OpenLineage events

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -351,20 +351,29 @@ class DbtCloudRunJobOperator(BaseOperator):
         """Returns DBT Cloud hook."""
         return DbtCloudHook(self.dbt_cloud_conn_id, **self.hook_params)
 
+    def get_openlineage_facets_on_start(self, task_instance) -> OperatorLineage:
+        """Expose dbt Cloud job metadata on the Airflow task START event when available."""
+        from airflow.providers.dbt.cloud.utils.openlineage import _build_dbt_cloud_job_lineage
+
+        return _build_dbt_cloud_job_lineage(self)
+
     def get_openlineage_facets_on_complete(self, task_instance) -> OperatorLineage:
         """
         Implement _on_complete because job_run needs to be triggered first in execute method.
 
         This should send additional events only if operator `wait_for_termination` is set to True.
         """
-        from airflow.providers.openlineage.extractors import OperatorLineage
+        from airflow.providers.dbt.cloud.utils.openlineage import (
+            _build_dbt_cloud_job_lineage,
+            generate_openlineage_events_from_dbt_cloud_run,
+        )
 
         if not isinstance(self.run_id, int):
             self.log.info("Skipping OpenLineage event extraction: `self.run_id` is not set.")
-            return OperatorLineage()
+            return _build_dbt_cloud_job_lineage(self)
         if not self.wait_for_termination:
             self.log.info("Skipping OpenLineage event extraction: `self.wait_for_termination` is False.")
-            return OperatorLineage()
+            return _build_dbt_cloud_job_lineage(self)
         return generate_openlineage_events_from_dbt_cloud_run(operator=self, task_instance=task_instance)
 
 

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/sensors/dbt.py
@@ -126,6 +126,12 @@ class DbtCloudJobRunSensor(BaseSensorOperator):
         self.log.info(event["message"])
         return int(event["run_id"])
 
+    def get_openlineage_facets_on_start(self, task_instance) -> OperatorLineage:
+        """Expose dbt Cloud job metadata on the Airflow task START event when available."""
+        from airflow.providers.dbt.cloud.utils.openlineage import _build_dbt_cloud_job_lineage
+
+        return _build_dbt_cloud_job_lineage(self)
+
     def get_openlineage_facets_on_complete(self, task_instance) -> OperatorLineage:
         """Implement _on_complete because job_run needs to be triggered first in execute method."""
         return generate_openlineage_events_from_dbt_cloud_run(operator=self, task_instance=task_instance)

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/utils/openlineage.py
@@ -97,6 +97,56 @@ def _get_parent_run_metadata(task_instance):
     )
 
 
+def _build_dbt_cloud_job_lineage(
+    operator: DbtCloudRunJobOperator | DbtCloudJobRunSensor,
+) -> OperatorLineage:
+    """
+    Attach dbt Cloud job metadata to the Airflow task OpenLineage event.
+
+    Short-term approach until top-level dbt invocation events land upstream
+    (OpenLineage/OpenLineage#4720).
+    """
+    from openlineage.client.facet_v2 import tags_job
+
+    from airflow.providers.openlineage.extractors import OperatorLineage
+
+    tags: list[tags_job.TagsJobFacetFields] = []
+    job_id = getattr(operator, "job_id", None)
+    if isinstance(job_id, int):
+        tags.append(
+            tags_job.TagsJobFacetFields(
+                key="dbt_cloud_job_id",
+                value=str(job_id),
+                source="dbt-cloud",
+            )
+        )
+
+    run_id = getattr(operator, "run_id", None)
+    if isinstance(run_id, int):
+        tags.append(
+            tags_job.TagsJobFacetFields(
+                key="dbt_cloud_run_id",
+                value=str(run_id),
+                source="dbt-cloud",
+            )
+        )
+
+    account_id = getattr(operator, "account_id", None)
+    if isinstance(account_id, int):
+        tags.append(
+            tags_job.TagsJobFacetFields(
+                key="dbt_cloud_account_id",
+                value=str(account_id),
+                source="dbt-cloud",
+            )
+        )
+
+    if not tags:
+        return OperatorLineage()
+
+    return OperatorLineage(job_facets={"tags": tags_job.TagsJobFacet(tags=tags)})
+
+
 @require_openlineage_version(provider_min_version="2.5.0")
 def generate_openlineage_events_from_dbt_cloud_run(
     operator: DbtCloudRunJobOperator | DbtCloudJobRunSensor, task_instance: TaskInstance
@@ -212,4 +262,4 @@ def generate_openlineage_events_from_dbt_cloud_run(
         log.debug("Emitted all OpenLineage events for artifact no. %s.", counter)
 
     log.info("OpenLineage has successfully finished processing information about DBT job run.")
-    return OperatorLineage()
+    return _build_dbt_cloud_job_lineage(operator)

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py
@@ -28,6 +28,7 @@ from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureEx
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook
 from airflow.providers.dbt.cloud.operators.dbt import DbtCloudRunJobOperator
 from airflow.providers.dbt.cloud.utils.openlineage import (
+    _build_dbt_cloud_job_lineage,
     _get_parent_run_metadata,
     generate_openlineage_events_from_dbt_cloud_run,
 )
@@ -157,6 +158,31 @@ def test_get_parent_run_metadata():
     assert result.root_parent_job_name == "dag_id"
 
 
+class TestBuildDbtCloudJobLineage:
+    def test_includes_job_and_run_ids(self):
+        operator = MagicMock()
+        operator.job_id = 1500
+        operator.run_id = 5555
+        operator.account_id = 11111
+
+        lineage = _build_dbt_cloud_job_lineage(operator)
+        tag_keys = {tag.key: tag.value for tag in lineage.job_facets["tags"].tags}
+
+        assert tag_keys == {
+            "dbt_cloud_job_id": "1500",
+            "dbt_cloud_run_id": "5555",
+            "dbt_cloud_account_id": "11111",
+        }
+
+    def test_returns_empty_lineage_without_ids(self):
+        operator = MagicMock()
+        operator.job_id = None
+        operator.run_id = None
+        operator.account_id = None
+
+        assert _build_dbt_cloud_job_lineage(operator) == OperatorLineage()
+
+
 class TestGenerateOpenLineageEventsFromDbtCloudRun:
     @patch("importlib.metadata.version", return_value="3.0.0")
     @patch("airflow.providers.openlineage.plugins.listener.get_openlineage_listener")
@@ -203,6 +229,7 @@ class TestGenerateOpenLineageEventsFromDbtCloudRun:
         mock_get_job_run_artifact.side_effect = get_dbt_artifact
         mock_operator.task_id = TASK_ID
         mock_operator.run_id = 188471607
+        mock_operator.job_id = 160645
 
         mock_task_instance = MagicMock()
         mock_task_instance.task_id = TASK_ID
@@ -216,10 +243,17 @@ class TestGenerateOpenLineageEventsFromDbtCloudRun:
 
         mock_build_task_instance_run_id.return_value = TASK_UUID
         mock_build_dag_run_id.return_value = DAG_UUID
-        generate_openlineage_events_from_dbt_cloud_run(mock_operator, task_instance=mock_task_instance)
+        lineage = generate_openlineage_events_from_dbt_cloud_run(
+            mock_operator, task_instance=mock_task_instance
+        )
         assert mock_adapter.emit.call_count == 4
+        tag_keys = {tag.key: tag.value for tag in lineage.job_facets["tags"].tags}
+        assert tag_keys["dbt_cloud_job_id"] == "160645"
+        assert tag_keys["dbt_cloud_run_id"] == "188471607"
 
     def test_do_not_raise_error_if_runid_not_set_on_operator(self):
         operator = DbtCloudRunJobOperator(task_id="dbt-job-runid-taskid", job_id=1500)
         assert operator.run_id is None
-        assert operator.get_openlineage_facets_on_complete(MagicMock()) == OperatorLineage()
+        lineage = operator.get_openlineage_facets_on_complete(MagicMock())
+        tag_keys = {tag.key: tag.value for tag in lineage.job_facets["tags"].tags}
+        assert tag_keys == {"dbt_cloud_job_id": "1500"}


### PR DESCRIPTION
## Summary
- Add `_build_dbt_cloud_job_lineage` to expose `dbt_cloud_job_id`, `dbt_cloud_run_id`, and `dbt_cloud_account_id` as OpenLineage job tags on the Airflow task event
- Wire into `get_openlineage_facets_on_start` / `get_openlineage_facets_on_complete` for `DbtCloudRunJobOperator` and `DbtCloudJobRunSensor`
- Short-term approach per maintainer feedback on #68661 until [OpenLineage#4720](https://github.com/OpenLineage/OpenLineage/issues/4720) lands

Relates to #68661

## Test plan
- [ ] `pytest providers/dbt/cloud/tests/unit/dbt/cloud/utils/test_openlineage.py -k BuildDbtCloudJobLineage`
- [ ] CI provider-dbt-cloud checks pass