### PR TITLE
Fix Neo4jOperator templated query validation

### DIFF
--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -63,16 +63,20 @@ class Neo4jOperator(BaseOperator):
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
-            if cypher is not None:
-                raise ValueError("Cannot provide both `sql` and `cypher`. Use `cypher` only.")
-            cypher = sql
-        if cypher is None:
-            raise ValueError("Parameter `cypher` is required.")
         self.neo4j_conn_id = neo4j_conn_id
         self.cypher = cypher
+        self.sql = sql
         self.parameters = parameters
 
     def execute(self, context: Context) -> None:
-        self.log.info("Executing: %s", self.cypher)
+        cypher = self.cypher
+        if self.sql is not None:
+            if cypher is not None:
+                raise ValueError("Cannot provide both `sql` and `cypher`. Use `cypher` only.")
+            cypher = self.render_template(self.sql, context)
+        if cypher is None:
+            raise ValueError("Parameter `cypher` is required.")
+
+        self.log.info("Executing: %s", cypher)
         hook = Neo4jHook(conn_id=self.neo4j_conn_id)
-        hook.run(self.cypher, self.parameters)
+        hook.run(cypher, self.parameters)

--- a/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
@@ -61,16 +61,20 @@ class TestNeo4jOperator:
             AirflowProviderDeprecationWarning,
             match="`sql` parameter is deprecated, please use `cypher` instead.",
         ):
-            op = Neo4jOperator(task_id="basic_neo4j", sql=cypher)
-        assert op.cypher == cypher
-        op.execute(mock.MagicMock())
+            op = Neo4jOperator(task_id="basic_neo4j", sql="{{ cypher }}")
+        assert op.sql == "{{ cypher }}"
+        op.execute({"cypher": cypher})
         mock_hook.return_value.run.assert_called_once_with(cypher, None)
 
-    def test_neo4j_operator_both_sql_and_cypher_raises(self):
+    def test_neo4j_operator_both_sql_and_cypher_raises_on_execute(self):
         with pytest.warns(AirflowProviderDeprecationWarning):
-            with pytest.raises(ValueError, match="Cannot provide both `sql` and `cypher`"):
-                Neo4jOperator(task_id="basic_neo4j", sql="a", cypher="b")
+            op = Neo4jOperator(task_id="basic_neo4j", sql="a", cypher="b")
 
-    def test_neo4j_operator_missing_cypher_raises(self):
+        with pytest.raises(ValueError, match="Cannot provide both `sql` and `cypher`"):
+            op.execute(mock.MagicMock())
+
+    def test_neo4j_operator_missing_cypher_raises_on_execute(self):
+        op = Neo4jOperator(task_id="basic_neo4j")
+
         with pytest.raises(ValueError, match="Parameter `cypher` is required."):
-            Neo4jOperator(task_id="basic_neo4j")
+            op.execute(mock.MagicMock())

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -77,7 +77,6 @@ providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/gcs_to_wasb.py::GCSToAzureBlobStorageOperator
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py::OracleToAzureDataLakeOperator
 providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py::PsrpOperator
-providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py::Neo4jOperator
 providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py::OracleToOracleOperator
 providers/papermill/src/airflow/providers/papermill/operators/papermill.py::PapermillOperator
 providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_containers.py::SnowparkContainerJobOperator


### PR DESCRIPTION

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Fix Neo4jOperator so templated Cypher queries are validated after template rendering instead of during operator construction.

This also removes Neo4jOperator from the operator init validator exemption list.

related: #70296

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

-  `[X]`  Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
