### PR TITLE
[v3-3-test] Mark dags state and next-execution CLI commands as migrated to airflowctl (#69305)

### DIFF
--- a/airflow-core/src/airflow/cli/commands/dag_command.py
+++ b/airflow-core/src/airflow/cli/commands/dag_command.py
@@ -408,6 +408,7 @@ def _get_dagbag_dag_details(dag: DAG) -> dict:
     }
 
 
+@deprecated_for_airflowctl("airflowctl dags state")
 @cli_utils.action_cli
 @providers_configuration_loaded
 @provide_session
@@ -437,6 +438,7 @@ def dag_state(args, *, session: Session = NEW_SESSION) -> None:
         print(dr.state)
 
 
+@deprecated_for_airflowctl("airflowctl dags next-execution")
 @cli_utils.action_cli
 @providers_configuration_loaded
 def dag_next_execution(args) -> None:

--- a/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
+++ b/airflow-core/tests/unit/cli/commands/test_command_deprecations.py
@@ -55,6 +55,8 @@ MIGRATED_CLI_COMMANDS = [
     (dag_command.dag_pause, "airflowctl dags pause"),
     (dag_command.dag_unpause, "airflowctl dags unpause"),
     (dag_command.dag_list_import_errors, "airflowctl dags list-import-errors"),
+    (dag_command.dag_state, "airflowctl dags state"),
+    (dag_command.dag_next_execution, "airflowctl dags next-execution"),
     (pool_command.pool_list, "airflowctl pools list"),
     (pool_command.pool_get, "airflowctl pools get"),
     (pool_command.pool_set, "airflowctl pools create"),


### PR DESCRIPTION
Backport of #69305 to `v3-3-test`.

Clean cherry-pick of 5628e8360dc3f0f77c90e96cea82b65b623ae7b3 (only surrounding context differs — v3-3-test has a shorter `MIGRATED_CLI_COMMANDS` list).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)