### PR TITLE
Remove unneeded forward-reference quotes from a type alias

### DIFF
--- a/airflow-core/src/airflow/models/dag.py
+++ b/airflow-core/src/airflow/models/dag.py
@@ -97,8 +97,8 @@ if TYPE_CHECKING:
     ScheduleArg = (
         ScheduleInterval
         | Timetable
-        | "SerializedAssetBase"
-        | Collection["SerializedAsset" | "SerializedAssetAlias"]
+        | SerializedAssetBase
+        | Collection[SerializedAsset | SerializedAssetAlias]
     )
 
 log = structlog.getLogger(__name__)


### PR DESCRIPTION
The names (`SerializedAsset`, `SerializedAssetAlias`, `SerializedAssetBase`) are imported on the line right before type alias definition, so no forward references needed.

https://github.com/apache/airflow/blob/c04b93baaaebd7025e55b53a5bc8352a70ddbc1a/airflow-core/src/airflow/models/dag.py#L85-L89

The whole block is inside `TYPE_CHECKING`, so it doesn't affect runtime in any way. But it will help some type checkers (e.g. pyrefly, pyright) that fail to detect `TYPE_CHECKING` context and flag `"SerializedAsset" | "SerializedAssetAlias"` as unexpected BitAnd operation between two string literals.


##### Was generative AI tooling used to co-author this PR?

No
