### PR TITLE
Fix Trigger Again showing empty config for the selected run

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
@@ -18,7 +18,7 @@
  */
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Wrapper } from "src/utils/Wrapper";
 
@@ -47,8 +47,10 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
+const useDagParamsMock = vi.hoisted(() => vi.fn());
+
 vi.mock("src/queries/useDagParams", () => ({
-  useDagParams: () => dagParams,
+  useDagParams: useDagParamsMock,
 }));
 
 vi.mock("src/queries/useTogglePause", () => ({
@@ -83,6 +85,46 @@ vi.mock("../JsonEditor", () => ({
 }));
 
 describe("TriggerDAGForm", () => {
+  beforeEach(() => {
+    useDagParamsMock.mockReturnValue(dagParams);
+  });
+
+  it("propagates the selected run's conf to the JSON editor when the Dag has no declared params", async () => {
+    useDagParamsMock.mockReturnValue({ paramsDict: {} });
+
+    render(
+      <TriggerDAGForm
+        dagDisplayName="No Params Dag"
+        dagId="example_no_params"
+        error={undefined}
+        hasSchedule={false}
+        isPartitioned={false}
+        isPaused={false}
+        isPending={false}
+        onSubmitTrigger={vi.fn()}
+        open
+        prefillConfig={{
+          conf: { message: "from selected run" },
+          logicalDate: undefined,
+          runId: "manual__test",
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByText("Advanced Options"));
+
+    await waitFor(() => {
+      const configJson = screen.getByLabelText("Configuration JSON");
+
+      if (!(configJson instanceof HTMLTextAreaElement)) {
+        throw new TypeError("Expected Configuration JSON to render as a textarea");
+      }
+
+      expect(configJson.value).toContain('"from selected run"');
+    });
+  });
+
   it("syncs Advanced Options JSON after Run Parameters edits in prefilled re-trigger mode", async () => {
     const { container } = render(
       <TriggerDAGForm

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -107,10 +107,14 @@ const TriggerDAGForm = ({
         note: "",
         partitionKey: undefined,
       });
-      // Also update the param store to keep it in sync.
-      // Wait until we have the initial params so section ordering stays consistent.
-      if (confString && Object.keys(initialParamsDict.paramsDict).length > 0) {
-        if (Object.keys(initialParamDict).length === 0) {
+      // Also update the param store to keep it in sync. Seed the initial params (for stable
+      // section ordering) only once they are available, but always push the conf so a run's
+      // configuration propagates even for Dags with no declared params or before params load.
+      if (confString) {
+        if (
+          Object.keys(initialParamsDict.paramsDict).length > 0 &&
+          Object.keys(initialParamDict).length === 0
+        ) {
           setInitialParamDict(initialParamsDict.paramsDict);
         }
         setConf(confString);


### PR DESCRIPTION
Re-triggering a Dag with the config of a selected run (the "Trigger DAG w/ config" / "Trigger Again with config" menu item) left the configuration empty — the JSON editor showed `{}` and the selected run's `conf` was not carried over.

The prefill only pushed the run's `conf` into the param store when the Dag's declared params were already present. For Dags with no declared params (or before the params query resolved), that branch was skipped, so the param store kept its default empty config and the sync effect reset the form back to `{}`, dropping the run's configuration. The conf is now always propagated to the param store on prefill; seeding the initial params (for stable section ordering) still waits until they are available.

Before / after (config carried over from the selected run):

## Before
https://github.com/user-attachments/assets/83555e55-c417-488f-b6ea-75560c13e6e0



## After
https://github.com/user-attachments/assets/ee7befab-6564-422a-83bf-6f4aacfe4644



---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)