### PR TITLE
Check EmrAddStepsOperator cluster arguments after template rendering

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py
@@ -140,8 +140,6 @@ class EmrAddStepsOperator(AwsBaseOperator[EmrHook]):
         ),
         **kwargs,
     ):
-        if not exactly_one(job_flow_id is None, job_flow_name is None):
-            raise AirflowException("Exactly one of job_flow_id or job_flow_name must be specified.")
         super().__init__(**kwargs)
         cluster_states = cluster_states or []
         steps = steps or []
@@ -186,6 +184,9 @@ class EmrAddStepsOperator(AwsBaseOperator[EmrHook]):
         return result
 
     def execute(self, context: Context) -> list[str]:
+        if not exactly_one(self.job_flow_id is None, self.job_flow_name is None):
+            raise AirflowException("Exactly one of job_flow_id or job_flow_name must be specified.")
+
         job_flow_id = self.job_flow_id or self.hook.get_cluster_id_by_name(
             str(self.job_flow_name), self.cluster_states
         )

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_emr_add_steps.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_emr_add_steps.py
@@ -93,12 +93,13 @@ class TestEmrAddStepsOperator:
     )
     def test_validate_mutually_exclusive_args(self, job_flow_id, job_flow_name):
         error_message = r"Exactly one of job_flow_id or job_flow_name must be specified\."
+        op = EmrAddStepsOperator(
+            task_id="test_validate_mutually_exclusive_args",
+            job_flow_id=job_flow_id,
+            job_flow_name=job_flow_name,
+        )
         with pytest.raises(AirflowException, match=error_message):
-            EmrAddStepsOperator(
-                task_id="test_validate_mutually_exclusive_args",
-                job_flow_id=job_flow_id,
-                job_flow_name=job_flow_name,
-            )
+            op.execute({})
 
     @pytest.mark.db_test
     def test_render_template(self, session, clean_dags_dagruns_and_dagbundles, testing_dag_bundle):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -7,7 +7,6 @@
 # execute()) MUST remove its entry in the same PR — the hook fails on stale entries.
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
 providers/amazon/src/airflow/providers/amazon/aws/operators/appflow.py::AppflowBaseOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/emr.py::EmrAddStepsOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/s3.py::S3DeleteObjectsOperator


### PR DESCRIPTION
`job_flow_id` and `job_flow_name` are template fields of `EmrAddStepsOperator`, but the "exactly one of" mutual-exclusion check ran in `__init__`, before Jinja rendering. This moves the check to the top of `execute()` (relocated verbatim), updates the existing test to assert the failure at execute time, and removes the class from the exemption list.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)