### PR TITLE
Fix MongoToS3Operator aggregate-pipeline detection before rendering

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -84,9 +84,7 @@ class MongoToS3Operator(BaseOperator):
         self.mongo_db = mongo_db
         self.mongo_collection = mongo_collection
 
-        # Grab query and determine if we need to run an aggregate pipeline
         self.mongo_query = mongo_query
-        self.is_pipeline = isinstance(self.mongo_query, list)
         self.mongo_projection = mongo_projection
 
         self.s3_bucket = s3_bucket
@@ -99,8 +97,12 @@ class MongoToS3Operator(BaseOperator):
         """Is written to depend on transform method."""
         s3_conn = S3Hook(self.aws_conn_id)
 
+        # mongo_query is a template field; decide aggregate-vs-find from the rendered value
+        # here rather than in __init__, where it would inspect the un-rendered value.
+        is_pipeline = isinstance(self.mongo_query, list)
+
         # Grab collection and execute query according to whether or not it is a pipeline
-        if self.is_pipeline:
+        if is_pipeline:
             results: CommandCursor[Any] | Cursor = MongoHook(self.mongo_conn_id).aggregate(
                 mongo_collection=self.mongo_collection,
                 aggregate_query=cast("list", self.mongo_query),

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_mongo_to_s3.py
@@ -111,7 +111,7 @@ class TestMongoToS3Operator:
         ti.dag_run = dag_run
         render_template_fields(ti, self.mock_operator)
         expected_rendered_template = {"$lt": "2017-01-01T00:00:00+00:00Z"}
-        assert expected_rendered_template == getattr(self.mock_operator, "mongo_query")
+        assert expected_rendered_template == self.mock_operator.mongo_query
 
     @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.MongoHook")
     @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.S3Hook")
@@ -139,6 +139,30 @@ class TestMongoToS3Operator:
         mock_s3_hook.return_value.load_string.assert_called_once_with(
             string_data=s3_doc_str, key=S3_KEY, bucket_name=S3_BUCKET, replace=False, compression=COMPRESSION
         )
+
+    @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.MongoHook")
+    @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.S3Hook")
+    def test_execute_runs_aggregate_when_query_renders_to_list(self, mock_s3_hook, mock_mongo_hook):
+        """
+        mongo_query is a template field, so whether to run an aggregate pipeline is decided from
+        the rendered value in execute(), not from the un-rendered value in __init__. A query that
+        resolves to a list after templating must take the aggregate path.
+        """
+        operator = self.mock_operator
+        # Simulate templating resolving mongo_query to a list (an aggregate pipeline) after __init__.
+        operator.mongo_query = [{"$match": {"foo": "bar"}}]
+        mock_mongo_hook.return_value.aggregate.return_value = iter(MOCK_MONGO_RETURN)
+        mock_s3_hook.return_value.load_string.return_value = True
+
+        operator.execute(None)
+
+        mock_mongo_hook.return_value.aggregate.assert_called_once_with(
+            mongo_collection=MONGO_COLLECTION,
+            aggregate_query=[{"$match": {"foo": "bar"}}],
+            mongo_db=None,
+            allowDiskUse=False,
+        )
+        mock_mongo_hook.return_value.find.assert_not_called()
 
     @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.MongoHook")
     @mock.patch("airflow.providers.amazon.aws.transfers.mongo_to_s3.S3Hook")

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -23,7 +23,6 @@ providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py::SageMa
 providers/amazon/src/airflow/providers/amazon/aws/operators/step_function.py::StepFunctionStartExecutionOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/base.py::AwsToAwsBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
-providers/amazon/src/airflow/providers/amazon/aws/transfers/mongo_to_s3.py::MongoToS3Operator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::S3ToRedshiftOperator
 providers/anthropic/src/airflow/providers/anthropic/operators/agent.py::AnthropicAgentSessionOperator
 providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py::HivePartitionSensor


### PR DESCRIPTION
Compute the aggregate-vs-find decision in `execute()` from the rendered `mongo_query`, instead of caching `self.is_pipeline = isinstance(self.mongo_query, list)` in `__init__`.

`mongo_query` is a template field, so it is rendered after the constructor runs. Deriving `is_pipeline` in `__init__` inspects the un-rendered Jinja expression, so a `mongo_query` that resolves to a list only after templating would be misclassified and sent through `find()` instead of `aggregate()`. Deciding in `execute()` uses the rendered value.

Part of the template-field constructor burn-down; removes the `MongoToS3Operator` entry from `scripts/ci/prek/validate_operators_init_exemptions.txt` in the same PR, as the hook requires.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
