### PR TITLE
Validate GCSToLocalFilesystemOperator arguments after template rendering

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -88,8 +88,6 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         file_encoding: str = "utf-8",
         **kwargs,
     ) -> None:
-        if filename is not None and store_to_xcom_key is not None:
-            raise ValueError("Either filename or store_to_xcom_key can be set")
         super().__init__(**kwargs)
         self.bucket = bucket
         self.filename = filename
@@ -100,6 +98,8 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         self.file_encoding = file_encoding
 
     def execute(self, context: Context):
+        if self.filename is not None and self.store_to_xcom_key is not None:
+            raise ValueError("Either filename or store_to_xcom_key can be set")
         self.log.info("Executing download: %s, %s, %s", self.bucket, self.object_name, self.filename)
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_local.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_local.py
@@ -56,6 +56,19 @@ class TestGoogleCloudStorageDownloadOperator:
         )
 
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_local.GCSHook")
+    def test_filename_and_xcom_key_fails_at_execute_time(self, mock_hook):
+        operator = GCSToLocalFilesystemOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            object_name=TEST_OBJECT,
+            filename=LOCAL_FILE_PATH,
+            store_to_xcom_key=XCOM_KEY,
+        )
+        with pytest.raises(ValueError, match="Either filename or store_to_xcom_key can be set"):
+            operator.execute(None)
+        mock_hook.return_value.download.assert_not_called()
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_local.GCSHook")
     def test_size_lt_max_xcom_size(self, mock_hook):
         operator = GCSToLocalFilesystemOperator(
             task_id=TASK_ID,

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -34,7 +34,6 @@ providers/google/src/airflow/providers/google/cloud/transfers/azure_fileshare_to
 providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py::BigQueryToMsSqlOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py::GCSToBigQueryOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py::GCSToGCSOperator
-providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py::GCSToLocalFilesystemOperator
 providers/google/src/airflow/providers/google/marketing_platform/operators/campaign_manager.py::GoogleCampaignManagerDeleteReportOperator
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/gcs_to_wasb.py::GCSToAzureBlobStorageOperator
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py::OracleToAzureDataLakeOperator


### PR DESCRIPTION
`filename` and `store_to_xcom_key` are template fields of `GCSToLocalFilesystemOperator`, but the "only one can be set" check ran in `__init__`, before Jinja rendering — so templated values were judged on their raw expressions at Dag parse time. The check now runs at the top of `execute()` on rendered values, with a test asserting the failure at execute time. Removes the class from the exemption list.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)