### PR TITLE
Normalize BigQuery DTS sensor expected statuses after rendering

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py
@@ -99,7 +99,7 @@ class BigQueryDataTransferServiceTransferRunSensor(BaseSensorOperator):
         self.retry = retry
         self.request_timeout = request_timeout
         self.metadata = metadata
-        self.expected_statuses = self._normalize_state_list(expected_statuses)
+        self.expected_statuses = expected_statuses
         self.project_id = project_id
         self.gcp_cloud_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
@@ -144,4 +144,4 @@ class BigQueryDataTransferServiceTransferRunSensor(BaseSensorOperator):
         if run.state in (TransferState.FAILED, TransferState.CANCELLED):
             message = f"Transfer {self.run_id} did not succeed"
             raise AirflowException(message)
-        return run.state in self.expected_statuses
+        return run.state in self._normalize_state_list(self.expected_statuses)

--- a/providers/google/tests/unit/google/cloud/sensors/test_bigquery_dts.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_bigquery_dts.py
@@ -89,3 +89,20 @@ class TestBigQueryDataTransferServiceTransferRunSensor:
             retry=DEFAULT,
             timeout=None,
         )
+
+    @mock.patch(
+        "airflow.providers.google.cloud.sensors.bigquery_dts.BiqQueryDataTransferServiceHook",
+        return_value=MM(get_transfer_run=MM(return_value=MM(state=TransferState.SUCCEEDED))),
+    )
+    def test_templated_expected_statuses_normalized_at_poke_time(self, mock_hook):
+        op = BigQueryDataTransferServiceTransferRunSensor(
+            transfer_config_id=TRANSFER_CONFIG_ID,
+            run_id=RUN_ID,
+            task_id="id",
+            project_id=PROJECT_ID,
+            expected_statuses="{{ var.value.expected_status }}",
+        )
+        # Template rendering replaces the Jinja expression with the resolved value before poke.
+        op.expected_statuses = "succeeded"
+
+        assert op.poke({}) is True

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -16,7 +16,6 @@ providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::Datap
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/functions.py::CloudFunctionDeployFunctionOperator
 providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSFileTransformOperator
-providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py::BigQueryDataTransferServiceTransferRunSensor
 providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py::CloudComposerExternalTaskSensor
 providers/google/src/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py::AzureFileShareToGCSOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py::GCSToBigQueryOperator


### PR DESCRIPTION
Part of the template-field validation burn-down tracked in #70296.

`BigQueryDataTransferServiceTransferRunSensor` lists `expected_statuses` in `template_fields` but converts it to `TransferState` members in `__init__` via `_normalize_state_list`, so passing a Jinja expression raised `KeyError` at parse time. The sensor now stores the raw value and normalizes it in `poke`, after rendering.

Added a test constructing the sensor with a templated `expected_statuses` that passes once the field holds the rendered value — it fails against the previous implementation. The class is removed from the exemption list and the `validate-operators-init` check passes locally.

Per the discussion in #70505 this is a genuine value transformation (not an argument-provision check), so it belongs at execute time.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)