### PR TITLE
Complete Polish translation of the Airflow UI

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/admin.json
@@ -191,6 +191,7 @@
           "title": "Pomiń"
         }
       },
+      "parsingFile": "Przetwarzanie pliku...",
       "title": "Importuj zmienne",
       "upload": "Prześlij plik JSON",
       "uploadPlaceholder": "Prześlij plik JSON zawierający zmienne (np. {\"key\": \"value\", ...})"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/assets.json
@@ -4,18 +4,21 @@
   "asset_many": "Zasobów",
   "asset_one": "Zasób",
   "asset_other": "Zasoby",
-  "assetStore": {
-    "add": "Dodaj magazyn zasobów",
+  "assetStateStore": {
+    "add": "Dodaj wpis magazynu stanu zasobu",
     "clearAll": {
-      "resource": "cały magazyn zasobów",
-      "title": "Wyczyść cały magazyn zasobów",
-      "warning": "Cały magazyn zasobów zostanie wyczyszczony. Zadania, które używają tego magazynu do koordynowania pracy, utracą swoje zapisane dane."
+      "resource": "całego magazynu stanu zasobu",
+      "title": "Wyczyść cały magazyn stanu zasobu",
+      "warning": "Cały magazyn stanu zasobu zostanie wyczyszczony. Zadania, które używają go do koordynacji pracy, utracą zachowane dane."
     },
-    "delete": "Usuń magazyn zasobów",
-    "deleteWarning": "Zasób utraci ten zapisany wpis magazynu.",
-    "edit": "Edytuj magazyn zasobów",
-    "emptyState": "Magazyn zasobów przechowuje wartości powiązane z identyfikatorem zasobu, współdzielone między wszystkimi uruchomieniami Dagów. Procesy robocze mogą zapisywać do magazynu zasobów za pomocą Task SDK.",
-    "title": "Magazyn zasobów"
+    "delete": "Usuń wpis magazynu stanu zasobu",
+    "deleteWarning": "Zasób utraci ten zachowany wpis magazynu stanu.",
+    "edit": "Edytuj wpis magazynu stanu zasobu",
+    "emptyState": "Magazyn stanu zasobu przechowuje wartości przypisane do tożsamości zasobu, współdzielone przez wszystkie wykonania Dagów. Workery mogą zapisywać do magazynu stanu zasobu przez Task SDK.",
+    "lastUpdatedBy": "Ostatnio zaktualizowane przez",
+    "lastUpdatedByApi": "API",
+    "lastUpdatedByWatcher": "Watcher",
+    "title": "Magazyn stanu zasobu"
   },
   "consumingDags": "Przetwarzanie Dagów",
   "consumingTasks": "Przetwarzanie zadań",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/common.json
@@ -8,6 +8,7 @@
     "Variables": "Zmienne"
   },
   "allOperators": "Wszystkie operatory",
+  "allTeams": "Wszystkie zespoły",
   "appearance": {
     "appearance": "Wygląd",
     "darkMode": "Tryb ciemny",
@@ -67,7 +68,8 @@
     "owner": "Właściciel",
     "params": "Parametry",
     "schedule": "Harmonogram",
-    "tags": "Etykiety"
+    "tags": "Etykiety",
+    "team": "Zespół"
   },
   "dagId": "Identyfikator Daga",
   "dagRun": {
@@ -82,6 +84,7 @@
     "expectedDuration": "Oczekiwany Czas Trwania",
     "lastSchedulingDecision": "Ostatnia decyzja harmonogramu",
     "mappedPartitionKey": "Zmapowany klucz partycji",
+    "partitionDate": "Data partycji",
     "partitionKey": "Klucz partycji",
     "queuedAt": "Zakolejkowano o",
     "runAfter": "Wykonaj po",
@@ -157,6 +160,9 @@
     "selectDateRange": "Wybierz zakres dat",
     "startTime": "Czas rozpoczęcia"
   },
+  "fullscreen": {
+    "tooltip": "Naciśnij {{hotkey}}, aby przejść na pełny ekran"
+  },
   "generateToken": "Wygeneruj token",
   "key": "Klucz",
   "logicalDate": "Data logiczna",
@@ -188,9 +194,12 @@
   "note": {
     "add": "Dodaj notatkę",
     "dagRun": "Notatki wykonania",
+    "edit": "Edytuj notatkę",
     "label": "Notatka",
     "placeholder": "Dodaj notatkę...",
-    "taskInstance": "Notatka instancji zadania"
+    "preview": "Podgląd",
+    "taskInstance": "Notatka instancji zadania",
+    "write": "Napisz"
   },
   "overallStatus": "Stan ogólny",
   "partitionedDagRun_few": "Partycjonowane wykonania Dagów",
@@ -204,6 +213,23 @@
   "pendingDagRun_many": "{{count}} oczekujących wykonań Dagów",
   "pendingDagRun_one": "{{count}} oczekujące wykonanie Daga",
   "pendingDagRun_other": "{{count}} oczekujących wykonań Dagów",
+  "presetFilters": {
+    "deleteTitle": "Usuń zapisany filtr",
+    "deleteWarning": "Zapisane filtry są przechowywane wyłącznie w tej przeglądarce.",
+    "duplicate": "Zapisany filtr \"{{name}}\" zawiera już dokładnie taką konfigurację.",
+    "empty": "Brak zapisanych filtrów",
+    "info": {
+      "default": "Przypnij zapisany filtr jako domyślny, a zostanie zastosowany automatycznie, gdy wejdziesz na tę stronę bez żadnych filtrów.",
+      "save": "Zapisz bieżące filtry i sortowanie jako nazwany filtr, aby móc do niego wrócić w dowolnej chwili.",
+      "storage": "Zapisane filtry są przechowywane w tej przeglądarce."
+    },
+    "namePlaceholder": "Nazwa zapisanego filtra",
+    "nothingToSave": "Nie ma czego zapisać. Zastosuj filtry lub sortowanie, aby zapisać filtr.",
+    "save": "Zapisz",
+    "setDefault": "Ustaw jako domyślny",
+    "title": "Zapisane filtry",
+    "unsetDefault": "Usuń ustawienie domyślne"
+  },
   "reset": "Resetuj",
   "runId": "Identyfikator wykonania",
   "runTypes": {
@@ -235,6 +261,47 @@
   },
   "selectLanguage": "Wybierz język",
   "selected": "Wybrano",
+  "shortcuts": {
+    "categories": {
+      "code": "Kod",
+      "dagView": "Widok Daga",
+      "filters": "Filtry",
+      "global": "Globalne",
+      "logs": "Logi",
+      "navigation": "Nawigacja",
+      "runActions": "Akcje wykonań i zadań",
+      "search": "Wyszukiwanie"
+    },
+    "descriptions": {
+      "clearRun": "Wyczyść wykonanie",
+      "clearTaskInstance": "Wyczyść instancję zadania",
+      "downloadLogs": "Pobierz logi",
+      "focusFilterSearch": "Przejdź do wyszukiwania filtrów",
+      "focusLogSearch": "Szukaj w logach",
+      "focusSearch": "Przejdź do wyszukiwania",
+      "markRunFailed": "Oznacz wykonanie jako nieudane",
+      "markRunSuccess": "Oznacz wykonanie jako udane",
+      "markTaskFailed": "Oznacz zadanie jako nieudane",
+      "markTaskGroupFailed": "Oznacz grupę zadań jako nieudaną",
+      "markTaskGroupSuccess": "Oznacz grupę zadań jako udaną",
+      "markTaskSuccess": "Oznacz zadanie jako udane",
+      "navigateTasks": "Nawiguj po zadaniach",
+      "openGraphFilters": "Otwórz filtry grafu",
+      "scrollBottom": "Przewiń do dołu",
+      "scrollTop": "Przewiń do góry",
+      "searchDags": "Szukaj Dagów",
+      "showHelp": "Pokaż skróty klawiszowe",
+      "toggleExpand": "Rozwiń lub zwiń wszystkie grupy",
+      "toggleFullscreen": "Przełącz pełny ekran",
+      "toggleGraphGrid": "Przełącz widok grafu / siatki",
+      "toggleSource": "Przełącz źródła",
+      "toggleTaskGroup": "Rozwiń lub zwiń grupę zadań",
+      "toggleTimestamp": "Przełącz znaczniki czasu",
+      "toggleWrap": "Przełącz zawijanie"
+    },
+    "empty": "Na tej stronie nie ma dostępnych skrótów klawiszowych.",
+    "title": "Skróty klawiszowe"
+  },
   "showDetailsPanel": "Pokaż panel szczegółów",
   "signedInAs": "Zalogowano jako",
   "source": {
@@ -279,6 +346,7 @@
     "from": "Od",
     "maxActiveRuns": "Maksymalna liczba aktywnych wykonań",
     "noTagsFound": "Nie znaleziono etykiet",
+    "noTeamsFound": "Nie znaleziono zespołów",
     "tagMode": {
       "all": "Wszystkie",
       "any": "Dowolne"
@@ -309,10 +377,12 @@
   "taskGroup_other": "Grupy zadań",
   "taskId": "Identyfikator Zadania",
   "taskInstance": {
+    "additionalAttributes": "Dodatkowe atrybuty instancji zadania",
     "dagVersion": "Wersja Daga",
     "executor": "Wykonawca",
     "executorConfig": "Konfiguracja wykonawcy",
     "hostname": "Nazwa hosta",
+    "id": "ID",
     "maxTries": "Maksymalna liczba prób",
     "pid": "PID",
     "pool": "Pula",
@@ -322,11 +392,13 @@
     "queuedWhen": "Zakolejkowano o",
     "renderedMapIndex": "Wyrenderowany indeks mapowania",
     "scheduledWhen": "Zaplanowano o",
+    "trigger": "Wyzwalacz",
     "triggerer": {
       "assigned": "Przypisany wyzwalacz",
       "class": "Klasa wyzwalacza",
       "createdAt": "Czas utworzenia wyzwalacza",
       "id": "Identyfikator wyzwalacza",
+      "job": "Zadanie wyzwalacza",
       "latestHeartbeat": "Ostatni heartbeat wyzwalacza",
       "title": "Informacje o wyzwalaczu"
     },

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/components.json
@@ -73,6 +73,7 @@
     "lastTaskInstance_many": "Ostatnich {{count}} instancji zadania",
     "lastTaskInstance_one": "Ostatnia instancja zadania",
     "lastTaskInstance_other": "Ostatnie {{count}} instancje zadania",
+    "medianTotalDuration": "Łącznie: {{duration}}",
     "queuedDuration": "Czas oczekiwania",
     "runAfter": "Uruchom po",
     "runDuration": "Czas trwania wykonania"
@@ -153,6 +154,7 @@
     "loading": "Ładowanie informacji o Dagach...",
     "loadingFailed": "Nie udało się załadować informacji o Dagach. Spróbuj ponownie.",
     "manualRunDenied": "Ręczne uruchamianie nie jest dozwolone dla tego Daga",
+    "partitionKeyHelp": "Opcjonalne - dotyczy tylko Dagów partycjonowanych",
     "runIdHelp": "Opcjonalne - zostanie wygenerowane, jeśli nie podano",
     "selectDescription": "Wyzwól pojedyncze wykonanie",
     "selectLabel": "Pojedyncze wykonanie",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dag.json
@@ -97,10 +97,6 @@
     "critical": "CRITICAL",
     "debug": "DEBUG",
     "error": "ERROR",
-    "fullscreen": {
-      "button": "Pełny ekran",
-      "tooltip": "Naciśnij {{hotkey}}, aby przejść do pełnego ekranu"
-    },
     "info": "INFO",
     "noTryNumber": "Brak numeru próby",
     "search": {
@@ -243,7 +239,7 @@
     "runs": "Wykonania",
     "storage": "Magazyn",
     "taskInstances": "Instancje zadań",
-    "taskStore": "Magazyn zadań",
+    "taskStateStore": "Magazyn stanu zadania",
     "tasks": "Zadania",
     "xcom": "XCom"
   },
@@ -251,17 +247,17 @@
     "collapseAll": "Zwiń wszystkie grupy zadań",
     "expandAll": "Rozwiń wszystkie grupy zadań"
   },
-  "taskStore": {
-    "add": "Dodaj magazyn zadań",
+  "taskStateStore": {
+    "add": "Dodaj wpis magazynu stanu zadania",
     "clearAll": {
-      "resource": "cały magazyn zadań",
-      "title": "Wyczyść cały magazyn zadań",
-      "warning": "Cały magazyn zadań zostanie wyczyszczony. Zadania, które używają tego magazynu do śledzenia zewnętrznej pracy, nie będą mogły jej wznowić bez ponownego uruchomienia."
+      "resource": "całego magazynu stanu zadania",
+      "title": "Wyczyść cały magazyn stanu zadania",
+      "warning": "Cały magazyn stanu zadania zostanie wyczyszczony. Zadania, które używają go do śledzenia pracy zewnętrznej, nie będą mogły jej wznowić bez uruchomienia od nowa."
     },
-    "delete": "Usuń magazyn zadań",
-    "deleteWarning": "Zadanie utraci te zapisane dane. Jeśli zadanie używa tego klucza do śledzenia zewnętrznej pracy (np. identyfikatora zewnętrznego zadania), nie będzie mogło jej wznowić.",
-    "edit": "Edytuj magazyn zadań",
-    "emptyStore": "Magazyn zadań przechowuje wartości, które są zachowywane między ponownymi próbami. Procesy robocze mogą zapisywać do magazynu zadań za pomocą Task SDK.",
+    "delete": "Usuń wpis magazynu stanu zadania",
+    "deleteWarning": "Zadanie utraci te zachowane dane. Jeśli używa tego klucza do śledzenia pracy zewnętrznej (np. zewnętrznego ID zadania), nie będzie mogło jej wznowić.",
+    "edit": "Edytuj wpis magazynu stanu zadania",
+    "emptyStore": "Magazyn stanu zadania przechowuje wartości zachowywane pomiędzy ponownymi próbami. Workery mogą zapisywać do magazynu stanu zadania przez Task SDK.",
     "expiresAt": {
       "column": "Wygasa o",
       "custom": "Niestandardowy",
@@ -269,6 +265,6 @@
       "label": "Wygaśnięcie",
       "never": "Nigdy"
     },
-    "title": "Magazyn zadań"
+    "title": "Magazyn stanu zadania"
   }
 }

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dags.json
@@ -10,11 +10,13 @@
   "filters": {
     "allRunTypes": "Wszystkie Typy Wykonań Dagów",
     "allStates": "Wszystkie Stany",
+    "anyRunState": "Dowolne wykonanie",
     "favorite": {
       "all": "Wszystkie",
       "favorite": "Ulubione",
       "unfavorite": "Nieulubione"
     },
+    "lastRunState": "Ostatnie wykonanie",
     "paused": {
       "active": "Aktywne",
       "all": "Wszystkie",
@@ -76,6 +78,11 @@
       "upstream": "Taski nadrzędne"
     }
   },
+  "runStateCounts": {
+    "label": "Stany wykonań",
+    "loading": "Ładowanie liczby wykonań według stanu",
+    "tooltip": "{{state}}: {{formattedCount}} — kliknij, aby filtrować wykonania"
+  },
   "search": {
     "advanced": "Wyszukiwanie zaawansowane",
     "clear": "Wyczyść wyszukiwanie",
@@ -88,9 +95,9 @@
       "asc": "Sortuj według Nazwy Wyświetlanej (A-Z)",
       "desc": "Sortuj według Nazwy Wyświetlanej (Z-A)"
     },
-    "lastRunStartDate": {
-      "asc": "Sortuj według Daty Rozpoczęcia Ostatniego Wykonania (Najwcześniejsze-Najnowsze)",
-      "desc": "Sortuj według Daty Rozpoczęcia Ostatniego Wykonania (Najnowsze-Najwcześniejsze)"
+    "lastRunAfter": {
+      "asc": "Sortuj według Daty Ostatniego Wykonania (Najwcześniejsze-Najnowsze)",
+      "desc": "Sortuj według Daty Ostatniego Wykonania (Najnowsze-Najwcześniejsze)"
     },
     "lastRunState": {
       "asc": "Sortuj według Stanu Ostatniego Wykonania (A-Z)",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/dashboard.json
@@ -1,4 +1,24 @@
 {
+  "alerts": {
+    "seeLessContext": "Pokaż mniej",
+    "seeMoreContext": "Pokaż więcej",
+    "showMoreAlerts_few": "+{{count}} alerty więcej",
+    "showMoreAlerts_many": "+{{count}} alertów więcej",
+    "showMoreAlerts_one": "+{{count}} alert więcej",
+    "showMoreAlerts_other": "+{{count}} alerty więcej"
+  },
+  "deadlines": {
+    "pending": {
+      "empty": "Brak nadchodzących terminów",
+      "title": "Nadchodzące"
+    },
+    "recentlyMissed": {
+      "empty": "Brak niedotrzymanych terminów",
+      "title": "Niedotrzymane terminy"
+    },
+    "showMore": "Pokaż więcej",
+    "title": "Terminy"
+  },
   "deferredSlotsNotCounted": "Odłożone, ale nieliczone do slotów: {{count}}",
   "deferredSlotsNotCountedTooltip": "Odłożone zadania pokazane na pasku są liczone do slotów puli. Odłożone zadania pokazane pod paskiem pochodzą z pul, które liczą sloty, nie licząc odłożonych zadań.",
   "favorite": {
@@ -18,7 +38,7 @@
     "metaDatabase": "Baza Danych Meta",
     "scheduler": "Planer zadań",
     "status": "Stan",
-    "triggerer": "Cyngiel",
+    "triggerer": "Wyzwalacz",
     "unhealthy": "Nieprawidłowy"
   },
   "history": "Historia",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/pl/hitl.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/pl/hitl.json
@@ -28,6 +28,20 @@
     "success": "Odpowiedź dla {{taskId}} została pomyślnie wysłana",
     "title": "Instancja zadania wymagająca interwencji człowieka - {{taskId}}"
   },
+  "review": {
+    "detail": {
+      "selectRequiredAction": "Wybierz wymaganą akcję, aby zobaczyć szczegóły"
+    },
+    "list": {
+      "completedRequiredActions": "Zakończone wymagane akcje ({{count}})",
+      "loadError": "Nie udało się załadować wymaganych akcji",
+      "loadingActions": "Ładowanie wymaganych akcji...",
+      "pendingRequiredActions": "Oczekujące wymagane akcje ({{count}})"
+    },
+    "openReviewDrawer": "Otwórz panel recenzji",
+    "pageLimitHint": "Wyświetlono tutaj tylko kilka pierwszych akcji. Użyj \"$t(review.viewAll)\", aby zobaczyć wszystkie.",
+    "viewAll": "Zobacz wszystkie wymagane akcje"
+  },
   "state": {
     "approvalReceived": "Zatwierdzenie otrzymane",
     "approvalRequired": "Wymagane zatwierdzenie",


### PR DESCRIPTION
Brings the Polish (`pl`) locale back in sync with the English source. The
locale had drifted as new UI features landed, leaving Polish users with
untranslated English strings in the keyboard-shortcut help, preset filters,
state store views, deadlines panel and required-action review drawer.

Also renames the `assetStore` / `taskStore` keys to `assetStateStore` /
`taskStateStore` to follow the English source, moves the fullscreen tooltip
to `common`, and fixes the dashboard triggerer health label ("Cyngiel" ->
"Wyzwalacz") to match the wording used everywhere else in the locale.

After this change the `pl` locale has zero keys missing relative to `en`
across all namespaces.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)