### PR TITLE
feat(dag-processing): let bundles supply a per-bundle parse PYTHONPATH

### DIFF
--- a/airflow-core/src/airflow/dag_processing/bundles/base.py
+++ b/airflow-core/src/airflow/dag_processing/bundles/base.py
@@ -360,6 +360,18 @@ class BaseDagBundle(ABC):
         After `initialize` has been called, all dag files in the bundle should be accessible from this path.
         """
 
+    @property
+    def parse_pythonpath(self) -> list[str]:
+        """
+        Extra ``sys.path`` entries to make importable when *parsing* this bundle's DAG files.
+
+        Override to return absolute paths (for example this bundle's own virtualenv ``site-packages``)
+        so that a single DAG processor can parse bundles that require different dependencies, each
+        against its own. The entries are prepended to ``sys.path`` in the parsing subprocess for this
+        bundle only. Empty by default, so parsing uses the DAG processor's environment unchanged.
+        """
+        return []
+
     @abstractmethod
     def get_current_version(self) -> str | BundleVersion | None:
         """

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -1383,6 +1383,9 @@ class DagFileProcessorManager(LoggingMixin):
         callback_to_execute_for_file = self._callback_to_execute.pop(dag_file, [])
         logger, logger_filehandle = self._get_logger_for_dag_file(dag_file)
 
+        bundle = next((b for b in self._dag_bundles if b.name == dag_file.bundle_name), None)
+        bundle_pythonpath = list(bundle.parse_pythonpath) if bundle is not None else []
+
         return DagFileProcessorProcess.start(
             id=id,
             path=dag_file.absolute_path,
@@ -1390,6 +1393,7 @@ class DagFileProcessorManager(LoggingMixin):
             bundle_name=dag_file.bundle_name,
             dag_file_rel_path=str(dag_file.rel_path),
             callbacks=callback_to_execute_for_file,
+            bundle_pythonpath=bundle_pythonpath,
             selector=self.selector,
             logger=logger,
             logger_filehandle=logger_filehandle,

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -20,6 +20,7 @@ import contextlib
 import importlib
 import logging
 import os
+import sys
 import traceback
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -125,6 +126,10 @@ class DagFileParseRequest(BaseModel):
 
     bundle_name: str
     """Bundle name for team-specific executor validation."""
+
+    bundle_pythonpath: list[str] = Field(default_factory=list)
+    """Extra ``sys.path`` entries to prepend before parsing this bundle's file (see
+    ``BaseDagBundle.parse_pythonpath``)."""
 
     callback_requests: list[CallbackRequest] = Field(default_factory=list)
     type: Literal["DagFileParseRequest"] = "DagFileParseRequest"
@@ -234,6 +239,14 @@ def _parse_file_entrypoint():
 
 def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileParsingResult | None:
     # TODO: Set known_pool names on DagBag!
+
+    if msg.bundle_pythonpath:
+        # Parse this bundle's file against the bundle's own dependencies (e.g. its virtualenv
+        # site-packages), so one DAG processor can serve bundles with differing requirements. This
+        # runs in the per-file parsing subprocess, so the change is scoped to this file's parse.
+        for entry in reversed(msg.bundle_pythonpath):
+            if entry not in sys.path:
+                sys.path.insert(0, entry)
 
     stability_check_result = check_dag_file_stability(os.fspath(msg.file))
 
@@ -582,6 +595,7 @@ class DagFileProcessorProcess(WatchedSubprocess, LoggingMixin):
         bundle_name: str,
         dag_file_rel_path: str,
         callbacks: list[CallbackRequest],
+        bundle_pythonpath: list[str] | None = None,
         target: Callable[[], None] = _parse_file_entrypoint,
         client: Client,
         **kwargs,
@@ -609,7 +623,7 @@ class DagFileProcessorProcess(WatchedSubprocess, LoggingMixin):
             **kwargs,
         )
         proc.had_callbacks = bool(callbacks)  # Track if this process had callbacks
-        proc._on_child_started(callbacks, path, bundle_path, bundle_name)
+        proc._on_child_started(callbacks, path, bundle_path, bundle_name, bundle_pythonpath or [])
         return proc
 
     def _on_child_started(
@@ -618,11 +632,13 @@ class DagFileProcessorProcess(WatchedSubprocess, LoggingMixin):
         path: str | os.PathLike[str],
         bundle_path: Path,
         bundle_name: str,
+        bundle_pythonpath: list[str] | None = None,
     ) -> None:
         msg = DagFileParseRequest(
             file=os.fspath(path),
             bundle_path=bundle_path,
             bundle_name=bundle_name,
+            bundle_pythonpath=bundle_pythonpath or [],
             callback_requests=callbacks,
         )
         self.send_msg(msg, request_id=0)

--- a/airflow-core/tests/unit/dag_processing/bundles/test_base.py
+++ b/airflow-core/tests/unit/dag_processing/bundles/test_base.py
@@ -79,6 +79,20 @@ def test_dag_bundle_root_storage_path():
         assert get_bundle_storage_root_path() == Path(tempfile.gettempdir(), "airflow", "dag_bundles")
 
 
+def test_parse_pythonpath_defaults_to_empty():
+    bundle = BasicBundle(name="x")
+    assert bundle.parse_pythonpath == []
+
+
+def test_parse_pythonpath_can_be_overridden():
+    class WithPythonpath(BasicBundle):
+        @property
+        def parse_pythonpath(self):
+            return ["/opt/x/site-packages"]
+
+    assert WithPythonpath(name="x").parse_pythonpath == ["/opt/x/site-packages"]
+
+
 def test_lock_acquisition():
     """Test that the lock context manager sets _locked and locks a lock file."""
     bundle = BasicBundle(name="locktest")

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -157,6 +157,54 @@ class TestDagFileProcessor:
         assert resp.import_errors is not None
         assert "a.py" in resp.import_errors
 
+    def test_parse_file_uses_bundle_pythonpath(self, tmp_path):
+        """A dep only on the bundle's ``parse_pythonpath`` is importable at parse for that bundle."""
+        site = tmp_path / "bundle_site"
+        (site / "mpdep").mkdir(parents=True)
+        (site / "mpdep" / "__init__.py").write_text("VALUE = 1\n")
+        dags = tmp_path / "dags"
+        dags.mkdir()
+        dag_file = dags / "needs_mpdep.py"
+        dag_file.write_text(
+            textwrap.dedent(
+                """
+                import datetime
+                import mpdep
+                from airflow import DAG
+                with DAG(dag_id="needs_mpdep", schedule=None,
+                         start_date=datetime.datetime(2024, 1, 1)):
+                    pass
+                """
+            )
+        )
+
+        def parse(bundle_pythonpath):
+            return _parse_file(
+                DagFileParseRequest(
+                    file=str(dag_file),
+                    bundle_path=dags,
+                    bundle_name="testing",
+                    bundle_pythonpath=bundle_pythonpath,
+                    callback_requests=[],
+                ),
+                log=structlog.get_logger(),
+            )
+
+        try:
+            # Without the bundle path, the dep is absent from the parse env -> import error.
+            without = parse([])
+            assert without is not None and not without.serialized_dags
+            assert any("mpdep" in e for e in (without.import_errors or {}).values())
+
+            # With the bundle's parse_pythonpath, the same file parses cleanly.
+            with_pp = parse([str(site)])
+            assert with_pp is not None
+            assert with_pp.serialized_dags
+            assert not with_pp.import_errors
+        finally:
+            sys.path[:] = [p for p in sys.path if p != str(site)]
+            sys.modules.pop("mpdep", None)
+
     def test_top_level_variable_access(
         self,
         spy_agency: SpyAgency,


### PR DESCRIPTION
### Why

A DAG bundle defines its *source* (a path and a version) but not the *environment* its files are parsed in. When one DAG processor serves multiple bundles, every bundle is parsed in that processor's single Python environment. Bundles from different teams that need different dependencies (or different versions of the same one) can't each be parsed against their own — a DAG that imports a team-only or version-pinned package builds fine for the team but fails `DagBag` import when a shared processor parses it. Today the only isolation is running a DAG processor per environment (`--bundle-name` scoping), which costs a process per dependency set.

### What

Add an opt-in `BaseDagBundle.parse_pythonpath` (empty by default). When set, the DAG processor prepends those entries to `sys.path` in the per-file parsing subprocess for that bundle only, so a single processor can parse bundles against their own dependencies (for example each bundle's own virtualenv `site-packages`). Bundles that declare nothing parse exactly as before.

- `BaseDagBundle.parse_pythonpath` property (default `[]`).
- `DagFileParseRequest.bundle_pythonpath`, threaded from `DagFileProcessorManager._create_process` through `DagFileProcessorProcess.start`.
- `_parse_file` prepends it to `sys.path` before parsing.

### Tests

`_parse_file` parses a DAG importing a module present only on the bundle's `parse_pythonpath`, and reproduces the import failure without it; plus `parse_pythonpath` default and override.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI
