### PR TITLE
UI: Show owning team on Dag, Dag Run, and Task Instance detail pages

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dag_runs.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, select, tuple_, union_all
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.interfaces import LoaderOption
 
+from airflow.api_fastapi.common.db.dags import eager_load_teams
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
@@ -56,14 +57,15 @@ def eager_load_dag_run_for_list() -> tuple[LoaderOption, ...]:
     Lightweight eager loading for the DagRun list endpoint.
 
     Only loads the direct relationships needed for serialization (dag_model,
-    dag_run_note, created_dag_version).  The dag_versions property — which
-    requires iterating every TI and TIH — is populated separately by
+    dag_run_note, created_dag_version, and the owning team).  The dag_versions
+    property — which requires iterating every TI and TIH — is populated separately by
     :func:`attach_dag_versions_to_runs` using a single DISTINCT query.
     """
     return (
         joinedload(DagRun.dag_model),
         joinedload(DagRun.dag_run_note),
         joinedload(DagRun.created_dag_version).joinedload(DagVersion.bundle),
+        *eager_load_teams(DagRun.dag_model),
     )
 
 

--- a/airflow-core/src/airflow/api_fastapi/common/db/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/dags.py
@@ -17,11 +17,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 
 from airflow.api_fastapi.common.db.common import (
     apply_filters_to_select,
@@ -29,10 +28,11 @@ from airflow.api_fastapi.common.db.common import (
 from airflow.api_fastapi.common.parameters import BaseParam, RangeFilter, SortParam
 from airflow.configuration import conf
 from airflow.models import DagModel
+from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
+    from sqlalchemy.orm.strategy_options import _AbstractLoad
     from sqlalchemy.sql import Select
 
 
@@ -98,18 +98,23 @@ def generate_dag_with_latest_run_query(
     return query
 
 
-def attach_team_names(objects: Sequence, *, session: Session) -> None:
+def eager_load_teams(*path: Any) -> tuple[_AbstractLoad, ...]:
     """
-    Attach the owning team name to each object exposing a ``dag_id``.
+    Eager loading options for the team owning a Dag, for serializing ``team_name``.
 
-    Only performs a database lookup when multi-team mode is enabled; otherwise every
-    object keeps its default ``team_name`` of ``None``. The resolved name is set as the
-    ``team_name`` attribute on each object so the response serializer can read it.
+    ``DagModel.bundle`` is ``lazy="raise"``, so any endpoint whose response exposes
+    ``team_name`` must apply these options. Nothing is loaded when multi-team mode is
+    off: :attr:`DagModel.team_name` short-circuits to ``None`` without touching the
+    relationship, so single-team deployments pay for no extra join.
+
+    :param path: relationship attributes leading to ``DagModel``, empty when selecting it
+        directly. For example, ``eager_load_teams(DagRun.dag_model)`` for a Dag run query.
     """
-    if not objects or not conf.getboolean("core", "multi_team"):
-        return
+    if not conf.getboolean("core", "multi_team"):
+        return ()
 
-    dag_ids = list({obj.dag_id for obj in objects})
-    team_names_by_dag_id = DagModel.get_dag_id_to_team_name_mapping(dag_ids, session=session)
-    for obj in objects:
-        obj.team_name = team_names_by_dag_id.get(obj.dag_id)
+    loader: Any = None
+    for attribute in path:
+        loader = joinedload(attribute) if loader is None else loader.joinedload(attribute)
+    bundle_loader = joinedload(DagModel.bundle) if loader is None else loader.joinedload(DagModel.bundle)
+    return (bundle_loader.selectinload(DagBundleModel.teams),)

--- a/airflow-core/src/airflow/api_fastapi/common/db/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/task_instances.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from sqlalchemy import Select
 from sqlalchemy.orm import contains_eager, joinedload
 
+from airflow.api_fastapi.common.db.dags import eager_load_teams
 from airflow.models import Base
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
@@ -48,7 +49,9 @@ def eager_load_TI_and_TIH_for_validation(
 
     query = query.join(orm_model.dag_run).outerjoin(orm_model.dag_version)
     query = query.options(
-        contains_eager(orm_model.dag_run).options(joinedload(DagRun.dag_model)),
+        contains_eager(orm_model.dag_run).options(
+            joinedload(DagRun.dag_model).options(*eager_load_teams()),
+        ),
         contains_eager(orm_model.dag_version).options(joinedload(DagVersion.bundle)),
     )
     if orm_model is TaskInstance:

--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/dags.py
@@ -207,6 +207,7 @@ class DAGDetailsResponse(DAGResponse):
     owner_links: dict[str, str] | None = None
     is_favorite: bool = False
     active_runs_count: int = 0
+    team_name: str | None = None
 
     @field_validator("timezone", mode="before")
     @classmethod

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13105,6 +13105,11 @@ components:
           type: integer
           title: Active Runs Count
           default: 0
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
         is_backfillable:
           type: boolean
           title: Is Backfillable

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -13099,6 +13099,11 @@ components:
           type: integer
           title: Active Runs Count
           default: 0
+        team_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Team Name
         is_backfillable:
           type: boolean
           title: Is Backfillable

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -141,6 +141,7 @@ def get_dag_run(dag_id: str, dag_run_id: str, session: SessionDep) -> DAGRunResp
             status.HTTP_404_NOT_FOUND,
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
+    attach_team_names([dag_run], session=session)
     return dag_run
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -42,7 +42,7 @@ from airflow.api_fastapi.common.db.dag_runs import (
     attach_dag_versions_to_runs,
     eager_load_dag_run_for_list,
 )
-from airflow.api_fastapi.common.db.dags import attach_team_names
+from airflow.api_fastapi.common.db.dags import eager_load_teams
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,
@@ -134,14 +134,15 @@ dag_run_at_dag_router = AirflowRouter(tags=["DagRun"], prefix="/dags/{dag_id}")
 )
 def get_dag_run(dag_id: str, dag_run_id: str, session: SessionDep) -> DAGRunResponse:
     dag_run = session.scalar(
-        select(DagRun).filter_by(dag_id=dag_id, run_id=dag_run_id).options(joinedload(DagRun.dag_model))
+        select(DagRun)
+        .filter_by(dag_id=dag_id, run_id=dag_run_id)
+        .options(joinedload(DagRun.dag_model), *eager_load_teams(DagRun.dag_model))
     )
     if dag_run is None:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             f"The DagRun with dag_id: `{dag_id}` and run_id: `{dag_run_id}` was not found",
         )
-    attach_team_names([dag_run], session=session)
     return dag_run
 
 
@@ -694,7 +695,6 @@ def get_dag_runs(
             has_next = has_more
 
         attach_dag_versions_to_runs(dag_runs, session=session)
-        attach_team_names(dag_runs, session=session)
 
         return DAGRunCollectionResponse(
             dag_runs=dag_runs,
@@ -714,7 +714,6 @@ def get_dag_runs(
     )
     dag_runs = list(session.scalars(dag_run_select))
     attach_dag_versions_to_runs(dag_runs, session=session)
-    attach_team_names(dag_runs, session=session)
 
     return DAGRunCollectionResponse(
         dag_runs=dag_runs,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -27,7 +27,7 @@ from sqlalchemy import delete, func, insert, select, update
 from airflow.api.common import delete_dag as delete_dag_module
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep, apply_filters_to_select, paginated_select
-from airflow.api_fastapi.common.db.dags import generate_dag_with_latest_run_query
+from airflow.api_fastapi.common.db.dags import attach_team_names, generate_dag_with_latest_run_query
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,
@@ -258,6 +258,8 @@ def get_dag_details(
     # Add is_favorite and active_runs_count fields to the Dag model
     setattr(dag_model, "is_favorite", is_favorite)
     setattr(dag_model, "active_runs_count", active_runs_count)
+
+    attach_team_names([dag_model], session=session)
 
     return DAGDetailsResponse.model_validate(dag_model)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dags.py
@@ -27,7 +27,7 @@ from sqlalchemy import delete, func, insert, select, update
 from airflow.api.common import delete_dag as delete_dag_module
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep, apply_filters_to_select, paginated_select
-from airflow.api_fastapi.common.db.dags import attach_team_names, generate_dag_with_latest_run_query
+from airflow.api_fastapi.common.db.dags import eager_load_teams, generate_dag_with_latest_run_query
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
     FilterParam,
@@ -228,7 +228,7 @@ def get_dag_details(
     """Get details of Dag."""
     dag = get_latest_version_of_dag(dag_bag, dag_id, session)
 
-    dag_model = session.get(DagModel, dag_id)
+    dag_model = session.scalar(select(DagModel).where(DagModel.dag_id == dag_id).options(*eager_load_teams()))
     if not dag_model:
         raise HTTPException(status.HTTP_404_NOT_FOUND, f"Unable to obtain dag with id {dag_id} from session")
 
@@ -258,8 +258,6 @@ def get_dag_details(
     # Add is_favorite and active_runs_count fields to the Dag model
     setattr(dag_model, "is_favorite", is_favorite)
     setattr(dag_model, "active_runs_count", active_runs_count)
-
-    attach_team_names([dag_model], session=session)
 
     return DAGDetailsResponse.model_validate(dag_model)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -157,6 +157,7 @@ def get_task_instance(
             status.HTTP_404_NOT_FOUND, "Task instance is mapped, add the map_index value to the URL"
         )
 
+    attach_team_names([task_instance], session=session)
     return task_instance
 
 
@@ -443,6 +444,7 @@ def get_mapped_task_instance(
             f"The Mapped Task Instance with dag_id: `{dag_id}`, run_id: `{dag_run_id}`, task_id: `{task_id}`, and map_index: `{map_index}` was not found",
         )
 
+    attach_team_names([task_instance], session=session)
     return task_instance
 
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/task_instances.py
@@ -41,7 +41,7 @@ from airflow.api_fastapi.common.dagbag import (
     resolve_run_on_latest_version,
 )
 from airflow.api_fastapi.common.db.common import SessionDep, apply_filters_to_select, paginated_select
-from airflow.api_fastapi.common.db.dags import attach_team_names
+from airflow.api_fastapi.common.db.dags import eager_load_teams
 from airflow.api_fastapi.common.db.task_instances import eager_load_TI_and_TIH_for_validation
 from airflow.api_fastapi.common.parameters import (
     FilterOptionEnum,
@@ -144,6 +144,7 @@ def get_task_instance(
         .options(joinedload(TI.rendered_task_instance_fields))
         .options(joinedload(TI.dag_version))
         .options(joinedload(TI.dag_run).options(joinedload(DagRun.dag_model)))
+        .options(*eager_load_teams(TI.dag_run, DagRun.dag_model))
     )
     task_instance = session.scalar(query)
 
@@ -157,7 +158,6 @@ def get_task_instance(
             status.HTTP_404_NOT_FOUND, "Task instance is mapped, add the map_index value to the URL"
         )
 
-    attach_team_names([task_instance], session=session)
     return task_instance
 
 
@@ -435,6 +435,7 @@ def get_mapped_task_instance(
         .options(joinedload(TI.rendered_task_instance_fields))
         .options(joinedload(TI.dag_version))
         .options(joinedload(TI.dag_run).options(joinedload(DagRun.dag_model)))
+        .options(*eager_load_teams(TI.dag_run, DagRun.dag_model))
     )
     task_instance = session.scalar(query)
 
@@ -444,7 +445,6 @@ def get_mapped_task_instance(
             f"The Mapped Task Instance with dag_id: `{dag_id}`, run_id: `{dag_run_id}`, task_id: `{task_id}`, and map_index: `{map_index}` was not found",
         )
 
-    attach_team_names([task_instance], session=session)
     return task_instance
 
 
@@ -642,8 +642,6 @@ def get_task_instances(
             has_prev = bool(cursor)
             has_next = has_more
 
-        attach_team_names(task_instances, session=session)
-
         return TaskInstanceCollectionResponse(
             task_instances=task_instances,
             next_cursor=(
@@ -665,7 +663,6 @@ def get_task_instances(
         session=session,
     )
     task_instances = list(session.scalars(task_instance_select))
-    attach_team_names(task_instances, session=session)
     return TaskInstanceCollectionResponse(
         task_instances=task_instances,
         total_entries=total_entries,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -390,6 +390,10 @@ class DagRun(StrictBaseModel):
             else:
                 values["note"] = None
 
+        # A property rather than a column, so the loop above never picks it up.
+        if not insp.detached:
+            values["team_name"] = data.team_name
+
         return values
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -297,8 +297,6 @@ def ti_run(
             or 0
         )
 
-        dr.team_name = get_team_name_for_ti(task_instance_id, session)
-
         context = TIRunContext(
             dag_run=dr,
             task_reschedule_count=task_reschedule_count,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -46,6 +46,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.auth.tokens import JWTGenerator
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
 from airflow.api_fastapi.common.db.common import SessionDep
+from airflow.api_fastapi.common.db.dags import eager_load_teams
 from airflow.api_fastapi.common.types import UtcDateTime
 from airflow.api_fastapi.compat import HTTP_422_UNPROCESSABLE_CONTENT
 from airflow.api_fastapi.core_api.openapi.exceptions import create_openapi_http_exception_doc
@@ -262,7 +263,7 @@ def ti_run(
             session.scalars(
                 select(DR)
                 .filter_by(dag_id=ti.dag_id, run_id=ti.run_id)
-                .options(joinedload(DR.consumed_asset_events))
+                .options(joinedload(DR.consumed_asset_events), *eager_load_teams(DR.dag_model))
             )
             .unique()
             .one_or_none()

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -38,6 +38,7 @@ from sqlalchemy import (
     Text,
     case,
     func,
+    inspect as sa_inspect,
     or_,
     select,
 )
@@ -63,7 +64,7 @@ from airflow.models.asset import AssetDagRunQueue
 from airflow.models.base import Base, StringID
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
-from airflow.models.team import Team, TeamOwnedMixin
+from airflow.models.team import Team
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.encoders import DAT, encode_deadline_alert
 from airflow.serialization.enums import Encoding
@@ -79,6 +80,7 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from dateutil.relativedelta import relativedelta
+    from sqlalchemy.orm.state import InstanceState
 
     from airflow.sdk import Context
     from airflow.serialization.definitions.assets import (
@@ -307,7 +309,7 @@ class DagOwnerAttributes(Base):
         return dag_links
 
 
-class DagModel(Base, TeamOwnedMixin):
+class DagModel(Base):
     """Table containing DAG properties."""
 
     __tablename__ = "dag"
@@ -440,15 +442,28 @@ class DagModel(Base, TeamOwnedMixin):
     dag_versions = relationship(
         "DagVersion", back_populates="dag_model", cascade="all, delete, delete-orphan"
     )
-    # The Dag's bundle, which carries the owning team. ``lazy="raise"`` forbids implicit
-    # loading so a caller that forgets ``eager_load_teams`` cannot emit a silent N+1;
-    # ``TeamOwnedMixin.team_name`` only reads this once loader options have populated it.
-    bundle = relationship(
-        "DagBundleModel",
-        primaryjoin="DagModel.bundle_name == DagBundleModel.name",
-        viewonly=True,
-        lazy="raise",
-    )
+    # Path from a Dag to its owning team, used by ``team_name`` below. ``lazy="raise"`` keeps the
+    # traversal opt-in so a caller that forgets eager_load_teams() cannot emit a silent N+1.
+    bundle = relationship("DagBundleModel", viewonly=True, lazy="raise")
+
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning this Dag, or ``None`` when it is not team-owned."""
+        if not airflow_conf.getboolean("core", "multi_team"):
+            return None
+
+        state: InstanceState = sa_inspect(self)
+        if "bundle" in state.unloaded:
+            # Serialization paths that fetch a Dag by primary key cannot apply loader options
+            # (e.g. Deadline.handle_miss, asset materialization), so fall back to the cached
+            # resolver rather than tripping ``lazy="raise"``. Reuse this instance's own session:
+            # ``get_team_name`` is ``@provide_session``, and the session it would otherwise open
+            # is the *same* scoped session the caller holds, so closing it on exit would detach
+            # every object still in use.
+            if state.session is not None:
+                return DagModel.get_team_name(self.dag_id, session=state.session)
+            return DagModel.get_team_name(self.dag_id)
+        return self.bundle.team_name if self.bundle else None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -63,7 +63,7 @@ from airflow.models.asset import AssetDagRunQueue
 from airflow.models.base import Base, StringID
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
-from airflow.models.team import Team
+from airflow.models.team import Team, TeamOwnedMixin
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.encoders import DAT, encode_deadline_alert
 from airflow.serialization.enums import Encoding
@@ -307,7 +307,7 @@ class DagOwnerAttributes(Base):
         return dag_links
 
 
-class DagModel(Base):
+class DagModel(Base, TeamOwnedMixin):
     """Table containing DAG properties."""
 
     __tablename__ = "dag"
@@ -439,6 +439,15 @@ class DagModel(Base):
     )
     dag_versions = relationship(
         "DagVersion", back_populates="dag_model", cascade="all, delete, delete-orphan"
+    )
+    # The Dag's bundle, which carries the owning team. ``lazy="raise"`` forbids implicit
+    # loading so a caller that forgets ``eager_load_teams`` cannot emit a silent N+1;
+    # ``TeamOwnedMixin.team_name`` only reads this once loader options have populated it.
+    bundle = relationship(
+        "DagBundleModel",
+        primaryjoin="DagModel.bundle_name == DagBundleModel.name",
+        viewonly=True,
+        lazy="raise",
     )
 
     def __init__(self, **kwargs):

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -39,6 +39,7 @@ from sqlalchemy import (
     and_,
     case,
     func,
+    inspect as sa_inspect,
     or_,
     select,
 )
@@ -64,7 +65,7 @@ from airflow.models.asset import AssetDagRunQueue, AssetModel
 from airflow.models.base import Base, StringID
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
-from airflow.models.team import Team, TeamOwnedMixin
+from airflow.models.team import Team
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.encoders import DAT, encode_deadline_alert
 from airflow.serialization.enums import Encoding
@@ -80,6 +81,7 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from dateutil.relativedelta import relativedelta
+    from sqlalchemy.orm.state import InstanceState
 
     from airflow.sdk import Context
     from airflow.serialization.definitions.assets import (
@@ -349,7 +351,7 @@ class DagOwnerAttributes(Base):
         return dag_links
 
 
-class DagModel(Base, TeamOwnedMixin):
+class DagModel(Base):
     """Table containing DAG properties."""
 
     __tablename__ = "dag"
@@ -482,15 +484,28 @@ class DagModel(Base, TeamOwnedMixin):
     dag_versions = relationship(
         "DagVersion", back_populates="dag_model", cascade="all, delete, delete-orphan"
     )
-    # The Dag's bundle, which carries the owning team. ``lazy="raise"`` forbids implicit
-    # loading so a caller that forgets ``eager_load_teams`` cannot emit a silent N+1;
-    # ``TeamOwnedMixin.team_name`` only reads this once loader options have populated it.
-    bundle = relationship(
-        "DagBundleModel",
-        primaryjoin="DagModel.bundle_name == DagBundleModel.name",
-        viewonly=True,
-        lazy="raise",
-    )
+    # Path from a Dag to its owning team, used by ``team_name`` below. ``lazy="raise"`` keeps the
+    # traversal opt-in so a caller that forgets eager_load_teams() cannot emit a silent N+1.
+    bundle = relationship("DagBundleModel", viewonly=True, lazy="raise")
+
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning this Dag, or ``None`` when it is not team-owned."""
+        if not airflow_conf.getboolean("core", "multi_team"):
+            return None
+
+        state: InstanceState = sa_inspect(self)
+        if "bundle" in state.unloaded:
+            # Serialization paths that fetch a Dag by primary key cannot apply loader options
+            # (e.g. Deadline.handle_miss, asset materialization), so fall back to the cached
+            # resolver rather than tripping ``lazy="raise"``. Reuse this instance's own session:
+            # ``get_team_name`` is ``@provide_session``, and the session it would otherwise open
+            # is the *same* scoped session the caller holds, so closing it on exit would detach
+            # every object still in use.
+            if state.session is not None:
+                return DagModel.get_team_name(self.dag_id, session=state.session)
+            return DagModel.get_team_name(self.dag_id)
+        return self.bundle.team_name if self.bundle else None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -64,7 +64,7 @@ from airflow.models.asset import AssetDagRunQueue, AssetModel
 from airflow.models.base import Base, StringID
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
-from airflow.models.team import Team
+from airflow.models.team import Team, TeamOwnedMixin
 from airflow.serialization.definitions.assets import SerializedAssetUniqueKey
 from airflow.serialization.encoders import DAT, encode_deadline_alert
 from airflow.serialization.enums import Encoding
@@ -349,7 +349,7 @@ class DagOwnerAttributes(Base):
         return dag_links
 
 
-class DagModel(Base):
+class DagModel(Base, TeamOwnedMixin):
     """Table containing DAG properties."""
 
     __tablename__ = "dag"
@@ -481,6 +481,15 @@ class DagModel(Base):
     )
     dag_versions = relationship(
         "DagVersion", back_populates="dag_model", cascade="all, delete, delete-orphan"
+    )
+    # The Dag's bundle, which carries the owning team. ``lazy="raise"`` forbids implicit
+    # loading so a caller that forgets ``eager_load_teams`` cannot emit a silent N+1;
+    # ``TeamOwnedMixin.team_name`` only reads this once loader options have populated it.
+    bundle = relationship(
+        "DagBundleModel",
+        primaryjoin="DagModel.bundle_name == DagBundleModel.name",
+        viewonly=True,
+        lazy="raise",
     )
 
     def __init__(self, **kwargs):

--- a/airflow-core/src/airflow/models/dagbundle.py
+++ b/airflow-core/src/airflow/models/dagbundle.py
@@ -59,6 +59,12 @@ class DagBundleModel(Base, LoggingMixin):
     template_params: Mapped[dict | None] = mapped_column(sa.JSON(), nullable=True)
     teams = relationship("Team", secondary=dag_bundle_team_association_table, back_populates="dag_bundles")
 
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning this bundle, if any."""
+        # unique index on dag_bundle_team.dag_bundle_name -> at most one team
+        return self.teams[0].name if self.teams else None
+
     def __init__(self, *, name: str, version: str | None = None):
         super().__init__()
         self.name = name

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -92,6 +92,7 @@ from airflow.models.taskinstance import TaskInstance as TI, _add_and_prime_mappe
 from airflow.models.taskinstancehistory import TaskInstanceHistory as TIH
 from airflow.models.tasklog import LogTemplate
 from airflow.models.taskmap import TaskMap
+from airflow.models.team import TeamOwnedMixin
 from airflow.serialization.definitions.deadline import SerializedReferenceModels
 from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 from airflow.ti_deps.dep_context import DepContext
@@ -237,7 +238,7 @@ def parent_trace_context(conf) -> context.Context | None:
     return ctx
 
 
-class DagRun(Base, LoggingMixin):
+class DagRun(Base, LoggingMixin, TeamOwnedMixin):
     """
     Invocation instance of a DAG.
 
@@ -393,6 +394,7 @@ class DagRun(Base, LoggingMixin):
     backfill = relationship(Backfill, uselist=False)
     backfill_max_active_runs = association_proxy("backfill", "max_active_runs")
     max_active_runs = association_proxy("dag_model", "max_active_runs")
+    _team_path = ("dag_model",)
 
     note = association_proxy("dag_run_note", "content", creator=_creator_note)
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -92,7 +92,6 @@ from airflow.models.taskinstance import TaskInstance as TI, _add_and_prime_mappe
 from airflow.models.taskinstancehistory import TaskInstanceHistory as TIH
 from airflow.models.tasklog import LogTemplate
 from airflow.models.taskmap import TaskMap
-from airflow.models.team import TeamOwnedMixin
 from airflow.serialization.definitions.deadline import SerializedReferenceModels
 from airflow.serialization.definitions.notset import NOTSET, ArgNotSet, is_arg_set
 from airflow.ti_deps.dep_context import DepContext
@@ -238,7 +237,7 @@ def parent_trace_context(conf) -> context.Context | None:
     return ctx
 
 
-class DagRun(Base, LoggingMixin, TeamOwnedMixin):
+class DagRun(Base, LoggingMixin):
     """
     Invocation instance of a DAG.
 
@@ -394,7 +393,14 @@ class DagRun(Base, LoggingMixin, TeamOwnedMixin):
     backfill = relationship(Backfill, uselist=False)
     backfill_max_active_runs = association_proxy("backfill", "max_active_runs")
     max_active_runs = association_proxy("dag_model", "max_active_runs")
-    _team_path = ("dag_model",)
+
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning this run's Dag, or ``None`` when it is not team-owned."""
+        # Gate before touching ``dag_model``: single-team deployments must not pay for the load.
+        if not airflow_conf.getboolean("core", "multi_team"):
+            return None
+        return self.dag_model.team_name if self.dag_model else None
 
     note = association_proxy("dag_run_note", "content", creator=_creator_note)
 

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -93,7 +93,6 @@ from airflow.models.log import Log
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
-from airflow.models.team import TeamOwnedMixin
 from airflow.models.xcom import XCOM_RETURN_KEY, LazyXComSelectSequence, XComModel
 from airflow.serialization.enums import stringify_encoding_keys
 from airflow.settings import task_instance_mutation_hook
@@ -563,7 +562,7 @@ def uuid7() -> UUID:
     return uuid6.uuid7()
 
 
-class TaskInstance(Base, LoggingMixin, BaseWorkload, TeamOwnedMixin):
+class TaskInstance(Base, LoggingMixin, BaseWorkload):
     """
     Task instances store the state of a task instance.
 
@@ -696,7 +695,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload, TeamOwnedMixin):
 
     run_after = association_proxy("dag_run", "run_after")
     logical_date = association_proxy("dag_run", "logical_date")
-    _team_path = ("dag_run", "dag_model")
+    team_name = association_proxy("dag_run", "team_name")
     task_instance_note = relationship(
         "TaskInstanceNote",
         back_populates="task_instance",

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -93,6 +93,7 @@ from airflow.models.log import Log
 from airflow.models.taskinstancekey import TaskInstanceKey
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
+from airflow.models.team import TeamOwnedMixin
 from airflow.models.xcom import XCOM_RETURN_KEY, LazyXComSelectSequence, XComModel
 from airflow.serialization.enums import stringify_encoding_keys
 from airflow.settings import task_instance_mutation_hook
@@ -562,7 +563,7 @@ def uuid7() -> UUID:
     return uuid6.uuid7()
 
 
-class TaskInstance(Base, LoggingMixin, BaseWorkload):
+class TaskInstance(Base, LoggingMixin, BaseWorkload, TeamOwnedMixin):
     """
     Task instances store the state of a task instance.
 
@@ -695,6 +696,7 @@ class TaskInstance(Base, LoggingMixin, BaseWorkload):
 
     run_after = association_proxy("dag_run", "run_after")
     logical_date = association_proxy("dag_run", "logical_date")
+    _team_path = ("dag_run", "dag_model")
     task_instance_note = relationship(
         "TaskInstanceNote",
         back_populates="task_instance",

--- a/airflow-core/src/airflow/models/team.py
+++ b/airflow-core/src/airflow/models/team.py
@@ -17,11 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from sqlalchemy import Column, ForeignKey, Index, String, Table, select
+from sqlalchemy import Column, ForeignKey, Index, String, Table, inspect as sa_inspect, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from airflow.configuration import conf
 from airflow.models.base import Base, StringID
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -78,3 +79,48 @@ class Team(Base):
         :return: Set of all team names
         """
         return set(session.scalars(select(Team.name)).all())
+
+
+class TeamOwnedMixin:
+    """
+    Exposes ``team_name`` on models that reach a team through a relationship path.
+
+    Teams only exist in multi-team mode, so the config is checked before any hop is
+    walked: single-team deployments answer ``None`` without loading a relationship, and
+    endpoints there pay for no extra join.  In multi-team mode the value comes from the
+    already-loaded relationships when the query applied
+    :func:`~airflow.api_fastapi.common.db.dags.eager_load_teams`, and falls back to the
+    per-Dag cached resolver otherwise — so the attribute stays correct on paths that
+    cannot eager load (an in-memory Dag run, a callback re-fetching by primary key)
+    instead of tripping the ``lazy="raise"`` guard that keeps N+1 loads out.
+    """
+
+    #: Attribute names to walk from ``self`` to the owning :class:`DagModel`.
+    _team_path: ClassVar[tuple[str, ...]] = ()
+
+    if TYPE_CHECKING:
+        # Every model mixing this in carries ``dag_id`` (it is the fallback lookup key).
+        dag_id: str
+
+    @property
+    def team_name(self) -> str | None:
+        """Name of the team owning this entity, or ``None`` when it is not team-owned."""
+        if not conf.getboolean("core", "multi_team"):
+            return None
+
+        from airflow.models.dag import DagModel
+
+        entity: Any = self
+        for attribute in (*self._team_path, "bundle", "teams"):
+            state = sa_inspect(entity)
+            if attribute in state.unloaded:
+                # Reuse this entity's own session. ``get_team_name`` is ``@provide_session``,
+                # and the session it would open is the *same* scoped session the caller is
+                # using, so closing it on exit detaches every object the caller still holds.
+                if state.session is not None:
+                    return DagModel.get_team_name(self.dag_id, session=state.session)
+                return DagModel.get_team_name(self.dag_id)
+            if (entity := getattr(entity, attribute)) is None:
+                return None
+        # A bundle maps to at most one team (unique index on dag_bundle_team.dag_bundle_name).
+        return entity[0].name if entity else None

--- a/airflow-core/src/airflow/models/team.py
+++ b/airflow-core/src/airflow/models/team.py
@@ -17,12 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING
 
-from sqlalchemy import Column, ForeignKey, Index, String, Table, inspect as sa_inspect, select
+from sqlalchemy import Column, ForeignKey, Index, String, Table, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from airflow.configuration import conf
 from airflow.models.base import Base, StringID
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -79,48 +78,3 @@ class Team(Base):
         :return: Set of all team names
         """
         return set(session.scalars(select(Team.name)).all())
-
-
-class TeamOwnedMixin:
-    """
-    Exposes ``team_name`` on models that reach a team through a relationship path.
-
-    Teams only exist in multi-team mode, so the config is checked before any hop is
-    walked: single-team deployments answer ``None`` without loading a relationship, and
-    endpoints there pay for no extra join.  In multi-team mode the value comes from the
-    already-loaded relationships when the query applied
-    :func:`~airflow.api_fastapi.common.db.dags.eager_load_teams`, and falls back to the
-    per-Dag cached resolver otherwise — so the attribute stays correct on paths that
-    cannot eager load (an in-memory Dag run, a callback re-fetching by primary key)
-    instead of tripping the ``lazy="raise"`` guard that keeps N+1 loads out.
-    """
-
-    #: Attribute names to walk from ``self`` to the owning :class:`DagModel`.
-    _team_path: ClassVar[tuple[str, ...]] = ()
-
-    if TYPE_CHECKING:
-        # Every model mixing this in carries ``dag_id`` (it is the fallback lookup key).
-        dag_id: str
-
-    @property
-    def team_name(self) -> str | None:
-        """Name of the team owning this entity, or ``None`` when it is not team-owned."""
-        if not conf.getboolean("core", "multi_team"):
-            return None
-
-        from airflow.models.dag import DagModel
-
-        entity: Any = self
-        for attribute in (*self._team_path, "bundle", "teams"):
-            state = sa_inspect(entity)
-            if attribute in state.unloaded:
-                # Reuse this entity's own session. ``get_team_name`` is ``@provide_session``,
-                # and the session it would open is the *same* scoped session the caller is
-                # using, so closing it on exit detaches every object the caller still holds.
-                if state.session is not None:
-                    return DagModel.get_team_name(self.dag_id, session=state.session)
-                return DagModel.get_team_name(self.dag_id)
-            if (entity := getattr(entity, attribute)) is None:
-                return None
-        # A bundle maps to at most one team (unique index on dag_bundle_team.dag_bundle_name).
-        return entity[0].name if entity else None

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -3247,6 +3247,17 @@ export const $DAGDetailsResponse = {
             title: 'Active Runs Count',
             default: 0
         },
+        team_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Team Name'
+        },
         is_backfillable: {
             type: 'boolean',
             title: 'Is Backfillable',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -901,6 +901,7 @@ export type DAGDetailsResponse = {
 } | null;
     is_favorite?: boolean;
     active_runs_count?: number;
+    team_name?: string | null;
     /**
      * Whether this Dag's schedule supports backfilling.
      */

--- a/airflow-core/src/airflow/ui/src/components/TeamName.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TeamName.test.tsx
@@ -1,0 +1,60 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { TeamName } from "./TeamName";
+
+const mockConfig: Record<string, unknown> = { multi_team: false };
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => mockConfig[key],
+}));
+
+describe("TeamName", () => {
+  beforeEach(() => {
+    mockConfig.multi_team = false;
+  });
+
+  it("links to the Dags list filtered on the team when multi-team is enabled", () => {
+    mockConfig.multi_team = true;
+    render(<TeamName teamName="team a" />, { wrapper: Wrapper });
+
+    expect(screen.getByRole("link", { name: "team a" })).toHaveAttribute("href", "/dags?teams=team%20a");
+  });
+
+  it.each([{ teamName: null }, { teamName: undefined }])(
+    "renders nothing when the team is $teamName",
+    ({ teamName }) => {
+      mockConfig.multi_team = true;
+      render(<TeamName teamName={teamName} />, { wrapper: Wrapper });
+
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    },
+  );
+
+  it("renders nothing when multi-team is disabled", () => {
+    render(<TeamName teamName="team-a" />, { wrapper: Wrapper });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/TeamName.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TeamName.tsx
@@ -1,0 +1,40 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { SearchParamsKeys } from "src/constants/searchParams";
+import { useShowTeam } from "src/hooks/useShowTeam";
+
+import { RouterLink } from "./ui";
+
+type Props = {
+  readonly teamName?: string | null;
+};
+
+export const TeamName = ({ teamName }: Props) => {
+  const showTeam = useShowTeam(teamName);
+
+  if (!showTeam) {
+    return undefined;
+  }
+
+  return (
+    <RouterLink to={`/dags?${SearchParamsKeys.TEAMS}=${encodeURIComponent(teamName as string)}`}>
+      {teamName}
+    </RouterLink>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/hooks/useShowTeam.ts
+++ b/airflow-core/src/airflow/ui/src/hooks/useShowTeam.ts
@@ -1,0 +1,26 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useConfig } from "src/queries/useConfig";
+
+/**
+ * Whether a team should be surfaced at all: teams only exist in multi-team
+ * deployments, and an entity may not be owned by any team.
+ */
+export const useShowTeam = (teamName?: string | null) =>
+  Boolean(useConfig("multi_team")) && teamName !== undefined && teamName !== null;

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -24,12 +24,14 @@ import { useDagServiceGetDagDetails } from "openapi/queries";
 import { DagVersionDetails } from "src/components/DagVersionDetails";
 import RenderedJsonField from "src/components/RenderedJsonField";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+import { ClipboardRoot, ClipboardIconButton, RouterLink } from "src/components/ui";
+import { useConfig } from "src/queries/useConfig";
 import { renderDuration } from "src/utils";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "dag"]);
   const { dagId = "" } = useParams();
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const { data: dag } = useDagServiceGetDagDetails({
     dagId,
@@ -53,6 +55,16 @@ export const Details = () => {
                 </HStack>
               </Table.Cell>
             </Table.Row>
+            {multiTeamEnabled && dag.team_name !== undefined && dag.team_name !== null ? (
+              <Table.Row data-testid="team-row">
+                <Table.Cell>{translate("dagDetails.team")}</Table.Cell>
+                <Table.Cell>
+                  <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name)}`}>
+                    {dag.team_name}
+                  </RouterLink>
+                </Table.Cell>
+              </Table.Row>
+            ) : undefined}
             <Table.Row data-testid="description-row">
               <Table.Cell>{translate("dagDetails.description")}</Table.Cell>
               <Table.Cell>{dag.description}</Table.Cell>

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Details.tsx
@@ -23,19 +23,21 @@ import { useParams } from "react-router-dom";
 import { useDagServiceGetDagDetails } from "openapi/queries";
 import { DagVersionDetails } from "src/components/DagVersionDetails";
 import RenderedJsonField from "src/components/RenderedJsonField";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardIconButton, RouterLink } from "src/components/ui";
-import { useConfig } from "src/queries/useConfig";
+import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+import { useShowTeam } from "src/hooks/useShowTeam";
 import { renderDuration } from "src/utils";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "dag"]);
   const { dagId = "" } = useParams();
-  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const { data: dag } = useDagServiceGetDagDetails({
     dagId,
   });
+
+  const showTeam = useShowTeam(dag?.team_name);
 
   return (
     <Box p={2}>
@@ -55,13 +57,11 @@ export const Details = () => {
                 </HStack>
               </Table.Cell>
             </Table.Row>
-            {multiTeamEnabled && dag.team_name !== undefined && dag.team_name !== null ? (
+            {showTeam ? (
               <Table.Row data-testid="team-row">
                 <Table.Cell>{translate("dagDetails.team")}</Table.Cell>
                 <Table.Cell>
-                  <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name)}`}>
-                    {dag.team_name}
-                  </RouterLink>
+                  <TeamName teamName={dag.team_name} />
                 </Table.Cell>
               </Table.Row>
             ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -19,13 +19,19 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 import type { DAGDetailsResponse } from "openapi-gen/requests/types.gen";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import i18n from "src/i18n/config";
 import { MOCK_DAG } from "src/mocks/handlers/dag";
 import { Wrapper } from "src/utils/Wrapper";
 
 import { Header } from "./Header";
+
+const mockConfig: Record<string, unknown> = { multi_team: false };
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => mockConfig[key],
+}));
 
 const mockDag = {
   ...MOCK_DAG,
@@ -50,6 +56,10 @@ const mockDag = {
 } as unknown as DAGDetailsResponse;
 
 describe("Header", () => {
+  afterEach(() => {
+    mockConfig.multi_team = false;
+  });
+
   it("shows a deactivated badge and hides stale-only next actions for stale dags", () => {
     render(
       <Wrapper>
@@ -70,5 +80,30 @@ describe("Header", () => {
 
     expect(screen.getByText(i18n.t("dag:dagDetails.nextRun"))).toBeInTheDocument();
     expect(screen.queryByText("2024-08-22 19:00:00")).not.toBeInTheDocument();
+  });
+
+  it("replaces the owner stat with the team when multi-team is enabled", () => {
+    mockConfig.multi_team = true;
+    render(
+      <Wrapper>
+        <Header dag={{ ...mockDag, team_name: "team-a" }} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText(i18n.t("common:dagDetails.team"))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "team-a" })).toHaveAttribute("href", "/dags?teams=team-a");
+    expect(screen.queryByText(i18n.t("common:dagDetails.owner"))).not.toBeInTheDocument();
+  });
+
+  it("shows the owner stat when multi-team is enabled but no team is resolved", () => {
+    mockConfig.multi_team = true;
+    render(
+      <Wrapper>
+        <Header dag={{ ...mockDag, team_name: null }} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText(i18n.t("common:dagDetails.owner"))).toBeInTheDocument();
+    expect(screen.queryByText(i18n.t("common:dagDetails.team"))).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.test.tsx
@@ -82,7 +82,7 @@ describe("Header", () => {
     expect(screen.queryByText("2024-08-22 19:00:00")).not.toBeInTheDocument();
   });
 
-  it("replaces the owner stat with the team when multi-team is enabled", () => {
+  it("shows the team alongside the owner when multi-team is enabled", () => {
     mockConfig.multi_team = true;
     render(
       <Wrapper>
@@ -92,7 +92,7 @@ describe("Header", () => {
 
     expect(screen.getByText(i18n.t("common:dagDetails.team"))).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "team-a" })).toHaveAttribute("href", "/dags?teams=team-a");
-    expect(screen.queryByText(i18n.t("common:dagDetails.owner"))).not.toBeInTheDocument();
+    expect(screen.getByText(i18n.t("common:dagDetails.owner"))).toBeInTheDocument();
   });
 
   it("shows the owner stat when multi-team is enabled but no team is resolved", () => {

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -32,6 +32,7 @@ import { HeaderCard } from "src/components/HeaderCard";
 import { NeedsReviewButtonWithModal } from "src/components/NeedsReviewButton";
 import { TogglePause } from "src/components/TogglePause";
 import { RouterLink } from "src/components/ui";
+import { useConfig } from "src/queries/useConfig";
 
 import { DagOwners } from "../DagsList/DagOwners";
 import { DagTags } from "../DagsList/DagTags";
@@ -58,6 +59,8 @@ export const Header = ({
   const { t: translate } = useTranslation(["common", "dag"]);
   // We would still like to show the dagId even if the dag object hasn't loaded yet
   const { dagId } = useParams();
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
+  const showTeam = multiTeamEnabled && dag?.team_name !== undefined && dag.team_name !== null;
   const isStale = dag?.is_stale;
 
   const nextRunStat = isStale
@@ -112,10 +115,19 @@ export const Header = ({
           ? undefined
           : `${dag.active_runs_count ?? 0} of ${dag.max_active_runs}`,
     },
-    {
-      label: translate("dagDetails.owner"),
-      value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
-    },
+    showTeam
+      ? {
+          label: translate("dagDetails.team"),
+          value: (
+            <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name as string)}`}>
+              {dag.team_name}
+            </RouterLink>
+          ),
+        }
+      : {
+          label: translate("dagDetails.owner"),
+          value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
+        },
     {
       label: translate("dagDetails.tags"),
       value: <DagTags tags={dag?.tags ?? []} />,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -30,9 +30,10 @@ import { DagVersion } from "src/components/DagVersion";
 import DisplayMarkdownButton from "src/components/DisplayMarkdownButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import { NeedsReviewButtonWithModal } from "src/components/NeedsReviewButton";
+import { TeamName } from "src/components/TeamName";
 import { TogglePause } from "src/components/TogglePause";
 import { RouterLink } from "src/components/ui";
-import { useConfig } from "src/queries/useConfig";
+import { useShowTeam } from "src/hooks/useShowTeam";
 
 import { DagOwners } from "../DagsList/DagOwners";
 import { DagTags } from "../DagsList/DagTags";
@@ -59,8 +60,7 @@ export const Header = ({
   const { t: translate } = useTranslation(["common", "dag"]);
   // We would still like to show the dagId even if the dag object hasn't loaded yet
   const { dagId } = useParams();
-  const multiTeamEnabled = Boolean(useConfig("multi_team"));
-  const showTeam = multiTeamEnabled && dag?.team_name !== undefined && dag.team_name !== null;
+  const showTeam = useShowTeam(dag?.team_name);
   const isStale = dag?.is_stale;
 
   const nextRunStat = isStale
@@ -115,19 +115,18 @@ export const Header = ({
           ? undefined
           : `${dag.active_runs_count ?? 0} of ${dag.max_active_runs}`,
     },
-    showTeam
-      ? {
-          label: translate("dagDetails.team"),
-          value: (
-            <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name as string)}`}>
-              {dag.team_name}
-            </RouterLink>
-          ),
-        }
-      : {
-          label: translate("dagDetails.owner"),
-          value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
-        },
+    {
+      label: translate("dagDetails.owner"),
+      value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
+    },
+    ...(showTeam
+      ? [
+          {
+            label: translate("dagDetails.team"),
+            value: <TeamName teamName={dag?.team_name} />,
+          },
+        ]
+      : []),
     {
       label: translate("dagDetails.tags"),
       value: <DagTags tags={dag?.tags ?? []} />,

--- a/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dag/Header.tsx
@@ -115,19 +115,22 @@ export const Header = ({
           ? undefined
           : `${dag.active_runs_count ?? 0} of ${dag.max_active_runs}`,
     },
-    showTeam
-      ? {
-          label: translate("dagDetails.team"),
-          value: (
-            <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name as string)}`}>
-              {dag.team_name}
-            </RouterLink>
-          ),
-        }
-      : {
-          label: translate("dagDetails.owner"),
-          value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
-        },
+    {
+      label: translate("dagDetails.owner"),
+      value: <DagOwners ownerLinks={dag?.owner_links ?? undefined} owners={dag?.owners} />,
+    },
+    ...(showTeam
+      ? [
+          {
+            label: translate("dagDetails.team"),
+            value: (
+              <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name as string)}`}>
+                {dag.team_name}
+              </RouterLink>
+            ),
+          },
+        ]
+      : []),
     {
       label: translate("dagDetails.tags"),
       value: <DagTags tags={dag?.tags ?? []} />,

--- a/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
@@ -42,6 +42,7 @@ import { MarkRunAsButton } from "src/components/MarkAs";
 import RenderedJsonField from "src/components/RenderedJsonField";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
 import { RouterLink } from "src/components/ui";
@@ -160,12 +161,7 @@ const runColumns = ({ dagId, multiTeam, open, translate }: ColumnProps): Array<C
     ? [
         {
           accessorKey: "team_name",
-          cell: ({ row: { original } }: DagRunRow) =>
-            original.team_name !== undefined && original.team_name !== null ? (
-              <RouterLink to={`/dags?teams=${encodeURIComponent(original.team_name)}`}>
-                {original.team_name}
-              </RouterLink>
-            ) : undefined,
+          cell: ({ row: { original } }: DagRunRow) => <TeamName teamName={original.team_name} />,
           enableSorting: false,
           header: translate("dagDetails.team"),
         },

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagCard.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
 import DagRunInfo from "src/components/DagRunInfo";
 import { Stat } from "src/components/Stat";
+import { TeamName } from "src/components/TeamName";
 import { RouterLink, Tooltip } from "src/components/ui";
 import { useNearViewport } from "src/hooks/useNearViewport";
 import { useConfig } from "src/queries/useConfig";
@@ -125,11 +126,7 @@ export const DagCard = ({ dag, runStateCounts, runStateCountsLoading, stateCount
         {multiTeamEnabled ? (
           <GridItem gridColumn={4} gridRow={1}>
             <Stat label={translate("dagDetails.team")}>
-              {dag.team_name === undefined || dag.team_name === null ? undefined : (
-                <RouterLink to={`/dags?teams=${encodeURIComponent(dag.team_name)}`}>
-                  {dag.team_name}
-                </RouterLink>
-              )}
+              <TeamName teamName={dag.team_name} />
             </Stat>
           </GridItem>
         ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -32,6 +32,7 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { NeedsReviewBadge } from "src/components/NeedsReviewBadge";
 import { SearchBar } from "src/components/SearchBar";
+import { TeamName } from "src/components/TeamName";
 import { TogglePause } from "src/components/TogglePause";
 import { TriggerDAGButton } from "src/components/TriggerDag/TriggerDAGButton";
 import { RouterLink } from "src/components/ui";
@@ -164,10 +165,9 @@ const createColumns = (
     ? [
         {
           accessorKey: "team_name",
-          cell: ({ row: { original } }: { row: { original: DAGWithLatestDagRunsResponse } }) =>
-            original.team_name !== undefined && original.team_name !== null ? (
-              <RouterLink to={`/dags?teams=${original.team_name}`}>{original.team_name}</RouterLink>
-            ) : undefined,
+          cell: ({ row: { original } }: { row: { original: DAGWithLatestDagRunsResponse } }) => (
+            <TeamName teamName={original.team_name} />
+          ),
           enableSorting: false,
           header: () => translate("dagDetails.team"),
         },

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -26,12 +26,14 @@ import RenderedJsonField from "src/components/RenderedJsonField";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+import { ClipboardRoot, ClipboardIconButton, RouterLink } from "src/components/ui";
+import { useConfig } from "src/queries/useConfig";
 import { getDuration, isStatePending, renderDuration, useAutoRefresh } from "src/utils";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "components"]);
   const { dagId = "", runId = "" } = useParams();
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const refetchInterval = useAutoRefresh({ dagId });
 
@@ -82,6 +84,16 @@ export const Details = () => {
             </HStack>
           </Table.Cell>
         </Table.Row>
+        {multiTeamEnabled && dagRun.team_name !== undefined && dagRun.team_name !== null ? (
+          <Table.Row>
+            <Table.Cell>{translate("dagDetails.team")}</Table.Cell>
+            <Table.Cell>
+              <RouterLink to={`/dags?teams=${encodeURIComponent(dagRun.team_name)}`}>
+                {dagRun.team_name}
+              </RouterLink>
+            </Table.Cell>
+          </Table.Row>
+        ) : undefined}
         <Table.Row>
           <Table.Cell>{translate("duration")}</Table.Cell>
           <Table.Cell>{getDuration(dagRun.start_date, dagRun.end_date)}</Table.Cell>

--- a/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Details.tsx
@@ -25,15 +25,15 @@ import { DagVersionDetails } from "src/components/DagVersionDetails";
 import RenderedJsonField from "src/components/RenderedJsonField";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import { StateBadge } from "src/components/StateBadge";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardIconButton, RouterLink } from "src/components/ui";
-import { useConfig } from "src/queries/useConfig";
+import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+import { useShowTeam } from "src/hooks/useShowTeam";
 import { getDuration, isStatePending, renderDuration, useAutoRefresh } from "src/utils";
 
 export const Details = () => {
   const { t: translate } = useTranslation(["common", "components"]);
   const { dagId = "", runId = "" } = useParams();
-  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const refetchInterval = useAutoRefresh({ dagId });
 
@@ -47,6 +47,8 @@ export const Details = () => {
   );
 
   const { data: dagRunStats } = useDagRunServiceGetDagRunStats({ dagId, dagRunId: runId });
+
+  const showTeam = useShowTeam(dagRun?.team_name);
 
   if (!dagRun) {
     return undefined;
@@ -84,13 +86,11 @@ export const Details = () => {
             </HStack>
           </Table.Cell>
         </Table.Row>
-        {multiTeamEnabled && dagRun.team_name !== undefined && dagRun.team_name !== null ? (
+        {showTeam ? (
           <Table.Row>
             <Table.Cell>{translate("dagDetails.team")}</Table.Cell>
             <Table.Cell>
-              <RouterLink to={`/dags?teams=${encodeURIComponent(dagRun.team_name)}`}>
-                {dagRun.team_name}
-              </RouterLink>
+              <TeamName teamName={dagRun.team_name} />
             </Table.Cell>
           </Table.Row>
         ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.test.tsx
@@ -45,6 +45,12 @@ vi.mock("openapi/queries", async (importOriginal) => {
   };
 });
 
+const mockConfig: Record<string, unknown> = { multi_team: false };
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => mockConfig[key],
+}));
+
 const { useDeadlinesServiceGetDagDeadlineAlerts } = await import("openapi/queries");
 
 const baseDagRun = {
@@ -73,6 +79,7 @@ const baseDagRun = {
 
 describe("Header", () => {
   beforeEach(() => {
+    mockConfig.multi_team = false;
     vi.mocked(useDeadlinesServiceGetDagDeadlineAlerts).mockReturnValue({
       data: undefined,
     } as ReturnType<typeof useDeadlinesServiceGetDagDeadlineAlerts>);
@@ -90,5 +97,19 @@ describe("Header", () => {
     render(<Header dagRun={{ ...baseDagRun, partition_key: null }} />, { wrapper: Wrapper });
 
     expect(screen.queryByText(i18n.t("dagRun.partitionKey"))).not.toBeInTheDocument();
+  });
+
+  it("shows the team stat when multi-team is enabled and a team is resolved", () => {
+    mockConfig.multi_team = true;
+    render(<Header dagRun={{ ...baseDagRun, team_name: "team-a" }} />, { wrapper: Wrapper });
+
+    expect(screen.getByText(i18n.t("common:dagDetails.team"))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "team-a" })).toHaveAttribute("href", "/dags?teams=team-a");
+  });
+
+  it("hides the team stat when multi-team is disabled", () => {
+    render(<Header dagRun={{ ...baseDagRun, team_name: "team-a" }} />, { wrapper: Wrapper });
+
+    expect(screen.queryByText(i18n.t("common:dagDetails.team"))).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -34,6 +34,7 @@ import Time from "src/components/Time";
 import { RouterLink } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import DeleteRunButton from "src/pages/DagRuns/DeleteRunButton";
+import { useConfig } from "src/queries/useConfig";
 import { useDagRunNote } from "src/queries/useDagRunNote";
 import { getDuration } from "src/utils";
 
@@ -42,6 +43,7 @@ import { DeadlineStatus } from "./DeadlineStatus";
 export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
   const { t: translate } = useTranslation();
   const { isPending, note, onOpen, onSave, setNote } = useDagRunNote(dagRun);
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
@@ -105,6 +107,18 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
                   ),
                 },
               ]),
+          ...(multiTeamEnabled && dagRun.team_name !== undefined && dagRun.team_name !== null
+            ? [
+                {
+                  label: translate("dagDetails.team"),
+                  value: (
+                    <RouterLink to={`/dags?teams=${encodeURIComponent(dagRun.team_name)}`}>
+                      <Text>{dagRun.team_name}</Text>
+                    </RouterLink>
+                  ),
+                },
+              ]
+            : []),
           {
             label: translate("dagRun.dagVersions"),
             value: (

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -30,11 +30,12 @@ import { MarkRunAsButton } from "src/components/MarkAs";
 import { NeedsReviewButtonWithModal } from "src/components/NeedsReviewButton";
 import NotePreview from "src/components/NotePreview";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 import { RouterLink } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { useShowTeam } from "src/hooks/useShowTeam";
 import DeleteRunButton from "src/pages/DagRuns/DeleteRunButton";
-import { useConfig } from "src/queries/useConfig";
 import { useDagRunNote } from "src/queries/useDagRunNote";
 import { getDuration } from "src/utils";
 
@@ -43,7 +44,7 @@ import { DeadlineStatus } from "./DeadlineStatus";
 export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
   const { t: translate } = useTranslation();
   const { isPending, note, onOpen, onSave, setNote } = useDagRunNote(dagRun);
-  const multiTeamEnabled = Boolean(useConfig("multi_team"));
+  const showTeam = useShowTeam(dagRun.team_name);
 
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
@@ -107,15 +108,11 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
                   ),
                 },
               ]),
-          ...(multiTeamEnabled && dagRun.team_name !== undefined && dagRun.team_name !== null
+          ...(showTeam
             ? [
                 {
                   label: translate("dagDetails.team"),
-                  value: (
-                    <RouterLink to={`/dags?teams=${encodeURIComponent(dagRun.team_name)}`}>
-                      <Text>{dagRun.team_name}</Text>
-                    </RouterLink>
-                  ),
+                  value: <TeamName teamName={dagRun.team_name} />,
                 },
               ]
             : []),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -30,8 +30,9 @@ import RenderedJsonField from "src/components/RenderedJsonField";
 import { StateBadge } from "src/components/StateBadge";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
+import { ClipboardRoot, ClipboardIconButton, RouterLink } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
+import { useConfig } from "src/queries/useConfig";
 import { useAutoRefresh, isStatePending, renderDuration } from "src/utils";
 
 import { BlockingDeps } from "./BlockingDeps";
@@ -42,6 +43,7 @@ export const Details = () => {
   const { t: translate } = useTranslation();
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const tryNumberParam = searchParams.get(SearchParamsKeys.TRY_NUMBER);
   const parsedMapIndex = parseInt(mapIndex, 10);
@@ -179,6 +181,16 @@ export const Details = () => {
             <Table.Cell>{translate("mapIndex")}</Table.Cell>
             <Table.Cell>{tryInstance?.map_index}</Table.Cell>
           </Table.Row>
+          {multiTeamEnabled && taskInstance?.team_name !== undefined && taskInstance.team_name !== null ? (
+            <Table.Row>
+              <Table.Cell>{translate("dagDetails.team")}</Table.Cell>
+              <Table.Cell>
+                <RouterLink to={`/dags?teams=${encodeURIComponent(taskInstance.team_name)}`}>
+                  {taskInstance.team_name}
+                </RouterLink>
+              </Table.Cell>
+            </Table.Row>
+          ) : undefined}
           <Table.Row>
             <Table.Cell>{translate("task.operator")}</Table.Cell>
             <Table.Cell>{tryInstance?.operator_name}</Table.Cell>

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Details.tsx
@@ -29,10 +29,11 @@ import { DagVersionDetails } from "src/components/DagVersionDetails";
 import RenderedJsonField from "src/components/RenderedJsonField";
 import { StateBadge } from "src/components/StateBadge";
 import { TaskTrySelect } from "src/components/TaskTrySelect";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
-import { ClipboardRoot, ClipboardIconButton, RouterLink } from "src/components/ui";
+import { ClipboardRoot, ClipboardIconButton } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
-import { useConfig } from "src/queries/useConfig";
+import { useShowTeam } from "src/hooks/useShowTeam";
 import { useAutoRefresh, isStatePending, renderDuration } from "src/utils";
 
 import { BlockingDeps } from "./BlockingDeps";
@@ -43,7 +44,6 @@ export const Details = () => {
   const { t: translate } = useTranslation();
   const { dagId = "", mapIndex = "-1", runId = "", taskId = "" } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
-  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const tryNumberParam = searchParams.get(SearchParamsKeys.TRY_NUMBER);
   const parsedMapIndex = parseInt(mapIndex, 10);
@@ -60,6 +60,8 @@ export const Details = () => {
       enabled: !isNaN(parsedMapIndex),
     },
   );
+
+  const showTeam = useShowTeam(taskInstance?.team_name);
 
   const onSelectTryNumber = (newTryNumber: number) => {
     if (newTryNumber === taskInstance?.try_number) {
@@ -181,13 +183,11 @@ export const Details = () => {
             <Table.Cell>{translate("mapIndex")}</Table.Cell>
             <Table.Cell>{tryInstance?.map_index}</Table.Cell>
           </Table.Row>
-          {multiTeamEnabled && taskInstance?.team_name !== undefined && taskInstance.team_name !== null ? (
+          {showTeam ? (
             <Table.Row>
               <Table.Cell>{translate("dagDetails.team")}</Table.Cell>
               <Table.Cell>
-                <RouterLink to={`/dags?teams=${encodeURIComponent(taskInstance.team_name)}`}>
-                  {taskInstance.team_name}
-                </RouterLink>
+                <TeamName teamName={taskInstance?.team_name} />
               </Table.Cell>
             </Table.Row>
           ) : undefined}

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.test.tsx
@@ -1,0 +1,78 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import i18n from "src/i18n/config";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { Header } from "./Header";
+
+// Action buttons and note preview pull in mutation/permission wiring that is
+// unrelated to the team stat under test; stub them out so the test only
+// depends on the stats rendered by Header itself.
+vi.mock("src/components/Clear", () => ({ ClearTaskInstanceButton: () => undefined }));
+vi.mock("src/components/Clear/TaskInstance/ClearTaskInstanceDialog", () => ({ default: () => undefined }));
+vi.mock("src/components/MarkAs", () => ({ MarkTaskInstanceAsButton: () => undefined }));
+vi.mock("src/components/NotePreview", () => ({ default: () => undefined }));
+
+const mockConfig: Record<string, unknown> = { multi_team: false };
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => mockConfig[key],
+}));
+
+const baseTaskInstance = {
+  dag_id: "test_dag",
+  dag_run_id: "run_1",
+  dag_version: null,
+  duration: null,
+  end_date: null,
+  map_index: -1,
+  note: null,
+  operator_name: "PythonOperator",
+  rendered_map_index: null,
+  start_date: null,
+  state: "success",
+  task_display_name: "test_task",
+  task_id: "test_task",
+  try_number: 1,
+} satisfies Partial<TaskInstanceResponse> as unknown as TaskInstanceResponse;
+
+describe("Header", () => {
+  beforeEach(() => {
+    mockConfig.multi_team = false;
+  });
+
+  it("shows the team stat when multi-team is enabled and a team is resolved", () => {
+    mockConfig.multi_team = true;
+    render(<Header taskInstance={{ ...baseTaskInstance, team_name: "team-a" }} />, { wrapper: Wrapper });
+
+    expect(screen.getByText(i18n.t("common:dagDetails.team"))).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "team-a" })).toHaveAttribute("href", "/dags?teams=team-a");
+  });
+
+  it("hides the team stat when multi-team is disabled", () => {
+    render(<Header taskInstance={{ ...baseTaskInstance, team_name: "team-a" }} />, { wrapper: Wrapper });
+
+    expect(screen.queryByText(i18n.t("common:dagDetails.team"))).not.toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -29,12 +29,15 @@ import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import NotePreview from "src/components/NotePreview";
 import Time from "src/components/Time";
+import { RouterLink } from "src/components/ui";
+import { useConfig } from "src/queries/useConfig";
 import { useTaskInstanceNote } from "src/queries/useTaskInstanceNote";
 import { getDuration, renderDuration } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
   const { t: translate } = useTranslation();
   const { isPending, note, onOpen, onSave, setNote } = useTaskInstanceNote(taskInstance);
+  const multiTeamEnabled = Boolean(useConfig("multi_team"));
 
   const stats = [
     { label: translate("task.operator"), value: taskInstance.operator_name },
@@ -53,6 +56,18 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
             value: Boolean(taskInstance.duration)
               ? renderDuration(taskInstance.duration)
               : getDuration(taskInstance.start_date, taskInstance.end_date),
+          },
+        ]
+      : []),
+    ...(multiTeamEnabled && taskInstance.team_name !== undefined && taskInstance.team_name !== null
+      ? [
+          {
+            label: translate("dagDetails.team"),
+            value: (
+              <RouterLink to={`/dags?teams=${encodeURIComponent(taskInstance.team_name)}`}>
+                {taskInstance.team_name}
+              </RouterLink>
+            ),
           },
         ]
       : []),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -28,16 +28,16 @@ import { DagVersion } from "src/components/DagVersion";
 import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import NotePreview from "src/components/NotePreview";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
-import { RouterLink } from "src/components/ui";
-import { useConfig } from "src/queries/useConfig";
+import { useShowTeam } from "src/hooks/useShowTeam";
 import { useTaskInstanceNote } from "src/queries/useTaskInstanceNote";
 import { getDuration, renderDuration } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
   const { t: translate } = useTranslation();
   const { isPending, note, onOpen, onSave, setNote } = useTaskInstanceNote(taskInstance);
-  const multiTeamEnabled = Boolean(useConfig("multi_team"));
+  const showTeam = useShowTeam(taskInstance.team_name);
 
   const stats = [
     { label: translate("task.operator"), value: taskInstance.operator_name },
@@ -59,15 +59,11 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
           },
         ]
       : []),
-    ...(multiTeamEnabled && taskInstance.team_name !== undefined && taskInstance.team_name !== null
+    ...(showTeam
       ? [
           {
             label: translate("dagDetails.team"),
-            value: (
-              <RouterLink to={`/dags?teams=${encodeURIComponent(taskInstance.team_name)}`}>
-                {taskInstance.team_name}
-              </RouterLink>
-            ),
+            value: <TeamName teamName={taskInstance.team_name} />,
           },
         ]
       : []),

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstances/TaskInstances.tsx
@@ -38,6 +38,7 @@ import { useTableURLState } from "src/components/DataTable/useTableUrlState";
 import { ErrorAlert } from "src/components/ErrorAlert";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import { StateBadge } from "src/components/StateBadge";
+import { TeamName } from "src/components/TeamName";
 import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
 import { RouterLink } from "src/components/ui";
@@ -181,12 +182,7 @@ const taskInstanceColumns = ({
     ? [
         {
           accessorKey: "team_name",
-          cell: ({ row: { original } }: TaskInstanceRow) =>
-            original.team_name !== undefined && original.team_name !== null ? (
-              <RouterLink to={`/dags?teams=${encodeURIComponent(original.team_name)}`}>
-                {original.team_name}
-              </RouterLink>
-            ) : undefined,
+          cell: ({ row: { original } }: TaskInstanceRow) => <TeamName teamName={original.team_name} />,
           enableSorting: false,
           header: translate("dagDetails.team"),
         },

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -413,6 +413,25 @@ class TestGetDagRun:
         assert body["triggered_by"] == triggered_by.value
         assert body["note"] == dag_run_note
 
+    @conf_vars({("core", "multi_team"): "True"})
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    def test_get_dag_run_includes_team_name(self, test_client, session):
+        original_bundle_name = _attach_dag_to_team(
+            session, DAG1_ID, bundle_name="team-bundle-run", team_name="team-run"
+        )
+        try:
+            response = test_client.get(f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}")
+            assert response.status_code == 200
+            assert response.json()["team_name"] == "team-run"
+        finally:
+            _detach_dag_from_team(
+                session,
+                DAG1_ID,
+                bundle_name="team-bundle-run",
+                team_name="team-run",
+                original_bundle_name=original_bundle_name,
+            )
+
     def test_get_dag_run_not_found(self, test_client):
         response = test_client.get(f"/dags/{DAG1_ID}/dagRuns/invalid")
         assert response.status_code == 404

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dags.py
@@ -21,17 +21,20 @@ from unittest import mock
 
 import pendulum
 import pytest
-from sqlalchemy import insert, select
+from sqlalchemy import delete, insert, select, update
 
 from airflow.models.asset import AssetModel, DagScheduleAssetReference
 from airflow.models.dag import DagModel, DagTag
 from airflow.models.dag_favorite import DagFavorite
+from airflow.models.dagbundle import DagBundleModel
 from airflow.models.dagrun import DagRun
+from airflow.models.team import Team
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 from tests_common.test_utils.asserts import assert_queries_count, count_queries
+from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import (
     clear_db_assets,
     clear_db_connections,
@@ -1082,6 +1085,7 @@ class TestDagDetails(TestDagEndpoint):
             "timetable_periodic": False,
             "timetable_summary": None,
             "timezone": UTC_JSON_REPR,
+            "team_name": None,
         }
         assert res_json == expected
 
@@ -1184,6 +1188,7 @@ class TestDagDetails(TestDagEndpoint):
             "timetable_partitioned": False,
             "timetable_periodic": False,
             "timezone": UTC_JSON_REPR,
+            "team_name": None,
         }
         assert res_json == expected
 
@@ -1288,6 +1293,35 @@ class TestDagDetails(TestDagEndpoint):
         assert "active_runs_count" in body
         assert isinstance(body["active_runs_count"], int)
         assert body["active_runs_count"] == 0
+
+    def test_dag_details_team_name_none_without_multi_team(self, test_client):
+        """Without multi-team enabled, ``team_name`` stays ``None`` and no lookup happens."""
+        response = test_client.get(f"/dags/{DAG1_ID}/details")
+        assert response.status_code == 200
+        assert response.json()["team_name"] is None
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_dag_details_includes_team_name(self, session, test_client):
+        original_bundle_name = session.scalar(select(DagModel.bundle_name).where(DagModel.dag_id == DAG1_ID))
+        bundle = DagBundleModel(name="team-bundle-details")
+        bundle.teams.append(Team(name="team-details"))
+        session.add(bundle)
+        session.flush()
+        session.execute(
+            update(DagModel).where(DagModel.dag_id == DAG1_ID).values(bundle_name="team-bundle-details")
+        )
+        session.commit()
+        try:
+            response = test_client.get(f"/dags/{DAG1_ID}/details")
+            assert response.status_code == 200
+            assert response.json()["team_name"] == "team-details"
+        finally:
+            session.execute(
+                update(DagModel).where(DagModel.dag_id == DAG1_ID).values(bundle_name=original_bundle_name)
+            )
+            session.execute(delete(DagBundleModel).where(DagBundleModel.name == "team-bundle-details"))
+            session.execute(delete(Team).where(Team.name == "team-details"))
+            session.commit()
 
 
 class TestGetDag(TestDagEndpoint):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_task_instances.py
@@ -274,6 +274,27 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "team_name": None,
         }
 
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_should_include_team_name(self, test_client, session):
+        self.create_task_instances(session)
+        original_bundle_name = _attach_dag_to_team(
+            session, "example_python_operator", bundle_name="team-bundle-ti", team_name="team-ti"
+        )
+        try:
+            response = test_client.get(
+                "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context"
+            )
+            assert response.status_code == 200
+            assert response.json()["team_name"] == "team-ti"
+        finally:
+            _detach_dag_from_team(
+                session,
+                "example_python_operator",
+                bundle_name="team-bundle-ti",
+                team_name="team-ti",
+                original_bundle_name=original_bundle_name,
+            )
+
     def test_should_respond_200_with_decorator(self, test_client, session):
         self.create_task_instances(session, "example_python_decorator")
         response = test_client.get(
@@ -700,6 +721,30 @@ class TestGetMappedTaskInstance(TestTaskInstanceEndpoint):
         assert response.json() == {
             "detail": "The Mapped Task Instance with dag_id: `example_python_operator`, run_id: `TEST_DAG_RUN_ID`, task_id: `print_the_context`, and map_index: `10` was not found"
         }
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_should_include_team_name(self, test_client, session):
+        self.create_task_instances(session)
+        original_bundle_name = _attach_dag_to_team(
+            session,
+            "example_python_operator",
+            bundle_name="team-bundle-mapped-ti",
+            team_name="team-mapped-ti",
+        )
+        try:
+            response = test_client.get(
+                "/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context/-1",
+            )
+            assert response.status_code == 200
+            assert response.json()["team_name"] == "team-mapped-ti"
+        finally:
+            _detach_dag_from_team(
+                session,
+                "example_python_operator",
+                bundle_name="team-bundle-mapped-ti",
+                team_name="team-mapped-ti",
+                original_bundle_name=original_bundle_name,
+            )
 
 
 class TestGetMappedTaskInstances:

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1032,6 +1032,65 @@ class TestTIRunState:
         assert response.status_code == 200
         assert response.json()["dag_run"]["team_name"] == (team_name if expect_team else None)
 
+    def test_ti_run_team_name_is_not_served_from_a_stale_cache(
+        self, client, session, dag_maker, time_machine
+    ):
+        """
+        ``ti_run`` must eager load the team rather than fall back to the cached resolver.
+
+        The fallback caches per dag_id for ``team_name_cache_ttl`` seconds, so a Dag whose team
+        was looked up before it moved bundles would keep reporting the old team to the worker.
+        """
+        from airflow.models.dag import clear_team_name_cache
+        from airflow.models.dagbundle import DagBundleModel
+        from airflow.models.team import Team
+
+        instant = timezone.parse("2024-09-30T12:00:00Z")
+        time_machine.move_to(instant, tick=False)
+
+        dag_id = str(uuid4())
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id="task")
+        dr = dag_maker.create_dagrun(
+            run_id="test", logical_date=instant, state=DagRunState.RUNNING, start_date=instant
+        )
+        ti = dr.get_task_instance(task_id="task")
+        ti.set_state(State.QUEUED)
+
+        for suffix in ("old", "new"):
+            bundle = DagBundleModel(name=f"bundle-{suffix}-{dag_id}")
+            bundle.teams.append(Team(name=f"team-{suffix}-{dag_id[:8]}"))
+            session.add(bundle)
+        session.flush()
+        session.execute(
+            update(DagModel).where(DagModel.dag_id == dag_id).values(bundle_name=f"bundle-old-{dag_id}")
+        )
+        session.commit()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            clear_team_name_cache()
+            # Warm the cache with the old team, then move the Dag to the other bundle.
+            assert DagModel.get_team_name(dag_id, session=session) == f"team-old-{dag_id[:8]}"
+            session.execute(
+                update(DagModel).where(DagModel.dag_id == dag_id).values(bundle_name=f"bundle-new-{dag_id}")
+            )
+            session.commit()
+
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "h",
+                    "unixname": "u",
+                    "pid": 1,
+                    "start_date": "2024-09-30T12:00:00Z",
+                },
+            )
+            clear_team_name_cache()
+
+        assert response.status_code == 200
+        assert response.json()["dag_run"]["team_name"] == f"team-new-{dag_id[:8]}"
+
     def test_ti_run_creates_audit_log(self, client, session, create_task_instance, time_machine):
         """Test that transitioning to RUNNING creates an audit log record."""
         instant_str = "2024-09-30T12:00:00Z"

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1031,6 +1031,65 @@ class TestTIRunState:
         assert response.status_code == 200
         assert response.json()["dag_run"]["team_name"] == (team_name if expect_team else None)
 
+    def test_ti_run_team_name_is_not_served_from_a_stale_cache(
+        self, client, session, dag_maker, time_machine
+    ):
+        """
+        ``ti_run`` must eager load the team rather than fall back to the cached resolver.
+
+        The fallback caches per dag_id for ``team_name_cache_ttl`` seconds, so a Dag whose team
+        was looked up before it moved bundles would keep reporting the old team to the worker.
+        """
+        from airflow.models.dag import clear_team_name_cache
+        from airflow.models.dagbundle import DagBundleModel
+        from airflow.models.team import Team
+
+        instant = timezone.parse("2024-09-30T12:00:00Z")
+        time_machine.move_to(instant, tick=False)
+
+        dag_id = str(uuid4())
+        with dag_maker(dag_id=dag_id, session=session):
+            EmptyOperator(task_id="task")
+        dr = dag_maker.create_dagrun(
+            run_id="test", logical_date=instant, state=DagRunState.RUNNING, start_date=instant
+        )
+        ti = dr.get_task_instance(task_id="task")
+        ti.set_state(State.QUEUED)
+
+        for suffix in ("old", "new"):
+            bundle = DagBundleModel(name=f"bundle-{suffix}-{dag_id}")
+            bundle.teams.append(Team(name=f"team-{suffix}-{dag_id[:8]}"))
+            session.add(bundle)
+        session.flush()
+        session.execute(
+            update(DagModel).where(DagModel.dag_id == dag_id).values(bundle_name=f"bundle-old-{dag_id}")
+        )
+        session.commit()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            clear_team_name_cache()
+            # Warm the cache with the old team, then move the Dag to the other bundle.
+            assert DagModel.get_team_name(dag_id, session=session) == f"team-old-{dag_id[:8]}"
+            session.execute(
+                update(DagModel).where(DagModel.dag_id == dag_id).values(bundle_name=f"bundle-new-{dag_id}")
+            )
+            session.commit()
+
+            response = client.patch(
+                f"/execution/task-instances/{ti.id}/run",
+                json={
+                    "state": "running",
+                    "hostname": "h",
+                    "unixname": "u",
+                    "pid": 1,
+                    "start_date": "2024-09-30T12:00:00Z",
+                },
+            )
+            clear_team_name_cache()
+
+        assert response.status_code == 200
+        assert response.json()["dag_run"]["team_name"] == f"team-new-{dag_id[:8]}"
+
     def test_ti_run_creates_audit_log(self, client, session, create_task_instance, time_machine):
         """Test that transitioning to RUNNING creates an audit log record."""
         instant_str = "2024-09-30T12:00:00Z"

--- a/airflow-core/tests/unit/models/test_team.py
+++ b/airflow-core/tests/unit/models/test_team.py
@@ -17,8 +17,23 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import delete, inspect as sa_inspect, select, update
 
+from airflow.api_fastapi.common.db.dags import eager_load_teams
+from airflow.models.dag import DagModel, clear_team_name_cache
+from airflow.models.dagbundle import DagBundleModel
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
 from airflow.models.team import Team
+
+from tests_common.test_utils.asserts import assert_queries_count
+from tests_common.test_utils.config import conf_vars
+
+pytestmark = pytest.mark.db_test
+
+DAG_ID = "team_owned_dag"
+BUNDLE_NAME = "team-owned-bundle"
+TEAM_NAME = "owning-team"
 
 
 class TestTeam:
@@ -38,3 +53,110 @@ class TestTeam:
 
         assert result == {"testing"}
         assert isinstance(result, set)
+
+
+class TestTeamOwnedMixin:
+    """``team_name`` resolution on the models that reach a team through a relationship."""
+
+    @pytest.fixture
+    def team_owned_run(self, dag_maker, session):
+        """A Dag run and task instance whose Dag is owned by ``TEAM_NAME`` via its bundle."""
+        with dag_maker(DAG_ID, session=session):
+            from airflow.providers.standard.operators.empty import EmptyOperator
+
+            EmptyOperator(task_id="task")
+        dag_run = dag_maker.create_dagrun()
+        original_bundle_name = session.scalar(select(DagModel.bundle_name).where(DagModel.dag_id == DAG_ID))
+
+        session.execute(delete(DagBundleModel).where(DagBundleModel.name == BUNDLE_NAME))
+        session.execute(delete(Team).where(Team.name == TEAM_NAME))
+        session.flush()
+        bundle = DagBundleModel(name=BUNDLE_NAME)
+        bundle.teams.append(Team(name=TEAM_NAME))
+        session.add(bundle)
+        session.flush()
+        session.execute(update(DagModel).where(DagModel.dag_id == DAG_ID).values(bundle_name=BUNDLE_NAME))
+        session.commit()
+        clear_team_name_cache()
+
+        yield dag_run
+
+        # bundle_name is a foreign key with no ON DELETE action, so restore it before
+        # dropping the bundle this fixture introduced.
+        session.execute(
+            update(DagModel).where(DagModel.dag_id == DAG_ID).values(bundle_name=original_bundle_name)
+        )
+        session.execute(delete(DagBundleModel).where(DagBundleModel.name == BUNDLE_NAME))
+        session.execute(delete(Team).where(Team.name == TEAM_NAME))
+        session.commit()
+        clear_team_name_cache()
+
+    def get_run(self, session, *, eager_load: bool) -> DagRun:
+        """Re-fetch the run, with or without the team eager loading options."""
+        session.expunge_all()
+        options = eager_load_teams(DagRun.dag_model) if eager_load else ()
+        return session.scalar(select(DagRun).where(DagRun.dag_id == DAG_ID).options(*options))
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_team_name_uses_eager_loaded_relationships(self, team_owned_run, session):
+        dag_run = self.get_run(session, eager_load=True)
+
+        with assert_queries_count(0, session=session):
+            assert dag_run.team_name == TEAM_NAME
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_team_name_falls_back_when_not_eager_loaded(self, team_owned_run, session):
+        """Paths that cannot eager load resolve via the cached resolver, not ``lazy="raise"``."""
+        dag_run = self.get_run(session, eager_load=False)
+
+        assert dag_run.team_name == TEAM_NAME
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_team_name_fallback_keeps_caller_objects_attached(self, team_owned_run, session):
+        """The fallback must not close the caller's scoped session out from under it."""
+        dag_run = self.get_run(session, eager_load=False)
+
+        assert dag_run.team_name == TEAM_NAME
+        assert not sa_inspect(dag_run).detached
+        # Would raise DetachedInstanceError if the resolver had closed the shared session.
+        assert dag_run.dag_model.dag_id == DAG_ID
+
+    @conf_vars({("core", "multi_team"): "False"})
+    def test_team_name_is_none_without_multi_team(self, team_owned_run, session):
+        """Single-team deployments answer ``None`` without loading anything."""
+        dag_run = self.get_run(session, eager_load=False)
+
+        with assert_queries_count(0, session=session):
+            assert dag_run.team_name is None
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_team_name_on_task_instance(self, team_owned_run, session):
+        task_instance = session.scalar(select(TaskInstance).where(TaskInstance.dag_id == DAG_ID))
+
+        assert task_instance.team_name == TEAM_NAME
+
+    @conf_vars({("core", "multi_team"): "True"})
+    def test_team_name_is_none_for_bundle_without_team(self, dag_maker, session):
+        with dag_maker("unteamed_dag", session=session):
+            from airflow.providers.standard.operators.empty import EmptyOperator
+
+            EmptyOperator(task_id="task")
+        dag_maker.create_dagrun()
+        session.commit()
+        clear_team_name_cache()
+
+        dag_run = session.scalar(
+            select(DagRun).where(DagRun.dag_id == "unteamed_dag").options(*eager_load_teams(DagRun.dag_model))
+        )
+
+        assert dag_run.team_name is None
+        clear_team_name_cache()
+
+    def test_eager_load_teams_is_a_no_op_without_multi_team(self):
+        with conf_vars({("core", "multi_team"): "False"}):
+            assert eager_load_teams() == ()
+            assert eager_load_teams(DagRun.dag_model) == ()
+
+        with conf_vars({("core", "multi_team"): "True"}):
+            assert eager_load_teams() != ()
+            assert eager_load_teams(DagRun.dag_model) != ()

--- a/airflow-core/tests/unit/models/test_team.py
+++ b/airflow-core/tests/unit/models/test_team.py
@@ -55,7 +55,7 @@ class TestTeam:
         assert isinstance(result, set)
 
 
-class TestTeamOwnedMixin:
+class TestTeamName:
     """``team_name`` resolution on the models that reach a team through a relationship."""
 
     @pytest.fixture
@@ -97,6 +97,12 @@ class TestTeamOwnedMixin:
         options = eager_load_teams(DagRun.dag_model) if eager_load else ()
         return session.scalar(select(DagRun).where(DagRun.dag_id == DAG_ID).options(*options))
 
+    def get_dag_model(self, session, *, eager_load: bool) -> DagModel:
+        """Re-fetch the Dag, with or without the team eager loading options."""
+        session.expunge_all()
+        options = eager_load_teams() if eager_load else ()
+        return session.scalar(select(DagModel).where(DagModel.dag_id == DAG_ID).options(*options))
+
     @conf_vars({("core", "multi_team"): "True"})
     def test_team_name_uses_eager_loaded_relationships(self, team_owned_run, session):
         dag_run = self.get_run(session, eager_load=True)
@@ -105,21 +111,23 @@ class TestTeamOwnedMixin:
             assert dag_run.team_name == TEAM_NAME
 
     @conf_vars({("core", "multi_team"): "True"})
-    def test_team_name_falls_back_when_not_eager_loaded(self, team_owned_run, session):
+    @pytest.mark.parametrize("entity", ["dag", "dag_run"])
+    def test_team_name_falls_back_when_not_eager_loaded(self, team_owned_run, session, entity):
         """Paths that cannot eager load resolve via the cached resolver, not ``lazy="raise"``."""
-        dag_run = self.get_run(session, eager_load=False)
-
-        assert dag_run.team_name == TEAM_NAME
+        if entity == "dag":
+            assert self.get_dag_model(session, eager_load=False).team_name == TEAM_NAME
+        else:
+            assert self.get_run(session, eager_load=False).team_name == TEAM_NAME
 
     @conf_vars({("core", "multi_team"): "True"})
     def test_team_name_fallback_keeps_caller_objects_attached(self, team_owned_run, session):
         """The fallback must not close the caller's scoped session out from under it."""
-        dag_run = self.get_run(session, eager_load=False)
+        dag_model = self.get_dag_model(session, eager_load=False)
 
-        assert dag_run.team_name == TEAM_NAME
-        assert not sa_inspect(dag_run).detached
+        assert dag_model.team_name == TEAM_NAME
+        assert not sa_inspect(dag_model).detached
         # Would raise DetachedInstanceError if the resolver had closed the shared session.
-        assert dag_run.dag_model.dag_id == DAG_ID
+        assert dag_model.dag_versions is not None
 
     @conf_vars({("core", "multi_team"): "False"})
     def test_team_name_is_none_without_multi_team(self, team_owned_run, session):

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -2640,6 +2640,7 @@ class DAGDetailsResponse(BaseModel):
     owner_links: Annotated[dict[str, str] | None, Field(title="Owner Links")] = None
     is_favorite: Annotated[bool | None, Field(title="Is Favorite")] = False
     active_runs_count: Annotated[int | None, Field(title="Active Runs Count")] = 0
+    team_name: Annotated[str | None, Field(title="Team Name")] = None
     is_backfillable: Annotated[
         bool, Field(description="Whether this Dag's schedule supports backfilling.", title="Is Backfillable")
     ]

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -1075,9 +1075,10 @@ class DagRunInfo(InfoJsonEncodable):
         # The Execution API delivers the team name on the DagRun payload it sends to the task
         # runner, so task events resolve it from there rather than through the bundle lookup below,
         # which needs a metadata DB session the task runner does not have.
-        # `hasattr` rather than a None check -- a team-less run legitimately carries None, while
-        # the scheduler's ORM DagRun has no such attribute at all.
-        if hasattr(dagrun, "team_name"):
+        # `hasattr` rather than a None check -- a team-less run legitimately carries None. The ORM
+        # DagRun exposes `team_name` too, but reading it lazy-loads the bundle, so scheduler-side
+        # runs stay on the guarded lookup below instead of risking a load on a detached instance.
+        if not isinstance(dagrun, DagRun) and hasattr(dagrun, "team_name"):
             return dagrun.team_name
 
         # Best-effort: the scheduler stamps `_team_name` on ORM DagRun objects before

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -1068,9 +1068,10 @@ class DagRunInfo(InfoJsonEncodable):
         # The Execution API delivers the team name on the DagRun payload it sends to the task
         # runner, so task events resolve it from there rather than through the bundle lookup below,
         # which needs a metadata DB session the task runner does not have.
-        # `hasattr` rather than a None check -- a team-less run legitimately carries None, while
-        # the scheduler's ORM DagRun has no such attribute at all.
-        if hasattr(dagrun, "team_name"):
+        # `hasattr` rather than a None check -- a team-less run legitimately carries None. The ORM
+        # DagRun exposes `team_name` too, but reading it lazy-loads the bundle, so scheduler-side
+        # runs stay on the guarded lookup below instead of risking a load on a detached instance.
+        if not isinstance(dagrun, DagRun) and hasattr(dagrun, "team_name"):
             return dagrun.team_name
 
         try:

--- a/scripts/ci/prek/check_ti_vs_tis_attributes.py
+++ b/scripts/ci/prek/check_ti_vs_tis_attributes.py
@@ -63,8 +63,8 @@ def compare_attributes(path1, path2):
         # Storing last heartbeat for historic TIs is not interesting/useful
         "last_heartbeat_at",
         "id",
-        # Config marker for TeamOwnedMixin's relationship walk, not a data attribute
-        "_team_path",
+        # Resolved through the dag_run relationship, not stored on the TI row
+        "team_name",
     }  # exclude attrs not necessary to be in TaskInstanceHistory
     if not diff:
         return

--- a/scripts/ci/prek/check_ti_vs_tis_attributes.py
+++ b/scripts/ci/prek/check_ti_vs_tis_attributes.py
@@ -63,6 +63,8 @@ def compare_attributes(path1, path2):
         # Storing last heartbeat for historic TIs is not interesting/useful
         "last_heartbeat_at",
         "id",
+        # Config marker for TeamOwnedMixin's relationship walk, not a data attribute
+        "_team_path",
     }  # exclude attrs not necessary to be in TaskInstanceHistory
     if not diff:
         return


### PR DESCRIPTION
Multi-team deployments need to see which team owns a Dag directly from the detail pages, not just from the list views. This surfaces the owning team on the Dag, Dag Run, and Task Instance detail pages as a linked row that filters the Dag list by that team, mirroring how the Owner field already behaves. It also adds it to the page detail header as a new column. **In the case of the Dag details page, it replaces the column `owner`.**

The team row/column is only shown when multi-team support is enabled and a team is resolved for the object, so single-team deployments see no change.

### Screenshots

### Dag details page
<img width="1310" height="349" alt="Screenshot 2026-07-23 at 1 47 47 PM" src="https://github.com/user-attachments/assets/6125f6d1-ae73-497e-89f3-b55d92c80772" />

### Dag run details page
<img width="1299" height="404" alt="Screenshot 2026-07-23 at 1 47 59 PM" src="https://github.com/user-attachments/assets/22bba3c8-fbc7-415f-bb55-337b60bba441" />

### Task instance details page
<img width="1292" height="464" alt="Screenshot 2026-07-23 at 1 48 11 PM" src="https://github.com/user-attachments/assets/172301a5-071e-432b-b702-087b198949a9" />

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Claude (Opus 4.8)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
