### PR TITLE
Use built-in exceptions for JDBC sqlalchemy connection extras

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -338,7 +338,6 @@ providers/http/src/airflow/providers/http/operators/http.py::2
 providers/http/src/airflow/providers/http/triggers/http.py::1
 providers/http/tests/unit/http/sensors/test_http.py::2
 providers/imap/src/airflow/providers/imap/hooks/imap.py::1
-providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py::2
 providers/jenkins/src/airflow/providers/jenkins/operators/jenkins_job_trigger.py::4
 providers/jenkins/src/airflow/providers/jenkins/sensors/jenkins.py::1
 providers/keycloak/src/airflow/providers/keycloak/auth_manager/keycloak_auth_manager.py::4

--- a/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
+++ b/providers/jdbc/src/airflow/providers/jdbc/hooks/jdbc.py
@@ -27,7 +27,6 @@ from urllib.parse import quote_plus, urlencode
 import jaydebeapi
 from sqlalchemy.engine import URL
 
-from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.common.sql.hooks.sql import DbApiHook
 
 if TYPE_CHECKING:
@@ -154,10 +153,10 @@ class JdbcHook(DbApiHook):
         conn = self.connection
         sqlalchemy_query = conn.extra_dejson.get("sqlalchemy_query", {})
         if not isinstance(sqlalchemy_query, dict):
-            raise AirflowException("The parameter 'sqlalchemy_query' must be of type dict!")
+            raise TypeError("The parameter 'sqlalchemy_query' must be of type dict!")
         sqlalchemy_scheme = conn.extra_dejson.get("sqlalchemy_scheme")
         if sqlalchemy_scheme is None:
-            raise AirflowException(
+            raise ValueError(
                 "The parameter 'sqlalchemy_scheme' must be defined in extra for JDBC connections!"
             )
         return URL.create(

--- a/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
+++ b/providers/jdbc/tests/unit/jdbc/hooks/test_jdbc.py
@@ -31,7 +31,6 @@ import jaydebeapi
 import pytest
 
 from airflow.models import Connection
-from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.jdbc.hooks.jdbc import JdbcHook, suppress_and_warn
 
 jdbc_conn_mock = Mock(name="jdbc_conn")
@@ -217,7 +216,7 @@ class TestJdbcHook:
         hook_params = {"driver_path": "ParamDriverPath", "driver_class": "ParamDriverClass"}
         hook = get_hook(hook_params=hook_params)
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(ValueError, match="'sqlalchemy_scheme' must be defined"):
             hook.sqlalchemy_url
 
     def test_sqlalchemy_url_with_sqlalchemy_scheme(self):
@@ -243,7 +242,7 @@ class TestJdbcHook:
         hook_params = {"driver_path": "ParamDriverPath", "driver_class": "ParamDriverClass"}
         hook = get_hook(conn_params=conn_params, hook_params=hook_params)
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(TypeError, match="'sqlalchemy_query' must be of type dict"):
             hook.sqlalchemy_url
 
     def test_get_sqlalchemy_engine_verify_creator_is_being_used(self):


### PR DESCRIPTION
Part of the ongoing clean-up of broad `AirflowException` usages (enforced by the `check-no-new-airflow-exceptions` ratchet), following the pattern of #66279.

`JdbcHook.sqlalchemy_url` raised `AirflowException` for two input-validation failures in the connection extras: a `sqlalchemy_query` that is not a dict (now `TypeError`) and a missing `sqlalchemy_scheme` (now `ValueError`). The `known_airflow_exceptions.txt` entry for the file drops from 2 to 0, and the two existing tests now assert the specific exception types and messages.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)