### PR TITLE
Preserve pinned version_data when a Dag version is still in use

### DIFF
--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -595,6 +595,21 @@ class SerializedDagModel(Base):
         }
 
     @classmethod
+    def _has_task_instances(cls, dag_id: str, dag_version_id: UUID, *, session: Session) -> bool:
+        """Check whether any task instance references the given DagVersion."""
+        return bool(
+            session.scalar(
+                select(
+                    exists().where(
+                        # Using dag_id filter to speed up query via the composite index.
+                        TaskInstance.dag_id == dag_id,
+                        TaskInstance.dag_version_id == dag_version_id,
+                    )
+                )
+            )
+        )
+
+    @classmethod
     @provide_session
     def write_dag(
         cls,
@@ -688,38 +703,44 @@ class SerializedDagModel(Base):
 
         new_dag_hash = cls.hash(dag.data)
 
+        preserve_pinned_version_data = False
         if serialized_dag_hash == new_dag_hash and dag_version and dag_version.bundle_name == bundle_name:
-            # Serialized content is unchanged, so we don't create a new DagVersion.
-            # But if the bundle advanced, refresh the latest version's pointer in place — tasks resolve
+            # Serialized content is unchanged, so we normally don't create a new DagVersion.
+            # If the bundle advanced, refresh the latest version's pointer in place — tasks resolve
             # their code from ``ti.dag_version.bundle_version`` at run time, so a stale
             # pointer makes runs execute an outdated commit.
             bundle_metadata_changed = (
                 dag_version.bundle_version != bundle_version or dag_version.version_data != version_data
             )
-            if bundle_metadata_changed:
-                dag_version.bundle_version = bundle_version
-                dag_version.version_data = version_data
-                session.merge(dag_version)
-                DagCode.update_source_code(dag_id=dag.dag_id, fileloc=dag.fileloc, session=session)
-            if name_updated or bundle_metadata_changed:
-                # A write occurred — a deadline alert name update and/or a bundle
-                # metadata refresh — so report True so callers know the DB changed.
-                return True
-            log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
-            return False
+            # The in-place refresh is safe only for bundles whose ``bundle_version`` alone can recover the
+            # code (e.g. Git: the commit SHA resolves against the immutable object store). When
+            # ``version_data`` is involved (e.g. For bundles like the S3 bundle a json manifest of S3 object
+            # versions), this row holds the only copy of the data which is needed for runs pinned to the old
+            # bundle_version to reconstruct their code. Overwriting it would break their reproducibility. In
+            # that case fall through and create a new DagVersion instead: the old row keeps serving pinned
+            # runs, the new row becomes the latest for new runs.
+            preserve_pinned_version_data = (
+                bundle_metadata_changed
+                and (dag_version.version_data is not None or version_data is not None)
+                and cls._has_task_instances(dag.dag_id, dag_version.id, session=session)
+            )
+            if not preserve_pinned_version_data:
+                if bundle_metadata_changed:
+                    dag_version.bundle_version = bundle_version
+                    dag_version.version_data = version_data
+                    session.merge(dag_version)
+                    DagCode.update_source_code(dag_id=dag.dag_id, fileloc=dag.fileloc, session=session)
+                if name_updated or bundle_metadata_changed:
+                    # A write occurred — a deadline alert name update and/or a bundle
+                    # metadata refresh — so report True so callers know the DB changed.
+                    return True
+                log.debug("Serialized DAG (%s) is unchanged. Skipping writing to DB", dag.dag_id)
+                return False
 
         has_task_instances: bool = False
         if dag_version:
-            has_task_instances = bool(
-                session.scalar(
-                    select(
-                        exists().where(
-                            # Using dag_id filter to speed up query via the composite index.
-                            TaskInstance.dag_id == dag.dag_id,
-                            TaskInstance.dag_version_id == dag_version.id,
-                        )
-                    )
-                )
+            has_task_instances = preserve_pinned_version_data or cls._has_task_instances(
+                dag.dag_id, dag_version.id, session=session
             )
 
         if dag_version and not has_task_instances:

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -633,6 +633,9 @@ class TestSerializedDagModel:
         content is unchanged, ``write_dag`` must refresh the latest DagVersion's
         ``bundle_version`` in place (so tasks resolve the current commit) without
         creating a new DagVersion (which would inflate versions on every commit).
+
+        This only applies to bundles without ``version_data`` (e.g. Git), where
+        ``bundle_version`` alone is enough to recover the code.
         """
         with dag_maker("test_dag_bundle_version_refresh", bundle_name="bundleA") as dag:
             EmptyOperator(task_id="task1")
@@ -643,21 +646,18 @@ class TestSerializedDagModel:
             LazyDeserializedDAG.from_dag(dag),
             bundle_name="bundleA",
             bundle_version="commit_A",
-            version_data={"manifest": "A"},
             session=session,
         )
         assert did_write is True
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
         latest = DagVersion.get_latest_version(dag.dag_id, session=session)
         assert latest.bundle_version == "commit_A"
-        assert latest.version_data == {"manifest": "A"}
 
         # Same content, same bundle_name, but the bundle moved to a new commit.
         did_write = SDM.write_dag(
             LazyDeserializedDAG.from_dag(dag),
             bundle_name="bundleA",
             bundle_version="commit_B",
-            version_data={"manifest": "B"},
             session=session,
         )
 
@@ -666,6 +666,101 @@ class TestSerializedDagModel:
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
         latest = DagVersion.get_latest_version(dag.dag_id, session=session)
         assert latest.bundle_version == "commit_B"
+
+    @pytest.mark.parametrize(
+        ("new_bundle_version", "new_version_data"),
+        [
+            pytest.param("hash_B", {"manifest": "B"}, id="manifest-changed"),
+            pytest.param(None, None, id="version-data-removed"),
+        ],
+    )
+    def test_new_dag_version_created_when_version_data_changes_and_version_in_use(
+        self, dag_maker, session, new_bundle_version, new_version_data
+    ):
+        """When ``version_data`` is in play (e.g. an S3 bundle manifest) and the current
+        DagVersion already has task instances, a bundle change with unchanged serialized
+        content must create a NEW DagVersion instead of overwriting the row in place.
+
+        The old row's ``version_data`` is the only way runs pinned to the old
+        ``bundle_version`` can reconstruct their code — overwriting it would break their
+        reproducibility.
+        """
+        with dag_maker("test_dag_version_data_preserved", bundle_name="bundleA") as dag:
+            EmptyOperator(task_id="task1")
+
+        SDM.write_dag(
+            LazyDeserializedDAG.from_dag(dag),
+            bundle_name="bundleA",
+            bundle_version="hash_A",
+            version_data={"manifest": "A"},
+            session=session,
+        )
+        # Task instances now reference the (hash_A, manifest A) version.
+        dag_maker.create_dagrun(run_id="test_run")
+        pinned = DagVersion.get_latest_version(dag.dag_id, session=session)
+
+        did_write = SDM.write_dag(
+            LazyDeserializedDAG.from_dag(dag),
+            bundle_name="bundleA",
+            bundle_version=new_bundle_version,
+            version_data=new_version_data,
+            session=session,
+        )
+        session.flush()
+
+        assert did_write is True
+        assert (
+            session.scalar(
+                select(func.count()).select_from(DagVersion).where(DagVersion.dag_id == dag.dag_id)
+            )
+            == 2
+        )
+        # The pinned version's manifest survives untouched.
+        session.refresh(pinned)
+        assert pinned.bundle_version == "hash_A"
+        assert pinned.version_data == {"manifest": "A"}
+        # The new version is the latest, carries the new metadata, and is fully usable
+        # (has its own serialized dag) so new runs can be created against it.
+        latest = DagVersion.get_latest_version(dag.dag_id, session=session)
+        assert latest.id != pinned.id
+        assert latest.version_number == pinned.version_number + 1
+        assert latest.bundle_version == new_bundle_version
+        assert latest.version_data == new_version_data
+        assert latest.serialized_dag is not None
+
+    def test_version_data_updated_in_place_when_version_not_in_use(self, dag_maker, session):
+        """Without task instances referencing the version, nothing is pinned to it, so the
+        bundle metadata (including ``version_data``) is refreshed in place without
+        creating a new DagVersion.
+        """
+        with dag_maker("test_dag_version_data_no_ti", bundle_name="bundleA") as dag:
+            EmptyOperator(task_id="task1")
+
+        SDM.write_dag(
+            LazyDeserializedDAG.from_dag(dag),
+            bundle_name="bundleA",
+            bundle_version="hash_A",
+            version_data={"manifest": "A"},
+            session=session,
+        )
+
+        did_write = SDM.write_dag(
+            LazyDeserializedDAG.from_dag(dag),
+            bundle_name="bundleA",
+            bundle_version="hash_B",
+            version_data={"manifest": "B"},
+            session=session,
+        )
+
+        assert did_write is True
+        assert (
+            session.scalar(
+                select(func.count()).select_from(DagVersion).where(DagVersion.dag_id == dag.dag_id)
+            )
+            == 1
+        )
+        latest = DagVersion.get_latest_version(dag.dag_id, session=session)
+        assert latest.bundle_version == "hash_B"
         assert latest.version_data == {"manifest": "B"}
 
     def test_write_dag_unchanged_with_same_bundle_version_skips_write(self, dag_maker, session):


### PR DESCRIPTION
### NOTE: The description is long, but it's worth reading to get the context of a deep in the weeds issue

  ## Problem
  
  When a Dag file's *behavior* changes but its *structure* doesn't (the very common case — e.g.
  editing a constant inside a `@task` function body, which is not serialized), `write_dag`
  does not create a new `DagVersion`. Instead it refreshes the latest row's bundle pointer
  **in place**:
  
      dag_version.bundle_version = bundle_version   # overwrite
      dag_version.version_data   = version_data     # overwrite
  
  For Git bundles this is harmless: a pinned run resolves its code from
  `dag_run.bundle_version` (a commit SHA, recorded on the run itself and never overwritten),
  and git's immutable object store can always check that SHA out.
  
  For bundles that rely on `version_data` (the json blob which represents the
    state of the code for that bundle version; for S3 this is a dictionary
    manifest containing the S3 version for each file in the bucket) the
  overwrite is destructive. The manifest stored in `DagVersion.version_data` is the **only**
  way to reconstruct the pinned code.
  
  Taking the upcoming S3 Bundle as an example: when the bucket content changes mid-run
 (for a change that doesn't modify the dag structure itself), the parse overwrites the row and the pinned run's
  manifest is gone:
  
      BEFORE (run pinned to v1)          AFTER re-parse of v2 (hash unchanged)
      ─────────────────────────          ─────────────────────────────────────
      DagRun.bundle_version: v1          DagRun.bundle_version: v1   (still!)
      DagVersion row:                    DagVersion row (same row):
        bundle_version: v1                 bundle_version: v2   ◄─ overwritten
        version_data:   manifest_v1        version_data:   manifest_v2 ◄─ v1 manifest DESTROYED
  
  A second, pre-existing symptom of the same overwrite (which in this case affects all versioned
  Bundles, including Git): triggering a run
  against a specific `bundle_version` resolves the serialized code via a `DagVersion` lookup keyed on
  `bundle_version`, so when the DagVersion is overwritten the `bundle_version`s are lost, `DagVersionNotFound`
  are raised. This will be possible to do now with these changes.
  
  ## Fix
  
   Now, when version_data is involved (e.g. a Bundle is being used which
    needs to store metadata in the DagVersion row AND versioning is
    enabled for that Bundle AND the DagVersion has active tasks) a new
    DagVersion is created instead of overwriting (mirroring the existing
    path we take when the dag has a structural change). The old row keeps
    serving pinned runs; the new row becomes the latest for new runs.
    Bundles without version_data (e.g. Git) keep the cheap in-place
    pointer refresh.

  
      BEFORE (run pinned to v1)          AFTER re-parse of v2 (hash unchanged)
      ─────────────────────────          ─────────────────────────────────────
      DagRun.bundle_version: v1          DagRun.bundle_version: v1
      DagVersion vN:                     DagVersion vN (untouched):
        bundle_version: v1                 bundle_version: v1
        version_data:   manifest_v1        version_data:   manifest_v1  ◄─ pinned runs keep it
                                         DagVersion vN+1 (new, latest):
                                           bundle_version: v2           ◄─ new runs inherit it
                                           version_data:   manifest_v2
  
  **Once a `(bundle_version, version_data)` pairing has been observed by task instances, it is
  effectively immutable.**
  
  Safety measures:
  
  - **Bundles without `version_data` (Git, Local): no change.** Either their `bundle_version` alone
    recovers the code or they don't support versioning at all. So the in-place DagVersion refresh
    behaviour remains.
  - **No task instances on the current version: no change.** Nothing is pinned to it, so the
    metadata (including `version_data`) is still refreshed in place.
  - New rows are created only when bucket content actually changes. Bucket updates are a deliberate
    action by the user and will not be as frequent as repository or local FS changes.
  - Rows are garbage collected by the existing `db_cleanup` handling for `dag_version`. 


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
