### PR TITLE
Resolve provider namespaces from the real directory tree in prek hooks

### DIFF
--- a/scripts/ci/prek/check_providers_subpackages_all_have_init.py
+++ b/scripts/ci/prek/check_providers_subpackages_all_have_init.py
@@ -30,8 +30,8 @@ from pathlib import Path
 from common_prek_utils import (
     AIRFLOW_PROVIDERS_ROOT_PATH,
     AIRFLOW_ROOT_PATH,
-    KNOWN_SECOND_LEVEL_PATHS,
     console,
+    get_provider_namespace_from_path,
 )
 
 ACCEPTED_NON_INIT_DIRS = [
@@ -66,7 +66,9 @@ missing_init_dirs: list[Path] = []
 missing_path_extension_dirs: list[Path] = []
 
 
-def _what_kind_of_test_init_py_needed(base_path: Path, folder: Path) -> tuple[bool, bool]:
+def _what_kind_of_test_init_py_needed(
+    base_path: Path, folder: Path, namespace: str | None
+) -> tuple[bool, bool]:
     """Returns a tuple of two booleans indicating need and type of __init__.py file.
 
     The first boolean is True if __init__.py is needed, False otherwise.
@@ -86,10 +88,22 @@ def _what_kind_of_test_init_py_needed(base_path: Path, folder: Path) -> tuple[bo
             _ErrorSignals.fatal_error = True
         return True, True
     if depth == 2:
-        # For known sub-packages that can occur in several packages we need to add __path__ extension
-        return True, folder.name in KNOWN_SECOND_LEVEL_PATHS
+        # For sub-packages that can occur in several packages we need to add __path__ extension
+        return True, folder.name == namespace
     # all other sub-packages should have plain __init__.py
     return True, False
+
+
+def _needs_path_extension_in_src(relative_root_path: Path, namespace: str | None) -> bool:
+    """Whether a folder under ``src/airflow`` is also shipped by other distributions.
+
+    ``airflow`` and ``airflow/providers`` are shared by every distribution, and the namespace
+    package below them by every distribution of that namespace.
+    """
+    parts = relative_root_path.parts
+    if len(parts) < 2:
+        return True
+    return len(parts) == 2 and parts[0] == "providers" and parts[1] == namespace
 
 
 def _determine_init_py_action(need_path_extension: bool, root_path: Path):
@@ -112,12 +126,15 @@ def check_dir_init_test_folders(folders: list[Path]) -> None:
     for root_distribution_path in folders:
         # We need init folders for all folders and for the common ones we need path extension
         tests_folder = root_distribution_path / "tests"
+        namespace = get_provider_namespace_from_path(root_distribution_path / "provider.yaml")
         print("Checking for __init__.py files in distribution for tests: ", tests_folder)
         for root, dirs, _ in os.walk(tests_folder):
             # Edit it in place, so we don't recurse to folders we don't care about
             dirs[:] = [d for d in dirs if d not in ACCEPTED_NON_INIT_DIRS]
             root_path = Path(root)
-            need_init_py, need_path_extension = _what_kind_of_test_init_py_needed(tests_folder, root_path)
+            need_init_py, need_path_extension = _what_kind_of_test_init_py_needed(
+                tests_folder, root_path, namespace
+            )
             if need_init_py:
                 _determine_init_py_action(need_path_extension, root_path)
 
@@ -127,6 +144,7 @@ def check_dir_init_src_folders(folders: list[Path]) -> None:
     for root_distribution_path in folders:
         # We need init folders for all folders and for the common ones we need path extension
         providers_base_folder = root_distribution_path / "src" / "airflow"
+        namespace = get_provider_namespace_from_path(root_distribution_path / "provider.yaml")
         print("Checking for __init__.py files in distribution for src: ", providers_base_folder)
         for root, dirs, _ in os.walk(providers_base_folder):
             print("Checking: ", root)
@@ -139,13 +157,7 @@ def check_dir_init_src_folders(folders: list[Path]) -> None:
                 and not any(pattern in root for pattern in IGNORE_DIR_PATTERNS)
             ]
             relative_root_path = root_path.relative_to(providers_base_folder)
-            need_path_extension = (
-                root_path == providers_base_folder
-                or len(relative_root_path.parts) == 1
-                or len(relative_root_path.parts) == 2
-                and relative_root_path.parts[1] in KNOWN_SECOND_LEVEL_PATHS
-                and relative_root_path.parts[0] == "providers"
-            )
+            need_path_extension = _needs_path_extension_in_src(relative_root_path, namespace)
             print("Needs path extension: ", need_path_extension)
             _determine_init_py_action(need_path_extension, root_path)
 

--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -41,9 +41,6 @@ AIRFLOW_PROVIDERS_ROOT_PATH = AIRFLOW_ROOT_PATH / "providers"
 AIRFLOW_TASK_SDK_ROOT_PATH = AIRFLOW_ROOT_PATH / "task-sdk"
 AIRFLOW_TASK_SDK_SOURCES_PATH = AIRFLOW_TASK_SDK_ROOT_PATH / "src"
 
-# Here we should add the second level paths that we want to have sub-packages in
-KNOWN_SECOND_LEVEL_PATHS = ["apache", "atlassian", "common", "cncf", "dbt", "ibm", "microsoft"]
-
 DEFAULT_PYTHON_MAJOR_MINOR_VERSION = "3.10"
 
 # Maps a Docker build platform string (as declared in ``provider.yaml`` under
@@ -589,6 +586,30 @@ def get_provider_base_dir_from_path(file_path: Path) -> Path | None:
         if (parent / "provider.yaml").exists():
             return parent
     return None
+
+
+def get_provider_namespace_from_path(file_path: Path) -> str | None:
+    """Get the namespace of the nested provider the file belongs to, None if it is not nested."""
+    provider_id = get_provider_id_from_path(file_path)
+    if not provider_id or "." not in provider_id:
+        return None
+    return provider_id.split(".")[0]
+
+
+def is_duplicated_namespace_init(file_path: Path) -> bool:
+    """Check whether the file is a namespace ``__init__.py`` repeated across the namespace."""
+    if file_path.name != "__init__.py":
+        return False
+    namespace = get_provider_namespace_from_path(file_path)
+    base_dir = get_provider_base_dir_from_path(file_path)
+    if namespace is None or base_dir is None:
+        return False
+    return file_path.relative_to(base_dir).parts in {
+        ("src", "airflow", "providers", namespace, "__init__.py"),
+        ("tests", "unit", namespace, "__init__.py"),
+        ("tests", "integration", namespace, "__init__.py"),
+        ("tests", "system", namespace, "__init__.py"),
+    }
 
 
 def get_all_provider_ids(

--- a/scripts/ci/prek/mypy_folder.py
+++ b/scripts/ci/prek/mypy_folder.py
@@ -30,10 +30,10 @@ import sys
 
 from common_prek_utils import (
     AIRFLOW_ROOT_PATH,
-    KNOWN_SECOND_LEVEL_PATHS,
     console,
     get_all_provider_ids,
     initialize_breeze_prek,
+    is_duplicated_namespace_init,
     is_hidden_within_root,
     run_command_via_breeze_run,
 )
@@ -76,18 +76,6 @@ MYPY_FILE_LIST.parent.mkdir(parents=True, exist_ok=True)
 
 FILE_ARGUMENT = "@/files/mypy_files.txt"
 
-all_provider_duplicated_path_to_ignore = []
-
-for second_level_path in KNOWN_SECOND_LEVEL_PATHS:
-    all_provider_duplicated_path_to_ignore.extend(
-        [
-            rf"^.*/providers/{second_level_path}/.*/src/airflow/providers/{second_level_path}/__init__.py$",
-            rf"^.*/providers/{second_level_path}/.*/tests/unit/{second_level_path}/__init__.py$",
-            rf"^.*/providers/{second_level_path}/.*/tests/integration/{second_level_path}/__init__.py$",
-            rf"^.*/providers/{second_level_path}/.*/tests/system/{second_level_path}/__init__.py$",
-        ]
-    )
-
 exclude_regexps = [
     re.compile(x)
     for x in [
@@ -100,7 +88,6 @@ exclude_regexps = [
         r"^.*/providers/.*/tests/unit/__init__.py$",
         r"^.*/providers/.*/tests/integration/__init__.py$",
         r"^.*/providers/.*/tests/system/__init__.py$",
-        *all_provider_duplicated_path_to_ignore,
     ]
 ]
 
@@ -110,7 +97,11 @@ def get_all_files(folder: str) -> list[str]:
     python_file_paths = (AIRFLOW_ROOT_PATH / folder).resolve().rglob("*.py")
     for file in python_file_paths:
         if (
-            (file.name not in ("conftest.py",) and not any(x.match(file.as_posix()) for x in exclude_regexps))
+            (
+                file.name not in ("conftest.py",)
+                and not any(x.match(file.as_posix()) for x in exclude_regexps)
+                and not is_duplicated_namespace_init(file)
+            )
             and not is_hidden_within_root(file, AIRFLOW_ROOT_PATH)
         ) and not file.as_posix().endswith("src/airflow/providers/__init__.py"):
             files_to_check.append(file.relative_to(AIRFLOW_ROOT_PATH).as_posix())

--- a/scripts/tests/ci/prek/test_check_providers_subpackages_all_have_init.py
+++ b/scripts/tests/ci/prek/test_check_providers_subpackages_all_have_init.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ci.prek.check_providers_subpackages_all_have_init import (
+    _needs_path_extension_in_src,
+    _what_kind_of_test_init_py_needed,
+)
+
+
+class TestPathExtensionDecisions:
+    @pytest.mark.parametrize(
+        ("folder", "namespace", "expected"),
+        [
+            pytest.param("unit/apache", "apache", True, id="namespace-folder-is-shared"),
+            pytest.param("unit/acme", "acme", True, id="unknown-namespace-folder-is-shared"),
+            pytest.param("unit/hive", "apache", False, id="provider-own-folder-is-not-shared"),
+            pytest.param("unit/amazon", None, False, id="top-level-provider-has-no-shared-folder"),
+        ],
+    )
+    def test_only_the_namespace_folder_needs_path_extension(self, tmp_path, folder, namespace, expected):
+        need_init_py, need_path_extension = _what_kind_of_test_init_py_needed(
+            tmp_path, tmp_path / folder, namespace
+        )
+
+        assert need_init_py is True
+        assert need_path_extension is expected
+
+    @pytest.mark.parametrize(
+        ("relative_path", "namespace", "expected"),
+        [
+            pytest.param(".", None, True, id="airflow-itself"),
+            pytest.param("providers", None, True, id="providers-package"),
+            pytest.param("providers/apache", "apache", True, id="namespace-package-is-shared"),
+            pytest.param("providers/acme", "acme", True, id="unknown-namespace-package-is-shared"),
+            pytest.param("providers/hive", "apache", False, id="provider-package-is-not-shared"),
+            pytest.param("providers/amazon", None, False, id="top-level-provider-package-is-not-shared"),
+            pytest.param("providers/apache/hive", "apache", False, id="deeper-package-is-not-shared"),
+        ],
+    )
+    def test_only_shared_folders_need_path_extension(self, relative_path, namespace, expected):
+        assert _needs_path_extension_in_src(Path(relative_path), namespace) is expected

--- a/scripts/tests/ci/prek/test_common_prek_utils.py
+++ b/scripts/tests/ci/prek/test_common_prek_utils.py
@@ -27,8 +27,10 @@ from ci.prek.common_prek_utils import (
     get_imports_from_file,
     get_provider_base_dir_from_path,
     get_provider_id_from_path,
+    get_provider_namespace_from_path,
     initialize_breeze_prek,
     insert_documentation,
+    is_duplicated_namespace_init,
     is_hidden_within_root,
     pre_process_mypy_files,
     read_airflow_version,
@@ -539,6 +541,95 @@ class TestGetProviderBaseDirFromPath:
         test_file.touch()
         result = get_provider_base_dir_from_path(test_file)
         assert result == outer
+
+
+class TestGetProviderNamespaceFromPath:
+    @pytest.mark.parametrize(
+        ("provider_path", "expected"),
+        [
+            pytest.param("providers/apache/hive", "apache", id="nested-provider"),
+            pytest.param("providers/acme/widget", "acme", id="unknown-nested-provider"),
+            pytest.param("providers/amazon", None, id="top-level-provider"),
+        ],
+    )
+    def test_namespace_comes_from_the_directory_tree(self, create_provider_tree, provider_path, expected):
+        assert get_provider_namespace_from_path(create_provider_tree(provider_path)) == expected
+
+    def test_returns_none_outside_any_provider(self, tmp_path):
+        unrelated = tmp_path / "file.py"
+        unrelated.touch()
+        assert get_provider_namespace_from_path(unrelated) is None
+
+
+class TestIsDuplicatedNamespaceInit:
+    @staticmethod
+    def _make_provider(tmp_path, provider_path: str, init_relative_path: str):
+        provider_dir = tmp_path / provider_path
+        provider_dir.mkdir(parents=True)
+        (provider_dir / "provider.yaml").touch()
+        init_file = provider_dir / init_relative_path
+        init_file.parent.mkdir(parents=True, exist_ok=True)
+        init_file.touch()
+        return init_file
+
+    @pytest.mark.parametrize(
+        ("provider_path", "init_relative_path", "expected"),
+        [
+            pytest.param(
+                "providers/apache/hive",
+                "src/airflow/providers/apache/__init__.py",
+                True,
+                id="src-namespace-init",
+            ),
+            pytest.param(
+                "providers/apache/hive", "tests/unit/apache/__init__.py", True, id="unit-namespace-init"
+            ),
+            pytest.param(
+                "providers/apache/hive",
+                "tests/integration/apache/__init__.py",
+                True,
+                id="integration-namespace-init",
+            ),
+            pytest.param(
+                "providers/apache/hive", "tests/system/apache/__init__.py", True, id="system-namespace-init"
+            ),
+            pytest.param(
+                "providers/acme/widget",
+                "src/airflow/providers/acme/__init__.py",
+                True,
+                id="unknown-namespace-init",
+            ),
+            pytest.param(
+                "providers/apache/hive",
+                "src/airflow/providers/apache/hive/__init__.py",
+                False,
+                id="provider-own-init-is-unique",
+            ),
+            pytest.param(
+                "providers/amazon",
+                "src/airflow/providers/amazon/__init__.py",
+                False,
+                id="top-level-provider-init-is-unique",
+            ),
+            pytest.param(
+                "providers/apache/hive",
+                "src/airflow/providers/apache/hive/hooks/hive.py",
+                False,
+                id="not-an-init-file",
+            ),
+        ],
+    )
+    def test_only_repeated_namespace_inits_are_reported(
+        self, tmp_path, provider_path, init_relative_path, expected
+    ):
+        init_file = self._make_provider(tmp_path, provider_path, init_relative_path)
+        assert is_duplicated_namespace_init(init_file) is expected
+
+    def test_returns_false_outside_any_provider(self, tmp_path):
+        unrelated = tmp_path / "airflow" / "providers" / "apache" / "__init__.py"
+        unrelated.parent.mkdir(parents=True)
+        unrelated.touch()
+        assert is_duplicated_namespace_init(unrelated) is False
 
 
 class TestInitializeBreezePrek:


### PR DESCRIPTION
## Why

- `KNOWN_SECOND_LEVEL_PATHS` is a hand-maintained list of namespace prefixes. A missing entry produces no signal at all.

## How

- `get_provider_id_from_path()` walks up to the nearest `provider.yaml` and returns the provider id relative to `providers/`: `apache.hive` for a nested provider, `amazon` for a top-level one.
- `get_provider_namespace_from_path()` uses `get_provider_id_from_path()` to detect the namespace. The segment before the dot is the namespace. The absence of a dot means the provider has none, so the answer comes from the provider's own position in the tree rather than from a list.
- `check_providers_subpackages_all_have_init.py`: `folder.name in KNOWN_SECOND_LEVEL_PATHS` becomes `folder.name == namespace`.
- `mypy_folder.py` uses `is_duplicated_namespace_init()` to resolve each file's own provider and checks whether that file is that provider's namespace `__init__.py`.

## Verification

- `uv run --project scripts pytest scripts/tests/`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
