### PR TITLE
reject backslash-after-scheme urls in is_safe_url

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -1007,12 +1007,13 @@ def is_safe_url(target_url: str, request: Request | None = None) -> bool:
 
     # According to WHATWG for http/https /// is interpreted as // whereas urllib doesnt
     # this leads to an inconsistency where python returns a target url with /// as a valid url
-    # The same thing also happens with \ where under WHATWG \ are translated to /
-    target_url = unquote(target_url).strip()
-    if target_url.startswith(("//", "/\\", "\\/", "\\\\")):
+    # The same thing also happens with \ where under WHATWG \ are translated to /, including
+    # after a scheme, so "https:\\host" is an authority for a browser but a path for urllib.
+    target_url = unquote(target_url).strip().replace("\\", "/")
+    if target_url.startswith("//"):
         return False
     for base_url, parsed_base in parsed_bases:
-        parsed_target = urlparse(urljoin(base_url, unquote(target_url)))  # Resolves relative URLs
+        parsed_target = urlparse(urljoin(base_url, target_url))  # Resolves relative URLs
 
         base_path = parsed_base.path or "/"
         target_path = parsed_target.path or "/"

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -632,6 +632,14 @@ class TestFastApiSecurity:
             ("\\\\some_netlock.com/prefix", False),
             # encoded url
             ("%5C%5C%5C%5Csome_netlock.com/prefix", False),
+            # \ after the scheme, which a browser reads as the start of the authority
+            ("https:\\\\some_netlock.com", False),
+            ("https:/\\some_netlock.com", False),
+            ("https:\\/some_netlock.com", False),
+            ("https%3A%5C%5Csome_netlock.com", False),
+            # a single leading \ still resolves to a same-origin path
+            ("\\some_page", True),
+            ("/some_page", True),
         ],
     )
     def test_is_safe_url_without_prefix(self, url, expected_is_safe):


### PR DESCRIPTION
`is_safe_url` in `airflow-core/src/airflow/api_fastapi/core_api/security.py` rejects a leading `//`, `/\`, `\/` and `\\`, but not a backslash that follows the scheme, so `https:\\evil.com` is parsed by urllib as a relative path, `urljoin` re-attaches the base netloc, and the netloc comparison passes. Browsers follow WHATWG, where `\` is `/` for special schemes, so the same string navigates to `https://evil.com` — `GET /auth/token/login?next=https:\\evil.com` returns it verbatim as the redirect location and `GET /auth/login?next=` forwards it to the auth manager login page, both without authentication. Normalising backslashes to forward slashes before the prefix check and the parse makes the helper agree with the parser that actually resolves the value; the second `unquote` goes away with it so the guard and the resolution look at the same string.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)