### PR TITLE
Reuse existing ORM session when resolving OpenLineage dag_team_name

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -38,6 +38,7 @@ from openlineage.client.facet_v2 import (
 )
 from openlineage.client.utils import RedactMixin
 from openlineage.client.uuid import generate_static_uuid
+from sqlalchemy.orm import object_session
 from sqlalchemy.orm.exc import DetachedInstanceError
 
 from airflow import __version__ as AIRFLOW_VERSION
@@ -1080,7 +1081,15 @@ class DagRunInfo(InfoJsonEncodable):
 
             from airflow.models.dagbundle import DagBundleModel
 
-            return DagBundleModel.get_team_name(bundle_name)
+            # Reuse the existing ORM session associated with the DagRun. Creating a new
+            # session here (via @provide_session) can trigger an unexpected commit within
+            # the scheduler callback, which breaks HA lock semantics.
+            session = object_session(dagrun)
+
+            if session is None:
+                return None
+
+            return DagBundleModel.get_team_name(bundle_name, session=session)
         except Exception as e:
             log.warning(
                 "OpenLineage failed to resolve the team name for dag `%s`: %s.",
@@ -1089,7 +1098,6 @@ class DagRunInfo(InfoJsonEncodable):
             )
             log.debug("Exception details:", exc_info=True)
             return None
-
 
 class TaskInstanceInfo(InfoJsonEncodable):
     """Defines encoding TaskInstance object to JSON."""

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -349,12 +349,17 @@ def test_dag_run_version(key):
 
 @pytest.mark.db_test
 @pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="multi-team requires Airflow 3.3+")
+@patch("airflow.providers.openlineage.utils.utils.object_session")
 @patch("airflow.models.dagbundle.DagBundleModel.get_team_name")
 @patch("airflow.providers.openlineage.utils.utils.airflow_conf.getboolean", return_value=True)
 def test_dag_run_team_name(
     mock_getboolean,
     mock_get_team_name,
+    mock_object_session,
 ):
+
+    session = MagicMock()
+    mock_object_session.return_value = session
 
     dagrun_mock = MagicMock(DagRun)
     dagrun_mock.dag_versions = [
@@ -370,7 +375,10 @@ def test_dag_run_team_name(
 
     assert DagRunInfo.team_name(dagrun_mock) == "team_a"
 
-    mock_get_team_name.assert_called_once_with("bundle_name")
+    mock_get_team_name.assert_called_once_with(
+        bundle_name="bundle_name",
+        session=session,
+    )
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
**Description**

This is a follow-up to PR #69109, which introduced the `dag_team_name` field to the OpenLineage `airflowDagRun` run facet.

This change updates the OpenLineage provider to reuse the existing SQLAlchemy session associated with the `DagRun` when resolving the `dag_team_name` field.

**Rationale**

During manual testing, it was discovered that creating a new managed session triggered Airflow's HA lock protection by performing an unexpected commit within the scheduler callback. Reusing the existing `DagRun` session ensures the lookup participates in the surrounding transaction while continuing to emit the `dag_team_name` field correctly.

**Tests**

Updated the existing `test_dag_run_team_name` unit test to verify that the existing SQLAlchemy session associated with the `DagRun` is reused when resolving `dag_team_name`.

###### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: [GPT 5.5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)