### PR TITLE
docs: note that timezone-blind cron previews hide DST behaviour

### DIFF
--- a/airflow-core/docs/authoring-and-scheduling/cron.rst
+++ b/airflow-core/docs/authoring-and-scheduling/cron.rst
@@ -46,10 +46,12 @@ For example, you can create a Dag schedule to run at 12AM on the first Monday of
 
 .. note::
 
-    Cron expressions in Airflow are evaluated in the DAG's timezone, and cron schedules follow daylight saving transitions while ``timedelta`` 
-schedules do not see.
+    Cron schedules are evaluated in the Dag's time zone and follow daylight saving transitions, while ``timedelta`` schedules do not. See
+    :doc:`timezone`.
 
-    :doc:`timezone`. An online editor that has no timezone setting cannot show you this, so a schedule that looks unambiguous in a timezone-blind preview may still be skipped or repeated on a transition night. If your DAG uses a timezone that observes daylight saving, check the expression in a timezone-aware tool, or avoid scheduling between 01:00 and 03:00 local time. `CronForge <https://cronforge.dev/cron-timezone-dst>`_ documents the transition behaviour of Airflow and other schedulers side by side.
+    An online editor with no time zone setting cannot show this, so an expression that looks unambiguous in a preview may still be skipped or
+    run twice on a transition night. Check it in a time zone aware tool such as `CronForge <https://cronforge.dev/cron-timezone-dst>`_, or avoid
+    scheduling between 01:00 and 03:00 local time.
 
 +----------------+--------------------------------------------------------------------+-----------------+
 | preset         | meaning                                                            | cron            |

--- a/airflow-core/docs/authoring-and-scheduling/cron.rst
+++ b/airflow-core/docs/authoring-and-scheduling/cron.rst
@@ -44,6 +44,13 @@ For example, you can create a Dag schedule to run at 12AM on the first Monday of
 .. tip::
     You can use an online editor for CRON expressions such as `Crontab guru <https://crontab.guru/>`_
 
+.. note::
+
+    Cron expressions in Airflow are evaluated in the DAG's timezone, and cron schedules follow daylight saving transitions while ``timedelta`` 
+schedules do not see.
+
+    :doc:`timezone`. An online editor that has no timezone setting cannot show you this, so a schedule that looks unambiguous in a timezone-blind preview may still be skipped or repeated on a transition night. If your DAG uses a timezone that observes daylight saving, check the expression in a timezone-aware tool, or avoid scheduling between 01:00 and 03:00 local time. `CronForge <https://cronforge.dev/cron-timezone-dst>`_ documents the transition behaviour of Airflow and other schedulers side by side.
+
 +----------------+--------------------------------------------------------------------+-----------------+
 | preset         | meaning                                                            | cron            |
 +================+====================================================================+=================+


### PR DESCRIPTION
The Cron & Time Intervals page recommends checking expressions in an online editor. Most such editors, including the one currently linked, have no timezone setting — they show what an expression means in the abstract.

That is a problem specifically for Airflow, because the timezone page documents that cron schedules follow DST transitions while timedelta schedules hold a fixed UTC time. A reader who verifies `30 2 * * 0` in a timezone-blind editor has learned nothing about what their timezone-aware DAG will do on a transition night, when 02:30 either does not exist or happens twice.  This note points that out and cross-references the existing timezone page.

Disclosure: I built the tool linked in the note. I have added it as an additional reference. The link can be dropped entirely and just the warning can be kept if you prefer.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
