### PR TITLE
Detect linked issues at the end of PR bodies in provider testing issue

### DIFF
--- a/dev/assign_cherry_picked_prs_with_milestone.py
+++ b/dev/assign_cherry_picked_prs_with_milestone.py
@@ -47,7 +47,6 @@ console = Console(width=400, color_system="standard")
 MY_DIR_PATH = os.path.dirname(__file__)
 SOURCE_DIR_PATH = os.path.abspath(os.path.join(MY_DIR_PATH, os.pardir))
 PR_PATTERN = re.compile(r".*\(#([0-9]+)\)")
-ISSUE_MATCH_IN_BODY = re.compile(r" #([0-9]+)[^0-9]")
 
 CHANGELOG_CHANGES_FILE = "changelog-changes.txt"
 DOC_ONLY_CHANGES_FILE = "doc-only-changes.txt"

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -256,7 +256,7 @@ MY_DIR_PATH = os.path.dirname(__file__)
 SOURCE_DIR_PATH = str(AIRFLOW_ROOT_PATH)
 PR_PATTERN = re.compile(r".*\(#([0-9]+)\)")
 PR_REFERENCE_PATTERN = re.compile(r"#([0-9]+)")
-ISSUE_MATCH_IN_BODY = re.compile(r" #([0-9]+)[^0-9]")
+ISSUE_MATCH_IN_BODY = re.compile(r" #([0-9]+)(?![0-9])")
 # Release-management commits (provider documentation / release preparation) are pure
 # release-process noise: they are not user-facing changes and existing providers already
 # exclude them (the release tooling parks them in the changelog's excluded section). Match

--- a/dev/breeze/tests/test_release_management_commands.py
+++ b/dev/breeze/tests/test_release_management_commands.py
@@ -23,6 +23,7 @@ import pytest
 
 from airflow_breeze.commands import release_management_commands
 from airflow_breeze.commands.release_management_commands import (
+    ISSUE_MATCH_IN_BODY,
     _ensure_default_python_for_reproducible_client,
     _is_initial_provider_release,
     _should_include_provider_in_issue,
@@ -292,3 +293,18 @@ def test_get_package_version_possibly_from_stable_txt_for_java_sdk(
         stable_txt.parent.mkdir(parents=True)
         stable_txt.write_text(stable_txt_content)
     assert get_package_version_possibly_from_stable_txt("java-sdk") == expected_version
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("Some description closes: #12345 and more text", [12345]),
+        # reference at the very end of the body (e.g. "Fixes #53843" as the last line)
+        ("Generated-by: some agent Fixes #53843", [53843]),
+        ("related: #111, also see #222", [111, 222]),
+        ("no references here", []),
+        ("PR#123 without space is not a reference", []),
+    ],
+)
+def test_issue_match_in_body(body: str, expected: list[int]):
+    assert [int(m.group(1)) for m in ISSUE_MATCH_IN_BODY.finditer(body)] == expected

--- a/dev/breeze/tests/test_release_management_commands.py
+++ b/dev/breeze/tests/test_release_management_commands.py
@@ -302,6 +302,7 @@ def test_get_package_version_possibly_from_stable_txt_for_java_sdk(
         # reference at the very end of the body (e.g. "Fixes #53843" as the last line)
         ("Generated-by: some agent Fixes #53843", [53843]),
         ("related: #111, also see #222", [111, 222]),
+        ("adjacent references see #111 #222", [111, 222]),
         ("no references here", []),
         ("PR#123 without space is not a reference", []),
     ],


### PR DESCRIPTION
The provider testing issue generator (`breeze release-management generate-issue-content-providers`) silently missed linked issues whose reference is the last thing in the PR body — a common shape, since `Fixes #NNNNN` often sits on the final line. `ISSUE_MATCH_IN_BODY` (`r" #([0-9]+)[^0-9]"`) requires a non-digit character *after* the number, which doesn't exist at end of string after the body's lines are joined.

Concrete occurrence: in the google 22.3.0rc1 testing issue (#70355), PR #69161 (body ending with `Fixes #53843`) was rendered with no linked issues, and the release manager had to add #53843 by hand.

Replacing the trailing `[^0-9]` with a negative lookahead `(?![0-9])` matches the same references without requiring a trailing character. Verified against the real #69161 body: the old pattern finds nothing, the new one finds 53843; mid-body references behave identically.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)