### PR TITLE
Move template-field checks out of __init__ in Hive sensors

### DIFF
--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py
@@ -63,11 +63,9 @@ class HivePartitionSensor(BaseSensorOperator):
         **kwargs: Any,
     ):
         super().__init__(poke_interval=poke_interval, **kwargs)
-        if not partition:
-            partition = "ds='{{ ds }}'"
         self.metastore_conn_id = metastore_conn_id
         self.table = table
-        self.partition = partition
+        self.partition = partition or "ds='{{ ds }}'"
         self.schema = schema
 
     def poke(self, context: Context) -> bool:

--- a/providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py
+++ b/providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py
@@ -56,9 +56,6 @@ class NamedHivePartitionSensor(BaseSensorOperator):
         super().__init__(poke_interval=poke_interval, **kwargs)
 
         self.next_index_to_poke = 0
-        if isinstance(partition_names, str):
-            raise TypeError("partition_names must be an array of strings")
-
         self.metastore_conn_id = metastore_conn_id
         self.partition_names = partition_names
         self.hook = hook
@@ -95,6 +92,8 @@ class NamedHivePartitionSensor(BaseSensorOperator):
         return self.hook.check_for_named_partition(schema, table, partition)
 
     def poke(self, context: Context) -> bool:
+        if isinstance(self.partition_names, str):
+            raise TypeError("partition_names must be an array of strings")
         number_of_partitions = len(self.partition_names)
         poke_index_start = self.next_index_to_poke
         for i in range(number_of_partitions):

--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
@@ -115,8 +115,7 @@ class TestNamedHivePartitionSensor:
         )
 
     def test_native_templated_partition_names(self):
-        # partition_names is a template field: a whole-list native template is a str in __init__
-        # (the un-rendered "{{ ... }}"), so the array-type check must run at poke, after rendering.
+        # A whole-list native template renders from a str, so the array-type check must run at poke.
         self.hook.metastore.__enter__().check_for_named_partition.return_value = True
         partitions = [f"{self.database}.{self.table}/{self.partition_by}={DEFAULT_DATE_DS}"]
         dag = DAG(

--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
@@ -114,6 +114,29 @@ class TestNamedHivePartitionSensor:
             self.database, self.table, f"{self.partition_by}={self.next_day}"
         )
 
+    def test_native_templated_partition_names(self):
+        # partition_names is a template field: a whole-list native template is a str in __init__
+        # (the un-rendered "{{ ... }}"), so the array-type check must run at poke, after rendering.
+        self.hook.metastore.__enter__().check_for_named_partition.return_value = True
+        partitions = [f"{self.database}.{self.table}/{self.partition_by}={DEFAULT_DATE_DS}"]
+        dag = DAG(
+            "named_hive_native",
+            schedule=None,
+            start_date=DEFAULT_DATE,
+            render_template_as_native_obj=True,
+        )
+        sensor = NamedHivePartitionSensor(
+            partition_names="{{ params.names }}",
+            task_id="test_native_templated_partition_names",
+            poke_interval=1,
+            hook=self.hook,
+            params={"names": partitions},
+            dag=dag,
+        )
+        sensor.render_template_fields({"params": {"names": partitions}})
+        assert sensor.partition_names == partitions
+        assert sensor.poke(None)
+
 
 @pytest.mark.skipif(
     "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"

--- a/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
+++ b/providers/apache/hive/tests/unit/apache/hive/sensors/test_named_hive_partition.py
@@ -115,7 +115,6 @@ class TestNamedHivePartitionSensor:
         )
 
     def test_native_templated_partition_names(self):
-        # A whole-list native template renders from a str, so the array-type check must run at poke.
         self.hook.metastore.__enter__().check_for_named_partition.return_value = True
         partitions = [f"{self.database}.{self.table}/{self.partition_by}={DEFAULT_DATE_DS}"]
         dag = DAG(
@@ -135,6 +134,17 @@ class TestNamedHivePartitionSensor:
         sensor.render_template_fields({"params": {"names": partitions}})
         assert sensor.partition_names == partitions
         assert sensor.poke(None)
+
+    def test_poke_rejects_str_partition_names(self):
+        """partition_names is validated at poke now, so a rendered str raises there, not in __init__."""
+        sensor = NamedHivePartitionSensor(
+            partition_names="not-a-list",
+            task_id="test_poke_rejects_str_partition_names",
+            poke_interval=1,
+            hook=self.hook,
+        )
+        with pytest.raises(TypeError, match="partition_names must be an array of strings"):
+            sensor.poke(None)
 
 
 @pytest.mark.skipif(

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -21,8 +21,6 @@ providers/amazon/src/airflow/providers/amazon/aws/transfers/base.py::AwsToAwsBas
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::S3ToRedshiftOperator
 providers/anthropic/src/airflow/providers/anthropic/operators/agent.py::AnthropicAgentSessionOperator
-providers/apache/hive/src/airflow/providers/apache/hive/sensors/hive_partition.py::HivePartitionSensor
-providers/apache/hive/src/airflow/providers/apache/hive/sensors/named_hive_partition.py::NamedHivePartitionSensor
 providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py::ProduceToTopicOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/kueue.py::KubernetesInstallKueueOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator


### PR DESCRIPTION
`table`/`partition` (HivePartitionSensor) and `partition_names` (NamedHivePartitionSensor) are template fields, so they are rendered after `__init__` runs. Two constructors read them:

- `HivePartitionSensor` defaulted `partition` with `if not partition: partition = "ds='{{ ds }}'"` — an imperative read of the field. Switched to the sanctioned `partition or "ds='{{ ds }}'"` idiom (behaviour identical).
- `NamedHivePartitionSensor` raised `TypeError` in `__init__` when `partition_names` was a `str`. A whole-list native template (`partition_names="{{ params.names }}"`) is a `str` before rendering, so the constructor rejected it outright. Moved the array-type check to `poke()`, which runs after rendering.

related: #70296

<details><summary>Testing Done</summary>

`validate_operators_init.py` exits 0 for both sensors after the change (RED before, flagging `if not partition:` and `if isinstance(partition_names, str):`).

New `test_native_templated_partition_names` drives the render→poke path with a native-templated list; it fails on the pre-fix source (`TypeError` at construction) and passes after. `test_named_hive_partition.py`: 6 passed, 4 skipped (need a live metastore). HivePartitionSensor's change is a behaviour-preserving refactor, covered by the existing suite.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

