### PR TITLE
Move template-field validation out of init for Amazon DataSync operator

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py
@@ -174,19 +174,6 @@ class DataSyncOperator(AwsBaseOperator[DataSyncHook]):
         self.task_execution_kwargs = task_execution_kwargs or {}
         self.delete_task_after_execution = delete_task_after_execution
 
-        # Validations
-        valid = False
-        if self.task_arn:
-            valid = True
-        if self.source_location_uri and self.destination_location_uri:
-            valid = True
-        if not valid:
-            raise AirflowException(
-                f"Either specify task_arn or both source_location_uri and destination_location_uri. "
-                f"task_arn={task_arn!r}, source_location_uri={source_location_uri!r}, "
-                f"destination_location_uri={destination_location_uri!r}"
-            )
-
         # Candidates - these are found in AWS as possible things
         # for us to use
         self.candidate_source_location_arns: list[str] | None = None
@@ -201,7 +188,22 @@ class DataSyncOperator(AwsBaseOperator[DataSyncHook]):
     def _hook_parameters(self) -> dict[str, Any]:
         return {**super()._hook_parameters, "wait_interval_seconds": self.wait_interval_seconds}
 
+    def validate_inputs(self) -> None:
+        valid = False
+        if self.task_arn:
+            valid = True
+        if self.source_location_uri and self.destination_location_uri:
+            valid = True
+        if not valid:
+            raise AirflowException(
+                f"Either specify task_arn or both source_location_uri and destination_location_uri. "
+                f"task_arn={self.task_arn!r}, source_location_uri={self.source_location_uri!r}, "
+                f"destination_location_uri={self.destination_location_uri!r}"
+            )
+
     def execute(self, context: Context):
+        self.validate_inputs()
+
         # If task_arn was not specified then try to
         # find 0, 1 or many candidate DataSync Tasks to run
         if not self.task_arn:

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
@@ -206,17 +206,20 @@ class TestDataSyncOperatorCreate(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
+    def test_execute_fails(self, mock_get_conn):
         # ### Set up mocks:
         mock_get_conn.return_value = self.client
         # ### Begin tests:
 
+        self.set_up_operator(task_id="task_1", source_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None)
+            self.datasync.execute(None)
+        self.set_up_operator(task_id="task_2", destination_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(destination_location_uri=None)
+            self.datasync.execute(None)
+        self.set_up_operator(task_id="task_3", source_location_uri=None, destination_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None, destination_location_uri=None)
+            self.datasync.execute(None)
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
@@ -430,17 +433,20 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
+    def test_execute_fails(self, mock_get_conn):
         # ### Set up mocks:
         mock_get_conn.return_value = self.client
         # ### Begin tests:
 
+        self.set_up_operator(task_id="task_1", source_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None)
+            self.datasync.execute(None)
+        self.set_up_operator(task_id="task_2", destination_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(destination_location_uri=None)
+            self.datasync.execute(None)
+        self.set_up_operator(task_id="task_3", source_location_uri=None, destination_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None, destination_location_uri=None)
+            self.datasync.execute(None)
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
@@ -640,13 +646,14 @@ class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
+    def test_execute_fails(self, mock_get_conn):
         # ### Set up mocks:
         mock_get_conn.return_value = self.client
         # ### Begin tests:
 
+        self.set_up_operator(task_arn=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(task_arn=None)
+            self.datasync.execute(None)
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
@@ -761,13 +768,14 @@ class TestDataSyncOperator(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
+    def test_execute_fails(self, mock_get_conn):
         # ### Set up mocks:
         mock_get_conn.return_value = self.client
         # ### Begin tests:
 
+        self.set_up_operator(task_arn=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(task_arn=None)
+            self.datasync.execute(None)
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
@@ -973,13 +981,14 @@ class TestDataSyncOperatorDelete(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
+    def test_execute_fails(self, mock_get_conn):
         # ### Set up mocks:
         mock_get_conn.return_value = self.client
         # ### Begin tests:
 
+        self.set_up_operator(task_arn=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(task_arn=None)
+            self.datasync.execute(None)
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -9,7 +9,6 @@
 providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py::AppflowBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py::BedrockCreateKnowledgeBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py::BedrockRaGOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py::DataSyncOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py::DmsModifyTaskOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py::DmsStartReplicationOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py::EcsRunTaskOperator


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

Template fields are rendered only after operators' constructor runs. Therefore, I moved the field validation logic out of `__init__` for Amazon DataSync operator. I also updated the unit tests accordingly and run them locally.

* related: #70296 | @shahar1

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)
- [X] No 


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
