### PR TITLE
Match providers to Explore categories by integration name, not just id

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -256,11 +256,15 @@ The Explore page and provider filtering use categories defined in
 
 - `id` — URL-safe identifier (e.g., `cloud`, `databases`, `ai-ml`)
 - `name` — Display name
-- `keywords` — List of substrings matched against `provider.id`
+- `keywords` — List of substrings matched against `provider.id` and the provider's
+  declared integration names (`provider.categories[].name`)
 - `icon`, `color`, `description` — Visual properties
 
 Providers are assigned to categories at build time by checking if any keyword in a
-category matches (substring) the provider's ID. A provider can belong to multiple
+category is a substring of the provider's ID or of one of its declared integration
+names, compared case-insensitively after collapsing runs of `-`, `_` and whitespace to
+a single space (so `pydantic-ai` matches the integration named "Pydantic AI"). The
+matcher lives in `src/_data/providerKeywordMatch.js`. A provider can belong to multiple
 categories.
 
 ### Homepage "New Providers" Section

--- a/registry/scripts/build-pagefind-index.mjs
+++ b/registry/scripts/build-pagefind-index.mjs
@@ -47,7 +47,10 @@ async function buildPagefindIndex() {
 
     await index.addCustomRecord({
       url: `/providers/${provider.id}/${provider.version}/`,
-      content: `${provider.name} ${provider.description} ${integrations}`,
+      // The id is indexed on its own, not as part of the distribution name:
+      // the `apache-airflow-providers-` prefix is shared by every provider and
+      // would make 'apache' or 'airflow' match all of them.
+      content: `${provider.name} ${provider.id} ${provider.description} ${integrations}`,
       language: 'en',
       meta: {
         type: 'provider',

--- a/registry/scripts/build-pagefind-index.mjs
+++ b/registry/scripts/build-pagefind-index.mjs
@@ -40,9 +40,14 @@ async function buildPagefindIndex() {
   let modulesAdded = 0;
 
   for (const provider of providers.providers) {
+    const integrations = (provider.categories || [])
+      .map((category) => category.name)
+      .filter(Boolean)
+      .join(' ');
+
     await index.addCustomRecord({
       url: `/providers/${provider.id}/${provider.version}/`,
-      content: `${provider.name} ${provider.description}`,
+      content: `${provider.name} ${provider.description} ${integrations}`,
       language: 'en',
       meta: {
         type: 'provider',

--- a/registry/src/_data/exploreCategories.js
+++ b/registry/src/_data/exploreCategories.js
@@ -55,7 +55,7 @@ module.exports = [
     name: 'AI & Machine Learning',
     icon: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>',
     color: 'amber',
-    keywords: ['openai', 'cohere', 'anthropic', 'huggingface', 'mlflow', 'pinecone', 'qdrant', 'weaviate', 'pgvector', 'langchain', 'llamaindex', 'mcp', 'pydantic ai', 'pydantic-ai'],
+    keywords: ['openai', 'cohere', 'anthropic', 'huggingface', 'mlflow', 'pinecone', 'qdrant', 'weaviate', 'pgvector', 'langchain', 'llamaindex', 'mcp', 'pydantic ai'],
     description: 'OpenAI, vector DBs, and ML platforms',
   },
   {

--- a/registry/src/_data/exploreCategories.js
+++ b/registry/src/_data/exploreCategories.js
@@ -55,7 +55,7 @@ module.exports = [
     name: 'AI & Machine Learning',
     icon: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>',
     color: 'amber',
-    keywords: ['openai', 'cohere', 'anthropic', 'huggingface', 'mlflow', 'pinecone', 'qdrant', 'weaviate', 'pgvector'],
+    keywords: ['openai', 'cohere', 'anthropic', 'huggingface', 'mlflow', 'pinecone', 'qdrant', 'weaviate', 'pgvector', 'langchain', 'llamaindex', 'mcp', 'pydantic ai', 'pydantic-ai'],
     description: 'OpenAI, vector DBs, and ML platforms',
   },
   {

--- a/registry/src/_data/exploreCategories.js
+++ b/registry/src/_data/exploreCategories.js
@@ -31,7 +31,7 @@ module.exports = [
     name: 'Databases',
     icon: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4" /></svg>',
     color: 'blue',
-    keywords: ['postgres', 'mysql', 'mongo', 'redis', 'neo4j', 'elasticsearch', 'cassandra', 'couchbase', 'influxdb', 'sqlite', 'odbc', 'jdbc', 'common-sql'],
+    keywords: ['postgres', 'mysql', 'mongo', 'redis', 'neo4j', 'elasticsearch', 'cassandra', 'couchbase', 'influxdb', 'sqlite', 'odbc', 'jdbc', 'common-sql', 'mssql', 'opensearch', 'cloudant', 'arangodb'],
     description: 'SQL, NoSQL, and time-series databases',
   },
   {
@@ -39,7 +39,7 @@ module.exports = [
     name: 'Data Warehouses',
     icon: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" /></svg>',
     color: 'purple',
-    keywords: ['snowflake', 'databricks', 'teradata', 'vertica', 'trino', 'presto', 'dbt'],
+    keywords: ['snowflake', 'databricks', 'teradata', 'vertica', 'trino', 'presto', 'dbt', 'exasol', 'clickhouse'],
     description: 'Snowflake, Databricks, and analytics platforms',
   },
   {
@@ -47,7 +47,7 @@ module.exports = [
     name: 'Messaging & Notifications',
     icon: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>',
     color: 'green',
-    keywords: ['slack', 'sendgrid', 'smtp', 'discord', 'telegram', 'pagerduty', 'opsgenie', 'twilio'],
+    keywords: ['slack', 'sendgrid', 'smtp', 'discord', 'telegram', 'pagerduty', 'opsgenie', 'twilio', 'dingtalk', 'apprise'],
     description: 'Slack, email, SMS, and alerting services',
   },
   {
@@ -71,7 +71,7 @@ module.exports = [
     name: 'Workflow & Orchestration',
     icon: '<svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>',
     color: 'rose',
-    keywords: ['standard', 'celery', 'docker', 'kubernetes', 'ssh', 'http', 'ftp', 'sftp'],
+    keywords: ['standard', 'celery', 'docker', 'kubernetes', 'ssh', 'http', 'ftp', 'sftp', 'grpc'],
     description: 'Core operators, executors, and connectivity',
   },
 ];

--- a/registry/src/_data/exploreCategoryProviders.js
+++ b/registry/src/_data/exploreCategoryProviders.js
@@ -33,6 +33,13 @@ module.exports = function () {
         }
       }
     }
+    // explore.njk shows only the first six as badges, so rank before slicing
+    // (as its Top/Incubating rows already do) — otherwise the row is whatever
+    // providers.json happened to list first, and widening a category's
+    // membership silently pushes the well-known names off it.
+    matched.sort(
+      (a, b) => (b.pypi_downloads?.monthly || 0) - (a.pypi_downloads?.monthly || 0),
+    );
     map[category.id] = matched;
   }
   return map;

--- a/registry/src/_data/exploreCategoryProviders.js
+++ b/registry/src/_data/exploreCategoryProviders.js
@@ -19,6 +19,7 @@
 
 const providersData = require("./providers.json");
 const exploreCategories = require("./exploreCategories");
+const { providerMatchesKeyword } = require("./providerKeywordMatch");
 
 module.exports = function () {
   const map = {};
@@ -26,10 +27,7 @@ module.exports = function () {
     const matched = [];
     for (const provider of providersData.providers) {
       for (const keyword of category.keywords) {
-        if (
-          provider.id.includes(keyword) ||
-          keyword.includes(provider.id)
-        ) {
+        if (providerMatchesKeyword(provider, keyword)) {
           matched.push(provider);
           break;
         }

--- a/registry/src/_data/providerCategoryMap.js
+++ b/registry/src/_data/providerCategoryMap.js
@@ -19,6 +19,7 @@
 
 const providersData = require("./providers.json");
 const exploreCategories = require("./exploreCategories");
+const { providerMatchesKeyword } = require("./providerKeywordMatch");
 
 module.exports = function () {
   const map = {};
@@ -26,7 +27,7 @@ module.exports = function () {
     const cats = [];
     for (const category of exploreCategories) {
       for (const keyword of category.keywords) {
-        if (provider.id.includes(keyword) || keyword.includes(provider.id)) {
+        if (providerMatchesKeyword(provider, keyword)) {
           cats.push(category.id);
           break;
         }

--- a/registry/src/_data/providerKeywordMatch.js
+++ b/registry/src/_data/providerKeywordMatch.js
@@ -22,34 +22,30 @@
 // respectively by the per-provider page's category chips and the Explore
 // landing page's per-category provider listing) can't drift apart.
 
-// Two arbitrary strings "match" a keyword if either contains the other
-// (case-insensitively), mirroring the original id-only substring check.
+// A value "matches" a keyword if the value contains the keyword,
+// case-insensitively, after collapsing runs of "-_\s" to a single space
+// (so 'pydantic-ai' matches "Pydantic AI"). Collapse, don't strip:
+// stripping would turn "Microsoft Power BI" into "microsoftpowerbi",
+// which contains "ftp" and would falsely match the orchestration category.
+function normalize(text) {
+  return text.toLowerCase().replace(/[-_\s]+/g, ' ');
+}
+
 function fuzzyIncludes(value, keyword) {
   if (!value) {
     return false;
   }
-  const normalizedValue = value.toLowerCase();
-  const normalizedKeyword = keyword.toLowerCase();
-  return normalizedValue.includes(normalizedKeyword) || normalizedKeyword.includes(normalizedValue);
+  return normalize(value).includes(normalize(keyword));
 }
 
-// Every string a provider is searchable by: its id/slug, its declared
+// Every string a provider is searchable by: its id/slug and its declared
 // integration names (provider.categories[].name — e.g. "LangChain",
-// "Pydantic AI"), and, once populated, each connection type's declared
-// external integrations. The latter field doesn't exist in the generated
-// data yet, so this reads as an empty list until a future change in
-// dev/registry/extract_metadata.py starts populating it — no further
-// changes needed here when that lands.
+// "Pydantic AI").
 function collectSearchableValues(provider) {
   const values = [provider.id];
   for (const category of provider.categories || []) {
     if (category.name) {
       values.push(category.name);
-    }
-  }
-  for (const connectionType of provider.connection_types || []) {
-    for (const externalIntegration of connectionType.external_integrations || []) {
-      values.push(externalIntegration);
     }
   }
   return values;

--- a/registry/src/_data/providerKeywordMatch.js
+++ b/registry/src/_data/providerKeywordMatch.js
@@ -1,0 +1,62 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Shared by providerCategoryMap.js and exploreCategoryProviders.js so the
+// two directions of the same provider <-> explore-category matching (used
+// respectively by the per-provider page's category chips and the Explore
+// landing page's per-category provider listing) can't drift apart.
+
+// Two arbitrary strings "match" a keyword if either contains the other
+// (case-insensitively), mirroring the original id-only substring check.
+function fuzzyIncludes(value, keyword) {
+  if (!value) {
+    return false;
+  }
+  const normalizedValue = value.toLowerCase();
+  const normalizedKeyword = keyword.toLowerCase();
+  return normalizedValue.includes(normalizedKeyword) || normalizedKeyword.includes(normalizedValue);
+}
+
+// Every string a provider is searchable by: its id/slug, its declared
+// integration names (provider.categories[].name — e.g. "LangChain",
+// "Pydantic AI"), and, once populated, each connection type's declared
+// external integrations. The latter field doesn't exist in the generated
+// data yet, so this reads as an empty list until a future change in
+// dev/registry/extract_metadata.py starts populating it — no further
+// changes needed here when that lands.
+function collectSearchableValues(provider) {
+  const values = [provider.id];
+  for (const category of provider.categories || []) {
+    if (category.name) {
+      values.push(category.name);
+    }
+  }
+  for (const connectionType of provider.connection_types || []) {
+    for (const externalIntegration of connectionType.external_integrations || []) {
+      values.push(externalIntegration);
+    }
+  }
+  return values;
+}
+
+function providerMatchesKeyword(provider, keyword) {
+  return collectSearchableValues(provider).some((value) => fuzzyIncludes(value, keyword));
+}
+
+module.exports = { providerMatchesKeyword };

--- a/registry/src/_data/providerKeywordMatch.js
+++ b/registry/src/_data/providerKeywordMatch.js
@@ -19,8 +19,8 @@
 
 // Shared by providerCategoryMap.js and exploreCategoryProviders.js so the
 // two directions of the same provider <-> explore-category matching (used
-// respectively by the per-provider page's category chips and the Explore
-// landing page's per-category provider listing) can't drift apart.
+// respectively by the category dropdown on /providers/ and the Explore landing
+// page's per-category provider listing) can't drift apart.
 
 // A value "matches" a keyword if the value contains the keyword,
 // case-insensitively, after collapsing runs of "-_\s" to a single space

--- a/registry/src/js/provider-filters.js
+++ b/registry/src/js/provider-filters.js
@@ -41,18 +41,31 @@
     return text.toLowerCase().replace(/[-_\s]+/g, ' ');
   }
 
+  // The card prints the full distribution name under the title, so that string
+  // has to be a working query. Matching against it directly would make
+  // 'apache', 'airflow' and 'providers' match every card, so drop the shared
+  // prefix off the query instead and match the id alone.
+  const PACKAGE_PREFIX = normalize('apache-airflow-providers-');
+
+  function normalizeSearch(text) {
+    const search = normalize(text);
+    return search.startsWith(PACKAGE_PREFIX) ? search.slice(PACKAGE_PREFIX.length) : search;
+  }
+
   function filterProviders() {
     let visibleCount = 0;
+    const search = normalizeSearch(currentSearch);
 
     providerItems.forEach(item => {
       const lifecycle = item.dataset.lifecycle;
       const name = item.dataset.name || '';
+      const id = item.dataset.id || '';
       const categories = item.dataset.categories || '';
       const integrations = item.dataset.integrations || '';
 
       const matchesLifecycle = currentLifecycle === 'all' || lifecycle === currentLifecycle;
-      const search = normalize(currentSearch);
       const matchesSearch = normalize(name).includes(search) ||
+        normalize(id).includes(search) ||
         normalize(integrations).includes(search);
       const matchesCategory = currentCategory === 'all' ||
         categories.split(',').includes(currentCategory);

--- a/registry/src/js/provider-filters.js
+++ b/registry/src/js/provider-filters.js
@@ -40,9 +40,11 @@
       const lifecycle = item.dataset.lifecycle;
       const name = item.dataset.name || '';
       const categories = item.dataset.categories || '';
+      const integrations = item.dataset.integrations || '';
 
       const matchesLifecycle = currentLifecycle === 'all' || lifecycle === currentLifecycle;
-      const matchesSearch = name.includes(currentSearch.toLowerCase());
+      const search = currentSearch.toLowerCase();
+      const matchesSearch = name.includes(search) || integrations.includes(search);
       const matchesCategory = currentCategory === 'all' ||
         categories.split(',').includes(currentCategory);
 

--- a/registry/src/js/provider-filters.js
+++ b/registry/src/js/provider-filters.js
@@ -33,6 +33,14 @@
   let currentSearch = '';
   let debounceTimer;
 
+  // Kept in sync by hand with normalize() in src/_data/providerKeywordMatch.js:
+  // that module runs at build time under CommonJS and this file is a browser
+  // IIFE, so the two can't share it. If the two drift, a query like
+  // 'pydantic-ai' stops finding the integration named "Pydantic AI".
+  function normalize(text) {
+    return text.toLowerCase().replace(/[-_\s]+/g, ' ');
+  }
+
   function filterProviders() {
     let visibleCount = 0;
 
@@ -43,8 +51,9 @@
       const integrations = item.dataset.integrations || '';
 
       const matchesLifecycle = currentLifecycle === 'all' || lifecycle === currentLifecycle;
-      const search = currentSearch.toLowerCase();
-      const matchesSearch = name.includes(search) || integrations.includes(search);
+      const search = normalize(currentSearch);
+      const matchesSearch = normalize(name).includes(search) ||
+        normalize(integrations).includes(search);
       const matchesCategory = currentCategory === 'all' ||
         categories.split(',').includes(currentCategory);
 

--- a/registry/src/providers.njk
+++ b/registry/src/providers.njk
@@ -63,19 +63,13 @@ mainClass: providers-page
       {% set lc = provider.lifecycle or "production" %}
       {% set lcDisplay = "incubation" if lc == "incubation" else ("deprecated" if lc == "deprecated" else "stable") %}
       {% set cats = providerCategoryMap[provider.id] or [] %}
-      {% set integrations = [] %}
-      {% for cat in provider.categories or [] %}
-        {% if cat.name %}
-        {% set integrations = (integrations.push(cat.name | lower), integrations) %}
-        {% endif %}
-      {% endfor %}
       <li class="provider-item"
           data-lifecycle="{{ lcDisplay }}"
           data-name="{{ provider.name | lower }}"
           data-downloads="{{ provider.pypi_downloads.monthly }}"
           data-updated="{{ provider.last_updated or '' }}"
           data-categories="{{ cats | join(',') }}"
-          data-integrations="{{ integrations | join(',') }}">
+          data-integrations="{{ (provider.categories or []) | selectattr('name') | join(',', 'name') | lower }}">
         {% include "provider-card.njk" %}
       </li>
       {% endfor %}

--- a/registry/src/providers.njk
+++ b/registry/src/providers.njk
@@ -66,6 +66,7 @@ mainClass: providers-page
       <li class="provider-item"
           data-lifecycle="{{ lcDisplay }}"
           data-name="{{ provider.name | lower }}"
+          data-id="{{ provider.id | lower }}"
           data-downloads="{{ provider.pypi_downloads.monthly }}"
           data-updated="{{ provider.last_updated or '' }}"
           data-categories="{{ cats | join(',') }}"

--- a/registry/src/providers.njk
+++ b/registry/src/providers.njk
@@ -63,12 +63,19 @@ mainClass: providers-page
       {% set lc = provider.lifecycle or "production" %}
       {% set lcDisplay = "incubation" if lc == "incubation" else ("deprecated" if lc == "deprecated" else "stable") %}
       {% set cats = providerCategoryMap[provider.id] or [] %}
+      {% set integrations = [] %}
+      {% for cat in provider.categories or [] %}
+        {% if cat.name %}
+        {% set integrations = (integrations.push(cat.name | lower), integrations) %}
+        {% endif %}
+      {% endfor %}
       <li class="provider-item"
           data-lifecycle="{{ lcDisplay }}"
           data-name="{{ provider.name | lower }}"
           data-downloads="{{ provider.pypi_downloads.monthly }}"
           data-updated="{{ provider.last_updated or '' }}"
-          data-categories="{{ cats | join(',') }}">
+          data-categories="{{ cats | join(',') }}"
+          data-integrations="{{ integrations | join(',') }}">
         {% include "provider-card.njk" %}
       </li>
       {% endfor %}


### PR DESCRIPTION
## Why
The Explore page and each provider's category chips only matched a provider to a category by substring-matching the category's keywords against the provider's id. Providers whose id doesn't happen to   contain a relevant keyword never showed up, even when their
`provider.yaml` declares integrations that obviously belong there.
e.g., `common-ai` (wraps `pydantic-ai`) ships hooks named "Pydantic AI", "MCP Server", "LangChain", and "LlamaIndex", each tagged ai, but none of those words are substrings of the id "common-ai", so it never appeared under AI & Machine Learning or in a search for "LangChain"/"MCP".

## What
Match against each provider's declared integration names (already extracted as provider.categories[].name) in addition to its id, and add the ai-ml category keywords needed for common-ai's integrations. Also scan connection_types[].external_integrations when present so a future field populating that data benefits automatically.

Note on scope: matching by integration name also widens the umbrella providers, since they
declare many integrations — `amazon` goes from 1 category to 4 (Databases, Data Processing, Workflow), `google` 1 to 3, `alibaba` and `cncf-kubernetes` 1 to 2. These memberships are accurate; the id-only matcher just couldn't see them. Expect the same effect from future keyword additions.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
