### PR TITLE
Resolve AwsToAwsBaseOperator destination connection after template rendering

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/base.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/base.py
@@ -54,8 +54,10 @@ class AwsToAwsBaseOperator(BaseOperator):
         super().__init__(**kwargs)
         self.source_aws_conn_id = source_aws_conn_id
         self.dest_aws_conn_id = dest_aws_conn_id
-        self.source_aws_conn_id = source_aws_conn_id
-        if is_arg_set(dest_aws_conn_id):
-            self.dest_aws_conn_id = dest_aws_conn_id
-        else:
-            self.dest_aws_conn_id = self.source_aws_conn_id
+
+    @property
+    def resolved_dest_aws_conn_id(self) -> str | None:
+        """Destination connection id, falling back to source_aws_conn_id when not set."""
+        if is_arg_set(self.dest_aws_conn_id):
+            return self.dest_aws_conn_id
+        return self.source_aws_conn_id

--- a/providers/amazon/src/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
@@ -224,7 +224,9 @@ class DynamoDBToS3Operator(AwsToAwsBaseOperator):
                 raise e
             finally:
                 if err is None:
-                    _upload_file_to_s3(f, self.s3_bucket_name, self.s3_key_prefix, self.dest_aws_conn_id)
+                    _upload_file_to_s3(
+                        f, self.s3_bucket_name, self.s3_key_prefix, self.resolved_dest_aws_conn_id
+                    )
 
     def _scan_dynamodb_and_upload_to_s3(self, temp_file: IO, scan_kwargs: dict, table: Any) -> IO:
         while True:
@@ -242,7 +244,9 @@ class DynamoDBToS3Operator(AwsToAwsBaseOperator):
 
             # Upload the file to S3 if reach file size limit
             if os.path.getsize(temp_file.name) >= self.file_size:
-                _upload_file_to_s3(temp_file, self.s3_bucket_name, self.s3_key_prefix, self.dest_aws_conn_id)
+                _upload_file_to_s3(
+                    temp_file, self.s3_bucket_name, self.s3_key_prefix, self.resolved_dest_aws_conn_id
+                )
                 temp_file.close()
 
                 temp_file = NamedTemporaryFile()

--- a/providers/amazon/tests/unit/amazon/aws/transfers/test_base.py
+++ b/providers/amazon/tests/unit/amazon/aws/transfers/test_base.py
@@ -73,3 +73,20 @@ class TestAwsToAwsBaseOperator:
         render_template_fields(ti, operator)
         assert getattr(operator, "source_aws_conn_id") == "2020-01-01"
         assert getattr(operator, "dest_aws_conn_id") == "2020-01-01"
+
+    @pytest.mark.parametrize(
+        ("dest_kwargs", "expected"),
+        [
+            pytest.param({}, "source-conn", id="fallback-to-source"),
+            pytest.param({"dest_aws_conn_id": "dest-conn"}, "dest-conn", id="explicit-dest"),
+            pytest.param({"dest_aws_conn_id": None}, None, id="explicit-none"),
+        ],
+    )
+    def test_resolved_dest_aws_conn_id(self, dest_kwargs, expected):
+        operator = AwsToAwsBaseOperator(
+            task_id="test_resolved_dest",
+            dag=self.dag,
+            source_aws_conn_id="source-conn",
+            **dest_kwargs,
+        )
+        assert operator.resolved_dest_aws_conn_id == expected

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -14,7 +14,6 @@ providers/amazon/src/airflow/providers/amazon/aws/operators/s3.py::S3DeleteObjec
 providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py::SageMakerCreateNotebookOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py::SageMakerProcessingOperator
 providers/amazon/src/airflow/providers/amazon/aws/operators/step_function.py::StepFunctionStartExecutionOperator
-providers/amazon/src/airflow/providers/amazon/aws/transfers/base.py::AwsToAwsBaseOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/s3_to_redshift.py::S3ToRedshiftOperator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator


### PR DESCRIPTION
`source_aws_conn_id` and `dest_aws_conn_id` are template fields of `AwsToAwsBaseOperator`, but the fallback ("dest not set → use source") was resolved in `__init__`, before Jinja rendering. `__init__` now keeps plain assignments (also dropping a duplicated `source_aws_conn_id` assignment) and the fallback lives in a `resolved_dest_aws_conn_id` property, which `DynamoDBToS3Operator` (the only in-repo consumer) reads at execute time. Removes the class from the exemption list.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)