### PR TITLE
Fix DbtCloudRunJobOperator having false failures during deferred polling

### DIFF
--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -351,6 +351,16 @@ class DbtCloudHook(HttpHook):
 
     @cached_property
     def connection(self) -> Connection:
+        """
+        Resolve and cache the dbt Cloud connection (sync).
+
+        Do not read this property from async code running inside the triggerer's
+        event loop — it calls the synchronous ``get_connection()``, whose secret-masking
+        step raises ``RuntimeError`` when invoked from a thread that's already running an
+        event loop. Use ``_resolve_connection_async()`` instead; it shares this property's
+        cache slot so the connection is still only looked up once per hook instance
+        regardless of which path is used first.
+        """
         return self._require_password(self.get_connection(self.dbt_cloud_conn_id))
 
     async def _resolve_connection_async(self) -> Connection:

--- a/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/providers/dbt/cloud/src/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -41,7 +41,7 @@ from airflow.providers.http.hooks.http import HttpHook
 if TYPE_CHECKING:
     from requests.models import PreparedRequest, Response
 
-    from airflow.models import Connection
+    from airflow.providers.common.compat.sdk import Connection
 
 DBT_CAUSE_MAX_LENGTH = 255
 
@@ -254,12 +254,13 @@ class DbtCloudHook(HttpHook):
 
     async def get_headers_tenants_from_connection(self) -> tuple[dict[str, Any], str]:
         """Get Headers, tenants from the connection details."""
+        conn = await self._resolve_connection_async()
         headers: dict[str, Any] = {}
-        tenant = self._get_tenant_domain(self.connection)
+        tenant = self._get_tenant_domain(conn)
         package_name, provider_version = _get_provider_info()
         headers["User-Agent"] = f"{package_name}-v{provider_version}"
         headers["Content-Type"] = "application/json"
-        headers["Authorization"] = f"Token {self.connection.password}"
+        headers["Authorization"] = f"Token {conn.password}"
         return headers, tenant
 
     def _log_request_error(self, attempt_num: int, error: str) -> None:
@@ -307,7 +308,8 @@ class DbtCloudHook(HttpHook):
         endpoint = f"{account_id}/runs/{run_id}/"
         headers, tenant = await self.get_headers_tenants_from_connection()
         url, params = self.get_request_url_params(tenant, endpoint, include_related)
-        proxies = self._get_proxies(self.connection) or {}
+        conn = await self._resolve_connection_async()
+        proxies = self._get_proxies(conn) or {}
         proxy = proxies.get("https") if proxies and url.startswith("https") else proxies.get("http")
         extra_request_args = {}
 
@@ -341,13 +343,30 @@ class DbtCloudHook(HttpHook):
         job_run_status: int = response["data"]["status"]
         return job_run_status
 
+    @staticmethod
+    def _require_password(conn: Connection) -> Connection:
+        if not conn.password:
+            raise AirflowException("An API token is required to connect to dbt Cloud.")
+        return conn
+
     @cached_property
     def connection(self) -> Connection:
-        _connection = self.get_connection(self.dbt_cloud_conn_id)
-        if not _connection.password:
-            raise AirflowException("An API token is required to connect to dbt Cloud.")
+        return self._require_password(self.get_connection(self.dbt_cloud_conn_id))
 
-        return _connection  # type: ignore[return-value]
+    async def _resolve_connection_async(self) -> Connection:
+        """
+        Resolve and cache the dbt Cloud connection (async).
+
+        Shares the ``connection`` cached_property's cache slot so a connection
+        fetched from either the sync or async path is not looked up twice on
+        the same hook instance, and so the async path never touches the sync
+        ``get_connection()``/``mask_secret()`` path from inside a running
+        event loop (which raises in the triggerer).
+        """
+        if "connection" not in self.__dict__:
+            conn = await get_async_connection(self.dbt_cloud_conn_id)
+            self.__dict__["connection"] = self._require_password(conn)
+        return self.__dict__["connection"]
 
     def get_conn(self, *args, **kwargs) -> Session:
         tenant = self._get_tenant_domain(self.connection)

--- a/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
+++ b/providers/dbt/cloud/tests/unit/dbt/cloud/hooks/test_dbt.py
@@ -356,6 +356,107 @@ class TestDbtCloudHook:
             assert mock_get_connection.call_count == 1
             assert mock_get_async_connection.call_count == 0
 
+    @pytest.mark.asyncio
+    async def test_get_headers_tenants_from_connection_does_not_use_sync_get_connection(self):
+        hook = DbtCloudHook(ACCOUNT_ID_CONN)
+
+        with (
+            patch.object(DbtCloudHook, "get_connection") as mock_get_connection,
+            patch(
+                "airflow.providers.dbt.cloud.hooks.dbt.get_async_connection",
+                new=AsyncMock(
+                    return_value=Connection(
+                        conn_id=ACCOUNT_ID_CONN,
+                        conn_type=DbtCloudHook.conn_type,
+                        login=str(DEFAULT_ACCOUNT_ID),
+                        password=TOKEN,
+                        host=SINGLE_TENANT_DOMAIN,
+                    )
+                ),
+            ) as mock_get_async_connection,
+        ):
+            headers, tenant = await hook.get_headers_tenants_from_connection()
+
+            assert tenant == SINGLE_TENANT_DOMAIN
+            assert headers["Authorization"] == f"Token {TOKEN}"
+            mock_get_connection.assert_not_called()
+            assert mock_get_async_connection.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resolve_connection_cached_async(self):
+        hook = DbtCloudHook(ACCOUNT_ID_CONN)
+
+        with patch(
+            "airflow.providers.dbt.cloud.hooks.dbt.get_async_connection",
+            new=AsyncMock(
+                return_value=Connection(
+                    conn_id=ACCOUNT_ID_CONN,
+                    conn_type=DbtCloudHook.conn_type,
+                    login=str(DEFAULT_ACCOUNT_ID),
+                    password=TOKEN,
+                )
+            ),
+        ) as mock_get_async_connection:
+            first_call = await hook._resolve_connection_async()
+            second_call = await hook._resolve_connection_async()
+
+            assert first_call.password == TOKEN
+            assert second_call.password == TOKEN
+            assert mock_get_async_connection.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_connection_cache_shared_between_sync_and_async(self):
+        hook = DbtCloudHook(ACCOUNT_ID_CONN)
+
+        with (
+            patch.object(
+                DbtCloudHook,
+                "get_connection",
+                return_value=Connection(
+                    conn_id=ACCOUNT_ID_CONN,
+                    conn_type=DbtCloudHook.conn_type,
+                    login=str(DEFAULT_ACCOUNT_ID),
+                    password=TOKEN,
+                ),
+            ) as mock_get_connection,
+            patch(
+                "airflow.providers.dbt.cloud.hooks.dbt.get_async_connection",
+                new=AsyncMock(
+                    return_value=Connection(
+                        conn_id=ACCOUNT_ID_CONN,
+                        conn_type=DbtCloudHook.conn_type,
+                        login=str(DEFAULT_ACCOUNT_ID),
+                        password=TOKEN,
+                    )
+                ),
+            ) as mock_get_async_connection,
+        ):
+            sync_conn = hook.connection
+            async_conn = await hook._resolve_connection_async()
+
+            assert sync_conn.password == TOKEN
+            assert async_conn.password == TOKEN
+
+            assert mock_get_connection.call_count == 1
+            assert mock_get_async_connection.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_resolve_connection_async_requires_password(self):
+        hook = DbtCloudHook(ACCOUNT_ID_CONN)
+
+        with patch(
+            "airflow.providers.dbt.cloud.hooks.dbt.get_async_connection",
+            new=AsyncMock(
+                return_value=Connection(
+                    conn_id=ACCOUNT_ID_CONN,
+                    conn_type=DbtCloudHook.conn_type,
+                    login=str(DEFAULT_ACCOUNT_ID),
+                )
+            ),
+        ):
+            with pytest.raises(AirflowException, match="An API token is required"):
+                await hook._resolve_connection_async()
+
     @pytest.mark.parametrize(
         argnames=("conn_id", "account_id"),
         argvalues=[(ACCOUNT_ID_CONN, None), (NO_ACCOUNT_ID_CONN, ACCOUNT_ID)],


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

closes: #70398

### Why?

Deferred `DbtCloudRunJobOperator` tasks failed within seconds of deferring with a misleading `DbtCloudJobRunException: Job run <id> has failed`, even though the dbt Cloud job kept running and completed successfully hours later.


### What 

`DbtCloudHook.get_headers_tenants_from_connection()` and `get_job_details()` resolved the connection through the hook's synchronous `connection` cached_property while running inside the triggerer's live event loop. That
path masks the connection's secret via a synchronous comms call, which `asgiref` rejects when called from a thread already running an event loop the resulting `RuntimeError` propagated up through the trigger and was surfaced by the operator as a job failure instead of the real (transient) error it was.

Both call sites now resolve the connection through the existing async safe `get_async_connection()` helper, sharing a cache slot with the sync `connection` cached_property so neither path performs a duplicate connection lookup. Also switched the file's `Connection` type import to the `airflow.providers.common.compat.sdk` compat shim (matching what
`get_connection()`/`get_async_connection()` actually return under Airflow 3), which let a stale `# type: ignore[return-value]` on the `connection` property be removed.






---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
