### PR TITLE
airflowctl: Fix datetime.datetime CLI parameter parsing

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -209,6 +209,16 @@ def json_dict_type(val: str | dict[str, Any]) -> dict[str, Any]:
     return parsed
 
 
+def iso_datetime_type(val: str) -> datetime.datetime:
+    """Parse an ISO-8601 datetime string."""
+    try:
+        return datetime.datetime.fromisoformat(val)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            f"invalid datetime value: {val!r}"
+        ) from e
+
+
 def _load_help_texts_yaml() -> dict[str, dict[str, str]]:
     """Load the help texts yaml for the auto-generated commands."""
     help_texts_path = Path(__file__).parent / "help_texts.yaml"
@@ -546,7 +556,7 @@ class CommandFactory:
             "dict": json_dict_type,
             "tuple": tuple,
             "set": set,
-            "datetime.datetime": datetime.datetime,
+            "datetime.datetime": iso_datetime_type,
             "dict[str, typing.Any]": json_dict_type,
         }
         # Default to ``str`` to preserve previous behaviour for any unrecognised

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 from argparse import BooleanOptionalAction
 from pathlib import Path
 from textwrap import dedent
@@ -34,6 +35,7 @@ from airflowctl.ctl.cli_config import (
     GroupCommand,
     add_auth_token_to_all_commands,
     json_dict_type,
+    iso_datetime_type,
     merge_commands,
     safe_call_command,
 )
@@ -353,6 +355,25 @@ class TestCommandFactory:
         """Invalid JSON raises an ArgumentTypeError."""
         with pytest.raises(argparse.ArgumentTypeError, match="invalid JSON object"):
             json_dict_type("{not valid json}")
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("2026-07-01", datetime.datetime(2026, 7, 1, 0, 0)),
+            ("2026-07-01T14:30:00", datetime.datetime(2026, 7, 1, 14, 30, 0)),
+        ],
+    )
+    def test_iso_datetime_type_parses_valid_values(self, value, expected):
+        """Valid ISO datetime strings are parsed into datetime objects."""
+        assert iso_datetime_type(value) == expected
+
+    def test_iso_datetime_type_rejects_invalid_datetime(self):
+        """Invalid datetime strings raise an ArgumentTypeError."""
+        with pytest.raises(
+            argparse.ArgumentTypeError,
+            match="invalid datetime value",
+        ):
+            iso_datetime_type("not-a-datetime")
 
     @pytest.mark.parametrize(
         "value",


### PR DESCRIPTION
Fixes `datetime.datetime`-typed CLI parameter parsing in `airflowctl`.

Previously, `datetime.datetime` parameters were mapped directly to the `datetime.datetime` constructor, causing valid ISO-8601 datetime strings (for example, `2026-07-01` and `2026-07-01T14:30:00`) to be rejected by `argparse`.

This change:

* Adds `iso_datetime_type()` to parse ISO-8601 datetime strings using `datetime.datetime.fromisoformat()`.
* Updates `datetime.datetime`-typed CLI arguments to use the parser instead of the bare constructor.
* Adds unit tests covering valid datetime inputs and invalid values that should raise `argparse.ArgumentTypeError`.

closes: #70232

---

##### Was generative AI tooling used to co-author this PR?

* [x] Yes (ChatGPT)

Generated-by: ChatGPT following the guidelines.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=33e4718 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @guptakushal03** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
