### PR TITLE
Validate DatabricksCopyIntoOperator template fields after rendering

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
@@ -534,8 +534,7 @@ FILEFORMAT = {self._file_format}
         return build_query_tags(context, self.query_tags, self.include_airflow_query_tags)
 
     def execute(self, context: Context) -> Any:
-        # files/table_name/file_location are template fields; validate after rendering here rather
-        # than in __init__, where they are still the un-rendered Jinja expressions.
+        # files/table_name/file_location are template fields; validate after rendering.
         if self.files is not None and self._pattern is not None:
             raise AirflowException("Only one of 'pattern' or 'files' should be specified")
         if self.table_name == "":

--- a/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
+++ b/providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py
@@ -405,12 +405,6 @@ class DatabricksCopyIntoOperator(BaseOperator):
     ) -> None:
         """Create a new ``DatabricksCopyIntoOperator``."""
         super().__init__(**kwargs)
-        if files is not None and pattern is not None:
-            raise AirflowException("Only one of 'pattern' or 'files' should be specified")
-        if table_name == "":
-            raise AirflowException("table_name shouldn't be empty")
-        if file_location == "":
-            raise AirflowException("file_location shouldn't be empty")
         if file_format not in COPY_INTO_APPROVED_FORMATS:
             raise AirflowException(f"file_format '{file_format}' isn't supported")
         self.files = files
@@ -540,6 +534,14 @@ FILEFORMAT = {self._file_format}
         return build_query_tags(context, self.query_tags, self.include_airflow_query_tags)
 
     def execute(self, context: Context) -> Any:
+        # files/table_name/file_location are template fields; validate after rendering here rather
+        # than in __init__, where they are still the un-rendered Jinja expressions.
+        if self.files is not None and self._pattern is not None:
+            raise AirflowException("Only one of 'pattern' or 'files' should be specified")
+        if self.table_name == "":
+            raise AirflowException("table_name shouldn't be empty")
+        if self.file_location == "":
+            raise AirflowException("file_location shouldn't be empty")
         self._sql = self._create_sql_query()
         self.log.info("Executing: %s", self._sql)
         hook = self._get_hook()

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_copy.py
@@ -195,37 +195,40 @@ VALIDATE 10 ROWS
 
 def test_incorrect_params_files_patterns():
     exception_message = "Only one of 'pattern' or 'files' should be specified"
+    op = DatabricksCopyIntoOperator(
+        task_id=TASK_ID,
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="test",
+        files=["file1", "file2", "file3"],
+        pattern="abc",
+    )
     with pytest.raises(AirflowException, match=exception_message):
-        DatabricksCopyIntoOperator(
-            task_id=TASK_ID,
-            file_location=COPY_FILE_LOCATION,
-            file_format="JSON",
-            table_name="test",
-            files=["file1", "file2", "file3"],
-            pattern="abc",
-        )
+        op.execute(context={})
 
 
 def test_incorrect_params_emtpy_table():
     exception_message = "table_name shouldn't be empty"
+    op = DatabricksCopyIntoOperator(
+        task_id=TASK_ID,
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="",
+    )
     with pytest.raises(AirflowException, match=exception_message):
-        DatabricksCopyIntoOperator(
-            task_id=TASK_ID,
-            file_location=COPY_FILE_LOCATION,
-            file_format="JSON",
-            table_name="",
-        )
+        op.execute(context={})
 
 
 def test_incorrect_params_emtpy_location():
     exception_message = "file_location shouldn't be empty"
+    op = DatabricksCopyIntoOperator(
+        task_id=TASK_ID,
+        file_location="",
+        file_format="JSON",
+        table_name="abc",
+    )
     with pytest.raises(AirflowException, match=exception_message):
-        DatabricksCopyIntoOperator(
-            task_id=TASK_ID,
-            file_location="",
-            file_format="JSON",
-            table_name="abc",
-        )
+        op.execute(context={})
 
 
 def test_incorrect_params_wrong_format():

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
@@ -610,22 +610,3 @@ class TestDatabricksCopyIntoOperatorQueryTags:
             op.execute(None)
 
             assert mock_hook.query_tags == {"env": "prod"}
-
-
-class TestDatabricksCopyIntoOperatorValidation:
-    """files/table_name/file_location are template fields; their checks run at execute."""
-
-    def test_files_and_pattern_rejected_at_execute(self):
-        from airflow.providers.common.compat.sdk import AirflowException
-        from airflow.providers.databricks.operators.databricks_sql import DatabricksCopyIntoOperator
-
-        op = DatabricksCopyIntoOperator(
-            task_id=TASK_ID,
-            table_name="test_table",
-            file_location="s3://bucket/path",
-            file_format="CSV",
-            files=["a.csv"],
-            pattern="*.csv",
-        )
-        with pytest.raises(AirflowException, match="Only one of 'pattern' or 'files'"):
-            op.execute(context={})

--- a/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
+++ b/providers/databricks/tests/unit/databricks/operators/test_databricks_sql.py
@@ -610,3 +610,22 @@ class TestDatabricksCopyIntoOperatorQueryTags:
             op.execute(None)
 
             assert mock_hook.query_tags == {"env": "prod"}
+
+
+class TestDatabricksCopyIntoOperatorValidation:
+    """files/table_name/file_location are template fields; their checks run at execute."""
+
+    def test_files_and_pattern_rejected_at_execute(self):
+        from airflow.providers.common.compat.sdk import AirflowException
+        from airflow.providers.databricks.operators.databricks_sql import DatabricksCopyIntoOperator
+
+        op = DatabricksCopyIntoOperator(
+            task_id=TASK_ID,
+            table_name="test_table",
+            file_location="s3://bucket/path",
+            file_format="CSV",
+            files=["a.csv"],
+            pattern="*.csv",
+        )
+        with pytest.raises(AirflowException, match="Only one of 'pattern' or 'files'"):
+            op.execute(context={})

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -39,7 +39,6 @@ providers/common/ai/src/airflow/providers/common/ai/operators/document_loader.py
 providers/databricks/src/airflow/providers/databricks/operators/databricks_repos.py::DatabricksReposCreateOperator
 providers/databricks/src/airflow/providers/databricks/operators/databricks_repos.py::DatabricksReposDeleteOperator
 providers/databricks/src/airflow/providers/databricks/operators/databricks_repos.py::DatabricksReposUpdateOperator
-providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py::DatabricksCopyIntoOperator
 providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::DatabricksSQLStatementsSensor
 providers/dbt/cloud/src/airflow/providers/dbt/cloud/operators/dbt.py::DbtCloudGetJobRunArtifactOperator
 providers/docker/src/airflow/providers/docker/operators/docker.py::DockerOperator


### PR DESCRIPTION
`files`, `table_name` and `file_location` are template fields, so they are rendered after `__init__` runs. The constructor checked `files`/`pattern` mutual exclusivity and rejected an empty `table_name`/`file_location` there, acting on the un-rendered Jinja expressions — so a templated `table_name` couldn't resolve before the empty check ran. Move those three checks into `execute()`. The `file_format` check reads no template field and stays in `__init__`.

related: #70296

<details><summary>Testing Done</summary>

New `test_files_and_pattern_rejected_at_execute` constructs with both `files` and `pattern` and asserts the `AirflowException` now surfaces from `execute()`. It fails on the pre-fix source (the constructor raises first) and passes after. `test_databricks_sql.py`: 52 passed. `validate_operators_init.py` exits 0 and the `raise AirflowException` count is unchanged.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
