### PR TITLE
Support setting an S3 object ACL for remote task logs

### DIFF
--- a/providers/amazon/docs/logging/s3-task-handler.rst
+++ b/providers/amazon/docs/logging/s3-task-handler.rst
@@ -43,6 +43,26 @@ To enable this feature, ``airflow.cfg`` must be configured as follows:
 
 In the above example, Airflow will try to use ``S3Hook(aws_conn_id='my_s3_conn')``.
 
+Setting an object ACL for cross-account logging
+'''''''''''''''''''''''''''''''''''''''''''''''
+
+When Airflow runs under one AWS account but writes logs to a bucket owned by a different
+account, S3 makes the writing account the owner of each uploaded log object. As a result the
+bucket owner cannot read or manage the logs. Applying the ``bucket-owner-full-control`` ACL
+on upload grants the bucket owner full control over the log objects.
+
+Set the ACL with the ``[aws] s3_task_handler_acl_policy`` option:
+
+.. code-block:: ini
+
+    [aws]
+    # ACL applied to every task log object uploaded to S3, e.g. for cross-account buckets.
+    s3_task_handler_acl_policy = bucket-owner-full-control
+
+When unset, no ACL is sent and the bucket's default object ownership applies. The same value can
+also be supplied through ``[logging] remote_task_handler_kwargs``, for example
+``{"acl_policy": "bucket-owner-full-control"}``.
+
 You can also use `LocalStack <https://localstack.cloud/>`_ to emulate Amazon S3 locally.
 To configure it, you must additionally set the endpoint url to point to your local stack.
 You can do this via the Connection Extra ``endpoint_url`` field.

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -1181,7 +1181,7 @@ config:
 
           When unset, no ACL is sent and the bucket's default object ownership applies.
         type: string
-        version_added: 9.33.0
+        version_added: 9.34.0
         example: bucket-owner-full-control
         default: ~
   aws_batch_executor:

--- a/providers/amazon/provider.yaml
+++ b/providers/amazon/provider.yaml
@@ -1169,6 +1169,21 @@ config:
         version_added: 8.7.2
         example: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize
         default: airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy
+      s3_task_handler_acl_policy:
+        description: |
+          The ACL applied to task log objects uploaded to S3 by the S3 remote log handler,
+          for example ``bucket-owner-full-control``.
+
+          This is primarily useful for cross-account remote logging: when Airflow runs under one AWS
+          account but writes logs to a bucket owned by another account, S3 makes the writing account
+          the object owner, so the bucket owner cannot read or manage the log objects. Setting
+          ``bucket-owner-full-control`` grants the bucket owner full control over the uploaded logs.
+
+          When unset, no ACL is sent and the bucket's default object ownership applies.
+        type: string
+        version_added: 9.33.0
+        example: bucket-owner-full-control
+        default: ~
   aws_batch_executor:
     description: |
       This section only applies if you are using the AwsBatchExecutor in

--- a/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -44,6 +44,7 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
     remote_base: str
     base_log_folder: pathlib.Path = attrs.field(converter=pathlib.Path)
     delete_local_copy: bool
+    acl_policy: str | None = None
 
     processors = ()
 
@@ -68,6 +69,7 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
                 "base_log_folder": os.path.expanduser(conf.get_mandatory_value("logging", "base_log_folder")),
                 "remote_base": conf.get_mandatory_value("logging", "remote_base_log_folder"),
                 "delete_local_copy": conf.getboolean("logging", "delete_local_logs"),
+                "acl_policy": conf.get("aws", "s3_task_handler_acl_policy", fallback=None) or None,
             }
             | io_kwargs,
         )
@@ -161,6 +163,8 @@ class S3RemoteLogIO(LoggingMixin):  # noqa: D101
         extra_args = {}
         if conf.getboolean("logging", "ENCRYPT_S3_LOGS"):
             extra_args["ServerSideEncryption"] = "AES256"
+        if self.acl_policy:
+            extra_args["ACL"] = self.acl_policy
 
         # Default to a single retry attempt because s3 upload failures are
         # rare but occasionally occur.  Multiple retry attempts are unlikely
@@ -234,6 +238,9 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             base_log_folder=base_log_folder,
             delete_local_copy=kwargs.get(
                 "delete_local_copy", conf.getboolean("logging", "delete_local_logs")
+            ),
+            acl_policy=kwargs.get(
+                "acl_policy", conf.get("aws", "s3_task_handler_acl_policy", fallback=None) or None
             ),
         )
 

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1283,6 +1283,13 @@ def get_provider_info():
                         "example": "airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize",
                         "default": "airflow.providers.amazon.aws.log.cloudwatch_task_handler.json_serialize_legacy",
                     },
+                    "s3_task_handler_acl_policy": {
+                        "description": "The ACL applied to task log objects uploaded to S3 by the S3 remote log handler,\nfor example ``bucket-owner-full-control``.\n\nThis is primarily useful for cross-account remote logging: when Airflow runs under one AWS\naccount but writes logs to a bucket owned by another account, S3 makes the writing account\nthe object owner, so the bucket owner cannot read or manage the log objects. Setting\n``bucket-owner-full-control`` grants the bucket owner full control over the uploaded logs.\n\nWhen unset, no ACL is sent and the bucket's default object ownership applies.\n",
+                        "type": "string",
+                        "version_added": "9.33.0",
+                        "example": "bucket-owner-full-control",
+                        "default": None,
+                    },
                 },
             },
             "aws_batch_executor": {

--- a/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
+++ b/providers/amazon/src/airflow/providers/amazon/get_provider_info.py
@@ -1286,7 +1286,7 @@ def get_provider_info():
                     "s3_task_handler_acl_policy": {
                         "description": "The ACL applied to task log objects uploaded to S3 by the S3 remote log handler,\nfor example ``bucket-owner-full-control``.\n\nThis is primarily useful for cross-account remote logging: when Airflow runs under one AWS\naccount but writes logs to a bucket owned by another account, S3 makes the writing account\nthe object owner, so the bucket owner cannot read or manage the log objects. Setting\n``bucket-owner-full-control`` grants the bucket owner full control over the uploaded logs.\n\nWhen unset, no ACL is sent and the bucket's default object ownership applies.\n",
                         "type": "string",
-                        "version_added": "9.33.0",
+                        "version_added": "9.34.0",
                         "example": "bucket-owner-full-control",
                         "default": None,
                     },

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -132,6 +132,50 @@ class TestS3RemoteLogIOFromConfig:
         assert conn_id == "aws_default"
         legacy_discover.assert_not_called()
 
+    @conf_vars(
+        {
+            ("logging", "remote_base_log_folder"): "s3://bucket/remote/log/location",
+            ("aws", "s3_task_handler_acl_policy"): "bucket-owner-full-control",
+        }
+    )
+    def test_from_config_reads_acl_policy(self):
+        subject = S3RemoteLogIO.from_config()
+
+        assert subject.acl_policy == "bucket-owner-full-control"
+
+    @conf_vars({("logging", "remote_base_log_folder"): "s3://bucket/remote/log/location"})
+    def test_from_config_acl_policy_defaults_to_none(self):
+        subject = S3RemoteLogIO.from_config()
+
+        assert subject.acl_policy is None
+
+    @conf_vars(
+        {
+            ("logging", "remote_base_log_folder"): "s3://bucket/remote/log/location",
+            ("logging", "remote_task_handler_kwargs"): '{"acl_policy": "bucket-owner-full-control"}',
+        }
+    )
+    def test_from_config_acl_policy_via_remote_task_handler_kwargs(self):
+        subject = S3RemoteLogIO.from_config()
+
+        assert subject.acl_policy == "bucket-owner-full-control"
+
+
+class TestS3TaskHandlerInit:
+    @conf_vars({("aws", "s3_task_handler_acl_policy"): "bucket-owner-full-control"})
+    def test_init_reads_acl_policy_from_conf(self):
+        handler = S3TaskHandler("/tmp/local", "s3://bucket/remote/log/location")
+
+        assert handler.io.acl_policy == "bucket-owner-full-control"
+
+    @conf_vars({("aws", "s3_task_handler_acl_policy"): "bucket-owner-full-control"})
+    def test_init_acl_policy_kwarg_overrides_conf(self):
+        handler = S3TaskHandler(
+            "/tmp/local", "s3://bucket/remote/log/location", acl_policy="bucket-owner-read"
+        )
+
+        assert handler.io.acl_policy == "bucket-owner-read"
+
 
 @pytest.mark.db_test
 class TestS3RemoteLogIO:
@@ -277,6 +321,15 @@ class TestS3RemoteLogIO:
         self.subject.write("text", self.remote_log_location)
         resp = self.conn.head_object(Bucket="bucket", Key=self.remote_log_key)
         assert resp["ServerSideEncryption"] == "AES256"
+        body = boto3.resource("s3").Object("bucket", self.remote_log_key).get()["Body"].read()
+        assert body == b"text"
+
+    def test_write_with_acl_policy(self):
+        self.subject.acl_policy = "bucket-owner-full-control"
+        conn = self.subject.hook.get_conn()
+        with mock.patch.object(conn, "put_object", wraps=conn.put_object) as mock_put_object:
+            self.subject.write("text", self.remote_log_location)
+        assert mock_put_object.call_args.kwargs["ACL"] == "bucket-owner-full-control"
         body = boto3.resource("s3").Object("bucket", self.remote_log_key).get()["Body"].read()
         assert body == b"text"
 


### PR DESCRIPTION
### Why

- When Airflow runs under one AWS account but writes logs to a bucket owned by another account, S3 (ACL-enabled) makes the writing account the object owner, so the bucket owner cannot read or manage the logs.
- Setting the `bucket-owner-full-control` ACL on upload is the standard remedy, but the S3 remote log handler previously had no way to set any ACL.

### How

- Add an `acl_policy` field to `S3RemoteLogIO`; when set, `write()` passes it as the `ACL` argument to the underlying `put_object` call.

### Verification

- Real two-account AWS e2e: A bucket under account A set to Bucket owner preferred. A task run under account B writing logs to account A's bucket:
  - Round 1 — no ACL: account A (bucket owner) gets `AccessDenied` reading the uploaded log.
  - Round 2 — `s3_task_handler_acl_policy = bucket-owner-full-control`: account A can read the log, and object ownership transfers to the bucket owner.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
* closes: #8917
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
