### PR TITLE
Improve OpenTelemetry auto-instrumentation & global textmap propagation

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -29,9 +29,9 @@ import attrs
 import structlog
 from cadwyn import VersionedAPIRouter
 from fastapi import Body, HTTPException, Query, Response, Security, status
-from opentelemetry import trace
+from opentelemetry import propagate, trace
+from opentelemetry.propagate import get_global_textmap
 from opentelemetry.trace import StatusCode
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import JsonValue
 from sqlalchemy import and_, func, or_, tuple_, update
 from sqlalchemy.engine import CursorResult
@@ -538,7 +538,7 @@ def _emit_task_span(ti, state):
         return
     if not isinstance(ti.context_carrier, dict):
         return
-    dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
+    dr_ctx = get_global_textmap().extract(ti.dag_run.context_carrier)
 
     # Skip if the run was head-sampled out, so every span in the run agrees with the
     # carrier's decision. A parent-based sampler would already drop this child span,
@@ -550,7 +550,7 @@ def _emit_task_span(ti, state):
     if dr_span_context.is_valid and not dr_span_context.trace_flags.sampled:
         return
 
-    ti_ctx = TraceContextTextMapPropagator().extract(ti.context_carrier)
+    ti_ctx = get_global_textmap().extract(ti.context_carrier)
     ti_span = trace.get_current_span(context=ti_ctx)
     span_context = ti_span.get_span_context()
     start_time_candidates = (x for x in (ti.queued_dttm, ti.start_date, timezone.utcnow()) if x)

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -39,9 +39,9 @@ import anyio
 import attrs
 import greenback
 import structlog
-from opentelemetry import trace
+from opentelemetry import propagate, trace
+from opentelemetry.propagate import get_global_textmap
 from opentelemetry.trace import Status, StatusCode
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import BaseModel, Field, TypeAdapter
 from sqlalchemy import func, select
 from structlog.contextvars import bind_contextvars as bind_log_contextvars
@@ -157,7 +157,7 @@ def _make_trigger_span(
     ti: TaskInstanceDTO | None, trigger_id: int, name: str
 ) -> _AgnosticContextManager[trace.Span]:
     parent_context = (
-        TraceContextTextMapPropagator().extract(ti.context_carrier) if ti and ti.context_carrier else None
+        get_global_textmap().extract(ti.context_carrier) if ti and ti.context_carrier else None
     )
     attributes: dict[str, str | int] = {
         "airflow.trigger.name": name,

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -28,10 +28,10 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar, cast, overload
 from uuid import UUID
 
 import structlog
-from opentelemetry import trace
+from opentelemetry import propagate, trace
 from opentelemetry.context import context
+from opentelemetry.propagate import get_global_textmap
 from opentelemetry.trace import StatusCode
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sqlalchemy import (
     JSON,
     Enum,
@@ -228,7 +228,7 @@ def parent_trace_context(conf) -> context.Context | None:
         case _:
             return None
     try:
-        ctx = TraceContextTextMapPropagator().extract(carrier)
+        ctx = get_global_textmap().extract(carrier)
     except Exception:
         # Never let a malformed conf value fail run creation; fall back to a root trace.
         return None
@@ -1188,7 +1188,7 @@ class DagRun(Base, LoggingMixin):
         if not isinstance(self.context_carrier, dict):
             return
 
-        ctx = TraceContextTextMapPropagator().extract(self.context_carrier)
+        ctx = get_global_textmap().extract(self.context_carrier)
         span = trace.get_current_span(context=ctx)
         span_context = span.get_span_context()
 

--- a/shared/observability/pyproject.toml
+++ b/shared/observability/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
 ]
 "all" = ["apache-airflow-shared-observability[otel,statsd,datadog]"]
 
+[project.entry-points."opentelemetry_id_generator"]
+airflow_overrideable = "airflow_shared.observability.traces:OverrideableRandomIdGenerator"
+
 [dependency-groups]
 dev = [
     "apache-airflow-devel-common",

--- a/shared/observability/src/airflow_shared/observability/traces/__init__.py
+++ b/shared/observability/src/airflow_shared/observability/traces/__init__.py
@@ -23,14 +23,14 @@ from contextlib import contextmanager
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 
-from opentelemetry import context, trace
+from opentelemetry import context, propagate, trace
+from opentelemetry.propagate import get_global_textmap
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.sdk.trace.sampling import Decision
 from opentelemetry.trace import NonRecordingSpan, Span, SpanContext, TraceFlags, TraceState
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 if TYPE_CHECKING:
     from configparser import ConfigParser
@@ -149,18 +149,18 @@ def new_dagrun_trace_carrier(
     )
     ctx = trace.set_span_in_context(NonRecordingSpan(span_ctx))
     carrier: dict[str, str] = {}
-    TraceContextTextMapPropagator().inject(carrier, context=ctx)
+    get_global_textmap().inject(carrier, context=ctx)
     return carrier
 
 
 def new_task_run_carrier(dag_run_context_carrier):
     parent_context = (
-        TraceContextTextMapPropagator().extract(dag_run_context_carrier) if dag_run_context_carrier else None
+        get_global_textmap().extract(dag_run_context_carrier) if dag_run_context_carrier else None
     )
     span = tracer.start_span("notused", context=parent_context)  # intentionally never closed
     new_ctx = trace.set_span_in_context(span)
     carrier: dict[str, str] = {}
-    TraceContextTextMapPropagator().inject(carrier, context=new_ctx)
+    get_global_textmap().inject(carrier, context=new_ctx)
     return carrier
 
 

--- a/shared/observability/tests/observability/test_traces.py
+++ b/shared/observability/tests/observability/test_traces.py
@@ -360,3 +360,37 @@ class TestGetTaskSpanDetailLevel:
 
         span = trace.get_current_span(ctx)
         assert get_task_span_detail_level(span) == 3
+
+
+class TestIdGeneratorEntryPoint:
+    def test_id_generator_entry_point_config(self):
+        import pathlib
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib
+        pyproject_path = pathlib.Path(__file__).parents[2] / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+        entry_points = data.get("project", {}).get("entry-points", {}).get("opentelemetry_id_generator", {})
+        assert entry_points.get("airflow_overrideable") == "airflow_shared.observability.traces:OverrideableRandomIdGenerator"
+
+        from airflow_shared.observability.traces import OverrideableRandomIdGenerator
+        from importlib.metadata import EntryPoint
+        ep = EntryPoint(name="airflow_overrideable", value="airflow_shared.observability.traces:OverrideableRandomIdGenerator", group="opentelemetry_id_generator")
+        assert ep.load() is OverrideableRandomIdGenerator
+
+
+class TestGlobalTextMapPropagation:
+    def test_new_dagrun_trace_carrier_uses_global_textmap(self, monkeypatch):
+        class DummyPropagator:
+            def inject(self, carrier, context=None, setter=None):
+                carrier["custom_header"] = "custom_value"
+
+            def extract(self, carrier, context=None, getter=None):
+                return context or {}
+
+        monkeypatch.setattr("airflow_shared.observability.traces.get_global_textmap", lambda: DummyPropagator())
+        carrier = new_dagrun_trace_carrier()
+        assert carrier.get("custom_header") == "custom_value"
+

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -32,7 +32,7 @@ import httpx
 import msgspec
 import structlog
 from opentelemetry import trace
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.propagate import get_global_textmap
 from pydantic import BaseModel, JsonValue
 from tenacity import (
     before_log,
@@ -177,7 +177,7 @@ def getuser() -> str:
 
 log = structlog.get_logger(logger_name=__name__)
 
-_trace_propagator = TraceContextTextMapPropagator()
+_trace_propagator = get_global_textmap()
 _log_retry_warning = before_log(log, logging.WARNING)
 
 __all__ = [

--- a/task-sdk/src/airflow/sdk/execution_time/comms.py
+++ b/task-sdk/src/airflow/sdk/execution_time/comms.py
@@ -108,9 +108,9 @@ except ImportError:
     # Available on Unix and Windows (so "everywhere") but lets be safe
     recv_fds = None  # type: ignore[assignment]
 
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.propagate import get_global_textmap
 
-_trace_propagator = TraceContextTextMapPropagator()
+_trace_propagator = get_global_textmap()
 
 
 if TYPE_CHECKING:

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -161,10 +161,10 @@ try:
 except ImportError:
     send_fds = None  # type: ignore[assignment]
 
-from opentelemetry import context as otel_context, trace
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry import context as otel_context, propagate, trace
+from opentelemetry.propagate import get_global_textmap
 
-_trace_propagator = TraceContextTextMapPropagator()
+_trace_propagator = get_global_textmap()
 
 if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger, WrappedLogger

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -36,9 +36,9 @@ from urllib.parse import quote
 import attrs
 import lazy_object_proxy
 import structlog
-from opentelemetry import trace
+from opentelemetry import propagate, trace
+from opentelemetry.propagate import get_global_textmap
 from opentelemetry.trace import INVALID_SPAN, Status, StatusCode
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from pydantic import AwareDatetime, ConfigDict, Field, JsonValue, TypeAdapter
 from structlog.contextvars import bind_contextvars
 
@@ -201,7 +201,7 @@ class detail_span:
 @contextmanager
 def _make_task_span(msg: StartupDetails):
     parent_context = (
-        TraceContextTextMapPropagator().extract(msg.ti.context_carrier) if msg.ti.context_carrier else None
+        get_global_textmap().extract(msg.ti.context_carrier) if msg.ti.context_carrier else None
     )
     ti = msg.ti
     span_name = f"worker.{ti.task_id}"


### PR DESCRIPTION
- Register opentelemetry_id_generator entry point for OverrideableRandomIdGenerator in shared/observability/pyproject.toml so OTEL_PYTHON_ID_GENERATOR can resolve it automatically.

- Replace hardcoded TraceContextTextMapPropagator() with opentelemetry.propagate.get_global_textmap() across shared/observability, task-sdk, and airflow-core.

- Add unit tests for entry point configuration and global textmap propagator usage.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=2c27833 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @AIMindCrafter** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
