### PR TITLE
Update French (fr) UI translations to 100% coverage

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/admin.json
@@ -184,6 +184,7 @@
           "title": "Ignorer"
         }
       },
+      "parsingFile": "Analyse du fichier...",
       "title": "Importer des Variables",
       "upload": "Soumettre un Fichier JSON",
       "uploadPlaceholder": "Soumettre un fichier JSON contenant des variables (par exemple, {\"key\": \"value\", ...})"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
@@ -3,6 +3,22 @@
   "asset_many": "Assets",
   "asset_one": "Asset",
   "asset_other": "Assets",
+  "assetStateStore": {
+    "add": "Ajouter un Stockage d'état d'Asset",
+    "clearAll": {
+      "resource": "tout le stockage d'état d'Asset",
+      "title": "Effacer tout le Stockage d'état d'Asset",
+      "warning": "Tout le stockage d'état d'Asset sera effacé. Les tâches qui utilisent ce stockage pour coordonner leur travail perdront leur mémoire persistée."
+    },
+    "delete": "Supprimer le Stockage d'état d'Asset",
+    "deleteWarning": "L'Asset perdra cette entrée de stockage d'état persistée.",
+    "edit": "Modifier le Stockage d'état d'Asset",
+    "emptyState": "Le stockage d'état d'Asset stocke des valeurs liées à l'identité d'un Asset, partagées entre toutes les exécutions de Dag. Les workers peuvent écrire dans le stockage d'état d'Asset via le Task SDK.",
+    "lastUpdatedBy": "Dernière mise à jour par",
+    "lastUpdatedByApi": "API",
+    "lastUpdatedByWatcher": "Watcher",
+    "title": "Stockage d'état d'Asset"
+  },
   "consumingDags": "Dags consomatteurs",
   "consumingTasks": "Tâches consommatrices",
   "createEvent": {
@@ -26,6 +42,7 @@
     },
     "title": "Créer un événement d'Asset pour {{name}}"
   },
+  "events": "Événements",
   "extra": "Extra",
   "group": "Group",
   "lastAssetEvent": "Dernier événement d'Asset",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/assets.json
@@ -4,15 +4,15 @@
   "asset_one": "Asset",
   "asset_other": "Assets",
   "assetStateStore": {
-    "add": "Ajouter un Stockage d'état d'Asset",
+    "add": "Ajouter un stockage d'état d'Asset",
     "clearAll": {
       "resource": "tout le stockage d'état d'Asset",
-      "title": "Effacer tout le Stockage d'état d'Asset",
+      "title": "Effacer tout le stockage d'état d'Asset",
       "warning": "Tout le stockage d'état d'Asset sera effacé. Les tâches qui utilisent ce stockage pour coordonner leur travail perdront leur mémoire persistée."
     },
-    "delete": "Supprimer le Stockage d'état d'Asset",
+    "delete": "Supprimer le stockage d'état d'Asset",
     "deleteWarning": "L'Asset perdra cette entrée de stockage d'état persistée.",
-    "edit": "Modifier le Stockage d'état d'Asset",
+    "edit": "Modifier le stockage d'état d'Asset",
     "emptyState": "Le stockage d'état d'Asset stocke des valeurs liées à l'identité d'un Asset, partagées entre toutes les exécutions de Dag. Les workers peuvent écrire dans le stockage d'état d'Asset via le Task SDK.",
     "lastUpdatedBy": "Dernière mise à jour par",
     "lastUpdatedByApi": "API",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/browse.json
@@ -11,6 +11,25 @@
     },
     "title": "Journal d'Audit"
   },
+  "deadlines": {
+    "columns": {
+      "alertName": "Nom de l'alerte",
+      "deadlineTime": "Heure de l'échéance",
+      "status": "Statut"
+    },
+    "deadline_many": "Échéances",
+    "deadline_one": "Échéance",
+    "deadline_other": "Échéances",
+    "filters": {
+      "status": "Statut",
+      "statusOptions": {
+        "all": "Toutes",
+        "missed": "Manquée",
+        "pending": "En attente"
+      }
+    },
+    "title": "Échéances"
+  },
   "xcom": {
     "add": {
       "error": "Échec de l'ajout du XCom",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/common.json
@@ -8,6 +8,7 @@
     "Variables": "Variables"
   },
   "allOperators": "Tous les opérateurs",
+  "allTeams": "Toutes les équipes",
   "appearance": {
     "appearance": "Apparence",
     "darkMode": "Mode sombre",
@@ -20,11 +21,15 @@
   "assetEvent_many": "Événements d'Asset",
   "assetEvent_one": "Événement d'Asset",
   "assetEvent_other": "Événements d'Asset",
+  "assetInactive": {
+    "tooltip": "L'Asset en amont a été désactivé ; le planificateur suspend l'évaluation des partitions jusqu'à sa réactivation."
+  },
   "backfill_many": "Rattrapages",
   "backfill_one": "Rattrapage",
   "backfill_other": "Rattrapages",
   "browse": {
     "auditLog": "Journal d'audit",
+    "deadlines": "Échéances",
     "jobs": "Travaux",
     "requiredActions": "Actions requises",
     "xcoms": "XComs"
@@ -58,7 +63,8 @@
     "owner": "Propriétaire",
     "params": "Paramètres",
     "schedule": "Planification",
-    "tags": "Tags"
+    "tags": "Tags",
+    "team": "Équipe"
   },
   "dagId": "ID du Dag",
   "dagRun": {
@@ -73,6 +79,7 @@
     "expectedDuration": "Durée Attendue",
     "lastSchedulingDecision": "Dernière décision de planification",
     "mappedPartitionKey": "Clé de partition mappée",
+    "partitionDate": "Date de partition",
     "partitionKey": "Clé de partition",
     "queuedAt": "Mis en file à",
     "runAfter": "Exécuté après",
@@ -147,7 +154,11 @@
     "selectDateRange": "Sélectionner une plage de dates",
     "startTime": "Heure de début"
   },
+  "fullscreen": {
+    "tooltip": "Appuyez sur {{hotkey}} pour le plein écran"
+  },
   "generateToken": "Générer un jeton",
+  "key": "Clé",
   "logicalDate": "Date logique",
   "logout": "Déconnexion",
   "logoutConfirmation": "Vous êtes sur le point de vous déconnecter de l'application.",
@@ -177,10 +188,14 @@
   "note": {
     "add": "Ajouter une note",
     "dagRun": "Note d'exécution du Run",
+    "edit": "Modifier la note",
     "label": "Note",
     "placeholder": "Ajouter une note...",
-    "taskInstance": "Note de Task Instance"
+    "preview": "Aperçu",
+    "taskInstance": "Note de Task Instance",
+    "write": "Écrire"
   },
+  "overallStatus": "Statut global",
   "partitionedDagRun_many": "Exécutions de Dag partitionnées",
   "partitionedDagRun_one": "Exécution de Dag partitionnée",
   "partitionedDagRun_other": "Exécutions de Dag partitionnées",
@@ -190,6 +205,23 @@
   "pendingDagRun_many": "{{count}} exécutions de Dag en attente",
   "pendingDagRun_one": "{{count}} exécution de Dag en attente",
   "pendingDagRun_other": "{{count}} exécutions de Dag en attente",
+  "presetFilters": {
+    "deleteTitle": "Supprimer le filtre prédéfini",
+    "deleteWarning": "Les filtres prédéfinis sont stockés uniquement dans ce navigateur.",
+    "duplicate": "Le filtre prédéfini « {{name}} » enregistre déjà exactement cette configuration.",
+    "empty": "Aucun filtre prédéfini pour le moment",
+    "info": {
+      "default": "Épinglez un filtre prédéfini comme filtre par défaut et il sera appliqué automatiquement lorsque vous arrivez sur cette page sans filtre appliqué.",
+      "save": "Enregistrez les filtres et le tri actuels comme filtre prédéfini nommé, puis revenez-y à tout moment.",
+      "storage": "Les filtres prédéfinis sont stockés dans ce navigateur."
+    },
+    "namePlaceholder": "Nom du filtre prédéfini",
+    "nothingToSave": "Rien à enregistrer. Appliquez des filtres ou un tri pour enregistrer un filtre prédéfini.",
+    "save": "Enregistrer",
+    "setDefault": "Définir par défaut",
+    "title": "Filtres prédéfinis",
+    "unsetDefault": "Annuler le filtre par défaut"
+  },
   "reset": "Réinitialiser",
   "runId": "ID d'exécution",
   "runTypes": {
@@ -221,6 +253,47 @@
   },
   "selectLanguage": "Choisir la langue",
   "selected": "Sélectionné",
+  "shortcuts": {
+    "categories": {
+      "code": "Code",
+      "dagView": "Vue Dag",
+      "filters": "Filtres",
+      "global": "Général",
+      "logs": "Journaux",
+      "navigation": "Navigation",
+      "runActions": "Actions de Run et de tâche",
+      "search": "Recherche"
+    },
+    "descriptions": {
+      "clearRun": "Effacer $t(dagRun_one)",
+      "clearTaskInstance": "Effacer $t(taskInstance_one)",
+      "downloadLogs": "Télécharger les journaux",
+      "focusFilterSearch": "Cibler la recherche de filtres",
+      "focusLogSearch": "Rechercher dans les journaux",
+      "focusSearch": "Cibler la recherche",
+      "markRunFailed": "Marquer $t(dagRun_one) comme échoué",
+      "markRunSuccess": "Marquer $t(dagRun_one) comme réussi",
+      "markTaskFailed": "Marquer $t(task_one) comme échoué",
+      "markTaskGroupFailed": "Marquer $t(taskGroup_one) comme échoué",
+      "markTaskGroupSuccess": "Marquer $t(taskGroup_one) comme réussi",
+      "markTaskSuccess": "Marquer $t(task_one) comme réussi",
+      "navigateTasks": "Naviguer entre les $t(task_other)",
+      "openGraphFilters": "Ouvrir les filtres du graphe",
+      "scrollBottom": "Défiler vers le bas",
+      "scrollTop": "Défiler vers le haut",
+      "searchDags": "Rechercher des $t(dag_other)",
+      "showHelp": "Afficher $t(shortcuts.title)",
+      "toggleExpand": "Développer ou réduire tous les groupes",
+      "toggleFullscreen": "Basculer le plein écran",
+      "toggleGraphGrid": "Basculer entre la vue graphe et grille",
+      "toggleSource": "Basculer la source",
+      "toggleTaskGroup": "Développer ou réduire $t(taskGroup_one)",
+      "toggleTimestamp": "Basculer les horodatages",
+      "toggleWrap": "Basculer $t(wrap.wrap)"
+    },
+    "empty": "Aucun raccourci clavier n'est disponible sur cette page.",
+    "title": "Raccourcis clavier"
+  },
   "showDetailsPanel": "Afficher le panneau des détails",
   "signedInAs": "Connecté en tant que",
   "source": {
@@ -234,6 +307,7 @@
   "startDate": "Date de début",
   "state": "État",
   "states": {
+    "awaiting_input": "En attente de saisie",
     "deferred": "Différé",
     "failed": "Échoué",
     "no_status": "Aucun statut",
@@ -262,31 +336,41 @@
     "from": "De",
     "maxActiveRuns": "Exécutions actives max.",
     "noTagsFound": "Aucun tag trouvé",
+    "noTeamsFound": "Aucune équipe trouvée",
     "tagMode": {
       "all": "Tous",
       "any": "N'importe lequel"
     },
     "tagPlaceholder": "Filtrer par tag",
-    "to": "À"
+    "to": "À",
+    "updatedAt": "Mis à jour le"
   },
   "task": {
+    "dependsOnPast": "Dépend du passé",
     "documentation": "Documentation de la tâche",
     "lastInstance": "Dernière instance",
     "operator": "Opérateur",
-    "triggerRule": "Règle de déclenchement"
+    "retries": "Tentatives",
+    "triggerRule": "Règle de déclenchement",
+    "waitForDownstream": "Attendre l'aval"
   },
   "task_many": "Tâches",
   "task_one": "Tâche",
   "task_other": "Tâches",
+  "taskGroup": {
+    "documentation": "Documentation du groupe de tâches"
+  },
   "taskGroup_many": "Groupes de tâches",
   "taskGroup_one": "Groupe de tâches",
   "taskGroup_other": "Groupes de tâches",
   "taskId": "ID de la tâche",
   "taskInstance": {
+    "additionalAttributes": "Attributs supplémentaires de l'instance de tâche",
     "dagVersion": "Version du Dag",
     "executor": "Exécuteur",
     "executorConfig": "Configuration de l'exécuteur",
     "hostname": "Nom d'hôte",
+    "id": "ID",
     "maxTries": "Essais max.",
     "pid": "PID",
     "pool": "Pool",
@@ -296,11 +380,13 @@
     "queuedWhen": "Mis en file à",
     "renderedMapIndex": "Map Index rendu",
     "scheduledWhen": "Planifié à",
+    "trigger": "Déclencheur",
     "triggerer": {
       "assigned": "Déclencheur assigné",
       "class": "Classe de déclencheur",
       "createdAt": "Heure de création du déclencheur",
       "id": "ID du déclencheur",
+      "job": "Job du déclencheur",
       "latestHeartbeat": "Dernier battement du déclencheur",
       "title": "Infos sur le déclencheur"
     },
@@ -398,6 +484,7 @@
     "mustBeAtLeast": "Doit être au moins {{min}}.",
     "mustBeValidNumber": "Doit être un nombre valide."
   },
+  "value": "Valeur",
   "wrap": {
     "hotkey": "w",
     "tooltip": "Appuyez sur {{hotkey}} pour activer/désactiver le retour à la ligne",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/components.json
@@ -16,6 +16,7 @@
     "reprocessBehavior": "Comportement de réexécution",
     "run": "Lancer le rattrapage",
     "scheduleNotBackfillable": "La planification de ce Dag ne prend pas en charge les rattrapages",
+    "schedulerPriorityHint": "Les exécutions de Dag de rattrapage sont ordonnées après les exécutions de Dag hors rattrapage à chaque cycle du planificateur. Les exécutions de rattrapage peuvent rester en file plus longtemps si d'autres exécutions hors rattrapage sont présentes.",
     "selectDescription": "Exécuter ce Dag pour une plage de dates",
     "selectLabel": "Rattrapage",
     "title": "Lancer un rattrapage",
@@ -68,6 +69,7 @@
     "lastTaskInstance_many": "Dernières {{count}} Task Instances",
     "lastTaskInstance_one": "Dernière Task Instance",
     "lastTaskInstance_other": "Dernières {{count}} Task Instances",
+    "medianTotalDuration": "Total : {{duration}}",
     "queuedDuration": "Durée en file d'attente",
     "runAfter": "Exécuté après",
     "runDuration": "Durée d'exécution"
@@ -78,6 +80,7 @@
     "files_other": "{{count}} fichiers"
   },
   "flexibleForm": {
+    "durationPlaceholder": "Saisissez la durée au format ISO 8601",
     "placeholder": "Sélectionner une valeur",
     "placeholderArray": "Entrez chaque mot sur une ligne séparée",
     "placeholderExamples": "Commencez à taper pour voir les options",
@@ -85,6 +88,7 @@
     "validationErrorArrayNotArray": "La valeur doit être un tableau.",
     "validationErrorArrayNotNumbers": "Tous les éléments du tableau doivent être des nombres.",
     "validationErrorArrayNotObject": "Tous les éléments du tableau doivent être des objets.",
+    "validationErrorDuration": "Format de durée ISO 8601 invalide",
     "validationErrorRequired": "Ce champ est requis"
   },
   "graph": {
@@ -142,6 +146,7 @@
     "loading": "Chargement des informations du Dag...",
     "loadingFailed": "Échec du chargement des informations du Dag. Veuillez réessayer.",
     "manualRunDenied": "Les exécutions manuelles ne sont pas autorisées pour ce Dag",
+    "partitionKeyHelp": "Optionnel - s'applique uniquement aux Dags partitionnés",
     "runIdHelp": "Optionnel – sera généré s'il n'est pas fourni",
     "selectDescription": "Déclencher une exécution unique de ce Dag",
     "selectLabel": "Exécution unique",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
@@ -94,10 +94,6 @@
     "critical": "CRITIQUE",
     "debug": "DÉBOGAGE",
     "error": "ERREUR",
-    "fullscreen": {
-      "button": "Plein écran",
-      "tooltip": "Appuyez sur {{hotkey}} pour le plein écran"
-    },
     "info": "INFO",
     "noTryNumber": "Aucun essai",
     "search": {
@@ -233,12 +229,34 @@
     "renderedTemplates": "Modèles rendus",
     "requiredActions": "Actions requises",
     "runs": "Runs",
+    "storage": "Stockage",
     "taskInstances": "Task Instances",
+    "taskStateStore": "Stockage d'état de tâche",
     "tasks": "Tâches",
     "xcom": "XCom"
   },
   "taskGroups": {
     "collapseAll": "Réduire tous les groupes de tâches",
     "expandAll": "Développer tous les groupes de tâches"
+  },
+  "taskStateStore": {
+    "add": "Ajouter un Stockage d'état de tâche",
+    "clearAll": {
+      "resource": "tout le stockage d'état de tâche",
+      "title": "Effacer tout le Stockage d'état de tâche",
+      "warning": "Tout le stockage d'état de tâche sera effacé. Les tâches qui utilisent ce stockage pour suivre un travail externe ne pourront pas reprendre sans être ré-exécutées depuis le début."
+    },
+    "delete": "Supprimer le Stockage d'état de tâche",
+    "deleteWarning": "La tâche perdra cette mémoire persistée. Si la tâche utilise cette clé pour suivre un travail externe (par exemple un ID de job externe), elle ne pourra pas le reprendre.",
+    "edit": "Modifier le Stockage d'état de tâche",
+    "emptyStore": "Le stockage d'état de tâche stocke des valeurs qui persistent entre les tentatives. Les workers peuvent écrire dans le stockage d'état de tâche via le Task SDK.",
+    "expiresAt": {
+      "column": "Expire le",
+      "custom": "Personnalisé",
+      "default": "Par défaut ({{interval}})",
+      "label": "Expiration",
+      "never": "Jamais"
+    },
+    "title": "Stockage d'état de tâche"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dag.json
@@ -240,15 +240,15 @@
     "expandAll": "Développer tous les groupes de tâches"
   },
   "taskStateStore": {
-    "add": "Ajouter un Stockage d'état de tâche",
+    "add": "Ajouter un stockage d'état de tâche",
     "clearAll": {
       "resource": "tout le stockage d'état de tâche",
-      "title": "Effacer tout le Stockage d'état de tâche",
+      "title": "Effacer tout le stockage d'état de tâche",
       "warning": "Tout le stockage d'état de tâche sera effacé. Les tâches qui utilisent ce stockage pour suivre un travail externe ne pourront pas reprendre sans être ré-exécutées depuis le début."
     },
-    "delete": "Supprimer le Stockage d'état de tâche",
+    "delete": "Supprimer le stockage d'état de tâche",
     "deleteWarning": "La tâche perdra cette mémoire persistée. Si la tâche utilise cette clé pour suivre un travail externe (par exemple un ID de job externe), elle ne pourra pas le reprendre.",
-    "edit": "Modifier le Stockage d'état de tâche",
+    "edit": "Modifier le stockage d'état de tâche",
     "emptyStore": "Le stockage d'état de tâche stocke des valeurs qui persistent entre les tentatives. Les workers peuvent écrire dans le stockage d'état de tâche via le Task SDK.",
     "expiresAt": {
       "column": "Expire le",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dags.json
@@ -10,11 +10,13 @@
   "filters": {
     "allRunTypes": "Tous les types de Run",
     "allStates": "Tous les états",
+    "anyRunState": "N'importe quel Run",
     "favorite": {
       "all": "Tous",
       "favorite": "Favoris",
       "unfavorite": "Non favoris"
     },
+    "lastRunState": "Dernier Run",
     "paused": {
       "active": "Actif",
       "all": "Tous",
@@ -76,6 +78,11 @@
       "upstream": "En amont"
     }
   },
+  "runStateCounts": {
+    "label": "États des Runs",
+    "loading": "Chargement du décompte des états des Runs",
+    "tooltip": "{{state}} : {{formattedCount}} — cliquez pour filtrer les Runs"
+  },
   "search": {
     "advanced": "Recherche avancée",
     "clear": "Effacer la recherche",
@@ -88,9 +95,9 @@
       "asc": "Trier par nom affiché (A-Z)",
       "desc": "Trier par nom affiché (Z-A)"
     },
-    "lastRunStartDate": {
-      "asc": "Trier par date de début du dernier Run (du plus ancien au plus récent)",
-      "desc": "Trier par date de début du dernier Run (du plus récent au plus ancien)"
+    "lastRunAfter": {
+      "asc": "Trier par dernier Run After (du plus ancien au plus récent)",
+      "desc": "Trier par dernier Run After (du plus récent au plus ancien)"
     },
     "lastRunState": {
       "asc": "Trier par état du dernier Run (A-Z)",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/dashboard.json
@@ -1,4 +1,25 @@
 {
+  "alerts": {
+    "seeLessContext": "Voir moins",
+    "seeMoreContext": "Voir plus",
+    "showMoreAlerts_many": "+{{count}} alertes supplémentaires",
+    "showMoreAlerts_one": "+{{count}} alerte supplémentaire",
+    "showMoreAlerts_other": "+{{count}} alertes supplémentaires"
+  },
+  "deadlines": {
+    "pending": {
+      "empty": "Aucune échéance à venir",
+      "title": "À venir"
+    },
+    "recentlyMissed": {
+      "empty": "Aucune échéance manquée",
+      "title": "Échéances manquées"
+    },
+    "showMore": "Voir plus",
+    "title": "Échéances"
+  },
+  "deferredSlotsNotCounted": "Différées non comptées dans les slots : {{count}}",
+  "deferredSlotsNotCountedTooltip": "Les tâches différées affichées dans la barre sont comptées dans les slots des Pools. Les tâches différées affichées sous la barre proviennent de Pools qui ne comptent pas les tâches différées dans les slots.",
   "favorite": {
     "favoriteDags_many": "{{count}} premiers Dags favoris",
     "favoriteDags_one": "{{count}} premier Dag favori",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/fr/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/fr/hitl.json
@@ -26,6 +26,20 @@
     "success": "Réponse pour {{taskId}} réussie",
     "title": "Instance de tâche humaine - {{taskId}}"
   },
+  "review": {
+    "detail": {
+      "selectRequiredAction": "Sélectionnez une action requise pour voir les détails"
+    },
+    "list": {
+      "completedRequiredActions": "Actions requises terminées ({{count}})",
+      "loadError": "Impossible de charger les actions requises",
+      "loadingActions": "Chargement des actions requises...",
+      "pendingRequiredActions": "Actions requises en attente ({{count}})"
+    },
+    "openReviewDrawer": "Ouvrir le panneau de revue",
+    "pageLimitHint": "Seules les premières actions sont affichées ici. Utilisez « $t(review.viewAll) » pour toutes les voir.",
+    "viewAll": "Voir toutes les actions requises"
+  },
   "state": {
     "approvalReceived": "Approbation reçue",
     "approvalRequired": "Approbation requise",


### PR DESCRIPTION
Brings the French (`fr`) UI locale to 100% coverage: translated the 145 newly-introduced keys (scaffolded with `breeze ui check-translation-completeness --add-missing`) and removed 4 keys that no longer exist upstream (`--remove-unused`). Follows the glossary and tone in `.github/skills/airflow-translations/locales/fr.md` (formal "vous", English-kept Airflow terms, established glossary translations).

No code or unrelated translation files touched — only `locales/fr/*.json`.

<!-- drag the /tmp/fr-main.png screenshot here -->

---
<img width="1970" height="1197" alt="fr-main" src="https://github.com/user-attachments/assets/230733c2-9679-47af-8f45-4ef772ae2cde" />


##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)