### PR TITLE
Add last_asset_event_timestamp sort option to GET /assets

### DIFF
--- a/airflow-core/newsfragments/70511.feature.rst
+++ b/airflow-core/newsfragments/70511.feature.rst
@@ -1,1 +1,0 @@
-Added ``last_asset_event_timestamp`` to the sortable attributes for the ``GET /assets`` endpoint, so the Assets list UI can sort by the latest asset event.

--- a/airflow-core/newsfragments/70511.feature.rst
+++ b/airflow-core/newsfragments/70511.feature.rst
@@ -1,0 +1,1 @@
+Added ``last_asset_event_timestamp`` to the sortable attributes for the ``GET /assets`` endpoint, so the Assets list UI can sort by the latest asset event.

--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -38,7 +38,7 @@ def generate_last_asset_event_query() -> Subquery:
     return (
         select(
             AssetEvent.asset_id,  
-            func.max(AssetEvent.id).label("last_asset_event_id"),  # The ID of the last AssetEvent
+            func.max(AssetEvent.id).label("last_asset_event_id"),  
             func.max(AssetEvent.timestamp).label("last_asset_event_timestamp"),
         )
         .join(

--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -37,7 +37,7 @@ def generate_last_asset_event_query() -> Subquery:
 
     return (
         select(
-            AssetEvent.asset_id,  # The ID of the Asset, which we'll need to JOIN to the AssetModel
+            AssetEvent.asset_id,  
             func.max(AssetEvent.id).label("last_asset_event_id"),  # The ID of the last AssetEvent
             func.max(AssetEvent.timestamp).label("last_asset_event_timestamp"),
         )

--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, func, select
+
+from airflow.models.asset import AssetEvent
+
+if TYPE_CHECKING:
+    from sqlalchemy.sql import Subquery
+
+
+def generate_last_asset_event_query() -> Subquery:
+    """Build a subquery yielding the ID and timestamp of the latest AssetEvent per asset."""
+    last_asset_event_per_asset = (
+        select(AssetEvent.asset_id, func.max(AssetEvent.timestamp).label("last_timestamp"))
+        .group_by(AssetEvent.asset_id)
+        .subquery()
+    )
+
+    return (
+        select(
+            AssetEvent.asset_id,  # The ID of the Asset, which we'll need to JOIN to the AssetModel
+            func.max(AssetEvent.id).label("last_asset_event_id"),  # The ID of the last AssetEvent
+            func.max(AssetEvent.timestamp).label("last_asset_event_timestamp"),
+        )
+        .join(
+            last_asset_event_per_asset,
+            and_(
+                AssetEvent.asset_id == last_asset_event_per_asset.c.asset_id,
+                AssetEvent.timestamp == last_asset_event_per_asset.c.last_timestamp,
+            ),
+        )
+        .group_by(AssetEvent.asset_id)
+        .subquery()
+    )

--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -37,8 +37,8 @@ def generate_last_asset_event_query() -> Subquery:
 
     return (
         select(
-            AssetEvent.asset_id,  
-            func.max(AssetEvent.id).label("last_asset_event_id"),  
+            AssetEvent.asset_id,
+            func.max(AssetEvent.id).label("last_asset_event_id"),
             func.max(AssetEvent.timestamp).label("last_asset_event_timestamp"),
         )
         .join(

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -136,13 +136,13 @@ paths:
             type: string
           description: 'Attributes to order by, multi criteria sort is supported.
             Prefix with `-` for descending order. Supported attributes: `id, name,
-            uri, created_at, updated_at`'
+            uri, created_at, updated_at, last_asset_event_timestamp`'
           default:
           - id
           title: Order By
         description: 'Attributes to order by, multi criteria sort is supported. Prefix
           with `-` for descending order. Supported attributes: `id, name, uri, created_at,
-          updated_at`'
+          updated_at, last_asset_event_timestamp`'
       responses:
         '200':
           description: Successful Response

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -170,7 +170,7 @@ def get_assets(
     """Get assets."""
     assets_select_statement = select(
         AssetModel,
-        _last_asset_event_query.c.last_asset_event_id,  
+        _last_asset_event_query.c.last_asset_event_id,
         _last_asset_event_query.c.last_asset_event_timestamp,
     ).outerjoin(_last_asset_event_query, AssetModel.id == _last_asset_event_query.c.asset_id)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -170,7 +170,7 @@ def get_assets(
     """Get assets."""
     assets_select_statement = select(
         AssetModel,
-        _last_asset_event_query.c.last_asset_event_id,  # This should be the AssetEvent.id
+        _last_asset_event_query.c.last_asset_event_id,  
         _last_asset_event_query.c.last_asset_event_timestamp,
     ).outerjoin(_last_asset_event_query, AssetModel.id == _last_asset_event_query.c.asset_id)
 

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, cast
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import and_, delete, func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import joinedload, subqueryload
 
@@ -29,6 +29,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.app import get_auth_manager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.api_fastapi.common.dagbag import DagBagDep, get_latest_version_of_dag
+from airflow.api_fastapi.common.db.assets import generate_last_asset_event_query
 from airflow.api_fastapi.common.db.common import SessionDep, paginated_select
 from airflow.api_fastapi.common.parameters import (
     BaseParam,
@@ -131,6 +132,9 @@ class OnlyActiveFilter(BaseParam[bool]):
         return cls().set_value(only_active)
 
 
+_last_asset_event_query = generate_last_asset_event_query()
+
+
 @assets_router.get(
     "/assets",
     responses=create_openapi_http_exception_doc([status.HTTP_404_NOT_FOUND]),
@@ -151,42 +155,24 @@ def get_assets(
     only_active: Annotated[OnlyActiveFilter, Depends(OnlyActiveFilter.depends)],
     order_by: Annotated[
         SortParam,
-        Depends(SortParam(["id", "name", "uri", "created_at", "updated_at"], AssetModel).dynamic_depends()),
+        Depends(
+            SortParam(
+                ["id", "name", "uri", "created_at", "updated_at", "last_asset_event_timestamp"],
+                AssetModel,
+                to_replace={
+                    "last_asset_event_timestamp": _last_asset_event_query.c.last_asset_event_timestamp,
+                },
+            ).dynamic_depends()
+        ),
     ],
     session: SessionDep,
 ) -> AssetCollectionResponse:
     """Get assets."""
-    # Build a query that will be used to retrieve the ID and timestamp of the latest AssetEvent
-    last_asset_events = (
-        select(AssetEvent.asset_id, func.max(AssetEvent.timestamp).label("last_timestamp"))
-        .group_by(AssetEvent.asset_id)
-        .subquery()
-    )
-
-    # First, we're pulling the Asset ID, AssetEvent ID, and AssetEvent timestamp for the latest (last)
-    # AssetEvent. We'll eventually OUTER JOIN this to the AssetModel
-    asset_event_query = (
-        select(
-            AssetEvent.asset_id,  # The ID of the Asset, which we'll need to JOIN to the AssetModel
-            func.max(AssetEvent.id).label("last_asset_event_id"),  # The ID of the last AssetEvent
-            func.max(AssetEvent.timestamp).label("last_asset_event_timestamp"),
-        )
-        .join(
-            last_asset_events,
-            and_(
-                AssetEvent.asset_id == last_asset_events.c.asset_id,
-                AssetEvent.timestamp == last_asset_events.c.last_timestamp,
-            ),
-        )
-        .group_by(AssetEvent.asset_id)
-        .subquery()
-    )
-
     assets_select_statement = select(
         AssetModel,
-        asset_event_query.c.last_asset_event_id,  # This should be the AssetEvent.id
-        asset_event_query.c.last_asset_event_timestamp,
-    ).outerjoin(asset_event_query, AssetModel.id == asset_event_query.c.asset_id)
+        _last_asset_event_query.c.last_asset_event_id,  # This should be the AssetEvent.id
+        _last_asset_event_query.c.last_asset_event_timestamp,
+    ).outerjoin(_last_asset_event_query, AssetModel.id == _last_asset_event_query.c.asset_id)
 
     assets_select, total_entries = paginated_select(
         statement=assets_select_statement,

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -17,7 +17,7 @@ import * as Common from "./common";
 * @param data.uriPrefixPattern Case-sensitive, index-friendly prefix match. See "Filtering with pattern parameters".
 * @param data.dagIds
 * @param data.onlyActive
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at, last_asset_event_timestamp`
 * @returns AssetCollectionResponse Successful Response
 * @throws ApiError
 */

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -17,7 +17,7 @@ import * as Common from "./common";
 * @param data.uriPrefixPattern Case-sensitive, index-friendly prefix match. See "Filtering with pattern parameters".
 * @param data.dagIds
 * @param data.onlyActive
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at, last_asset_event_timestamp`
 * @returns AssetCollectionResponse Successful Response
 * @throws ApiError
 */

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -17,7 +17,7 @@ import * as Common from "./common";
 * @param data.uriPrefixPattern Case-sensitive, index-friendly prefix match. See "Filtering with pattern parameters".
 * @param data.dagIds
 * @param data.onlyActive
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at, last_asset_event_timestamp`
 * @returns AssetCollectionResponse Successful Response
 * @throws ApiError
 */

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -17,7 +17,7 @@ import * as Common from "./common";
 * @param data.uriPrefixPattern Case-sensitive, index-friendly prefix match. See "Filtering with pattern parameters".
 * @param data.dagIds
 * @param data.onlyActive
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at, last_asset_event_timestamp`
 * @returns AssetCollectionResponse Successful Response
 * @throws ApiError
 */

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -19,7 +19,7 @@ export class AssetService {
      * @param data.uriPrefixPattern Case-sensitive, index-friendly prefix match. See "Filtering with pattern parameters".
      * @param data.dagIds
      * @param data.onlyActive
-     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at`
+     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at, last_asset_event_timestamp`
      * @returns AssetCollectionResponse Successful Response
      * @throws ApiError
      */

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2836,7 +2836,7 @@ export type GetAssetsData = {
     offset?: number;
     onlyActive?: boolean;
     /**
-     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at`
+     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, name, uri, created_at, updated_at, last_asset_event_timestamp`
      */
     orderBy?: Array<(string)>;
     /**

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -54,7 +54,7 @@ const createColumns = (
     header: () => translate("name"),
   },
   {
-    accessorKey: "last_asset_event",
+    accessorFn: (row) => row.last_asset_event?.timestamp,
     cell: ({ row: { original } }: AssetRow) => {
       const assetEvent = original.last_asset_event;
       const timestamp = assetEvent?.timestamp;
@@ -65,8 +65,8 @@ const createColumns = (
 
       return <Time datetime={timestamp} />;
     },
-    enableSorting: false,
     header: () => translate("lastAssetEvent"),
+    id: "last_asset_event_timestamp",
   },
   {
     accessorKey: "group",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -172,7 +172,16 @@ def _create_provided_asset_alias(session, asset_alias: AssetAliasModel) -> None:
     session.commit()
 
 
-def _create_assets_events(session, num: int = 2, varying_timestamps=False) -> None:
+def _create_assets_events(
+    session,
+    num: int = 2,
+    timestamp_day_offsets: list[int] | None = None,
+) -> None:
+    if timestamp_day_offsets is not None and len(timestamp_day_offsets) != num:
+        raise ValueError("timestamp_day_offsets must have length num")
+
+    offsets = [0] * num if timestamp_day_offsets is None else timestamp_day_offsets
+
     assets_events = [
         AssetEvent(
             id=i,
@@ -181,9 +190,9 @@ def _create_assets_events(session, num: int = 2, varying_timestamps=False) -> No
             source_task_id="source_task_id",
             source_dag_id="source_dag_id",
             source_run_id=f"source_run_id_{i}",
-            timestamp=DEFAULT_DATE + timedelta(days=i - 1) if varying_timestamps else DEFAULT_DATE,
+            timestamp=DEFAULT_DATE + timedelta(days=offset),
         )
-        for i in range(1, 1 + num)
+        for i, offset in enumerate(offsets, start=1)
     ]
     session.add_all(assets_events)
     session.commit()
@@ -281,8 +290,18 @@ class TestAssets:
         _create_provided_asset(session=session, asset=asset)
 
     @provide_session
-    def create_assets_events(self, num: int = 2, varying_timestamps: bool = False, *, session):
-        _create_assets_events(session=session, num=num, varying_timestamps=varying_timestamps)
+    def create_assets_events(
+        self,
+        num: int = 2,
+        timestamp_day_offsets: list[int] | None = None,
+        *,
+        session,
+    ):
+        _create_assets_events(
+            session=session,
+            num=num,
+            timestamp_day_offsets=timestamp_day_offsets,
+        )
 
     @provide_session
     def create_assets_events_with_sensitive_extra(self, num: int = 2, *, session):
@@ -498,18 +517,16 @@ class TestGetAssets(TestAssets):
         assert response.json()["detail"] == msg
 
     def test_order_by_last_asset_event_timestamp(self, test_client, session):
-        assets = self.create_assets(session=session, num=3)
-        self.create_assets_events(session=session, num=3, varying_timestamps=True)
+        self.create_assets(session=session, num=3)
+        self.create_assets_events(session=session, num=3, timestamp_day_offsets=[2, 0, 1])
 
         response = test_client.get("/assets?order_by=last_asset_event_timestamp")
         assert response.status_code == 200
-        assert [asset["id"] for asset in response.json()["assets"]] == [asset.id for asset in assets]
+        assert [asset["id"] for asset in response.json()["assets"]] == [2, 3, 1]
 
         response = test_client.get("/assets?order_by=-last_asset_event_timestamp")
         assert response.status_code == 200
-        assert [asset["id"] for asset in response.json()["assets"]] == [
-            asset.id for asset in reversed(assets)
-        ]
+        assert [asset["id"] for asset in response.json()["assets"]] == [1, 3, 2]
 
     @pytest.mark.parametrize(
         ("params", "expected_assets"),
@@ -986,7 +1003,7 @@ class TestGetAssetEvents(TestAssets):
     def test_filter_by_timestamp_gte_and_lte(self, test_client, params, expected_ids, session):
         # Create sample assets and asset events with specified timestamps
         self.create_assets()
-        self.create_assets_events(num=3, varying_timestamps=True)
+        self.create_assets_events(num=3, timestamp_day_offsets=[0, 1, 2])
         self.create_dag_run()
         self.create_asset_dag_run()
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -497,6 +497,20 @@ class TestGetAssets(TestAssets):
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
         assert response.json()["detail"] == msg
 
+    def test_order_by_last_asset_event_timestamp(self, test_client, session):
+        assets = self.create_assets(session=session, num=3)
+        self.create_assets_events(session=session, num=3, varying_timestamps=True)
+
+        response = test_client.get("/assets?order_by=last_asset_event_timestamp")
+        assert response.status_code == 200
+        assert [asset["id"] for asset in response.json()["assets"]] == [asset.id for asset in assets]
+
+        response = test_client.get("/assets?order_by=-last_asset_event_timestamp")
+        assert response.status_code == 200
+        assert [asset["id"] for asset in response.json()["assets"]] == [
+            asset.id for asset in reversed(assets)
+        ]
+
     @pytest.mark.parametrize(
         ("params", "expected_assets"),
         [


### PR DESCRIPTION
## Why

- Users could see last_asset_event in the list but couldn't sort by it, making it hard to find recently-active (or long-stale) assets in a large asset list.

## How

- Created a helper function `generate_last_asset_event_query()` to query assets with the latest event timestamp.
- Added `last_asset_event_timestamp` as a sortable attribute on GET /assets via SortParam's `to_replace`.
- Wired the Assets list UI's "Last Asset Event" column to the new field and enabled sorting on it.


https://github.com/user-attachments/assets/c3a5faca-183b-4ae8-ab07-403b6a54f532




related: https://github.com/apache/airflow/pull/50279, https://github.com/apache/airflow/issues/53052

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)