### PR TITLE
Fix merge_dicts raising when a dict replaces a non-dict value

### DIFF
--- a/airflow-core/newsfragments/70457.bugfix.rst
+++ b/airflow-core/newsfragments/70457.bugfix.rst
@@ -1,0 +1,1 @@
+``merge_dicts`` no longer raises when a dict in the right-hand mapping replaces a non-dict value on the left. It now overwrites, as the function documents. Previously ``merge_dicts({"a": "x"}, {"a": {"b": 1}})`` raised ``AttributeError: 'str' object has no attribute 'copy'``, which surfaced when JSON log extras or an executor ``exec_config`` promoted a scalar to a mapping.

--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -176,8 +176,11 @@ def merge_dicts(dict1: dict, dict2: dict) -> dict:
     """
     merged = dict1.copy()
     for k, v in dict2.items():
-        if k in merged and isinstance(v, dict):
-            merged[k] = merge_dicts(merged.get(k, {}), v)
+        # Recurse only when both sides are dicts. Recursing on a non-dict left
+        # side would call .copy()/item access on it and raise, instead of
+        # letting dict2 overwrite as documented above.
+        if isinstance(v, dict) and isinstance(merged.get(k), dict):
+            merged[k] = merge_dicts(merged[k], v)
         else:
             merged[k] = v
     return merged

--- a/airflow-core/tests/unit/utils/test_helpers.py
+++ b/airflow-core/tests/unit/utils/test_helpers.py
@@ -114,6 +114,21 @@ class TestHelpers:
         merged = merge_dicts(dict1, dict2)
         assert merged == {"a": 1, "r": {"b": 0, "c": 3}}
 
+    @pytest.mark.parametrize(
+        "existing",
+        ["a string", ["a", "list"], None, 42],
+        ids=["str", "list", "none", "int"],
+    )
+    def test_merge_dicts_dict_overwrites_non_dict(self, existing):
+        """
+        Test merge_dicts when dict2 replaces a non-dict value with a dict.
+
+        Recursing into the non-dict left side used to raise instead of
+        overwriting, which is what the docstring promises.
+        """
+        merged = merge_dicts({"a": existing}, {"a": {"b": 1}})
+        assert merged == {"a": {"b": 1}}
+
     def test_build_airflow_dagrun_url(self):
         expected_url = "/dags/somedag/runs/abc123"
         assert build_airflow_dagrun_url(dag_id="somedag", run_id="abc123") == expected_url


### PR DESCRIPTION
## Problem

`merge_dicts` recurses whenever the key exists on the left and the right value is a dict, without checking that the left value is a dict too. When it is not, the recursive call runs `.copy()` or item access on the non-dict and raises:

```python
merge_dicts({"a": "x"},    {"a": {"b": 1}})  # AttributeError: 'str' object has no attribute 'copy'
merge_dicts({"a": [1, 2]}, {"a": {"b": 1}})  # TypeError: list indices must be integers or slices, not str
merge_dicts({"a": None},   {"a": {"b": 1}})  # AttributeError: 'NoneType' object has no attribute 'copy'
merge_dicts({"a": 42},     {"a": {"b": 1}})  # AttributeError: 'int' object has no attribute 'copy'
```

The docstring says *"Items in dict2 overwrite those also found in dict1"*, so overwriting is the documented behaviour here — the exception is not.

Where it can surface:

- `airflow/utils/log/json_formatter.py` merges `self.extras` over the log record dict, so a configured extra whose name collides with a scalar record field turns a log line into an `AttributeError`.
- The Amazon `ecs_executor.py` and `batch_executor.py` merge a user-supplied `exec_config` over `run_task_kwargs` / `submit_job_api`. A user promoting a scalar to a mapping gets `'str' object has no attribute 'copy'` rather than the override they asked for.

Existing coverage exercised only matching types on both sides (flat, one level of nesting, two levels, and right-only nesting), which is why this held.

## Change

Recurse only when both sides are dicts; otherwise fall through to the existing `merged[k] = v` overwrite. No behaviour change for any input where both sides are dicts.

## Testing

- Added `test_merge_dicts_dict_overwrites_non_dict`, parametrized over `str`, `list`, `None` and `int` on the left.
- Red→green: reverting only `helpers.py` fails all four new cases with the errors above; the four pre-existing `merge_dicts` tests pass either way.
- `pytest airflow-core/tests/unit/utils/test_helpers.py` → **28 passed** (24 on `main`; the 4 added cases are the difference).
- `pytest airflow-core/tests/unit/utils/log/test_json_formatter.py` → 5 passed.
- `pytest airflow-core/tests/unit/utils/` → **630 passed, 6 failed** with this change vs **626 passed, 6 failed** on `main`. The same 6 failures appear in both runs — they are pre-existing in my local environment (dot renderer and an S3 remote-log handler test) and untouched here.
- `ruff format --check` reports both files already formatted; `ruff check` reports an identical 3 pre-existing findings before and after (`BLE001` in `render_template`, `ISC004` in an unrelated test parametrization).

A newsfragment is added in a follow-up commit now that the PR number is known.
