### PR TITLE
Resolve GCSFileTransformOperator destination fallbacks after rendering

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/gcs.py
@@ -603,8 +603,8 @@ class GCSFileTransformOperator(GoogleCloudBaseOperator):
         super().__init__(**kwargs)
         self.source_bucket = source_bucket
         self.source_object = source_object
-        self.destination_bucket = destination_bucket or self.source_bucket
-        self.destination_object = destination_object or self.source_object
+        self.destination_bucket = destination_bucket
+        self.destination_object = destination_object
 
         self.gcp_conn_id = gcp_conn_id
         self.transform_script = transform_script
@@ -612,6 +612,8 @@ class GCSFileTransformOperator(GoogleCloudBaseOperator):
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context: Context) -> None:
+        self.destination_bucket = self.destination_bucket or self.source_bucket
+        self.destination_object = self.destination_object or self.source_object
         hook = GCSHook(gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain)
 
         with NamedTemporaryFile() as source_file, NamedTemporaryFile() as destination_file:
@@ -658,8 +660,8 @@ class GCSFileTransformOperator(GoogleCloudBaseOperator):
             name=self.source_object,
         )
         output_dataset = Dataset(
-            namespace=f"gs://{self.destination_bucket}",
-            name=self.destination_object,
+            namespace=f"gs://{self.destination_bucket or self.source_bucket}",
+            name=self.destination_object or self.source_object,
         )
 
         return OperatorLineage(inputs=[input_dataset], outputs=[output_dataset])

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -17,7 +17,6 @@ providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_tran
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocCreateClusterOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/functions.py::CloudFunctionDeployFunctionOperator
-providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSFileTransformOperator
 providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py::BigQueryDataTransferServiceTransferRunSensor
 providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py::CloudComposerExternalTaskSensor
 providers/google/src/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py::AzureFileShareToGCSOperator


### PR DESCRIPTION
Part of the template-field validation burn-down tracked in #70296.

`GCSFileTransformOperator` resolves `destination_bucket`/`destination_object` fallbacks (`destination_bucket or source_bucket`) in `__init__`, where the source fields still hold un-rendered Jinja expressions. This moves the fallback resolution to `execute()` (and mirrors it in `get_openlineage_facets_on_start`, which runs before `execute`), so the fallback applies to the rendered values.

Scope notes from review:
- The `delimiter` deprecation warning in `GCSListObjectsOperator` stays in `__init__` — deprecation applies to any usage of the argument, not the rendered value.
- The `objects`/`prefix` provision checks in `GCSDeleteObjectsOperator` stay in `__init__` — they are false positives under the relaxed validator definition proposed in #70505. Both classes keep their exemption entries; only the `GCSFileTransformOperator` entry is removed.

Note: `TestGCSDeleteObjectsOperator::test_get_openlineage_facets_on_start[objects]` fails on a pristine `main` checkout as well — pre-existing and unrelated to this change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)