### PR TITLE
Derive DbtCloudGetJobRunArtifactOperator default file name after rendering

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -410,10 +410,14 @@ class DbtCloudGetJobRunArtifactOperator(BaseOperator):
         self.path = path
         self.account_id = account_id
         self.step = step
-        self.output_file_name = output_file_name or f"{self.run_id}_{self.path}".replace("/", "-")
+        self.output_file_name = output_file_name
         self.hook_params = hook_params or {}
 
     def execute(self, context: Context) -> str:
+        # run_id/path/output_file_name are template fields; derive the default name here, after
+        # rendering, so it reflects the resolved run_id and path rather than the Jinja expressions.
+        if not self.output_file_name:
+            self.output_file_name = f"{self.run_id}_{self.path}".replace("/", "-")
         hook = DbtCloudHook(self.dbt_cloud_conn_id, **self.hook_params)
         response = hook.get_job_run_artifact(
             run_id=self.run_id, path=self.path, account_id=self.account_id, step=self.step

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py
@@ -414,8 +414,8 @@ class DbtCloudGetJobRunArtifactOperator(BaseOperator):
         self.hook_params = hook_params or {}
 
     def execute(self, context: Context) -> str:
-        # run_id/path/output_file_name are template fields; derive the default name here, after
-        # rendering, so it reflects the resolved run_id and path rather than the Jinja expressions.
+        # run_id/path are template fields; derive the default name after rendering so it uses the
+        # resolved values, not the Jinja expressions.
         if not self.output_file_name:
             self.output_file_name = f"{self.run_id}_{self.path}".replace("/", "-")
         hook = DbtCloudHook(self.dbt_cloud_conn_id, **self.hook_params)

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -1059,6 +1059,28 @@ class TestDbtCloudGetJobRunArtifactOperator:
         assert return_value == operator.output_file_name
 
     @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
+    def test_default_output_file_name_uses_rendered_path(self, mock_get_artifact, tmp_path, monkeypatch):
+        # run_id/path are template fields: the default file name (and its "/"->"-" flattening) must
+        # be derived after rendering, so a templated path resolves before its slashes are replaced.
+        operator = DbtCloudGetJobRunArtifactOperator(
+            task_id=TASK_ID,
+            dbt_cloud_conn_id=ACCOUNT_ID_CONN,
+            run_id=RUN_ID,
+            path="{{ params.p }}",
+            params={"p": "path/to/my/manifest.json"},
+            dag=self.dag,
+        )
+        operator.render_template_fields({"params": {"p": "path/to/my/manifest.json"}})
+
+        mock_get_artifact.return_value.json.return_value = {"data": "file contents"}
+        with monkeypatch.context() as ctx:
+            ctx.chdir(tmp_path)
+            return_value = operator.execute(context={})
+
+        assert operator.output_file_name == f"{RUN_ID}_path-to-my-manifest.json"
+        assert return_value == operator.output_file_name
+
+    @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
     @pytest.mark.parametrize(
         ("conn_id", "account_id"),
         [(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/operators/test_dbt.py
@@ -1060,8 +1060,7 @@ class TestDbtCloudGetJobRunArtifactOperator:
 
     @patch("airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook.get_job_run_artifact")
     def test_default_output_file_name_uses_rendered_path(self, mock_get_artifact, tmp_path, monkeypatch):
-        # run_id/path are template fields: the default file name (and its "/"->"-" flattening) must
-        # be derived after rendering, so a templated path resolves before its slashes are replaced.
+        # The default name flattens "/"->"-", so a templated path must resolve before that.
         operator = DbtCloudGetJobRunArtifactOperator(
             task_id=TASK_ID,
             dbt_cloud_conn_id=ACCOUNT_ID_CONN,

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -41,7 +41,6 @@ providers/databricks/src/airflow/providers/databricks/operators/databricks_repos
 providers/databricks/src/airflow/providers/databricks/operators/databricks_repos.py::DatabricksReposUpdateOperator
 providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py::DatabricksCopyIntoOperator
 providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::DatabricksSQLStatementsSensor
-providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py::DbtCloudGetJobRunArtifactOperator
 providers/docker/src/airflow/providers/docker/operators/docker.py::DockerOperator
 providers/google/src/airflow/providers/google/cloud/operators/bigquery.py::BigQueryInsertJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator


### PR DESCRIPTION
`run_id`, `path` and `output_file_name` are template fields, so they are rendered after `__init__` runs. When `output_file_name` was omitted, the constructor built the default from `self.run_id` and `self.path` and flattened slashes then — on the un-rendered Jinja expressions. With a templated `path`, the `'/'`→`'-'` replacement ran on the expression, not the resolved path, so a rendered path like `a/b/c.json` kept its slashes in the file name (`Path` then wrote into nested directories). Derive the default in `execute()`, after rendering.

related: #70296

<details><summary>Testing Done</summary>

New `test_default_output_file_name_uses_rendered_path` renders a templated `path` (`{{ params.p }}` → `path/to/my/manifest.json`) and asserts the default name is `<run_id>_path-to-my-manifest.json`. It fails on the pre-fix source (slashes survive, name is `<run_id>_path/to/my/manifest.json`) and passes after. `TestDbtCloudGetJobRunArtifactOperator`: 11 passed. `validate_operators_init.py` on the operator exits 0.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

