### PR TITLE
Validate TriggerDagRunOperator logical_date after template rendering

### DIFF
--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -221,7 +221,6 @@ class TriggerDagRunOperator(BaseOperator):
         self.openlineage_inject_parent_info = openlineage_inject_parent_info
         self.note = note
         self.deferrable = deferrable
-        logical_date = _validate_datetime_param("logical_date", logical_date)
         run_after = _validate_datetime_param("run_after", run_after)
         self.logical_date = logical_date
         self.run_after = run_after
@@ -232,6 +231,7 @@ class TriggerDagRunOperator(BaseOperator):
             )
 
     def execute(self, context: Context):
+        _validate_datetime_param("logical_date", self.logical_date)
         if self.logical_date is NOTSET:
             if self.run_after is not NOTSET:
                 parsed_logical_date = None

--- a/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
+++ b/providers/standard/tests/unit/standard/operators/test_trigger_dagrun.py
@@ -259,6 +259,15 @@ class TestDagRunOperator:
 
         assert exc_info.value.logical_date == timezone.datetime(2021, 1, 2, 3, 4, 5)
 
+    def test_trigger_dagrun_with_invalid_logical_date_type_fails_at_execute_time(self):
+        task = TriggerDagRunOperator(
+            task_id="test_trigger_dagrun_with_invalid_logical_date_type",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            logical_date=12345,
+        )
+        with pytest.raises(TypeError, match="Expected str, datetime.datetime, or None"):
+            task.execute(context={})
+
     def test_trigger_dagrun_operator_templated_invalid_conf(self, dag_maker):
         """Test passing a conf that is not JSON Serializable raise error."""
         with dag_maker(

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -41,4 +41,3 @@ providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/oracle
 providers/microsoft/psrp/src/airflow/providers/microsoft/psrp/operators/psrp.py::PsrpOperator
 providers/oracle/src/airflow/providers/oracle/transfers/oracle_to_oracle.py::OracleToOracleOperator
 providers/standard/src/airflow/providers/standard/operators/bash.py::BashOperator
-providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py::TriggerDagRunOperator


### PR DESCRIPTION
`logical_date` is a template field of `TriggerDagRunOperator`, but its str/datetime/None type validation ran in `__init__`, before Jinja rendering. The check now runs at the top of `execute()` on the rendered value (`run_after` keeps its constructor validation — it is not a template field). Removes the class from the exemption list.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)