### PR TITLE
Enable provider-based GCS remote logging resolution

### DIFF
--- a/providers/google/provider.yaml
+++ b/providers/google/provider.yaml
@@ -1489,5 +1489,9 @@ logging:
   - airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler
   - airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverTaskHandler
 
+remote-logging:
+  - classpath: airflow.providers.google.cloud.log.gcs_task_handler.GCSRemoteLogIO
+    scheme: gs
+
 queues:
   - airflow.providers.google.event_scheduling.events.pubsub.PubSubMessageQueueEventTriggerContainer

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 import shutil
@@ -69,6 +70,32 @@ class GCSRemoteLogIO(LoggingMixin):  # noqa: D101
     scopes: Collection[str] | None = _DEFAULT_SCOPESS
 
     processors = ()
+
+    @classmethod
+    def from_config(cls) -> GCSRemoteLogIO:
+        """Build the remote log IO from Airflow logging configuration."""
+        remote_task_handler_kwargs = conf.getjson("logging", "remote_task_handler_kwargs", fallback={})
+        if not isinstance(remote_task_handler_kwargs, dict):
+            raise ValueError(
+                "logging/remote_task_handler_kwargs must be a JSON object (a python dict), we got "
+                f"{type(remote_task_handler_kwargs)}"
+            )
+        # remote_task_handler_kwargs mixes FileTaskHandler kwargs with IO kwargs; only the
+        # latter belong to this class (same split as airflow_local_settings.py).
+        fth_params = frozenset(inspect.signature(FileTaskHandler.__init__).parameters) - {
+            "self",
+            "base_log_folder",
+        }
+        io_kwargs = {k: v for k, v in remote_task_handler_kwargs.items() if k not in fth_params}
+        return cls(
+            **{
+                "base_log_folder": os.path.expanduser(conf.get_mandatory_value("logging", "base_log_folder")),
+                "remote_base": conf.get_mandatory_value("logging", "remote_base_log_folder"),
+                "delete_local_copy": conf.getboolean("logging", "delete_local_logs"),
+                "gcp_key_path": conf.get_mandatory_value("logging", "google_key_path", fallback=None),
+            }
+            | io_kwargs,
+        )
 
     def upload(self, path: os.PathLike | str, ti: RuntimeTI | None = None) -> None:
         """Upload the given log path to the remote storage."""

--- a/providers/google/src/airflow/providers/google/get_provider_info.py
+++ b/providers/google/src/airflow/providers/google/get_provider_info.py
@@ -1705,6 +1705,12 @@ def get_provider_info():
             "airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler",
             "airflow.providers.google.cloud.log.stackdriver_task_handler.StackdriverTaskHandler",
         ],
+        "remote-logging": [
+            {
+                "classpath": "airflow.providers.google.cloud.log.gcs_task_handler.GCSRemoteLogIO",
+                "scheme": "gs",
+            }
+        ],
         "queues": [
             "airflow.providers.google.event_scheduling.events.pubsub.PubSubMessageQueueEventTriggerContainer"
         ],

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -20,6 +20,7 @@ import copy
 import io
 import logging
 import os
+import pathlib
 from types import GeneratorType
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -47,6 +48,88 @@ def patch_mock_client_for_list_blobs(mock_client: MagicMock, blob_names: list[st
         mock_blob.name = name
         mock_blobs.append(mock_blob)
     mock_client.return_value.list_blobs.return_value = mock_blobs
+
+
+class TestGCSRemoteLogIOFromConfig:
+    @conf_vars(
+        {
+            ("logging", "base_log_folder"): "~/airflow/logs",
+            ("logging", "remote_base_log_folder"): "gs://bucket/remote/log/location",
+            ("logging", "delete_local_logs"): "True",
+            ("logging", "google_key_path"): "/tmp/gcs-logging-key.json",
+        }
+    )
+    def test_from_config(self):
+        subject = GCSRemoteLogIO.from_config()
+
+        assert subject.remote_base == "gs://bucket/remote/log/location"
+        assert subject.base_log_folder == pathlib.Path(os.path.expanduser("~/airflow/logs"))
+        assert subject.delete_local_copy is True
+        assert subject.gcp_key_path == "/tmp/gcs-logging-key.json"
+
+    @conf_vars(
+        {
+            ("logging", "base_log_folder"): "/tmp/airflow/logs",
+            ("logging", "remote_base_log_folder"): "gs://bucket/remote/log/location",
+            ("logging", "delete_local_logs"): "False",
+            ("logging", "remote_task_handler_kwargs"): '{"delete_local_copy": true, "max_bytes": 1024}',
+        }
+    )
+    def test_from_config_applies_io_kwargs_and_filters_file_handler_kwargs(self):
+        subject = GCSRemoteLogIO.from_config()
+
+        assert subject.delete_local_copy is True
+        assert not hasattr(subject, "max_bytes")
+
+    @conf_vars({("logging", "remote_task_handler_kwargs"): '["not", "a", "dict"]'})
+    def test_from_config_rejects_non_dict_remote_task_handler_kwargs(self):
+        with pytest.raises(ValueError, match="remote_task_handler_kwargs"):
+            GCSRemoteLogIO.from_config()
+
+    def test_provider_registers_gs_scheme(self):
+        from airflow.providers_manager import ProvidersManager
+
+        manager = ProvidersManager()
+        if not hasattr(manager, "remote_logging_handler_by_scheme"):
+            pytest.skip("Airflow core does not support remote logging provider dispatch")
+
+        info = manager.remote_logging_handler_by_scheme("gs")
+
+        assert info is not None
+        assert info.classpath == "airflow.providers.google.cloud.log.gcs_task_handler.GCSRemoteLogIO"
+
+    @pytest.mark.parametrize(
+        "manager_classpath",
+        [
+            pytest.param("airflow.providers_manager.ProvidersManager", id="core"),
+            pytest.param(
+                "airflow.sdk.providers_manager_runtime.ProvidersManagerTaskRuntime", id="task-runtime"
+            ),
+        ],
+    )
+    @conf_vars(
+        {
+            ("logging", "remote_logging"): "True",
+            ("logging", "remote_base_log_folder"): "gs://bucket/remote/log/location",
+            ("logging", "remote_log_conn_id"): "google_cloud_default",
+        }
+    )
+    def test_resolve_remote_task_log_uses_provider_dispatch_not_local_settings(self, manager_classpath):
+        factory = pytest.importorskip("airflow._shared.logging.factory")
+        from airflow._shared.module_loading import import_string
+        from airflow.configuration import conf
+
+        with mock.patch.object(factory, "discover_remote_log_handler", autospec=True) as legacy_discover:
+            remote_task_log, conn_id = factory.resolve_remote_task_log(
+                conf=conf,
+                providers_manager=import_string(manager_classpath)(),
+                import_string=import_string,
+            )
+
+        assert isinstance(remote_task_log, GCSRemoteLogIO)
+        assert remote_task_log.remote_base == "gs://bucket/remote/log/location"
+        assert conn_id == "google_cloud_default"
+        legacy_discover.assert_not_called()
 
 
 @pytest.mark.db_test


### PR DESCRIPTION
closes: #70266
related: #70265
related: #67056

## Summary

Migrate the `gs` remote logging scheme to the provider dispatch introduced by #67056:

- add `GCSRemoteLogIO.from_config()`, preserving the legacy GCS config mapping and IO kwargs;
- register `gs` in the Google provider metadata generated from `provider.yaml`.

Core and the Task SDK can now resolve GCS logging through `ProvidersManager`. The existing legacy path remains as a compatibility fallback.

## Validation

Tested against a real GCS bucket from Breeze using forwarded user ADC and:

```ini
remote_logging = True
remote_base_log_folder = gs://airflow-70266-<random>/airflow-70266
delete_local_logs = True
```

No `remote_log_conn_id` or `google_key_path` was set, so the handler used ADC.

- `gs` resolved to `airflow.providers.google.cloud.log.gcs_task_handler.GCSRemoteLogIO`;
- the task emitted `AIRFLOW_70266_GCS_REMOTE_LOG_E2E_OK`, and `gcloud storage cat` returned the same marker from `attempt=1.log`;
- the corresponding local log no longer existed after upload;
- the Airflow UI reported the `gs://.../attempt=1.log` source and displayed the marker.

Airflow UI reading the task log from GCS after local cleanup:

<img width="1431" height="533" alt="70266_1" src="https://github.com/user-attachments/assets/4dbd0bc6-1d49-4c29-aa53-ed0e7e3084eb" />

The uploaded `attempt=1.log` in the real GCS bucket:

<img width="1431" height="591" alt="70266_2" src="https://github.com/user-attachments/assets/bdcaba81-e3e7-4662-9cb7-ea9e028e4629" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [GPT 5.6 Sol] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
