### PR TITLE
Validate AzureVirtualMachineStateSensor target_state after rendering

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py
@@ -60,10 +60,6 @@ class AzureVirtualMachineStateSensor(BaseSensorOperator):
         deferrable: bool = conf.getboolean("operators", "default_deferrable", fallback=False),
         **kwargs,
     ) -> None:
-        if target_state not in self.VALID_STATES:
-            raise ValueError(
-                f"Invalid target_state: {target_state}. Must be one of {sorted(self.VALID_STATES)}"
-            )
         super().__init__(**kwargs)
         self.resource_group_name = resource_group_name
         self.vm_name = vm_name
@@ -72,6 +68,12 @@ class AzureVirtualMachineStateSensor(BaseSensorOperator):
         self.deferrable = deferrable
 
     def poke(self, context: Context) -> bool:
+        # target_state is a template field; validate the rendered value here rather than in
+        # __init__, which only sees the un-rendered Jinja expression.
+        if self.target_state not in self.VALID_STATES:
+            raise ValueError(
+                f"Invalid target_state: {self.target_state}. Must be one of {sorted(self.VALID_STATES)}"
+            )
         hook = AzureComputeHook(azure_conn_id=self.azure_conn_id)
         current_state = hook.get_power_state(self.resource_group_name, self.vm_name)
         self.log.info("VM %s power state: %s", self.vm_name, current_state)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py
@@ -68,8 +68,7 @@ class AzureVirtualMachineStateSensor(BaseSensorOperator):
         self.deferrable = deferrable
 
     def poke(self, context: Context) -> bool:
-        # target_state is a template field; validate the rendered value here rather than in
-        # __init__, which only sees the un-rendered Jinja expression.
+        # target_state is a template field; validate the rendered value here, not in __init__.
         if self.target_state not in self.VALID_STATES:
             raise ValueError(
                 f"Invalid target_state: {self.target_state}. Must be one of {sorted(self.VALID_STATES)}"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_compute.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_compute.py
@@ -44,8 +44,6 @@ class TestAzureVirtualMachineStateSensor:
         assert sensor.azure_conn_id == CONN_ID
 
     def test_invalid_target_state_rejected_at_poke(self):
-        # __init__ no longer validates the template field; the ValueError surfaces at poke,
-        # once target_state has been rendered.
         sensor = AzureVirtualMachineStateSensor(
             task_id="sense_vm",
             resource_group_name=RESOURCE_GROUP,
@@ -56,7 +54,6 @@ class TestAzureVirtualMachineStateSensor:
             sensor.poke(context=None)
 
     def test_templated_target_state_constructs(self):
-        # A templated target_state must construct: in __init__ it is still the un-rendered expression.
         sensor = AzureVirtualMachineStateSensor(
             task_id="sense_vm",
             resource_group_name=RESOURCE_GROUP,

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_compute.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_compute.py
@@ -43,14 +43,27 @@ class TestAzureVirtualMachineStateSensor:
         assert sensor.target_state == "running"
         assert sensor.azure_conn_id == CONN_ID
 
-    def test_init_invalid_target_state(self):
+    def test_invalid_target_state_rejected_at_poke(self):
+        # __init__ no longer validates the template field; the ValueError surfaces at poke,
+        # once target_state has been rendered.
+        sensor = AzureVirtualMachineStateSensor(
+            task_id="sense_vm",
+            resource_group_name=RESOURCE_GROUP,
+            vm_name=VM_NAME,
+            target_state="invalid_state",
+        )
         with pytest.raises(ValueError, match="Invalid target_state"):
-            AzureVirtualMachineStateSensor(
-                task_id="sense_vm",
-                resource_group_name=RESOURCE_GROUP,
-                vm_name=VM_NAME,
-                target_state="invalid_state",
-            )
+            sensor.poke(context=None)
+
+    def test_templated_target_state_constructs(self):
+        # A templated target_state must construct: in __init__ it is still the un-rendered expression.
+        sensor = AzureVirtualMachineStateSensor(
+            task_id="sense_vm",
+            resource_group_name=RESOURCE_GROUP,
+            vm_name=VM_NAME,
+            target_state="{{ params.state }}",
+        )
+        assert sensor.target_state == "{{ params.state }}"
 
     def test_template_fields(self):
         sensor = AzureVirtualMachineStateSensor(

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -73,7 +73,6 @@ providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py::GCSToGCSOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py::GCSToLocalFilesystemOperator
 providers/google/src/airflow/providers/google/marketing_platform/operators/campaign_manager.py::GoogleCampaignManagerDeleteReportOperator
-providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py::AzureVirtualMachineStateSensor
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/gcs_to_wasb.py::GCSToAzureBlobStorageOperator
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py::OracleToAzureDataLakeOperator
 providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py::PsrpOperator


### PR DESCRIPTION
`target_state` is a template field, so it is rendered after `__init__` runs. `AzureVirtualMachineStateSensor` validated it against `VALID_STATES` and raised `ValueError` in the constructor, so a templated `target_state` could never be built — `__init__` saw the un-rendered Jinja expression and rejected it:

```
ValueError: Invalid target_state: {{ params.state }}. Must be one of ['deallocated', 'deallocating', 'running', 'starting', 'stopped']
```

Store `target_state` verbatim in the constructor and move the check into `poke()`, which runs after rendering (both the synchronous and deferrable paths reach `poke()` before using the value).

related: #70296

<details><summary>Testing Done</summary>

Reverting only the source and running the new tests reproduces the bug:

```
test_templated_target_state_constructs FAILED
  ValueError: Invalid target_state: {{ params.state }}. Must be one of [...]
test_invalid_target_state_rejected_at_poke FAILED
```

With the fix, `test_compute.py`: 9 passed. `validate_operators_init.py` on the sensor exits 0 (the constructor no longer reads the template field).

</details>



---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


