### PR TITLE
Fix EcsRunTaskOperator deferred logs read from the wrong region

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/ecs.py
@@ -554,6 +554,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
                         waiter_max_attempts=self.waiter_max_attempts,
                         aws_conn_id=self.aws_conn_id,
                         region_name=self.region_name,
+                        log_region_name=self.resolve_awslogs_region(),
                         log_group=self.awslogs_group,
                         log_stream=self._get_logs_stream_name(),
                         verify=self.verify,

--- a/providers/amazon/src/airflow/providers/amazon/aws/triggers/ecs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/triggers/ecs.py
@@ -128,6 +128,9 @@ class TaskDoneTrigger(BaseTrigger):
         Will fail after that many unsuccessful attempts.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
     :param region_name: The AWS region where the cluster is located. Used to build the hook.
+    :param log_region_name: The AWS region where the CloudWatch logs are stored. Defaults to
+        ``region_name`` when not set, which is correct unless the task definition ships its logs
+        to another region.
     :param verify: Whether or not to verify SSL certificates. Used to build the hook.
     :param botocore_config: Configuration dictionary for the botocore client. Used to build the hook.
     :param region: (deprecated) use ``region_name`` instead.
@@ -146,6 +149,7 @@ class TaskDoneTrigger(BaseTrigger):
         verify: bool | str | None = None,
         botocore_config: dict | None = None,
         region: str | None = None,
+        log_region_name: str | None = None,
     ):
         if region is not None:
             warnings.warn(
@@ -167,6 +171,7 @@ class TaskDoneTrigger(BaseTrigger):
 
         self.log_group = log_group
         self.log_stream = log_stream
+        self.log_region_name = log_region_name
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         return (
@@ -178,6 +183,7 @@ class TaskDoneTrigger(BaseTrigger):
                 "waiter_max_attempts": self.waiter_max_attempts,
                 "aws_conn_id": self.aws_conn_id,
                 "region_name": self.region_name,
+                "log_region_name": self.log_region_name,
                 "log_group": self.log_group,
                 "log_stream": self.log_stream,
                 "verify": self.verify,
@@ -186,6 +192,9 @@ class TaskDoneTrigger(BaseTrigger):
         )
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
+        # Triggers serialized before ``log_region_name`` existed deserialize without it, so an
+        # unset value keeps reading logs from the cluster region as before.
+        log_region_name = self.log_region_name if self.log_region_name is not None else self.region_name
         async with (
             await EcsHook(
                 aws_conn_id=self.aws_conn_id,
@@ -195,7 +204,7 @@ class TaskDoneTrigger(BaseTrigger):
             ).get_async_conn() as ecs_client,
             await AwsLogsHook(
                 aws_conn_id=self.aws_conn_id,
-                region_name=self.region_name,
+                region_name=log_region_name,
                 verify=self.verify,
                 config=self.botocore_config,
             ).get_async_conn() as logs_client,

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_ecs.py
@@ -846,6 +846,26 @@ class TestEcsRunTaskOperator(EcsBaseTestCase):
         assert isinstance(deferred.value.trigger, TaskDoneTrigger)
         assert deferred.value.trigger.task_arn == f"arn:aws:ecs:us-east-1:012345678910:task/{TASK_ID}"
 
+    @mock.patch.object(EcsRunTaskOperator, "client")
+    def test_with_defer_passes_awslogs_region_to_trigger(self, client_mock):
+        self.set_up_operator(
+            awslogs_group="awslogs-group",
+            awslogs_region="logs-region",
+            awslogs_stream_prefix="prefix",
+            region_name="task-region",
+            deferrable=True,
+        )
+        client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
+
+        mock_ti = mock.MagicMock()
+        mock_context = {"ti": mock_ti, "task_instance": mock_ti}
+
+        with pytest.raises(TaskDeferred) as deferred:
+            self.ecs.execute(mock_context)
+
+        assert deferred.value.trigger.region_name == "task-region"
+        assert deferred.value.trigger.log_region_name == "logs-region"
+
     @mock.patch.object(EcsRunTaskOperator, "client", new_callable=PropertyMock)
     def test_execute_complete(self, client_mock):
         event = {"status": "success", "task_arn": "my_arn", "cluster": "test_cluster"}

--- a/providers/amazon/tests/unit/amazon/aws/triggers/test_ecs.py
+++ b/providers/amazon/tests/unit/amazon/aws/triggers/test_ecs.py
@@ -35,6 +35,15 @@ if TYPE_CHECKING:
     from airflow.triggers.base import TriggerEvent
 
 
+def _make_async_hook(client):
+    ctx = mock.MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    instance = mock.MagicMock()
+    instance.get_async_conn = AsyncMock(return_value=ctx)
+    return instance
+
+
 class TestTaskDoneTrigger:
     def test_deprecated_region_alias(self):
         with pytest.warns(AirflowProviderDeprecationWarning, match="region"):
@@ -73,28 +82,35 @@ class TestTaskDoneTrigger:
             "waiter_max_attempts": 10,
             "aws_conn_id": "my_conn",
             "region_name": "eu-west-1",
+            "log_region_name": None,
             "log_group": "lg",
             "log_stream": "ls",
             "verify": False,
             "botocore_config": {"read_timeout": 7},
         }
 
+    def test_serialize_keeps_log_region_name_as_passed(self):
+        trigger = TaskDoneTrigger(
+            cluster="cluster",
+            task_arn="task_arn",
+            waiter_delay=5,
+            waiter_max_attempts=10,
+            aws_conn_id="my_conn",
+            region_name="ap-northeast-1",
+            log_region_name="us-east-1",
+        )
+        _, kwargs = trigger.serialize()
+        assert kwargs["log_region_name"] == "us-east-1"
+        assert kwargs["region_name"] == "ap-northeast-1"
+
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.amazon.aws.triggers.ecs.AwsLogsHook")
     @mock.patch("airflow.providers.amazon.aws.triggers.ecs.EcsHook")
     async def test_run_builds_hooks_with_generic_params(self, ecs_hook_cls, logs_hook_cls):
-        def make_hook(client):
-            ctx = mock.MagicMock()
-            ctx.__aenter__ = AsyncMock(return_value=client)
-            ctx.__aexit__ = AsyncMock(return_value=False)
-            instance = mock.MagicMock()
-            instance.get_async_conn = AsyncMock(return_value=ctx)
-            return instance
-
         ecs_client = mock.MagicMock()
         ecs_client.get_waiter().wait = AsyncMock()
-        ecs_hook_cls.return_value = make_hook(ecs_client)
-        logs_hook_cls.return_value = make_hook(mock.MagicMock())
+        ecs_hook_cls.return_value = _make_async_hook(ecs_client)
+        logs_hook_cls.return_value = _make_async_hook(mock.MagicMock())
 
         trigger = TaskDoneTrigger(
             cluster="cluster",
@@ -116,6 +132,38 @@ class TestTaskDoneTrigger:
         }
         ecs_hook_cls.assert_called_once_with(**expected)
         logs_hook_cls.assert_called_once_with(**expected)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("log_region_name", "expected_logs_hook_region"),
+        [
+            pytest.param(None, "ap-northeast-1", id="falls-back-to-cluster-region"),
+            pytest.param("us-east-1", "us-east-1", id="uses-explicit-log-region"),
+        ],
+    )
+    @mock.patch("airflow.providers.amazon.aws.triggers.ecs.AwsLogsHook")
+    @mock.patch("airflow.providers.amazon.aws.triggers.ecs.EcsHook")
+    async def test_run_reads_logs_from_log_region(
+        self, ecs_hook_cls, logs_hook_cls, log_region_name, expected_logs_hook_region
+    ):
+        ecs_client = mock.MagicMock()
+        ecs_client.get_waiter().wait = AsyncMock()
+        ecs_hook_cls.return_value = _make_async_hook(ecs_client)
+        logs_hook_cls.return_value = _make_async_hook(mock.MagicMock())
+
+        trigger = TaskDoneTrigger(
+            cluster="cluster",
+            task_arn="task_arn",
+            waiter_delay=0,
+            waiter_max_attempts=10,
+            aws_conn_id="my_conn",
+            region_name="ap-northeast-1",
+            log_region_name=log_region_name,
+        )
+        await trigger.run().asend(None)
+
+        assert ecs_hook_cls.call_args.kwargs["region_name"] == "ap-northeast-1"
+        assert logs_hook_cls.call_args.kwargs["region_name"] == expected_logs_hook_region
 
     @pytest.mark.asyncio
     @mock.patch.object(EcsHook, "get_async_conn")


### PR DESCRIPTION
When `EcsRunTaskOperator` runs with `deferrable=True` and the task definition ships its container logs to a different region than the one the task runs in (`awslogs_region` != `region_name`), no logs are forwarded during deferral -- the trigger just repeats "Tried to get logs from stream ... but it didn't exist (yet)" for the whole task duration.

`TaskDoneTrigger` was given a single `region_name` and used it for two different clients: the ECS waiter (correct) and the CloudWatch `get_log_events` client (wrong -- the log group lives in the other region).

The operator never passed the logs region to the trigger, so the trigger had no way to tell them apart.

This adds a `log_region_name` parameter to `TaskDoneTrigger`, used only for the `AwsLogsHook`, and has the operator pass `resolve_awslogs_region()` when deferring. The `EcsHook` keeps using `region_name`.

The parameter defaults to `None` and falls back to `region_name`, so triggers that were already serialized before this change deserialize without the key and keep their current behaviour.

This is the remaining half of the log-region resolution: #70464 fixed the post-deferral fetch in `execute_complete`, and the non-deferrable path already used `resolve_awslogs_region()` via `_get_task_log_fetcher()`.

closes: #70465

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5) for writing Tests
