### PR TITLE
Breeze: Make postgres driver explicit and version-aware

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 from base64 import b64encode
 from copy import deepcopy
@@ -563,6 +564,23 @@ services:
         return is_docker_rootless()
 
     @property
+    def postgres_driver(self) -> str:
+        """
+        Driver to use in the postgres ``sql_alchemy_conn``.
+
+        psycopg (v3) is the default only for Airflow's own sources. Releases before 3.2.0 (the first
+        with a ``sqlalchemy>=2.0`` floor) can run on SQLAlchemy 1.4, which has no
+        ``postgresql+psycopg`` dialect at all, and the default constraints file of a released version
+        pins psycopg2 rather than psycopg. Migration tests install a released Airflow into this same
+        container, so those runs fall back to psycopg2.
+        Only an ``x.y[.z]`` value names a released version; none/wheel/sdist, ``owner/repo:branch``
+        and a bare PR number do not, so they keep psycopg.
+        """
+        if self.use_airflow_version and re.match(r"^\d+\.\d+", self.use_airflow_version):
+            return "psycopg2"
+        return "psycopg"
+
+    @property
     def env_variables_for_docker_commands(self) -> dict[str, str]:
         """
         Constructs environment variables needed by the docker-compose command, based on Shell parameters
@@ -682,6 +700,7 @@ services:
         _set_var(_env, "NUM_RUNS", self.num_runs)
         _set_var(_env, "ONLY_MIN_VERSION_UPDATE", self.only_min_version_update)
         _set_var(_env, "DISTRIBUTION_FORMAT", self.distribution_format)
+        _set_var(_env, "POSTGRES_DRIVER", self.postgres_driver)
         _set_var(_env, "POSTGRES_HOST_PORT", None, POSTGRES_HOST_PORT)
         _set_var(_env, "POSTGRES_VERSION", self.postgres_version)
         _set_var(_env, "PROVIDERS_CONSTRAINTS_LOCATION", self.providers_constraints_location)

--- a/dev/breeze/tests/test_shell_params.py
+++ b/dev/breeze/tests/test_shell_params.py
@@ -166,6 +166,42 @@ console = Console(width=400, color_system="standard")
             },
             id="PYTHONWARNINGS should be set when specified in environment",
         ),
+        pytest.param(
+            {},
+            {},
+            {"POSTGRES_DRIVER": "psycopg"},
+            id="POSTGRES_DRIVER defaults to psycopg (v3)",
+        ),
+        pytest.param(
+            {},
+            {"use_airflow_version": "2.11.0"},
+            {"POSTGRES_DRIVER": "psycopg2"},
+            id="POSTGRES_DRIVER falls back to psycopg2 on Airflow 2.x (SQLAlchemy 1.4)",
+        ),
+        pytest.param(
+            {},
+            {"use_airflow_version": "3.1.0"},
+            {"POSTGRES_DRIVER": "psycopg2"},
+            id="POSTGRES_DRIVER falls back to psycopg2 on released Airflow 3.x",
+        ),
+        pytest.param(
+            {},
+            {"use_airflow_version": "wheel"},
+            {"POSTGRES_DRIVER": "psycopg"},
+            id="POSTGRES_DRIVER stays psycopg when installing from sources",
+        ),
+        pytest.param(
+            {},
+            {"use_airflow_version": "70496"},
+            {"POSTGRES_DRIVER": "psycopg"},
+            id="POSTGRES_DRIVER stays psycopg when installing from a PR number",
+        ),
+        pytest.param(
+            {},
+            {"use_airflow_version": "apache/airflow:main"},
+            {"POSTGRES_DRIVER": "psycopg"},
+            id="POSTGRES_DRIVER stays psycopg when installing from a GitHub branch",
+        ),
     ],
 )
 def test_shell_params_to_env_var_conversion(

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -19,7 +19,7 @@ services:
   airflow:
     environment:
       - BACKEND=postgres
-      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql://postgres:airflow@postgres/airflow
+      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg://postgres:airflow@postgres/airflow
       - AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql+psycopg://postgres:airflow@postgres/airflow
     depends_on:
       postgres:

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -19,8 +19,8 @@ services:
   airflow:
     environment:
       - BACKEND=postgres
-      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg://postgres:airflow@postgres/airflow
-      - AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql+psycopg://postgres:airflow@postgres/airflow
+      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+${POSTGRES_DRIVER:-psycopg}://postgres:airflow@postgres/airflow
+      - AIRFLOW__CELERY__RESULT_BACKEND=db+postgresql+${POSTGRES_DRIVER:-psycopg}://postgres:airflow@postgres/airflow
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Since #69469 moved Breeze's `backend-postgres.yml` to a bare `postgresql://` scheme (so that core's autodetection selects psycopg3), every Breeze postgres session running Airflow from sources emits a `FutureWarning` at config load — `main` now lists the bare scheme in `bad_schemes`.

Making the driver explicit has to be version-aware: the migration tests install a released Airflow into the same container, no released version ships psycopg (v3) in its default constraints, and releases before 3.2.0 can run on SQLAlchemy 1.4, which has no `postgresql+psycopg` dialect at all — an explicit psycopg3 URL crashes them with `sqlalchemy.exc.NoSuchModuleError` (this is exactly what failed the Postgres core jobs on this PR's first revision).

Breeze now derives `POSTGRES_DRIVER` from `--use-airflow-version` — psycopg2 when a released version is installed, psycopg for sources/wheel/sdist/branch/PR installs — and the compose file interpolates it into both `sql_alchemy_conn` and the Celery result backend URL, defaulting to psycopg.

Verified locally: the Airflow 2.11.0 migration leg resolves `postgresql+psycopg2://` and completes, and a from-sources session resolves `postgresql+psycopg://` with no `FutureWarning`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5, Opus 5)

Generated-by: Claude Code (Fable 5, Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)