### PR TITLE
Add ElasticsearchRemoteLogIO.from_config and register elasticsearch scheme

### DIFF
--- a/providers/elasticsearch/docs/logging/index.rst
+++ b/providers/elasticsearch/docs/logging/index.rst
@@ -37,6 +37,19 @@ First, to use the handler, ``airflow.cfg`` must be configured as follows:
     [elasticsearch]
     host = <host>:<port>
 
+On Airflow 3.x you can also route remote logging to Elasticsearch through the provider
+dispatch mechanism by adding an ``elasticsearch://`` scheme to
+``[logging] remote_base_log_folder``:
+
+.. code-block:: ini
+
+    [logging]
+    remote_logging = True
+    remote_base_log_folder = elasticsearch://
+
+    [elasticsearch]
+    host = <host>:<port>
+
 To output task logs to stdout in JSON format, the following config could be used:
 
 .. code-block:: ini

--- a/providers/elasticsearch/provider.yaml
+++ b/providers/elasticsearch/provider.yaml
@@ -116,6 +116,10 @@ connection-types:
 logging:
   - airflow.providers.elasticsearch.log.es_task_handler.ElasticsearchTaskHandler
 
+remote-logging:
+  - classpath: airflow.providers.elasticsearch.log.es_task_handler.ElasticsearchRemoteLogIO
+    scheme: elasticsearch
+
 config:
   elasticsearch:
     description: ~

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/get_provider_info.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/get_provider_info.py
@@ -48,6 +48,12 @@ def get_provider_info():
             }
         ],
         "logging": ["airflow.providers.elasticsearch.log.es_task_handler.ElasticsearchTaskHandler"],
+        "remote-logging": [
+            {
+                "classpath": "airflow.providers.elasticsearch.log.es_task_handler.ElasticsearchRemoteLogIO",
+                "scheme": "elasticsearch",
+            }
+        ],
         "config": {
             "elasticsearch": {
                 "description": None,

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -724,7 +724,7 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
         return cls(
             base_log_folder=os.path.expanduser(conf.get_mandatory_value("logging", "base_log_folder")),
             delete_local_copy=conf.getboolean("logging", "delete_local_logs"),
-            host=conf.get("elasticsearch", "host", fallback=""),
+            host=conf.get("elasticsearch", "host") or "http://localhost:9200",
             target_index=conf.get_mandatory_value("elasticsearch", "target_index"),
             write_stdout=conf.getboolean("elasticsearch", "write_stdout"),
             write_to_es=conf.getboolean("elasticsearch", "write_to_es"),

--- a/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/providers/elasticsearch/src/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -712,6 +712,28 @@ class ElasticsearchRemoteLogIO(LoggingMixin):  # noqa: D101
 
     processors = ()
 
+    @classmethod
+    def from_config(cls) -> ElasticsearchRemoteLogIO:
+        """
+        Build the remote log IO from Airflow logging and ``[elasticsearch]`` configuration.
+
+        Mirrors the legacy branch in ``airflow_local_settings.py``. Unlike the object-storage
+        backends, this does not merge ``[logging] remote_task_handler_kwargs`` IO-kwargs, matching
+        the legacy behavior for Elasticsearch.
+        """
+        return cls(
+            base_log_folder=os.path.expanduser(conf.get_mandatory_value("logging", "base_log_folder")),
+            delete_local_copy=conf.getboolean("logging", "delete_local_logs"),
+            host=conf.get("elasticsearch", "host", fallback=""),
+            target_index=conf.get_mandatory_value("elasticsearch", "target_index"),
+            write_stdout=conf.getboolean("elasticsearch", "write_stdout"),
+            write_to_es=conf.getboolean("elasticsearch", "write_to_es"),
+            json_format=conf.getboolean("elasticsearch", "json_format"),
+            host_field=conf.get_mandatory_value("elasticsearch", "host_field"),
+            offset_field=conf.get_mandatory_value("elasticsearch", "offset_field"),
+            log_id_template=conf.get_mandatory_value("elasticsearch", "log_id_template"),
+        )
+
     def __attrs_post_init__(self):
         es_kwargs = get_es_kwargs_from_config()
         self.client = apply_compat_with(elasticsearch.Elasticsearch(self.host, **es_kwargs))

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
+import os
 import re
 from io import StringIO
 from pathlib import Path
@@ -1016,3 +1017,47 @@ class TestSafeBuildStructuredLogMessage:
         assert result.event == str(["a", "b"])
         assert result.timestamp is not None
         mock_logger.debug.assert_called_once()
+
+
+class TestElasticsearchRemoteLogIOFromConfig:
+    @conf_vars(
+        {
+            ("logging", "base_log_folder"): "~/airflow/logs",
+            ("logging", "delete_local_logs"): "True",
+            ("elasticsearch", "host"): "http://elasticsearch.example.com:9200",
+            ("elasticsearch", "target_index"): "my-logs",
+            ("elasticsearch", "write_stdout"): "True",
+            ("elasticsearch", "write_to_es"): "True",
+            ("elasticsearch", "json_format"): "True",
+            ("elasticsearch", "host_field"): "host.name",
+            ("elasticsearch", "offset_field"): "log.offset",
+            ("elasticsearch", "log_id_template"): "{dag_id}-{task_id}-{run_id}",
+        }
+    )
+    def test_from_config(self):
+        subject = ElasticsearchRemoteLogIO.from_config()
+
+        assert subject.base_log_folder == Path(os.path.expanduser("~/airflow/logs"))
+        assert subject.delete_local_copy is True
+        assert subject.host == "http://elasticsearch.example.com:9200"
+        assert subject.target_index == "my-logs"
+        assert subject.write_stdout is True
+        assert subject.write_to_es is True
+        assert subject.json_format is True
+        assert subject.host_field == "host.name"
+        assert subject.offset_field == "log.offset"
+        assert subject.log_id_template == "{dag_id}-{task_id}-{run_id}"
+
+    def test_provider_registers_elasticsearch_scheme(self):
+        from airflow.providers_manager import ProvidersManager
+
+        manager = ProvidersManager()
+        if not hasattr(manager, "remote_logging_handler_by_scheme"):
+            pytest.skip("Airflow core does not support remote logging provider dispatch")
+
+        info = manager.remote_logging_handler_by_scheme("elasticsearch")
+
+        assert info is not None
+        assert (
+            info.classpath == "airflow.providers.elasticsearch.log.es_task_handler.ElasticsearchRemoteLogIO"
+        )

--- a/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
+++ b/providers/elasticsearch/tests/unit/elasticsearch/log/test_es_task_handler.py
@@ -1048,6 +1048,23 @@ class TestElasticsearchRemoteLogIOFromConfig:
         assert subject.offset_field == "log.offset"
         assert subject.log_id_template == "{dag_id}-{task_id}-{run_id}"
 
+    @conf_vars(
+        {
+            ("logging", "base_log_folder"): "~/airflow/logs",
+            ("elasticsearch", "host"): "",
+            ("elasticsearch", "target_index"): "my-logs",
+            ("elasticsearch", "host_field"): "host",
+            ("elasticsearch", "offset_field"): "offset",
+            ("elasticsearch", "log_id_template"): "{dag_id}-{task_id}-{run_id}",
+        }
+    )
+    def test_from_config_missing_host_keeps_class_default(self):
+        # An empty [elasticsearch] host must not override the class default with "", which would
+        # make elasticsearch.Elasticsearch("") raise and silently disable remote logging.
+        subject = ElasticsearchRemoteLogIO.from_config()
+
+        assert subject.host == "http://localhost:9200"
+
     def test_provider_registers_elasticsearch_scheme(self):
         from airflow.providers_manager import ProvidersManager
 


### PR DESCRIPTION


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

closes: #70271
related: #70265
related: #67056

Migrates the Elasticsearch remote-logging backend to the provider dispatch mechanism: adds `ElasticsearchRemoteLogIO.from_config()` and registers an `elasticsearch` scheme, so `[logging] remote_base_log_folder = elasticsearch://` routes through the provider.

The legacy host-based selection still works via the fallback in `airflow_local_settings.py`, so existing configs are unaffected.

### End-to-end verification
`breeze start-airflow --integration elasticsearch`, `remote_base_log_folder = elasticsearch://`, ran a task with remote logging enabled.

**Written to Elasticsearch:**
```
[Breeze:3.10.20] root@e01884b83d1e:/opt/airflow$ curl -s "http://elasticsearch:9200/_cat/indices?v" | grep airflow-logs
yellow open   airflow-logs lejo5BB3RJa-3h0J0fzmBA   1   1         10            0     20.7kb         20.7kb       20.7kb
[Breeze:3.10.20] root@e01884b83d1e:/opt/airflow$ curl -s "http://elasticsearch:9200/airflow-logs/_search?size=1&pretty" | head -40
{
  "took" : 1104,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 10,
      "relation" : "eq"
    },
    "max_score" : 1.0,
    "hits" : [
      {
        "_index" : "airflow-logs",
        "_id" : "urj5o58BYIM3Bhrt3lZ7",
        "_score" : 1.0,
        "_source" : {
          "timestamp" : "2026-07-27T14:27:55.643862Z",
          "level" : "info",
          "event" : "::group::Pre Execute",
          "logger" : "task",
          "filename" : "task_runner.py",
          "lineno" : 2356,
          "log_id" : "example_xcom-push_sample_xcoms-manual__2026-07-27T14:27:53.127874+00:00--1-1",
          "offset" : 1
        }
      }
    ]
  }
}
```

**Read back in the UI:**

<img width="566" height="159" alt="image" src="https://github.com/user-attachments/assets/76e4bdd1-ebd7-4f35-8985-cfbdd2d3fa89" />


---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
  - Opus 4.8

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
