### PR TITLE
Preserve absolute zero fields when serializing relativedelta

### DIFF
--- a/airflow-core/src/airflow/serialization/encoders.py
+++ b/airflow-core/src/airflow/serialization/encoders.py
@@ -119,7 +119,8 @@ def encode_expand_input(var: ExpandInput) -> dict[str, Any]:
 
 def encode_relativedelta(var: relativedelta) -> dict[str, Any]:
     """Encode a relativedelta object."""
-    encoded = {k: v for k, v in var.__dict__.items() if not k.startswith("_") and v}
+    defaults = type(var)().__dict__
+    encoded = {k: v for k, v in var.__dict__.items() if not k.startswith("_") and v != defaults[k]}
     if var.weekday and var.weekday.n:
         # Every n'th Friday for example
         encoded["weekday"] = [var.weekday.weekday, var.weekday.n]

--- a/airflow-core/tests/unit/serialization/test_dag_serialization.py
+++ b/airflow-core/tests/unit/serialization/test_dag_serialization.py
@@ -1220,6 +1220,11 @@ class TestStringifiedDAGs:
                 relativedelta(weekday=FR(2)),
                 {"__type": "relativedelta", "__var": {"weekday": [4, 2]}},
             ),
+            # First of the month at midnight: all absolute time fields are 0 and must be kept.
+            (
+                relativedelta(day=1, hour=0, minute=0, second=0),
+                {"__type": "relativedelta", "__var": {"day": 1, "hour": 0, "minute": 0, "second": 0}},
+            ),
         ],
     )
     def test_roundtrip_relativedelta(self, val, expected):


### PR DESCRIPTION
`encode_relativedelta` dropped absolute fields set to `0` (e.g. `hour=0` for midnight) because it filtered with `and v`. Relative fields default to `0` and can be omitted; absolute fields default to `None`, so `0` is meaningful and must be kept.

A schedule like `relativedelta(weekday=FR, hour=0, minute=0, second=0)` therefore lost the midnight snap after Dag serialization. After decode, the delta only retained `weekday` and applied the base datetime's wall clock (e.g. 15:30:45) instead of 00:00:00.

**Fix:** encode only fields that differ from an empty `relativedelta()`. That keeps absolute zeros (`hour=0` ≠ default `None`) and still drops relative zeros (`hours=0` is the default).

Round-trip coverage added for first of month at midnight (`day=1` + zero absolute time fields).

```python
# before: hour=0 stripped
encode(relativedelta(weekday=FR, hour=0))  # {"weekday": [4]}

# after: hour=0 preserved
encode(relativedelta(weekday=FR, hour=0))  # {"hour": 0, "weekday": [4]}
```

closes: #70527

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.