### PR TITLE
Fix EcsRunTaskOperator deferred-logs region and template field init

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
@@ -491,9 +491,6 @@ class EcsRunTaskOperator(EcsBaseOperator):
         self.reattach = reattach
         self.number_logs_exception = number_logs_exception
 
-        if self.awslogs_region is None:
-            self.awslogs_region = self.region_name
-
         self.arn: str | None = None
         self.container_name: str | None = container_name
         self._started_by: str | None = None
@@ -513,11 +510,6 @@ class EcsRunTaskOperator(EcsBaseOperator):
         )
         self.stop_task_on_failure = stop_task_on_failure
 
-        if self._aws_logs_enabled() and not self.wait_for_completion:
-            self.log.warning(
-                "Trying to get logs without waiting for the task to complete is undefined behavior."
-            )
-
     @staticmethod
     def _get_ecs_task_id(task_arn: str | None) -> str | None:
         if task_arn is None:
@@ -525,6 +517,11 @@ class EcsRunTaskOperator(EcsBaseOperator):
         return task_arn.split("/")[-1]
 
     def execute(self, context):
+        if self._aws_logs_enabled() and not self.wait_for_completion:
+            self.log.warning(
+                "Trying to get logs without waiting for the task to complete is undefined behavior."
+            )
+
         self.log.info(
             "Running ECS Task - Task definition: %s - on cluster %s", self.task_definition, self.cluster
         )
@@ -623,7 +620,9 @@ class EcsRunTaskOperator(EcsBaseOperator):
         self._after_execution()
         if self._aws_logs_enabled():
             # same behavior as non-deferrable mode, return last line of logs of the task.
-            logs_client = AwsLogsHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name).conn
+            logs_client = AwsLogsHook(
+                aws_conn_id=self.aws_conn_id, region_name=self.resolve_awslogs_region()
+            ).conn
             one_log = logs_client.get_log_events(
                 logGroupName=self.awslogs_group,
                 logStreamName=self._get_logs_stream_name(),
@@ -737,13 +736,16 @@ class EcsRunTaskOperator(EcsBaseOperator):
             return f"{self.awslogs_stream_prefix}/{self.container_name}/{self._get_ecs_task_id(self.arn)}"
         return f"{self.awslogs_stream_prefix}/{self._get_ecs_task_id(self.arn)}"
 
+    def resolve_awslogs_region(self) -> str | None:
+        return self.awslogs_region if self.awslogs_region is not None else self.region_name
+
     def _get_task_log_fetcher(self) -> AwsTaskLogFetcher:
         if not self.awslogs_group:
             raise ValueError("must specify awslogs_group to fetch task logs")
 
         return AwsTaskLogFetcher(
             aws_conn_id=self.aws_conn_id,
-            region_name=self.awslogs_region,
+            region_name=self.resolve_awslogs_region(),
             log_group=self.awslogs_group,
             log_stream_name=self._get_logs_stream_name(),
             fetch_interval=self.awslogs_fetch_interval,

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
@@ -180,6 +180,16 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert self.ecs.task_definition == "t"
         assert self.ecs.cluster == "c"
         assert self.ecs.overrides == {}
+        assert self.ecs.awslogs_region is None
+
+    def test_get_task_log_fetcher_uses_region_name_when_awslogs_region_not_set(self):
+        self.set_up_operator(
+            awslogs_group="awslogs-group", awslogs_stream_prefix="prefix", region_name="region"
+        )
+
+        fetcher = self.ecs._get_task_log_fetcher()
+
+        assert fetcher.hook.region_name == "region"
 
     def test_template_fields_overrides(self):
         assert self.ecs.template_fields == (
@@ -405,6 +415,26 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
     def test_task_id_parsing(self):
         id = EcsRunTaskOperator._get_ecs_task_id(f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}")
         assert id == TASK_ID
+
+    @mock.patch.object(EcsBaseOperator, "client")
+    def test_execute_warns_when_fetching_logs_without_waiting(self, client_mock, caplog):
+        self.set_up_operator(
+            awslogs_group="awslogs-group",
+            awslogs_stream_prefix="prefix",
+            wait_for_completion=False,
+        )
+        caplog.clear()
+        client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
+        mock_ti = mock.MagicMock()
+        mock_context = {"ti": mock_ti, "task_instance": mock_ti}
+
+        result = self.ecs.execute(mock_context)
+
+        assert result is None
+        assert (
+            "Trying to get logs without waiting for the task to complete is undefined behavior."
+            in caplog.messages
+        )
 
     @mock.patch.object(EcsBaseOperator, "client")
     def test_execute_with_failures(self, client_mock):
@@ -828,6 +858,30 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
 
         # task gets described to assert its success
         client_mock().describe_tasks.assert_called_once_with(cluster="test_cluster", tasks=["my_arn"])
+
+    @mock.patch("airflow.providers.amazon.aws.operators.ecs.AwsLogsHook")
+    @mock.patch.object(EcsRunTaskOperator, "_check_success_task")
+    def test_execute_complete_uses_awslogs_region(self, check_mock, logs_hook_mock):
+        self.set_up_operator(
+            awslogs_group="awslogs-group",
+            awslogs_region="logs-region",
+            awslogs_stream_prefix="prefix",
+            region_name="task-region",
+        )
+        logs_hook_mock.return_value.conn.get_log_events.return_value = {"events": [{"message": "Log output"}]}
+
+        result = self.ecs.execute_complete(
+            {},
+            {
+                "status": "success",
+                "task_arn": f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}",
+                "cluster": "test_cluster",
+            },
+        )
+
+        assert result == "Log output"
+        check_mock.assert_called_once_with()
+        logs_hook_mock.assert_called_once_with(aws_conn_id=self.ecs.aws_conn_id, region_name="logs-region")
 
     @mock.patch.object(EcsBaseOperator, "client")
     @mock.patch("airflow.providers.amazon.aws.utils.task_log_fetcher.AwsTaskLogFetcher")

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -7,7 +7,6 @@
 # execute()) MUST remove its entry in the same PR — the hook fails on stale entries.
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
 providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py::AppflowBaseOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py::EcsRunTaskOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py::EmrAddStepsOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator


### PR DESCRIPTION

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
Move `EcsRunTaskOperator` template-field decisions out of `__init__` so templated values are rendered before they affect ECS log handling.

This removes the operator from the `validate_operators_init` exemption list.

Besides moving the template-field logic out of ` __init__` (so templated awslogs_region/region_name values are rendered before they take effect), this also fixes a real bug in the deferrable path: `execute_complete` built its `AwsLogsHook` with `region_name=self.region_name`, so when `awslogs_region` was explicitly set to a different region than the task's region, the final log fetch after deferral queried CloudWatch in the wrong region and found no log stream. The new `resolve_awslogs_region()` helper is now the single place the log region is resolved (explicit `awslogs_region`, falling back to `region_name`), and both `execute_complete` and the task log fetcher use it. Note this covers only the post-deferral fetch — log forwarding during deferral still uses the task region inside `TaskDoneTrigger`; that remaining half is tracked in https://github.com/apache/airflow/issues/70465.

related: #70296


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
