### PR TITLE
Add password field type to FlexibleForm

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -75,10 +75,12 @@
   },
   "flexibleForm": {
     "durationPlaceholder": "Enter Duration in ISO 8601 format",
+    "hidePassword": "Hide value",
     "placeholder": "Select Value",
     "placeholderArray": "Enter each string on a new line",
     "placeholderExamples": "Start typing to see options",
     "placeholderMulti": "Select one or multiple values",
+    "showPassword": "Show value",
     "validationErrorArrayNotArray": "Value must be an array.",
     "validationErrorArrayNotNumbers": "All elements in the array must be numbers.",
     "validationErrorArrayNotObject": "All elements in the array must be objects.",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/components.json
@@ -75,12 +75,10 @@
   },
   "flexibleForm": {
     "durationPlaceholder": "Enter Duration in ISO 8601 format",
-    "hidePassword": "Hide value",
     "placeholder": "Select Value",
     "placeholderArray": "Enter each string on a new line",
     "placeholderExamples": "Start typing to see options",
     "placeholderMulti": "Select one or multiple values",
-    "showPassword": "Show value",
     "validationErrorArrayNotArray": "Value must be an array.",
     "validationErrorArrayNotNumbers": "All elements in the array must be numbers.",
     "validationErrorArrayNotObject": "All elements in the array must be objects.",
@@ -113,6 +111,10 @@
   "logs": {
     "file": "File",
     "location": "line {{line}} in {{name}}"
+  },
+  "passwordToggle": {
+    "hide": "Hide value",
+    "show": "Show value"
   },
   "reparseDag": "Reparse Dag",
   "sortedAscending": "sorted ascending",

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.test.tsx
@@ -93,4 +93,23 @@ describe("FieldPassword", () => {
     expect(mockParamsDict.private_key.value).toBeNull();
     expect(onUpdate).toHaveBeenLastCalledWith("");
   });
+  it("toggles between masked and plain text when the button is clicked", () => {
+    mockParamsDict.private_key = {
+      schema: { format: "password", type: "string" },
+      value: "s3cret",
+    };
+
+    render(<FieldPassword name="private_key" onUpdate={vi.fn()} />, { wrapper: Wrapper });
+
+    const input = getInputByName("private_key");
+    const toggle = document.querySelector("button") as HTMLButtonElement;
+
+    expect(input.type).toBe("password");
+
+    fireEvent.click(toggle);
+    expect(input.type).toBe("text");
+
+    fireEvent.click(toggle);
+    expect(input.type).toBe("password");
+  });
 });

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.test.tsx
@@ -1,0 +1,96 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { fireEvent, render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { Wrapper } from "src/utils/Wrapper";
+
+import { FieldPassword } from "./FieldPassword";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockParamsDict: Record<string, any> = {};
+const mockSetParamsDict = vi.fn();
+
+vi.mock("src/queries/useParamStore", () => ({
+  paramPlaceholder: {
+    schema: {},
+    value: null,
+  },
+  useParamStore: () => ({
+    disabled: false,
+    paramsDict: mockParamsDict,
+    setParamsDict: mockSetParamsDict,
+  }),
+}));
+
+const getInputByName = (name: string) =>
+  document.querySelector<HTMLInputElement>(`#element_${name}`) as HTMLInputElement;
+
+describe("FieldPassword", () => {
+  beforeEach(() => {
+    mockSetParamsDict.mockClear();
+    Object.keys(mockParamsDict).forEach((key) => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete mockParamsDict[key];
+    });
+  });
+
+  it("renders a masked input for a password-format field", () => {
+    mockParamsDict.private_key = {
+      schema: { format: "password", type: "string" },
+      value: null,
+    };
+
+    render(<FieldPassword name="private_key" onUpdate={vi.fn()} />, { wrapper: Wrapper });
+
+    expect(getInputByName("private_key").type).toBe("password");
+  });
+
+  it("stores the typed value in the param store", () => {
+    mockParamsDict.private_key = {
+      schema: { format: "password", type: "string" },
+      value: null,
+    };
+    const onUpdate = vi.fn();
+
+    render(<FieldPassword name="private_key" onUpdate={onUpdate} />, { wrapper: Wrapper });
+
+    fireEvent.change(getInputByName("private_key"), { target: { value: "s3cret" } });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockParamsDict.private_key.value).toBe("s3cret");
+    expect(onUpdate).toHaveBeenLastCalledWith("s3cret");
+  });
+
+  it("clears the param to null when the input is emptied", () => {
+    mockParamsDict.private_key = {
+      schema: { format: "password", type: "string" },
+      value: "s3cret",
+    };
+    const onUpdate = vi.fn();
+
+    render(<FieldPassword name="private_key" onUpdate={onUpdate} />, { wrapper: Wrapper });
+
+    fireEvent.change(getInputByName("private_key"), { target: { value: "" } });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(mockParamsDict.private_key.value).toBeNull();
+    expect(onUpdate).toHaveBeenLastCalledWith("");
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Input } from "@chakra-ui/react";
+import { Input, InputGroup } from "@chakra-ui/react";
 import { useState } from "react";
 
 import { PasswordToggle } from "src/components/PasswordToggle";
@@ -39,7 +39,11 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
   };
 
   return (
-    <div style={{ position: "relative", width: "100%" }}>
+    <InputGroup
+      endElement={
+        <PasswordToggle isVisible={showPassword} onToggle={() => setShowPassword(!showPassword)} />
+      }
+    >
       <Input
         autoComplete="new-password"
         disabled={disabled}
@@ -54,14 +58,6 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
         type={showPassword ? "text" : "password"}
         value={(param.value ?? "") as string}
       />
-      <PasswordToggle
-        isVisible={showPassword}
-        onToggle={() => setShowPassword(!showPassword)}
-        position="absolute"
-        right={2}
-        top="50%"
-        transform="translateY(-50%)"
-      />
-    </div>
+    </InputGroup>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -18,7 +18,6 @@
  */
 import { Input } from "@chakra-ui/react";
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
 
 import { PasswordToggle } from "src/components/PasswordToggle";
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
@@ -27,7 +26,6 @@ import type { FlexibleFormElementProps } from ".";
 
 export const FieldPassword = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
   const [showPassword, setShowPassword] = useState(false);
-  const { t: translate } = useTranslation("components");
   const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
   const handleChange = (value: string) => {
@@ -41,35 +39,29 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
   };
 
   return (
-    <>
-      <div style={{ position: "relative", width: "100%" }}>
-        <Input
-          autoComplete="new-password"
-          disabled={disabled}
-          id={`element_${name}`}
-          list={param.schema.examples ? `list_${name}` : undefined}
-          maxLength={param.schema.maxLength ?? undefined}
-          minLength={param.schema.minLength ?? undefined}
-          name={`element_${name}`}
-          onChange={(event) => {
-            handleChange(event.target.value);
-          }}
-          placeholder={param.schema.examples ? translate("flexibleForm.placeholderExamples") : undefined}
-          size="sm"
-          type={showPassword ? "text" : "password"}
-          value={(param.value ?? "") as string}
-        />
-        <PasswordToggle isVisible={showPassword} onToggle={() => setShowPassword(!showPassword)} />
-      </div>
-      {param.schema.examples ? (
-        <datalist id={`list_${name}`}>
-          {param.schema.examples.map((example) => (
-            <option key={example} value={example}>
-              {example}
-            </option>
-          ))}
-        </datalist>
-      ) : undefined}
-    </>
+    <div style={{ position: "relative", width: "100%" }}>
+      <Input
+        autoComplete="new-password"
+        disabled={disabled}
+        id={`element_${name}`}
+        maxLength={param.schema.maxLength ?? undefined}
+        minLength={param.schema.minLength ?? undefined}
+        name={`element_${name}`}
+        onChange={(event) => {
+          handleChange(event.target.value);
+        }}
+        size="sm"
+        type={showPassword ? "text" : "password"}
+        value={(param.value ?? "") as string}
+      />
+      <PasswordToggle
+        isVisible={showPassword}
+        onToggle={() => setShowPassword(!showPassword)}
+        position="absolute"
+        right={2}
+        top="50%"
+        transform="translateY(-50%)"
+      />
+    </div>
   );
 };

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -40,9 +40,7 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
 
   return (
     <InputGroup
-      endElement={
-        <PasswordToggle isVisible={showPassword} onToggle={() => setShowPassword(!showPassword)} />
-      }
+      endElement={<PasswordToggle isVisible={showPassword} onToggle={() => setShowPassword(!showPassword)} />}
     >
       <Input
         autoComplete="new-password"

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -19,8 +19,8 @@
 import { Input } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FiEye, FiEyeOff } from "react-icons/fi";
 
+import { PasswordToggle } from "src/components/PasswordToggle";
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
@@ -59,22 +59,7 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
           type={showPassword ? "text" : "password"}
           value={(param.value ?? "") as string}
         />
-        <button
-          aria-label={
-            showPassword ? translate("flexibleForm.hidePassword") : translate("flexibleForm.showPassword")
-          }
-          onClick={() => setShowPassword(!showPassword)}
-          style={{
-            cursor: "pointer",
-            position: "absolute",
-            right: "10px",
-            top: "50%",
-            transform: "translateY(-50%)",
-          }}
-          type="button"
-        >
-          {showPassword ? <FiEye size={15} /> : <FiEyeOff size={15} />}
-        </button>
+        <PasswordToggle isVisible={showPassword} onToggle={() => setShowPassword(!showPassword)} />
       </div>
       {param.schema.examples ? (
         <datalist id={`list_${name}`}>

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -44,6 +44,7 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
     <>
       <div style={{ position: "relative", width: "100%" }}>
         <Input
+          autoComplete="new-password"
           disabled={disabled}
           id={`element_${name}`}
           list={param.schema.examples ? `list_${name}` : undefined}

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -1,0 +1,68 @@
+  /*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Input } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+
+import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
+
+import type { FlexibleFormElementProps } from ".";
+
+export const FieldPassword = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
+  const { t: translate } = useTranslation("components");
+  const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
+  const param = paramsDict[name] ?? paramPlaceholder;
+  const handleChange = (value: string) => {
+    if (paramsDict[name]) {
+      // "undefined" values are removed from params, so we set it to null to avoid falling back to DAG defaults.
+      paramsDict[name].value = value === "" ? null : value;
+    }
+
+    setParamsDict(paramsDict);
+    onUpdate(value);
+  };
+
+  return (
+    <>
+      <Input
+        disabled={disabled}
+        id={`element_${name}`}
+        list={param.schema.examples ? `list_${name}` : undefined}
+        maxLength={param.schema.maxLength ?? undefined}
+        minLength={param.schema.minLength ?? undefined}
+        name={`element_${name}`}
+        onChange={(event) => {
+          handleChange(event.target.value);
+        }}
+        placeholder={param.schema.examples ? translate("flexibleForm.placeholderExamples") : undefined}
+        size="sm"
+        type="password"
+        value={(param.value ?? "") as string}
+      />
+      {param.schema.examples ? (
+        <datalist id={`list_${name}`}>
+          {param.schema.examples.map((example) => (
+            <option key={example} value={example}>
+              {example}
+            </option>
+          ))}
+        </datalist>
+      ) : undefined}
+    </>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -17,13 +17,16 @@
  * under the License.
  */
 import { Input } from "@chakra-ui/react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FiEye, FiEyeOff } from "react-icons/fi";
 
 import { paramPlaceholder, useParamStore } from "src/queries/useParamStore";
 
 import type { FlexibleFormElementProps } from ".";
 
 export const FieldPassword = ({ name, namespace = "default", onUpdate }: FlexibleFormElementProps) => {
+  const [showPassword, setShowPassword] = useState(false);
   const { t: translate } = useTranslation("components");
   const { disabled, paramsDict, setParamsDict } = useParamStore(namespace);
   const param = paramsDict[name] ?? paramPlaceholder;
@@ -39,21 +42,39 @@ export const FieldPassword = ({ name, namespace = "default", onUpdate }: Flexibl
 
   return (
     <>
-      <Input
-        disabled={disabled}
-        id={`element_${name}`}
-        list={param.schema.examples ? `list_${name}` : undefined}
-        maxLength={param.schema.maxLength ?? undefined}
-        minLength={param.schema.minLength ?? undefined}
-        name={`element_${name}`}
-        onChange={(event) => {
-          handleChange(event.target.value);
-        }}
-        placeholder={param.schema.examples ? translate("flexibleForm.placeholderExamples") : undefined}
-        size="sm"
-        type="password"
-        value={(param.value ?? "") as string}
-      />
+      <div style={{ position: "relative", width: "100%" }}>
+        <Input
+          disabled={disabled}
+          id={`element_${name}`}
+          list={param.schema.examples ? `list_${name}` : undefined}
+          maxLength={param.schema.maxLength ?? undefined}
+          minLength={param.schema.minLength ?? undefined}
+          name={`element_${name}`}
+          onChange={(event) => {
+            handleChange(event.target.value);
+          }}
+          placeholder={param.schema.examples ? translate("flexibleForm.placeholderExamples") : undefined}
+          size="sm"
+          type={showPassword ? "text" : "password"}
+          value={(param.value ?? "") as string}
+        />
+        <button
+          aria-label={
+            showPassword ? translate("flexibleForm.hidePassword") : translate("flexibleForm.showPassword")
+          }
+          onClick={() => setShowPassword(!showPassword)}
+          style={{
+            cursor: "pointer",
+            position: "absolute",
+            right: "10px",
+            top: "50%",
+            transform: "translateY(-50%)",
+          }}
+          type="button"
+        >
+          {showPassword ? <FiEye size={15} /> : <FiEyeOff size={15} />}
+        </button>
+      </div>
       {param.schema.examples ? (
         <datalist id={`list_${name}`}>
           {param.schema.examples.map((example) => (

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldPassword.tsx
@@ -1,4 +1,4 @@
-  /*!
+/*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
@@ -30,6 +30,7 @@ import { FieldMultiType } from "./FieldMultiType";
 import { FieldMultilineText } from "./FieldMultilineText";
 import { FieldNumber } from "./FieldNumber";
 import { FieldObject } from "./FieldObject";
+import { FieldPassword } from "./FieldPassword";
 import { FieldString } from "./FieldString";
 import { FieldStringArray } from "./FieldStringArray";
 
@@ -90,6 +91,8 @@ const isFieldNumber = (fieldType: string) => {
 
 const isFieldObject = (fieldType: string) => fieldType === "object";
 
+const isFieldPassword = (fieldType: string, fieldSchema: ParamSchema) =>
+  fieldType === "string" && fieldSchema.format === "password";
 const isFieldStringArray = (fieldType: string, fieldSchema: ParamSchema) =>
   fieldType === "array" && (fieldSchema.items?.type === undefined || fieldSchema.items.type === "string");
 
@@ -148,6 +151,8 @@ export const FieldSelector = ({ name, namespace = "default", onUpdate }: Flexibl
     return <FieldDuration name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else if (isFieldMultilineText(fieldType, param.schema)) {
     return <FieldMultilineText name={name} namespace={namespace} onUpdate={onUpdate} />;
+  } else if (isFieldPassword(fieldType, param.schema)) {
+    return <FieldPassword name={name} namespace={namespace} onUpdate={onUpdate} />;
   } else {
     return <FieldString name={name} namespace={namespace} onUpdate={onUpdate} />;
   }

--- a/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FlexibleForm/FieldSelector.tsx
@@ -93,6 +93,7 @@ const isFieldObject = (fieldType: string) => fieldType === "object";
 
 const isFieldPassword = (fieldType: string, fieldSchema: ParamSchema) =>
   fieldType === "string" && fieldSchema.format === "password";
+
 const isFieldStringArray = (fieldType: string, fieldSchema: ParamSchema) =>
   fieldType === "array" && (fieldSchema.items?.type === undefined || fieldSchema.items.type === "string");
 

--- a/airflow-core/src/airflow/ui/src/components/PasswordToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PasswordToggle.tsx
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import type { IconButtonProps } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 
@@ -24,20 +25,17 @@ import { IconButton } from "src/components/ui";
 type Props = {
   readonly isVisible: boolean;
   readonly onToggle: () => void;
-};
+} & IconButtonProps;
 
-export const PasswordToggle = ({ isVisible, onToggle }: Props) => {
+export const PasswordToggle = ({ isVisible, onToggle, ...rest }: Props) => {
   const { t: translate } = useTranslation("components");
 
   return (
     <IconButton
       label={isVisible ? translate("passwordToggle.hide") : translate("passwordToggle.show")}
       onClick={onToggle}
-      position="absolute"
-      right={2}
       size="xs"
-      top="50%"
-      transform="translateY(-50%)"
+      {...rest}
     >
       {isVisible ? <FiEye size={15} /> : <FiEyeOff size={15} />}
     </IconButton>

--- a/airflow-core/src/airflow/ui/src/components/PasswordToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PasswordToggle.tsx
@@ -1,0 +1,45 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useTranslation } from "react-i18next";
+import { FiEye, FiEyeOff } from "react-icons/fi";
+
+import { IconButton } from "src/components/ui";
+
+type Props = {
+  readonly isVisible: boolean;
+  readonly onToggle: () => void;
+};
+
+export const PasswordToggle = ({ isVisible, onToggle }: Props) => {
+  const { t: translate } = useTranslation("common");
+
+  return (
+    <IconButton
+      label={isVisible ? translate("password.hide") : translate("password.show")}
+      onClick={onToggle}
+      position="absolute"
+      right={2}
+      size="xs"
+      top="50%"
+      transform="translateY(-50%)"
+    >
+      {isVisible ? <FiEye size={15} /> : <FiEyeOff size={15} />}
+    </IconButton>
+  );
+};

--- a/airflow-core/src/airflow/ui/src/components/PasswordToggle.tsx
+++ b/airflow-core/src/airflow/ui/src/components/PasswordToggle.tsx
@@ -27,11 +27,11 @@ type Props = {
 };
 
 export const PasswordToggle = ({ isVisible, onToggle }: Props) => {
-  const { t: translate } = useTranslation("common");
+  const { t: translate } = useTranslation("components");
 
   return (
     <IconButton
-      label={isVisible ? translate("password.hide") : translate("password.show")}
+      label={isVisible ? translate("passwordToggle.hide") : translate("passwordToggle.show")}
       onClick={onToggle}
       position="absolute"
       right={2}

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionStandardFields.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionStandardFields.tsx
@@ -59,6 +59,7 @@ const StandardFields = ({ control, standardFields }: StandardFieldsProps) => {
                     <div style={{ position: "relative", width: "100%" }}>
                       <Input
                         {...field}
+                        autoComplete={key === "password" ? "new-password" : undefined}
                         placeholder={fields.placeholder ?? ""}
                         type={
                           key === "password" && !showPassword
@@ -72,6 +73,10 @@ const StandardFields = ({ control, standardFields }: StandardFieldsProps) => {
                         <PasswordToggle
                           isVisible={showPassword}
                           onToggle={() => setShowPassword(!showPassword)}
+                          position="absolute"
+                          right={2}
+                          top="50%"
+                          transform="translateY(-50%)"
                         />
                       )}
                     </div>

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionStandardFields.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionStandardFields.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Field, Stack, Textarea, Input } from "@chakra-ui/react";
+import { Field, Stack, Textarea, Input, InputGroup } from "@chakra-ui/react";
 import { useState } from "react";
 import { type Control, Controller } from "react-hook-form";
 
@@ -56,7 +56,16 @@ const StandardFields = ({ control, standardFields }: StandardFieldsProps) => {
                   {key === "description" ? (
                     <Textarea {...field} placeholder={fields.placeholder ?? ""} />
                   ) : (
-                    <div style={{ position: "relative", width: "100%" }}>
+                    <InputGroup
+                      endElement={
+                        key === "password" ? (
+                          <PasswordToggle
+                            isVisible={showPassword}
+                            onToggle={() => setShowPassword(!showPassword)}
+                          />
+                        ) : undefined
+                      }
+                    >
                       <Input
                         {...field}
                         autoComplete={key === "password" ? "new-password" : undefined}
@@ -69,17 +78,7 @@ const StandardFields = ({ control, standardFields }: StandardFieldsProps) => {
                               : "text"
                         }
                       />
-                      {key === "password" && (
-                        <PasswordToggle
-                          isVisible={showPassword}
-                          onToggle={() => setShowPassword(!showPassword)}
-                          position="absolute"
-                          right={2}
-                          top="50%"
-                          transform="translateY(-50%)"
-                        />
-                      )}
-                    </div>
+                    </InputGroup>
                   )}
                 </Stack>
               </Field.Root>

--- a/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionStandardFields.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Connections/ConnectionStandardFields.tsx
@@ -19,8 +19,8 @@
 import { Field, Stack, Textarea, Input } from "@chakra-ui/react";
 import { useState } from "react";
 import { type Control, Controller } from "react-hook-form";
-import { FiEye, FiEyeOff } from "react-icons/fi";
 
+import { PasswordToggle } from "src/components/PasswordToggle";
 import type { StandardFieldSpec } from "src/queries/useConnectionTypeMeta";
 
 import type { ConnectionBody } from "./Connections";
@@ -69,19 +69,10 @@ const StandardFields = ({ control, standardFields }: StandardFieldsProps) => {
                         }
                       />
                       {key === "password" && (
-                        <button
-                          onClick={() => setShowPassword(!showPassword)}
-                          style={{
-                            cursor: "pointer",
-                            position: "absolute",
-                            right: "10px",
-                            top: "50%",
-                            transform: "translateY(-50%)",
-                          }}
-                          type="button"
-                        >
-                          {showPassword ? <FiEye size={15} /> : <FiEyeOff size={15} />}
-                        </button>
+                        <PasswordToggle
+                          isVisible={showPassword}
+                          onToggle={() => setShowPassword(!showPassword)}
+                        />
                       )}
                     </div>
                   )}


### PR DESCRIPTION
Extra fields that a provider declares with `format: "password"` are rendered as
plain text in the connection form. `FieldSelector` has no branch for that format,
so they fall through to `FieldString`, which renders an Input with no type.
The standard `password` field has been masked with a toggle for a while;
declared extra fields never got the same treatment.

This adds a `FieldPassword` component to `FlexibleForm` and the matching branch in
`FieldSelector`, reusing the (`FiEye`/`FiEyeOff`) toggle pattern from
ConnectionStandardFields. `FieldSelector` is shared with the Dag trigger form, so
params declared with `format: "password"` are masked there too.

Verified on a Salesforce connection — Security Token, Consumer Secret and Private
Key mask correctly and the toggle works, other extra fields are unaffected — and
on a Dag param form. Tests cover the masked input, value storage, clearing, and
the toggle.

This does not cover free-form keys a provider doesn't declare, 
such as `private_key` on an SSH connection, which is what the reporter hit.
Those have no schema and no format, so the UI has no signal to go on; 
masking them would need the backend to mark sensitive keys. 
Happy to look at that separately.

before:
<img width="1288" height="936" alt="image" src="https://github.com/user-attachments/assets/1127a142-731a-4ee4-bafe-7d7c6daa63be" />
<img width="1232" height="980" alt="image" src="https://github.com/user-attachments/assets/69d933cf-05b4-4aaa-8d78-d45a8809cb81" />


after:
<img width="1212" height="980" alt="image" src="https://github.com/user-attachments/assets/6c543775-efaf-48c2-9d81-b638eac20eff" />

related: #53410

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)