### PR TITLE
Revert "Make Redshift system-test clusters non-public in sql_to_s3/s3_to_sql"

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
+++ b/providers/amazon/tests/system/amazon/aws/example_s3_to_sql.py
@@ -115,7 +115,6 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         vpc_security_group_ids=[security_group_id],
         cluster_subnet_group_name=cluster_subnet_group_name,
-        publicly_accessible=False,
         cluster_type="single-node",
         node_type="ra3.large",
         master_username=DB_LOGIN,

--- a/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
+++ b/providers/amazon/tests/system/amazon/aws/example_sql_to_s3.py
@@ -122,7 +122,6 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         vpc_security_group_ids=[security_group_id],
         cluster_subnet_group_name=cluster_subnet_group_name,
-        publicly_accessible=False,
         cluster_type="single-node",
         node_type="ra3.large",
         master_username=DB_LOGIN,


### PR DESCRIPTION
Due to https://github.com/apache/airflow/pull/69890 the [system test](https://aws-mwaa.github.io/#/open-source/system-tests/dashboard.html) with the flag `publicly_accessible=False`, so this PR is the reversion