### PR TITLE
Mount ts-sdk sources in Breeze container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,6 +40,7 @@
 !airflow-ctl/
 !go-sdk/
 !java-sdk/
+!ts-sdk/
 
 # Add all "test" distributions
 !tests

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -114,6 +114,7 @@ VOLUMES_FOR_SELECTED_MOUNTS = [
     ("scripts/docker/entrypoint_ci.sh", "/entrypoint"),
     ("shared", "/opt/airflow/shared"),
     ("task-sdk", "/opt/airflow/task-sdk"),
+    ("ts-sdk", "/opt/airflow/ts-sdk"),
 ]
 
 

--- a/scripts/ci/docker-compose/local.yml
+++ b/scripts/ci/docker-compose/local.yml
@@ -132,6 +132,9 @@ services:
       - type: bind
         source: ../../../task-sdk
         target: /opt/airflow/task-sdk
+      - type: bind
+        source: ../../../ts-sdk
+        target: /opt/airflow/ts-sdk
         # END automatically generated volumes from VOLUMES_FOR_SELECTED_MOUNTS in docker_command_utils.py
 volumes:
   root-airflow-volume:


### PR DESCRIPTION
- related: #69295

## Why

`ts-sdk/` is the only language-SDK distribution missing from Breeze's `VOLUMES_FOR_SELECTED_MOUNTS` allowlist and the `.dockerignore` build-context allowlist, so unlike `task-sdk`, `go-sdk`, and `java-sdk` it never appears under `/opt/airflow` in Breeze shells (default `MOUNT_SELECTED` mode) or in the CI image.

## What

- Add `ts-sdk` to `VOLUMES_FOR_SELECTED_MOUNTS` in `docker_command_utils.py` so it is bind-mounted at `/opt/airflow/ts-sdk`.
- Add `!ts-sdk/` to the `.dockerignore` allowlist for parity with the other SDK distributions (`**/node_modules` stays excluded).
- Regenerate `scripts/ci/docker-compose/local.yml` via `breeze setup synchronize-local-mounts`.

## Verification

```console
$ breeze run ls /opt/airflow/ts-sdk
LICENSE
NOTICE
README.md
eslint.config.js
example
package.json
pnpm-lock.yaml
scripts
src
tests
tsconfig.build.json
tsconfig.json
vitest.config.ts
```

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Fable 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
