### PR TITLE
Drop unused post_submit_commands copy from SparkSubmitOperator init

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -263,7 +263,6 @@ class SparkSubmitOperator(ResumableJobMixin, BaseOperator):
         self._deploy_mode = deploy_mode
         self._hook: SparkSubmitHook | None = None
         self.post_submit_commands = post_submit_commands
-        self._post_submit_commands = list(post_submit_commands) if post_submit_commands else []
         self._conn_id = conn_id
         self._use_krb5ccache = use_krb5ccache
         self._yarn_track_via_rm_api = yarn_track_via_rm_api

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -29,7 +29,6 @@ providers/anthropic/src/airflow/providers/anthropic/operators/agent.py::Anthropi
 providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py::HivePartitionSensor
 providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py::NamedHivePartitionSensor
 providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py::ProduceToTopicOperator
-providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py::SparkSubmitOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/kueue.py::KubernetesInstallKueueOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py::KubernetesResourceBaseOperator


### PR DESCRIPTION
`post_submit_commands` is a template field, so it is rendered after `__init__` runs. The constructor also kept a private `self._post_submit_commands = list(post_submit_commands) if post_submit_commands else []`, built from the un-rendered value. Nothing reads that copy: the operator forwards the rendered `self.post_submit_commands` to `SparkSubmitHook`, which builds its own list and runs the commands. Removing it stops the constructor reading the template field and clears its `validate-operators-init` exemption.

related: #70296

<details><summary>Testing Done</summary>

`validate_operators_init.py` on the operator, before (with the exemption removed):

```
SparkSubmitOperator's constructor applies logic to template fields. Template fields are
rendered after the constructor runs, so validation or transformation here acts on the
un-rendered Jinja expression and should move to execute():
  line 266: self._post_submit_commands = list(post_submit_commands) if post_submit_commands else []  (post_submit_commands)
```

After removing the line, the validator exits 0.

`test_spark_submit.py` (operator suite): 69 passed. The removed attribute had no readers, so behaviour is unchanged.

</details>



---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


