### PR TITLE
Fire failure listeners when TriggerDagRunOperator API call fails

### DIFF
--- a/airflow-core/newsfragments/70506.bugfix.rst
+++ b/airflow-core/newsfragments/70506.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``on_task_instance_failed`` and ``on_failure_callback`` not firing when ``TriggerDagRunOperator`` fails to trigger a Dag (e.g. target Dag not found). The API error is now routed through the normal task failure path, so listeners fire and retry policy is honored.

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1626,7 +1626,7 @@ def run(
         try:
             msg, state = _handle_trigger_dag_run(drte, context, ti, log)
         except AirflowRuntimeError as e:
-            # The supervisor reports API-server errors (target DAG not found, permission
+            # The supervisor reports API-server errors (target Dag not found, permission
             # denied, ...) by raising here. Route through the normal failure path so
             # finalize() fires failure listeners; re-raising would escape run() entirely
             # and skip finalize().

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1623,7 +1623,16 @@ def run(
         msg, state = _handle_current_task_success(context, ti)
     except DagRunTriggerException as drte:
         log.info("::group::Post Execute")
-        msg, state = _handle_trigger_dag_run(drte, context, ti, log)
+        try:
+            msg, state = _handle_trigger_dag_run(drte, context, ti, log)
+        except AirflowRuntimeError as e:
+            # The supervisor reports API-server errors (target DAG not found, permission
+            # denied, ...) by raising here. Route through the normal failure path so
+            # finalize() fires failure listeners; re-raising would escape run() entirely
+            # and skip finalize().
+            log.exception("Triggering Dag Run failed")
+            msg, state = _handle_current_task_failed(ti, e, log, context)
+            error = e
     except TaskDeferred as defer:
         log.info("::group::Post Execute")
         msg, state = _defer_task(defer, ti, log)

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -133,6 +133,7 @@ from airflow.sdk.execution_time.comms import (
     PreviousTIResult,
     PrevSuccessfulDagRunResult,
     RescheduleTask,
+    RetryTask,
     SetAssetStateStoreByName,
     SetAssetStateStoreByUri,
     SetRenderedFields,
@@ -5188,6 +5189,72 @@ class TestTriggerDagRunOperator:
         # The original error must surface, not UnboundLocalError on ``state``.
         with pytest.raises(_TriggerSendError):
             run(ti, ti.get_template_context(), log)
+
+    @pytest.mark.parametrize(
+        ("should_retry", "expected_state"),
+        [
+            (False, TaskInstanceState.FAILED),
+            (True, TaskInstanceState.UP_FOR_RETRY),
+        ],
+    )
+    @time_machine.travel("2025-01-01 00:00:00", tick=False)
+    def test_handle_trigger_dag_run_api_error_fails_task(
+        self, should_retry, expected_state, create_runtime_ti, mock_supervisor_comms
+    ):
+        """API errors (e.g. 404 target DAG not found) must route through the failure path.
+
+        Regression test: the AirflowRuntimeError used to escape run() entirely, so
+        finalize() never ran and on_task_instance_failed listeners were never called.
+        """
+        from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
+
+        task = TriggerDagRunOperator(
+            task_id="test_task",
+            trigger_dag_id="missing_dag",
+            trigger_run_id="test_run_id",
+        )
+        ti = create_runtime_ti(
+            dag_id="test_handle_trigger_dag_run_api_error_fails_task",
+            run_id="test_run",
+            task=task,
+            should_retry=should_retry,
+        )
+
+        api_error = AirflowRuntimeError(
+            error=ErrorResponse(
+                error=ErrorType.API_SERVER_ERROR,
+                detail={
+                    "status_code": 404,
+                    "detail": {"reason": "not_found", "message": "Dag with dag_id: 'missing_dag' not found"},
+                },
+            )
+        )
+
+        def _send(msg=None, **kwargs):
+            # Fail only the TriggerDagRun comms (the call that 404s for a missing DAG).
+            if isinstance(msg, TriggerDagRun):
+                raise api_error
+            return mock.DEFAULT
+
+        mock_supervisor_comms.send.side_effect = _send
+
+        log = mock.MagicMock()
+
+        state, _, error = run(ti, ti.get_template_context(), log)
+
+        assert state == expected_state
+        assert error is api_error
+        # The success-path xcom must not be pushed; a terminal state must reach the supervisor
+        sent_msgs = [
+            call.args[0] if call.args else call.kwargs["msg"]
+            for call in mock_supervisor_comms.send.call_args_list
+        ]
+        assert not any(isinstance(sent, SetXCom) and sent.key == "trigger_run_id" for sent in sent_msgs)
+        if should_retry:
+            assert isinstance(sent_msgs[-1], RetryTask)
+        else:
+            assert isinstance(sent_msgs[-1], TaskState)
+            assert sent_msgs[-1].state == TaskInstanceState.FAILED
 
     @pytest.mark.parametrize(
         ("allowed_states", "failed_states", "target_dr_state", "expected_task_state"),

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5201,13 +5201,11 @@ class TestTriggerDagRunOperator:
     def test_handle_trigger_dag_run_api_error_fails_task(
         self, should_retry, expected_state, create_runtime_ti, mock_supervisor_comms
     ):
-        """API errors (e.g. 404 target DAG not found) must route through the failure path.
+        """API errors (e.g. 404 target Dag not found) must route through the failure path.
 
         Regression test: the AirflowRuntimeError used to escape run() entirely, so
         finalize() never ran and on_task_instance_failed listeners were never called.
         """
-        from airflow.providers.standard.operators.trigger_dagrun import TriggerDagRunOperator
-
         task = TriggerDagRunOperator(
             task_id="test_task",
             trigger_dag_id="missing_dag",


### PR DESCRIPTION
When `TriggerDagRunOperator` targets a nonexistent Dag (or the API server otherwise rejects the trigger with 403/5xx), the supervisor reports the error by raising `AirflowRuntimeError` from the `TriggerDagRun` comms round-trip. That raise happens inside `run()`'s `except DagRunTriggerException` handler, and an exception raised in an except handler is not caught by the sibling except clauses — it escaped `run()` entirely. `main()` then never reached `finalize()`, the only place `on_task_instance_failed` / `on_failure_callback` listeners run. The task still showed FAILED in the UI (via the supervisor's exit-code fallback), but alerting plugins were silently skipped for exactly this failure mode.

The fix routes the error through the normal failure path (`_handle_current_task_failed`), so the task returns a terminal state, `finalize()` fires the listeners, and retry policy is honored (`UP_FOR_RETRY` when retries remain).

Relationship to prior work on #63089: the reported `UnboundLocalError` symptom was already fixed by #67955 (the `state` variable is now initialized and the `ti.finish` stats emission is guarded), and #63207 was an earlier, unmerged attempt at the full fix. What remains — and what this PR addresses — is the API error escaping `run()` entirely, which silently skips failure listeners, failure callbacks, and retry handling.

Regression tests cover both the no-retry (`FAILED`) and retry (`UP_FOR_RETRY`) paths, asserting the terminal state reaches the supervisor instead of the error escaping `run()`.

closes: #63089

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Kimi Code CLI

Generated-by: Kimi Code CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
