### PR TITLE
Fix Connection port field range validation (#68382)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/connections.py
@@ -191,7 +191,7 @@ class ConnectionBody(StrictBaseModel):
     host: str | None = Field(default=None)
     login: str | None = Field(default=None)
     schema_: str | None = Field(None, alias="schema")
-    port: int | None = Field(default=None)
+    port: int | None = Field(default=None, ge=1, le=65535)
     password: str | None = Field(default=None)
     extra: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -28,7 +28,7 @@ from typing import Any
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 from sqlalchemy import ForeignKey, Integer, String, Text, select
-from sqlalchemy.orm import Mapped, mapped_column, reconstructor
+from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
@@ -218,6 +218,22 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
         except json.JSONDecodeError:
             raise ValueError(f"Encountered non-JSON in `extra` field for connection {conn_id!r}.")
         return None
+
+    @validates("port")
+    def validate_port(self, key, value):
+        if value is None:
+            return None
+        if isinstance(value, str) and not value.strip():
+            return None
+        try:
+            port_val = int(value)
+        except (ValueError, TypeError):
+            raise ValueError(f"Expected integer value for `port`, but got {value!r} instead.")
+        if not (1 <= port_val <= 65535):
+            raise ValueError(
+                f"The `port` field must be a value between 1 and 65535, but got {port_val!r} instead."
+            )
+        return port_val
 
     @reconstructor
     def on_db_load(self):

--- a/airflow-core/src/airflow/models/connection.py
+++ b/airflow-core/src/airflow/models/connection.py
@@ -30,6 +30,7 @@ from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 from sqlalchemy import ForeignKey, Integer, String, Text, select
 from sqlalchemy.orm import Mapped, mapped_column, reconstructor, validates
 
+from airflow._shared.configuration import parse_and_validate_port
 from airflow._shared.module_loading import import_string
 from airflow._shared.secrets_backend.base import call_secrets_backend_method
 from airflow._shared.secrets_masker import mask_secret
@@ -221,19 +222,7 @@ class Connection(Base, FernetFieldsMixin, LoggingMixin):
 
     @validates("port")
     def validate_port(self, key, value):
-        if value is None:
-            return None
-        if isinstance(value, str) and not value.strip():
-            return None
-        try:
-            port_val = int(value)
-        except (ValueError, TypeError):
-            raise ValueError(f"Expected integer value for `port`, but got {value!r} instead.")
-        if not (1 <= port_val <= 65535):
-            raise ValueError(
-                f"The `port` field must be a value between 1 and 65535, but got {port_val!r} instead."
-            )
-        return port_val
+        return parse_and_validate_port(value)
 
     @reconstructor
     def on_db_load(self):

--- a/airflow-core/tests/unit/models/test_connection.py
+++ b/airflow-core/tests/unit/models/test_connection.py
@@ -540,3 +540,26 @@ class TestConnection:
             "test_conn2": None,
         }
         clear_db_connections()
+
+    def test_port_validation(self):
+        """Test that Connection model validates the port field correctly."""
+        # Valid ports
+        assert Connection(conn_id="test_port_1", port=80).port == 80
+        assert Connection(conn_id="test_port_2", port="8080").port == 8080
+        assert Connection(conn_id="test_port_3", port=None).port is None
+        assert Connection(conn_id="test_port_4", port="").port is None
+        assert Connection(conn_id="test_port_5", port="  ").port is None
+
+        # Invalid ports - out of range
+        with pytest.raises(ValueError, match="The `port` field must be a value between 1 and 65535"):
+            Connection(conn_id="test_port_fail_1", port=70000)
+
+        with pytest.raises(ValueError, match="The `port` field must be a value between 1 and 65535"):
+            Connection(conn_id="test_port_fail_2", port=0)
+
+        with pytest.raises(ValueError, match="The `port` field must be a value between 1 and 65535"):
+            Connection(conn_id="test_port_fail_3", port=-80)
+
+        # Invalid ports - type errors
+        with pytest.raises(ValueError, match="Expected integer value for `port`"):
+            Connection(conn_id="test_port_fail_4", port="invalid_port")

--- a/shared/configuration/src/airflow_shared/configuration/connection.py
+++ b/shared/configuration/src/airflow_shared/configuration/connection.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,16 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Shared configuration parser for Airflow distributions."""
-
 from __future__ import annotations
 
-__all__ = [
-    "AirflowConfigException",
-    "AirflowConfigParser",
-    "parse_and_validate_port",
-]
 
-from .connection import parse_and_validate_port
-from .exceptions import AirflowConfigException
-from .parser import AirflowConfigParser
+def parse_and_validate_port(port: int | str | None) -> int | None:
+    """Parse and validate connection port range."""
+    if port is None:
+        return None
+    if isinstance(port, str) and not port.strip():
+        return None
+    try:
+        port_val = int(port)
+    except (ValueError, TypeError):
+        raise ValueError(f"Expected integer value for `port`, but got {port!r} instead.")
+    if not (1 <= port_val <= 65535):
+        raise ValueError(
+            f"The `port` field must be a value between 1 and 65535, but got {port_val!r} instead."
+        )
+    return port_val

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -25,6 +25,7 @@ from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit
 
 import attrs
 
+from airflow.sdk._shared.configuration import parse_and_validate_port
 from airflow.sdk.exceptions import AirflowException, AirflowNotFoundException, AirflowRuntimeError, ErrorType
 from airflow.sdk.providers_manager_runtime import ProvidersManagerTaskRuntime
 
@@ -154,19 +155,7 @@ class Connection:
             self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
 
     def __attrs_post_init__(self) -> None:
-        if self.port is not None:
-            if isinstance(self.port, str) and not self.port.strip():
-                self.port = None
-                return
-            try:
-                port_val = int(self.port)
-            except (ValueError, TypeError):
-                raise ValueError(f"Expected integer value for `port`, but got {self.port!r} instead.")
-            if not (1 <= port_val <= 65535):
-                raise ValueError(
-                    f"The `port` field must be a value between 1 and 65535, but got {port_val!r} instead."
-                )
-            self.port = port_val
+        self.port = parse_and_validate_port(self.port)
 
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""

--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -153,6 +153,21 @@ class Connection:
         else:
             self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
 
+    def __attrs_post_init__(self) -> None:
+        if self.port is not None:
+            if isinstance(self.port, str) and not self.port.strip():
+                self.port = None
+                return
+            try:
+                port_val = int(self.port)
+            except (ValueError, TypeError):
+                raise ValueError(f"Expected integer value for `port`, but got {self.port!r} instead.")
+            if not (1 <= port_val <= 65535):
+                raise ValueError(
+                    f"The `port` field must be a value between 1 and 65535, but got {port_val!r} instead."
+                )
+            self.port = port_val
+
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""
         from urllib.parse import parse_qsl

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -421,3 +421,41 @@ class TestConnectionFromUri:
             original_extra = json.loads(conn_from_original.extra)
             roundtrip_extra = json.loads(conn_from_roundtrip.extra)
             assert original_extra == roundtrip_extra
+
+
+class TestConnectionPortValidation:
+    """Test connection port validation in the task-sdk."""
+
+    def test_port_validation(self):
+        """Test that Connection model validates the port field correctly."""
+        # Valid ports
+        assert Connection(conn_id="test_port_1", port=80).port == 80
+        assert Connection(conn_id="test_port_2", port="8080").port == 8080
+        assert Connection(conn_id="test_port_3", port=None).port is None
+
+        # Invalid ports - out of range
+        with pytest.raises(ValueError, match="The `port` field must be a value between 1 and 65535"):
+            Connection(conn_id="test_port_fail_1", port=70000)
+
+        with pytest.raises(ValueError, match="The `port` field must be a value between 1 and 65535"):
+            Connection(conn_id="test_port_fail_2", port=0)
+
+        with pytest.raises(ValueError, match="The `port` field must be a value between 1 and 65535"):
+            Connection(conn_id="test_port_fail_3", port=-80)
+
+        # Invalid ports - type errors
+        with pytest.raises(ValueError, match="Expected integer value for `port`"):
+            Connection(conn_id="test_port_fail_4", port="invalid_port")
+
+    def test_from_uri_port_validation(self):
+        """Test that Connection.from_uri validates the port field correctly."""
+        # Valid port from URI
+        assert Connection.from_uri("postgres://host:5432/db", conn_id="test").port == 5432
+
+        # Invalid port from URI - out of range
+        with pytest.raises(ValueError, match="Port out of range 0-65535"):
+            Connection.from_uri("postgres://host:70000/db", conn_id="test")
+
+        # Invalid port from URI - type/invalid format
+        with pytest.raises(ValueError, match="Port could not be cast to integer value"):
+            Connection.from_uri("postgres://host:abc/db", conn_id="test")


### PR DESCRIPTION
### Related Issue
Closes: #68382

### Description
Connection models in Apache Airflow accept integer values for the `port` field but do not enforce that the value is a valid network port in the range `[1, 65535]`.
This PR adds validation logic to connection ports at three layers:
1. **SQLAlchemy Connection model** validation via `@validates("port")` to ensure port numbers assigned are integers between 1 and 65535.
2. **Task SDK Connection model** validation in `__attrs_post_init__` to enforce range limits and format validation during standard instantiation and URI parsing.
3. **Pydantic API datamodel** validation using `Field(ge=1, le=65535)` on the REST API gateway connections schema.

Additionally, this PR refactors port validation logic into a shared validator in `airflow_shared.configuration.connection` and includes unit tests for both SQLAlchemy and Task SDK model implementations.

### PR Checklist
- [x] Related Issue: #68382
- [x] Unit tests added and passing
- [x] Code rebased on latest `upstream/main`