### PR TITLE
Check GCSToS3Operator match_glob support after template rendering

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -146,10 +146,6 @@ class GCSToS3Operator(BaseOperator):
                 self.__is_match_glob_supported = False
         except ImportError:  # __version__ was added in 10.1.0, so this means it's < 10.3.0
             self.__is_match_glob_supported = False
-        if not self.__is_match_glob_supported and match_glob:
-            raise AirflowException(
-                "The 'match_glob' parameter requires 'apache-airflow-providers-google>=10.3.0'."
-            )
         self.match_glob = match_glob
         self.gcp_user_project = gcp_user_project
 
@@ -165,6 +161,10 @@ class GCSToS3Operator(BaseOperator):
         return file_path
 
     def execute(self, context: Context) -> list[str]:
+        if not self.__is_match_glob_supported and self.match_glob:
+            raise AirflowException(
+                "The 'match_glob' parameter requires 'apache-airflow-providers-google>=10.3.0'."
+            )
         # list all files in an Google Cloud Storage bucket
         gcs_hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_gcs_to_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_gcs_to_s3.py
@@ -25,6 +25,7 @@ from moto import mock_aws
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
+from airflow.providers.common.compat.sdk import AirflowException
 
 TASK_ID = "test-gcs-list-operator"
 GCS_BUCKET = "test-bucket"
@@ -74,6 +75,19 @@ class TestGCSToS3Operator:
                 prefix=PREFIX,
                 user_project=None,
             )
+
+    @mock.patch("airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook")
+    def test_execute_match_glob_fails_on_unsupported_google_provider(self, mock_hook):
+        operator = GCSToS3Operator(
+            task_id=TASK_ID,
+            gcs_bucket=GCS_BUCKET,
+            dest_s3_key=S3_BUCKET,
+            match_glob=f"**/*{DELIMITER}",
+        )
+        operator._GCSToS3Operator__is_match_glob_supported = False
+        with pytest.raises(AirflowException, match=r"requires 'apache-airflow-providers-google>=10\.3\.0'"):
+            operator.execute(None)
+        mock_hook.return_value.list.assert_not_called()
 
     @mock.patch("airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSHook")
     def test_execute_incremental(self, mock_hook):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -15,7 +15,6 @@ providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py::SageMa
 providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py::SageMakerProcessingOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/step_function.py::StepFunctionStartExecutionOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/base.py::AwsToAwsBaseOperator
-providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::S3ToRedshiftOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
 providers/google/src/airflow/providers/google/cloud/operators/bigquery.py::BigQueryInsertJobOperator


### PR DESCRIPTION
`match_glob` is a template field of `GCSToS3Operator`, but the guard that rejects it on `apache-airflow-providers-google<10.3.0` ran in `__init__`, before Jinja rendering. A templated `match_glob` therefore failed at Dag parse time even when the rendered value would be empty. The provider-version probe stays in `__init__` (it does not touch template fields); only the raise moves to `execute()`, relocated verbatim. Removes the class from the exemption list.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)