### PR TITLE
Fix db migrate failure to Airflow 2.9.2 under PyMySQL driver

### DIFF
--- a/airflow-core/newsfragments/70235.bugfix.rst
+++ b/airflow-core/newsfragments/70235.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``airflow db migrate`` failing with ``pymysql.err.ProgrammingError`` when migrating to Airflow 2.9.2 using the PyMySQL driver

--- a/airflow-core/newsfragments/70235.bugfix.rst
+++ b/airflow-core/newsfragments/70235.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``airflow db migrate`` failing with ``pymysql.err.ProgrammingError`` when migrating to Airflow 2.9.2 using the PyMySQL driver

--- a/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
+++ b/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
@@ -44,35 +44,23 @@ def upgrade():
     conn = op.get_bind()
     if conn.dialect.name == "mysql":
         # TODO: Rewrite these queries to use alembic when lowest MYSQL version supports IF EXISTS
-        conn.execute(
-            sa.text("""
-        set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-            CONSTRAINT_SCHEMA = DATABASE() AND
-            TABLE_NAME        = 'connection' AND
-            CONSTRAINT_NAME   = 'unique_conn_id' AND
-            CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE connection
-            DROP INDEX unique_conn_id','select 1');
-
-        prepare stmt from @var;
-        execute stmt;
-        deallocate prepare stmt;
-        """)
-        )
-        # Dropping the below and recreating cause there's no IF NOT EXISTS in mysql
-        conn.execute(
-            sa.text("""
-                set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-                    CONSTRAINT_SCHEMA = DATABASE() AND
-                    TABLE_NAME        = 'connection' AND
-                    CONSTRAINT_NAME   = 'connection_conn_id_uq' AND
-                    CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE connection
-                    DROP INDEX connection_conn_id_uq','select 1');
-
-                prepare stmt from @var;
-                execute stmt;
-                deallocate prepare stmt;
+        # `prepare`/`execute`/`deallocate prepare` is not supported by PyMySQL, so look up the
+        # existing unique constraints first and only drop the ones that are actually present.
+        existing_indexes = {
+            row[0]
+            for row in conn.execute(
+                sa.text("""
+                    SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+                    WHERE CONSTRAINT_SCHEMA = DATABASE()
+                    AND TABLE_NAME = 'connection'
+                    AND CONSTRAINT_TYPE = 'UNIQUE'
                 """)
-        )
+            )
+        }
+        # Dropping the below and recreating cause there's no IF NOT EXISTS in mysql
+        for index_name in ("unique_conn_id", "connection_conn_id_uq"):
+            if index_name in existing_indexes:
+                conn.execute(sa.text(f"ALTER TABLE connection DROP INDEX {index_name}"))
     elif conn.dialect.name == "sqlite":
         # SQLite does not support DROP CONSTRAINT
         # We have to recreate the table without the constraint
@@ -121,63 +109,28 @@ def upgrade():
         batch_op.drop_constraint("task_reschedule_dr_fkey", type_="foreignkey")
 
     if conn.dialect.name == "mysql":
-        conn.execute(
-            sa.text("""
-                        set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-                            CONSTRAINT_SCHEMA = DATABASE() AND
-                            TABLE_NAME        = 'dag_run' AND
-                            CONSTRAINT_NAME   = 'dag_run_dag_id_execution_date_uq' AND
-                            CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE dag_run
-                            DROP INDEX dag_run_dag_id_execution_date_uq','select 1');
-
-                        prepare stmt from @var;
-                        execute stmt;
-                        deallocate prepare stmt;
-                        """)
-        )
-        conn.execute(
-            sa.text("""
-                        set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-                            CONSTRAINT_SCHEMA = DATABASE() AND
-                            TABLE_NAME        = 'dag_run' AND
-                            CONSTRAINT_NAME   = 'dag_run_dag_id_run_id_uq' AND
-                            CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE dag_run
-                            DROP INDEX dag_run_dag_id_run_id_uq','select 1');
-
-                        prepare stmt from @var;
-                        execute stmt;
-                        deallocate prepare stmt;
-                        """)
-        )
+        # `prepare`/`execute`/`deallocate prepare` is not supported by PyMySQL, so look up the
+        # existing unique constraints first and only drop the ones that are actually present.
+        existing_dag_run_indexes = {
+            row[0]
+            for row in conn.execute(
+                sa.text("""
+                    SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+                    WHERE CONSTRAINT_SCHEMA = DATABASE()
+                    AND TABLE_NAME = 'dag_run'
+                    AND CONSTRAINT_TYPE = 'UNIQUE'
+                """)
+            )
+        }
         # below we drop and recreate the constraints because there's no IF NOT EXISTS
-        conn.execute(
-            sa.text("""
-                                set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-                                    CONSTRAINT_SCHEMA = DATABASE() AND
-                                    TABLE_NAME        = 'dag_run' AND
-                                    CONSTRAINT_NAME   = 'dag_run_dag_id_execution_date_key' AND
-                                    CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE dag_run
-                                    DROP INDEX dag_run_dag_id_execution_date_key','select 1');
-
-                                prepare stmt from @var;
-                                execute stmt;
-                                deallocate prepare stmt;
-                                """)
-        )
-        conn.execute(
-            sa.text("""
-                            set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
-                                CONSTRAINT_SCHEMA = DATABASE() AND
-                                TABLE_NAME        = 'dag_run' AND
-                                CONSTRAINT_NAME   = 'dag_run_dag_id_run_id_key' AND
-                                CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE dag_run
-                                DROP INDEX dag_run_dag_id_run_id_key','select 1');
-
-                            prepare stmt from @var;
-                            execute stmt;
-                            deallocate prepare stmt;
-                            """)
-        )
+        for index_name in (
+            "dag_run_dag_id_execution_date_uq",
+            "dag_run_dag_id_run_id_uq",
+            "dag_run_dag_id_execution_date_key",
+            "dag_run_dag_id_run_id_key",
+        ):
+            if index_name in existing_dag_run_indexes:
+                conn.execute(sa.text(f"ALTER TABLE dag_run DROP INDEX {index_name}"))
         with op.batch_alter_table("callback_request", schema=None) as batch_op:
             batch_op.alter_column(
                 "processor_subdir",

--- a/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
+++ b/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
@@ -28,7 +28,7 @@ Create Date: 2024-04-15 14:19:49.913797
 from __future__ import annotations
 
 import sqlalchemy as sa
-from alembic import op
+from alembic import context, op
 from sqlalchemy import literal
 
 # revision identifiers, used by Alembic.
@@ -39,28 +39,57 @@ depends_on = None
 airflow_version = "2.9.2"
 
 
+def _mysql_drop_unique_constraint_if_exists(conn, table: str, index_name: str) -> None:
+    """
+    Drop a MySQL unique constraint only if it is actually present.
+
+    MySQL has no ``DROP INDEX IF EXISTS``, and PyMySQL does not support the
+    ``prepare``/``execute``/``deallocate prepare`` sequence in a single
+    ``cursor.execute()`` call, so the existence check and the drop are issued as two
+    separate single statements. In offline (``--sql``) mode there is no live connection
+    to query information_schema against, so the guarded dynamic SQL is emitted as literal
+    script text instead, to be run later through a real SQL client that supports
+    multi-statement scripts.
+    """
+    if context.is_offline_mode():
+        conn.execute(
+            sa.text(f"""
+                set @var=if((SELECT true FROM information_schema.TABLE_CONSTRAINTS WHERE
+                    CONSTRAINT_SCHEMA = DATABASE() AND
+                    TABLE_NAME        = '{table}' AND
+                    CONSTRAINT_NAME   = '{index_name}' AND
+                    CONSTRAINT_TYPE   = 'UNIQUE') = true,'ALTER TABLE {table}
+                    DROP INDEX {index_name}','select 1');
+
+                prepare stmt from @var;
+                execute stmt;
+                deallocate prepare stmt;
+                """)
+        )
+        return
+    existing_indexes = {
+        row[0]
+        for row in conn.execute(
+            sa.text(f"""
+                SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
+                WHERE CONSTRAINT_SCHEMA = DATABASE()
+                AND TABLE_NAME = '{table}'
+                AND CONSTRAINT_TYPE = 'UNIQUE'
+            """)
+        )
+    }
+    if index_name in existing_indexes:
+        conn.execute(sa.text(f"ALTER TABLE {table} DROP INDEX {index_name}"))
+
+
 def upgrade():
     """Apply Update missing constraints."""
     conn = op.get_bind()
     if conn.dialect.name == "mysql":
         # TODO: Rewrite these queries to use alembic when lowest MYSQL version supports IF EXISTS
-        # `prepare`/`execute`/`deallocate prepare` is not supported by PyMySQL, so look up the
-        # existing unique constraints first and only drop the ones that are actually present.
-        existing_indexes = {
-            row[0]
-            for row in conn.execute(
-                sa.text("""
-                    SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
-                    WHERE CONSTRAINT_SCHEMA = DATABASE()
-                    AND TABLE_NAME = 'connection'
-                    AND CONSTRAINT_TYPE = 'UNIQUE'
-                """)
-            )
-        }
         # Dropping the below and recreating cause there's no IF NOT EXISTS in mysql
         for index_name in ("unique_conn_id", "connection_conn_id_uq"):
-            if index_name in existing_indexes:
-                conn.execute(sa.text(f"ALTER TABLE connection DROP INDEX {index_name}"))
+            _mysql_drop_unique_constraint_if_exists(conn, "connection", index_name)
     elif conn.dialect.name == "sqlite":
         # SQLite does not support DROP CONSTRAINT
         # We have to recreate the table without the constraint
@@ -109,19 +138,6 @@ def upgrade():
         batch_op.drop_constraint("task_reschedule_dr_fkey", type_="foreignkey")
 
     if conn.dialect.name == "mysql":
-        # `prepare`/`execute`/`deallocate prepare` is not supported by PyMySQL, so look up the
-        # existing unique constraints first and only drop the ones that are actually present.
-        existing_dag_run_indexes = {
-            row[0]
-            for row in conn.execute(
-                sa.text("""
-                    SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
-                    WHERE CONSTRAINT_SCHEMA = DATABASE()
-                    AND TABLE_NAME = 'dag_run'
-                    AND CONSTRAINT_TYPE = 'UNIQUE'
-                """)
-            )
-        }
         # below we drop and recreate the constraints because there's no IF NOT EXISTS
         for index_name in (
             "dag_run_dag_id_execution_date_uq",
@@ -129,8 +145,7 @@ def upgrade():
             "dag_run_dag_id_execution_date_key",
             "dag_run_dag_id_run_id_key",
         ):
-            if index_name in existing_dag_run_indexes:
-                conn.execute(sa.text(f"ALTER TABLE dag_run DROP INDEX {index_name}"))
+            _mysql_drop_unique_constraint_if_exists(conn, "dag_run", index_name)
         with op.batch_alter_table("callback_request", schema=None) as batch_op:
             batch_op.alter_column(
                 "processor_subdir",

--- a/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
+++ b/airflow-core/src/airflow/migrations/versions/0017_2_9_2_fix_inconsistency_between_ORM_and_migration_files.py
@@ -43,8 +43,9 @@ def _mysql_drop_unique_constraint_if_exists(conn, table: str, index_name: str) -
     """
     Drop a MySQL unique constraint only if it is actually present.
 
-    MySQL has no ``DROP INDEX IF EXISTS``, and PyMySQL does not support the
-    ``prepare``/``execute``/``deallocate prepare`` sequence in a single
+    MySQL has no ``DROP INDEX IF EXISTS``, and PyMySQL does not enable
+    ``CLIENT.MULTI_STATEMENTS``, so it cannot run the
+    ``prepare``/``execute``/``deallocate prepare`` script in a single
     ``cursor.execute()`` call, so the existence check and the drop are issued as two
     separate single statements. In offline (``--sql``) mode there is no live connection
     to query information_schema against, so the guarded dynamic SQL is emitted as literal
@@ -70,12 +71,13 @@ def _mysql_drop_unique_constraint_if_exists(conn, table: str, index_name: str) -
     existing_indexes = {
         row[0]
         for row in conn.execute(
-            sa.text(f"""
+            sa.text("""
                 SELECT CONSTRAINT_NAME FROM information_schema.TABLE_CONSTRAINTS
                 WHERE CONSTRAINT_SCHEMA = DATABASE()
-                AND TABLE_NAME = '{table}'
+                AND TABLE_NAME = :table
                 AND CONSTRAINT_TYPE = 'UNIQUE'
-            """)
+            """),
+            {"table": table},
         )
     }
     if index_name in existing_indexes:


### PR DESCRIPTION
Migrating the metadata database to Airflow 2.9.2 (revision `686269002441`) raised `pymysql.err.ProgrammingError` on MySQL when using the PyMySQL driver, because the migration used MySQL's `PREPARE`/`EXECUTE`/`DEALLOCATE PREPARE` dynamic SQL to conditionally drop unique constraints on the `connection` and `dag_run` tables. This syntax is not supported by PyMySQL (see [PyMySQL#202](https://github.com/PyMySQL/PyMySQL/issues/202)), so any deployment using PyMySQL as its MySQL driver could not migrate past this revision.

Replaced the dynamic SQL with a plain lookup of existing constraints from `information_schema.TABLE_CONSTRAINTS`, followed by conditional `ALTER TABLE ... DROP INDEX` statements — this works with any MySQL driver.

Verified against a real MySQL backend forced to use `mysql+pymysql://`: downgrading to `bff083ad727d` and re-running `airflow db migrate` now completes without error, and the expected unique constraints (`connection_conn_id_uq`, `dag_run_dag_id_*_key`) are present afterward.

closes: #43690

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)