### PR TITLE
UI: Make the Dag pause toggle distinguishable in dark mode

### DIFF
--- a/airflow-core/src/airflow/ui/src/theme.ts
+++ b/airflow-core/src/airflow/ui/src/theme.ts
@@ -382,6 +382,12 @@ const defaultAirflowTheme: ThemingConfig = {
     },
     switch: {
       slots: [],
+      base: {
+        control: {
+          shadow: "inset 0 0 0px 1px var(--shadow-color)",
+          shadowColor: { _dark: "gray.500", _light: "gray.400" },
+        },
+      },
       defaultVariants: { size: "sm" } as Record<string, string>,
     },
     // size="sm" gives px/py:2 on cell and columnHeader vs px/py:3 for "md".


### PR DESCRIPTION
In dark mode the Dag pause toggle is hard to make out: its off-state track uses
`bg.emphasized`, which in this palette lands within 0.05 oklch lightness of the page
background (0.08 in light mode), so only the white thumb reads and the pill has no
visible edge.

This gives the switch control a 1px inset ring so the shape is legible in both modes.

### Why an inset shadow and not a border

Two earlier attempts, #67406 and #69159, added a `border` to the control and were closed
after review found the thumb was no longer centred and the horizontal layout shifted.
That is unavoidable with a border: the thumb's size and its checked travel are both
derived from `--switch-height` / `--switch-width`, so any box-model space the control
takes shrinks the content box the thumb sits in while its translate distance stays the
same. `box-shadow: inset` costs no layout space.

The thumb also stays concentric with the track's end cap — both are centred on (8, 8),
with radii 6.4 and 8. Measured in a running UI:

| | control | thumb | thumb gap T / B / leading |
|---|---|---|---|
| `main` | 32×16 | 12.8×12.8 | 1.60 / 1.60 / 1.60 |
| this PR | 32×16 | 12.8×12.8 | 1.60 / 1.60 / 1.60 |

### Before / after

Dags list, `breeze start-airflow --dev-mode`.

**Dark mode** — before, then after:

![dark mode before](https://raw.githubusercontent.com/eddiesr93/airflow/pr-66759-screenshots/before.png)

![dark mode after](https://raw.githubusercontent.com/eddiesr93/airflow/pr-66759-screenshots/after.png)

**Light mode.** The same problem is milder but present: against a striped row the
off-state track sits about 0.04 oklch from the row behind it, so the pill loses its edge
there too. That is why the ring is applied in both modes rather than only in dark.

![light mode before](https://raw.githubusercontent.com/eddiesr93/airflow/pr-66759-screenshots/light-before.png)

![light mode after](https://raw.githubusercontent.com/eddiesr93/airflow/pr-66759-screenshots/light-after.png)

closes: #66759

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

Drafted-by: Claude Code (Opus 4.8); reviewed by @eddiesr93 before posting
