### PR TITLE
Remove stale experimental note from Lineage docs

### DIFF
--- a/airflow-core/docs/administration-and-deployment/lineage.rst
+++ b/airflow-core/docs/administration-and-deployment/lineage.rst
@@ -20,8 +20,6 @@
 Lineage
 ========
 
-.. note:: Lineage support is very experimental and subject to change.
-
 Airflow provides a powerful feature for tracking data lineage not only between tasks but also from hooks used within those tasks.
 This functionality helps you understand how data flows throughout your Airflow pipelines.
 


### PR DESCRIPTION
## Human Summary
This PR removes an outdated note regarding the experimental status of Lineage.

## AI Summary

<details>
<summary>Click here</summary>
The lineage docs carried a note that lineage support is "very experimental and subject to change," dating back to the original 2018 lineage API (`LineageBackend`, `prepare_lineage`/`apply_lineage`), which no longer exists in the codebase.

The page today documents the AIP-62 hook-level lineage collector (`HookLineageCollector`/`HookLineageReader`), which has shipped since Airflow 2.10, gained configurable limits (`[lineage] max_assets_per_collector` / `max_extras_per_collector`) in 3.2.0, and is consumed by multiple providers (amazon, google, openlineage). It's no longer experimental, so the note is removed.
</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)