### PR TITLE
Validate storage transfer job body after template rendering

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -257,19 +257,19 @@ class CloudDataTransferServiceCreateJobOperator(GoogleCloudBaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.body = body
-        if isinstance(self.body, dict):
-            self.body = deepcopy(body)
         self.aws_conn_id = aws_conn_id
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self.project_id = project_id
         self.google_impersonation_chain = google_impersonation_chain
-        self._validate_inputs()
 
     def _validate_inputs(self) -> None:
         TransferJobValidator(body=self.body).validate_body()
 
     def execute(self, context: Context) -> dict:
+        if isinstance(self.body, dict):
+            self.body = deepcopy(self.body)
+        self._validate_inputs()
         TransferJobPreprocessor(body=self.body, aws_conn_id=self.aws_conn_id).process_body()
         hook = CloudDataTransferServiceHook(
             api_version=self.api_version,

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_storage_transfer_service.py
@@ -286,6 +286,18 @@ class TestGcpStorageTransferJobCreateOperator:
     @mock.patch(
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook"
     )
+    def test_templated_body_validated_at_execute_time(self, mock_hook):
+        op = CloudDataTransferServiceCreateJobOperator(body="{{ var.value.body }}", task_id=TASK_ID)
+        # Template rendering replaces the Jinja expression with the resolved value before execute.
+        op.body = {"transferSpec": {"awsS3DataSource": {"awsAccessKey": TEST_AWS_ACCESS_KEY}}}
+
+        with pytest.raises(AirflowException, match="AWS credentials detected inside the body parameter"):
+            op.execute(context=mock.MagicMock())
+        mock_hook.return_value.create_transfer_job.assert_not_called()
+
+    @mock.patch(
+        "airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceHook"
+    )
     def test_job_create_gcs(self, mock_hook):
         mock_hook.return_value.create_transfer_job.return_value = VALID_TRANSFER_JOB_GCS
         body = deepcopy(VALID_TRANSFER_JOB_GCS)

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -19,7 +19,6 @@ providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py
 providers/google/src/airflow/providers/google/cloud/operators/bigquery.py::BigQueryInsertJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator
-providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py::CloudDataTransferServiceCreateJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocCreateClusterOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/functions.py::CloudFunctionDeployFunctionOperator


### PR DESCRIPTION
Part of the template-field validation burn-down tracked in #70296.

`CloudDataTransferServiceCreateJobOperator` lists `body` in `template_fields` but deep-copies and validates it in `__init__`. With a fully templated `body` (a Jinja expression or XComArg), the validator ran against the un-rendered expression, so `TransferJobValidator`'s checks — the AWS-credential restriction and the single-data-source rule — were silently bypassed. The deep copy and validation now run at the start of `execute()`, against the rendered value, right before `TransferJobPreprocessor` mutates the body.

Added a test constructing the operator with a templated `body` that renders to a body embedding AWS credentials — with the previous implementation the credential check never fires and the job is created; now it raises before calling the hook. The class is removed from the exemption list and the `validate-operators-init` check passes locally.

Per the discussion in #70505 this is a genuine value read (validation of the rendered dict), not an argument-provision check.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)