### PR TITLE
Fix template-field validation in PapermillOperator

### DIFF
--- a/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
+++ b/providers/papermill/src/airflow/providers/papermill/operators/papermill.py
@@ -89,12 +89,8 @@ class PapermillOperator(BaseOperator):
         super().__init__(**kwargs)
         self.parameters = parameters
 
-        if not input_nb:
-            raise ValueError("Input notebook is not specified")
         self.input_nb = input_nb
 
-        if not output_nb:
-            raise ValueError("Output notebook is not specified")
         self.output_nb = output_nb
 
         self.kernel_name = kernel_name
@@ -105,6 +101,10 @@ class PapermillOperator(BaseOperator):
         self.nbconvert_args = nbconvert_args
 
     def execute(self, context: Context):
+        if not self.input_nb:
+            raise ValueError("Input notebook is not specified")
+        if not self.output_nb:
+            raise ValueError("Output notebook is not specified")
         if not isinstance(self.input_nb, NoteBook):
             self.input_nb = NoteBook(url=self.input_nb, parameters=self.parameters)
         if not isinstance(self.output_nb, NoteBook):

--- a/providers/papermill/tests/unit/papermill/operators/test_papermill.py
+++ b/providers/papermill/tests/unit/papermill/operators/test_papermill.py
@@ -42,13 +42,20 @@ class TestNoteBook:
 class TestPapermillOperator:
     """Test PapermillOperator."""
 
+    def test_init_does_not_validate_notebooks(self):
+        """__init__ must not validate template fields; input_nb/output_nb are rendered after construction."""
+        op = PapermillOperator(task_id="missing_input_nb", output_nb="foo-bar")
+        assert op.input_nb is None
+        op = PapermillOperator(task_id="missing_output_nb", input_nb="foo-bar")
+        assert op.output_nb is None
+
     def test_mandatory_attributes(self):
-        """Test missing Input or Output notebooks."""
+        """Test missing Input or Output notebooks are validated at execute() time, after templating."""
         with pytest.raises(ValueError, match="Input notebook is not specified"):
-            PapermillOperator(task_id="missing_input_nb", output_nb="foo-bar")
+            PapermillOperator(task_id="missing_input_nb", output_nb="foo-bar").execute(context={})
 
         with pytest.raises(ValueError, match="Output notebook is not specified"):
-            PapermillOperator(task_id="missing_input_nb", input_nb="foo-bar")
+            PapermillOperator(task_id="missing_output_nb", input_nb="foo-bar").execute(context={})
 
     @pytest.mark.parametrize(
         ("output_nb_url", "output_as_object"),

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -55,7 +55,6 @@ providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/gcs_to
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py::OracleToAzureDataLakeOperator
 providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py::PsrpOperator
 providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py::OracleToOracleOperator
-providers/papermill/src/airflow/providers/papermill/operators/papermill.py::PapermillOperator
 providers/standard/src/airflow/providers/standard/operators/bash.py::BashOperator
 providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py::TriggerDagRunOperator
 providers/standard/src/airflow/providers/standard/sensors/date_time.py::DateTimeSensor


### PR DESCRIPTION
Fixes the `papermill` provider's entry from the #70296 exemption-list burn-down: `PapermillOperator`.

`input_nb` and `output_nb` are template fields, but were validated in `__init__` — before Jinja templating runs, so the check ran against the raw un-rendered value.

- Moved validation from `__init__` to `execute()`, after templating occurs.
- `__init__` now only does plain assignments.
- Removed `PapermillOperator` from the exemption list.
- Updated existing test + added a new test covering the fixed behavior.

Related to #70296

**Gen-AI disclosure:** I used a generative AI tool to help identify the root
cause, write tests, and draft the PR description. I reviewed, tested, and
verified all changes locally before submitting.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)