### PR TITLE
Fix SSHRemoteJobOperator cleanup validating against wrong base dir when remote_base_dir is customized

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
@@ -452,9 +452,9 @@ class SSHRemoteJobOperator(BaseOperator):
         """
         self.log.info("Cleaning up remote job directory: %s", job_dir)
         if remote_os == "posix":
-            cleanup_cmd = build_posix_cleanup_command(job_dir)
+            cleanup_cmd = build_posix_cleanup_command(job_dir, self.remote_base_dir)
         else:
-            cleanup_cmd = build_windows_cleanup_command(job_dir)
+            cleanup_cmd = build_windows_cleanup_command(job_dir, self.remote_base_dir)
 
         last_error: Exception | None = None
         for attempt in range(1, self.cleanup_retries + 1):

--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -30,23 +30,27 @@ POSIX_DEFAULT_BASE_DIR = "/tmp/airflow-ssh-jobs"
 WINDOWS_DEFAULT_BASE_DIR = "$env:TEMP\\airflow-ssh-jobs"
 
 
-def _validate_job_dir(job_dir: str, remote_os: Literal["posix", "windows"]) -> None:
+def _validate_job_dir(
+    job_dir: str, remote_os: Literal["posix", "windows"], base_dir: str | None = None
+) -> None:
     """
     Validate that job_dir is under the expected base directory.
 
     :param job_dir: The job directory path to validate
     :param remote_os: Operating system type
+    :param base_dir: The base directory job_dir is expected to be under. Defaults to the
+        standard POSIX/Windows default base directory when not provided, so callers that
+        never customize ``remote_base_dir`` keep the previous behavior.
     :raises ValueError: If job_dir doesn't start with the expected base path
     """
-    if remote_os == "posix":
-        expected_prefix = POSIX_DEFAULT_BASE_DIR + "/"
-    else:
-        expected_prefix = WINDOWS_DEFAULT_BASE_DIR + "\\"
+    if base_dir is None:
+        base_dir = POSIX_DEFAULT_BASE_DIR if remote_os == "posix" else WINDOWS_DEFAULT_BASE_DIR
+
+    sep = "/" if remote_os == "posix" else "\\"
+    expected_prefix = base_dir + sep
 
     if not job_dir.startswith(expected_prefix):
-        raise ValueError(
-            f"Invalid job directory '{job_dir}'. Expected path under '{expected_prefix[:-1]}' for safety."
-        )
+        raise ValueError(f"Invalid job directory '{job_dir}'. Expected path under '{base_dir}' for safety.")
 
 
 def _validate_env_var_name(name: str) -> None:
@@ -452,27 +456,33 @@ if (Test-Path $path) {{
     return f"powershell.exe -NoProfile -NonInteractive -EncodedCommand {encoded_script}"
 
 
-def build_posix_cleanup_command(job_dir: str) -> str:
+def build_posix_cleanup_command(job_dir: str, base_dir: str | None = None) -> str:
     """
     Build a POSIX command to clean up the job directory.
 
     :param job_dir: Path to the job directory
+    :param base_dir: The configured remote base directory job_dir is expected to be
+        under (e.g. ``SSHRemoteJobOperator.remote_base_dir``). Defaults to the standard
+        POSIX default when not provided.
     :return: Shell command to remove the directory
     :raises ValueError: If job_dir is not under the expected base directory
     """
-    _validate_job_dir(job_dir, "posix")
+    _validate_job_dir(job_dir, "posix", base_dir)
     return f"rm -rf '{job_dir}'"
 
 
-def build_windows_cleanup_command(job_dir: str) -> str:
+def build_windows_cleanup_command(job_dir: str, base_dir: str | None = None) -> str:
     """
     Build a PowerShell command to clean up the job directory.
 
     :param job_dir: Path to the job directory
+    :param base_dir: The configured remote base directory job_dir is expected to be
+        under (e.g. ``SSHRemoteJobOperator.remote_base_dir``). Defaults to the standard
+        Windows default when not provided.
     :return: PowerShell command to remove the directory
     :raises ValueError: If job_dir is not under the expected base directory
     """
-    _validate_job_dir(job_dir, "windows")
+    _validate_job_dir(job_dir, "windows", base_dir)
     escaped_path = job_dir.replace("'", "''")
     script = f"Remove-Item -Recurse -Force -Path '{escaped_path}' -ErrorAction SilentlyContinue"
     script_bytes = script.encode("utf-16-le")

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -413,3 +413,28 @@ class TestCleanupCommands:
         """Test Windows cleanup rejects paths outside expected base directory."""
         with pytest.raises(ValueError, match="Invalid job directory"):
             build_windows_cleanup_command("C:\\temp\\other_dir")
+
+    def test_posix_cleanup_accepts_custom_base_dir(self):
+        """A job dir under a custom remote_base_dir should not be rejected as invalid.
+
+        Regression test for a bug where cleanup always validated job_dir against the
+        hardcoded POSIX_DEFAULT_BASE_DIR, even when the operator was configured with a
+        custom remote_base_dir, causing cleanup to fail with a spurious ValueError.
+        """
+        cmd = build_posix_cleanup_command(
+            "/tmp-data/airflow-ssh-jobs/job_123", base_dir="/tmp-data/airflow-ssh-jobs"
+        )
+        assert "rm -rf" in cmd
+        assert "/tmp-data/airflow-ssh-jobs/job_123" in cmd
+
+    def test_posix_cleanup_still_rejects_path_outside_custom_base_dir(self):
+        """A custom base_dir should still reject job dirs outside of it."""
+        with pytest.raises(ValueError, match="Invalid job directory"):
+            build_posix_cleanup_command("/tmp/other_dir/job_123", base_dir="/tmp-data/airflow-ssh-jobs")
+
+    def test_windows_cleanup_accepts_custom_base_dir(self):
+        """Windows equivalent of test_posix_cleanup_accepts_custom_base_dir."""
+        cmd = build_windows_cleanup_command(
+            "C:\\custom\\airflow-ssh-jobs\\job_123", base_dir="C:\\custom\\airflow-ssh-jobs"
+        )
+        assert "powershell.exe" in cmd


### PR DESCRIPTION
Picking this one up because it looked like a well contained bug and a good way to learn how the ssh provider's remote job cleanup works.

## What I changed

`SSHRemoteJobOperator` lets you set a custom `remote_base_dir` for where job files get created on the remote host. The job actually runs fine under that custom directory, but when the operator tries to clean up afterward, `_validate_job_dir()` in `remote_job.py` was always checking the job dir against the hardcoded `POSIX_DEFAULT_BASE_DIR`/`WINDOWS_DEFAULT_BASE_DIR` constants instead of whatever `remote_base_dir` was actually configured. So cleanup would raise a `ValueError` ("Expected path under ...") for anyone not using the default directory, even though nothing was actually wrong.

I gave `_validate_job_dir()`, `build_posix_cleanup_command()`, and `build_windows_cleanup_command()` an optional `base_dir` parameter, and `_cleanup_remote_job()` now passes `self.remote_base_dir` through so validation checks against the directory the job actually used. When `base_dir` isn't passed (or is `None`) it still falls back to the old default, so this shouldn't change behavior for anyone not customizing `remote_base_dir`.

## Testing

- `pytest tests/unit/ssh/utils/test_remote_job.py tests/unit/ssh/operators/test_ssh_remote_job.py` — 49 passed (46 existing + 3 new)
- Added 3 tests covering: a custom base_dir being accepted, a path outside a custom base_dir still being rejected, and the Windows equivalent
- Confirmed the new tests actually catch the bug by checking them against the old code first (they fail with a clear `TypeError`/would fail with the old `ValueError` behavior)
- `ruff check` and `ruff format --check` clean on the changed files
- `mypy` clean on the two changed source files

Still fairly new to the codebase so let me know if I should tweak anything, especially if there's a reason the validation was written against the fixed default in the first place.

Fixes #69813

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=6cffa07 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @ylemiesa57** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
