### PR TITLE
UI: Wire advanced-search toggle for Grid Triggering User filter

### DIFF
--- a/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridRuns.ts
@@ -56,6 +56,15 @@ export const useGridRuns = ({
     value: runIdPattern,
   });
 
+  // Advanced-search toggle picks between the substring ``triggeringUser`` and the
+  // index-friendly ``triggeringUserPrefix`` variants of the Triggering User filter.
+  const triggeringUserArg = useAdvancedSearchArg({
+    patternApiKey: "triggeringUser",
+    prefixApiKey: "triggeringUserPrefix",
+    storageKey: SearchParamsKeys.TRIGGERING_USER_NAME_PATTERN,
+    value: triggeringUser,
+  });
+
   const { data: GridRuns, ...rest } = useGridServiceGetGridRuns(
     {
       dagId,
@@ -67,7 +76,7 @@ export const useGridRuns = ({
       ...runIdPatternArg,
       runType: runType ? [runType] : undefined,
       state: dagRunState ? [dagRunState] : undefined,
-      triggeringUser: triggeringUser ?? undefined,
+      ...triggeringUserArg,
     },
     undefined,
     {

--- a/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
+++ b/airflow-core/src/airflow/ui/src/queries/useGridStructure.ts
@@ -59,6 +59,15 @@ export const useGridStructure = ({
     value: runIdPattern,
   });
 
+  // Advanced-search toggle picks between the substring ``triggeringUser`` and the
+  // index-friendly ``triggeringUserPrefix`` variants of the Triggering User filter.
+  const triggeringUserArg = useAdvancedSearchArg({
+    patternApiKey: "triggeringUser",
+    prefixApiKey: "triggeringUserPrefix",
+    storageKey: SearchParamsKeys.TRIGGERING_USER_NAME_PATTERN,
+    value: triggeringUser,
+  });
+
   // This is necessary for keepPreviousData
   const { data: dagStructure, ...rest } = useGridServiceGetDagStructure(
     {
@@ -72,7 +81,7 @@ export const useGridStructure = ({
       ...runIdPatternArg,
       runType: runType ? [runType] : undefined,
       state: dagRunState ? [dagRunState] : undefined,
-      triggeringUser: triggeringUser ?? undefined,
+      ...triggeringUserArg,
     },
     undefined,
     {


### PR DESCRIPTION
The Grid endpoint accepts both the substring ``triggering_user`` and the index-friendly ``triggering_user_prefix`` variants of the Triggering User filter, and the pill on the Grid's filter bar already renders the substring/prefix advanced-search toggle. But the Grid query hooks were only ever sending the substring param regardless of toggle state — so the toggle effectively did nothing on the Grid.

Route the value through ``useAdvancedSearchArg`` in ``useGridRuns`` and ``useGridStructure`` so the toggle actually selects between the two variants on each request, matching the Run ID filter wiring landed in #70150 and the Dag Runs page.

<img width="1988" height="769" alt="image" src="https://github.com/user-attachments/assets/cfb7749d-2152-4e62-98cb-21670ef7d5de" />

<img width="2548" height="804" alt="image" src="https://github.com/user-attachments/assets/ba28d1f1-5a61-4dd5-9942-9fd3e84abefb" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)