### PR TITLE
Keep SSH remote job running when its PTY session hangs up

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -223,10 +223,14 @@ mv "'"$exit_code_tmp"'" "'"$exit_code_file"'"
 exit 0
 '
 
+# Redirect stdin from /dev/null too, not just stdout/stderr: a fresh setsid session
+# leader that keeps the launching terminal on any fd re-acquires it as its controlling
+# terminal, so a hangup (SSH session with a PTY dropping) would SIGHUP the detached job
+# and defeat the whole point of running it in its own session.
 if command -v setsid >/dev/null 2>&1; then
-  setsid bash -c "$job_script" >/dev/null 2>&1 &
+  setsid bash -c "$job_script" </dev/null >/dev/null 2>&1 &
 else
-  nohup bash -c "$job_script" >/dev/null 2>&1 &
+  nohup bash -c "$job_script" </dev/null >/dev/null 2>&1 &
 fi
 echo "{paths.job_id}"
 """

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -397,11 +397,6 @@ class TestPosixKillBehaviour:
         pgid = self._await_recorded_pid(paths)
         self._assert_kill_tears_down(paths, pgid, marker)
 
-    # Same environment-dependent process-group race that #69384 added reruns for on the
-    # sibling test; that marker was dropped in #69490 when this pty variant was written.
-    # The launch still depends on how the runner schedules the setsid fork, so keep main
-    # green on a fresh draw - the first attempt's assertion text stays in the CI log.
-    @pytest.mark.flaky(reruns=5)
     def test_kill_terminates_whole_job_tree_under_job_control(self, tmp_path):
         """With job control on, setsid(1) forks and the launcher's ``$!`` would name the
         short-lived setsid parent, not the job -- the condition the old wrapper orphaned
@@ -414,8 +409,9 @@ class TestPosixKillBehaviour:
         self._run_bash_mc_under_pty(
             wrapper + "\necho SUBMIT_DONE\n",
             b"SUBMIT_DONE",
-            # The job records its pid only after setsid(2) has put it in its own session, so
-            # a non-empty pid file is proof the pty hangup below can no longer reach it.
+            # Hang up only once the job is up (pid file written), so the pgrep below sees a
+            # started job. The job survives the hangup regardless: the wrapper detaches its
+            # stdin from the terminal, so the setsid session never adopts the pty.
             detached=lambda: pid_path.exists() and bool(pid_path.read_text().strip()),
         )
         pgid = self._await_recorded_pid(paths)


### PR DESCRIPTION
`SSHRemoteJobOperator` launches the remote job detached under `setsid` so it survives the SSH connection dropping. The wrapper redirected the job's stdout/stderr to `/dev/null` but left its **stdin** on the launching terminal. A fresh `setsid` session leader that still holds a terminal on any fd re-adopts it as its controlling terminal, so when an SSH session that allocated a PTY (`get_pty=True`) hangs up, the detached job receives `SIGHUP` and dies — orphaning the work the operator exists to keep alive.

Redirecting stdin from `/dev/null` as well (standard daemonization) leaves the job in a session with no controlling terminal, immune to the hangup.

This is also the root cause of the flaky `test_kill_terminates_whole_job_tree_under_job_control`: its PTY harness hangs up the terminal and then asserts the job is still running. The job was being killed by that hangup, which the `@pytest.mark.flaky(reruns=5)` marker only masked. With the wrapper fixed the test is deterministic, so the marker and its stale "process-group race" comment are removed.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)