### PR TITLE
Correct supervisor comments on kill escalation and finish() states

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1016,11 +1016,13 @@ class WatchedSubprocess:
         """
         Attempt to terminate the subprocess with a given signal.
 
-        If the process does not exit within `escalation_delay` seconds, escalate to SIGTERM and eventually SIGKILL if necessary.
+        Only `signal_to_send` is sent unless `force` is set. With `force=True`, if the process does not exit
+        within `escalation_delay` seconds, escalate along SIGINT -> SIGTERM -> SIGKILL, starting from
+        `signal_to_send`.
 
         :param signal_to_send: The signal to send initially (default is SIGINT).
-        :param escalation_delay: Time in seconds to wait before escalating to a stronger signal.
-        :param force: If True, ensure escalation through all signals without skipping.
+        :param escalation_delay: Time in seconds to wait for the process to exit after each signal.
+        :param force: If True, escalate through the remaining signals instead of sending only `signal_to_send`.
         """
         if self._exit_code is not None:
             return
@@ -1453,9 +1455,9 @@ class ActivitySubprocess(WatchedSubprocess):
             self._replay_pending_terminal_state_msg()
             return
 
-        # If the process has finished a non-directly-patched state (e.g.
-        # FAILED, UP_FOR_RETRY without RetryTask), `finish()` is the
-        # dedicated endpoint for those transitions. For states already in
+        # If the process has finished in a non-directly-patched state (e.g.
+        # FAILED, or SKIPPED reported via a TaskState message), `finish()` is
+        # the dedicated endpoint for those transitions. For states already in
         # STATES_SENT_DIRECTLY whose direct API call succeeded, no further
         # action is needed.
         if self.final_state not in STATES_SENT_DIRECTLY:


### PR DESCRIPTION
## Why

Two comments in `task-sdk/src/airflow/sdk/execution_time/supervisor.py` describe
behaviour the code does not have. A reader who trusts them draws the wrong
conclusion about how a task subprocess is terminated, and about which task
states reach the `finish()` endpoint.

`WatchedSubprocess.kill()` — the docstring presents the SIGINT -> SIGTERM ->
SIGKILL escalation as what always happens, so it reads as a guarantee that a
stuck process is eventually SIGKILLed. Escalation is gated on `force`, which
defaults to `False`. The default call sends a single signal, waits
`escalation_delay`, and gives up.

`ActivitySubprocess.update_task_state_if_needed()` — the comment offers
`UP_FOR_RETRY without RetryTask` as an example of a state handled by `finish()`.
`UP_FOR_RETRY` is a member of `STATES_SENT_DIRECTLY`, so the
`not in STATES_SENT_DIRECTLY` guard is never true for it and that branch is
unreachable. `FAILED` and `SKIPPED` are the only states that get there.

## What

Comment and docstring wording only — no behaviour change, so no tests and no
newsfragment.

- `kill()`: say that only `signal_to_send` is sent unless `force=True`, and
  correct the `escalation_delay` and `force` parameter descriptions.
- `update_task_state_if_needed()`: replace the unreachable `UP_FOR_RETRY`
  example with `FAILED` / `SKIPPED`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)
