### PR TITLE
Use ValueError when no ArangoDB collection operation is specified

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -147,7 +147,6 @@ providers/apache/pinot/src/airflow/providers/apache/pinot/hooks/pinot.py::1
 providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_sql.py::2
 providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py::10
 providers/arangodb/src/airflow/providers/arangodb/hooks/arangodb.py::9
-providers/arangodb/src/airflow/providers/arangodb/operators/arangodb.py::1
 providers/atlassian/jira/src/airflow/providers/atlassian/jira/hooks/jira.py::1
 providers/celery/src/airflow/providers/celery/executors/celery_executor_utils.py::2
 providers/celery/src/airflow/providers/celery/executors/default_celery.py::2

--- a/providers/arangodb/src/airflow/providers/arangodb/operators/arangodb.py
+++ b/providers/arangodb/src/airflow/providers/arangodb/operators/arangodb.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from airflow.providers.arangodb.hooks.arangodb import ArangoDBHook
-from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 
 if TYPE_CHECKING:
     from airflow.providers.common.compat.sdk import Context
@@ -112,7 +112,7 @@ class ArangoDBCollectionOperator(BaseOperator):
                 self.delete_collection,
             ]
         ):
-            raise AirflowException("At least one operation must be specified.")
+            raise ValueError("At least one operation must be specified.")
 
         if self.documents_to_insert:
             self.log.info(

--- a/providers/arangodb/tests/unit/arangodb/operators/test_arangodb.py
+++ b/providers/arangodb/tests/unit/arangodb/operators/test_arangodb.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import pytest
+
 from airflow.providers.arangodb.operators.arangodb import AQLOperator, ArangoDBCollectionOperator
 
 
@@ -47,3 +49,13 @@ class TestArangoDBCollectionOperator:
         op.execute(mock.MagicMock())
         mock_hook.assert_called_once_with(arangodb_conn_id="arangodb_default")
         mock_hook.return_value.insert_documents.assert_called_once_with("students", documents_to_insert)
+
+    @mock.patch("airflow.providers.arangodb.operators.arangodb.ArangoDBHook")
+    def test_no_operation_fails(self, mock_hook):
+        op = ArangoDBCollectionOperator(
+            task_id="noop_task",
+            collection_name="students",
+        )
+        with pytest.raises(ValueError, match="At least one operation must be specified."):
+            op.execute(mock.MagicMock())
+        mock_hook.return_value.insert_documents.assert_not_called()


### PR DESCRIPTION
Part of the ongoing clean-up of broad `AirflowException` usages (enforced by the `check-no-new-airflow-exceptions` ratchet), following the pattern of #66279.

`ArangoDBCollectionOperator.execute` raised `AirflowException` when none of the insert/update/replace/delete operations was specified — a plain input-validation error, now a `ValueError`. The `known_airflow_exceptions.txt` entry for the file drops from 1 to 0. The raise had no test coverage, so the PR adds one asserting the new type and that no hook operation is invoked.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)