### PR TITLE
Use ValueError for unsupported recursive glob in ADLS upload

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -361,7 +361,6 @@ providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/synaps
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/data_factory.py::1
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/msgraph.py::1
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/sensors/wasb.py::4
-providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_adls.py::1
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/sftp_to_wasb.py::1
 providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_asb.py::3
 providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_asb.py::3

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_adls.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/transfers/local_to_adls.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from airflow.providers.common.compat.sdk import AirflowException, BaseOperator
+from airflow.providers.common.compat.sdk import BaseOperator
 from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 
 if TYPE_CHECKING:
@@ -82,7 +82,7 @@ class LocalFilesystemToADLSOperator(BaseOperator):
 
     def execute(self, context: Context) -> None:
         if "**" in self.local_path:
-            raise AirflowException("Recursive glob patterns using `**` are not supported")
+            raise ValueError("Recursive glob patterns using `**` are not supported")
         if not self.extra_upload_options:
             self.extra_upload_options = {}
         hook = AzureDataLakeHook(azure_data_lake_conn_id=self.azure_data_lake_conn_id)

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/transfers/test_local_to_adls.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/transfers/test_local_to_adls.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.common.compat.sdk import AirflowException
 from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalFilesystemToADLSOperator
 
 TASK_ID = "test-adls-upload-operator"
@@ -51,7 +50,7 @@ class TestADLSUploadOperator:
         operator = LocalFilesystemToADLSOperator(
             task_id=TASK_ID, local_path=BAD_LOCAL_PATH, remote_path=REMOTE_PATH
         )
-        with pytest.raises(AirflowException) as ctx:
+        with pytest.raises(ValueError, match="Recursive glob patterns using") as ctx:
             operator.execute(None)
         assert str(ctx.value) == "Recursive glob patterns using `**` are not supported"
 


### PR DESCRIPTION
Part of the ongoing clean-up of broad `AirflowException` usages (enforced by the `check-no-new-airflow-exceptions` ratchet), following the pattern of #66279.

`LocalFilesystemToADLSOperator.execute` raised `AirflowException` when `local_path` contains an unsupported `**` recursive glob — a plain input-validation error, now a `ValueError`. The `known_airflow_exceptions.txt` entry for the file drops from 1 to 0, and the existing test asserts the new type.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Fable 5)

Generated-by: Claude Code (Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)