### PR TITLE
Rename Neptune operator db_cluster_id argument to cluster_id

### DIFF
--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -26,6 +26,12 @@
 Changelog
 ---------
 
+.. note::
+    The ``db_cluster_id`` argument of ``NeptuneStartDbClusterOperator`` and
+    ``NeptuneStopDbClusterOperator`` is renamed to ``cluster_id`` so that it matches the
+    operators' templated ``cluster_id`` attribute. Update Dags that pass ``db_cluster_id=``
+    to use ``cluster_id=`` instead.
+
 9.34.0
 ......
 

--- a/providers/amazon/docs/changelog.rst
+++ b/providers/amazon/docs/changelog.rst
@@ -26,6 +26,12 @@
 Changelog
 ---------
 
+.. note::
+    The ``db_cluster_id`` argument of ``NeptuneStartDbClusterOperator`` and
+    ``NeptuneStopDbClusterOperator`` is renamed to ``cluster_id`` so that it matches the
+    operators' templated ``cluster_id`` attribute. Update Dags that pass ``db_cluster_id=``
+    to use ``cluster_id=`` instead.
+
 9.33.0
 ......
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py
@@ -93,7 +93,7 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:NeptuneStartDbClusterOperator`
 
-    :param db_cluster_id: The DB cluster identifier of the Neptune DB cluster to be started.
+    :param cluster_id: The DB cluster identifier of the Neptune DB cluster to be started.
     :param wait_for_completion: Whether to wait for the cluster to start. (default: True)
     :param deferrable: If True, the operator will wait asynchronously for the cluster to start.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
@@ -117,7 +117,7 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
 
     def __init__(
         self,
-        db_cluster_id: str,
+        cluster_id: str,
         wait_for_completion: bool = True,
         waiter_delay: int = 30,
         waiter_max_attempts: int = 60,
@@ -125,7 +125,7 @@ class NeptuneStartDbClusterOperator(AwsBaseOperator[NeptuneHook]):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.cluster_id = db_cluster_id
+        self.cluster_id = cluster_id
         self.wait_for_completion = wait_for_completion
         self.deferrable = deferrable
         self.waiter_delay = waiter_delay
@@ -211,7 +211,7 @@ class NeptuneStopDbClusterOperator(AwsBaseOperator[NeptuneHook]):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:NeptuneStartDbClusterOperator`
 
-    :param db_cluster_id: The DB cluster identifier of the Neptune DB cluster to be stopped.
+    :param cluster_id: The DB cluster identifier of the Neptune DB cluster to be stopped.
     :param wait_for_completion: Whether to wait for cluster to stop. (default: True)
     :param deferrable: If True, the operator will wait asynchronously for the cluster to stop.
         This implies waiting for completion. This mode requires aiobotocore module to be installed.
@@ -234,7 +234,7 @@ class NeptuneStopDbClusterOperator(AwsBaseOperator[NeptuneHook]):
 
     def __init__(
         self,
-        db_cluster_id: str,
+        cluster_id: str,
         wait_for_completion: bool = True,
         waiter_delay: int = 30,
         waiter_max_attempts: int = 60,
@@ -242,7 +242,7 @@ class NeptuneStopDbClusterOperator(AwsBaseOperator[NeptuneHook]):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.cluster_id = db_cluster_id
+        self.cluster_id = cluster_id
         self.wait_for_completion = wait_for_completion
         self.deferrable = deferrable
         self.waiter_delay = waiter_delay

--- a/providers/amazon/tests/system/amazon/aws/example_neptune.py
+++ b/providers/amazon/tests/system/amazon/aws/example_neptune.py
@@ -67,11 +67,11 @@ with DAG(
     cluster_id = f"{env_id}-cluster"
 
     # [START howto_operator_start_neptune_cluster]
-    start_cluster = NeptuneStartDbClusterOperator(task_id="start_task", db_cluster_id=cluster_id)
+    start_cluster = NeptuneStartDbClusterOperator(task_id="start_task", cluster_id=cluster_id)
     # [END howto_operator_start_neptune_cluster]
 
     # [START howto_operator_stop_neptune_cluster]
-    stop_cluster = NeptuneStopDbClusterOperator(task_id="stop_task", db_cluster_id=cluster_id)
+    stop_cluster = NeptuneStopDbClusterOperator(task_id="stop_task", cluster_id=cluster_id)
     # [END howto_operator_stop_neptune_cluster]
 
     chain(

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_neptune.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_neptune.py
@@ -60,7 +60,7 @@ class TestNeptuneStartClusterOperator:
     def test_start_cluster_wait_for_completion(self, mock_hook_get_waiter, mock_conn):
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -75,7 +75,7 @@ class TestNeptuneStartClusterOperator:
     def test_start_cluster_no_wait(self, mock_hook_get_waiter, mock_conn):
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -92,7 +92,7 @@ class TestNeptuneStartClusterOperator:
         mock_get_cluster_status.return_value = "available"
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -108,7 +108,7 @@ class TestNeptuneStartClusterOperator:
     def test_start_cluster_deferrable(self, mock_conn):
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -124,7 +124,7 @@ class TestNeptuneStartClusterOperator:
         mock_get_cluster_status.return_value = "migration-failed"
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -145,7 +145,7 @@ class TestNeptuneStartClusterOperator:
         mock_conn.start_db_cluster.side_effect = exception
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -171,7 +171,7 @@ class TestNeptuneStartClusterOperator:
 
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -192,7 +192,7 @@ class TestNeptuneStartClusterOperator:
         mock_conn.start_db_cluster.side_effect = exception
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -206,7 +206,7 @@ class TestNeptuneStartClusterOperator:
     def test_template_fields(self):
         operator = NeptuneStartDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -223,7 +223,7 @@ class TestNeptuneStopClusterOperator:
         mock_get_cluster_status.return_value = "available"
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -241,7 +241,7 @@ class TestNeptuneStopClusterOperator:
 
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -258,7 +258,7 @@ class TestNeptuneStopClusterOperator:
         mock_get_cluster_status.return_value = "stopped"
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -277,7 +277,7 @@ class TestNeptuneStopClusterOperator:
         mock_get_cluster_status.return_value = "migration-failed"
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -293,7 +293,7 @@ class TestNeptuneStopClusterOperator:
         mock_get_cluster_status.return_value = "backing-up"
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=True,
             aws_conn_id="aws_default",
@@ -313,7 +313,7 @@ class TestNeptuneStopClusterOperator:
         mock_conn.stop_db_cluster.side_effect = exception
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -335,7 +335,7 @@ class TestNeptuneStopClusterOperator:
 
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=False,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -356,7 +356,7 @@ class TestNeptuneStopClusterOperator:
         mock_conn.stop_db_cluster.side_effect = exception
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -372,7 +372,7 @@ class TestNeptuneStopClusterOperator:
     def test_stop_cluster_deferrable(self, mock_conn):
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",
@@ -384,7 +384,7 @@ class TestNeptuneStopClusterOperator:
     def test_template_fields(self):
         operator = NeptuneStopDbClusterOperator(
             task_id="task_test",
-            db_cluster_id=CLUSTER_ID,
+            cluster_id=CLUSTER_ID,
             deferrable=True,
             wait_for_completion=False,
             aws_conn_id="aws_default",

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -5,8 +5,6 @@
 #
 # Fixing a class MUST remove its entry in the same PR — the hook fails on stale entries.
 # Burn-down tracked at https://github.com/apache/airflow/issues/70296
-providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStartDbClusterOperator
-providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator


### PR DESCRIPTION
Part of the template-field validation burn-down tracked in #70296.

`NeptuneStartDbClusterOperator` and `NeptuneStopDbClusterOperator` declare `cluster_id` in `template_fields` but expose the value as the `db_cluster_id` constructor argument, assigning `self.cluster_id = db_cluster_id` in `__init__` — which the `validate-operators-init` check flags. Per review feedback, this renames the **argument** to `cluster_id` (rather than renaming the attribute as in the first iteration of this PR), so the templated attribute and `template_fields` entry stay exactly as they are on main and existing Dags templating the attribute are unaffected.

**Breaking change**: Dags passing `db_cluster_id=` to these two operators must switch to `cluster_id=`, and now fail loudly with a `TypeError` at construction time. A note was added to the provider changelog. The `db_cluster_id` keys in the operators' XCom return values and in the Neptune trigger/hook APIs are unchanged.

Both classes are removed from the exemption list and the `validate-operators-init` check passes locally, as do the unit tests.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)