### PR TITLE
Handle DockerOperator mounts after rendering instead of in __init__

### DIFF
--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -308,9 +308,8 @@ class DockerOperator(BaseOperator):
         self.mount_tmp_dir = mount_tmp_dir
         self.tmp_dir = tmp_dir
         self.user = user
-        # mounts is a template field; keep the raw input (dicts or Mount objects) here so Jinja
-        # renders it (Mount is a dict subclass, so its values render natively), and convert to
-        # Mount objects in execute(), after rendering.
+        # mounts is a template field; keep the raw dicts/Mounts so Jinja renders them (Mount is a
+        # dict subclass), and convert to Mount objects in execute() after rendering.
         self.mounts = mounts or []
         self.entrypoint = entrypoint
         self.working_dir = working_dir
@@ -490,8 +489,7 @@ class DockerOperator(BaseOperator):
             return lib.load(file)
 
     def execute(self, context: Context) -> list[str] | str | None:
-        # mounts is a template field held as raw input; convert to Mount objects now, after
-        # Jinja rendering has resolved their values.
+        # Convert the rendered mounts (raw dicts or Mounts) to Mount objects, now that rendering ran.
         self.mounts = [m if isinstance(m, Mount) else Mount(**m) for m in self.mounts]
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):

--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -308,10 +308,10 @@ class DockerOperator(BaseOperator):
         self.mount_tmp_dir = mount_tmp_dir
         self.tmp_dir = tmp_dir
         self.user = user
-        mounts = [mount if isinstance(mount, Mount) else Mount(**mount) for mount in (mounts or [])]
-        self.mounts: list[Mount] = mounts
-        for mount in self.mounts:
-            mount.template_fields = ("Source", "Target", "Type")
+        # mounts is a template field; keep the raw input (dicts or Mount objects) here so Jinja
+        # renders it (Mount is a dict subclass, so its values render natively), and convert to
+        # Mount objects in execute(), after rendering.
+        self.mounts = mounts or []
         self.entrypoint = entrypoint
         self.working_dir = working_dir
         self.xcom_all = xcom_all
@@ -490,6 +490,9 @@ class DockerOperator(BaseOperator):
             return lib.load(file)
 
     def execute(self, context: Context) -> list[str] | str | None:
+        # mounts is a template field held as raw input; convert to Mount objects now, after
+        # Jinja rendering has resolved their values.
+        self.mounts = [m if isinstance(m, Mount) else Mount(**m) for m in self.mounts]
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):
             self.log.info("::group::Pulling docker image %s", self.image)

--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -308,8 +308,6 @@ class DockerOperator(BaseOperator):
         self.mount_tmp_dir = mount_tmp_dir
         self.tmp_dir = tmp_dir
         self.user = user
-        # mounts is a template field; keep the raw dicts/Mounts so Jinja renders them (Mount is a
-        # dict subclass), and convert to Mount objects in execute() after rendering.
         self.mounts = mounts or []
         self.entrypoint = entrypoint
         self.working_dir = working_dir
@@ -489,7 +487,6 @@ class DockerOperator(BaseOperator):
             return lib.load(file)
 
     def execute(self, context: Context) -> list[str] | str | None:
-        # Convert the rendered mounts (raw dicts or Mounts) to Mount objects, now that rendering ran.
         self.mounts = [m if isinstance(m, Mount) else Mount(**m) for m in self.mounts]
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):

--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -486,8 +486,11 @@ class DockerOperator(BaseOperator):
             lib = getattr(self, "pickling_library", pickle)
             return lib.load(file)
 
-    def execute(self, context: Context) -> list[str] | str | None:
+    def _normalize_mounts(self) -> None:
         self.mounts = [m if isinstance(m, Mount) else Mount(**m) for m in self.mounts]
+
+    def execute(self, context: Context) -> list[str] | str | None:
+        self._normalize_mounts()
         # Pull the docker image if `force_pull` is set or image does not exist locally
         if self.force_pull or not self.cli.images(name=self.image):
             self.log.info("::group::Pulling docker image %s", self.image)

--- a/providers/docker/src/airflow/providers/docker/operators/docker.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker.py
@@ -487,7 +487,10 @@ class DockerOperator(BaseOperator):
             return lib.load(file)
 
     def _normalize_mounts(self) -> None:
-        self.mounts = [m if isinstance(m, Mount) else Mount(**m) for m in self.mounts]
+        # A user dict is rebuilt into a Mount, but rendering flattens a Mount into a
+        # plain dict with API-cased keys (Target/Source/Type) that docker-py already
+        # accepts, so leave those (and any real Mount) alone.
+        self.mounts = [m if isinstance(m, Mount) or "Target" in m else Mount(**m) for m in self.mounts]
 
     def execute(self, context: Context) -> list[str] | str | None:
         self._normalize_mounts()

--- a/providers/docker/src/airflow/providers/docker/operators/docker_swarm.py
+++ b/providers/docker/src/airflow/providers/docker/operators/docker_swarm.py
@@ -174,6 +174,7 @@ class DockerSwarmOperator(DockerOperator):
             self.log_driver_config = None
 
     def execute(self, context: Context) -> None:
+        self._normalize_mounts()
         self.environment["AIRFLOW_TMP_DIR"] = self.tmp_dir
         return self._run_service()
 

--- a/providers/docker/tests/unit/docker/operators/test_docker.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker.py
@@ -874,8 +874,7 @@ class TestDockerOperator:
                 Mount(target="/logs", source="logs", type="volume"),
             ],
         )
-        # mounts is a template field, so __init__ keeps the raw input; normalization to Mount
-        # objects happens in execute(), after rendering.
+        # __init__ keeps the raw input; execute() normalizes to Mount objects.
         assert not isinstance(op.mounts[0], Mount)
 
         op.execute(None)
@@ -899,6 +898,5 @@ class TestDockerOperator:
             ],
         )
         rendered = ti.render_templates()
-        # mounts stays a raw dict through rendering (Mount is a dict subclass; Jinja renders its
-        # values natively), so the templated value resolves before execute() converts it.
+        # Raw dict keeps its lowercase input keys through rendering; execute() converts to Mount.
         assert rendered.mounts[0]["target"] == f"/{ti.run_id}"

--- a/providers/docker/tests/unit/docker/operators/test_docker.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker.py
@@ -874,12 +874,18 @@ class TestDockerOperator:
                 Mount(target="/logs", source="logs", type="volume"),
             ],
         )
-        assert all(isinstance(m, Mount) for m in op.mounts)
-        assert op.mounts[0]["Target"] == "/data"
-        assert op.mounts[0]["Source"] == "workspace"
-        assert op.mounts[0]["Type"] == "volume"
-        assert op.mounts[0]["ReadOnly"] is False
-        assert op.mounts[1]["Target"] == "/logs"
+        # mounts is a template field, so __init__ keeps the raw input; normalization to Mount
+        # objects happens in execute(), after rendering.
+        assert not isinstance(op.mounts[0], Mount)
+
+        op.execute(None)
+
+        passed_mounts = self.client_mock.create_host_config.call_args.kwargs["mounts"]
+        assert all(isinstance(m, Mount) for m in passed_mounts)
+        assert passed_mounts[0]["Target"] == "/data"
+        assert passed_mounts[0]["Source"] == "workspace"
+        assert passed_mounts[0]["ReadOnly"] is False
+        assert passed_mounts[1]["Target"] == "/logs"
 
     @pytest.mark.db_test
     def test_dict_mounts_are_templated(self, create_task_instance_of_operator):
@@ -893,4 +899,6 @@ class TestDockerOperator:
             ],
         )
         rendered = ti.render_templates()
-        assert rendered.mounts[0]["Target"] == f"/{ti.run_id}"
+        # mounts stays a raw dict through rendering (Mount is a dict subclass; Jinja renders its
+        # values natively), so the templated value resolves before execute() converts it.
+        assert rendered.mounts[0]["target"] == f"/{ti.run_id}"

--- a/providers/docker/tests/unit/docker/operators/test_docker.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker.py
@@ -898,3 +898,23 @@ class TestDockerOperator:
         )
         rendered = ti.render_templates()
         assert rendered.mounts[0]["target"] == f"/{ti.run_id}"
+
+    @pytest.mark.db_test
+    def test_mount_objects_survive_render_then_execute(self, create_task_instance_of_operator):
+        # A user-supplied Mount is a dict subclass, so the templater flattens it to a
+        # plain API-cased dict during rendering. Drive the real render -> execute path
+        # to prove execute() forwards it to docker-py instead of raising on it.
+        ti = create_task_instance_of_operator(
+            operator_class=DockerOperator,
+            dag_id="test",
+            task_id="test",
+            image="test",
+            mount_tmp_dir=False,
+            mounts=[Mount(source="workspace", target="/{{task_instance.run_id}}", type="volume")],
+        )
+        task = ti.render_templates()
+        task.execute(None)
+
+        passed_mounts = self.client_mock.create_host_config.call_args.kwargs["mounts"]
+        assert passed_mounts[0]["Target"] == f"/{ti.run_id}"
+        assert passed_mounts[0]["Source"] == "workspace"

--- a/providers/docker/tests/unit/docker/operators/test_docker.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker.py
@@ -874,7 +874,6 @@ class TestDockerOperator:
                 Mount(target="/logs", source="logs", type="volume"),
             ],
         )
-        # __init__ keeps the raw input; execute() normalizes to Mount objects.
         assert not isinstance(op.mounts[0], Mount)
 
         op.execute(None)
@@ -898,5 +897,4 @@ class TestDockerOperator:
             ],
         )
         rendered = ti.render_templates()
-        # Raw dict keeps its lowercase input keys through rendering; execute() converts to Mount.
         assert rendered.mounts[0]["target"] == f"/{ti.run_id}"

--- a/providers/docker/tests/unit/docker/operators/test_docker_swarm.py
+++ b/providers/docker/tests/unit/docker/operators/test_docker_swarm.py
@@ -209,6 +209,25 @@ class TestDockerSwarmOperator:
             "Docker service being removed even when `auto_remove` set to `never`"
         )
 
+    @mock.patch("airflow.providers.docker.operators.docker_swarm.types")
+    def test_dict_mounts_converted_at_execute(self, types_mock, docker_api_client_patcher):
+        client_mock = mock.Mock(spec=APIClient)
+        client_mock.create_service.return_value = {"ID": "some_id"}
+        client_mock.images.return_value = []
+        client_mock.pull.return_value = [b'{"status":"pull log"}']
+        client_mock.tasks.return_value = [{"ServiceID": "some_id", "Status": {"State": "complete"}}]
+        docker_api_client_patcher.return_value = client_mock
+
+        operator = DockerSwarmOperator(
+            image="",
+            task_id="unittest",
+            enable_logging=False,
+            mounts=[{"source": "/host", "target": "/container", "type": "bind"}],
+        )
+        operator.execute(None)
+
+        assert all(isinstance(m, types.Mount) for m in operator.mounts)
+
     @pytest.mark.parametrize("status", ["failed", "shutdown", "rejected", "orphaned", "remove"])
     @mock.patch("airflow.providers.docker.operators.docker_swarm.types")
     def test_non_complete_service_raises_error(self, types_mock, docker_api_client_patcher, status):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -22,7 +22,6 @@ providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::S3ToRedshiftOperator
 providers/anthropic/src/airflow/providers/anthropic/operators/agent.py::AnthropicAgentSessionOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
-providers/docker/src/airflow/providers/docker/operators/docker.py::DockerOperator
 providers/google/src/airflow/providers/google/cloud/operators/bigquery.py::BigQueryInsertJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator


### PR DESCRIPTION
`mounts` is a template field, so it is rendered after `__init__` runs. The constructor converted dict mounts into `Mount` objects and tagged each with `template_fields = ("Source", "Target", "Type")` so their nested values would render — the template-field-in-`__init__` logic #70296 is burning down.

Keep the raw input in `__init__` and handle it at the start of `execute()`, after rendering. The SDK templater flattens any `dict` subclass — `Mount` included — into a plain API-cased dict, so a rendered mount already has the shape docker-py wants: rebuild a `Mount` only from a raw user dict, and leave rendered dicts (and any real `Mount`) alone. `DockerSwarmOperator` shares `_normalize_mounts`, so it is covered by the same method.

related: #70296

<details><summary>Testing Done</summary>

Ran the real render then execute path (docker client mocked), red on the pre-fix source and green after — the path a plain `execute()`-only test misses, because the templater only flattens the `Mount` during `render_templates()`:

```
# pre-fix: user Mount is flattened to {'Target','Source','Type','ReadOnly'} on render,
# then _normalize_mounts rebuilds it with Mount(**api_cased_keys):
test_mount_objects_survive_render_then_execute FAILED
E   TypeError: Mount.__init__() got an unexpected keyword argument 'Target'

# with the fix:
test_dict_mounts_are_normalized_to_mount_objects PASSED
test_dict_mounts_are_templated PASSED
test_mount_objects_survive_render_then_execute PASSED
3 passed

# full operator test file:
62 passed
```

`test_mount_objects_survive_render_then_execute` builds a task instance with a templated `Mount`, calls `render_templates()` then `execute()`, and asserts the mount reaching `create_host_config` rendered to `/{run_id}`. It fails on the pre-fix source and passes after. `validate_operators_init` no longer exempts `DockerOperator`.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

