### PR TITLE
Document the sql extra required for LLMSQLQueryOperator

### DIFF
--- a/providers/common/ai/docs/operators/llm_sql.rst
+++ b/providers/common/ai/docs/operators/llm_sql.rst
@@ -26,6 +26,11 @@ SQL queries from natural language using an LLM.
 The operator generates SQL but does not execute it. The generated query is returned
 as XCom and can be passed to ``SQLExecuteQueryOperator`` or used in downstream tasks.
 
+Install the ``sql`` extra, which adds ``apache-airflow-providers-common-sql`` and
+`sqlglot <https://github.com/tobymao/sqlglot>`__ (used to validate the generated SQL)::
+
+    pip install "apache-airflow-providers-common-ai[sql]"
+
 .. seealso::
     :ref:`Connection configuration <howto/connection:pydanticai>`
 


### PR DESCRIPTION
Point users at the `sql` extra for `LLMSQLQueryOperator`. The `common.sql` extra installs `apache-airflow-providers-common-sql` without `sqlglot`, so a DAG that imports the operator fails to parse when only `common.sql` is installed — the `sql` extra adds `sqlglot`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)