### PR TITLE
Move ts-sdk prek hooks to its own config and add compile hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -249,32 +249,6 @@ repos:
           ^pyproject\.toml$
         pass_filenames: false
         require_serial: true
-      - id: ts-sdk-lint
-        name: Lint TypeScript SDK
-        entry: ./ts-sdk/scripts/ci/prek/ts_sdk_lint.py
-        language: node
-        files: |
-          (?x)
-          ^ts-sdk/.*\.(js|ts|json)$
-        exclude: |
-          (?x)
-          ^ts-sdk/node_modules/.*|
-          ^ts-sdk/.pnpm-store/.*|
-          ^ts-sdk/dist/.*
-        additional_dependencies: ['pnpm@10.28.1']
-        pass_filenames: false
-        require_serial: true
-      - id: check-ts-sdk-supervisor-schema
-        name: Check TypeScript SDK supervisor schema is up to date
-        entry: ./ts-sdk/scripts/ci/prek/check_supervisor_schema.py
-        language: node
-        files: >
-          (?x)
-          ^ts-sdk/src/generated/supervisor\.ts$|
-          ^ts-sdk/scripts/generate-supervisor\.mjs$
-        additional_dependencies: ['pnpm@10.28.1']
-        pass_filenames: false
-        require_serial: true
       - id: check-ci-workflows-in-sync
         name: Check ci-arm.yml and ci-amd.yml stay in sync
         entry: ./scripts/ci/prek/check_ci_workflows_in_sync.py

--- a/ts-sdk/.pre-commit-config.yaml
+++ b/ts-sdk/.pre-commit-config.yaml
@@ -54,7 +54,12 @@ repos:
         entry: ./scripts/ci/prek/compile_ts_sdk.py
         language: node
         stages: [manual]
-        always_run: true
+        files: |
+          (?x)
+          ^src/.*\.ts$|
+          ^package\.json$|
+          ^pnpm-lock\.yaml$|
+          ^tsconfig(\.build)?\.json$
         additional_dependencies: ['pnpm@10.28.1']
         pass_filenames: false
         require_serial: true

--- a/ts-sdk/.pre-commit-config.yaml
+++ b/ts-sdk/.pre-commit-config.yaml
@@ -54,12 +54,7 @@ repos:
         entry: ./scripts/ci/prek/compile_ts_sdk.py
         language: node
         stages: [manual]
-        files: >
-          (?x)
-          ^src/.*|
-          ^package\.json$|
-          ^pnpm-lock\.yaml$|
-          ^tsconfig.*\.json$
+        always_run: true
         additional_dependencies: ['pnpm@10.28.1']
         pass_filenames: false
         require_serial: true

--- a/ts-sdk/.pre-commit-config.yaml
+++ b/ts-sdk/.pre-commit-config.yaml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+---
+default_stages: [pre-commit, pre-push]
+minimum_prek_version: '0.3.4'
+default_language_version:
+  python: python3
+  node: 22.19.0
+repos:
+  - repo: local
+    hooks:
+      - id: ts-sdk-lint
+        name: Lint TypeScript SDK
+        entry: ./scripts/ci/prek/ts_sdk_lint.py
+        language: node
+        files: |
+          (?x)
+          \.(js|ts|json)$
+        exclude: |
+          (?x)
+          ^node_modules/.*|
+          ^\.pnpm-store/.*|
+          ^dist/.*
+        additional_dependencies: ['pnpm@10.28.1']
+        pass_filenames: false
+        require_serial: true
+      - id: check-ts-sdk-supervisor-schema
+        name: Check TypeScript SDK supervisor schema is up to date
+        entry: ./scripts/ci/prek/check_supervisor_schema.py
+        language: node
+        files: >
+          (?x)
+          ^src/generated/supervisor\.ts$|
+          ^scripts/generate-supervisor\.mjs$
+        additional_dependencies: ['pnpm@10.28.1']
+        pass_filenames: false
+        require_serial: true
+      - id: compile-ts-sdk
+        name: Compile TypeScript SDK
+        entry: ./scripts/ci/prek/compile_ts_sdk.py
+        language: node
+        stages: [manual]
+        files: >
+          (?x)
+          ^src/.*|
+          ^package\.json$|
+          ^pnpm-lock\.yaml$|
+          ^tsconfig.*\.json$
+        additional_dependencies: ['pnpm@10.28.1']
+        pass_filenames: false
+        require_serial: true

--- a/ts-sdk/README.md
+++ b/ts-sdk/README.md
@@ -203,3 +203,10 @@ pnpm test
 pnpm run typecheck
 pnpm run build
 ```
+
+Without a local pnpm install, [prek](https://prek.j178.dev) can compile the SDK
+with its own managed node + pnpm toolchain:
+
+```bash
+prek run compile-ts-sdk
+```

--- a/ts-sdk/scripts/ci/prek/compile_ts_sdk.py
+++ b/ts-sdk/scripts/ci/prek/compile_ts_sdk.py
@@ -26,7 +26,7 @@ from common_prek_utils import AIRFLOW_ROOT_PATH, run_command
 
 if __name__ not in ("__main__", "__mp_main__"):
     raise SystemExit(
-        "This file is intended to be executed as an executable program. You cannot use it as a module."
+        "This file is intended to be executed as an executable program. You cannot use it as a module. "
         f"To run this script, run the ./{__file__} command"
     )
 

--- a/ts-sdk/scripts/ci/prek/compile_ts_sdk.py
+++ b/ts-sdk/scripts/ci/prek/compile_ts_sdk.py
@@ -34,6 +34,4 @@ if __name__ == "__main__":
     directory = AIRFLOW_ROOT_PATH / "ts-sdk"
     run_command(["pnpm", "config", "set", "store-dir", ".pnpm-store"], cwd=directory)
     run_command(["pnpm", "install", "--frozen-lockfile", "--config.confirmModulesPurge=false"], cwd=directory)
-    run_command(["pnpm", "run", "lint:fix"], cwd=directory)
-    run_command(["pnpm", "run", "format"], cwd=directory)
-    run_command(["pnpm", "run", "typecheck"], cwd=directory)
+    run_command(["pnpm", "run", "build"], cwd=directory)


### PR DESCRIPTION

## Why

The ts-sdk prek hooks lived in the root `.pre-commit-config.yaml` even though their scripts already live under `ts-sdk/scripts/ci/prek/` and every other workspace project (`task-sdk`, `airflow-core`, `go-sdk`, `shared/*`, ...) owns its hooks in a nested config; building the ts-sdk also required a locally installed pnpm.

## Verification

- `prek run ts-sdk-lint --all-files`, `prek run check-ts-sdk-supervisor-schema --all-files` — both pass from the new workspace config.
- `prek run compile-ts-sdk` — builds `ts-sdk/dist/` with prek-managed pnpm; excluded from default-stage runs (`prek run --dry-run` on a ts-sdk file does not list it), so ordinary commits do not trigger a build.
- Trigger parity: `prek run ts-sdk-lint --files ts-sdk/src/index.ts` runs the hook; `--files README.md` skips it.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
