### PR TITLE
Fix flaky Glue OpenLineage test that calls the real AWS endpoint

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/operators/test_glue.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_glue.py
@@ -769,6 +769,9 @@ class TestGlueJobOperatorOpenLineageInjection:
         mock_ti = mock.MagicMock()
         mock_ti.xcom_pull.return_value = None  # no previous run
         context = {"ti": mock_ti}
+        mock_glue_client = mock.MagicMock()
+        glue.hook.conn = mock_glue_client
+        mock_glue_client.get_job_runs.return_value = {"JobRuns": []}
         glue.execute(context)
 
         mock_inject_parent.assert_called_once()


### PR DESCRIPTION
## Why

- The `test_inject_parent_job_info_with_resume_on_retry` patches `GlueJobHook.get_conn`, but `GlueJobOperator` reads `self.hook.conn`. `AwsBaseHook.conn` calls `get_client_type()` and doesn't go through `get_conn()`, so the patch has no effect and the test builds a real boto3 Glue client. The CI result timeout sometimes.
- Failed Run:
  - https://github.com/apache/airflow/actions/runs/30101195251/job/89516428888
  - https://github.com/apache/airflow/actions/runs/30190105178/job/89762841436
- Error message:

```
TestGlueJobOperatorOpenLineageInjection.test_inject_parent_job_info_with_resume_on_retry ________________________________________________________
  providers/amazon/tests/unit/amazon/aws/operators/test_glue.py:772: in test_inject_parent_job_info_with_resume_on_retry
      glue.execute(context)
  task-sdk/src/airflow/sdk/bases/operator.py:445: in wrapper
      return func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py:302: in execute
      existing = self._find_job_run_id_by_task_uuid(task_uuid)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  providers/amazon/src/airflow/providers/amazon/aws/operators/glue.py:258: in _find_job_run_id_by_task_uuid
      response = self.hook.conn.get_job_runs(**request)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/client.py:602: in _api_call
      return self._make_api_call(operation_name, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/context.py:123: in wrapper
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/client.py:1060: in _make_api_call
      http, parsed_response = self._make_request(
  /usr/python/lib/python3.13/site-packages/botocore/client.py:1084: in _make_request
      return self._endpoint.make_request(operation_model, request_dict)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/endpoint.py:119: in make_request
      return self._send_request(request_dict, operation_model)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/endpoint.py:197: in _send_request
      success_response, exception = self._get_response(
  /usr/python/lib/python3.13/site-packages/botocore/endpoint.py:239: in _get_response
      success_response, exception = self._do_get_response(
  /usr/python/lib/python3.13/site-packages/botocore/endpoint.py:279: in _do_get_response
      http_response = self._send(request)
                      ^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/endpoint.py:383: in _send
      return self.http_session.send(request)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/botocore/httpsession.py:477: in send
      urllib_response = conn.urlopen(
  /usr/python/lib/python3.13/site-packages/urllib3/connectionpool.py:789: in urlopen
      response = self._make_request(
  /usr/python/lib/python3.13/site-packages/urllib3/connectionpool.py:466: in _make_request
      self._validate_conn(conn)
  /usr/python/lib/python3.13/site-packages/urllib3/connectionpool.py:1095: in _validate_conn
      conn.connect()
  /usr/python/lib/python3.13/site-packages/urllib3/connection.py:615: in connect
      self.sock = sock = self._new_conn()
                         ^^^^^^^^^^^^^^^^
  /usr/python/lib/python3.13/site-packages/urllib3/connection.py:196: in _new_conn
      sock = connection.create_connection(
  /usr/python/lib/python3.13/site-packages/urllib3/util/connection.py:73: in create_connection
      sock.connect(sa)
  E   Failed: Timeout >60.0s
```

## How

- Assign `glue.hook.conn` before `execute()` and stub `get_job_runs` to return an empty `JobRuns` list.

## Verification

- `uv run --project providers/amazon pytest providers/amazon/tests/unit/amazon/aws/operators/test_glue.py -q`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
