### PR TITLE
Add support for operators that achieve durable execution manually in registry

### DIFF
--- a/dev/registry/extract_parameters.py
+++ b/dev/registry/extract_parameters.py
@@ -386,11 +386,29 @@ def load_resumable_job_mixin() -> type | None:
 
 
 def is_durable_capable(cls: type, resumable_mixin: type | None) -> bool:
-    """Return True if a class fully implements ResumableJobMixin's crash-recovery contract.
+    """Return True if a class implements durable/crash-safe execution.
 
-    Inheriting the mixin is not sufficient: a complete override is inert unless
-    execute() actually calls execute_resumable().
+    Two ways to qualify:
+    1. A class-level `__supports_durable_execution = True`
+    declaration (for operators that implement this directly against
+    task_state_store, without ResumableJobMixin -- e.g. KubernetesPodOperator,
+    AgentOperator).
+    2. Genuinely implementing ResumableJobMixin's contract.
+
+    The first path deliberately looks up the class prefixed attribute
+    (`_{ClassName}__supports_durable_execution`) rather than a fixed string.
+    A subclass that overrides execute() itself (e.g. SparkKubernetesOperator)
+    may not preserve the parent's task_state_store reconnect behavior, so the
+    declaration must not be inherited -- only the exact class that wrote
+    `__supports_durable_execution` in its own body qualifies this way.
+
+    Inheriting the mixin alone is not sufficient for the second path: a
+    complete override is inert unless execute() actually calls
+    execute_resumable().
     """
+    if getattr(cls, f"_{cls.__name__}__supports_durable_execution", None) is True:
+        return True
+
     if resumable_mixin is None or resumable_mixin not in cls.__mro__:
         return False
 

--- a/dev/registry/tests/test_extract_parameters.py
+++ b/dev/registry/tests/test_extract_parameters.py
@@ -225,6 +225,24 @@ class PlainOperator:
         return None
 
 
+class ManuallyDurableOperator:
+    """Implements durable execution directly (e.g. via task_state_store), without
+    ResumableJobMixin -- mirrors KubernetesPodOperator/AgentOperator."""
+
+    __supports_durable_execution = True
+
+    def execute(self, context):
+        return None
+
+
+class ManuallyDurableSubclass(ManuallyDurableOperator):
+    """Overrides execute() itself -- must NOT inherit the parent's declaration,
+    since nothing here verifies it preserves the reconnect behavior."""
+
+    def execute(self, context):
+        return "something else entirely"
+
+
 class TestIsDurableCapable:
     def test_fully_implemented_and_wired_qualifies(self):
         assert is_durable_capable(FullyImplementedResumableOperator, FakeResumableJobMixin) is True
@@ -240,6 +258,12 @@ class TestIsDurableCapable:
 
     def test_mixin_unavailable_disqualifies(self):
         assert is_durable_capable(FullyImplementedResumableOperator, None) is False
+
+    def test_manual_durable_marker_qualifies_without_mixin(self):
+        assert is_durable_capable(ManuallyDurableOperator, None) is True
+
+    def test_subclass_not_redeclaring_marker_disqualifies(self):
+        assert is_durable_capable(ManuallyDurableSubclass, FakeResumableJobMixin) is False
 
 
 # ---------------------------------------------------------------------------

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -285,7 +285,7 @@ class KubernetesPodOperator(BaseOperator):
 
     # This operator supports durable execution directly, without ResumableJobMixin --
     # it reconnects via task_state_store on retry instead of resubmitting.
-    _supports_durable_execution: ClassVar[bool] = True
+    __supports_durable_execution: ClassVar[bool] = True
 
     # This field can be overloaded at the instance level via base_container_name
     BASE_CONTAINER_NAME = "base"

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -34,7 +34,7 @@ from collections.abc import Callable, Container, Iterable, Mapping, Sequence
 from contextlib import AbstractContextManager, suppress
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import kubernetes
 import pendulum
@@ -282,6 +282,10 @@ class KubernetesPodOperator(BaseOperator):
 
     # !!! Changes in KubernetesPodOperator's arguments should be also reflected in !!!
     #  - airflow-core/src/airflow/decorators/__init__.pyi  (by a separate PR)
+
+    # This operator supports durable execution directly, without ResumableJobMixin --
+    # it reconnects via task_state_store on retry instead of resubmitting.
+    _supports_durable_execution: ClassVar[bool] = True
 
     # This field can be overloaded at the instance level via base_container_name
     BASE_CONTAINER_NAME = "base"

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2777,7 +2777,7 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.reattach_on_restart is False
 
     def test_supports_durable_execution_marker(self):
-        assert KubernetesPodOperator.__supports_durable_execution is True
+        assert KubernetesPodOperator._KubernetesPodOperator__supports_durable_execution is True
 
 
 class TestSuppress:

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2776,6 +2776,9 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.durable is False
         assert k.reattach_on_restart is False
 
+    def test_supports_durable_execution_marker(self):
+        assert KubernetesPodOperator._supports_durable_execution is True
+
 
 class TestSuppress:
     def test__suppress(self, caplog):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_pod.py
@@ -2777,7 +2777,7 @@ class TestKubernetesPodOperatorDurableExecution:
         assert k.reattach_on_restart is False
 
     def test_supports_durable_execution_marker(self):
-        assert KubernetesPodOperator._supports_durable_execution is True
+        assert KubernetesPodOperator.__supports_durable_execution is True
 
 
 class TestSuppress:

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -223,7 +223,7 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
 
     # This operator supports durable execution directly, without ResumableJobMixin --
     # it caches step results via task_state_store for replay on retry.
-    _supports_durable_execution: ClassVar[bool] = True
+    __supports_durable_execution: ClassVar[bool] = True
 
     template_fields: Sequence[str] = (
         "prompt",

--- a/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py
@@ -221,6 +221,10 @@ class AgentOperator(BaseOperator, HITLReviewMixin):
 
     deserialization_allowed_class_fields: ClassVar[tuple[str, ...]] = ("output_type",)
 
+    # This operator supports durable execution directly, without ResumableJobMixin --
+    # it caches step results via task_state_store for replay on retry.
+    _supports_durable_execution: ClassVar[bool] = True
+
     template_fields: Sequence[str] = (
         "prompt",
         "llm_conn_id",

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -759,6 +759,9 @@ class TestAgentOperatorDurable:
 
         storage.cleanup.assert_not_called()
 
+    def test_supports_durable_execution_marker(self):
+        assert AgentOperator._supports_durable_execution is True
+
 
 @pytest.mark.skipif(
     not AIRFLOW_V_3_1_PLUS, reason="Human in the loop is only compatible with Airflow >= 3.1.0"

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -760,7 +760,7 @@ class TestAgentOperatorDurable:
         storage.cleanup.assert_not_called()
 
     def test_supports_durable_execution_marker(self):
-        assert AgentOperator._supports_durable_execution is True
+        assert AgentOperator.__supports_durable_execution is True
 
 
 @pytest.mark.skipif(

--- a/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
+++ b/providers/common/ai/tests/unit/common/ai/operators/test_agent.py
@@ -760,7 +760,7 @@ class TestAgentOperatorDurable:
         storage.cleanup.assert_not_called()
 
     def test_supports_durable_execution_marker(self):
-        assert AgentOperator.__supports_durable_execution is True
+        assert AgentOperator._AgentOperator__supports_durable_execution is True
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes: claude sonnet 4.6

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->


---

### What

Follow-up to https://github.com/apache/airflow/pull/70289, which added `__supports_durable_execution: ClassVar[bool] = True` directly to `KubernetesPodOperator` and `AgentOperator` both of which implement crash-safe execution against `task_state_store` without inheriting `ResumableJobMixin`. That attribute wasn't read by anything yet; the Registry's `is_durable_capable()` only checked for `ResumableJobMixin` in the MRO, so both operators stayed invisible to the badge despite genuinely qualifying.

### Current behaviour

`is_durable_capable()` in `dev/registry/extract_parameters.py` only qualifies a class via the `ResumableJobMixin` structural check (inherits it, all abstract methods overridden, `execute_resumable` reachable from `execute()`). Classes that implement durable execution some other way have no path to qualify.

### Proposed change

Adds a second, independent qualifying path: `is_durable_capable()` now also checks for a class level `__supports_durable_execution = True` declaration. Because the attribute name uses a double leading underscore, Python name mangles it to `_{ClassName}__supports_durable_execution` on whichever class declares it. The check computes that mangled name per class being inspected (`f"_{cls.__name__}__supports_durable_execution"`) rather than a fixed string, so it only matches the exact class that wrote the declaration in its own body -- not any subclass that merely inherits from it.

### Changes of Note

This distinction matters concretely: `KubernetesPodOperator` has real subclasses (`SparkKubernetesOperator`, `KubernetesJobOperator`, `KubernetesStartKueueJobOperator`) that override `execute()` themselves. Nothing verifies those overrides preserve the `task_state_store` reconnect behavior yet, so the marker must not propagate to them automatically. 

### Testing

Manual validation after generating registry data shows:

```json
    {
      "id": "common-ai-agent-AgentOperator",
      "name": "AgentOperator",
      "type": "operator",
      "import_path": "airflow.providers.common.ai.operators.agent.AgentOperator",
      "module_path": "airflow.providers.common.ai.operators.agent",
      "short_description": "Run a pydantic-ai Agent with tools and multi-turn reasoning.",
      "docs_url": "https://airflow.apache.org/docs/apache-airflow-providers-common-ai/stable/_api/airflow/providers/common/ai/operators/agent/index.html#airflow.providers.common.ai.operators.agent.AgentOperator",
      "source_url": "https://github.com/apache/airflow/blob/providers-common-ai/0.7.0/providers/common/ai/src/airflow/providers/common/ai/operators/agent.py#L120",
      "category": "common-ai",
      "provider_id": "common-ai",
      "provider_name": "Common AI",
      "supports_durable_execution": true
    },
```

And

```json
    {
      "id": "cncf-kubernetes-pod-KubernetesPodOperator",
      "name": "KubernetesPodOperator",
      "type": "operator",
      "import_path": "airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator",
      "module_path": "airflow.providers.cncf.kubernetes.operators.pod",
      "short_description": "Execute a task in a Kubernetes Pod.",
      "docs_url": "https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/_api/airflow/providers/cncf/kubernetes/operators/pod/index.html#airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator",
      "source_url": "https://github.com/apache/airflow/blob/providers-cncf-kubernetes/10.20.0/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py#L142",
      "category": "kubernetes",
      "provider_id": "cncf-kubernetes",
      "provider_name": "Kubernetes",
      "supports_durable_execution": true
    },
```

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
