### PR TITLE
Fix E2E flaky test failure rates

### DIFF
--- a/scripts/ci/analyze_e2e_flaky_tests.py
+++ b/scripts/ci/analyze_e2e_flaky_tests.py
@@ -221,10 +221,8 @@ def identify_flaky_candidates(failures_by_test: dict[str, dict], runs_with_data:
 
     candidates = []
     for test_name, data in failures_by_test.items():
-        # Use runs where this test appeared rather than total runs * browsers,
-        # since not every test runs in every browser or every run.
-        runs_seen = len(data["run_ids"]) if data["run_ids"] else 1
-        failure_rate = data["count"] / (runs_seen * len(data["browsers"])) if data["browsers"] else 0
+        # A workflow run counts once even if the test failed in multiple browsers.
+        failure_rate = len(data["run_ids"]) / runs_with_data
         if failure_rate >= FLAKY_THRESHOLD:
             candidates.append(
                 {

--- a/scripts/tests/ci/test_analyze_e2e_flaky_tests.py
+++ b/scripts/tests/ci/test_analyze_e2e_flaky_tests.py
@@ -72,7 +72,7 @@ class TestIdentifyFlakyCandidates:
     def test_zero_runs(self, analyze_module):
         assert analyze_module.identify_flaky_candidates({"test": {}}, 0) == []
 
-    def test_identifies_flaky_test(self, analyze_module):
+    def test_failure_rate_counts_unique_failing_runs(self, analyze_module):
         failures = {
             "test_a": {
                 "count": 5,
@@ -84,15 +84,15 @@ class TestIdentifyFlakyCandidates:
         candidates = analyze_module.identify_flaky_candidates(failures, 5)
         assert len(candidates) == 1
         assert candidates[0]["test"] == "test_a"
-        assert candidates[0]["failure_rate"] > 0
+        assert candidates[0]["failure_rate"] == 60.0
 
-    def test_excludes_low_failure_rate(self, analyze_module):
+    def test_excludes_failure_seen_in_one_of_ten_runs(self, analyze_module):
         failures = {
             "test_a": {
                 "count": 1,
-                "browsers": ["chromium", "firefox", "webkit"],
+                "browsers": ["chromium"],
                 "errors": [],
-                "run_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                "run_ids": [1],
             },
         }
         candidates = analyze_module.identify_flaky_candidates(failures, 10)
@@ -107,15 +107,15 @@ class TestIdentifyFlakyCandidates:
                 "run_ids": [1, 2, 3],
             },
             "test_high": {
-                "count": 10,
+                "count": 8,
                 "browsers": ["chromium"],
                 "errors": [],
-                "run_ids": [1, 2, 3],
+                "run_ids": [1, 2, 3, 4, 5, 6, 7, 8],
             },
         }
         candidates = analyze_module.identify_flaky_candidates(failures, 10)
-        if len(candidates) >= 2:
-            assert candidates[0]["failure_rate"] >= candidates[1]["failure_rate"]
+        assert [candidate["test"] for candidate in candidates] == ["test_high", "test_low"]
+        assert [candidate["failure_rate"] for candidate in candidates] == [80.0, 30.0]
 
 
 class TestFormatSlackMessage:


### PR DESCRIPTION
The E2E flaky-test report currently derives its observation count from `run_ids`, which contains only runs where the test failed. A one-off failure can therefore appear as 100% and incorrectly cross the 30% flaky-candidate threshold.

Use all workflow runs with downloadable data as the denominator while counting each failing run once, regardless of how many browsers failed. Update the regression fixtures to cover an exact 60% rate, a one-in-ten non-candidate, and deterministic 80%-then-30% ordering.

This keeps the raw browser-level failure count in the report while making the failure rate match the documented fraction of runs.

Checks:

- `uv run --project scripts pytest scripts/tests/ci/test_analyze_e2e_flaky_tests.py -q` (13 passed)
- `uv run --project scripts pytest scripts/tests -q` (957 passed)
- `prek run --from-ref upstream/main --stage pre-commit`
- `prek run --from-ref upstream/main --stage manual`
- `breeze ci selective-check --commit-ref HEAD` (scripts tests selected)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
