### PR TITLE
Ignore hidden directories when listing UI translation locales

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ui_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ui_commands.py
@@ -191,7 +191,7 @@ def get_locale_files() -> list[LocaleFiles]:
             locale=locale_dir.name, files=[f.name for f in locale_dir.iterdir() if f.suffix == ".json"]
         )
         for locale_dir in LOCALES_DIR.iterdir()
-        if locale_dir.is_dir()
+        if locale_dir.is_dir() and not locale_dir.name.startswith(".")
     ]
 
 

--- a/dev/breeze/tests/test_ui_commands.py
+++ b/dev/breeze/tests/test_ui_commands.py
@@ -25,6 +25,7 @@ from airflow_breeze.commands.ui_commands import (
     compare_keys,
     expand_plural_keys,
     flatten_keys,
+    get_locale_files,
     get_plural_base,
 )
 
@@ -273,6 +274,22 @@ class TestCompareKeys:
             # Previously these could be falsely flagged as unused.
             assert "dagWarnings.error_few" not in summary["test.json"].unused_keys.get("pl", [])
             assert "dagWarnings.error_many" not in summary["test.json"].unused_keys.get("pl", [])
+        finally:
+            ui_commands.LOCALES_DIR = original_locales_dir
+
+
+class TestGetLocaleFiles:
+    def test_hidden_directories_are_not_treated_as_locales(self, tmp_path):
+        (tmp_path / "en").mkdir()
+        (tmp_path / "en" / "common.json").write_text(json.dumps({"greeting": "Hello"}))
+        (tmp_path / ".claude" / ".cc-writes").mkdir(parents=True)
+
+        import airflow_breeze.commands.ui_commands as ui_commands
+
+        original_locales_dir = ui_commands.LOCALES_DIR
+        ui_commands.LOCALES_DIR = tmp_path
+        try:
+            assert get_locale_files() == [LocaleFiles(locale="en", files=["common.json"])]
         finally:
             ui_commands.LOCALES_DIR = original_locales_dir
 


### PR DESCRIPTION
`breeze ui check-translation-completeness` (and the other `breeze ui` translation commands) treated **every** subdirectory of `airflow-core/src/airflow/ui/public/i18n/locales/` as a locale, including dot-directories left behind by agent/editor tooling — e.g. a stray `.claude/.cc-writes/` scratch dir, which git never surfaces because empty directories are untracked.

The result was a hard failure with a misleading message that gives no hint the directory is not a locale at all:

```
Error: No plural suffixes defined for language '.claude'.
```

`get_locale_files()` now skips directories whose name starts with `.`, plus a regression test.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)