### PR TITLE
Fail deferred Cloud Composer tasks when the GCP operation errors

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/cloud_composer.py
@@ -80,9 +80,12 @@ class CloudComposerExecutionTrigger(BaseTrigger):
         while True:
             operation = await self.gcp_hook.get_operation(operation_name=self.operation_name)
             if operation.done:
+                # A long-running operation signals failure as done=True with ``error`` set; while
+                # it is still running neither ``error`` nor ``response`` is populated. Checking
+                # ``error`` only in the not-done branch would therefore never see a failure.
+                if operation.error.message:
+                    raise AirflowException(f"Cloud Composer Environment error: {operation.error.message}")
                 break
-            elif operation.error.message:
-                raise AirflowException(f"Cloud Composer Environment error: {operation.error.message}")
             await asyncio.sleep(self.pooling_period_seconds)
         yield TriggerEvent(
             {

--- a/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_cloud_composer.py
@@ -18,15 +18,18 @@
 from __future__ import annotations
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
+from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.google.cloud.triggers.cloud_composer import (
     CloudComposerAirflowCLICommandTrigger,
     CloudComposerDAGRunTrigger,
+    CloudComposerExecutionTrigger,
     CloudComposerExternalTaskTrigger,
 )
 from airflow.triggers.base import TriggerEvent
@@ -59,6 +62,23 @@ TEST_EXEC_RESULT = {
     "output_end": True,
     "exit_info": {"exit_code": 0, "error": ""},
 }
+TEST_OPERATION_NAME = "test_operation_name"
+TEST_POOLING_PERIOD_SECONDS = 30
+TEST_OPERATION_ERROR_MESSAGE = "Environment creation failed: quota exceeded"
+
+
+def make_operation(*, done: bool, error_message: str = ""):
+    """
+    Build a stand-in for a ``google.longrunning.Operation``.
+
+    Per the LRO contract, a finished operation has ``done=True`` and exactly one of
+    ``error`` or ``response`` set; while it is still running neither is set.
+    """
+    return SimpleNamespace(
+        name=TEST_OPERATION_NAME,
+        done=done,
+        error=SimpleNamespace(message=error_message),
+    )
 
 
 @pytest.fixture
@@ -125,6 +145,45 @@ def external_task_trigger(mock_conn):
         poll_interval=TEST_POLL_INTERVAL,
         composer_airflow_version=TEST_COMPOSER_AIRFLOW_VERSION,
     )
+
+
+@pytest.fixture
+@mock.patch(
+    "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_connection",
+    return_value=Connection(conn_id="test_conn"),
+)
+def execution_trigger(mock_conn):
+    return CloudComposerExecutionTrigger(
+        project_id=TEST_PROJECT_ID,
+        region=TEST_LOCATION,
+        operation_name=TEST_OPERATION_NAME,
+        gcp_conn_id=TEST_GCP_CONN_ID,
+        impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        pooling_period_seconds=TEST_POOLING_PERIOD_SECONDS,
+    )
+
+
+class TestCloudComposerExecutionTrigger:
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.hooks.cloud_composer.CloudComposerAsyncHook.get_operation")
+    async def test_run_raises_when_operation_finished_with_error(self, mock_get_operation, execution_trigger):
+        mock_get_operation.return_value = make_operation(
+            done=True, error_message=TEST_OPERATION_ERROR_MESSAGE
+        )
+
+        with pytest.raises(AirflowException, match=TEST_OPERATION_ERROR_MESSAGE):
+            await execution_trigger.run().asend(None)
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.hooks.cloud_composer.CloudComposerAsyncHook.get_operation")
+    async def test_run_yields_event_when_operation_finished_without_error(
+        self, mock_get_operation, execution_trigger
+    ):
+        mock_get_operation.return_value = make_operation(done=True)
+
+        actual_event = await execution_trigger.run().asend(None)
+
+        assert actual_event == TriggerEvent({"operation_name": TEST_OPERATION_NAME, "operation_done": True})
 
 
 class TestCloudComposerAirflowCLICommandTrigger:


### PR DESCRIPTION
`CloudComposerExecutionTrigger.run()` checked `operation.done` before `operation.error`, in an `if`/`elif`. Per the [long-running operation contract](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.operations), "if `done` == `false`, neither `error` nor `response` is set", and a finished operation has `done=True` with exactly one of `error` or `response` populated.

So the two branches were inverted relative to the API:

- the `elif operation.error.message` branch was only ever reached while `done` was `false` — the one state where `error` is guaranteed unset, making it dead code;
- a genuinely failed operation (`done=True` with `error` set) broke out of the loop and yielded `operation_done: True`, the success shape.

The consequence differs per operator, all three of which defer with this trigger:

| Operator | `execute_complete` | Result when the operation failed |
|---|---|---|
| `CloudComposerUpdateEnvironmentOperator` | returns on `operation_done`, no state check | task marked **success** |
| `CloudComposerDeleteEnvironmentOperator` | `pass` | task marked **success** |
| `CloudComposerCreateEnvironmentOperator` | re-fetches the environment and validates its state | task fails, but with a misleading `NotFound`/wrong-state error rather than the GCP failure reason |

This also made the deferrable path disagree with the synchronous one: with `deferrable=False` the operators call `hook.wait_for_operation()` → `operation.result()`, which raises on a failed operation.

Checking `error` inside the `done` branch fixes all three. The existing `raise` is relocated, not new.

`CloudComposerExecutionTrigger` had no test coverage, so this adds two cases: a finished-with-error operation must raise, and a finished-without-error operation must still yield `operation_done: True`. The first fails without this change; the second guards the new nested condition against over-raising on success.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
