### PR TITLE
Validate KubernetesResourceBaseOperator yaml_conf after rendering

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
@@ -84,6 +84,9 @@ class KubernetesResourceBaseOperator(BaseOperator):
         self.namespaced = namespaced
         self.config_file = config_file
 
+    def _validate_yaml_conf(self) -> None:
+        # yaml_conf/yaml_conf_file are template fields; validate after rendering (from execute),
+        # not in __init__ where they are still the un-rendered Jinja expressions.
         if not any([self.yaml_conf, self.yaml_conf_file]):
             raise AirflowException("One of `yaml_conf` or `yaml_conf_file` arguments must be provided")
 
@@ -144,6 +147,7 @@ class KubernetesCreateResourceOperator(KubernetesResourceBaseOperator):
             k8s_resource_iterator(self.create_custom_from_yaml_object, objects)
 
     def execute(self, context) -> None:
+        self._validate_yaml_conf()
         if self.yaml_conf:
             self._create_objects(yaml.safe_load_all(self.yaml_conf))
         elif self.yaml_conf_file and os.path.exists(self.yaml_conf_file):
@@ -176,6 +180,7 @@ class KubernetesDeleteResourceOperator(KubernetesResourceBaseOperator):
             k8s_resource_iterator(self.delete_custom_from_yaml_object, objects)
 
     def execute(self, context) -> None:
+        self._validate_yaml_conf()
         if self.yaml_conf:
             self._delete_objects(yaml.safe_load_all(self.yaml_conf))
         elif self.yaml_conf_file and os.path.exists(self.yaml_conf_file):

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py
@@ -85,8 +85,7 @@ class KubernetesResourceBaseOperator(BaseOperator):
         self.config_file = config_file
 
     def _validate_yaml_conf(self) -> None:
-        # yaml_conf/yaml_conf_file are template fields; validate after rendering (from execute),
-        # not in __init__ where they are still the un-rendered Jinja expressions.
+        # yaml_conf/yaml_conf_file are template fields; validate after rendering, called from execute.
         if not any([self.yaml_conf, self.yaml_conf_file]):
             raise AirflowException("One of `yaml_conf` or `yaml_conf_file` arguments must be provided")
 

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_resource.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_resource.py
@@ -27,6 +27,7 @@ from airflow.providers.cncf.kubernetes.operators.resource import (
     KubernetesCreateResourceOperator,
     KubernetesDeleteResourceOperator,
 )
+from airflow.providers.common.compat.sdk import AirflowException
 from airflow.utils import timezone
 
 TEST_VALID_RESOURCE_YAML = """
@@ -92,6 +93,14 @@ class TestKubernetesXResourceOperator:
     def setup_method(self):
         args = {"owner": "airflow", "start_date": timezone.datetime(2020, 2, 1)}
         self.dag = DAG("test_dag_id", schedule=None, default_args=args)
+
+    def test_missing_yaml_conf_rejected_at_execute(self, context):
+        # yaml_conf/yaml_conf_file are template fields: the presence check must run at execute
+        # (after rendering), so constructing with neither no longer raises in __init__.
+        for operator_class in (KubernetesCreateResourceOperator, KubernetesDeleteResourceOperator):
+            op = operator_class(task_id="test_task_id")
+            with pytest.raises(AirflowException, match="One of `yaml_conf` or `yaml_conf_file`"):
+                op.execute(context={})
 
     @patch("kubernetes.config.load_kube_config")
     @patch("kubernetes.client.api.CoreV1Api.create_namespaced_persistent_volume_claim")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_resource.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/operators/test_resource.py
@@ -95,8 +95,7 @@ class TestKubernetesXResourceOperator:
         self.dag = DAG("test_dag_id", schedule=None, default_args=args)
 
     def test_missing_yaml_conf_rejected_at_execute(self, context):
-        # yaml_conf/yaml_conf_file are template fields: the presence check must run at execute
-        # (after rendering), so constructing with neither no longer raises in __init__.
+        # yaml_conf/yaml_conf_file are template fields; the presence check runs at execute.
         for operator_class in (KubernetesCreateResourceOperator, KubernetesDeleteResourceOperator):
             op = operator_class(task_id="test_task_id")
             with pytest.raises(AirflowException, match="One of `yaml_conf` or `yaml_conf_file`"):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -32,7 +32,6 @@ providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py::
 providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py::SparkSubmitOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/kueue.py::KubernetesInstallKueueOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
-providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/resource.py::KubernetesResourceBaseOperator
 providers/cohere/src/airflow/providers/cohere/operators/embedding.py::CohereEmbeddingOperator
 providers/common/ai/src/airflow/providers/common/ai/operators/agent.py::AgentOperator
 providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py::DocumentLoaderOperator


### PR DESCRIPTION
`yaml_conf` and `yaml_conf_file` are template fields, so they are rendered after `__init__` runs. The base constructor raised `AirflowException` when neither was set — a check against the un-rendered values. Move it into a `_validate_yaml_conf()` helper called from `execute()` in both the create and delete operators, so the presence check runs after rendering.

related: #70296

<details><summary>Testing Done</summary>

New `test_missing_yaml_conf_rejected_at_execute` constructs both operators with neither field and asserts the `AirflowException` now surfaces from `execute()`. It fails on the pre-fix source (the constructor raises first) and passes after. `test_resource.py`: 12 passed. `validate_operators_init.py` on the module exits 0; the `raise AirflowException` count is unchanged.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
