### PR TITLE
Clarify how to stop Breeze environments

### DIFF
--- a/contributing-docs/03_contributors_quick_start.rst
+++ b/contributing-docs/03_contributors_quick_start.rst
@@ -629,13 +629,22 @@ Using Breeze
              alt="Connecting to postgresql">
       </div>
 
-4. Stopping breeze
+4. Stopping Breeze
 
-If ``breeze`` was started with ``breeze start-airflow``, this command will stop breeze and Airflow:
+If Breeze was started with ``breeze start-airflow``, first exit the terminal multiplexer so that the
+Breeze container stops and releases its forwarded ports:
+
+* With mprocs (the default), press ``q`` in the mprocs interface.
+* With tmux, run ``stop_airflow`` from the main shell pane:
 
 .. code-block:: bash
 
   [Breeze:3.10.19] root@f3619b74c59a:/opt/airflow# stop_airflow
+
+After returning to the host shell, stop the remaining Docker Compose services:
+
+.. code-block:: bash
+
   breeze down
 
 If ``breeze`` was started with ``breeze --python 3.10 --backend postgres`` (or similar):
@@ -646,7 +655,8 @@ If ``breeze`` was started with ``breeze --python 3.10 --backend postgres`` (or s
   breeze down
 
 .. note::
-    ``stop_airflow`` is available only when ``breeze`` is started with ``breeze start-airflow``.
+    ``stop_airflow`` is available only when ``breeze start-airflow`` uses tmux. Use ``q`` to quit
+    the default mprocs interface.
 
 Using tmux Instead of mprocs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/contributing-docs/mprocs/MPROCS_QUICK_REFERENCE.md
+++ b/contributing-docs/mprocs/MPROCS_QUICK_REFERENCE.md
@@ -70,6 +70,14 @@ use it outside of Breeze if needed.
 | `q`  | Quit mprocs                |
 | `?`  | Show help                  |
 
+When stopping the Breeze environment, press `q` rather than stopping only the
+selected process. Quitting mprocs lets the `breeze start-airflow` container exit
+and release its forwarded ports. After returning to the host shell, run:
+
+```bash
+breeze down
+```
+
 ## Components Managed
 
 - **scheduler** - Airflow scheduler

--- a/dev/breeze/doc/03_developer_tasks.rst
+++ b/dev/breeze/doc/03_developer_tasks.rst
@@ -685,10 +685,16 @@ Make sure to substitute the port numbers if you have customized them via the abo
 Stopping the environment
 ------------------------
 
-After starting up, the environment runs in the background and takes quite some memory which you might
-want to free for other things you are running on your host.
+After starting up, the environment takes quite some memory which you might want to free for other things
+you are running on your host.
 
-You can always stop it via:
+If you used ``breeze start-airflow``, first exit its terminal multiplexer so that the foreground
+container releases its forwarded ports:
+
+* With mprocs (the default), press ``q`` in the mprocs interface.
+* With tmux, run ``stop_airflow`` from its main shell pane.
+
+After returning to the host shell, stop the remaining Docker Compose services:
 
 .. code-block:: bash
 
@@ -699,8 +705,9 @@ about — ``breeze shell``, ``breeze testing``, ``breeze build-docs``, ``breeze 
 release-management, registry, ``breeze run``, and prek-hook compose projects — by
 reading the ``com.docker.compose.project`` label that compose sets on every container
 it creates. Each matching project is brought down with ``--remove-orphans`` and
-``--volumes`` (unless ``--preserve-volumes`` is passed). One ``breeze down`` is
-enough to leave the host clean.
+``--volumes`` (unless ``--preserve-volumes`` is passed). A running
+``breeze start-airflow`` container must exit first; otherwise it continues to use
+the project's forwarded ports, network, and volumes.
 
 If you have an unrelated docker compose project running on the host that does not
 match any breeze prefix, it is left alone by default. Pass ``--all-projects`` to


### PR DESCRIPTION
## Why

`breeze start-airflow` uses mprocs by default, but the Contributor Quick Start tells users to run `stop_airflow`, which is only available with tmux. Running `breeze down` while the `start-airflow` container is still active can leave forwarded ports, networks, and volumes in use.

## What

Document `q` as the exit command for mprocs and `stop_airflow` for tmux, followed by `breeze down` from the host shell. Update the mprocs quick reference and Breeze developer docs to use the same shutdown flow.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)


Generated-by: Codex 5.6-sol following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
