### PR TITLE
Expand $env:TEMP in Windows SSH remote job paths

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
@@ -65,7 +65,10 @@ class SSHRemoteJobOperator(BaseOperator):
     :param remote_host: Override the host from the connection (templated)
     :param environment: Environment variables to set for the command (templated)
     :param remote_base_dir: Base directory for job artifacts (templated).
-        Defaults to /tmp/airflow-ssh-jobs on POSIX, C:\\Windows\\Temp\\airflow-ssh-jobs on Windows
+        Defaults to /tmp/airflow-ssh-jobs on POSIX, $env:TEMP\airflow-ssh-jobs on Windows.
+        Must be a literal path: it is emitted as a single-quoted PowerShell/shell string
+        and is not subject to environment-variable or other shell expansion (the default
+        above is the one built-in exception, expanded internally via ``Join-Path``).
     :param poll_interval: Seconds between status polls (default: 5)
     :param log_chunk_size: Max bytes to read per poll (default: 65536)
     :param timeout: Hard timeout in seconds for the entire operation

--- a/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
@@ -65,10 +65,9 @@ class SSHRemoteJobOperator(BaseOperator):
     :param remote_host: Override the host from the connection (templated)
     :param environment: Environment variables to set for the command (templated)
     :param remote_base_dir: Base directory for job artifacts (templated).
-        Defaults to /tmp/airflow-ssh-jobs on POSIX, $env:TEMP\airflow-ssh-jobs on Windows.
-        Must be a literal path: it is emitted as a single-quoted PowerShell/shell string
-        and is not subject to environment-variable or other shell expansion (the default
-        above is the one built-in exception, expanded internally via ``Join-Path``).
+        Defaults to ``/tmp/airflow-ssh-jobs`` on POSIX and
+        ``$env:TEMP\airflow-ssh-jobs`` on Windows. Custom values must be
+        literal paths and are not expanded by the remote shell.
     :param poll_interval: Seconds between status polls (default: 5)
     :param log_chunk_size: Max bytes to read per poll (default: 65536)
     :param timeout: Hard timeout in seconds for the entire operation

--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -50,7 +50,7 @@ def _powershell_path(path: str) -> str:
     if path == WINDOWS_TEMP_PREFIX or path.startswith(WINDOWS_TEMP_PREFIX + "\\"):
         relative = path[len(WINDOWS_TEMP_PREFIX) :].lstrip("\\")
         if not relative:
-            return "$env:TEMP"
+            return WINDOWS_TEMP_PREFIX
         escaped_relative = relative.replace("'", "''")
         return f"(Join-Path $env:TEMP '{escaped_relative}')"
     escaped_path = path.replace("'", "''")

--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -29,6 +29,33 @@ from typing import Literal
 POSIX_DEFAULT_BASE_DIR = "/tmp/airflow-ssh-jobs"
 WINDOWS_DEFAULT_BASE_DIR = "$env:TEMP\\airflow-ssh-jobs"
 
+# The default Windows base dir above is a PowerShell *expression*, not a literal path:
+# it must be expanded via Join-Path. Every other path is emitted as a single-quoted
+# PowerShell literal, where "$env:TEMP" is inert text -- PowerShell would try to resolve
+# a nonexistent "$env" PSDrive and fail (#70438). WINDOWS_TEMP_PREFIX lets
+# ``_powershell_path`` recognize that one sentinel and expand only its prefix, while a
+# user-supplied ``remote_base_dir`` (a real path) always stays a literal.
+WINDOWS_TEMP_PREFIX = "$env:TEMP"
+
+
+def _powershell_path(path: str) -> str:
+    """
+    Render a remote path as a PowerShell expression.
+
+    Paths are emitted as single-quoted literals so that nothing in them is interpreted.
+    The one exception is the default Windows base directory, which is a PowerShell
+    expression (``$env:TEMP``) rather than a real path: its prefix is expanded with
+    ``Join-Path`` while the rest stays literal.
+    """
+    if path == WINDOWS_TEMP_PREFIX or path.startswith(WINDOWS_TEMP_PREFIX + "\\"):
+        relative = path[len(WINDOWS_TEMP_PREFIX) :].lstrip("\\")
+        if not relative:
+            return "$env:TEMP"
+        escaped_relative = relative.replace("'", "''")
+        return f"(Join-Path $env:TEMP '{escaped_relative}')"
+    escaped_path = path.replace("'", "''")
+    return f"'{escaped_path}'"
+
 
 def _validate_job_dir(job_dir: str, remote_os: Literal["posix", "windows"]) -> None:
     """
@@ -264,35 +291,29 @@ def build_windows_wrapper_command(
     def ps_escape(s: str) -> str:
         return s.replace("'", "''")
 
-    job_dir = ps_escape(paths.job_dir)
-    log_file = ps_escape(paths.log_file)
-    exit_code_file = ps_escape(paths.exit_code_file)
-    exit_code_tmp = ps_escape(paths.exit_code_tmp_file)
-    pid_file = ps_escape(paths.pid_file)
-    status_file = ps_escape(paths.status_file)
     escaped_command = ps_escape(command)
     job_id = ps_escape(paths.job_id)
 
     child_script = f"""$ErrorActionPreference = 'Continue'
-$env:LOG_FILE = '{log_file}'
-$env:STATUS_FILE = '{status_file}'
+$env:LOG_FILE = {_powershell_path(paths.log_file)}
+$env:STATUS_FILE = {_powershell_path(paths.status_file)}
 {env_setup}
 {escaped_command}
 $ec = $LASTEXITCODE
 if ($null -eq $ec) {{ $ec = 0 }}
-Set-Content -NoNewline -Path '{exit_code_tmp}' -Value $ec
-Move-Item -Force -Path '{exit_code_tmp}' -Destination '{exit_code_file}'
+Set-Content -NoNewline -Path {_powershell_path(paths.exit_code_tmp_file)} -Value $ec
+Move-Item -Force -Path {_powershell_path(paths.exit_code_tmp_file)} -Destination {_powershell_path(paths.exit_code_file)}
 """
     child_script_bytes = child_script.encode("utf-16-le")
     encoded_script = base64.b64encode(child_script_bytes).decode("ascii")
 
-    wrapper = f"""$jobDir = '{job_dir}'
+    wrapper = f"""$jobDir = {_powershell_path(paths.job_dir)}
 New-Item -ItemType Directory -Force -Path $jobDir | Out-Null
-$log = '{log_file}'
+$log = {_powershell_path(paths.log_file)}
 '' | Set-Content -Path $log
 
 $p = Start-Process -FilePath 'powershell.exe' -ArgumentList @('-NoProfile', '-NonInteractive', '-EncodedCommand', '{encoded_script}') -RedirectStandardOutput $log -RedirectStandardError $log -PassThru -WindowStyle Hidden
-Set-Content -NoNewline -Path '{pid_file}' -Value $p.Id
+Set-Content -NoNewline -Path {_powershell_path(paths.pid_file)} -Value $p.Id
 Write-Output '{job_id}'
 """
     wrapper_bytes = wrapper.encode("utf-16-le")
@@ -324,8 +345,7 @@ def build_windows_log_tail_command(log_file: str, offset: int, max_bytes: int) -
     :param max_bytes: Maximum bytes to read
     :return: PowerShell command that outputs the log chunk
     """
-    escaped_path = log_file.replace("'", "''")
-    script = f"""$path = '{escaped_path}'
+    script = f"""$path = {_powershell_path(log_file)}
 if (Test-Path $path) {{
   try {{
     $fs = [System.IO.File]::Open($path, 'Open', 'Read', 'ReadWrite')
@@ -360,8 +380,7 @@ def build_windows_file_size_command(file_path: str) -> str:
     :param file_path: Path to the file
     :return: PowerShell command that outputs the file size
     """
-    escaped_path = file_path.replace("'", "''")
-    script = f"""$path = '{escaped_path}'
+    script = f"""$path = {_powershell_path(file_path)}
 if (Test-Path $path) {{
   (Get-Item $path).Length
 }} else {{
@@ -389,8 +408,7 @@ def build_windows_completion_check_command(exit_code_file: str) -> str:
     :param exit_code_file: Path to the exit code file
     :return: PowerShell command that outputs exit code if done, empty otherwise
     """
-    escaped_path = exit_code_file.replace("'", "''")
-    script = f"""$path = '{escaped_path}'
+    script = f"""$path = {_powershell_path(exit_code_file)}
 if (Test-Path $path) {{
   $txt = Get-Content -Raw -Path $path
   if ($txt -match '^[0-9]+$') {{ $txt.Trim() }}
@@ -441,8 +459,7 @@ def build_windows_kill_command(pid_file: str) -> str:
     :param pid_file: Path to the PID file
     :return: PowerShell command to kill the process
     """
-    escaped_path = pid_file.replace("'", "''")
-    script = f"""$path = '{escaped_path}'
+    script = f"""$path = {_powershell_path(pid_file)}
 if (Test-Path $path) {{
   $procId = Get-Content $path
   & taskkill.exe /PID $procId /T /F 2>$null
@@ -473,8 +490,7 @@ def build_windows_cleanup_command(job_dir: str) -> str:
     :raises ValueError: If job_dir is not under the expected base directory
     """
     _validate_job_dir(job_dir, "windows")
-    escaped_path = job_dir.replace("'", "''")
-    script = f"Remove-Item -Recurse -Force -Path '{escaped_path}' -ErrorAction SilentlyContinue"
+    script = f"Remove-Item -Recurse -Force -Path {_powershell_path(job_dir)} -ErrorAction SilentlyContinue"
     script_bytes = script.encode("utf-16-le")
     encoded_script = base64.b64encode(script_bytes).decode("ascii")
     return f"powershell.exe -NoProfile -NonInteractive -EncodedCommand {encoded_script}"

--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -40,12 +40,11 @@ WINDOWS_TEMP_PREFIX = "$env:TEMP"
 
 def _powershell_path(path: str) -> str:
     """
-    Render a remote path as a PowerShell expression.
+    Render a path as a PowerShell expression.
 
-    Paths are emitted as single-quoted literals so that nothing in them is interpreted.
-    The one exception is the default Windows base directory, which is a PowerShell
-    expression (``$env:TEMP``) rather than a real path: its prefix is expanded with
-    ``Join-Path`` while the rest stays literal.
+    Most paths are emitted as literals. Paths under the built-in
+    ``$env:TEMP`` base directory are emitted as expressions so the
+    environment variable is expanded at runtime.
     """
     if path == WINDOWS_TEMP_PREFIX or path.startswith(WINDOWS_TEMP_PREFIX + "\\"):
         relative = path[len(WINDOWS_TEMP_PREFIX) :].lstrip("\\")

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -176,6 +176,75 @@ class TestBuildWindowsWrapperCommand:
         assert "-EncodedCommand" in wrapper
 
 
+class TestWindowsDefaultBaseDirExpansion:
+    """Regression tests for #70438.
+
+    ``$env:TEMP\\airflow-ssh-jobs`` is a PowerShell expression used as the default
+    Windows base directory, but every path is interpolated into a *single-quoted*
+    PowerShell string where ``$env:`` is not expanded -- it is emitted literally and
+    PowerShell fails trying to resolve a ``$env`` PSDrive. Only the default-base-dir
+    sentinel should be expanded (via ``Join-Path``); a user-supplied ``remote_base_dir``
+    must stay a literal, unexpanded string.
+    """
+
+    def _decode(self, cmd: str) -> str:
+        encoded_script = cmd.split("-EncodedCommand ")[1]
+        return base64.b64decode(encoded_script).decode("utf-16-le")
+
+    def test_wrapper_expands_default_base_dir(self):
+        """The wrapper for a default-base-dir job must expand $env:TEMP via Join-Path,
+        not emit it inside a single-quoted literal (which PowerShell cannot expand)."""
+        paths = RemoteJobPaths(job_id="test_job", remote_os="windows")
+        wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
+        decoded = self._decode(wrapper)
+
+        assert "Join-Path $env:TEMP" in decoded
+        # The literal single-quoted form is exactly what breaks on real PowerShell:
+        # PowerShell parses the leading "$env" as a (nonexistent) PSDrive name.
+        assert "'$env:TEMP\\" not in decoded
+
+    def test_cleanup_expands_default_base_dir(self):
+        """The cleanup command for a default-base-dir job must likewise expand $env:TEMP."""
+        paths = RemoteJobPaths(job_id="test_job", remote_os="windows")
+        cmd = build_windows_cleanup_command(paths.job_dir)
+        decoded = self._decode(cmd)
+
+        assert "Join-Path $env:TEMP" in decoded
+        assert "'$env:TEMP\\" not in decoded
+
+    def test_custom_base_dir_stays_literal(self):
+        """A custom remote_base_dir is a real path, not a PowerShell expression: it must
+        stay a plain single-quoted literal and must NOT be run through Join-Path. This is
+        the property that keeps a user's own '$' characters safe from expansion."""
+        paths = RemoteJobPaths(job_id="test_job", remote_os="windows", base_dir="D:\\jobs\\airflow-ssh-jobs")
+        wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
+        decoded = self._decode(wrapper)
+
+        assert "Join-Path" not in decoded
+        assert "$jobDir = 'D:\\jobs\\airflow-ssh-jobs\\test_job'" in decoded
+
+    def test_single_quote_escaped_in_expanded_branch(self):
+        """A single quote in the job-id portion of a default-base-dir path must still be
+        escaped as '' inside the Join-Path literal."""
+        job_dir = "$env:TEMP\\airflow-ssh-jobs\\job's"
+        cmd = build_windows_cleanup_command(job_dir)
+        decoded = self._decode(cmd)
+
+        assert "Join-Path $env:TEMP" in decoded
+        assert "job''s" in decoded
+
+    def test_single_quote_escaped_in_literal_branch(self):
+        """A single quote in a custom base dir must still be escaped as '' in the plain
+        single-quoted literal (custom base dirs are real paths, not PowerShell
+        expressions, and must never be run through Join-Path)."""
+        paths = RemoteJobPaths(job_id="job1", remote_os="windows", base_dir="D:\\jo'bs")
+        wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
+        decoded = self._decode(wrapper)
+
+        assert "Join-Path" not in decoded
+        assert "jo''bs" in decoded
+
+
 class TestLogTailCommands:
     def test_posix_log_tail(self):
         """Test POSIX log tail command uses efficient tail+head pipeline."""

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -177,15 +177,7 @@ class TestBuildWindowsWrapperCommand:
 
 
 class TestWindowsDefaultBaseDirExpansion:
-    """Regression tests for #70438.
-
-    ``$env:TEMP\\airflow-ssh-jobs`` is a PowerShell expression used as the default
-    Windows base directory, but every path is interpolated into a *single-quoted*
-    PowerShell string where ``$env:`` is not expanded -- it is emitted literally and
-    PowerShell fails trying to resolve a ``$env`` PSDrive. Only the default-base-dir
-    sentinel should be expanded (via ``Join-Path``); a user-supplied ``remote_base_dir``
-    must stay a literal, unexpanded string.
-    """
+    """Regression tests for Windows default base directory expansion (#70438)."""
 
     def _decode(self, cmd: str) -> str:
         encoded_script = cmd.split("-EncodedCommand ")[1]
@@ -193,21 +185,16 @@ class TestWindowsDefaultBaseDirExpansion:
 
     @staticmethod
     def _decode_child(outer_script: str) -> str:
-        """Decode the *child* script nested inside a wrapper's outer script.
-
-        ``build_windows_wrapper_command`` launches a second, independently
-        base64-encoded PowerShell process via
-        ``Start-Process ... -ArgumentList @(..., '-EncodedCommand', '<base64>')``.
-        That child script -- not the outer one -- owns ``$env:LOG_FILE``,
-        ``$env:STATUS_FILE``, the ``exit_code.tmp`` write, and the ``Move-Item``
-        rename, so it must be decoded and asserted on separately.
-        """
+        """Decode the *child* script nested inside a wrapper's outer script."""
+        # build_windows_wrapper_command launches a second, independently base64-encoded
+        # PowerShell process. That child script -- not the outer one -- owns
+        # $env:LOG_FILE, $env:STATUS_FILE, the exit_code.tmp write and the Move-Item
+        # rename, so it has to be decoded and asserted on separately.
         inner = outer_script.split("-EncodedCommand', '")[1].split("'")[0]
         return base64.b64decode(inner).decode("utf-16-le")
 
     def test_wrapper_expands_default_base_dir(self):
-        """The wrapper for a default-base-dir job must expand $env:TEMP via Join-Path,
-        not emit it inside a single-quoted literal (which PowerShell cannot expand)."""
+        """The default base dir is expanded via Join-Path, not emitted as a literal."""
         paths = RemoteJobPaths(job_id="test_job", remote_os="windows")
         wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
         decoded = self._decode(wrapper)
@@ -226,7 +213,7 @@ class TestWindowsDefaultBaseDirExpansion:
         assert "'$env:TEMP\\" not in child_decoded
 
     def test_cleanup_expands_default_base_dir(self):
-        """The cleanup command for a default-base-dir job must likewise expand $env:TEMP."""
+        """The cleanup command expands the default base dir too."""
         paths = RemoteJobPaths(job_id="test_job", remote_os="windows")
         cmd = build_windows_cleanup_command(paths.job_dir)
         decoded = self._decode(cmd)
@@ -234,20 +221,34 @@ class TestWindowsDefaultBaseDirExpansion:
         assert "Join-Path $env:TEMP" in decoded
         assert "'$env:TEMP\\" not in decoded
 
-    def test_custom_base_dir_stays_literal(self):
-        """A custom remote_base_dir is a real path, not a PowerShell expression: it must
-        stay a plain single-quoted literal and must NOT be run through Join-Path. This is
-        the property that keeps a user's own '$' characters safe from expansion."""
-        paths = RemoteJobPaths(job_id="test_job", remote_os="windows", base_dir="D:\\jobs\\airflow-ssh-jobs")
+    @pytest.mark.parametrize(
+        ("base_dir", "expected_literal"),
+        [
+            pytest.param(
+                "D:\\jobs\\airflow-ssh-jobs",
+                "$jobDir = 'D:\\jobs\\airflow-ssh-jobs\\test_job'",
+                id="custom-base-dir",
+            ),
+            # $env:TEMPORARY starts with the sentinel as a substring but is a different
+            # variable, so it must not be mistaken for it.
+            pytest.param(
+                "$env:TEMPORARY\\jobs",
+                "$jobDir = '$env:TEMPORARY\\jobs\\test_job'",
+                id="near-miss-prefix",
+            ),
+        ],
+    )
+    def test_custom_base_dir_stays_literal(self, base_dir, expected_literal):
+        """Only the built-in sentinel is expanded; any other base dir stays literal."""
+        paths = RemoteJobPaths(job_id="test_job", remote_os="windows", base_dir=base_dir)
         wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
         decoded = self._decode(wrapper)
 
         assert "Join-Path" not in decoded
-        assert "$jobDir = 'D:\\jobs\\airflow-ssh-jobs\\test_job'" in decoded
+        assert expected_literal in decoded
 
     def test_single_quote_escaped_in_expanded_branch(self):
-        """A single quote in the job-id portion of a default-base-dir path must still be
-        escaped as '' inside the Join-Path literal."""
+        """A quote in the expanded branch is still escaped as ''."""
         job_dir = "$env:TEMP\\airflow-ssh-jobs\\job's"
         cmd = build_windows_cleanup_command(job_dir)
         decoded = self._decode(cmd)
@@ -256,9 +257,7 @@ class TestWindowsDefaultBaseDirExpansion:
         assert "job''s" in decoded
 
     def test_single_quote_escaped_in_literal_branch(self):
-        """A single quote in a custom base dir must still be escaped as '' in the plain
-        single-quoted literal (custom base dirs are real paths, not PowerShell
-        expressions, and must never be run through Join-Path)."""
+        """A quote in the literal branch is still escaped as ''."""
         paths = RemoteJobPaths(job_id="job1", remote_os="windows", base_dir="D:\\jo'bs")
         wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
         decoded = self._decode(wrapper)
@@ -276,9 +275,7 @@ class TestWindowsDefaultBaseDirExpansion:
         ],
     )
     def test_poll_builders_expand_default_base_dir(self, builder, path_attr):
-        """Each single-path polling builder must also expand the default-base-dir
-        sentinel. These builders were previously only exercised with hard-coded
-        ``C:\\temp\\...`` literals, which never touch the sentinel branch at all."""
+        """Every polling builder expands the default base dir, not just the wrapper."""
         paths = RemoteJobPaths(job_id="test_job", remote_os="windows")
         path = getattr(paths, path_attr)
         cmd = builder(path)
@@ -286,17 +283,6 @@ class TestWindowsDefaultBaseDirExpansion:
 
         assert "Join-Path $env:TEMP" in decoded
         assert "'$env:TEMP\\" not in decoded
-
-    def test_near_miss_prefix_stays_literal(self):
-        """A base_dir that merely starts with the sentinel string as a substring --
-        ``$env:TEMPORARY`` is not ``$env:TEMP`` -- must NOT be mistaken for the sentinel.
-        It must stay a plain single-quoted literal, not be run through Join-Path."""
-        paths = RemoteJobPaths(job_id="test_job", remote_os="windows", base_dir="$env:TEMPORARY\\jobs")
-        wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
-        decoded = self._decode(wrapper)
-
-        assert "Join-Path" not in decoded
-        assert "$jobDir = '$env:TEMPORARY\\jobs\\test_job'" in decoded
 
 
 class TestLogTailCommands:

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -191,6 +191,20 @@ class TestWindowsDefaultBaseDirExpansion:
         encoded_script = cmd.split("-EncodedCommand ")[1]
         return base64.b64decode(encoded_script).decode("utf-16-le")
 
+    @staticmethod
+    def _decode_child(outer_script: str) -> str:
+        """Decode the *child* script nested inside a wrapper's outer script.
+
+        ``build_windows_wrapper_command`` launches a second, independently
+        base64-encoded PowerShell process via
+        ``Start-Process ... -ArgumentList @(..., '-EncodedCommand', '<base64>')``.
+        That child script -- not the outer one -- owns ``$env:LOG_FILE``,
+        ``$env:STATUS_FILE``, the ``exit_code.tmp`` write, and the ``Move-Item``
+        rename, so it must be decoded and asserted on separately.
+        """
+        inner = outer_script.split("-EncodedCommand', '")[1].split("'")[0]
+        return base64.b64decode(inner).decode("utf-16-le")
+
     def test_wrapper_expands_default_base_dir(self):
         """The wrapper for a default-base-dir job must expand $env:TEMP via Join-Path,
         not emit it inside a single-quoted literal (which PowerShell cannot expand)."""
@@ -202,6 +216,14 @@ class TestWindowsDefaultBaseDirExpansion:
         # The literal single-quoted form is exactly what breaks on real PowerShell:
         # PowerShell parses the leading "$env" as a (nonexistent) PSDrive name.
         assert "'$env:TEMP\\" not in decoded
+
+        # The outer script only creates the job directory and launches the child
+        # process; the child script is the one that sets $env:LOG_FILE/$env:STATUS_FILE,
+        # writes exit_code.tmp, and moves it into place. All of those paths are under
+        # the same default base dir and must be expanded there too.
+        child_decoded = self._decode_child(decoded)
+        assert "Join-Path $env:TEMP" in child_decoded
+        assert "'$env:TEMP\\" not in child_decoded
 
     def test_cleanup_expands_default_base_dir(self):
         """The cleanup command for a default-base-dir job must likewise expand $env:TEMP."""
@@ -243,6 +265,38 @@ class TestWindowsDefaultBaseDirExpansion:
 
         assert "Join-Path" not in decoded
         assert "jo''bs" in decoded
+
+    @pytest.mark.parametrize(
+        ("builder", "path_attr"),
+        [
+            (lambda path: build_windows_log_tail_command(path, 0, 100), "log_file"),
+            (build_windows_file_size_command, "log_file"),
+            (build_windows_completion_check_command, "exit_code_file"),
+            (build_windows_kill_command, "pid_file"),
+        ],
+    )
+    def test_poll_builders_expand_default_base_dir(self, builder, path_attr):
+        """Each single-path polling builder must also expand the default-base-dir
+        sentinel. These builders were previously only exercised with hard-coded
+        ``C:\\temp\\...`` literals, which never touch the sentinel branch at all."""
+        paths = RemoteJobPaths(job_id="test_job", remote_os="windows")
+        path = getattr(paths, path_attr)
+        cmd = builder(path)
+        decoded = self._decode(cmd)
+
+        assert "Join-Path $env:TEMP" in decoded
+        assert "'$env:TEMP\\" not in decoded
+
+    def test_near_miss_prefix_stays_literal(self):
+        """A base_dir that merely starts with the sentinel string as a substring --
+        ``$env:TEMPORARY`` is not ``$env:TEMP`` -- must NOT be mistaken for the sentinel.
+        It must stay a plain single-quoted literal, not be run through Join-Path."""
+        paths = RemoteJobPaths(job_id="test_job", remote_os="windows", base_dir="$env:TEMPORARY\\jobs")
+        wrapper = build_windows_wrapper_command("C:\\scripts\\test.ps1", paths)
+        decoded = self._decode(wrapper)
+
+        assert "Join-Path" not in decoded
+        assert "$jobDir = '$env:TEMPORARY\\jobs\\test_job'" in decoded
 
 
 class TestLogTailCommands:


### PR DESCRIPTION
Closes: #70438

`WINDOWS_DEFAULT_BASE_DIR` is a PowerShell expression rather than a real path:

```python
WINDOWS_DEFAULT_BASE_DIR = "$env:TEMP\\airflow-ssh-jobs"
```

but every builder interpolated the resulting paths into **single-quoted** PowerShell
strings, where nothing is expanded. PowerShell then parses the leading `$env:` as a
PSDrive qualifier and fails:

```
New-Item : Cannot find drive. A drive with the name '$env' does not exist.
```

So `SSHRemoteJobOperator` could not create its job directory on a Windows remote at all
unless `remote_base_dir` was set to a literal path. Cleanup failed the same way, but
silently, because of `-ErrorAction SilentlyContinue`.

## Approach

The sentinel stays opaque on the Python side and is expanded only where a path is
rendered into PowerShell, through one helper:

```python
def _powershell_path(path: str) -> str:
    if path == WINDOWS_TEMP_PREFIX or path.startswith(WINDOWS_TEMP_PREFIX + "\\"):
        relative = path[len(WINDOWS_TEMP_PREFIX) :].lstrip("\\")
        if not relative:
            return WINDOWS_TEMP_PREFIX
        return f"(Join-Path $env:TEMP '{relative.replace(chr(39), chr(39) * 2)}')"
    return f"'{path.replace(chr(39), chr(39) * 2)}'"
```

so `$jobDir = '{job_dir}'` now emits

```powershell
$jobDir = (Join-Path $env:TEMP 'airflow-ssh-jobs\af_dag_task_run_try1_abcdef')
```

I picked this over resolving the temp directory remotely, or switching to expanding
quotes, because:

- **Every user-supplied path stays inert data.** Only the exact default prefix is
  treated as an expression, so a `$` inside a user's `remote_base_dir` is still used
  verbatim.
- **`_validate_job_dir` is untouched.** Both the job dir and the default base dir keep
  the sentinel on the Python side, so the existing prefix comparison still holds.
- **The operator, the trigger and the event payload are untouched.** Cleanup runs from
  `execute_complete` after deferral, where `_paths` is `None`, so a remotely-resolved
  base directory would have had to be threaded through the trigger event.

The change is confined to the six `build_windows_*` builders. The POSIX builders,
`RemoteJobPaths`, `WINDOWS_DEFAULT_BASE_DIR` and the operator's logic are unchanged.

Also corrected the `remote_base_dir` docstring, which documented the Windows default as
`C:\Windows\Temp\airflow-ssh-jobs` — a value that has never been the default and that
the operator's own `_validate_base_dir` warns about, since `C:\Windows` is in its
`dangerous_patterns` list.

## Verification

Ran the generated scripts in Windows PowerShell 5.1 (Windows 11).

Before, `New-Item` raised `DriveNotFoundException` and nothing was created anywhere —
not even a literal `$env:TEMP` directory. After, the emitted script creates
`C:\Users\<user>\AppData\Local\Temp\airflow-ssh-jobs\af_test_job_abcdef` and its
`stdout.log`, and the emitted cleanup command removes it.

Every generated script was also checked with
`[System.Management.Automation.Language.Parser]::ParseInput` and by binding the emitted
expressions to `Set-Content -Path`, `Move-Item -Path`/`-Destination` and
`Remove-Item -Path` on a real host.

## Tests

There are twelve path interpolation sites across the six builders, and four of them live
in a *second* base64 payload nested inside the wrapper. Tests that decode only the outer
layer pass even when those four are broken, so the new tests decode both layers and
sweep the four polling builders explicitly. I verified this by mutation: reverting any
individual site to the old single-quoted form makes a test fail.

Covered: the wrapper and the cleanup command expand the default; a custom base dir stays
a plain literal; a near-miss prefix such as `$env:TEMPORARY\jobs` is *not* expanded; and
a single quote is escaped correctly in both branches.

## Notes

- `$env:TEMP` is now resolved per SSH session — submission, polling, cleanup and
  `on_kill` each open their own connection. That is stable for ordinary Windows OpenSSH,
  and it is what makes the default work at all, but it is worth being aware of.
- Only `$env:TEMP` is special-cased. The `remote_base_dir` docstring now states that the
  value must be a literal path, so `remote_base_dir="$env:LOCALAPPDATA\jobs"` is not
  silently treated as an expression.
- No newsfragment: `providers/ssh` has no `newsfragments/` directory.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=8f72a93 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @xFrone** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
