### PR TITLE
Use built-in exceptions for Postgres hook input validation

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -376,7 +376,6 @@ providers/opensearch/src/airflow/providers/opensearch/log/os_task_handler.py::1
 providers/opensearch/src/airflow/providers/opensearch/operators/opensearch.py::9
 providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty.py::1
 providers/pagerduty/src/airflow/providers/pagerduty/hooks/pagerduty_events.py::2
-providers/postgres/src/airflow/providers/postgres/hooks/postgres.py::2
 providers/presto/src/airflow/providers/presto/hooks/presto.py::1
 providers/samba/src/airflow/providers/samba/transfers/gcs_to_samba.py::1
 providers/segment/src/airflow/providers/segment/hooks/segment.py::2

--- a/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
+++ b/providers/postgres/src/airflow/providers/postgres/hooks/postgres.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeAlias, c
 from more_itertools import chunked
 
 from airflow.providers.common.compat.sdk import (
-    AirflowException,
     AirflowOptionalProviderFeatureException,
     Connection,
     conf,
@@ -189,7 +188,7 @@ class PostgresHook(DbApiHook):
         conn = self.connection
         query = conn.extra_dejson.get("sqlalchemy_query", {})
         if not isinstance(query, dict):
-            raise AirflowException("The parameter 'sqlalchemy_query' must be of type dict!")
+            raise TypeError("The parameter 'sqlalchemy_query' must be of type dict!")
         if conn.extra_dejson.get("iam", False):
             conn.login, conn.password, conn.port = self.get_iam_token(conn)
         return URL.create(
@@ -222,9 +221,7 @@ class PostgresHook(DbApiHook):
             if _cursor == "namedtuplecursor":
                 return namedtuple_row
             if _cursor == "realdictcursor":
-                raise AirflowException(
-                    "realdictcursor is not supported with psycopg3. Use dictcursor instead."
-                )
+                raise ValueError("realdictcursor is not supported with psycopg3. Use dictcursor instead.")
             valid_cursors = "dictcursor, namedtuplecursor"
             raise ValueError(f"Invalid cursor passed {_cursor}. Valid options are: {valid_cursors}")
 

--- a/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
+++ b/providers/postgres/tests/unit/postgres/hooks/test_postgres.py
@@ -27,7 +27,7 @@ import pytest
 import sqlalchemy
 
 from airflow.models import Connection
-from airflow.providers.common.compat.sdk import AirflowException, AirflowOptionalProviderFeatureException
+from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
 from airflow.providers.postgres.dialects.postgres import PostgresDialect
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
@@ -110,7 +110,7 @@ class TestPostgresHookConn:
         )
         hook = PostgresHook(connection=conn)
 
-        with pytest.raises(AirflowException):
+        with pytest.raises(TypeError, match="'sqlalchemy_query' must be of type dict"):
             hook.sqlalchemy_url
 
     @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])


### PR DESCRIPTION
Part of the ongoing clean-up of broad `AirflowException` usages (enforced by the `check-no-new-airflow-exceptions` ratchet), following the pattern of #66279.

`PostgresHook` raised `AirflowException` for two input-validation failures: a `sqlalchemy_query` connection extra that is not a dict (now `TypeError`), and requesting `realdictcursor` with psycopg3 (now `ValueError`, matching the invalid-cursor branch immediately below it that already raises `ValueError`). The `known_airflow_exceptions.txt` entry for the file drops from 2 to 0, and the existing test now asserts the specific exception type and message.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)