### PR TITLE
Mark KubernetesPodOperator and AgentOperator as durable capable

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -285,7 +285,7 @@ class KubernetesPodOperator(BaseOperator):
 
     # This operator supports durable execution directly, without ResumableJobMixin --
     # it reconnects via task_state_store on retry instead of resubmitting.
-    _supports_durable_execution: ClassVar[bool] = True
+    __supports_durable_execution: ClassVar[bool] = True
 
     # This field can be overloaded at the instance level via base_container_name
     BASE_CONTAINER_NAME = "base"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -34,7 +34,7 @@ from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from contextlib import AbstractContextManager, suppress
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import kubernetes
 import pendulum
@@ -282,6 +282,10 @@ class KubernetesPodOperator(BaseOperator):
 
     # !!! Changes in KubernetesPodOperator's arguments should be also reflected in !!!
     #  - airflow-core/src/airflow/decorators/__init__.pyi  (by a separate PR)
+
+    # This operator supports durable execution directly, without ResumableJobMixin --
+    # it reconnects via task_state_store on retry instead of resubmitting.
+    _supports_durable_execution: ClassVar[bool] = True
 
     # This field can be overloaded at the instance level via base_container_name
     BASE_CONTAINER_NAME = "base"

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2777,7 +2777,7 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.reattach_on_restart is False
 
     def test_supports_durable_execution_marker(self):
-        assert KubernetesPodOperator.__supports_durable_execution is True
+        assert KubernetesPodOperator._KubernetesPodOperator__supports_durable_execution is True
 
 
 class TestSuppress:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2776,6 +2776,9 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.durable is False
         assert k.reattach_on_restart is False
 
+    def test_supports_durable_execution_marker(self):
+        assert KubernetesPodOperator._supports_durable_execution is True
+
 
 class TestSuppress:
     def test__suppress(self, caplog):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2777,7 +2777,7 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.reattach_on_restart is False
 
     def test_supports_durable_execution_marker(self):
-        assert KubernetesPodOperator._supports_durable_execution is True
+        assert KubernetesPodOperator.__supports_durable_execution is True
 
 
 class TestSuppress:

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -223,7 +223,7 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
 
     # This operator supports durable execution directly, without ResumableJobMixin --
     # it caches step results via task_state_store for replay on retry.
-    _supports_durable_execution: ClassVar[bool] = True
+    __supports_durable_execution: ClassVar[bool] = True
 
     template_fields: Sequence[str] = (
         "prompt",

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -221,6 +221,10 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
 
     deserialization_allowed_class_fields: ClassVar[tuple[str, ...]] = ("output_type",)
 
+    # This operator supports durable execution directly, without ResumableJobMixin --
+    # it caches step results via task_state_store for replay on retry.
+    _supports_durable_execution: ClassVar[bool] = True
+
     template_fields: Sequence[str] = (
         "prompt",
         "llm_conn_id",

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -759,6 +759,9 @@ class TestAgentOperatorDurable:
 
         storage.cleanup.assert_not_called()
 
+    def test_supports_durable_execution_marker(self):
+        assert AgentOperator._supports_durable_execution is True
+
 
 @pytest.mark.skipif(
     not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -760,7 +760,7 @@ class TestAgentOperatorDurable:
         storage.cleanup.assert_not_called()
 
     def test_supports_durable_execution_marker(self):
-        assert AgentOperator._supports_durable_execution is True
+        assert AgentOperator.__supports_durable_execution is True
 
 
 @pytest.mark.skipif(

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -760,7 +760,7 @@ class TestAgentOperatorDurable:
         storage.cleanup.assert_not_called()
 
     def test_supports_durable_execution_marker(self):
-        assert AgentOperator.__supports_durable_execution is True
+        assert AgentOperator._AgentOperator__supports_durable_execution is True
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes claude sonnet

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---

### What

Enhancement to: https://github.com/apache/airflow/pull/69651, where the Airflow Registry added a `supports_durable_execution` signal (built on top of `ResumableJobMixin`), badging operators that survive a worker crash/retry without redoing expensive work. `KubernetesPodOperator` (#69914) and `AgentOperator` (`common.ai`) both already implement this same crash-safe property, but neither inherits `ResumableJobMixin` -- they implement it directly against `task_state_store`, since their own execution shapes (pod lifecycle management, LLM step/tool-call replay caching) don't fit the mixin's submit/poll/result contract.

The registry detection is purely MRO-based, so both operators are currently invisible to it despite genuinely qualifying.

### Proposed change

Adds `__supports_durable_execution: ClassVar[bool] = True` directly to both operator classes, indicating that durable execution is implemented directly here, not via `ResumableJobMixin`. This is a plain class attribute, not a new mixin or shared marker class -- there's no common contract between pod-lifecycle management and LLM-call caching to anchor a reusable base class on, so a class-level declaration is the simplest correct signal.

The name uses a double leading underscore deliberately, not a single one. Python name-mangles it to `_KubernetesPodOperator__supports_durable_execution` / `_AgentOperator__supports_durable_execution` on each declaring class. This matters because both operators have subclasses that override `execute()` themselves (e.g. `SparkKubernetesOperator`, `KubernetesJobOperator`, `KubernetesStartKueueJobOperator` for KPO) -- we have no way to verify those subclasses preserve the `task_state_store` reconnect behavior, so the attribute must not be treated as true for them just because they inherit from a durable-capable parent. A subclass that doesn't redeclare the attribute in its own class body will not match a per-class mangled-name lookup, unlike a plain single-underscore attribute, which would be silently inherited by every subclass regardless of whether it actually preserves the mechanism.

### Changes of Note

This attribute is not read by anything yet. It will be a follow-up change, not part of this PR.

### What's next

A follow-up change to `dev/registry/extract_parameters.py`'s `is_durable_capable()` to also treat `__supports_durable_execution = True` as qualifying. The check must compute the mangled attribute name per class being inspected (`f"_{cls.__name__}__supports_durable_execution"`) rather than a fixed string, so it only matches a class that declares the attribute itself, not one that merely inherits from a durable-capable base.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
