### PR TITLE
Fail Neo4jOperator argument mistakes at Dag parse time

### DIFF
--- a/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
+++ b/providers/neo4j/src/airflow/providers/neo4j/operators/neo4j.py
@@ -57,6 +57,10 @@ class Neo4jOperator(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
+        if sql is not None and cypher is not None:
+            raise ValueError("Cannot provide both `sql` and `cypher`. Use `cypher` only.")
+        if cypher is None and sql is None:
+            raise ValueError("Parameter `cypher` is required.")
         self.neo4j_conn_id = neo4j_conn_id
         self.cypher = cypher
         self.sql = sql
@@ -70,10 +74,10 @@ class Neo4jOperator(BaseOperator):
                 AirflowProviderDeprecationWarning,
                 stacklevel=2,
             )
-            if cypher is not None:
-                raise ValueError("Cannot provide both `sql` and `cypher`. Use `cypher` only.")
             cypher = self.sql
         if cypher is None:
+            # The constructor only sees whether the argument was passed; a passed field can still
+            # render to None, and the hook needs a query string.
             raise ValueError("Parameter `cypher` is required.")
 
         self.log.info("Executing: %s", cypher)

--- a/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
+++ b/providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py
@@ -66,15 +66,17 @@ class TestNeo4jOperator:
             op.execute(mock.MagicMock())
         mock_hook.return_value.run.assert_called_once_with(cypher, None)
 
-    def test_neo4j_operator_both_sql_and_cypher_raises_on_execute(self):
-        op = Neo4jOperator(task_id="basic_neo4j", sql="a", cypher="b")
+    def test_neo4j_operator_both_sql_and_cypher_raises(self):
+        with pytest.raises(ValueError, match="Cannot provide both `sql` and `cypher`"):
+            Neo4jOperator(task_id="basic_neo4j", sql="a", cypher="b")
 
-        with pytest.warns(AirflowProviderDeprecationWarning):
-            with pytest.raises(ValueError, match="Cannot provide both `sql` and `cypher`"):
-                op.execute(mock.MagicMock())
+    def test_neo4j_operator_missing_cypher_raises(self):
+        with pytest.raises(ValueError, match="Parameter `cypher` is required."):
+            Neo4jOperator(task_id="basic_neo4j")
 
-    def test_neo4j_operator_missing_cypher_raises_on_execute(self):
-        op = Neo4jOperator(task_id="basic_neo4j")
+    def test_neo4j_operator_cypher_rendering_to_none_raises_on_execute(self):
+        op = Neo4jOperator(task_id="basic_neo4j", cypher="{{ missing }}")
+        op.cypher = None
 
         with pytest.raises(ValueError, match="Parameter `cypher` is required."):
             op.execute(mock.MagicMock())


### PR DESCRIPTION
> [!NOTE]
> Blocked on #70505. The `validate-operators-init` hook on `main` still flags
> `is None` provision checks in `__init__`, so CI will be red until that merges.
> Kept as a draft until then — verified clean against the checker from #70505
> (exit 0, no exemption entry needed).

Moves the two argument-provision checks of `Neo4jOperator` back to `__init__`, one of the reverts tracked in #70503.

Whether `cypher` or `sql` was passed is a property of how the Dag was written, not of the rendered value. `execute()` cannot answer it: with `render_template_as_native_obj=True` a supplied field can render to `None`, so the check there reports an argument the author did provide as missing. Checking at construction also turns a static authoring mistake into a Dag import error rather than a failure on every task instance.

**Both** provision checks move, not only `cypher is None`. After #70373 the operator keeps `sql` and `cypher` as separate fields, so `Neo4jOperator(sql=...)` is valid with `cypher` unset — the constructor check has to be `cypher is None and sql is None`. Once it is written that way, leaving the mutual-exclusivity check in `execute()` would split two checks that ask the same question across two phases.

The `execute()` guard is kept deliberately: `Neo4jHook.run` takes a `str`, and the constructor check does not narrow `self.cypher` to `str` (it is legitimately `None` when `sql` was used). A passed field can also render to `None`, which is exactly the case the guard covers. `cast` would hide that and `assert` is not allowed in production code.

<details><summary>Testing done</summary>

- `providers/neo4j/tests/unit/neo4j/operators/test_neo4j.py`: 6 passed. The two
  reverted tests assert construction-time failure again; a new test covers the
  `execute()` guard by rendering a supplied field to `None`.
- Checker from #70505 on the operator: exit 0 — no exemption entry needs re-adding.
- Checker on `main`: exit 1, as expected before #70505 merges.
- `breeze run mypy` on the operator: clean.

</details>

related: #70503, #70505

---

Drafted-by: Claude Code (Opus 5); reviewed by @ColtenOuO before posting