### PR TITLE
Fix merge_dicts crash when a dict overrides a non-dict value

### DIFF
--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -176,8 +176,8 @@ def merge_dicts(dict1: dict, dict2: dict) -> dict:
     """
     merged = dict1.copy()
     for k, v in dict2.items():
-        if k in merged and isinstance(v, dict):
-            merged[k] = merge_dicts(merged.get(k, {}), v)
+        if k in merged and isinstance(v, dict) and isinstance(merged[k], dict):
+            merged[k] = merge_dicts(merged[k], v)
         else:
             merged[k] = v
     return merged

--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -174,8 +174,8 @@ def merge_dicts(dict1: dict, dict2: dict) -> dict:
     """
     merged = dict1.copy()
     for k, v in dict2.items():
-        if k in merged and isinstance(v, dict):
-            merged[k] = merge_dicts(merged.get(k, {}), v)
+        if k in merged and isinstance(v, dict) and isinstance(merged[k], dict):
+            merged[k] = merge_dicts(merged[k], v)
         else:
             merged[k] = v
     return merged

--- a/airflow-core/tests/unit/utils/test_helpers.py
+++ b/airflow-core/tests/unit/utils/test_helpers.py
@@ -114,6 +114,14 @@ class TestHelpers:
         merged = merge_dicts(dict1, dict2)
         assert merged == {"a": 1, "r": {"b": 0, "c": 3}}
 
+    def test_merge_dicts_overwrites_non_dict_with_dict(self):
+        """
+        When dict1 holds a non-dict for a key and dict2 holds a dict, dict2 overwrites
+        (per the documented contract) instead of recursing into the non-dict and raising.
+        """
+        assert merge_dicts({"a": 1}, {"a": {"b": 2}}) == {"a": {"b": 2}}
+        assert merge_dicts({"a": [1, 2]}, {"a": {"b": 2}}) == {"a": {"b": 2}}
+
     def test_build_airflow_dagrun_url(self):
         expected_url = "/dags/somedag/runs/abc123"
         assert build_airflow_dagrun_url(dag_id="somedag", run_id="abc123") == expected_url

--- a/airflow-core/tests/unit/utils/test_helpers.py
+++ b/airflow-core/tests/unit/utils/test_helpers.py
@@ -113,6 +113,14 @@ class TestHelpers:
         merged = merge_dicts(dict1, dict2)
         assert merged == {"a": 1, "r": {"b": 0, "c": 3}}
 
+    def test_merge_dicts_overwrites_non_dict_with_dict(self):
+        """
+        When dict1 holds a non-dict for a key and dict2 holds a dict, dict2 overwrites
+        (per the documented contract) instead of recursing into the non-dict and raising.
+        """
+        assert merge_dicts({"a": 1}, {"a": {"b": 2}}) == {"a": {"b": 2}}
+        assert merge_dicts({"a": [1, 2]}, {"a": {"b": 2}}) == {"a": {"b": 2}}
+
     def test_build_airflow_dagrun_url(self):
         expected_url = "/dags/somedag/runs/abc123"
         assert build_airflow_dagrun_url(dag_id="somedag", run_id="abc123") == expected_url


### PR DESCRIPTION
`merge_dicts` recurses whenever the value in `dict2` is a dict, without checking that the existing value in `dict1` is also a dict. Merging a dict over a scalar or list value therefore raised instead of overwriting it, contradicting the documented contract ("Items in dict2 overwrite those also found in dict1").

Reproduces on `main`:

```python
merge_dicts({"a": 1}, {"a": {"b": 2}})       # AttributeError: 'int' object has no attribute 'copy'
merge_dicts({"a": [1, 2]}, {"a": {"b": 2}})  # TypeError: list indices must be integers or slices, not str
```

Both now return `{"a": {"b": 2}}`. Adds a regression test; the existing `merge_dicts` tests still pass.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)