### PR TITLE
Show the deprecated Neo4jOperator sql query in Rendered Templates

### DIFF
--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -44,8 +44,8 @@ class Neo4jOperator(BaseOperator):
     :param parameters: the parameters to send to Neo4j driver session
     """
 
-    template_fields: Sequence[str] = ("cypher", "parameters")
-    template_fields_renderers = {"cypher": "sql", "parameters": "json"}
+    template_fields: Sequence[str] = ("cypher", "sql", "parameters")
+    template_fields_renderers = {"cypher": "sql", "sql": "sql", "parameters": "json"}
 
     def __init__(
         self,
@@ -57,12 +57,6 @@ class Neo4jOperator(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if sql is not None:
-            warnings.warn(
-                "`sql` parameter is deprecated, please use `cypher` instead.",
-                AirflowProviderDeprecationWarning,
-                stacklevel=2,
-            )
         self.neo4j_conn_id = neo4j_conn_id
         self.cypher = cypher
         self.sql = sql
@@ -71,9 +65,14 @@ class Neo4jOperator(BaseOperator):
     def execute(self, context: Context) -> None:
         cypher = self.cypher
         if self.sql is not None:
+            warnings.warn(
+                "`sql` parameter is deprecated, please use `cypher` instead.",
+                AirflowProviderDeprecationWarning,
+                stacklevel=2,
+            )
             if cypher is not None:
                 raise ValueError("Cannot provide both `sql` and `cypher`. Use `cypher` only.")
-            cypher = self.render_template(self.sql, context)
+            cypher = self.sql
         if cypher is None:
             raise ValueError("Parameter `cypher` is required.")
 

--- a/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
@@ -57,21 +57,21 @@ class TestNeo4jOperator:
         cypher = """
             MATCH (tom {name: "Tom Hanks"}) RETURN tom
             """
+        op = Neo4jOperator(task_id="basic_neo4j", sql=cypher)
+        assert "sql" in op.template_fields
         with pytest.warns(
             AirflowProviderDeprecationWarning,
             match="`sql` parameter is deprecated, please use `cypher` instead.",
         ):
-            op = Neo4jOperator(task_id="basic_neo4j", sql="{{ cypher }}")
-        assert op.sql == "{{ cypher }}"
-        op.execute({"cypher": cypher})
+            op.execute(mock.MagicMock())
         mock_hook.return_value.run.assert_called_once_with(cypher, None)
 
     def test_neo4j_operator_both_sql_and_cypher_raises_on_execute(self):
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            op = Neo4jOperator(task_id="basic_neo4j", sql="a", cypher="b")
+        op = Neo4jOperator(task_id="basic_neo4j", sql="a", cypher="b")
 
-        with pytest.raises(ValueError, match="Cannot provide both `sql` and `cypher`"):
-            op.execute(mock.MagicMock())
+        with pytest.warns(AirflowProviderDeprecationWarning):
+            with pytest.raises(ValueError, match="Cannot provide both `sql` and `cypher`"):
+                op.execute(mock.MagicMock())
 
     def test_neo4j_operator_missing_cypher_raises_on_execute(self):
         op = Neo4jOperator(task_id="basic_neo4j")


### PR DESCRIPTION
## AI Summary
Follow-up to #70348.

`sql` is a deprecated alias for `cypher`. It used to be folded into `cypher` in the constructor, so it went through the normal template-field machinery: the resolved query appeared in the **Rendered Templates** view (with the `sql` renderer) and `op.cypher` held it.

It is now kept as a separate attribute that is *not* declared a template field, and is rendered by an ad-hoc `self.render_template(self.sql, context)` inside `execute()`. So for anyone still on `sql=`:

- Rendered Templates shows `cypher: None` while a different query actually runs — the executed query is no longer visible anywhere but the task log.
- The query is rendered outside the standard pipeline (no RTIF, no `template_fields_renderers`).

Declaring `sql` a template field lets the framework render it like every other field and drops the manual call.

The deprecation warning moves to `execute()` as a consequence: reading a template field in `__init__` is exactly what `validate_operators_init` now forbids, and the constructor would only see the un-rendered expression anyway. The warning still fires once per task run, and both `ValueError`s are unchanged.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)