### PR TITLE
Keep Grid scroll position when opening a task.

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/BaseLayout.tsx
@@ -24,6 +24,7 @@ import { Outlet } from "react-router-dom";
 import { usePluginServiceGetPlugins } from "openapi/queries";
 import type { ReactAppResponse } from "openapi/requests/types.gen";
 import { KeyboardShortcutsModal } from "src/components/KeyboardShortcuts";
+import { useResetGridScrollOnLeave } from "src/layouts/Details/Grid/useGridScrollRestoration";
 import { ReactPlugin } from "src/pages/ReactPlugin";
 import { useConfig } from "src/queries/useConfig";
 import { DocumentTitleProvider } from "src/utils";
@@ -34,6 +35,8 @@ export const BaseLayout = ({ children }: PropsWithChildren) => {
   const { i18n } = useTranslation();
   const { data: pluginData } = usePluginServiceGetPlugins();
   const theme = useConfig("theme") as unknown as { icon?: string; icon_dark_mode?: string } | undefined;
+
+  useResetGridScrollOnLeave();
 
   const baseReactPlugins =
     pluginData?.plugins

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/Grid.tsx
@@ -42,6 +42,7 @@ import { TaskNames } from "./TaskNames";
 import { GANTT_ROW_OFFSET_PX, GRID_HEADER_HEIGHT_PX, GRID_HEADER_PADDING_PX, ROW_HEIGHT } from "./constants";
 import { useGridPagination } from "./useGridPagination";
 import { useGridRunsWithVersionFlags } from "./useGridRunsWithVersionFlags";
+import { useGridScrollRestoration } from "./useGridScrollRestoration";
 import { estimateTaskNameColumnWidthPx, flattenNodes } from "./utils";
 
 dayjs.extend(dayjsDuration);
@@ -180,15 +181,22 @@ export const Grid = ({
   const handleCellClick = useCallback(() => setMode(NavigationModes.TI), [setMode]);
   const handleColumnClick = useCallback(() => setMode(NavigationModes.RUN), [setMode]);
 
+  // Stable ref shared by the virtualizer and the scroll-restoration hook (Grid is not auto-memoized).
+  const getScrollElement = useCallback(
+    (): HTMLDivElement | null =>
+      usesSharedScroll ? (sharedScrollContainerRef?.current ?? null) : scrollContainerRef.current,
+    [usesSharedScroll, sharedScrollContainerRef],
+  );
+
   const rowVirtualizer = useVirtualizer({
     count: flatNodes.length,
     estimateSize: () => ROW_HEIGHT,
-    // @tanstack/react-virtual: pass element resolver inline; hook tracks scroll container via its own subscriptions.
-    getScrollElement: () =>
-      usesSharedScroll ? (sharedScrollContainerRef?.current ?? null) : scrollContainerRef.current,
+    getScrollElement,
     overscan: 5,
     scrollPaddingStart: usesSharedScroll ? GANTT_ROW_OFFSET_PX : GRID_INNER_SCROLL_PADDING_START_PX,
   });
+
+  useGridScrollRestoration({ dagId, getScrollElement, rowCount: flatNodes.length });
 
   const virtualItems = rowVirtualizer.getVirtualItems();
 

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/useGridScrollRestoration.test.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/useGridScrollRestoration.test.tsx
@@ -1,0 +1,267 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { act, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearGridScrollOffsets,
+  extractDagIdFromPath,
+  readGridScrollOffset,
+  saveGridScrollOffset,
+  useGridScrollRestoration,
+  useResetGridScrollOnLeave,
+} from "./useGridScrollRestoration";
+
+/** Minimal stand-in for the scroll container: a settable scrollTop plus event wiring. */
+const makeScrollElement = () => {
+  const listeners: Array<() => void> = [];
+
+  return {
+    addEventListener: (_type: string, callback: () => void) => listeners.push(callback),
+    dispatchScroll() {
+      listeners.forEach((callback) => callback());
+    },
+    get listenerCount() {
+      return listeners.length;
+    },
+    removeEventListener: (_type: string, callback: () => void) => {
+      const index = listeners.indexOf(callback);
+
+      if (index !== -1) {
+        listeners.splice(index, 1);
+      }
+    },
+    scrollTop: 0,
+  };
+};
+
+type FakeElement = ReturnType<typeof makeScrollElement>;
+
+const renderRestoration = (dagId: string, element: FakeElement | null, rowCount: number) =>
+  renderHook(
+    (props: { count: number; id: string }) =>
+      useGridScrollRestoration({
+        dagId: props.id,
+        getScrollElement: () => element as unknown as HTMLElement | null,
+        rowCount: props.count,
+      }),
+    { initialProps: { count: rowCount, id: dagId } },
+  );
+
+const renderReset = (path: string) =>
+  renderHook(
+    () => {
+      useResetGridScrollOnLeave();
+
+      return useNavigate();
+    },
+    {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+      ),
+    },
+  );
+
+// The offset store is module scope, so it outlives each test.
+beforeEach(clearGridScrollOffsets);
+
+describe("extractDagIdFromPath", () => {
+  it.each<[string, string | undefined]>([
+    ["/dags/my_dag", "my_dag"],
+    ["/dags/my_dag/runs/run_1", "my_dag"],
+    ["/dags/my_dag/runs/run_1/tasks/task_1", "my_dag"],
+    ["/dags/other_dag", "other_dag"],
+    ["/dags", undefined],
+    ["/dags/", undefined],
+    ["/", undefined],
+    ["/assets", undefined],
+  ])("returns %s → %s", (pathname, expected) => {
+    expect(extractDagIdFromPath(pathname)).toBe(expected);
+  });
+});
+
+describe("clearGridScrollOffsets", () => {
+  it("drops every saved offset", () => {
+    saveGridScrollOffset("dag_clear_a", 100);
+    saveGridScrollOffset("dag_clear_b", 200);
+
+    clearGridScrollOffsets();
+
+    expect(readGridScrollOffset("dag_clear_a")).toBeUndefined();
+    expect(readGridScrollOffset("dag_clear_b")).toBeUndefined();
+  });
+});
+
+// BaseLayout is the root route element and never remounts, so a pathname change is the only
+// thing that fires the reset in production.
+describe("useResetGridScrollOnLeave", () => {
+  it("keeps saved offsets when navigating between pages of the same Dag", async () => {
+    const { result } = renderReset("/dags/dag_within");
+
+    saveGridScrollOffset("dag_within", 300);
+    await act(async () => result.current("/dags/dag_within/runs/run_1/tasks/task_1"));
+
+    expect(readGridScrollOffset("dag_within")).toBe(300);
+  });
+
+  it("clears saved offsets when navigating out of the Dag detail area", async () => {
+    const { result } = renderReset("/dags/dag_nav/tasks/task_1");
+
+    saveGridScrollOffset("dag_nav", 300);
+    await act(async () => result.current("/dags"));
+
+    expect(readGridScrollOffset("dag_nav")).toBeUndefined();
+  });
+
+  it("clears saved offsets when switching to another Dag", async () => {
+    const { result } = renderReset("/dags/dag_from");
+
+    saveGridScrollOffset("dag_from", 300);
+    await act(async () => result.current("/dags/dag_to"));
+
+    expect(readGridScrollOffset("dag_from")).toBeUndefined();
+  });
+
+  it("does not remember the position after visiting another Dag and coming back", async () => {
+    const { result } = renderReset("/dags/dag_round_trip");
+
+    saveGridScrollOffset("dag_round_trip", 300);
+    await act(async () => result.current("/dags/dag_elsewhere"));
+    await act(async () => result.current("/dags/dag_round_trip"));
+
+    expect(readGridScrollOffset("dag_round_trip")).toBeUndefined();
+  });
+});
+
+describe("saveGridScrollOffset / readGridScrollOffset", () => {
+  it("round-trips an offset for a dagId", () => {
+    saveGridScrollOffset("dag_roundtrip", 250);
+
+    expect(readGridScrollOffset("dag_roundtrip")).toBe(250);
+  });
+
+  it("ignores an empty dagId", () => {
+    saveGridScrollOffset("", 999);
+
+    expect(readGridScrollOffset("")).toBeUndefined();
+  });
+
+  it("returns undefined for a dagId that was never saved", () => {
+    expect(readGridScrollOffset("dag_never_seen")).toBeUndefined();
+  });
+});
+
+describe("useGridScrollRestoration", () => {
+  it("saves scrollTop to the store on every scroll event", () => {
+    const element = makeScrollElement();
+
+    renderRestoration("dag_save", element, 30);
+
+    element.scrollTop = 480;
+    element.dispatchScroll();
+
+    expect(readGridScrollOffset("dag_save")).toBe(480);
+  });
+
+  it("restores the saved offset once the grid has rows", () => {
+    saveGridScrollOffset("dag_restore", 320);
+    const element = makeScrollElement();
+
+    renderRestoration("dag_restore", element, 30);
+
+    expect(element.scrollTop).toBe(320);
+  });
+
+  it("waits for rows before restoring, then restores when they appear", () => {
+    saveGridScrollOffset("dag_deferred", 300);
+    const element = makeScrollElement();
+
+    const { rerender } = renderRestoration("dag_deferred", element, 0);
+
+    expect(element.scrollTop).toBe(0);
+
+    rerender({ count: 30, id: "dag_deferred" });
+
+    expect(element.scrollTop).toBe(300);
+  });
+
+  it("restores only once so later user scrolling is not clobbered", () => {
+    saveGridScrollOffset("dag_once", 300);
+    const element = makeScrollElement();
+
+    const { rerender } = renderRestoration("dag_once", element, 30);
+
+    expect(element.scrollTop).toBe(300);
+
+    // No scroll event on purpose: the store must keep 300 so a second restore would show up as
+    // 300. Dispatching here would save 50 and make the assertion pass either way.
+    element.scrollTop = 50;
+    rerender({ count: 40, id: "dag_once" });
+
+    expect(element.scrollTop).toBe(50);
+  });
+
+  it("does not touch scrollTop when there is no saved offset", () => {
+    const element = makeScrollElement();
+
+    element.scrollTop = 17;
+    renderRestoration("dag_no_saved", element, 30);
+
+    expect(element.scrollTop).toBe(17);
+  });
+
+  it("does not restore a zero offset", () => {
+    saveGridScrollOffset("dag_zero", 0);
+    const element = makeScrollElement();
+
+    element.scrollTop = 42;
+    renderRestoration("dag_zero", element, 30);
+
+    expect(element.scrollTop).toBe(42);
+  });
+
+  it("removes the scroll listener on unmount", () => {
+    const element = makeScrollElement();
+
+    const { unmount } = renderRestoration("dag_cleanup", element, 30);
+
+    expect(element.listenerCount).toBe(1);
+
+    unmount();
+
+    expect(element.listenerCount).toBe(0);
+  });
+
+  it("neither saves nor restores when the scroll element is missing", () => {
+    saveGridScrollOffset("dag_null_el", 300);
+
+    expect(() => renderRestoration("dag_null_el", null, 30)).not.toThrow();
+    expect(readGridScrollOffset("dag_null_el")).toBe(300);
+  });
+
+  it("does not attach a scroll listener when the dagId is empty", () => {
+    const element = makeScrollElement();
+
+    renderRestoration("", element, 30);
+
+    expect(element.listenerCount).toBe(0);
+  });
+});

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/useGridScrollRestoration.ts
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/useGridScrollRestoration.ts
@@ -1,0 +1,103 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+
+/**
+ * Grid vertical scroll offset per ``dagId``, kept at module scope so it survives the
+ * remount that happens when navigating between the sibling ``<Dag>`` / ``<Run>`` /
+ * ``<Task>`` / ``<TaskInstance>`` routes — each mounts its own ``Grid``, which would
+ * otherwise start at ``scrollTop = 0``.
+ */
+const gridScrollOffsetByDagId = new Map<string, number>();
+
+// Matches a specific Dag (`/dags/<id>...`) but not the `/dags` list.
+const DAG_DETAILS_PATH = /^\/dags\/(?<dagId>[^/]+)/u;
+
+export const extractDagIdFromPath = (pathname: string): string | undefined =>
+  DAG_DETAILS_PATH.exec(pathname)?.groups?.dagId;
+
+export const saveGridScrollOffset = (dagId: string, offset: number): void => {
+  if (dagId !== "") {
+    gridScrollOffsetByDagId.set(dagId, offset);
+  }
+};
+
+export const readGridScrollOffset = (dagId: string): number | undefined => gridScrollOffsetByDagId.get(dagId);
+
+export const clearGridScrollOffsets = (): void => gridScrollOffsetByDagId.clear();
+
+type Params = {
+  readonly dagId: string;
+  readonly getScrollElement: () => HTMLElement | null;
+  /** Number of rendered rows — restore waits until the list has rows (and thus height). */
+  readonly rowCount: number;
+};
+
+/**
+ * Preserves the grid's vertical scroll position across the route transitions that
+ * remount the grid. Saves ``scrollTop`` on every scroll and restores it once, after
+ * the rows exist, so the remount is invisible to the user.
+ */
+export const useGridScrollRestoration = ({ dagId, getScrollElement, rowCount }: Params): void => {
+  const hasRestoredRef = useRef(false);
+
+  useEffect(() => {
+    const element = getScrollElement();
+
+    if (element === null || dagId === "") {
+      return undefined;
+    }
+
+    const handleScroll = () => saveGridScrollOffset(dagId, element.scrollTop);
+
+    element.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => element.removeEventListener("scroll", handleScroll);
+  }, [dagId, getScrollElement]);
+
+  // Layout effect (not a plain effect) so the position is set before paint, avoiding
+  // a visible flash at the top of the list on remount.
+  useLayoutEffect(() => {
+    if (hasRestoredRef.current || dagId === "" || rowCount === 0) {
+      return;
+    }
+
+    const element = getScrollElement();
+    const saved = readGridScrollOffset(dagId);
+
+    if (element !== null && saved !== undefined && saved > 0) {
+      element.scrollTop = saved;
+    }
+
+    hasRestoredRef.current = true;
+  }, [dagId, getScrollElement, rowCount]);
+};
+
+// Call once from the app shell, so an offset never outlives the Dag visit that produced it.
+export const useResetGridScrollOnLeave = (): void => {
+  const { pathname } = useLocation();
+  const dagId = extractDagIdFromPath(pathname);
+
+  // Keyed on the Dag, not the pathname: moving within one Dag (grid → task → run) must keep the
+  // offset, which is the whole point of the restore.
+  useEffect(() => {
+    clearGridScrollOffsets();
+  }, [dagId]);
+};


### PR DESCRIPTION
## Summary

In the Dag details view, the Grid on the left keeps its own vertical scroll position. Clicking a task that is scrolled below the fold currently snaps the Grid back to the top the **first** time you do it — losing your place. This PR keeps the scroll position across that navigation, while still resetting to the top when you leave the Dag entirely and come back.

## Problem

On a Dag with enough tasks to overflow the Grid, scroll down and click a task that is off the top of the viewport. The list jumps back to `scrollTop = 0` (the first task) even though the layout looks unchanged. Clicking a *second* task (task → task) does **not** reset the scroll — it stays put. So the reset happens exactly once, on the first click, and it gets more painful the longer the list is (e.g. when task groups are expanded). 

## Screenrecords 

#### Original 

https://github.com/user-attachments/assets/f4eec01c-efe5-4e1a-9f2d-286633942a5e

#### Current

https://github.com/user-attachments/assets/f44ec326-7e56-4fb7-89be-6f555381dd5a

## Root cause

The Grid lives inside `DetailsLayout`, and **every** top-level page renders its own `DetailsLayout`:

- `dags/:dagId` → `<Dag>`
- `dags/:dagId/tasks/:taskId` → `<Task>`
- `dags/:dagId/runs/:runId` → `<Run>`
- `dags/:dagId/runs/:runId/tasks/:taskId` → `<TaskInstance>`
- `<GroupTaskInstance>`, `<MappedTaskInstance>`

These are **sibling routes** in `router.tsx`, not nested under a shared layout.

- **First click** (`<Dag>` → `<Task>`): the matched route element changes, so React unmounts `<Dag>` (destroying its `DetailsLayout`, its `Grid`, and the scroll container DOM node) and mounts a fresh `<Task>`. The new scroll container starts at `scrollTop = 0`, and `useVirtualizer` reads `0` on mount and renders the top rows.
- **Subsequent clicks** (`<Task>` → `<Task>`): the matched element type is unchanged; only the `:taskId` param updates. React keeps the instance and its DOM, so the scroll position survives.

That asymmetry — cross-element on the first hop, same-element afterwards — is why it resets exactly once. It is not task-group specific; groups just make the list longer so more scroll is lost.

## Solution (this PR)

Remember the Grid's `scrollTop` across the remount and restore it, scoped to a single Dag visit.

- **Persist + restore** — `useGridScrollRestoration` saves `scrollTop` (in a module-scoped `Map` keyed by `dagId`, which survives the remount) on scroll, and restores it once, after the rows exist, in a `useLayoutEffect` (before
  paint, no flash). Covers both the plain-Grid and the shared Grid + Gantt scroll containers.
- **Reset on leave** — `useResetGridScrollOnLeave` (called once from the always-mounted `BaseLayout`) clears the store whenever the route is not a Dag detail path (`/dags/<id>…`). So scroll is kept only *within* a Dag; leaving to
  the Dags list / home / assets and returning starts at the top.

| Navigation | Scroll |
|---|---|
| Dag → Task → Run → Task Instance (same `dagId`) | preserved |
| Dag → Dags list / home / assets → back to Dag | reset to top |
| First visit to a Dag | starts at top |

Files: `useGridScrollRestoration.ts` (+ test), `Grid.tsx` (wire-up), and one line in `BaseLayout.tsx` (reset-on-leave). Routing and the panel layout are untouched.

## Alternative considered (not taken)

**Make `DetailsLayout` a single shared parent route** so the Grid mounts once and persists across Dag ↔ Run ↔ Task ↔ TaskInstance (the "correct" React Router structure), with per-page content flowing through the existing `<Outlet/>`.

Rejected as disproportionate: it is a large refactor with real regression risk.

## Testing

New unit tests cover:
  - **Persist/restore:** save-on-scroll, restore-once-rows-exist, deferred restore when rows arrive later, restore fires only once (does not clobber later user scrolling), no-op when there is no saved offset / a zero offset / a missing scroll element, and listener cleanup on unmount.
  - **Reset-on-leave:** `isDagDetailsPath` for detail vs non-detail paths, `clearGridScrollOffsets` drops every entry, and the hook clears on a non-detail path but keeps offsets while inside a Dag (via `MemoryRouter`).

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
Co-authored-by: [Claude Opus 5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
