### PR TITLE
Read HITLOperator subject/body into the summary lazily

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -132,18 +132,16 @@ class HITLOperator(BaseOperator):
         self.validate_params()
         self.validate_defaults()
 
-        # Runtime/subclass additions to the summary (e.g. timeout_datetime, approved,
-        # branches_to_execute); the config-derived entries come from the hitl_summary property.
+        # Runtime/subclass additions to the summary; config-derived entries live in the property.
         self._hitl_summary_extra: dict[str, Any] = {}
 
     @property
     def hitl_summary(self) -> dict[str, Any]:
         """
-        Summary of the Human-in-the-loop request, for the use of listeners/observability.
+        Summary of the Human-in-the-loop request, for listeners/observability.
 
-        Exposed as a property so the ``subject``/``body`` template fields are read at access time --
-        after rendering, e.g. when OpenLineage builds the task START event -- rather than in
-        ``__init__`` where they would still hold un-rendered Jinja.
+        A property so the ``subject``/``body`` template fields are read after rendering, not
+        captured as un-rendered Jinja in ``__init__``.
         """
         return {
             "subject": self.subject,

--- a/providers/standard/src/airflow/providers/standard/operators/hitl.py
+++ b/providers/standard/src/airflow/providers/standard/operators/hitl.py
@@ -132,8 +132,20 @@ class HITLOperator(BaseOperator):
         self.validate_params()
         self.validate_defaults()
 
-        # HITL summary for the use of listeners; subclasses can extend it.
-        self.hitl_summary: dict[str, Any] = {
+        # Runtime/subclass additions to the summary (e.g. timeout_datetime, approved,
+        # branches_to_execute); the config-derived entries come from the hitl_summary property.
+        self._hitl_summary_extra: dict[str, Any] = {}
+
+    @property
+    def hitl_summary(self) -> dict[str, Any]:
+        """
+        Summary of the Human-in-the-loop request, for the use of listeners/observability.
+
+        Exposed as a property so the ``subject``/``body`` template fields are read at access time --
+        after rendering, e.g. when OpenLineage builds the task START event -- rather than in
+        ``__init__`` where they would still hold un-rendered Jinja.
+        """
+        return {
             "subject": self.subject,
             "body": self.body,
             "options": self.options,
@@ -141,6 +153,7 @@ class HITLOperator(BaseOperator):
             "multiple": self.multiple,
             "assigned_users": self.assigned_users,
             "serialized_params": self.serialized_params or None,
+            **self._hitl_summary_extra,
         }
 
     def validate_options(self) -> None:
@@ -210,7 +223,9 @@ class HITLOperator(BaseOperator):
             timeout_datetime = None
 
         # Enrich summary with runtime info
-        self.hitl_summary["timeout_datetime"] = timeout_datetime.isoformat() if timeout_datetime else None
+        self._hitl_summary_extra["timeout_datetime"] = (
+            timeout_datetime.isoformat() if timeout_datetime else None
+        )
 
         self.log.info("Waiting for response")
         for notifier in self.notifiers:
@@ -246,7 +261,7 @@ class HITLOperator(BaseOperator):
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
         if "error" in event:
-            self.hitl_summary["error_type"] = event["error_type"]
+            self._hitl_summary_extra["error_type"] = event["error_type"]
             self.process_trigger_event_error(event)
 
         chosen_options = event["chosen_options"]
@@ -254,7 +269,7 @@ class HITLOperator(BaseOperator):
         self.validate_chosen_options(chosen_options)
         self.validate_params_input(params_input)
 
-        self.hitl_summary.update(
+        self._hitl_summary_extra.update(
             {
                 "chosen_options": chosen_options,
                 "params_input": params_input,
@@ -432,14 +447,14 @@ class ApprovalOperator(HITLOperator, SkipMixin):
             **kwargs,
         )
 
-        self.hitl_summary["ignore_downstream_trigger_rules"] = self.ignore_downstream_trigger_rules
-        self.hitl_summary["fail_on_reject"] = self.fail_on_reject
+        self._hitl_summary_extra["ignore_downstream_trigger_rules"] = self.ignore_downstream_trigger_rules
+        self._hitl_summary_extra["fail_on_reject"] = self.fail_on_reject
 
     def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
         ret = super().execute_complete(context=context, event=event)
 
         chosen_option = ret["chosen_options"][0]
-        self.hitl_summary["approved"] = chosen_option == self.APPROVE
+        self._hitl_summary_extra["approved"] = chosen_option == self.APPROVE
         if chosen_option == self.APPROVE:
             self.log.info("Approved. Proceeding with downstream tasks...")
             return ret
@@ -493,7 +508,7 @@ class HITLBranchOperator(HITLOperator, BranchMixIn):
         super().__init__(**kwargs)
         self.options_mapping = options_mapping or {}
         self.validate_options_mapping()
-        self.hitl_summary["options_mapping"] = self.options_mapping
+        self._hitl_summary_extra["options_mapping"] = self.options_mapping
 
     def validate_options_mapping(self) -> None:
         """
@@ -528,7 +543,7 @@ class HITLBranchOperator(HITLOperator, BranchMixIn):
 
         # Map options to task IDs using the mapping, fallback to original option
         chosen_options = [self.options_mapping.get(option, option) for option in chosen_options]
-        self.hitl_summary["branches_to_execute"] = chosen_options
+        self._hitl_summary_extra["branches_to_execute"] = chosen_options
         return self.do_branch(context=context, branches_to_execute=chosen_options)
 
 

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -974,6 +974,27 @@ class TestHITLSummaryForListeners:
             "serialized_params": None,
         }
 
+    def test_summary_reflects_rendered_subject_body(self) -> None:
+        """subject/body in the summary are read live, so post-render values reach listeners.
+
+        Guards #70296: subject/body are template fields; snapshotting them into the summary in
+        ``__init__`` captured un-rendered Jinja. The summary is a property now, so once Airflow
+        renders the template fields in place -- before the OpenLineage task START event is built --
+        the summary reflects the rendered values.
+        """
+        op = HITLOperator(
+            task_id="test",
+            subject="Review for {{ ds }}",
+            body="Deploy {{ ds }}?",
+            options=["Yes", "No"],
+        )
+        # Airflow renders template fields by setting them back on the operator before execute.
+        op.subject = "Review for 2020-01-01"
+        op.body = "Deploy 2020-01-01?"
+
+        assert op.hitl_summary["subject"] == "Review for 2020-01-01"
+        assert op.hitl_summary["body"] == "Deploy 2020-01-01?"
+
     def test_approval_operator_init_summary(self) -> None:
         """ApprovalOperator hitl_summary includes base + approval-specific fields."""
         op = ApprovalOperator(
@@ -1382,7 +1403,8 @@ class TestHITLSummaryForListeners:
             },
         )
 
-        assert s == {
+        # hitl_summary is a property, so re-read it to see the execute_complete additions.
+        assert op.hitl_summary == {
             "subject": "Release v2.0?",
             "body": "Please approve the production deployment.",
             "options": ["Approve", "Reject"],

--- a/providers/standard/tests/unit/standard/operators/test_hitl.py
+++ b/providers/standard/tests/unit/standard/operators/test_hitl.py
@@ -975,20 +975,14 @@ class TestHITLSummaryForListeners:
         }
 
     def test_summary_reflects_rendered_subject_body(self) -> None:
-        """subject/body in the summary are read live, so post-render values reach listeners.
-
-        Guards #70296: subject/body are template fields; snapshotting them into the summary in
-        ``__init__`` captured un-rendered Jinja. The summary is a property now, so once Airflow
-        renders the template fields in place -- before the OpenLineage task START event is built --
-        the summary reflects the rendered values.
-        """
+        """The summary reads subject/body live, so it reflects rendered values (guards #70296)."""
         op = HITLOperator(
             task_id="test",
             subject="Review for {{ ds }}",
             body="Deploy {{ ds }}?",
             options=["Yes", "No"],
         )
-        # Airflow renders template fields by setting them back on the operator before execute.
+        # Airflow renders template fields in place before execute.
         op.subject = "Review for 2020-01-01"
         op.body = "Deploy 2020-01-01?"
 

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -84,7 +84,6 @@ providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_container
 providers/ssh/src/airflow/providers/ssh/operators/ssh.py::SSHOperator
 providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py::SSHRemoteJobOperator
 providers/standard/src/airflow/providers/standard/operators/bash.py::BashOperator
-providers/standard/src/airflow/providers/standard/operators/hitl.py::HITLOperator
 providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py::TriggerDagRunOperator
 providers/standard/src/airflow/providers/standard/sensors/date_time.py::DateTimeSensor
 providers/teradata/src/airflow/providers/teradata/transfers/teradata_to_teradata.py::TeradataToTeradataOperator


### PR DESCRIPTION
`subject` and `body` are template fields, rendered after `__init__` runs. `hitl_summary` was built in the constructor from `self.subject`/`self.body`, so it captured the **un-rendered** Jinja. OpenLineage reads `hitl_summary` when it builds the task START event, so a templated `subject`/`body` was emitted as raw `{{ ... }}` instead of the resolved value.

Make `hitl_summary` a property that reads `subject`/`body` at access time — after rendering — so listeners and the OpenLineage START event see the resolved values. Runtime and subclass additions (`timeout_datetime`, `approved`, `branches_to_execute`, …) go through a private `_hitl_summary_extra` dict that the property merges in; the summary keys are otherwise unchanged.

related: #70296

<details><summary>Testing Done</summary>

New `test_summary_reflects_rendered_subject_body` renders a templated `subject`/`body` and asserts the summary exposes the resolved values. RED on the pre-fix source, GREEN after the property:

```
# pre-fix: subject/body snapshotted un-rendered in __init__
assert op.hitl_summary["subject"] == "Review for 2020-01-01"
E   AssertionError: assert equals failed
E      -'Review for {{ ds }}'     +'Review for 2020-01-01'

# after: full suite
81 passed, 1 skipped
```

The `example_openlineage_hitl_dag` system DAG (all four HITL variants) drives the START/COMPLETE events end-to-end in CI and checks each event's `hitl_summary` carries the rendered `subject`. `validate_operators_init.py` on the operator exits 0.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
