### PR TITLE
Fail AzureVirtualMachineStateSensor fast on an invalid target_state

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/compute.py
@@ -68,11 +68,6 @@ class AzureVirtualMachineStateSensor(BaseSensorOperator):
         self.deferrable = deferrable
 
     def poke(self, context: Context) -> bool:
-        # target_state is a template field; validate the rendered value here, not in __init__.
-        if self.target_state not in self.VALID_STATES:
-            raise ValueError(
-                f"Invalid target_state: {self.target_state}. Must be one of {sorted(self.VALID_STATES)}"
-            )
         hook = AzureComputeHook(azure_conn_id=self.azure_conn_id)
         current_state = hook.get_power_state(self.resource_group_name, self.vm_name)
         self.log.info("VM %s power state: %s", self.vm_name, current_state)
@@ -85,6 +80,10 @@ class AzureVirtualMachineStateSensor(BaseSensorOperator):
         In deferrable mode, the polling is deferred to the triggerer. Otherwise
         the sensor waits synchronously.
         """
+        if self.target_state not in self.VALID_STATES:
+            raise ValueError(
+                f"Invalid target_state: {self.target_state}. Must be one of {sorted(self.VALID_STATES)}"
+            )
         if not self.deferrable:
             super().execute(context=context)
         else:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_compute.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/sensors/test_compute.py
@@ -43,15 +43,19 @@ class TestAzureVirtualMachineStateSensor:
         assert sensor.target_state == "running"
         assert sensor.azure_conn_id == CONN_ID
 
-    def test_invalid_target_state_rejected_at_poke(self):
+    @pytest.mark.parametrize("deferrable", [False, True])
+    def test_invalid_target_state_rejected_at_execute(self, deferrable):
         sensor = AzureVirtualMachineStateSensor(
             task_id="sense_vm",
             resource_group_name=RESOURCE_GROUP,
             vm_name=VM_NAME,
             target_state="invalid_state",
+            deferrable=deferrable,
+            silent_fail=True,
+            timeout=0,
         )
         with pytest.raises(ValueError, match="Invalid target_state"):
-            sensor.poke(context=None)
+            sensor.execute(context=None)
 
     def test_templated_target_state_constructs(self):
         sensor = AzureVirtualMachineStateSensor(


### PR DESCRIPTION
## AI Summary
Follow-up to #70329, which correctly moved the `target_state` check out of `__init__` (it is a template field, so the constructor only ever sees the un-rendered Jinja expression) but landed it in `poke()`.

`poke()` runs inside the error handling of `BaseSensorOperator.execute()`:

- `silent_fail=True` — the `ValueError` is logged and turned into `poke_return = False`, so a misconfigured sensor keeps polling until its `timeout` (7 days by default) instead of failing.
- `never_fail=True` / `soft_fail=True` — it is converted to `AirflowSkipException`, so the sensor reports **no failure at all** and downstream tasks proceed. A typo such as `target_state="Running"` (`VALID_STATES` are lowercase) silently skips.

It also re-ran on every poke.

Checking once in `execute()`, before the poll loop and before deferring, keeps the run-time check the template field requires while restoring an immediate, unambiguous failure. The added test uses `silent_fail=True` so it fails if the check ever moves back into `poke()`.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)