### PR TITLE
Allow separate object and pod labels for chart components

### DIFF
--- a/chart/newsfragments/53190.feature.rst
+++ b/chart/newsfragments/53190.feature.rst
@@ -1,0 +1,1 @@
+Allow Dag processor pod labels to be configured separately with ``dagProcessor.podLabels``.

--- a/chart/newsfragments/53190.feature.rst
+++ b/chart/newsfragments/53190.feature.rst
@@ -1,1 +1,1 @@
-Allow Dag processor pod labels to be configured separately with ``dagProcessor.podLabels``.
+Allow pod labels to be configured separately from object labels with ``podLabels``, for ``apiServer``, ``scheduler``, ``workers.celery``, ``triggerer``, ``dagProcessor``, ``flower``, ``statsd``, ``pgbouncer``, ``redis`` and ``otelCollector``. Leaving ``podLabels`` unset keeps the existing behaviour.

--- a/chart/templates/api-server/api-server-deployment.yaml
+++ b/chart/templates/api-server/api-server-deployment.yaml
@@ -30,6 +30,12 @@
 {{- $containerSecurityContext := include "containerSecurityContext" (list .Values.apiServer .Values) }}
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list .Values.apiServer.waitForMigrations .Values) }}
 {{- $containerLifecycleHooks := or .Values.apiServer.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.apiServer.labels }}
+{{- if ne .Values.apiServer.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.apiServer.labels) .Values.labels }}
+  {{- $podLabels = .Values.apiServer.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,7 +46,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.apiServer.annotations }}
@@ -80,8 +86,8 @@ spec:
         tier: airflow
         component: api-server
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.apiServer.labels }}
-          {{- mustMerge .Values.apiServer.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -31,6 +31,12 @@
 {{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list .Values.dagProcessor.logGroomerSidecar .Values) }}
 {{- $containerSecurityContextWaitForMigrations := include "containerSecurityContext" (list .Values.dagProcessor.waitForMigrations .Values) }}
 {{- $containerLifecycleHooks := or .Values.dagProcessor.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.dagProcessor.labels }}
+{{- if ne .Values.dagProcessor.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.dagProcessor.labels) .Values.labels }}
+  {{- $podLabels = .Values.dagProcessor.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,7 +47,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.dagProcessor.annotations }}
@@ -66,8 +72,8 @@ spec:
         tier: airflow
         component: dag-processor
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.dagProcessor.labels }}
-          {{- mustMerge .Values.dagProcessor.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -29,6 +29,12 @@
 {{- $securityContext := include "airflowPodSecurityContext" (list .Values.flower .Values) }}
 {{- $containerSecurityContext := include "containerSecurityContext" (list .Values.flower .Values) }}
 {{- $containerLifecycleHooks := or .Values.flower.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.flower.labels }}
+{{- if ne .Values.flower.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.flower.labels) .Values.labels }}
+  {{- $podLabels = .Values.flower.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,7 +45,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.flower.annotations }}
@@ -61,8 +67,8 @@ spec:
         tier: airflow
         component: flower
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.flower.labels }}
-          {{- mustMerge .Values.flower.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}

--- a/chart/templates/otel-collector/otel-collector-deployment.yaml
+++ b/chart/templates/otel-collector/otel-collector-deployment.yaml
@@ -26,6 +26,10 @@
 {{- $tolerations := or .Values.otelCollector.tolerations .Values.tolerations }}
 {{- $topologySpreadConstraints := or .Values.otelCollector.topologySpreadConstraints .Values.topologySpreadConstraints }}
 {{- $revisionHistoryLimit := include "airflow.revisionHistoryLimit" (list .Values.otelCollector.revisionHistoryLimit .Values.revisionHistoryLimit) }}
+{{- $podLabels := .Values.otelCollector.labels }}
+{{- if ne .Values.otelCollector.podLabels nil }}
+  {{- $podLabels = .Values.otelCollector.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,8 +62,8 @@ spec:
         tier: airflow
         component: otel-collector
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.otelCollector.labels }}
-          {{- mustMerge .Values.otelCollector.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/otel-collector-config: {{ include (print $.Template.BasePath "/configmaps/otel-collector-configmap.yaml") . | sha256sum }}

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -31,6 +31,12 @@
 {{- $containerSecurityContextMetricsExporter := include "externalContainerSecurityContext" .Values.pgbouncer.metricsExporterSidecar }}
 {{- $containerLifecycleHooks := .Values.pgbouncer.containerLifecycleHooks }}
 {{- $containerLifecycleHooksMetricsExporter := .Values.pgbouncer.metricsExporterSidecar.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.pgbouncer.labels }}
+{{- if ne .Values.pgbouncer.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.pgbouncer.labels) .Values.labels }}
+  {{- $podLabels = .Values.pgbouncer.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,7 +47,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.pgbouncer.annotations }}
@@ -67,8 +73,8 @@ spec:
         tier: airflow
         component: pgbouncer
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.pgbouncer.labels }}
-          {{- mustMerge .Values.pgbouncer.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -29,6 +29,12 @@
 {{- $containerSecurityContext := include "externalContainerSecurityContext" .Values.redis }}
 {{- $containerLifecycleHooks := .Values.redis.containerLifecycleHooks }}
 {{- $persistence := .Values.redis.persistence.enabled }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.redis.labels }}
+{{- if ne .Values.redis.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.redis.labels) .Values.labels }}
+  {{- $podLabels = .Values.redis.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -39,7 +45,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.redis.annotations }}
@@ -61,8 +67,8 @@ spec:
         tier: airflow
         component: redis
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.redis.labels }}
-          {{- mustMerge .Values.redis.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       {{- if or .Values.redis.safeToEvict .Values.redis.podAnnotations }}
       annotations:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -38,6 +38,12 @@
 {{- $containerSecurityContextLogGroomerSidecar := include "containerSecurityContext" (list .Values.scheduler.logGroomerSidecar .Values) }}
 {{- $containerLifecycleHooks := or .Values.scheduler.containerLifecycleHooks .Values.containerLifecycleHooks }}
 {{- $containerLifecycleHooksLogGroomerSidecar := or .Values.scheduler.logGroomerSidecar.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.scheduler.labels }}
+{{- if ne .Values.scheduler.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.scheduler.labels) .Values.labels }}
+  {{- $podLabels = .Values.scheduler.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: {{ if $stateful }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
@@ -49,7 +55,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     executor: {{ .Values.executor | replace "," "-" | replace ":" "-" | trunc 63 | trimSuffix "-" | trimSuffix ":" | trimSuffix "_" | trimSuffix "." | quote }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.scheduler.annotations }}
@@ -83,8 +89,8 @@ spec:
         tier: airflow
         component: scheduler
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.scheduler.labels }}
-          {{- mustMerge .Values.scheduler.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -29,6 +29,12 @@
 {{- $securityContext := include "localPodSecurityContext" .Values.statsd }}
 {{- $containerSecurityContext := include "externalContainerSecurityContext" .Values.statsd }}
 {{- $containerLifecycleHooks := .Values.statsd.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.statsd.labels }}
+{{- if ne .Values.statsd.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.statsd.labels) .Values.labels }}
+  {{- $podLabels = .Values.statsd.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,7 +45,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with .Values.statsd.annotations }}
@@ -61,8 +67,8 @@ spec:
         tier: airflow
         component: statsd
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.statsd.labels }}
-          {{- mustMerge .Values.statsd.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       {{- if or .Values.statsd.extraMappings .Values.statsd.podAnnotations }}
       annotations:

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -34,6 +34,12 @@
 {{- $containerSecurityContextLogGroomer := include "containerSecurityContext" (list .Values.triggerer.logGroomerSidecar .Values) }}
 {{- $containerLifecycleHooks := or .Values.triggerer.containerLifecycleHooks .Values.containerLifecycleHooks }}
 {{- $containerLifecycleHooksLogGroomerSidecar := or .Values.triggerer.logGroomerSidecar.containerLifecycleHooks .Values.containerLifecycleHooks }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.triggerer.labels }}
+{{- if ne .Values.triggerer.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.triggerer.labels) .Values.labels }}
+  {{- $podLabels = .Values.triggerer.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
@@ -44,7 +50,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.triggerer.annotations }}
@@ -80,8 +86,8 @@ spec:
         tier: airflow
         component: triggerer
         release: {{ .Release.Name }}
-        {{- if or .Values.labels .Values.triggerer.labels }}
-          {{- mustMerge .Values.triggerer.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -53,6 +53,12 @@
 {{- $safeToEvict := dict "cluster-autoscaler.kubernetes.io/safe-to-evict" (.Values.workers.celery.safeToEvict | toString) }}
 {{- $podAnnotations := mergeOverwrite (deepCopy .Values.airflowPodAnnotations) $safeToEvict .Values.workers.celery.podAnnotations }}
 {{- $schedulerName := or .Values.workers.celery.schedulerName .Values.schedulerName }}
+{{- $deploymentLabels := .Values.labels }}
+{{- $podLabels := .Values.workers.celery.labels }}
+{{- if ne .Values.workers.celery.podLabels nil }}
+  {{- $deploymentLabels = mustMerge (deepCopy .Values.workers.celery.labels) .Values.labels }}
+  {{- $podLabels = .Values.workers.celery.podLabels }}
+{{- end }}
 apiVersion: apps/v1
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 metadata:
@@ -63,7 +69,7 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-    {{- with .Values.labels }}
+    {{- with $deploymentLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.workers.celery.annotations }}
@@ -108,8 +114,8 @@ spec:
         {{- if ne .Values.workers.celery.name "default" }}
         worker-set: {{ .Values.workers.celery.name }}
         {{- end }}
-        {{- if or .Values.labels .Values.workers.celery.labels }}
-          {{- mustMerge .Values.workers.celery.labels .Values.labels | toYaml | nindent 8 }}
+        {{- if or .Values.labels $podLabels }}
+          {{- mustMerge (deepCopy $podLabels) .Values.labels | toYaml | nindent 8 }}
         {{- end }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}

--- a/chart/tests/helm_tests/airflow_aux/test_pod_labels.py
+++ b/chart/tests/helm_tests/airflow_aux/test_pod_labels.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from chart_utils.helm_template_generator import render_chart
+
+# Components whose workload object carries only the global labels until
+# ``podLabels`` is set. ``dagProcessor`` has its own dedicated module in
+# ``helm_tests/dagprocessor/test_labels_deployment.py``.
+COMPONENTS = [
+    ("apiServer", "templates/api-server/api-server-deployment.yaml", {}),
+    ("scheduler", "templates/scheduler/scheduler-deployment.yaml", {}),
+    (
+        "workers.celery",
+        "templates/workers/worker-deployment.yaml",
+        {"executor": "CeleryExecutor"},
+    ),
+    ("triggerer", "templates/triggerer/triggerer-deployment.yaml", {}),
+    (
+        "flower",
+        "templates/flower/flower-deployment.yaml",
+        {"executor": "CeleryExecutor", "flower": {"enabled": True}},
+    ),
+    ("statsd", "templates/statsd/statsd-deployment.yaml", {}),
+    (
+        "pgbouncer",
+        "templates/pgbouncer/pgbouncer-deployment.yaml",
+        {"pgbouncer": {"enabled": True}},
+    ),
+    ("redis", "templates/redis/redis-statefulset.yaml", {"executor": "CeleryExecutor"}),
+]
+
+GLOBAL_LABELS = {"test_global_label": "test_global_label_value", "common_label": "global_value"}
+COMPONENT_LABELS = {
+    "test_component_label": "test_component_label_value",
+    "common_label": "component_value",
+}
+POD_LABELS = {"test_pod_label": "test_pod_label_value", "common_label": "pod_value"}
+OTEL_ENABLED = {"otelCollector": {"tracesEnabled": True}}
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _nest(values_key: str, payload: dict) -> dict:
+    """Expand a dotted values key, so ``workers.celery`` reaches the right table."""
+    for part in reversed(values_key.split(".")):
+        payload = {part: payload}
+    return payload
+
+
+def _render(values_key: str, show_only: str, extra_values: dict, component: dict) -> tuple[dict, dict]:
+    values = _deep_merge({"labels": GLOBAL_LABELS}, extra_values)
+    values = _deep_merge(values, _nest(values_key, component))
+    docs = render_chart(values=values, show_only=[show_only])
+    return docs[0]["metadata"]["labels"], docs[0]["spec"]["template"]["metadata"]["labels"]
+
+
+@pytest.mark.parametrize(("values_key", "show_only", "extra_values"), COMPONENTS)
+class TestPodLabels:
+    """Tests separating workload object labels from pod labels."""
+
+    def test_should_keep_component_labels_on_pods_when_pod_labels_are_unset(
+        self, values_key, show_only, extra_values
+    ):
+        object_labels, pod_labels = _render(values_key, show_only, extra_values, {"labels": COMPONENT_LABELS})
+
+        # Backward compatible: component labels reach pods, not the workload object.
+        assert object_labels["test_global_label"] == "test_global_label_value"
+        assert "test_component_label" not in object_labels
+        assert object_labels["common_label"] == "global_value"
+        assert pod_labels["test_global_label"] == "test_global_label_value"
+        assert pod_labels["test_component_label"] == "test_component_label_value"
+        assert pod_labels["common_label"] == "component_value"
+
+    def test_should_separate_object_and_pod_labels(self, values_key, show_only, extra_values):
+        object_labels, pod_labels = _render(
+            values_key,
+            show_only,
+            extra_values,
+            {"labels": COMPONENT_LABELS, "podLabels": POD_LABELS},
+        )
+
+        assert object_labels["test_global_label"] == "test_global_label_value"
+        assert object_labels["test_component_label"] == "test_component_label_value"
+        assert "test_pod_label" not in object_labels
+        assert object_labels["common_label"] == "component_value"
+        assert pod_labels["test_global_label"] == "test_global_label_value"
+        assert "test_component_label" not in pod_labels
+        assert pod_labels["test_pod_label"] == "test_pod_label_value"
+        assert pod_labels["common_label"] == "pod_value"
+
+    def test_should_treat_empty_pod_labels_as_separate(self, values_key, show_only, extra_values):
+        object_labels, pod_labels = _render(
+            values_key, show_only, extra_values, {"labels": COMPONENT_LABELS, "podLabels": {}}
+        )
+
+        assert object_labels["test_component_label"] == "test_component_label_value"
+        assert "test_component_label" not in pod_labels
+        assert pod_labels["test_global_label"] == "test_global_label_value"
+        assert pod_labels["common_label"] == "global_value"
+
+
+class TestOtelCollectorPodLabels:
+    """OTel Collector already merges component labels onto its Deployment."""
+
+    SHOW_ONLY = "templates/otel-collector/otel-collector-deployment.yaml"
+
+    def test_should_keep_component_labels_on_both_when_pod_labels_are_unset(self):
+        object_labels, pod_labels = _render(
+            "otelCollector", self.SHOW_ONLY, OTEL_ENABLED, {"labels": COMPONENT_LABELS}
+        )
+
+        assert object_labels["test_component_label"] == "test_component_label_value"
+        assert pod_labels["test_component_label"] == "test_component_label_value"
+        assert object_labels["common_label"] == "component_value"
+        assert pod_labels["common_label"] == "component_value"
+
+    def test_should_separate_object_and_pod_labels(self):
+        object_labels, pod_labels = _render(
+            "otelCollector",
+            self.SHOW_ONLY,
+            OTEL_ENABLED,
+            {"labels": COMPONENT_LABELS, "podLabels": POD_LABELS},
+        )
+
+        assert object_labels["test_component_label"] == "test_component_label_value"
+        assert "test_pod_label" not in object_labels
+        assert "test_component_label" not in pod_labels
+        assert pod_labels["test_pod_label"] == "test_pod_label_value"
+        assert pod_labels["common_label"] == "pod_value"
+
+    def test_should_treat_empty_pod_labels_as_separate(self):
+        object_labels, pod_labels = _render(
+            "otelCollector",
+            self.SHOW_ONLY,
+            OTEL_ENABLED,
+            {"labels": COMPONENT_LABELS, "podLabels": {}},
+        )
+
+        assert object_labels["test_component_label"] == "test_component_label_value"
+        assert "test_component_label" not in pod_labels
+        assert pod_labels["test_global_label"] == "test_global_label_value"

--- a/chart/tests/helm_tests/dagprocessor/test_labels_deployment.py
+++ b/chart/tests/helm_tests/dagprocessor/test_labels_deployment.py
@@ -57,6 +57,82 @@ class TestDagProcessorDeployment:
             == "test_component_label_value"
         )
 
+    def test_should_preserve_component_labels_on_pods_when_pod_labels_are_unset(self):
+        docs = render_chart(
+            values={
+                "labels": {
+                    "test_global_label": "test_global_label_value",
+                    "common_label": "global_value",
+                },
+                "dagProcessor": {
+                    "labels": {
+                        "test_component_label": "test_component_label_value",
+                        "common_label": "component_value",
+                    },
+                },
+            },
+            show_only=[self.TEMPLATE_FILE],
+        )
+
+        deployment_labels = jmespath.search("metadata.labels", docs[0])
+        pod_labels = jmespath.search("spec.template.metadata.labels", docs[0])
+        assert deployment_labels["test_global_label"] == "test_global_label_value"
+        assert "test_component_label" not in deployment_labels
+        assert deployment_labels["common_label"] == "global_value"
+        assert pod_labels["test_global_label"] == "test_global_label_value"
+        assert pod_labels["test_component_label"] == "test_component_label_value"
+        assert pod_labels["common_label"] == "component_value"
+
+    def test_should_separate_deployment_and_pod_labels(self):
+        docs = render_chart(
+            values={
+                "labels": {
+                    "test_global_label": "test_global_label_value",
+                    "common_label": "global_value",
+                },
+                "dagProcessor": {
+                    "labels": {
+                        "test_component_label": "test_component_label_value",
+                        "common_label": "component_value",
+                    },
+                    "podLabels": {
+                        "test_pod_label": "test_pod_label_value",
+                        "common_label": "pod_value",
+                    },
+                },
+            },
+            show_only=[self.TEMPLATE_FILE],
+        )
+
+        deployment_labels = jmespath.search("metadata.labels", docs[0])
+        pod_labels = jmespath.search("spec.template.metadata.labels", docs[0])
+        assert deployment_labels["test_global_label"] == "test_global_label_value"
+        assert deployment_labels["test_component_label"] == "test_component_label_value"
+        assert "test_pod_label" not in deployment_labels
+        assert deployment_labels["common_label"] == "component_value"
+        assert pod_labels["test_global_label"] == "test_global_label_value"
+        assert "test_component_label" not in pod_labels
+        assert pod_labels["test_pod_label"] == "test_pod_label_value"
+        assert pod_labels["common_label"] == "pod_value"
+
+    def test_should_treat_empty_pod_labels_as_separate(self):
+        docs = render_chart(
+            values={
+                "labels": {"test_global_label": "test_global_label_value"},
+                "dagProcessor": {
+                    "labels": {"test_component_label": "test_component_label_value"},
+                    "podLabels": {},
+                },
+            },
+            show_only=[self.TEMPLATE_FILE],
+        )
+
+        deployment_labels = jmespath.search("metadata.labels", docs[0])
+        pod_labels = jmespath.search("spec.template.metadata.labels", docs[0])
+        assert deployment_labels["test_component_label"] == "test_component_label_value"
+        assert "test_component_label" not in pod_labels
+        assert pod_labels["test_global_label"] == "test_global_label_value"
+
     def test_should_merge_global_and_component_specific_labels(self):
         """Test adding both .Values.labels and .Values.dagProcessor.labels."""
         docs = render_chart(

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4883,9 +4883,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels specific to dag processor objects and pods",
+                    "description": "Labels for dag processor objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for dag processor pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2397,9 +2397,20 @@
                             }
                         },
                         "labels": {
-                            "description": "Labels to add to the Airflow Celery workers objects.",
+                            "description": "Labels for Airflow Celery workers objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                             "type": "object",
                             "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        },
+                        "podLabels": {
+                            "description": "Labels for Airflow Celery workers pods. Set to an empty object to use only global labels on pods.",
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "default": null,
                             "additionalProperties": {
                                 "type": "string"
                             }
@@ -3598,9 +3609,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the scheduler objects and pods.",
+                    "description": "Labels for scheduler objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for scheduler pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -4154,9 +4176,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the triggerer objects and pods.",
+                    "description": "Labels for triggerer objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for triggerer pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -6381,9 +6414,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the API server objects and pods.",
+                    "description": "Labels for Airflow API server objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for Airflow API server pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -7026,9 +7070,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the flower objects and pods.",
+                    "description": "Labels for flower objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for flower pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -7440,9 +7495,20 @@
                     ]
                 },
                 "labels": {
-                    "description": "Labels specific to statsd objects and pods",
+                    "description": "Labels for statsd objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for statsd pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -7648,9 +7714,20 @@
                     "default": null
                 },
                 "labels": {
-                    "description": "Labels specific to OTel Collector objects and pods.",
+                    "description": "Labels to add to the OTel Collector objects, and to its pods when podLabels is not set.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for OTel Collector pods. Defaults to labels when unset. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -7755,9 +7832,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the PgBouncer objects and pods.",
+                    "description": "Labels for PgBouncer objects. If podLabels is not set, these labels are applied to pods but not the Deployment for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for PgBouncer pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }
@@ -8685,9 +8773,20 @@
                     }
                 },
                 "labels": {
-                    "description": "Labels to add to the redis objects and pods.",
+                    "description": "Labels for redis objects. If podLabels is not set, these labels are applied to pods but not the StatefulSet for backward compatibility.",
                     "type": "object",
                     "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "podLabels": {
+                    "description": "Labels for redis pods. Set to an empty object to use only global labels on pods.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "default": null,
                     "additionalProperties": {
                         "type": "string"
                     }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2316,8 +2316,12 @@ dagProcessor:
     securityContexts:
       container: {}
 
-  # Labels specific to dag processor objects
+  # Labels for dag processor objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for dag processor pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   # Environment variables to add to dag processor container
   env: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -931,8 +931,12 @@ workers:
     # Pod annotations for the Airflow Celery workers (templated)
     podAnnotations: {}
 
-    # Labels specific to Airflow Celery workers objects
+    # Labels for Airflow Celery workers objects. If podLabels is not set, these labels are
+    # applied to pods but not the Deployment for backward compatibility.
     labels: {}
+
+    # Labels for Airflow Celery workers pods. Set to {} to use only global labels on pods.
+    podLabels: ~
 
     # Log groomer configuration for Airflow Celery workers
     logGroomerSidecar:
@@ -1332,8 +1336,12 @@ scheduler:
   # Pod annotations for scheduler pods (templated)
   podAnnotations: {}
 
-  # Labels specific to scheduler objects and pods
+  # Labels for scheduler objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for scheduler pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   logGroomerSidecar:
     # Whether to deploy the Airflow scheduler log groomer sidecar.
@@ -1661,8 +1669,12 @@ apiServer:
   # Max number of old ReplicaSets to retain
   revisionHistoryLimit: ~
 
-  # Labels specific to Airflow API server objects and pods
+  # Labels for Airflow API server objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for Airflow API server pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   # Command to use when running the Airflow API server (templated).
   command: ~
@@ -2017,8 +2029,12 @@ triggerer:
   # Pod annotations for triggerer pods (templated)
   podAnnotations: {}
 
-  # Labels specific to triggerer objects and pods
+  # Labels for triggerer objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for triggerer pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   logGroomerSidecar:
     # Whether to deploy the Airflow triggerer log groomer sidecar.
@@ -2528,8 +2544,12 @@ flower:
   # Pod annotations for flower pods (templated)
   podAnnotations: {}
 
-  # Labels specific to flower objects and pods
+  # Labels for flower objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for flower pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   env: []
 
@@ -2641,8 +2661,12 @@ statsd:
   # Pod annotations for StatsD pods (templated)
   podAnnotations: {}
 
-  # Labels specific to StatsD objects and pods
+  # Labels for StatsD objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for StatsD pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   # Environment variables to add to StatsD container
   env: []
@@ -2725,6 +2749,10 @@ otelCollector:
   topologySpreadConstraints: []
   priorityClassName: ~
   labels: {}
+
+  # Labels for OTel Collector pods. Defaults to labels when unset. Set to {} to
+  # use only global labels on pods.
+  podLabels: ~
   podAnnotations: {}
 
   securityContexts:
@@ -2965,8 +2993,12 @@ pgbouncer:
     #       mountPath: "{{ .Values.my_custom_path }}"
     #       readOnly: true
 
-  # Labels specific to PgBouncer objects and pods
+  # Labels for PgBouncer objects. If podLabels is not set, these labels are
+  # applied to pods but not the Deployment for backward compatibility.
   labels: {}
+
+  # Labels for PgBouncer pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   # Environment variables to add to PgBouncer container
   env: []
@@ -3071,8 +3103,12 @@ redis:
   # Container level lifecycle hooks
   containerLifecycleHooks: {}
 
-  # Labels specific to redis objects and pods
+  # Labels for redis objects. If podLabels is not set, these labels are
+  # applied to pods but not the StatefulSet for backward compatibility.
   labels: {}
+
+  # Labels for redis pods. Set to {} to use only global labels on pods.
+  podLabels: ~
 
   # Pod annotations for Redis pods (templated)
   podAnnotations: {}


### PR DESCRIPTION
Add `podLabels` so workload object labels and pod labels can be configured separately, for `apiServer`, `scheduler`, `workers.celery`, `triggerer`, `dagProcessor`, `flower`, `statsd`, `pgbouncer`, `redis` and `otelCollector`.

When `podLabels` is unset, existing behavior remains unchanged: `<component>.labels` stays on the pods, while the Deployment or StatefulSet receives only global labels. Setting `podLabels` (including `{}`) opts into separation: `<component>.labels` applies to the workload object and `<component>.podLabels` applies to pods. Component values retain precedence over global labels.

`otelCollector` is the one exception: its Deployment already merged component labels onto the object, so only its pod side gains the new knob and its object labels are unchanged.

closes: #53190

Behaviour matrix, verified by rendering every affected workload:

| `podLabels` | workload object labels | pod labels |
| --- | --- | --- |
| unset (default `~`) | global only — unchanged | component + global |
| set | component + global | podLabels + global |
| `{}` | component + global | global only |

Tests:

- `pytest helm_tests/airflow_aux/test_pod_labels.py helm_tests/dagprocessor` — 38 passed. The new module parametrizes all three states over every component; `dagProcessor` keeps its existing dedicated module.
- `pytest helm_tests/{dagprocessor,statsd,otel_collector,redis} helm_tests/airflow_core/test_{api_server,scheduler,triggerer,worker}.py helm_tests/other/test_{flower,pgbouncer}.py` — 779 passed, 1 failed.
- `pytest helm_tests/airflow_aux/test_{chart_quality,basic_helm_chart,annotations}.py` — 114 passed, 9 failed.
- Backward compatibility: `helm template` with every component's `labels` set and `podLabels` unset is **byte-identical to main across 3638 lines** (random secrets pinned so the render is deterministic).

The 10 local failures are pre-existing and unrelated: they assert on Helm's JSON-schema error wording (`value must be one of 'X'`) while local Helm 3.14.4 emits `must be one of the following: "X"`, and they cover `dags.persistence.accessMode`, `*.pullPolicy` and `apiServer.securityContext`. Re-running the same modules on a clean checkout reproduces exactly the same counts, so this change adds no new failures.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5) for the initial `dagProcessor` commit, Claude Opus 5 for this revision

Generated-by: Codex (GPT-5), Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
