### PR TITLE
Validate AppflowBaseOperator source after template rendering

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py
@@ -84,8 +84,6 @@ class AppflowBaseOperator(AwsBaseOperator[AppflowHook]):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if source is not None and source not in SUPPORTED_SOURCES:
-            raise ValueError(f"{source} is not a supported source (options: {SUPPORTED_SOURCES})!")
         self.filter_date = filter_date
         self.flow_name = flow_name
         self.source = source
@@ -96,6 +94,8 @@ class AppflowBaseOperator(AwsBaseOperator[AppflowHook]):
         self.wait_for_completion = wait_for_completion
 
     def execute(self, context: Context) -> None:
+        if self.source is not None and self.source not in SUPPORTED_SOURCES:
+            raise ValueError(f"{self.source} is not a supported source (options: {SUPPORTED_SOURCES})!")
         self.filter_date_parsed: datetime | None = (
             datetime.fromisoformat(self.filter_date) if self.filter_date else None
         )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_appflow.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_appflow.py
@@ -135,6 +135,20 @@ def test_unsupported_source_fails_at_execute_time():
 
 
 @pytest.mark.db_test
+def test_templated_source_passes_validation_after_rendering(appflow_conn, ctx, waiter_mock):
+    operator = AppflowRunOperator(
+        task_id=TASK_ID,
+        source="{{ var.value.appflow_source }}",
+        flow_name=FLOW_NAME,
+        poll_interval=0,
+    )
+    # Template rendering replaces the Jinja expression with the resolved value before execute.
+    operator.source = SOURCE
+    operator.execute(ctx)
+    appflow_conn.start_flow.assert_called_once_with(flowName=FLOW_NAME)
+
+
+@pytest.mark.db_test
 def test_run_full(appflow_conn, ctx, waiter_mock):
     operator = AppflowRunFullOperator(**DUMP_COMMON_ARGS)
     operator.execute(ctx)

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_appflow.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_appflow.py
@@ -124,6 +124,16 @@ def test_run(appflow_conn, ctx, waiter_mock):
     appflow_conn.describe_flow_execution_records.assert_called_once()
 
 
+def test_unsupported_source_fails_at_execute_time():
+    operator = AppflowRunOperator(
+        task_id=TASK_ID,
+        source="not-a-source",
+        flow_name=FLOW_NAME,
+    )
+    with pytest.raises(ValueError, match="not-a-source is not a supported source"):
+        operator.execute({})
+
+
 @pytest.mark.db_test
 def test_run_full(appflow_conn, ctx, waiter_mock):
     operator = AppflowRunFullOperator(**DUMP_COMMON_ARGS)

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -6,7 +6,6 @@
 # Fixing a class (moving template-field validation/transformation out of __init__ into
 # execute()) MUST remove its entry in the same PR — the hook fails on stale entries.
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
-providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py::AppflowBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py::EmrAddStepsOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator


### PR DESCRIPTION
`source` is one of `AppflowBaseOperator`'s template fields, but it was validated against `SUPPORTED_SOURCES` inside `__init__`, which runs before Jinja rendering — so a templated `source` was rejected at Dag parse time with the raw expression in the error message. This moves the check to the top of `execute()`, where the rendered value is available, and removes the class from the exemption list.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)