### PR TITLE
Add LangChainAzureHook for Azure OpenAI support

### DIFF
--- a/providers/common/ai/provider.yaml
+++ b/providers/common/ai/provider.yaml
@@ -404,6 +404,41 @@ connection-types:
           type:
             - string
             - 'null'
+  - hook-class-name: airflow.providers.common.ai.hooks.langchain.LangChainAzureHook
+    hook-name: "LangChain (Azure OpenAI)"
+    connection-type: langchain-azure
+    ui-field-behaviour:
+      hidden-fields:
+        - schema
+        - port
+        - login
+      relabeling:
+        password: API Key
+        host: Azure Endpoint
+      placeholders:
+        host: "https://<resource>.openai.azure.com"
+    conn-fields:
+      model:
+        label: Chat Model
+        description: "Chat model in azure_openai:name format (e.g. azure_openai:gpt-4o)."
+        schema:
+          type:
+            - string
+            - 'null'
+      embed_model:
+        label: Embedding Model
+        description: "Embedding model in azure_openai:name format (e.g. azure_openai:text-embedding-3-small)."
+        schema:
+          type:
+            - string
+            - 'null'
+      api_version:
+        label: API Version
+        description: "Azure OpenAI API version (e.g. 2024-07-01-preview)."
+        schema:
+          type:
+            - string
+            - 'null'
   - hook-class-name: airflow.providers.common.ai.hooks.llamaindex.LlamaIndexHook
     hook-name: "LlamaIndex"
     connection-type: llamaindex

--- a/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/get_provider_info.py
@@ -316,6 +316,33 @@ def get_provider_info():
                 },
             },
             {
+                "hook-class-name": "airflow.providers.common.ai.hooks.langchain.LangChainAzureHook",
+                "hook-name": "LangChain (Azure OpenAI)",
+                "connection-type": "langchain-azure",
+                "ui-field-behaviour": {
+                    "hidden-fields": ["schema", "port", "login"],
+                    "relabeling": {"password": "API Key", "host": "Azure Endpoint"},
+                    "placeholders": {"host": "https://<resource>.openai.azure.com"},
+                },
+                "conn-fields": {
+                    "model": {
+                        "label": "Chat Model",
+                        "description": "Chat model in azure_openai:name format (e.g. azure_openai:gpt-4o).",
+                        "schema": {"type": ["string", "null"]},
+                    },
+                    "embed_model": {
+                        "label": "Embedding Model",
+                        "description": "Embedding model in azure_openai:name format (e.g. azure_openai:text-embedding-3-small).",
+                        "schema": {"type": ["string", "null"]},
+                    },
+                    "api_version": {
+                        "label": "API Version",
+                        "description": "Azure OpenAI API version (e.g. 2024-07-01-preview).",
+                        "schema": {"type": ["string", "null"]},
+                    },
+                },
+            },
+            {
                 "hook-class-name": "airflow.providers.common.ai.hooks.llamaindex.LlamaIndexHook",
                 "hook-name": "LlamaIndex",
                 "connection-type": "llamaindex",

--- a/providers/common/ai/src/airflow/providers/common/ai/hooks/langchain.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/hooks/langchain.py
@@ -45,9 +45,9 @@ class LangChainHook(BaseHook):
     OpenAI-compatible providers (OpenAI itself, Anthropic, Groq, Mistral AI
     chat, Ollama, DeepSeek, ...) work with this hook's ``api_key`` + optional
     ``base_url`` credential surface. Providers with bespoke auth (AWS Bedrock,
-    Google Vertex AI / GenAI, Azure OpenAI, Cohere, HuggingFace) reject these
-    kwargs; per-vendor subclasses can be added later mirroring the pydantic-ai
-    pattern.
+    Google Vertex AI / GenAI, Cohere, HuggingFace) reject these kwargs;
+    per-vendor subclasses can be added later mirroring the pydantic-ai
+    pattern. Azure OpenAI already has one: :class:`LangChainAzureHook`.
 
     Connection fields:
 
@@ -123,9 +123,8 @@ class LangChainHook(BaseHook):
             )
         return model_id
 
-    @staticmethod
-    def _connection_kwargs(conn: Any) -> dict[str, Any]:
-        """Return shared init_* kwargs (api_key, base_url) derived from the connection."""
+    def _connection_kwargs(self, conn: Any) -> dict[str, Any]:
+        """Return init_* kwargs (api_key, base_url) derived from the connection."""
         kwargs: dict[str, Any] = {}
         if conn.password:
             kwargs["api_key"] = conn.password
@@ -171,3 +170,53 @@ class LangChainHook(BaseHook):
             kind="embedding",
         )
         return init_embeddings(model_id, **self._connection_kwargs(conn))
+
+
+class LangChainAzureHook(LangChainHook):
+    """
+    Hook for Azure OpenAI via LangChain.
+
+    ``LangChainHook``'s ``api_key`` + ``base_url`` credential surface doesn't
+    match what Azure OpenAI's LangChain classes (``AzureChatOpenAI``,
+    ``AzureOpenAIEmbeddings``) expect: an ``azure_endpoint`` and an
+    ``api_version`` rather than a generic ``base_url``. This subclass maps
+    the connection to those fields instead, mirroring
+    :class:`~airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIAzureHook`.
+
+    Connection fields:
+        - **password**: Azure API key
+        - **host**: Azure endpoint (e.g. ``https://<resource>.openai.azure.com``)
+        - **extra** JSON::
+
+            {"model": "azure_openai:gpt-4o", "api_version": "2024-07-01-preview"}
+
+    :param llm_conn_id: Airflow connection ID.
+    """
+
+    conn_type = "langchain-azure"
+    default_conn_name = "langchain_azure_default"
+    hook_name = "LangChain (Azure OpenAI)"
+
+    @staticmethod
+    def get_ui_field_behaviour() -> dict[str, Any]:
+        """Return custom field behaviour for the Airflow connection form."""
+        return {
+            "hidden_fields": ["schema", "port", "login"],
+            "relabeling": {"password": "API Key", "host": "Azure Endpoint"},
+            "placeholders": {
+                "host": "https://<resource>.openai.azure.com",
+                "extra": '{"model": "azure_openai:gpt-4o", "api_version": "2024-07-01-preview"}',
+            },
+        }
+
+    def _connection_kwargs(self, conn: Any) -> dict[str, Any]:
+        """Map connection fields to Azure OpenAI's azure_endpoint/api_version shape."""
+        kwargs: dict[str, Any] = {}
+        if conn.password:
+            kwargs["api_key"] = conn.password
+        if conn.host:
+            kwargs["azure_endpoint"] = conn.host
+        api_version = conn.extra_dejson.get("api_version")
+        if api_version:
+            kwargs["api_version"] = api_version
+        return kwargs

--- a/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
+++ b/providers/common/ai/tests/unit/common/ai/hooks/test_langchain.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow.providers.common.ai.hooks.langchain import LangChainHook
+from airflow.providers.common.ai.hooks.langchain import LangChainAzureHook, LangChainHook
 
 
 @pytest.fixture(autouse=True)
@@ -291,3 +291,81 @@ class TestSameHookForBoth:
         mock_init_embeddings.assert_called_once_with("openai:text-embedding-3-small", api_key="sk-test")
         assert chat is mock_init_chat_model.return_value
         assert embed is mock_init_embeddings.return_value
+
+
+class TestLangChainAzureHookInit:
+    def test_conn_type_is_langchain_azure(self):
+        assert LangChainAzureHook.conn_type == "langchain-azure"
+        assert LangChainAzureHook.default_conn_name == "langchain_azure_default"
+        assert LangChainAzureHook.hook_name == "LangChain (Azure OpenAI)"
+
+    def test_default_conn_name_does_not_leak_into_base_class(self):
+        assert LangChainAzureHook().llm_conn_id == "langchain_azure_default"
+        assert LangChainHook().llm_conn_id == "langchain_default"
+
+
+class TestLangChainAzureGetUiFieldBehaviour:
+    def test_shape(self):
+        behaviour = LangChainAzureHook.get_ui_field_behaviour()
+        assert behaviour["hidden_fields"] == ["schema", "port", "login"]
+        assert behaviour["relabeling"] == {"password": "API Key", "host": "Azure Endpoint"}
+        assert behaviour["placeholders"]["host"] == "https://<resource>.openai.azure.com"
+
+
+class TestLangChainAzureConnectionKwargs:
+    @patch("langchain.chat_models.init_chat_model")
+    @patch.object(LangChainAzureHook, "get_connection")
+    def test_maps_host_to_azure_endpoint(self, mock_get_conn, mock_init_chat_model):
+        mock_get_conn.return_value = _conn(password="azure-key", host="https://my-resource.openai.azure.com")
+
+        hook = LangChainAzureHook(llm_model="azure_openai:gpt-4o")
+        hook.get_chat_model()
+
+        mock_init_chat_model.assert_called_once_with(
+            "azure_openai:gpt-4o",
+            api_key="azure-key",
+            azure_endpoint="https://my-resource.openai.azure.com",
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    @patch.object(LangChainAzureHook, "get_connection")
+    def test_includes_api_version_from_extra(self, mock_get_conn, mock_init_chat_model):
+        mock_get_conn.return_value = _conn(
+            password="azure-key",
+            host="https://my-resource.openai.azure.com",
+            extra={"api_version": "2024-07-01-preview"},
+        )
+
+        hook = LangChainAzureHook(llm_model="azure_openai:gpt-4o")
+        hook.get_chat_model()
+
+        mock_init_chat_model.assert_called_once_with(
+            "azure_openai:gpt-4o",
+            api_key="azure-key",
+            azure_endpoint="https://my-resource.openai.azure.com",
+            api_version="2024-07-01-preview",
+        )
+
+    @patch("langchain.embeddings.init_embeddings")
+    @patch.object(LangChainAzureHook, "get_connection")
+    def test_embedding_model_also_uses_azure_kwargs(self, mock_get_conn, mock_init_embeddings):
+        mock_get_conn.return_value = _conn(password="azure-key", host="https://my-resource.openai.azure.com")
+
+        hook = LangChainAzureHook(embed_model="azure_openai:text-embedding-3-small")
+        hook.get_embedding_model()
+
+        mock_init_embeddings.assert_called_once_with(
+            "azure_openai:text-embedding-3-small",
+            api_key="azure-key",
+            azure_endpoint="https://my-resource.openai.azure.com",
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    @patch.object(LangChainAzureHook, "get_connection")
+    def test_no_credentials_passes_empty_kwargs(self, mock_get_conn, mock_init_chat_model):
+        mock_get_conn.return_value = _conn()
+
+        hook = LangChainAzureHook(llm_model="azure_openai:gpt-4o")
+        hook.get_chat_model()
+
+        mock_init_chat_model.assert_called_once_with("azure_openai:gpt-4o")


### PR DESCRIPTION
## Summary

`LangChainHook`'s docstring already flagged this gap: "Providers with bespoke auth (AWS Bedrock, Google Vertex AI / GenAI, Azure OpenAI, Cohere, HuggingFace) reject these kwargs; per-vendor subclasses can be added later mirroring the pydantic-ai pattern." `PydanticAIHook` already has that pattern (`PydanticAIAzureHook`/`PydanticAIBedrockHook`/`PydanticAIVertexHook`, each overriding `_get_provider_kwargs`) -- this PR adds the first LangChain equivalent.

Without it, `LangChainHook` always calls `init_chat_model(model, api_key=..., base_url=...)`, but Azure OpenAI's LangChain classes (`AzureChatOpenAI`, `AzureOpenAIEmbeddings`) don't accept `base_url` -- they need `azure_endpoint` and `api_version`. Verified against the real `langchain-openai` package: those are the actual constructor fields/aliases.

## Changes

- `LangChainHook._connection_kwargs`: `@staticmethod` -> instance method, so subclasses can override it (matches `PydanticAIHook`'s `_get_provider_kwargs`). No behavior change for the base class.
- Add `LangChainAzureHook(LangChainHook)`, overriding `_connection_kwargs` to map `conn.host` -> `azure_endpoint` and read  `api_version` from `conn.extra`.
- Register the new `langchain-azure` connection type in `provider.yaml`; regenerated `get_provider_info.py` via `breeze release-management prepare-provider-documentation --reapply-templates-only --skip-changelog --skip-readme` (not hand-edited).

## Test plan

- Added 7 tests: class attributes, UI field behaviour, `host -> azure_endpoint` mapping, `api_version` from extra, embedding model uses the same mapping, empty kwargs when no credentials set.
- Full `test_langchain.py` passes (28 passed).
- `ruff format`/`ruff check`, `breeze run mypy` clean (mypy caught the staticmethod/instance-method override incompatibility, since fixed).
- `scripts/ci/prek/check_provider_yaml_files.py` passes: `LangChainAzureHook` registered correctly, 0 errors.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)
