### PR TITLE
Add task log message when the Execution API is unreachable

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2562,6 +2562,20 @@ def supervise_task(
                 final_state=result.final_state,
             )
             return result.exit_code
+        except httpx.RequestError as e:
+            # Otherwise a UI-only user sees a failed task with an empty log.
+            if logger is not None:
+                # Close any group the child left open so the error renders at the top level, not
+                # folded inside a collapsed group.
+                logger.info("::endgroup::")
+                logger.error(
+                    "Could not reach the Execution API server. Verify the `[core] "
+                    "execution_api_server_url` (or `[api] base_url`) setting points at a reachable "
+                    "Airflow API server.",
+                    server=server,
+                    error=str(e),
+                )
+            raise
         finally:
             if log_path and log_file_descriptor:
                 log_file_descriptor.close()

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -262,6 +262,48 @@ class TestSupervisor:
             with expectation:
                 supervise_task(**kw)
 
+    def test_supervise_task_logs_config_hint_on_connection_error(self, mocker):
+        """Test that a connection failure reaching the Execution API is surfaced in the task
+        log, naming the responsible config, and still propagates."""
+        ti = TaskInstance(
+            id=uuid7(),
+            task_id="b",
+            dag_id="c",
+            run_id="d",
+            try_number=1,
+            dag_version_id=uuid7(),
+            queue="default",
+        )
+        server = "http://nonexistent-api-server:8080/execution/"
+        coordinator = mocker.Mock()
+        coordinator.execute_task.side_effect = httpx.ConnectError("Name or service not known")
+        mocker.patch(
+            "airflow.sdk.execution_time.supervisor.get_coordinator_manager"
+        ).return_value.for_queue.return_value = coordinator
+
+        task_logger = mocker.Mock()
+        mocker.patch(
+            "airflow.sdk.execution_time.supervisor._configure_logging",
+            return_value=(task_logger, mocker.MagicMock()),
+        )
+
+        with pytest.raises(httpx.ConnectError):
+            supervise_task(
+                ti=ti,
+                dag_rel_path="c.py",
+                token="",
+                server=server,
+                client=mocker.Mock(spec=sdk_client.Client),
+                bundle_info=BundleInfo(name="my-bundle", version=None),
+                log_path="attempt=1.log",
+            )
+
+        task_logger.error.assert_called_once()
+        message, kwargs = task_logger.error.call_args.args[0], task_logger.error.call_args.kwargs
+        assert "execution_api_server_url" in message
+        assert "base_url" in message
+        assert kwargs["server"] == server
+
 
 @pytest.mark.usefixtures("disable_capturing")
 class TestWatchedSubprocess:


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why

A supervisor connection failure to the Execution API only showed up in the executor's stdout. As a result, UI users only saw a failed task with an empty log, making it difficult to identify the root cause.

## How

- Catch `httpx.RequestError` in `supervise_task` and log the failure (with the relevant config to check) to the task's own log before re-raising
- Add a test covering the new log message

related: #51163

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)