### PR TITLE
Fix airflowctl trigger sending unrecognized fields to older API servers

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -603,7 +603,7 @@ class DagsOperations(BaseOperations):
             trigger_dag_run.conf = {}
         try:
             self.response = self.client.post(
-                f"dags/{dag_id}/dagRuns", json=trigger_dag_run.model_dump(mode="json")
+                f"dags/{dag_id}/dagRuns", json=trigger_dag_run.model_dump(mode="json", exclude_none=True)
             )
             return DAGRunResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -503,8 +503,13 @@ class DagsOperations(BaseOperations):
         """Create a Dag run."""
         if trigger_dag_run.conf is None:
             trigger_dag_run.conf = {}
+        # partition_key and bundle_version were added in Airflow 3.2.0; older API
+        # servers (extra="forbid") reject them as unrecognized fields even when null.
+        # logical_date must stay in the body even when None - the server declares it
+        # without a default, making it a required (though nullable) field.
         self.response = self.client.post(
-            f"dags/{dag_id}/dagRuns", json=trigger_dag_run.model_dump(mode="json")
+            f"dags/{dag_id}/dagRuns",
+            json=trigger_dag_run.model_dump(mode="json", exclude={"partition_key", "bundle_version"}),
         )
         return DAGRunResponse.model_validate_json(self.response.content)
 

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1157,6 +1157,36 @@ class TestDagOperations:
         response = client.dags.trigger(dag_id=self.dag_id, trigger_dag_run=self.trigger_dag_run)
         assert response == self.dag_run_response
 
+    def test_trigger_excludes_none_fields_from_request_body(self):
+        """Regression test: trigger() must exclude unset (None) fields from the
+        request body. Older API servers reject unrecognized fields (e.g.
+        partition_key, bundle_version, added in a later API version) with a
+        422 extra_forbidden error if they're present at all, even as null.
+        """
+        captured_body = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_body
+            captured_body = json.loads(request.content)
+            return httpx.Response(200, json=json.loads(self.dag_run_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        client.dags.trigger(dag_id=self.dag_id, trigger_dag_run=self.trigger_dag_run)
+
+        # conf is explicitly defaulted to {} by trigger() when unset, so it's expected.
+        assert captured_body == {"conf": {}}
+        for field in (
+            "dag_run_id",
+            "data_interval_start",
+            "data_interval_end",
+            "logical_date",
+            "run_after",
+            "note",
+            "partition_key",
+            "bundle_version",
+        ):
+            assert field not in captured_body, f"{field} should be excluded when unset"
+
 
 class TestDagRunOperations:
     dag_id = "dag_id"

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1260,6 +1260,28 @@ class TestDagOperations:
         response = client.dags.trigger(dag_id=self.dag_id, trigger_dag_run=self.trigger_dag_run)
         assert response == self.dag_run_response
 
+    def test_trigger_excludes_unsupported_fields_from_request_body(self):
+        """Regression test: trigger() must exclude partition_key/bundle_version
+        (added in Airflow 3.2.0) so older API servers don't reject the request
+        with extra_forbidden - but must still send logical_date (even as null),
+        since the server declares it as a required (non-defaulted) field.
+        """
+        captured_body = {}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            nonlocal captured_body
+            captured_body = json.loads(request.content)
+            return httpx.Response(200, json=json.loads(self.dag_run_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        client.dags.trigger(dag_id=self.dag_id, trigger_dag_run=self.trigger_dag_run)
+
+        for field in ("partition_key", "bundle_version"):
+            assert field not in captured_body, f"{field} should be excluded (unsupported by older servers)"
+
+        # logical_date must still be present (even as null) - the server requires it.
+        assert "logical_date" in captured_body
+
 
 class TestDagRunOperations:
     dag_id = "dag_id"


### PR DESCRIPTION

DagOperations.trigger() didn't exclude None fields when serializing the request, unlike create_event() in the same file. This meant every trigger request included partition_key and bundle_version (added in Airflow 3.2.0), which older API servers reject as unrecognized fields.

Adds exclude_none=True to match create_event()'s existing pattern, plus a regression test asserting unset fields are excluded from the request body.

Manually verified against a live Airflow 3.1.x deployment (Charmed Airflow on Kubernetes): confirmed dags trigger fails with the extra_forbidden error on the unpatched code, and succeeds cleanly — both with and without --logical-date passed explicitly, once the fix is applied.

* closes: #70327 

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:


* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
