### PR TITLE
Sanitize error message in DatabricksExecutionTrigger 

### DIFF
--- a/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
@@ -28,13 +28,6 @@ _JSONB_INVALID_CHARS = re.compile(r"[\x00\ud800-\udfff]")
 def make_jsonb_safe(error: str | int) -> str | int:
     """
     Strip characters that cannot be stored in a Postgres ``jsonb`` column from error text.
-
-    Databricks run output is arbitrary external text and can contain NUL bytes or
-    unpaired UTF-16 surrogates (for example when a task emits binary data). These are
-    rejected by Postgres ``jsonb``, and since a failed task's error is persisted into
-    the deferred task instance's ``next_kwargs`` via the trigger event, an unsanitised
-    value crashes the triggerer when it writes the event. Non-string values are returned
-    unchanged.
     """
     if isinstance(error, str):
         return _JSONB_INVALID_CHARS.sub("", error)

--- a/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
@@ -17,8 +17,28 @@
 # under the License.
 from __future__ import annotations
 
+import re
+
 from airflow.providers.common.compat.sdk import AirflowException, XComArg
 from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunState
+
+_JSONB_INVALID_CHARS = re.compile(r"[\x00\ud800-\udfff]")
+
+
+def make_jsonb_safe(error: str | int) -> str | int:
+    """
+    Strip characters that cannot be stored in a Postgres ``jsonb`` column from error text.
+
+    Databricks run output is arbitrary external text and can contain NUL bytes or
+    unpaired UTF-16 surrogates (for example when a task emits binary data). These are
+    rejected by Postgres ``jsonb``, and since a failed task's error is persisted into
+    the deferred task instance's ``next_kwargs`` via the trigger event, an unsanitised
+    value crashes the triggerer when it writes the event. Non-string values are returned
+    unchanged.
+    """
+    if isinstance(error, str):
+        return _JSONB_INVALID_CHARS.sub("", error)
+    return error
 
 
 def normalise_json_content(content, json_path: str = "json") -> str | bool | list | dict | XComArg:
@@ -75,7 +95,9 @@ def extract_failed_task_errors(
                     error = run_output["error"]
                 else:
                     error = run_state.state_message
-                failed_tasks.append({"task_key": task_key, "run_id": task_run_id, "error": error})
+                failed_tasks.append(
+                    {"task_key": task_key, "run_id": task_run_id, "error": make_jsonb_safe(error)}
+                )
     return failed_tasks
 
 
@@ -101,7 +123,9 @@ async def extract_failed_task_errors_async(
                     error = run_output["error"]
                 else:
                     error = run_state.state_message
-                failed_tasks.append({"task_key": task_key, "run_id": task_run_id, "error": error})
+                failed_tasks.append(
+                    {"task_key": task_key, "run_id": task_run_id, "error": make_jsonb_safe(error)}
+                )
     return failed_tasks
 
 

--- a/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/utils/databricks.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from airflow.providers.common.compat.sdk import AirflowException, XComArg
 from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunState
@@ -25,10 +26,8 @@ from airflow.providers.databricks.hooks.databricks import DatabricksHook, RunSta
 _JSONB_INVALID_CHARS = re.compile(r"[\x00\ud800-\udfff]")
 
 
-def make_jsonb_safe(error: str | int) -> str | int:
-    """
-    Strip characters that cannot be stored in a Postgres ``jsonb`` column from error text.
-    """
+def make_jsonb_safe(error: Any) -> Any:
+    """Strip characters that cannot be stored in a Postgres ``jsonb`` column from error text."""
     if isinstance(error, str):
         return _JSONB_INVALID_CHARS.sub("", error)
     return error

--- a/providers/databricks/tests/unit/databricks/utils/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/utils/test_databricks.py
@@ -27,6 +27,7 @@ from airflow.providers.databricks.hooks.databricks import RunState
 from airflow.providers.databricks.utils.databricks import (
     extract_failed_task_errors,
     extract_failed_task_errors_async,
+    make_jsonb_safe,
     normalise_json_content,
     validate_trigger_event,
 )
@@ -94,6 +95,18 @@ class TestDatabricksOperatorSharedFunctions:
         event = {}
         with pytest.raises(AirflowException):
             validate_trigger_event(event)
+
+    def test_make_jsonb_safe_strips_nul_bytes(self):
+        assert make_jsonb_safe("PK\x03\x04binary\x00error") == "PK\x03\x04binaryerror"
+
+    def test_make_jsonb_safe_strips_unpaired_surrogates(self):
+        assert make_jsonb_safe("bad\ud800surrogate\udfff") == "badsurrogate"
+
+    def test_make_jsonb_safe_leaves_clean_text_unchanged(self):
+        assert make_jsonb_safe(ERROR_MESSAGE) == ERROR_MESSAGE
+
+    def test_make_jsonb_safe_passes_through_non_strings(self):
+        assert make_jsonb_safe(123) == 123
 
 
 class TestExtractFailedTaskErrors:
@@ -177,6 +190,37 @@ class TestExtractFailedTaskErrors:
         ]
         assert result == expected
         hook.get_run_output.assert_called_once_with(TASK_RUN_ID_1)
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    def test_extract_failed_task_errors_sanitizes_error_output(self, mock_hook_class):
+        """Error text with jsonb-incompatible characters is sanitized so it can be persisted."""
+        hook = mock_hook_class.return_value
+        hook.get_run_output = mock_dict({"error": "PK\x03\x04\x00broken\ud800"})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Task failed",
+                    },
+                }
+            ],
+        }
+
+        result = extract_failed_task_errors(hook, run_info, run_state)
+
+        assert result == [{"task_key": TASK_KEY_1, "run_id": TASK_RUN_ID_1, "error": "PK\x03\x04broken"}]
 
     @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
     def test_extract_failed_task_errors_single_failed_task_without_error_output(self, mock_hook_class):
@@ -384,6 +428,38 @@ class TestExtractFailedTaskErrorsAsync:
         ]
         assert result == expected
         hook.a_get_run_output.assert_called_once_with(TASK_RUN_ID_1)
+
+    @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
+    @pytest.mark.asyncio
+    async def test_extract_failed_task_errors_async_sanitizes_error_output(self, mock_hook_class):
+        """Error text with jsonb-incompatible characters is sanitized so it can be persisted (async)."""
+        hook = mock_hook_class.return_value
+        hook.a_get_run_output = mock.AsyncMock(return_value={"error": "PK\x03\x04\x00broken\ud800"})
+
+        run_state = RunState("TERMINATED", "FAILED", "Job failed")
+        run_info = {
+            "run_id": RUN_ID,
+            "state": {
+                "life_cycle_state": "TERMINATED",
+                "result_state": "FAILED",
+                "state_message": "Job failed",
+            },
+            "tasks": [
+                {
+                    "run_id": TASK_RUN_ID_1,
+                    "task_key": TASK_KEY_1,
+                    "state": {
+                        "life_cycle_state": "TERMINATED",
+                        "result_state": "FAILED",
+                        "state_message": "Task failed",
+                    },
+                }
+            ],
+        }
+
+        result = await extract_failed_task_errors_async(hook, run_info, run_state)
+
+        assert result == [{"task_key": TASK_KEY_1, "run_id": TASK_RUN_ID_1, "error": "PK\x03\x04broken"}]
 
     @mock.patch("airflow.providers.databricks.hooks.databricks.DatabricksHook")
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

Strip characters that Postgres `jsonb` cannot store (NUL bytes and unpaired UTF-16 surrogates) from a failed Databricks task's error text, in both `extract_failed_task_errors` and `extract_failed_task_errors_async`.

## Why

`DatabricksExecutionTrigger` puts each failed task's error into its `TriggerEvent` which gets persisted in the deferred task instance's `next_kwargs`, which is a Postgres `jsonb` column. Since Databricks output can contain NUL bytes, postgres rejects this with an error like this:

```
sqlalchemy.exc.DataError: (psycopg2.errors.UntranslatableCharacter) unsupported Unicode escape sequence
DETAIL: \u0000 cannot be converted to text.
```

Because the invalid event is retried, the triggerer enters a `CrashLoopBackOff` which makes it unhealthy.

## How

A small `make_jsonb_safe()` helper regex-strips `\x00` and `\ud800-\udfff` from the error string (non-string values pass through unchanged). It is applied to the extracted error in both the sync and async helpers, so the emitted trigger event is always persistable.

## Tests

Added unit tests in `providers/databricks/tests/unit/databricks/utils/test_databricks.py`:
- direct `make_jsonb_safe` cases (NUL strip, unpaired-surrogate strip, clean-text passthrough, non-string passthrough)
- `extract_failed_task_errors` and `extract_failed_task_errors_async` sanitize error output

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Cursor was used to help draft this change; the author reviewed it.

Generated-by: Cursor

Made with [Cursor](https://cursor.com)