### PR TITLE
Move DataSync validation after template rendering

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py
@@ -174,19 +174,6 @@ class DataSyncOperator(AwsBaseOperator[DataSyncHook]):
         self.task_execution_kwargs = task_execution_kwargs or {}
         self.delete_task_after_execution = delete_task_after_execution
 
-        # Validations
-        valid = False
-        if self.task_arn:
-            valid = True
-        if self.source_location_uri and self.destination_location_uri:
-            valid = True
-        if not valid:
-            raise AirflowException(
-                f"Either specify task_arn or both source_location_uri and destination_location_uri. "
-                f"task_arn={task_arn!r}, source_location_uri={source_location_uri!r}, "
-                f"destination_location_uri={destination_location_uri!r}"
-            )
-
         # Candidates - these are found in AWS as possible things
         # for us to use
         self.candidate_source_location_arns: list[str] | None = None
@@ -202,6 +189,8 @@ class DataSyncOperator(AwsBaseOperator[DataSyncHook]):
         return {**super()._hook_parameters, "wait_interval_seconds": self.wait_interval_seconds}
 
     def execute(self, context: Context):
+        self._validate_inputs()
+
         # If task_arn was not specified then try to
         # find 0, 1 or many candidate DataSync Tasks to run
         if not self.task_arn:
@@ -252,6 +241,19 @@ class DataSyncOperator(AwsBaseOperator[DataSyncHook]):
             self._delete_datasync_task()
 
         return {"TaskArn": self.task_arn, "TaskExecutionArn": self.task_execution_arn}
+
+    def _validate_inputs(self) -> None:
+        valid = False
+        if self.task_arn:
+            valid = True
+        if self.source_location_uri and self.destination_location_uri:
+            valid = True
+        if not valid:
+            raise AirflowException(
+                f"Either specify task_arn or both source_location_uri and destination_location_uri. "
+                f"task_arn={self.task_arn!r}, source_location_uri={self.source_location_uri!r}, "
+                f"destination_location_uri={self.destination_location_uri!r}"
+            )
 
     def _get_tasks_and_locations(self) -> None:
         """Find existing DataSync Task based on source and dest Locations."""

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_datasync.py
@@ -206,18 +206,25 @@ class TestDataSyncOperatorCreate(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
-        # ### Set up mocks:
+    def test_execute_fails_with_missing_location_inputs(self, mock_get_conn):
         mock_get_conn.return_value = self.client
-        # ### Begin tests:
 
+        self.set_up_operator(task_id="missing_source_location_uri", source_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None)
+            self.datasync.execute(None)
+
+        self.set_up_operator(task_id="missing_destination_location_uri", destination_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(destination_location_uri=None)
+            self.datasync.execute(None)
+
+        self.set_up_operator(
+            task_id="missing_source_and_destination_location_uri",
+            source_location_uri=None,
+            destination_location_uri=None,
+        )
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None, destination_location_uri=None)
-        # ### Check mocks:
+            self.datasync.execute(None)
+
         mock_get_conn.assert_not_called()
 
     def test_create_task(self, mock_get_conn):
@@ -430,18 +437,25 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
-        # ### Set up mocks:
+    def test_execute_fails_with_missing_location_inputs(self, mock_get_conn):
         mock_get_conn.return_value = self.client
-        # ### Begin tests:
 
+        self.set_up_operator(task_id="missing_source_location_uri", source_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None)
+            self.datasync.execute(None)
+
+        self.set_up_operator(task_id="missing_destination_location_uri", destination_location_uri=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(destination_location_uri=None)
+            self.datasync.execute(None)
+
+        self.set_up_operator(
+            task_id="missing_source_and_destination_location_uri",
+            source_location_uri=None,
+            destination_location_uri=None,
+        )
         with pytest.raises(AirflowException):
-            self.set_up_operator(source_location_uri=None, destination_location_uri=None)
-        # ### Check mocks:
+            self.datasync.execute(None)
+
         mock_get_conn.assert_not_called()
 
     def test_get_no_location(self, mock_get_conn):
@@ -640,14 +654,13 @@ class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
-        # ### Set up mocks:
+    def test_execute_fails_with_missing_task_arn(self, mock_get_conn):
         mock_get_conn.return_value = self.client
-        # ### Begin tests:
 
+        self.set_up_operator(task_arn=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(task_arn=None)
-        # ### Check mocks:
+            self.datasync.execute(None)
+
         mock_get_conn.assert_not_called()
 
     def test_update_task(self, mock_get_conn):
@@ -761,14 +774,13 @@ class TestDataSyncOperator(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
-        # ### Set up mocks:
+    def test_execute_fails_with_missing_task_arn(self, mock_get_conn):
         mock_get_conn.return_value = self.client
-        # ### Begin tests:
 
+        self.set_up_operator(task_arn=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(task_arn=None)
-        # ### Check mocks:
+            self.datasync.execute(None)
+
         mock_get_conn.assert_not_called()
 
     def test_task_extra_links(self, mock_get_conn):
@@ -973,14 +985,13 @@ class TestDataSyncOperatorDelete(DataSyncTestCaseBase):
         # ### Check mocks:
         mock_get_conn.assert_not_called()
 
-    def test_init_fails(self, mock_get_conn):
-        # ### Set up mocks:
+    def test_execute_fails_with_missing_task_arn(self, mock_get_conn):
         mock_get_conn.return_value = self.client
-        # ### Begin tests:
 
+        self.set_up_operator(task_arn=None)
         with pytest.raises(AirflowException):
-            self.set_up_operator(task_arn=None)
-        # ### Check mocks:
+            self.datasync.execute(None)
+
         mock_get_conn.assert_not_called()
 
     def test_delete_task(self, mock_get_conn):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -9,7 +9,6 @@
 providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py::AppflowBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py::BedrockCreateKnowledgeBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/bedrock.py::BedrockRaGOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/datasync.py::DataSyncOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py::DmsModifyTaskOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py::DmsStartReplicationOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py::EcsRunTaskOperator


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Move `DataSyncOperator` input validation out of `__init__` so templated fields are validated after rendering during execution.

This also removes `DataSyncOperator` from the operator constructor validation exemptions list.

related: #70296

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]`Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
