### PR TITLE
fix: DateTimeSensorAsync.__init__ called

### DIFF
--- a/providers/standard/docs/changelog.rst
+++ b/providers/standard/docs/changelog.rst
@@ -43,6 +43,11 @@ Features
 
 * ``Propagate 'partition_date' to consumers of partitioned assets (#67285)``
 
+Bug Fixes
+~~~~~~~~~
+
+* ``Fix 'DateTimeSensorAsync' crashing Dag parsing with templated 'target_time' and 'start_from_trigger=True' (#70284)``
+
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
    * ``Document each provider's optional extras in its docs index (#69478)``

--- a/providers/standard/src/airflow/providers/standard/sensors/date_time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/date_time.py
@@ -21,6 +21,8 @@ import datetime
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from pendulum.parsing.exceptions import ParserError
+
 from airflow.providers.common.compat.sdk import BaseSensorOperator, timezone
 from airflow.providers.standard.triggers.temporal import DateTimeTrigger
 from airflow.providers.standard.version_compat import AIRFLOW_V_3_0_PLUS
@@ -96,7 +98,9 @@ class DateTimeSensorAsync(DateTimeSensor):
     Deferring itself to avoid taking up a worker slot while it is waiting.
     It is a drop-in replacement for DateTimeSensor.
 
-    :param target_time: datetime after which the job succeeds. (templated)
+    :param target_time: datetime after which the job succeeds. (templated). Must be a static
+        datetime (not a Jinja template) when ``start_from_trigger`` is True, since the task is
+        deferred straight from the triggerer and template fields are never rendered.
     :param start_from_trigger: Start the task directly from the triggerer without going into the worker.
     :param trigger_kwargs: The keyword arguments passed to the trigger when start_from_trigger is set to True
         during dynamic task mapping. This argument is not used in standard usage.
@@ -125,8 +129,16 @@ class DateTimeSensorAsync(DateTimeSensor):
 
         self.start_from_trigger = start_from_trigger
         if self.start_from_trigger:
+            try:
+                moment = timezone.parse(self.target_time)
+            except ParserError as e:
+                raise ValueError(
+                    "`target_time` must be a static datetime, not a Jinja template, when "
+                    "`start_from_trigger` is True: the task defers straight from the triggerer "
+                    f"without ever rendering template fields. Got {self.target_time!r}."
+                ) from e
             self.start_trigger_args.trigger_kwargs = dict(
-                moment=timezone.parse(self.target_time),
+                moment=moment,
                 end_from_trigger=self.end_from_trigger,
             )
 

--- a/providers/standard/tests/unit/standard/sensors/test_date_time.py
+++ b/providers/standard/tests/unit/standard/sensors/test_date_time.py
@@ -24,7 +24,7 @@ import pytest
 
 from airflow import macros
 from airflow.models.dag import DAG
-from airflow.providers.standard.sensors.date_time import DateTimeSensor
+from airflow.providers.standard.sensors.date_time import DateTimeSensor, DateTimeSensorAsync
 
 from tests_common.test_utils.version_compat import timezone
 
@@ -124,3 +124,38 @@ class TestDateTimeSensor:
         sensor.render_template_fields(ctx)
 
         assert isinstance(sensor._moment, expected_type)
+
+
+class TestDateTimeSensorAsync:
+    @classmethod
+    def setup_class(cls):
+        args = {"owner": "airflow", "start_date": DEFAULT_DATE}
+        cls.dag = DAG("test_dag_async", schedule=None, default_args=args)
+
+    def test_start_from_trigger_with_templated_target_time_raises(self):
+        with pytest.raises(ValueError, match="must be a static datetime"):
+            DateTimeSensorAsync(
+                task_id="templated_target_time",
+                target_time="{{ data_interval_end.tomorrow().replace(hour=1) }}",
+                start_from_trigger=True,
+                dag=self.dag,
+            )
+
+    def test_start_from_trigger_with_static_datetime(self):
+        moment = timezone.datetime(2020, 7, 6, 13, tzinfo=timezone.utc)
+        op = DateTimeSensorAsync(
+            task_id="static_target_time",
+            target_time=moment,
+            start_from_trigger=True,
+            dag=self.dag,
+        )
+        assert op.start_trigger_args.trigger_kwargs["moment"] == moment
+
+    def test_templated_target_time_without_start_from_trigger(self):
+        """A templated target_time is fine as long as start_from_trigger is not used."""
+        op = DateTimeSensorAsync(
+            task_id="templated_no_start_from_trigger",
+            target_time="{{ data_interval_end.tomorrow().replace(hour=1) }}",
+            dag=self.dag,
+        )
+        assert op.target_time == "{{ data_interval_end.tomorrow().replace(hour=1) }}"


### PR DESCRIPTION
Fixes #70284

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

---

DateTimeSensorAsync.__init__ called timezone.parse(self.target_time) eagerly at Dag-parse time whenever start_from_trigger=True, crashing the whole Dag file if target_time was a Jinja template (the documented, normal usage of this templated field) since there's no rendering step before the trigger-kwargs are computed. Wrapped the parse in a try/except ParserError and raise a clear ValueError explaining that target_time must be a static datetime when start_from_trigger=True, leaving normal templated usage without start_from_trigger unaffected; added a changelog entry per the verification gate.

**How this was tested:** `airflow dags test`

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=46716c0 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @singlaamitesh** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
> - :x: **Pre-commit / static checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
