### PR TITLE
Fix airflowctl always using production creds when --env is passed

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -494,6 +494,7 @@ class Client(httpx.Client):
 def get_client(
     kind: Literal[ClientKind.CLI, ClientKind.AUTH, ClientKind.NO_AUTH] = ClientKind.CLI,
     api_token: str | None = None,
+    api_environment: str = "production",
 ):
     """
     Get CLI API client.
@@ -505,10 +506,12 @@ def get_client(
     try:
         # API URL always loaded from the config file, please save with it if you are using other than ClientKind.CLI
         if kind == ClientKind.NO_AUTH:
-            credentials = Credentials(client_kind=kind).load()
+            credentials = Credentials(client_kind=kind, api_environment=api_environment).load()
             resolved_token = None
         else:
-            credentials = Credentials(client_kind=kind, api_token=api_token).load()
+            credentials = Credentials(
+                client_kind=kind, api_token=api_token, api_environment=api_environment
+            ).load()
             resolved_token = api_token or credentials.api_token
         api_client = Client(
             base_url=credentials.api_url or "http://localhost:8080",
@@ -542,7 +545,14 @@ def provide_api_client(
         def wrapper(*args, **kwargs) -> RT:
             if "api_client" not in kwargs:
                 api_token = getattr(args[0], "api_token", None) if args else None
-                with get_client(kind=kind, api_token=api_token) as api_client:
+                # ``args.env`` is populated by ``ARG_AUTH_ENVIRONMENT`` (default "production") on every
+                # command that accepts ``--env``/``-e``; commands without that arg (or callers that pass
+                # a bare namespace in tests) fall back to the same "production" default ``Credentials``
+                # itself uses, so behavior for callers that never pass ``--env`` is unchanged.
+                api_environment = (getattr(args[0], "env", None) if args else None) or "production"
+                with get_client(
+                    kind=kind, api_token=api_token, api_environment=api_environment
+                ) as api_client:
                     return func(*args, api_client=api_client, **kwargs)
             # The CLI API Client should be only passed for Mocking and Testing
             return func(*args, **kwargs)

--- a/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
+++ b/airflow-ctl/src/airflowctl/ctl/commands/version_command.py
@@ -26,7 +26,10 @@ def version_info(arg):
     """Get version information."""
     version_dict = {"airflowctl_version": airflowctl_version}
     if arg.remote:
-        with get_client(kind=ClientKind.NO_AUTH) as api_client:
+        # See the note in provide_api_client (api/client.py): "production" mirrors both
+        # ARG_AUTH_ENVIRONMENT's default and Credentials' own default.
+        api_environment = getattr(arg, "env", None) or "production"
+        with get_client(kind=ClientKind.NO_AUTH, api_environment=api_environment) as api_client:
             version_response = api_client.version.get()
             version_dict.update(version_response.model_dump())
     rich.print(version_dict)

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -597,4 +597,3 @@ class TestProvideApiClientEnvironment:
             command(args)
 
         assert recorded_kwargs == {"kind": ClientKind.CLI, "api_token": "TOKEN", "api_environment": "staging"}
-        

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -597,3 +597,4 @@ class TestProvideApiClientEnvironment:
             command(args)
 
         assert recorded_kwargs == {"kind": ClientKind.CLI, "api_token": "TOKEN", "api_environment": "staging"}
+        

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -35,6 +36,7 @@ from airflowctl.api.client import (
     _bounded_get_new_password,
     get_client,
     get_json_error,
+    provide_api_client,
 )
 from airflowctl.api.operations import ServerResponseError
 from airflowctl.exceptions import (
@@ -477,3 +479,121 @@ def test_credentials_rejects_unsafe_env_from_environment_variable(monkeypatch, a
     monkeypatch.setenv("AIRFLOW_CLI_ENVIRONMENT", api_environment)
     with pytest.raises(AirflowCtlException, match="environment"):
         Credentials(client_kind=ClientKind.CLI)
+
+
+class TestGetClientEnvironment:
+    """Regression coverage for GH#70519.
+
+    ``get_client`` (and therefore every ``@provide_api_client``-decorated command) must
+    resolve the config file and token for the *requested* environment, not silently fall
+    back to "production" for every command except ``auth login``.
+    """
+
+    @staticmethod
+    def _write_environment_config(tmp_path, environment: str, api_url: str) -> None:
+        (tmp_path / f"{environment}.json").write_text(json.dumps({"api_url": api_url}), encoding="utf-8")
+
+    def test_get_client_defaults_to_production(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AIRFLOW_HOME", str(tmp_path))
+        self._write_environment_config(tmp_path, "production", "https://prod.example.com")
+        self._write_environment_config(tmp_path, "staging", "https://staging.example.com")
+
+        with get_client(kind=ClientKind.CLI, api_token="TOKEN") as client:
+            assert str(client.base_url) == "https://prod.example.com/api/v2/"
+
+    def test_get_client_uses_the_requested_environment(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AIRFLOW_HOME", str(tmp_path))
+        self._write_environment_config(tmp_path, "production", "https://prod.example.com")
+        self._write_environment_config(tmp_path, "staging", "https://staging.example.com")
+
+        with get_client(kind=ClientKind.CLI, api_token="TOKEN", api_environment="staging") as client:
+            assert str(client.base_url) == "https://staging.example.com/api/v2/"
+
+    def test_get_client_no_auth_uses_the_requested_environment(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AIRFLOW_HOME", str(tmp_path))
+        self._write_environment_config(tmp_path, "staging", "https://staging.example.com")
+
+        with get_client(kind=ClientKind.NO_AUTH, api_environment="staging") as client:
+            assert str(client.base_url) == "https://staging.example.com/api/v2/"
+
+    def test_environment_variable_still_overrides_the_explicit_argument(self, monkeypatch, tmp_path):
+        """AIRFLOW_CLI_ENVIRONMENT keeps taking precedence, matching Credentials' own contract."""
+        monkeypatch.setenv("AIRFLOW_HOME", str(tmp_path))
+        monkeypatch.setenv("AIRFLOW_CLI_ENVIRONMENT", "staging")
+        self._write_environment_config(tmp_path, "staging", "https://staging.example.com")
+        self._write_environment_config(tmp_path, "production", "https://prod.example.com")
+
+        # Even though "production" is passed explicitly, the env var wins.
+        with get_client(kind=ClientKind.CLI, api_token="TOKEN", api_environment="production") as client:
+            assert str(client.base_url) == "https://staging.example.com/api/v2/"
+
+
+class TestProvideApiClientEnvironment:
+    """Regression coverage for GH#70519: the decorator every CLI command uses must read
+    ``args.env`` and forward it to ``get_client``, not silently drop it on the floor.
+    """
+
+    def test_forwards_env_from_args_to_get_client(self):
+        recorded_kwargs = {}
+
+        @contextlib.contextmanager
+        def fake_get_client(**kwargs):
+            recorded_kwargs.update(kwargs)
+            yield MagicMock()
+
+        args = MagicMock()
+        args.api_token = None
+        args.env = "staging"
+
+        @provide_api_client()
+        def command(_args, api_client=None):
+            return api_client
+
+        with patch("airflowctl.api.client.get_client", fake_get_client):
+            command(args)
+
+        assert recorded_kwargs["api_environment"] == "staging"
+
+    def test_defaults_to_production_when_env_is_not_set_on_args(self):
+        """A command whose args namespace has no ``env`` attribute (no ``--env`` registered,
+        or a bare mock in a test) must not crash and must keep the pre-existing default.
+        """
+        recorded_kwargs = {}
+
+        @contextlib.contextmanager
+        def fake_get_client(**kwargs):
+            recorded_kwargs.update(kwargs)
+            yield MagicMock()
+
+        class BareArgs:
+            api_token = None
+
+        @provide_api_client()
+        def command(_args, api_client=None):
+            return api_client
+
+        with patch("airflowctl.api.client.get_client", fake_get_client):
+            command(BareArgs())
+
+        assert recorded_kwargs["api_environment"] == "production"
+
+    def test_forwards_api_token_alongside_environment(self):
+        recorded_kwargs = {}
+
+        @contextlib.contextmanager
+        def fake_get_client(**kwargs):
+            recorded_kwargs.update(kwargs)
+            yield MagicMock()
+
+        args = MagicMock()
+        args.api_token = "TOKEN"
+        args.env = "staging"
+
+        @provide_api_client()
+        def command(_args, api_client=None):
+            return api_client
+
+        with patch("airflowctl.api.client.get_client", fake_get_client):
+            command(args)
+
+        assert recorded_kwargs == {"kind": ClientKind.CLI, "api_token": "TOKEN", "api_environment": "staging"}

--- a/airflow-ctl/tests/airflow_ctl/ctl/commands/test_version_command.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/commands/test_version_command.py
@@ -52,13 +52,20 @@ class TestVersionCommand:
             assert "version" in stdout.getvalue()
             assert "git_version" in stdout.getvalue()
             assert "airflowctl_version" in stdout.getvalue()
-            mock_get_client.assert_called_once_with(kind=ClientKind.NO_AUTH)
+            mock_get_client.assert_called_once_with(kind=ClientKind.NO_AUTH, api_environment="production")
 
     def test_ctl_version_remote_with_api_token(self, mock_client):
         with mock.patch("airflowctl.ctl.commands.version_command.get_client") as mock_get_client:
             mock_get_client.return_value.__enter__.return_value = mock_client
             version_info(self.parser.parse_args(["version", "--remote", "--api-token", "TOKEN"]))
-            mock_get_client.assert_called_once_with(kind=ClientKind.NO_AUTH)
+            mock_get_client.assert_called_once_with(kind=ClientKind.NO_AUTH, api_environment="production")
+
+    def test_ctl_version_remote_with_env(self, mock_client):
+        """`--env` must reach get_client instead of always resolving to production (GH#70519)."""
+        with mock.patch("airflowctl.ctl.commands.version_command.get_client") as mock_get_client:
+            mock_get_client.return_value.__enter__.return_value = mock_client
+            version_info(self.parser.parse_args(["version", "--remote", "--env", "staging"]))
+            mock_get_client.assert_called_once_with(kind=ClientKind.NO_AUTH, api_environment="staging")
 
     def test_ctl_version_only_local_version(self, mock_client):
         """Test the version command without --remote does not touch credentials."""


### PR DESCRIPTION
Ran into this while poking around the CLI — turns out --env/-e is accepted by pretty much every airflowctl command, but it's basically decorative outside of auth login. Everything else (dags list, connections list, dags trigger, you name it) quietly ignores it and talks to production no matter what you pass.

The reason is that provide_api_client's wrapper only ever forwards api_token down to get_client(), and get_client() doesn't even accept an environment argument. So Credentials falls back to its own default of "production" every single time, regardless of what you typed. auth login works fine because it builds Credentials directly with api_environment=args.env — it just never went through this shared path.

Practically, this means something like airflowctl dags trigger --env staging some_dag looks like it's targeting staging, but it's actually hitting production with whatever token happens to be sitting in the production keychain entry. Best case you get a confusing Token Expired/Invalid JWT error. Worst case it silently works — against the wrong environment.

Fix is pretty small: get_client() now takes an api_environment param, and provide_api_client reads args.env and passes it through, same as auth login already does. While I was in there I noticed version_command.py had the exact same bug on its own direct get_client() call for version --remote --env ..., so fixed that too.

AIRFLOW_CLI_ENVIRONMENT still takes priority over --env if both are set — that precedence already lived inside Credentials.__init__ and I didn't touch it.

Added tests for both get_client (spins up real per-environment config files and checks it resolves the right one) and provide_api_client, which didn't actually have any direct test coverage before this.

Closes #70519

## AI Disclosure

- [x] This contribution used AI assistance.

**Model(s) used:** Claude

**AI was used for:**
- Helping write this PR description.
- Running the test suite locally to make sure everything passes before submitting.
- Reviewing the implementation from a performance perspective.

The implementation and code changes were developed and validated by me.