### PR TITLE
UI: Add Select Recent Configurations dropdown to Trigger Dag form

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -138,6 +138,8 @@
     "loadingFailed": "Failed to load Dag information. Please try again.",
     "manualRunDenied": "Manual runs are not allowed for this Dag",
     "partitionKeyHelp": "Optional - only applies to partitioned Dags",
+    "recentConfig": "Recent configurations",
+    "recentConfigPlaceholder": "Select a recent configuration",
     "runIdHelp": "Optional - will be generated if not provided",
     "selectDescription": "Trigger a single run of this Dag",
     "selectLabel": "Single Run",

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/RecentConfigSelect.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/RecentConfigSelect.test.tsx
@@ -1,0 +1,157 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import RecentConfigSelect from "./RecentConfigSelect";
+
+const buildRun = (overrides: Record<string, unknown>) => ({
+  bundle_version: null,
+  conf: null,
+  dag_display_name: "test_dag",
+  dag_id: "test_dag",
+  dag_run_id: "run_1",
+  dag_versions: [],
+  data_interval_end: null,
+  data_interval_start: null,
+  duration: null,
+  end_date: null,
+  last_scheduling_decision: null,
+  logical_date: null,
+  note: null,
+  partition_key: null,
+  queued_at: null,
+  run_after: "2025-01-01T00:00:00Z",
+  run_type: "manual" as const,
+  start_date: null,
+  state: "success" as const,
+  triggered_by: "ui" as const,
+  triggering_user_name: null,
+  ...overrides,
+});
+
+let mockData: { dag_runs: Array<ReturnType<typeof buildRun>> } | undefined;
+const mockIsLoading = false;
+
+vi.mock("openapi/queries", () => ({
+  useDagRunServiceGetDagRuns: vi.fn(() => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+  })),
+}));
+
+const getItems = (container: HTMLElement) => container.querySelectorAll(".chakra-select__item");
+
+describe("RecentConfigSelect", () => {
+  it("renders one item per distinct non-empty conf", () => {
+    mockData = {
+      dag_runs: [
+        buildRun({ conf: { message: "First" }, dag_run_id: "run_1", run_after: "2025-01-03T00:00:00Z" }),
+        buildRun({ conf: { message: "Second" }, dag_run_id: "run_2", run_after: "2025-01-02T00:00:00Z" }),
+      ],
+    };
+
+    const { container } = render(<RecentConfigSelect dagId="test_dag" onSelectConf={vi.fn()} open />, {
+      wrapper: Wrapper,
+    });
+
+    expect(getItems(container)).toHaveLength(2);
+  });
+
+  it("dedups identical confs", () => {
+    mockData = {
+      dag_runs: [
+        buildRun({ conf: { message: "Same" }, dag_run_id: "run_1", run_after: "2025-01-03T00:00:00Z" }),
+        buildRun({ conf: { message: "Same" }, dag_run_id: "run_2", run_after: "2025-01-02T00:00:00Z" }),
+      ],
+    };
+
+    const { container } = render(<RecentConfigSelect dagId="test_dag" onSelectConf={vi.fn()} open />, {
+      wrapper: Wrapper,
+    });
+
+    expect(getItems(container)).toHaveLength(1);
+  });
+
+  it("excludes null/empty conf runs and renders nothing when none remain", () => {
+    mockData = {
+      dag_runs: [buildRun({ conf: null, dag_run_id: "run_1" }), buildRun({ conf: {}, dag_run_id: "run_2" })],
+    };
+
+    const { container } = render(<RecentConfigSelect dagId="test_dag" onSelectConf={vi.fn()} open />, {
+      wrapper: Wrapper,
+    });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders all distinct confs without capping the list", () => {
+    mockData = {
+      dag_runs: Array.from({ length: 8 }, (_unused, index) =>
+        buildRun({
+          conf: { message: `Message ${index}` },
+          dag_run_id: `run_${index}`,
+          run_after: `2025-01-${(10 - index).toString().padStart(2, "0")}T00:00:00Z`,
+        }),
+      ),
+    };
+
+    const { container } = render(<RecentConfigSelect dagId="test_dag" onSelectConf={vi.fn()} open />, {
+      wrapper: Wrapper,
+    });
+
+    expect(getItems(container)).toHaveLength(8);
+  });
+
+  it("calls onSelectConf with the selected run's conf", async () => {
+    mockData = {
+      dag_runs: [buildRun({ conf: { message: "Pick me" }, dag_run_id: "run_1" })],
+    };
+    const onSelectConf = vi.fn();
+
+    render(<RecentConfigSelect dagId="test_dag" onSelectConf={onSelectConf} open />, { wrapper: Wrapper });
+
+    fireEvent.click(screen.getByRole("combobox"));
+
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("run_1"));
+
+    await waitFor(() => expect(onSelectConf).toHaveBeenCalledWith({ message: "Pick me" }));
+  });
+
+  it("displays the selected run id in the trigger after selection", async () => {
+    mockData = {
+      dag_runs: [buildRun({ conf: { message: "Pick me" }, dag_run_id: "run_1" })],
+    };
+
+    render(<RecentConfigSelect dagId="test_dag" onSelectConf={vi.fn()} open />, { wrapper: Wrapper });
+
+    const trigger = screen.getByRole("combobox");
+
+    fireEvent.click(trigger);
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("run_1"));
+
+    await waitFor(() => expect(trigger).toHaveTextContent("run_1"));
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/RecentConfigSelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/RecentConfigSelect.tsx
@@ -1,0 +1,117 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { createListCollection, Flex, Select, type SelectValueChangeDetails, Text } from "@chakra-ui/react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { useDagRunServiceGetDagRuns } from "openapi/queries";
+import type { DAGRunResponse } from "openapi/requests/types.gen";
+
+import Time from "../Time";
+
+type RecentConfigOption = {
+  run: DAGRunResponse;
+  value: string;
+};
+
+type RecentConfigSelectProps = {
+  readonly dagId: string;
+  readonly onSelectConf: (conf: Record<string, unknown>) => void;
+  readonly open: boolean;
+};
+
+const RecentConfigSelect = ({ dagId, onSelectConf, open }: RecentConfigSelectProps) => {
+  const { t: translate } = useTranslation("components");
+  const [selectedValue, setSelectedValue] = useState<Array<string>>([]);
+  const { data, isLoading } = useDagRunServiceGetDagRuns(
+    { dagId, limit: 25, orderBy: ["-run_after"] },
+    undefined,
+    { enabled: open },
+  );
+
+  const options = useMemo(() => {
+    const seenConfs = new Set<string>();
+
+    return (data?.dag_runs ?? []).reduce<Array<RecentConfigOption>>((items, run) => {
+      const hasConf = run.conf !== null && Object.keys(run.conf).length > 0;
+      const confKey = hasConf ? JSON.stringify(run.conf) : undefined;
+      const isNewConf = confKey !== undefined && !seenConfs.has(confKey);
+
+      if (isNewConf) {
+        seenConfs.add(confKey);
+        items.push({ run, value: run.dag_run_id });
+      }
+
+      return items;
+    }, []);
+  }, [data?.dag_runs]);
+
+  const recentConfigOptions = createListCollection({
+    items: options,
+    itemToString: (item: RecentConfigOption) => item.run.dag_run_id,
+  });
+
+  const handleValueChange = ({ items, value }: SelectValueChangeDetails<RecentConfigOption>) => {
+    const [selected] = items;
+
+    setSelectedValue(value);
+    if (selected?.run.conf) {
+      onSelectConf(selected.run.conf);
+    }
+  };
+
+  if (!isLoading && options.length === 0) {
+    return undefined;
+  }
+
+  return (
+    <Select.Root
+      collection={recentConfigOptions}
+      data-testid="recent-config-select"
+      disabled={isLoading || options.length === 0}
+      onValueChange={handleValueChange}
+      size="sm"
+      value={selectedValue}
+    >
+      <Select.Label fontSize="xs">{translate("triggerDag.recentConfig")}</Select.Label>
+      <Select.Control>
+        <Select.Trigger>
+          <Select.ValueText placeholder={translate("triggerDag.recentConfigPlaceholder")} />
+        </Select.Trigger>
+        <Select.IndicatorGroup>
+          <Select.Indicator />
+        </Select.IndicatorGroup>
+      </Select.Control>
+      <Select.Positioner>
+        <Select.Content maxH="200px" overflowY="auto">
+          {recentConfigOptions.items.map((option) => (
+            <Select.Item item={option} key={option.run.dag_run_id}>
+              <Flex justifyContent="space-between" width="100%">
+                <Text>{option.run.dag_run_id}</Text>
+                <Time datetime={option.run.run_after} />
+              </Flex>
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Positioner>
+    </Select.Root>
+  );
+};
+
+export default RecentConfigSelect;

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Wrapper } from "src/utils/Wrapper";
@@ -51,6 +51,21 @@ const useDagParamsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("src/queries/useDagParams", () => ({
   useDagParams: useDagParamsMock,
+}));
+
+vi.mock("openapi/queries", () => ({
+  useDagRunServiceGetDagRuns: vi.fn(() => ({
+    data: {
+      dag_runs: [
+        {
+          conf: { message: "From recent" },
+          dag_run_id: "run_recent",
+          run_after: "2025-01-01T00:00:00Z",
+        },
+      ],
+    },
+    isLoading: false,
+  })),
 }));
 
 vi.mock("src/queries/useTogglePause", () => ({
@@ -213,5 +228,47 @@ describe("TriggerDAGForm", () => {
 
     await waitFor(() => expect(screen.getByText("dagRun.partitionKey")).toBeInTheDocument());
     expect(screen.getByText("components:triggerDag.partitionKeyHelp")).toBeInTheDocument();
+  });
+
+  it("prefills the form when a recent configuration is selected from the dropdown", async () => {
+    const { container } = render(
+      <TriggerDAGForm
+        dagDisplayName="Params Trigger UI"
+        dagId="example_params_trigger_ui"
+        error={undefined}
+        hasSchedule={false}
+        isPartitioned={false}
+        isPaused={false}
+        isPending={false}
+        onSubmitTrigger={vi.fn()}
+        open
+        prefillConfig={undefined}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const recentConfigSelect = screen.getByTestId("recent-config-select");
+
+    fireEvent.click(within(recentConfigSelect).getByRole("combobox"));
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("run_recent"));
+
+    await waitFor(() =>
+      expect(container.querySelector<HTMLInputElement>('input[name="element_message"]')?.value).toBe(
+        "From recent",
+      ),
+    );
+
+    fireEvent.click(screen.getByText("Advanced Options"));
+
+    await waitFor(() => {
+      const configJson = screen.getByLabelText("Configuration JSON");
+
+      if (!(configJson instanceof HTMLTextAreaElement)) {
+        throw new TypeError("Expected Configuration JSON to render as a textarea");
+      }
+
+      expect(configJson.value).toContain('"From recent"');
+    });
   });
 });

--- a/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TriggerDag/TriggerDAGForm.tsx
@@ -18,7 +18,7 @@
  */
 import { Button, Box, Spacer, HStack, Field, Stack, Text, VStack } from "@chakra-ui/react";
 import dayjs from "dayjs";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FiPlay } from "react-icons/fi";
@@ -33,6 +33,7 @@ import { DateTimeInput } from "../DateTimeInput";
 import { ErrorAlert, type ExpandedApiError } from "../ErrorAlert";
 import { Checkbox } from "../ui/Checkbox";
 import { RadioCardItem, RadioCardRoot } from "../ui/RadioCard";
+import RecentConfigSelect from "./RecentConfigSelect";
 import TriggerDAGAdvancedOptions from "./TriggerDAGAdvancedOptions";
 import { dataIntervalModeOptions, type DagRunTriggerParams } from "./types";
 
@@ -91,11 +92,12 @@ const TriggerDAGForm = ({
     },
   });
 
-  // Pre-fill form when prefillConfig is provided (priority over conf)
-  // Only restore 'conf' (parameters), not logicalDate, runId, or partitionKey to avoid 409 conflicts
-  useEffect(() => {
-    if (prefillConfig && open) {
-      const confString = prefillConfig.conf ? JSON.stringify(prefillConfig.conf, undefined, 2) : "";
+  // Apply a config to the form and param store, resetting the other fields to their defaults.
+  // Only 'conf' (parameters) is ever restored, never logicalDate, runId, or partitionKey, to avoid 409 conflicts.
+  // Shared by the prefill effect below (re-trigger with a prior run's config) and RecentConfigSelect.
+  const applyConf = useCallback(
+    (confObj: Record<string, unknown> | undefined) => {
+      const confString = confObj ? JSON.stringify(confObj, undefined, 2) : "";
 
       reset({
         conf: confString,
@@ -119,20 +121,19 @@ const TriggerDAGForm = ({
         }
         setConf(confString);
       }
+    },
+    [initialParamDict, initialParamsDict.paramsDict, isPartitioned, reset, setConf, setInitialParamDict],
+  );
+
+  // Pre-fill form when prefillConfig is provided (priority over conf)
+  useEffect(() => {
+    if (prefillConfig && open) {
+      applyConf(prefillConfig.conf);
       setHasAppliedPrefill(true);
     } else if (!open) {
       setHasAppliedPrefill(false);
     }
-  }, [
-    prefillConfig,
-    open,
-    reset,
-    setConf,
-    initialParamsDict.paramsDict,
-    initialParamDict,
-    setInitialParamDict,
-    isPartitioned,
-  ]);
+  }, [prefillConfig, open, applyConf]);
 
   // Automatically reset form when conf is fetched (only if no prefillConfig)
   useEffect(() => {
@@ -241,6 +242,7 @@ const TriggerDAGForm = ({
             <Spacer />
           </>
         ) : undefined}
+        <RecentConfigSelect dagId={dagId} onSelectConf={applyConf} open={open} />
         <ConfigForm
           control={control}
           errors={errors}


### PR DESCRIPTION
### Context 
According to the #69820's description, reusing a past run's config currently requires leaving the trigger flow to hunt for the right run in the run list and use "Trigger again with this config". In this PR, I'm going to restore the Airflow 2 in-form dropdown lets users pick any distinct config from the recent runs in a scrollable list while composing a run. The dropdown reuses the existing dagRuns list endpoint and the same conf-only prefill path as the menu item, so no new API surface is added.


closes: #69820

### Verification

<img width="1470" height="837" alt="image" src="https://github.com/user-attachments/assets/8a8f61da-cec8-42cf-be12-43ae927cd245" />

<img width="1470" height="828" alt="image" src="https://github.com/user-attachments/assets/32fdea90-6978-45c0-9054-38526fb6dcd2" />


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
