### PR TITLE
Docs: Correct Power BI connection docs operator name

### DIFF
--- a/providers/microsoft/azure/docs/connections/powerbi.rst
+++ b/providers/microsoft/azure/docs/connections/powerbi.rst
@@ -24,7 +24,7 @@ Microsoft Power BI Connection
 
 The Microsoft Power BI connection type enables the Power BI Integrations.
 
-The :class:`~airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook` and :class:`~airflow.providers.microsoft.azure.operators.powerbi.PowerBIDatasetOperator` requires a connection of type ``powerbi`` to authenticate with the Power BI.
+The :class:`~airflow.providers.microsoft.azure.hooks.powerbi.PowerBIHook` and :class:`~airflow.providers.microsoft.azure.operators.powerbi.PowerBIDatasetRefreshOperator` require a connection of type ``powerbi`` to authenticate with the Power BI.
 
 Authenticating to Power BI
 -------------------------------


### PR DESCRIPTION
The Microsoft Power BI connection documentation referred to PowerBIDatasetOperator, which does not exist in the Microsoft Azure provider. This change replaces it with PowerBIDatasetRefreshOperator, the operator that refreshes a Power BI dataset.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=950c9ba action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @sduvvuri26** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
