### PR TITLE
Move amazon dms operators template-field validation to execute()

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py
@@ -194,8 +194,6 @@ class DmsModifyTaskOperator(AwsBaseOperator[DmsHook]):
         **kwargs,
     ):
         super().__init__(aws_conn_id=aws_conn_id, **kwargs)
-        if cdc_start_time and cdc_start_position:
-            raise ValueError("Only one of cdc_start_time or cdc_start_position can be provided.")
         self.replication_task_arn = replication_task_arn
         self.table_mappings = table_mappings
         self.migration_type = migration_type
@@ -216,6 +214,9 @@ class DmsModifyTaskOperator(AwsBaseOperator[DmsHook]):
         )
 
     def execute(self, context: Context) -> dict:
+        if self.cdc_start_time and self.cdc_start_position:
+            raise ValueError("Only one of cdc_start_time or cdc_start_position can be provided.")
+
         tasks = self.hook.find_replication_tasks_by_arn(
             replication_task_arn=self.replication_task_arn, without_settings=True
         )
@@ -799,10 +800,10 @@ class DmsStartReplicationOperator(AwsBaseOperator[DmsHook]):
         self.waiter_max_attempts = waiter_max_attempts
         self.wait_for_completion = wait_for_completion
 
+    def execute(self, context: Context):
         if self.cdc_start_time and self.cdc_start_pos:
             raise AirflowException("Only one of cdc_start_time or cdc_start_pos should be provided.")
 
-    def execute(self, context: Context):
         result = self.hook.describe_replications(
             filters=[{"Name": "replication-config-arn", "Values": [self.replication_config_arn]}]
         )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_dms.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_dms.py
@@ -207,15 +207,16 @@ class TestDmsModifyTaskOperator:
     def _modifying_task(self):
         return [{"ReplicationTaskArn": self.TASK_ARN, "Status": "modifying"}]
 
-    def test_init_raises_if_both_cdc_start_params_provided(self):
+    def test_execute_raises_if_both_cdc_start_params_provided(self):
+        op = DmsModifyTaskOperator(
+            task_id="modify_task",
+            replication_task_arn=self.TASK_ARN,
+            cdc_start_time=datetime(2024, 1, 1),
+            cdc_start_position="mysql-bin.000001:4",
+        )
 
         with pytest.raises(ValueError, match="Only one of"):
-            DmsModifyTaskOperator(
-                task_id="modify_task",
-                replication_task_arn=self.TASK_ARN,
-                cdc_start_time=datetime(2024, 1, 1),
-                cdc_start_position="mysql-bin.000001:4",
-            )
+            op.execute(None)
 
     @pytest.mark.parametrize("status", ["stopped", "ready", "failed"])
     @mock.patch.object(DmsHook, "find_replication_tasks_by_arn")
@@ -1225,28 +1226,17 @@ class TestDmsStartReplicationOperator:
             }
         }
 
-    def test_arg_validation(self):
-        with pytest.raises(AirflowException):
-            DmsStartReplicationOperator(
-                task_id="start_replication",
-                replication_config_arn="XXXXXXXXXXXXXXX",
-                replication_start_type="cdc",
-                cdc_start_pos=1,
-                cdc_start_time="2024-01-01 00:00:00",
-            )
-        DmsStartReplicationOperator(
+    def test_execute_raises_if_both_cdc_start_params_provided(self):
+        op = DmsStartReplicationOperator(
             task_id="start_replication",
             replication_config_arn="XXXXXXXXXXXXXXX",
             replication_start_type="cdc",
             cdc_start_pos=1,
-        )
-
-        DmsStartReplicationOperator(
-            task_id="start_replication",
-            replication_config_arn="XXXXXXXXXXXXXXX",
-            replication_start_type="cdc",
             cdc_start_time="2024-01-01 00:00:00",
         )
+
+        with pytest.raises(AirflowException, match="Only one of"):
+            op.execute({})
 
     @mock.patch.object(DmsHook, "describe_replications")
     @mock.patch.object(DmsHook, "start_replication")

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -7,8 +7,6 @@
 # execute()) MUST remove its entry in the same PR — the hook fails on stale entries.
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
 providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py::AppflowBaseOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py::DmsModifyTaskOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py::DmsStartReplicationOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py::EcsRunTaskOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py::EmrAddStepsOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Description

This PR moves template_field validation out of operator `__init__` into `execute()` for the `DmsModifyTaskOperator` and `DmsStartReplicationOperator` operators in the providers/amazon/src/airflow/providers/amazon/aws/operators/dms.py file.

## Tests

- Fixed and updated tests under providers/amazon/tests/unit/amazon/aws/operators/test_dms.py to validate the new behaviour and make tests more consistent

related: #70296 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Antigravity IDE & Claude Web] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.