### PR TITLE
Move template field validation out of __init__ for Papermill operator (#70296)

### DIFF
--- a/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
+++ b/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
@@ -88,15 +88,8 @@ class PapermillOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.parameters = parameters
-
-        if not input_nb:
-            raise ValueError("Input notebook is not specified")
         self.input_nb = input_nb
-
-        if not output_nb:
-            raise ValueError("Output notebook is not specified")
         self.output_nb = output_nb
-
         self.kernel_name = kernel_name
         self.language_name = language_name
         self.kernel_conn_id = kernel_conn_id
@@ -105,6 +98,10 @@ class PapermillOperator(BaseOperator):
         self.nbconvert_args = nbconvert_args
 
     def execute(self, context: Context):
+        if not self.input_nb:
+            raise ValueError("Input notebook is not specified")
+        if not self.output_nb:
+            raise ValueError("Output notebook is not specified")
         if not isinstance(self.input_nb, NoteBook):
             self.input_nb = NoteBook(url=self.input_nb, parameters=self.parameters)
         if not isinstance(self.output_nb, NoteBook):

--- a/providers/papermill/tests/unit/papermill/operators/test_papermill.py
+++ b/providers/papermill/tests/unit/papermill/operators/test_papermill.py
@@ -43,12 +43,12 @@ class TestPapermillOperator:
     """Test PapermillOperator."""
 
     def test_mandatory_attributes(self):
-        """Test missing Input or Output notebooks."""
+        """Test missing Input or Output notebooks are validated at execute time."""
         with pytest.raises(ValueError, match="Input notebook is not specified"):
-            PapermillOperator(task_id="missing_input_nb", output_nb="foo-bar")
+            PapermillOperator(task_id="missing_input_nb", output_nb="foo-bar").execute(context={})
 
         with pytest.raises(ValueError, match="Output notebook is not specified"):
-            PapermillOperator(task_id="missing_input_nb", input_nb="foo-bar")
+            PapermillOperator(task_id="missing_output_nb", input_nb="foo-bar").execute(context={})
 
     @pytest.mark.parametrize(
         ("output_nb_url", "output_as_object"),

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -53,7 +53,6 @@ providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/gcs_to
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py::OracleToAzureDataLakeOperator
 providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py::PsrpOperator
 providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py::OracleToOracleOperator
-providers/papermill/src/airflow/providers/papermill/operators/papermill.py::PapermillOperator
 providers/standard/src/airflow/providers/standard/operators/bash.py::BashOperator
 providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py::TriggerDagRunOperator
 providers/standard/src/airflow/providers/standard/sensors/date_time.py::DateTimeSensor


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

### Description

Refactored `CohereEmbeddingOperator` and `PapermillOperator` to ensure template fields are validated during execution or render time rather than inside `__init__`, aligning with Airflow operator standards.

* Moved initialization checks dependent on template fields out of `__init__`.
* Updated corresponding unit tests in Cohere and Papermill provider test suites.
* Removed `CohereEmbeddingOperator` and `PapermillOperator` entries from `scripts/ci/prek/validate_operators_init_exemptions.txt`.

### Related Issue

works on: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Gemini)

Generated-by: Gemini following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)