### PR TITLE
Drain result_queue before dispatch to prevent runtime deadlock in LocalExecutor

### DIFF
--- a/airflow-core/src/airflow/executors/local_executor.py
+++ b/airflow-core/src/airflow/executors/local_executor.py
@@ -310,6 +310,7 @@ class LocalExecutor(BaseExecutor):
 
     def _process_workloads(self, workload_list):
         for workload in workload_list:
+            self._read_results()
             self.activity_queue.put(workload)
             # A valid workload will exist in exactly one of these dicts.
             # One pop will succeed, the others will return None gracefully.

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -369,43 +369,15 @@ class TestLocalExecutor:
 
         assert len(executor.event_buffer) == result_count
 
-    def test_process_workloads_drains_results_before_put(self):
-        executor = LocalExecutor(parallelism=1)
-        executor.activity_queue = mock.MagicMock()
-        executor.result_queue = mock.MagicMock()
-        executor._unread_messages = mock.MagicMock()
-        executor._check_workers = mock.MagicMock()
-        workload = mock.MagicMock()
-        workload.key = TaskInstanceKey("test_dag", "test_task", "test_run")
-        executor.queued_tasks = {workload.key: workload}
-
-        call_order = []
-        orig_read_results = executor._read_results
-        orig_put = executor.activity_queue.put
-
-        def tracking_read_results():
-            call_order.append("_read_results")
-            return orig_read_results()
-
-        def tracking_put(*args, **kwargs):
-            call_order.append("put")
-            return orig_put(*args, **kwargs)
-
-        executor._read_results = tracking_read_results
-        executor.activity_queue.put = tracking_put
-
-        executor._process_workloads([workload])
-
-        assert call_order == ["_read_results", "put"]
-
-    def test_process_workloads_drains_results_for_multiple_workloads(self):
+    @pytest.mark.parametrize("num_workloads", [1, 3])
+    def test_process_workloads_drains_results_before_put(self, num_workloads):
         executor = LocalExecutor(parallelism=1)
         executor.activity_queue = mock.MagicMock()
         executor.result_queue = mock.MagicMock()
         executor._unread_messages = mock.MagicMock()
         executor._check_workers = mock.MagicMock()
         workloads_list = []
-        for i in range(3):
+        for i in range(num_workloads):
             workload = mock.MagicMock()
             workload.key = TaskInstanceKey("test_dag", f"test_task_{i}", "test_run")
             workloads_list.append(workload)
@@ -428,7 +400,7 @@ class TestLocalExecutor:
 
         executor._process_workloads(workloads_list)
 
-        assert call_order == ["_read_results", "put", "_read_results", "put", "_read_results", "put"]
+        assert call_order == ["_read_results", "put"] * num_workloads
 
     @pytest.mark.parametrize(
         ("conf_values", "expected_server"),

--- a/airflow-core/tests/unit/executors/test_local_executor.py
+++ b/airflow-core/tests/unit/executors/test_local_executor.py
@@ -369,6 +369,67 @@ class TestLocalExecutor:
 
         assert len(executor.event_buffer) == result_count
 
+    def test_process_workloads_drains_results_before_put(self):
+        executor = LocalExecutor(parallelism=1)
+        executor.activity_queue = mock.MagicMock()
+        executor.result_queue = mock.MagicMock()
+        executor._unread_messages = mock.MagicMock()
+        executor._check_workers = mock.MagicMock()
+        workload = mock.MagicMock()
+        workload.key = TaskInstanceKey("test_dag", "test_task", "test_run")
+        executor.queued_tasks = {workload.key: workload}
+
+        call_order = []
+        orig_read_results = executor._read_results
+        orig_put = executor.activity_queue.put
+
+        def tracking_read_results():
+            call_order.append("_read_results")
+            return orig_read_results()
+
+        def tracking_put(*args, **kwargs):
+            call_order.append("put")
+            return orig_put(*args, **kwargs)
+
+        executor._read_results = tracking_read_results
+        executor.activity_queue.put = tracking_put
+
+        executor._process_workloads([workload])
+
+        assert call_order == ["_read_results", "put"]
+
+    def test_process_workloads_drains_results_for_multiple_workloads(self):
+        executor = LocalExecutor(parallelism=1)
+        executor.activity_queue = mock.MagicMock()
+        executor.result_queue = mock.MagicMock()
+        executor._unread_messages = mock.MagicMock()
+        executor._check_workers = mock.MagicMock()
+        workloads_list = []
+        for i in range(3):
+            workload = mock.MagicMock()
+            workload.key = TaskInstanceKey("test_dag", f"test_task_{i}", "test_run")
+            workloads_list.append(workload)
+            executor.queued_tasks[workload.key] = workload
+
+        call_order = []
+        orig_read_results = executor._read_results
+        orig_put = executor.activity_queue.put
+
+        def tracking_read_results():
+            call_order.append("_read_results")
+            return orig_read_results()
+
+        def tracking_put(*args, **kwargs):
+            call_order.append("put")
+            return orig_put(*args, **kwargs)
+
+        executor._read_results = tracking_read_results
+        executor.activity_queue.put = tracking_put
+
+        executor._process_workloads(workloads_list)
+
+        assert call_order == ["_read_results", "put", "_read_results", "put", "_read_results", "put"]
+
     @pytest.mark.parametrize(
         ("conf_values", "expected_server"),
         [


### PR DESCRIPTION
Fixes a runtime deadlock in LocalExecutor where the scheduler blocks indefinitely on activity_queue.put() during task dispatch, a gap left by #67881 which only addressed the shutdown path.

Workers fill the result_queue pipe buffer and block on put(). Blocked workers stop consuming activity_queue, so the scheduler blocks on activity_queue.put() and never reaches _read_results() to drain the pipe — a circular deadlock.

The fix: drain result_queue via _read_results() before each activity_queue.put() in _process_workloads, using the same drain-before-write pattern already applied to end().

closes: #70526

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenCode (DeepSeek v4 Pro)

Generated-by: OpenCode (DeepSeek v4 Pro) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)