### PR TITLE
Replace AirflowException with ValueError in ProduceToTopicOperator

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -136,7 +136,6 @@ providers/apache/hive/src/airflow/providers/apache/hive/hooks/hive.py::9
 providers/apache/hive/src/airflow/providers/apache/hive/operators/hive_stats.py::1
 providers/apache/hive/src/airflow/providers/apache/hive/transfers/s3_to_hive.py::6
 providers/apache/kafka/src/airflow/providers/apache/kafka/operators/consume.py::2
-providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py::1
 providers/apache/kafka/src/airflow/providers/apache/kafka/triggers/await_message.py::1
 providers/apache/kylin/src/airflow/providers/apache/kylin/hooks/kylin.py::1
 providers/apache/kylin/src/airflow/providers/apache/kylin/operators/kylin_cube.py::5

--- a/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
+++ b/providers/apache/kafka/src/airflow/providers/apache/kafka/operators/produce.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from airflow.providers.apache.kafka.hooks.produce import KafkaProducerHook
 from airflow.providers.common.compat.module_loading import import_string
-from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 local_logger = logging.getLogger("airflow")
 
@@ -58,7 +58,7 @@ class ProduceToTopicOperator(BaseOperator):
     :param synchronous: If writes to kafka should be fully synchronous, defaults to True
     :param poll_timeout: How long of a delay should be applied when calling poll after production to kafka,
         defaults to 0
-    :raises AirflowException: _description_
+    :raises ValueError: If ``topic`` or ``producer_function`` is not provided.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -102,7 +102,7 @@ class ProduceToTopicOperator(BaseOperator):
 
     def execute(self, context) -> None:
         if not (self.topic and self.producer_function):
-            raise AirflowException(
+            raise ValueError(
                 "topic and producer_function must be provided. Got topic="
                 f"{self.topic} and producer_function={self.producer_function}"
             )

--- a/providers/apache/kafka/tests/unit/apache/kafka/operators/test_produce.py
+++ b/providers/apache/kafka/tests/unit/apache/kafka/operators/test_produce.py
@@ -26,7 +26,6 @@ import pytest
 from airflow.models import Connection
 from airflow.models.dag import DAG
 from airflow.providers.apache.kafka.operators.produce import ProduceToTopicOperator
-from airflow.providers.common.compat.sdk import AirflowException
 
 log = logging.getLogger(__name__)
 
@@ -89,17 +88,26 @@ class TestProduceToTopic:
 
         operator.execute(context={})
 
-    def test_execute_rejects_empty_rendered_topic(self):
+    @pytest.mark.parametrize(
+        ("rendered_topic", "producer_function"),
+        [
+            pytest.param("", _simple_producer, id="empty-rendered-topic"),
+            pytest.param("test_1", None, id="missing-producer-function"),
+        ],
+    )
+    def test_execute_rejects_empty_rendered_topic_or_missing_producer_function(
+        self, rendered_topic, producer_function
+    ):
         with DAG("kafka_produce", schedule=None, start_date=pendulum.datetime(2020, 1, 1, tz="UTC")):
             operator = ProduceToTopicOperator(
                 kafka_config_id="kafka_d",
                 topic="{{ params.topic }}",
-                producer_function=_simple_producer,
+                producer_function=producer_function,
                 producer_function_args=(b"test", b"test"),
                 task_id="test",
                 synchronous=False,
             )
-        operator.render_template_fields({"params": {"topic": ""}})
-        assert operator.topic == ""
-        with pytest.raises(AirflowException, match="topic and producer_function must be provided"):
+        operator.render_template_fields({"params": {"topic": rendered_topic}})
+        assert operator.topic == rendered_topic
+        with pytest.raises(ValueError, match="topic and producer_function must be provided"):
             operator.execute(context={})


### PR DESCRIPTION
Based on `CLAUDE.md`, the community is actively reducing AirflowException usage. Replace `raise AirflowException(...)` with `raise ValueError(...)` in ProduceToTopicOperator.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
* related: #70296
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
