### PR TITLE
update readme similar projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Use Airflow to author workflows (Dags) that orchestrate tasks. The Airflow sched
 
 ## Project Focus
 
-Airflow works best with workflows that are mostly static and slowly changing. When the Dag structure is similar from one run to the next, it clarifies the unit of work and continuity. Other similar projects include [Luigi](https://github.com/spotify/luigi), [Oozie](https://oozie.apache.org/) and [Azkaban](https://azkaban.github.io/).
+Airflow works best with workflows that are mostly static and slowly changing. When the Dag structure is similar from one run to the next, it clarifies the unit of work and continuity. Other similar projects include [Flyte](https://github.com/flyteorg/flyte), [Dolphinscheduler](https://github.com/apache/dolphinscheduler)
 
 Airflow is commonly used to process data, but has the opinion that tasks should ideally be idempotent (i.e., results of the task will be the same, and will not create duplicated data in a destination system), and should not pass large quantities of data from one task to the next (though tasks can pass metadata using Airflow's [XCom feature](https://airflow.apache.org/docs/apache-airflow/stable/concepts/xcoms.html)). For high-volume, data-intensive tasks, a best practice is to delegate to external services specializing in that type of work.
 


### PR DESCRIPTION
Oozie and Azkaban have not been maintained for years

luigi is super low maintain and popular

Fully opensource and well know similar tools ( true programming code for pipelines, not  yaml/json/dsl/wrapper_sdk like Argo Workflows or Kubeflow ) are flyte and Dolphinscheduler

we could also maybe add temporal since it's now a Linux fondation project , but it's not so close to airflow , wdyt ?