### PR TITLE
Prevent premature validation in Gemini batch job operators

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py
@@ -475,15 +475,6 @@ class GenAIGeminiCreateBatchJobOperator(GoogleCloudBaseOperator):
         self.results_folder = results_folder
         self.deferrable = deferrable
 
-        if self.retrieve_result and not (self.wait_until_complete or self.deferrable):
-            raise AirflowException(
-                "Retrieving results is possible only if wait_until_complete set to True or in deferrable mode"
-            )
-        if self.results_folder and not isinstance(self.input_source, str):
-            raise AirflowException("results_folder works only when input_source is file name")
-        if self.results_folder and not os.path.exists(os.path.abspath(self.results_folder)):
-            raise AirflowException("path to results_folder does not exist, please provide correct path")
-
     def _wait_until_complete(self, job, polling_interval: int = 30):
         try:
             while True:
@@ -542,6 +533,17 @@ class GenAIGeminiCreateBatchJobOperator(GoogleCloudBaseOperator):
         )
 
     def execute(self, context: Context):
+        if self.retrieve_result and not (self.wait_until_complete or self.deferrable):
+            raise AirflowException(
+                "Retrieving results is possible only if wait_until_complete set to True or in deferrable mode"
+            )
+
+        if self.results_folder and not isinstance(self.input_source, str):
+            raise AirflowException("results_folder works only when input_source is file name")
+
+        if self.results_folder and not os.path.exists(os.path.abspath(self.results_folder)):
+            raise AirflowException("path to results_folder does not exist, please provide correct path")
+
         if self.deferrable:
             self.defer(
                 trigger=GenAIGeminiCreateBatchJobTrigger(
@@ -918,15 +920,6 @@ class GenAIGeminiCreateEmbeddingsBatchJobOperator(GoogleCloudBaseOperator):
         self.results_folder = results_folder
         self.deferrable = deferrable
 
-        if self.retrieve_result and not (self.wait_until_complete or self.deferrable):
-            raise AirflowException(
-                "Retrieving results is possible only if wait_until_complete set to True or in deferrable mode"
-            )
-        if self.results_folder and not isinstance(self.input_source, str):
-            raise AirflowException("results_folder works only when input_source is file name")
-        if self.results_folder and not os.path.exists(os.path.abspath(self.results_folder)):
-            raise AirflowException("path to results_folder does not exist, please provide correct path")
-
     def _wait_until_complete(self, job, polling_interval: int = 30):
         try:
             while True:
@@ -985,6 +978,16 @@ class GenAIGeminiCreateEmbeddingsBatchJobOperator(GoogleCloudBaseOperator):
         )
 
     def execute(self, context: Context):
+        if self.retrieve_result and not (self.wait_until_complete or self.deferrable):
+            raise AirflowException(
+                "Retrieving results is possible only if wait_until_complete set to True or in deferrable mode"
+            )
+
+        if self.results_folder and not isinstance(self.input_source, str):
+            raise AirflowException("results_folder works only when input_source is file name")
+
+        if self.results_folder and not os.path.exists(os.path.abspath(self.results_folder)):
+            raise AirflowException("path to results_folder does not exist, please provide correct path")
         if self.deferrable:
             self.defer(
                 trigger=GenAIGeminiCreateEmbeddingsBatchJobTrigger(

--- a/providers/google/tests/unit/google/cloud/operators/test_gen_ai.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_gen_ai.py
@@ -395,50 +395,67 @@ class TestGenAIGeminiCreateBatchJobOperator:
         mock_hook.return_value.get_batch_job.assert_called_once_with("test-name")
         mock_job.model_dump.assert_called_once_with(mode="json")
 
-    def test_init_retrieve_result_and_not_wait_until_complete_raises_airflow_exception(self):
-        with pytest.raises(AirflowException):
-            GenAIGeminiCreateBatchJobOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                location=GCP_LOCATION,
-                model=TEST_GEMINI_MODEL,
-                gcp_conn_id=GCP_CONN_ID,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                input_source=TEST_BATCH_JOB_INLINED_REQUESTS,
-                gemini_api_key=TEST_GEMINI_API_KEY,
-                wait_until_complete=False,
-                retrieve_result=True,
-            )
+    def test_execute_retrieve_result_and_not_wait_until_complete_raises_airflow_exception(self):
+        op = GenAIGeminiCreateBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            model=TEST_GEMINI_MODEL,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            input_source=TEST_BATCH_JOB_INLINED_REQUESTS,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            wait_until_complete=False,
+            retrieve_result=True,
+        )
 
-    def test_init_input_source_not_string_raises_airflow_exception(self):
-        with pytest.raises(AirflowException):
-            GenAIGeminiCreateBatchJobOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                location=GCP_LOCATION,
-                model=TEST_GEMINI_MODEL,
-                gcp_conn_id=GCP_CONN_ID,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                input_source=TEST_BATCH_JOB_INLINED_REQUESTS,
-                gemini_api_key=TEST_GEMINI_API_KEY,
-                wait_until_complete=False,
-                results_folder=TEST_FILE_PATH,
-            )
+        with pytest.raises(
+            AirflowException,
+            match=(
+                "Retrieving results is possible only if wait_until_complete set to True or in deferrable mode"
+            ),
+        ):
+            op.execute(context={"ti": mock.MagicMock()})
 
-    def test_init_results_folder_not_exists_raises_airflow_exception(self):
-        with pytest.raises(AirflowException):
-            GenAIGeminiCreateBatchJobOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                location=GCP_LOCATION,
-                model=TEST_GEMINI_MODEL,
-                gcp_conn_id=GCP_CONN_ID,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                input_source=TEST_FILE_NAME,
-                gemini_api_key=TEST_GEMINI_API_KEY,
-                wait_until_complete=False,
-                results_folder=TEST_FILE_PATH,
-            )
+    def test_execute_input_source_not_string_raises_airflow_exception(self):
+        op = GenAIGeminiCreateBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            model=TEST_GEMINI_MODEL,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            input_source=TEST_BATCH_JOB_INLINED_REQUESTS,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            wait_until_complete=False,
+            results_folder=TEST_FILE_PATH,
+        )
+
+        with pytest.raises(
+            AirflowException,
+            match="results_folder works only when input_source is file name",
+        ):
+            op.execute(context={"ti": mock.MagicMock()})
+
+    def test_execute_results_folder_not_exists_raises_airflow_exception(self):
+        op = GenAIGeminiCreateBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            model=TEST_GEMINI_MODEL,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            input_source=TEST_FILE_NAME,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            wait_until_complete=False,
+            results_folder=TEST_FILE_PATH,
+        )
+
+        with pytest.raises(
+            AirflowException,
+            match="path to results_folder does not exist, please provide correct path",
+        ):
+            op.execute(context={"ti": mock.MagicMock()})
 
     @mock.patch(GEN_AI_PATH.format("GenAIGeminiAPIHook"))
     def test__wait_until_complete_exception_raises_airflow_exception(self, mock_hook):
@@ -753,50 +770,67 @@ class TestGenAIGeminiCreateEmbeddingsBatchJobOperator:
             create_embeddings_config=None,
         )
 
-    def test_init_retrieve_result_and_not_wait_until_complete_raises_airflow_exception(self):
-        with pytest.raises(AirflowException):
-            GenAIGeminiCreateEmbeddingsBatchJobOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                location=GCP_LOCATION,
-                input_source=TEST_EMBEDDINGS_JOB_INLINED_REQUESTS,
-                model=EMBEDDING_MODEL,
-                gemini_api_key=TEST_GEMINI_API_KEY,
-                gcp_conn_id=GCP_CONN_ID,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                wait_until_complete=False,
-                retrieve_result=True,
-            )
+    def test_execute_retrieve_result_and_not_wait_until_complete_raises_airflow_exception(self):
+        op = GenAIGeminiCreateEmbeddingsBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            input_source=TEST_EMBEDDINGS_JOB_INLINED_REQUESTS,
+            model=EMBEDDING_MODEL,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            wait_until_complete=False,
+            retrieve_result=True,
+        )
 
-    def test_init_input_source_not_string_raises_airflow_exception(self):
-        with pytest.raises(AirflowException):
-            GenAIGeminiCreateEmbeddingsBatchJobOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                location=GCP_LOCATION,
-                input_source=TEST_EMBEDDINGS_JOB_INLINED_REQUESTS,
-                model=EMBEDDING_MODEL,
-                gemini_api_key=TEST_GEMINI_API_KEY,
-                gcp_conn_id=GCP_CONN_ID,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                wait_until_complete=False,
-                results_folder=TEST_FILE_PATH,
-            )
+        with pytest.raises(
+            AirflowException,
+            match=(
+                "Retrieving results is possible only if wait_until_complete set to True or in deferrable mode"
+            ),
+        ):
+            op.execute(context={"ti": mock.MagicMock()})
 
-    def test_init_results_folder_not_exists_raises_airflow_exception(self):
-        with pytest.raises(AirflowException):
-            GenAIGeminiCreateEmbeddingsBatchJobOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                location=GCP_LOCATION,
-                input_source=TEST_FILE_NAME,
-                model=EMBEDDING_MODEL,
-                gemini_api_key=TEST_GEMINI_API_KEY,
-                gcp_conn_id=GCP_CONN_ID,
-                impersonation_chain=IMPERSONATION_CHAIN,
-                wait_until_complete=False,
-                results_folder=TEST_FILE_PATH,
-            )
+    def test_execute_input_source_not_string_raises_airflow_exception(self):
+        op = GenAIGeminiCreateEmbeddingsBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            input_source=TEST_EMBEDDINGS_JOB_INLINED_REQUESTS,
+            model=EMBEDDING_MODEL,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            wait_until_complete=False,
+            results_folder=TEST_FILE_PATH,
+        )
+
+        with pytest.raises(
+            AirflowException,
+            match="results_folder works only when input_source is file name",
+        ):
+            op.execute(context={"ti": mock.MagicMock()})
+
+    def test_execute_results_folder_not_exists_raises_airflow_exception(self):
+        op = GenAIGeminiCreateEmbeddingsBatchJobOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            input_source=TEST_FILE_NAME,
+            model=EMBEDDING_MODEL,
+            gemini_api_key=TEST_GEMINI_API_KEY,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+            wait_until_complete=False,
+            results_folder=TEST_FILE_PATH,
+        )
+
+        with pytest.raises(
+            AirflowException,
+            match="path to results_folder does not exist, please provide correct path",
+        ):
+            op.execute(context={"ti": mock.MagicMock()})
 
     @mock.patch(GEN_AI_PATH.format("GenAIGeminiAPIHook"))
     def test__wait_until_complete_exception_raises_airflow_exception(self, mock_hook):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -60,8 +60,6 @@ providers/google/src/airflow/providers/google/cloud/operators/functions.py::Clou
 providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSDeleteObjectsOperator
 providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSFileTransformOperator
 providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSListObjectsOperator
-providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py::GenAIGeminiCreateBatchJobOperator
-providers/google/src/airflow/providers/google/cloud/operators/gen_ai.py::GenAIGeminiCreateEmbeddingsBatchJobOperator
 providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py::BigQueryDataTransferServiceTransferRunSensor
 providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py::CloudComposerExternalTaskSensor
 providers/google/src/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py::AzureFileShareToGCSOperator


### PR DESCRIPTION
Move argument validation from operator initialization to execution time for `GenAIGeminiCreateBatchJobOperator` and `GenAIGeminiCreateEmbeddingsBatchJobOperator`.

Template fields are rendered after operator initialization. Performing validation in `__init__` can therefore inspect unresolved Jinja expressions instead of their rendered values.

This change:

* moves the relevant validations to `execute`
* updates the corresponding unit tests to verify execution-time validation
* removes both operators from the operator initialization exemption list

Tests:

```bash
breeze run pytest providers/google/tests/unit/google/cloud/operators/test_gen_ai.py \
  -k "GenAIGeminiCreateBatchJobOperator or GenAIGeminiCreateEmbeddingsBatchJobOperator"
```

```bash
prek run --from-ref main
```

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

* [ ] Yes (please specify the tool below)

---

* Read the **[[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([[AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [[ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x)](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [[airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments)](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.