### PR TITLE
Mark Common Data Quality provider as not-ready

### DIFF
--- a/providers/common/dataquality/provider.yaml
+++ b/providers/common/dataquality/provider.yaml
@@ -21,7 +21,7 @@ name: Common Data Quality
 description: |
   Common Data Quality Provider
 
-state: ready
+state: not-ready
 lifecycle: incubation
 source-date-epoch: 1751587200
 build-system: flit_core


### PR DESCRIPTION
`common.dataquality` is currently only a skeleton (added in #69795) — the PR implementing its actual rules is still under discussion and unmerged — so it should not be picked up by provider release tooling yet.

It is currently `state: ready` with `lifecycle: incubation`. breeze's package filter gates purely on `state` and never reads `lifecycle` (`get_available_packages` in `dev/breeze/src/airflow_breeze/utils/packages.py`: `include_regular` admits `{"ready", "pre-release"}`, and `not-ready` is only admitted via `--include-not-ready-providers`). So `lifecycle: incubation` did not keep it out: the 2026-07-22 release wave (#70256) picked it up and regenerated its `README.rst`, which is what surfaced this in review.

Setting `state: not-ready` matches `ibm.mq`, the other in-development provider, and excludes it from release waves until it is ready to publish. Flip it back to `ready` when the implementation lands.

Scope check: `state` is not rendered into any provider template (`PROVIDER_README_TEMPLATE` / `PROVIDER_INDEX_TEMPLATE`), and `not-ready` providers still appear in `generated/provider_dependencies.json` and the root `pyproject.toml` exactly as `ready` ones do — so no generated files change. `not-ready` is a valid value in `provider.yaml.schema.json`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8, 1M context)

Generated-by: Claude Code (Opus 4.8, 1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)