### PR TITLE
[v3-3-test] Walk nested lists/tuples/sets in secrets masker key-name …

### DIFF
--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -369,8 +369,29 @@ class SecretsMasker(logging.Filter):
                     for dict_key, subval in item.items()
                 }
                 return to_return
-            # Avoid spending too much effort on pattern-based masking of
-            # deeply nested non-dict structures.
+            # Always walk lists/tuples/sets too, mirroring the unconditional dict
+            # walk above, so a sensitive key wrapped in an iterable is still
+            # caught at any nesting depth. Self-referential iterables hit Python's
+            # own recursion limit and are caught by the except clause below, which
+            # fails closed.
+            if isinstance(item, (tuple, set)):
+                # Turn set in to tuple!
+                return tuple(
+                    self._redact(
+                        subval, name=None, depth=(depth + 1), max_depth=max_depth, replacement=replacement
+                    )
+                    for subval in item
+                )
+            if isinstance(item, list):
+                return [
+                    self._redact(
+                        subval, name=None, depth=(depth + 1), max_depth=max_depth, replacement=replacement
+                    )
+                    for subval in item
+                ]
+            # The depth cutoff only bounds the work of pattern-based string
+            # masking below — key-name redaction (dicts and iterables above) is
+            # unbounded so sensitive keys fail closed at any depth.
             if depth > max_depth:
                 return item
             if isinstance(item, Enum):
@@ -393,21 +414,6 @@ class SecretsMasker(logging.Filter):
                     # the structure.
                     return self.replacer.sub(replacement, str(item))
                 return item
-            if isinstance(item, (tuple, set)):
-                # Turn set in to tuple!
-                return tuple(
-                    self._redact(
-                        subval, name=None, depth=(depth + 1), max_depth=max_depth, replacement=replacement
-                    )
-                    for subval in item
-                )
-            if isinstance(item, list):
-                return [
-                    self._redact(
-                        subval, name=None, depth=(depth + 1), max_depth=max_depth, replacement=replacement
-                    )
-                    for subval in item
-                ]
             return item
         # I think this should never happen, but it does not hurt to leave it just in case
         # Well. It happened (see https://github.com/apache/airflow/issues/19816#issuecomment-983311373)

--- a/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
+++ b/shared/secrets_masker/tests/secrets_masker/test_secrets_masker.py
@@ -718,6 +718,20 @@ class TestSecretsMasker:
                 {"a": {"b": {"c": {"d": {"e": {"api_key": "leaked"}}}}}},
                 {"a": {"b": {"c": {"d": {"e": {"api_key": "***"}}}}}},
             ),
+            # A sensitive key wrapped in a list beyond MAX_RECURSION_DEPTH is
+            # still redacted: the list is walked unconditionally, mirroring the
+            # unbounded dict walk above. Here the list sits at depth 6 (one past
+            # the cutoff), reached through the unbounded dict chain a..f.
+            (
+                {"a": {"b": {"c": {"d": {"e": {"f": [{"password": "leaked"}]}}}}}},
+                {"a": {"b": {"c": {"d": {"e": {"f": [{"password": "***"}]}}}}}},
+            ),
+            # Same for a tuple-wrapped sensitive key past MAX_RECURSION_DEPTH
+            # (a set cannot hold a dict, so only list/tuple are exercised here).
+            (
+                {"a": {"b": {"c": {"d": {"e": {"f": ({"token": "leaked"},)}}}}}},
+                {"a": {"b": {"c": {"d": {"e": {"f": ({"token": "***"},)}}}}}},
+            ),
         ],
     )
     def test_redact_sensitive_key_past_max_depth(self, val, expected):


### PR DESCRIPTION
…redaction (#68422)

The secrets masker walks dicts unconditionally for key-name-based redaction, so a sensitive key nested in dicts is masked at any depth. Lists, tuples, and sets were only walked below the recursion-depth cutoff, so a value carrying a sensitive key wrapped in an iterable beyond the cutoff was returned without key-name redaction.

Walk nested lists/tuples/sets unconditionally too, mirroring the dict handling, keeping the depth cutoff only for pattern-based string masking. Add regression tests for sensitive keys wrapped in lists and tuples past MAX_RECURSION_DEPTH.
(cherry picked from commit 4d39a855b1c6c3072e53b49465dc66f5a38e095a)


Generated-by: Claude Opus 4.8 (1M context) following the guidelines at
https: //github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
