### PR TITLE
Group Dependabot security updates and keep v3-3-test covered

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -266,6 +266,123 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # The remaining directories are mirrored onto v3-3-test as well. Dependabot raises security
+  # updates against the default branch only, so a fixed version reaches the maintenance branch
+  # through its own version updates - Dependabot resolves and regenerates the lock file on that
+  # branch, which a cherry-picked lock file diff from main cannot do. Majors stay ignored, so a
+  # fix that needs a major bump still has to be backported by hand.
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /providers/edge3/src/airflow/providers/edge3/plugins/www
+    schedule:
+      interval: "weekly"
+    target-branch: v3-3-test
+    groups:
+      3-3-edge-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /providers/fab/src/airflow/providers/fab/www
+    schedule:
+      interval: daily
+    target-branch: v3-3-test
+    groups:
+      3-3-fab-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /registry
+    schedule:
+      interval: "weekly"
+    target-branch: v3-3-test
+    groups:
+      3-3-registry-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /dev/react-plugin-tools/react_plugin_template
+    schedule:
+      interval: "weekly"
+    target-branch: v3-3-test
+    groups:
+      3-3-ui-plugin-template-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "uv"
+    cooldown:
+      default-days: 4
+    directory: "/dev/breeze"
+    schedule:
+      interval: "weekly"
+    target-branch: v3-3-test
+    groups:
+      3-3-uv-dependency-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 4
+    directory: "/go-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: v3-3-test
+    groups:
+      3-3-go-sdk-dependency-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "uv"
     cooldown:
       default-days: 4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@
 # specific language governing permissions and limitations
 # under the License
 ---
+# NOTE: a group applies to version updates unless it declares `applies-to: security-updates`.
+# Every entry below that targets the default branch therefore carries a matching
+# `*-security-updates` group, so alert-driven bumps arrive batched instead of one PR per
+# dependency. Entries using `target-branch` deliberately have no such group - Dependabot raises
+# security updates against the default branch only, so it would never match anything there.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -26,6 +31,10 @@ updates:
       interval: "weekly"
     groups:
       github-actions-updates:
+        patterns:
+          - "*"
+      github-actions-security-updates:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -59,6 +68,10 @@ updates:
       interval: daily
     groups:
       pip-dependency-updates:
+        patterns:
+          - "*"
+      pip-security-updates:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -96,12 +109,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      core-ui-major-version-updates:
+      core-ui-security-updates:
         patterns:
           - "*"
         applies-to: security-updates
-        update-types:
-          - "major"
 
   - package-ecosystem: npm
     cooldown:
@@ -117,12 +128,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      auth-ui-major-version-updates:
+      auth-ui-security-updates:
         patterns:
           - "*"
         applies-to: security-updates
-        update-types:
-          - "major"
 
   - package-ecosystem: npm
     cooldown:
@@ -138,6 +147,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      ui-plugin-template-security-updates:
+        patterns:
+          - "*"
+        applies-to: security-updates
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -153,6 +166,10 @@ updates:
       edge-ui-package-updates:
         patterns:
           - "*"
+      edge-ui-security-updates:
+        patterns:
+          - "*"
+        applies-to: security-updates
 
   - package-ecosystem: npm
     cooldown:
@@ -165,6 +182,10 @@ updates:
       fab-ui-package-updates:
         patterns:
           - "*"
+      fab-ui-security-updates:
+        patterns:
+          - "*"
+        applies-to: security-updates
 
   - package-ecosystem: npm
     cooldown:
@@ -180,12 +201,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      registry-major-version-updates:
+      registry-security-updates:
         patterns:
           - "*"
         applies-to: security-updates
-        update-types:
-          - "major"
 
   # Repeat dependency updates on v3-3-test branch as well
   - package-ecosystem: pip
@@ -257,3 +276,22 @@ updates:
       uv-dependency-updates:
         patterns:
           - "*"
+      uv-security-updates:
+        patterns:
+          - "*"
+        applies-to: security-updates
+
+  - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 4
+    directory: "/go-sdk"
+    schedule:
+      interval: "weekly"
+    groups:
+      go-sdk-dependency-updates:
+        patterns:
+          - "*"
+      go-sdk-security-updates:
+        patterns:
+          - "*"
+        applies-to: security-updates

--- a/dev/update_github_branch_config.py
+++ b/dev/update_github_branch_config.py
@@ -156,6 +156,123 @@ def update_dependabot(new_branch: str, prev_branch: str, new_dash: str) -> None:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
+  # The remaining directories are mirrored onto {new_branch} as well. Dependabot raises security
+  # updates against the default branch only, so a fixed version reaches the maintenance branch
+  # through its own version updates - Dependabot resolves and regenerates the lock file on that
+  # branch, which a cherry-picked lock file diff from main cannot do. Majors stay ignored, so a
+  # fix that needs a major bump still has to be backported by hand.
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /providers/edge3/src/airflow/providers/edge3/plugins/www
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-edge-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /providers/fab/src/airflow/providers/fab/www
+    schedule:
+      interval: daily
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-fab-ui-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /registry
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-registry-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 4
+    directories:
+      - /dev/react-plugin-tools/react_plugin_template
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-ui-plugin-template-package-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "uv"
+    cooldown:
+      default-days: 4
+    directory: "/dev/breeze"
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-uv-dependency-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 4
+    directory: "/go-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: {new_branch}
+    groups:
+      {new_dash}-go-sdk-dependency-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
 """
     prev_comment = f"  # Repeat dependency updates on {prev_branch} branch as well"
     content = content.replace(prev_comment, pip_npm_block + prev_comment, 1)


### PR DESCRIPTION
Dependabot groups only apply to security updates when they declare
`applies-to: security-updates` — without it, a group covers version updates
only. Every group in our config relied on that default, so alert-driven bumps
bypassed grouping entirely and opened one PR each:

- #70145 `axios` (edge3 www), #69132 / #69137 `mermaid` (core UI)
- #70428 `gitpython`, #68780 `zeep` (pip)
- #69265 `@hey-api/openapi-ts` (auth UI)
- #70226 `google.golang.org/grpc`, #69214 `golang.org/x/net` (`/go-sdk`)

Each one has a matching Dependabot alert — they are security updates, not
version updates.

This adds a `security-updates` group to every entry that targets the default
branch, so those bumps get batched the way version updates already are.

Three things worth calling out for reviewers:

1. **The `v3-3-test` entries are deliberately untouched.** Dependabot raises
   security updates against the default branch only, and per the docs an entry
   using `target-branch` is version-updates only. A security group there would
   never match anything, so I added comments saying so rather than leaving it
   looking like an oversight.

2. **`*-major-version-updates` groups are widened and renamed.** The core-ui,
   auth-ui and registry entries already had `applies-to: security-updates`
   groups, but restricted to `update-types: [major]` — so minor and patch
   security updates fell through ungrouped. They now cover all security updates
   and are renamed `*-security-updates` to match what they do. This changes the
   Dependabot branch names for those groups; no open PRs currently use them.

3. **New `gomod` entry for `/go-sdk`.** That directory had no configuration at
   all. Dependabot still raises security PRs for it (hence the two Go bumps
   above) but cannot group them without an entry. This adds weekly grouped
   version updates plus a security group.

4. **No new backport automation.** Auto-labelling security PRs `backport-to-v3-3-test`
   and letting `automatic-backport.yml` cherry-pick them was the other option, but
   lock file picks across diverged branches fail often enough that it would mostly
   generate failed-backport noise. Mirroring the config is the reliable route.

Major *version* updates in the UI directories (i18next 25→26,
eslint-plugin-unicorn, `@visx/shape`, `@stylistic`) stay ungrouped — the
minor+patch groups exclude them on purpose and I did not change that.

## Keeping v3-3-test covered

Security updates only ever target the default branch, so a fixed version landing
on `main` does not reach the maintenance branch by itself. Cherry-picking one over
is unreliable — these commits carry lock file diffs, and main's lock files have
long diverged from v3-3-test's, so the pick conflicts more often than not.

Letting Dependabot maintain the branch directly sidesteps that: it resolves the
dependency and regenerates the lock file *on v3-3-test itself*. Six directories
were tracked on `main` but not on the maintenance branch, so a fixed version had
no route there at all:

- npm: edge3 www, fab www, `/registry`, react plugin template
- uv: `/dev/breeze`
- gomod: `/go-sdk`

They now have `target-branch: v3-3-test` entries following the policy the branch
already applies to core-ui and auth-ui — minor and patch only, majors ignored.
Every ecosystem/directory tracked on `main` is now also tracked on v3-3-test
(10 entries each). A fix that needs a major bump still has to be backported by hand.

`dev/update_github_branch_config.py` generates the same six entries, so cutting
the next release branch does not silently reintroduce the gap. I verified this by
running it for a hypothetical v3-4-test: 10 main / 10 v3-4-test / 10 v3-3-test,
nothing unmirrored.

One thing worth knowing for reviewers: that script patches `dependabot.yml` by
exact string match, and one of its anchors requires `interval: "weekly"` to be
immediately followed by `target-branch: v3-3-test`. Explanatory comments therefore
live at the top of the file rather than inline, so the anchors stay intact.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Claude Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
