### PR TITLE
Go SDK: fix data race on Edge Worker's activeWorkloads map

### DIFF
--- a/go-sdk/edge/worker.go
+++ b/go-sdk/edge/worker.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/debug"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -58,7 +59,8 @@ type worker struct {
 	// Are we currently attempting to drain jobs?
 	drain bool
 
-	activeWorkloads map[uuid.UUID]bundlev1.ExecuteTaskWorkload
+	activeWorkloadsMu sync.Mutex
+	activeWorkloads   map[uuid.UUID]bundlev1.ExecuteTaskWorkload
 
 	// We need to send this on most requests, so we keep a copy of it around
 	sysInfo map[string]edgeapi.WorkerStateBody_Sysinfo_AdditionalProperties
@@ -230,7 +232,9 @@ func (w *worker) heartbeat(ctx context.Context) error {
 	slot.FromWorkerStateBodySysinfo1(edgeapi.WorkerStateBodySysinfo1(free))
 	w.sysInfo["free_concurrency"] = slot
 
+	w.activeWorkloadsMu.Lock()
 	jobsActive := len(w.activeWorkloads)
+	w.activeWorkloadsMu.Unlock()
 
 	resp, err := w.client.Worker().SetState(ctx, w.hostname, &edgeapi.WorkerStateBody{
 		State:      state,
@@ -324,7 +328,10 @@ func (w *worker) mainLoop(ctx context.Context) error {
 			return nil
 		}
 
-		if w.drain && len(w.activeWorkloads) == 0 {
+		w.activeWorkloadsMu.Lock()
+		activeCount := len(w.activeWorkloads)
+		w.activeWorkloadsMu.Unlock()
+		if w.drain && activeCount == 0 {
 			return nil
 		}
 	}
@@ -445,7 +452,9 @@ func (w *worker) runWorkload(
 ) error {
 	var err error
 	w.freeConcurrency.Add(-slots)
+	w.activeWorkloadsMu.Lock()
 	w.activeWorkloads[workload.TI.Id] = workload
+	w.activeWorkloadsMu.Unlock()
 
 	mapIndex := -1
 	if workload.TI.MapIndex != nil {
@@ -486,7 +495,9 @@ func (w *worker) runWorkload(
 		)
 
 		w.freeConcurrency.Add(slots)
+		w.activeWorkloadsMu.Lock()
 		delete(w.activeWorkloads, workload.TI.Id)
+		w.activeWorkloadsMu.Unlock()
 	}()
 
 	client, err := w.ClientForBundle(workload.BundleInfo.Name, workload.BundleInfo.Version)

--- a/go-sdk/edge/worker_test.go
+++ b/go-sdk/edge/worker_test.go
@@ -21,13 +21,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/apache/airflow/go-sdk/bundle/bundlev1"
+	"github.com/apache/airflow/go-sdk/pkg/bundles/shared"
 	"github.com/apache/airflow/go-sdk/pkg/edgeapi"
 )
 
@@ -104,4 +109,60 @@ func TestFetchJobDoesNotLogToken(t *testing.T) {
 	require.Contains(t, logOutput, "example_task")
 	require.NotContains(t, logOutput, secretToken)
 	require.NotContains(t, logOutput, "\"token\"")
+}
+
+func TestActiveWorkloadsMapConcurrentAccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{}"))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := edgeapi.NewClient(server.URL + "/")
+	require.NoError(t, err)
+
+	discovery := shared.NewDiscovery(t.TempDir(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	w := &worker{
+		Discovery:       discovery,
+		hostname:        "race-test-worker",
+		client:          client,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		maxConcurrency:  16,
+		activeWorkloads: map[uuid.UUID]bundlev1.ExecuteTaskWorkload{},
+	}
+	w.freeConcurrency.Store(16)
+
+	stopReaders := make(chan struct{})
+	var readers sync.WaitGroup
+	for range 4 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stopReaders:
+					return
+				default:
+					w.activeWorkloadsMu.Lock()
+					_ = len(w.activeWorkloads)
+					w.activeWorkloadsMu.Unlock()
+				}
+			}
+		}()
+	}
+
+	var writers sync.WaitGroup
+	for range 20 {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			workload := bundlev1.ExecuteTaskWorkload{}
+			workload.TI.Id = uuid.New()
+			_ = w.runWorkload(context.Background(), 1, workload)
+		}()
+	}
+	writers.Wait()
+	close(stopReaders)
+	readers.Wait()
 }


### PR DESCRIPTION
## Summary

`worker.activeWorkloads` (a plain `map[uuid.UUID]bundlev1.ExecuteTaskWorkload`)
is read and written from multiple goroutines with no synchronization:

- `mainLoop()` dispatches every fetched job via `go w.runWorkload(ctx, ...)`
  (a new goroutine per task), and `runWorkload` writes to the map on start
  and deletes from it on completion.
- `heartbeat()` and the drain check in `mainLoop()` read `len(w.activeWorkloads)`
  from a separate goroutine.

`maxConcurrency` defaults to 16, so running multiple tasks concurrently is
the normal operating mode of an Edge Worker, not an edge case. Any time two
tasks start/finish around the same moment a heartbeat or drain check reads
the map's length, this is a data race.

## Reproduction

Confirmed two ways before fixing:

1. `go test -race`: 4 distinct data races reported, all pointing at the
   documented read/write sites (map assignment, map delete, and the
   unsynchronized `len()` reads).
2. Without `-race`, running the same concurrent access pattern repeatedly
   reliably produces:

   ```
   fatal error: concurrent map writes

   goroutine 16 [running]:
   internal/runtime/maps.fatal(...)
   github.com/apache/airflow/go-sdk/edge.(*worker).runWorkload(...)
       /go-sdk/edge/worker.go:448
   ```

   This is a Go runtime `fatal error`, not a `panic` -- `recover()` cannot
   catch it, so it crashes the entire worker process (all in-flight tasks),
   not just the one task being started/finished at that moment.

## Changes

- Add `activeWorkloadsMu sync.Mutex` to `worker`, and guard all four
  access points (the write in `runWorkload`, the delete in its deferred
  cleanup, and the two `len()` reads in `heartbeat()` and `mainLoop()`'s
  drain check).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)
