### PR TITLE
Use ValueError for conflicting Git connection key arguments

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -200,7 +200,6 @@ providers/fab/src/airflow/providers/fab/auth_manager/models/db.py::1
 providers/fab/src/airflow/providers/fab/www/extensions/init_security.py::1
 providers/facebook/src/airflow/providers/facebook/ads/hooks/ads.py::2
 providers/git/src/airflow/providers/git/bundles/git.py::5
-providers/git/src/airflow/providers/git/hooks/git.py::1
 providers/git/tests/unit/git/bundles/test_git.py::1
 providers/github/src/airflow/providers/github/operators/github.py::2
 providers/github/src/airflow/providers/github/sensors/github.py::3

--- a/providers/git/src/airflow/providers/git/hooks/git.py
+++ b/providers/git/src/airflow/providers/git/hooks/git.py
@@ -30,7 +30,7 @@ from typing import Any
 from urllib.parse import quote as urlquote
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
-from airflow.providers.common.compat.sdk import AirflowException, BaseHook
+from airflow.providers.common.compat.sdk import BaseHook
 
 log = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class GitHook(BaseHook):
         self.env: dict[str, str] = {}
 
         if self.key_file and self.private_key:
-            raise AirflowException("Both 'key_file' and 'private_key' cannot be provided at the same time")
+            raise ValueError("Both 'key_file' and 'private_key' cannot be provided at the same time")
 
         if host_key_checking_defaulted and self._uses_ssh_transport_options():
             warnings.warn(

--- a/providers/git/tests/unit/git/hooks/test_git.py
+++ b/providers/git/tests/unit/git/hooks/test_git.py
@@ -26,7 +26,6 @@ from git import Repo
 
 from airflow.exceptions import AirflowProviderDeprecationWarning
 from airflow.models import Connection
-from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.git.hooks.git import GitHook
 
 from tests_common.test_utils.config import conf_vars
@@ -204,7 +203,7 @@ class TestGitHook:
         )
 
         with pytest.raises(
-            AirflowException, match="Both 'key_file' and 'private_key' cannot be provided at the same time"
+            ValueError, match="Both 'key_file' and 'private_key' cannot be provided at the same time"
         ):
             GitHook(git_conn_id=CONN_BOTH_PATH_INLINE)
 


### PR DESCRIPTION
Part of the ongoing clean-up of broad `AirflowException` usages (enforced by the `check-no-new-airflow-exceptions` ratchet), following the pattern of #66279.

`GitHook` raised `AirflowException` when a connection provides both `key_file` and `private_key` — a plain input-validation conflict, now a `ValueError`. The `known_airflow_exceptions.txt` entry for the file drops from 1 to 0, and the existing test asserts the new type.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)