### PR TITLE
UI: Fix task states stuck stale when a run finishes quickly

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.test.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.test.tsx
@@ -26,6 +26,8 @@ import {
   useGridServiceGetGridRunsKey,
   useTaskInstanceServiceGetTaskInstancesKey,
 } from "openapi/queries";
+import type { TaskInstanceState } from "openapi/requests";
+import { useAutoRefresh } from "src/utils";
 
 import { useGridTiSummariesStream } from "./useGridTISummaries";
 
@@ -256,5 +258,96 @@ describe("useGridTiSummariesStream", () => {
 
     // The state should NOT be updated with the aborted stream's value
     expect(result.current.summariesByRunId.get("run_1")).toBeUndefined();
+  });
+
+  it("re-streams one final time when runs finish before the next interval tick", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          staleTime: Infinity,
+        },
+      },
+    });
+    const wrapper = createWrapper(queryClient);
+
+    vi.mocked(useAutoRefresh).mockReturnValue(3000);
+
+    const runningChunk = `${JSON.stringify({ run_id: "run_1", state: "running", task_id: "task_1" })}\n`;
+    const successChunk = `${JSON.stringify({ run_id: "run_1", state: "success", task_id: "task_1" })}\n`;
+
+    mockFetch
+      .mockResolvedValueOnce(createMockResponse([runningChunk]))
+      .mockResolvedValueOnce(createMockResponse([successChunk]));
+
+    const { rerender, result } = renderHook(
+      ({ states }: { states: Array<TaskInstanceState> }) =>
+        useGridTiSummariesStream({ dagId: "dag_1", runIds: ["run_1"], states }),
+      { initialProps: { states: ["running"] as Array<TaskInstanceState> }, wrapper },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.summariesByRunId.get("run_1")).toEqual({
+      run_id: "run_1",
+      state: "running",
+      task_id: "task_1",
+    });
+
+    // The run reaches a terminal state before the 3s interval ever ticks
+    rerender({ states: ["success"] as Array<TaskInstanceState> });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.current.summariesByRunId.get("run_1")).toEqual({
+      run_id: "run_1",
+      state: "success",
+      task_id: "task_1",
+    });
+
+    // No interval remains armed once the runs are terminal
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-stream when runs are already terminal on mount", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: Infinity,
+          staleTime: Infinity,
+        },
+      },
+    });
+    const wrapper = createWrapper(queryClient);
+
+    vi.mocked(useAutoRefresh).mockReturnValue(3000);
+
+    mockFetch.mockImplementation(() => Promise.resolve(createMockResponse([])));
+
+    renderHook(
+      () =>
+        useGridTiSummariesStream({
+          dagId: "dag_1",
+          runIds: ["run_1"],
+          states: ["success"] as Array<TaskInstanceState>,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridTISummaries.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   useDagRunServiceGetDagRunsKey,
@@ -154,6 +154,17 @@ export const useGridTiSummariesStream = ({
 
     return () => clearInterval(timer);
   }, [hasActiveRuns, baseRefetchInterval]);
+
+  // The interval above is cleared the moment the last active run turns terminal, which can happen
+  // before its first tick for fast runs — re-stream once on that transition so final TI states land.
+  const wasActiveRef = useRef(false);
+
+  useEffect(() => {
+    if (wasActiveRef.current && !hasActiveRuns) {
+      setRefreshTick((tick) => tick + 1);
+    }
+    wasActiveRef.current = hasActiveRuns;
+  }, [hasActiveRuns]);
 
   // Re-stream whenever a mutation invalidates a grid-related query (TI states,
   // run states, or grid structure).  Invalidation events only fire from explicit


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---
## Why
The Grid/Graph task badges come from the `ti_summaries` stream. The stream only re-fetches while the dag run is active. If the run finishes before the next tick (default 3s), the interval is cleared and the final task states are never fetched. The badge then stays stale until a remount. 
I was testing my dag (which can finish within 3s). After it finished, the badge kept showing "no status" while the run panel already showed success:


https://github.com/user-attachments/assets/5729be3b-ad4a-4bec-b282-a0a8f432073a

## What

`useGridTiSummariesStream` now remembers whether the runs were active in a ref. When they go from active to terminal, it bumps `refreshTick` once, which triggers one final re-stream through the existing fetch path. Grid and Graph share this hook, so both views get the fix. 
Added two tests: the final re-stream happens exactly once (fails without the fix), and opening an already-finished run does not fetch twice.

After:

https://github.com/user-attachments/assets/198d8b1a-bdc9-4e33-895c-fd0bc0bceb4c

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
