### PR TITLE
Add missing Simplified Chinese (zh-CN) translations for dashboard and HITL

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dashboard.json
@@ -1,4 +1,22 @@
 {
+  "alerts": {
+    "seeLessContext": "查看更少",
+    "seeMoreContext": "查看更多",
+    "showMoreAlerts_one": "另有 {{count}} 条警报",
+    "showMoreAlerts_other": "另有 {{count}} 条警报"
+  },
+  "deadlines": {
+    "pending": {
+      "empty": "没有即将到期的截止期限",
+      "title": "即将到期"
+    },
+    "recentlyMissed": {
+      "empty": "没有错过的截止期限",
+      "title": "已错过的截止期限"
+    },
+    "showMore": "显示更多",
+    "title": "截止期限"
+  },
   "deferredSlotsNotCounted": "未计入配额的延迟任务：{{count}}",
   "deferredSlotsNotCountedTooltip": "条形图中显示的延迟任务会计入资源池配额。条形图下方显示的延迟任务来自不将延迟任务计入配额的资源池。",
   "favorite": {

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/hitl.json
@@ -24,6 +24,20 @@
     "success": "任务 {{taskId}} 响应成功",
     "title": "人类参与流程任务实例 - {{taskId}}"
   },
+  "review": {
+    "detail": {
+      "selectRequiredAction": "选择一个待操作的任务实例以查看详情"
+    },
+    "list": {
+      "completedRequiredActions": "已完成的待操作任务实例 ({{count}})",
+      "loadError": "无法加载待操作的任务实例",
+      "loadingActions": "正在加载待操作的任务实例...",
+      "pendingRequiredActions": "待处理的待操作任务实例 ({{count}})"
+    },
+    "openReviewDrawer": "打开审阅抽屉",
+    "pageLimitHint": "此处仅显示前几项待操作的任务实例。使用 \"$t(review.viewAll)\" 查看全部。",
+    "viewAll": "查看全部待操作的任务实例"
+  },
   "state": {
     "approvalReceived": "已批准",
     "approvalRequired": "需要批准",


### PR DESCRIPTION
Fill missing zh-CN UI strings for the 3.3.1 RC: dashboard deadlines/alerts widgets and the HITL review drawer. Reuses the established terms (截止期限, 待操作的任务实例, 警报); $t() references and {{placeholders}} preserved.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

**This was human verified by myself (native simplified Chinese writer) before posting.**