### PR TITLE
Revert Dataform workflow invocation dict normalization (#69161)

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataform.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataform.py
@@ -187,8 +187,6 @@ class DataformHook(GoogleBaseHook):
         """
         client = self.get_dataform_client()
         parent = f"projects/{project_id}/locations/{region}/repositories/{repository_id}"
-        if isinstance(workflow_invocation, dict):
-            workflow_invocation = WorkflowInvocation(workflow_invocation)
         return client.create_workflow_invocation(
             request={"parent": parent, "workflow_invocation": workflow_invocation},
             retry=retry,

--- a/providers/google/tests/unit/google/cloud/hooks/test_dataform.py
+++ b/providers/google/tests/unit/google/cloud/hooks/test_dataform.py
@@ -50,12 +50,6 @@ WORKFLOW_INVOCATION = {
         f"{REPOSITORY_ID}/compilationResults/{COMPILATION_RESULT_ID}"
     ),
 }
-FULL_REFRESH_WORKFLOW_INVOCATION = {
-    **WORKFLOW_INVOCATION,
-    "invocation_config": {
-        "fully_refresh_incremental_tables_enabled": True,
-    },
-}
 WORKFLOW_INVOCATION_ID = "test_workflow_invocation_id"
 PATH_TO_FOLDER = "path/to/folder"
 FILEPATH = "path/to/file.txt"
@@ -119,26 +113,11 @@ class TestDataformHook:
         )
         parent = f"projects/{PROJECT_ID}/locations/{REGION}/repositories/{REPOSITORY_ID}"
         mock_client.return_value.create_workflow_invocation.assert_called_once_with(
-            request=dict(parent=parent, workflow_invocation=WorkflowInvocation(WORKFLOW_INVOCATION)),
+            request=dict(parent=parent, workflow_invocation=WORKFLOW_INVOCATION),
             retry=DEFAULT,
             timeout=None,
             metadata=(),
         )
-
-    @mock.patch(DATAFORM_STRING.format("DataformHook.get_dataform_client"))
-    def test_create_workflow_invocation_preserves_invocation_config_from_dict(self, mock_client):
-        self.hook.create_workflow_invocation(
-            project_id=PROJECT_ID,
-            region=REGION,
-            repository_id=REPOSITORY_ID,
-            workflow_invocation=FULL_REFRESH_WORKFLOW_INVOCATION,
-        )
-
-        request = mock_client.return_value.create_workflow_invocation.call_args.kwargs["request"]
-        workflow_invocation = request["workflow_invocation"]
-        assert isinstance(workflow_invocation, WorkflowInvocation)
-        assert workflow_invocation.compilation_result == WORKFLOW_INVOCATION["compilation_result"]
-        assert workflow_invocation.invocation_config.fully_refresh_incremental_tables_enabled is True
 
     @mock.patch(DATAFORM_STRING.format("DataformHook.get_dataform_client"))
     def test_get_workflow_invocation(self, mock_client):


### PR DESCRIPTION
Reverts #69161. The change is a provably wire-identical no-op: proto-plus already converts nested dicts recursively, so the pre- and post-change `CreateWorkflowInvocationRequest` serialize byte-identically and the dict path never dropped `invocation_config`. Unknown fields raise `ValueError` in proto-plus, so a silent drop at this layer was never possible.

The symptom reported in #53843 was caused outside Airflow: dataform-core 3.0.10–3.0.16 defaulted incremental tables to `protected: true` (dataform-co/dataform#1914), which silently disables full refresh server-side; fixed upstream in core 3.0.17 (dataform-co/dataform#1942). Repos pin `dataformCoreVersion`, which is why the symptom persisted after the upstream fix. #53843 has been closed as not planned accordingly.

The accompanying test only pinned third-party proto-plus conversion behavior, which the project's testing standards exclude.

related: #53843

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)