### PR TITLE
Add missing Simplified Chinese (zh-CN) translations for dags, components, admin

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/admin.json
@@ -177,6 +177,7 @@
           "title": "非严格模式"
         }
       },
+      "parsingFile": "正在解析文件",
       "title": "导入变量",
       "upload": "上传 JSON 文件",
       "uploadPlaceholder": "上传包含变量的 JSON 文件 (例如：{\"key\": \"value\", ...})"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/admin.json
@@ -177,7 +177,7 @@
           "title": "非严格模式"
         }
       },
-      "parsingFile": "正在解析文件",
+      "parsingFile": "正在解析文件...",
       "title": "导入变量",
       "upload": "上传 JSON 文件",
       "uploadPlaceholder": "上传包含变量的 JSON 文件 (例如：{\"key\": \"value\", ...})"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
@@ -65,7 +65,7 @@
     "lastDagRun_other": "最近 {{count}} 次 Dag 执行",
     "lastTaskInstance_one": "最近 1 次任务实例",
     "lastTaskInstance_other": "最近 {{count}} 次任务实例",
-    "medianTotalDuration": "总计时长中位数：{{duration}}",
+    "medianTotalDuration": "总计：{{duration}}",
     "queuedDuration": "排队等候时间",
     "runAfter": "最早可执行时间",
     "runDuration": "执行持续时间"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/components.json
@@ -65,6 +65,7 @@
     "lastDagRun_other": "最近 {{count}} 次 Dag 执行",
     "lastTaskInstance_one": "最近 1 次任务实例",
     "lastTaskInstance_other": "最近 {{count}} 次任务实例",
+    "medianTotalDuration": "总计时长中位数：{{duration}}",
     "queuedDuration": "排队等候时间",
     "runAfter": "最早可执行时间",
     "runDuration": "执行持续时间"
@@ -136,6 +137,7 @@
     "loading": "正在加载 Dag 信息...",
     "loadingFailed": "加载 Dag 信息失败，请重试。",
     "manualRunDenied": "此 Dag 不允许手动执行",
+    "partitionKeyHelp": "选填 - 仅适用于分区 Dag",
     "runIdHelp": "选填 - 若未提供将会自动生成",
     "selectDescription": "触发此 Dag 单次执行",
     "selectLabel": "单次执行",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
@@ -10,13 +10,13 @@
   "filters": {
     "allRunTypes": "全部执行类型",
     "allStates": "全部状态",
-    "anyRunState": "任意执行状态",
+    "anyRunState": "任意执行",
     "favorite": {
       "all": "全部",
       "favorite": "已加入收藏",
       "unfavorite": "未加入收藏"
     },
-    "lastRunState": "最近一次执行状态",
+    "lastRunState": "最近一次执行",
     "paused": {
       "active": "已启用",
       "all": "全部",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-CN/dags.json
@@ -10,11 +10,13 @@
   "filters": {
     "allRunTypes": "全部执行类型",
     "allStates": "全部状态",
+    "anyRunState": "任意执行状态",
     "favorite": {
       "all": "全部",
       "favorite": "已加入收藏",
       "unfavorite": "未加入收藏"
     },
+    "lastRunState": "最近一次执行状态",
     "paused": {
       "active": "已启用",
       "all": "全部",


### PR DESCRIPTION
Fill missing zh-CN UI strings for the 3.3.1 RC: run-state filters, duration-chart total, partition-key helper, and variable import progress. $t()/{{placeholders}} preserved.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

**This was human verified by myself (native simplified Chinese writer) before posting.**