### PR TITLE
Fix deactivation of stale zip-packaged DAGs

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -452,20 +452,6 @@ class DagFileProcessorManager(LoggingMixin):
         """Clean up stale DAG bundle version usage records."""
         BundleUsageTrackingManager().remove_stale_bundle_versions()
 
-    @staticmethod
-    def _file_name_from_fileloc(fileloc: str) -> str:
-        """
-        If a python file comes from a zip module, return just the path to the zip file.
-
-        file parsing stats are keyed by the top-level filename (path/to/archive.zip).
-        in order to correctly link DAGs to their relevant parsing stats, we need to normalize
-        fileloc to the archive file location, if applicable.
-        """
-        if ".zip" in fileloc:
-            return fileloc[: fileloc.index(".zip") + 4]
-
-        return fileloc
-
     @provide_session
     def deactivate_stale_dags(
         self,
@@ -520,9 +506,11 @@ class DagFileProcessorManager(LoggingMixin):
             # When the Dag's last_parsed_time is more than the stale_dag_threshold older than the
             # Dag file's last_finish_time, the Dag is considered stale as has apparently been removed from the file,
             # This is especially relevant for Dag files that generate Dags in a dynamic manner.
-            file_info = DagFileInfo(
-                rel_path=Path(self._file_name_from_fileloc(dag.relative_fileloc)), bundle_name=dag.bundle_name
-            )
+            rel_path = Path(dag.relative_fileloc)
+            file_info = DagFileInfo(rel_path=rel_path, bundle_name=dag.bundle_name)
+            if file_info not in last_parsed:
+                # Zip-packaged dags are keyed by the archive path, not the inner file, so try the parent as well
+                file_info = DagFileInfo(rel_path=rel_path.parent, bundle_name=dag.bundle_name)
             if last_finish_time := last_parsed.get(file_info, None):
                 if dag.last_parsed_time + timedelta(seconds=self.stale_dag_threshold) < last_finish_time:
                     self.log.info(

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -452,6 +452,20 @@ class DagFileProcessorManager(LoggingMixin):
         """Clean up stale DAG bundle version usage records."""
         BundleUsageTrackingManager().remove_stale_bundle_versions()
 
+    @staticmethod
+    def _file_name_from_fileloc(fileloc: str) -> str:
+        """
+        If a python file comes from a zip module, return just the path to the zip file.
+
+        file parsing stats are keyed by the top-level filename (path/to/archive.zip).
+        in order to correctly link DAGs to their relevant parsing stats, we need to normalize
+        fileloc to the archive file location, if applicable.
+        """
+        if ".zip" in fileloc:
+            return fileloc[: fileloc.index(".zip") + 4]
+
+        return fileloc
+
     @provide_session
     def deactivate_stale_dags(
         self,
@@ -506,7 +520,9 @@ class DagFileProcessorManager(LoggingMixin):
             # When the Dag's last_parsed_time is more than the stale_dag_threshold older than the
             # Dag file's last_finish_time, the Dag is considered stale as has apparently been removed from the file,
             # This is especially relevant for Dag files that generate Dags in a dynamic manner.
-            file_info = DagFileInfo(rel_path=Path(dag.relative_fileloc), bundle_name=dag.bundle_name)
+            file_info = DagFileInfo(
+                rel_path=Path(self._file_name_from_fileloc(dag.relative_fileloc)), bundle_name=dag.bundle_name
+            )
             if last_finish_time := last_parsed.get(file_info, None):
                 if dag.last_parsed_time + timedelta(seconds=self.stale_dag_threshold) < last_finish_time:
                     self.log.info(

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1048,7 +1048,8 @@ class TestDagFileProcessorManager:
     def test_scan_stale_dags_deactivates_zip_packaged_dags(self, session, test_zip_path):
         """
         Ensure that zip-packaged DAGs are marked inactive when the file is parsed but the
-        DagModel.last_parsed_time is not updated.
+        DagModel.last_parsed_time is not updated, testing fallback to the parent path when
+        comparing DAG.relative_fileloc to last_parsed entries.
         """
         manager = DagFileProcessorManager(
             max_runs=1,

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -576,7 +576,6 @@ class TestDagFileProcessorManager:
         assert manager._file_queue == expected
 
         # Verify running it again produces same order
-        manager._files = []
         manager.prepare_file_queue(known_files=known_files)
         assert manager._file_queue == expected
 
@@ -1016,7 +1015,6 @@ class TestDagFileProcessorManager:
             run_count=1,
             last_num_of_db_queries=1,
         )
-        manager._files = [test_dag_path]
         manager._file_stats[test_dag_path] = stat
 
         active_dag_count = session.scalar(
@@ -1061,11 +1059,12 @@ class TestDagFileProcessorManager:
         manager._dag_bundles = [bundle]
 
         test_dag_path = DagFileInfo(
-            rel_path=Path(test_zip_path),
+            rel_path=Path("test_zip.zip"),
+            bundle_path=Path(test_zip_path).parent,
             bundle_name="testing",
         )
         dagbag = DagBag(
-            test_zip_path,
+            test_dag_path.absolute_path,
             bundle_path=test_dag_path.bundle_path,
         )
 
@@ -1082,7 +1081,6 @@ class TestDagFileProcessorManager:
             run_count=1,
             last_num_of_db_queries=1,
         )
-        manager._files = [test_dag_path]
         manager._file_stats[test_dag_path] = stat
 
         active_dag_count = session.scalar(

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -1047,6 +1047,72 @@ class TestDagFileProcessorManager:
         assert serialized_dag_count == 1
 
     @pytest.mark.usefixtures("testing_dag_bundle")
+    def test_scan_stale_dags_deactivates_zip_packaged_dags(self, session, test_zip_path):
+        """
+        Ensure that zip-packaged DAGs are marked inactive when the file is parsed but the
+        DagModel.last_parsed_time is not updated.
+        """
+        manager = DagFileProcessorManager(
+            max_runs=1,
+            processor_timeout=10 * 60,
+        )
+        bundle = MagicMock()
+        bundle.name = "testing"
+        manager._dag_bundles = [bundle]
+
+        test_dag_path = DagFileInfo(
+            rel_path=Path(test_zip_path),
+            bundle_name="testing",
+        )
+        dagbag = DagBag(
+            test_zip_path,
+            bundle_path=test_dag_path.bundle_path,
+        )
+
+        # Add stale DAG to the DB
+        dag = dagbag.get_dag("test_zip_dag")
+        sync_dag_to_db(dag, session=session)
+
+        # Add DAG to the file_parsing_stats
+        stat = DagFileStat(
+            num_dags=1,
+            import_errors=0,
+            last_finish_time=timezone.utcnow() + timedelta(hours=1),
+            last_duration=1,
+            run_count=1,
+            last_num_of_db_queries=1,
+        )
+        manager._files = [test_dag_path]
+        manager._file_stats[test_dag_path] = stat
+
+        active_dag_count = session.scalar(
+            select(func.count(DagModel.dag_id)).where(
+                DagModel.dag_id == "test_zip_dag",
+                ~DagModel.is_stale,
+                DagModel.relative_fileloc == str(test_dag_path.rel_path / "test_zip.py"),
+            )
+        )
+        assert active_dag_count == 1
+
+        manager._scan_stale_dags()
+
+        active_dag_count = session.scalar(
+            select(func.count(DagModel.dag_id)).where(
+                DagModel.dag_id == "test_zip_dag",
+                ~DagModel.is_stale,
+                DagModel.relative_fileloc == str(test_dag_path.rel_path / "test_zip.py"),
+            )
+        )
+        assert active_dag_count == 0
+
+        serialized_dag_count = session.scalar(
+            select(func.count(SerializedDagModel.dag_id)).where(SerializedDagModel.dag_id == dag.dag_id)
+        )
+        # Deactivating the DagModel should not delete the SerializedDagModel
+        # SerializedDagModel gives history about Dags
+        assert serialized_dag_count == 1
+
+    @pytest.mark.usefixtures("testing_dag_bundle")
     def test_deactivate_stale_dags_marks_dags_in_inactive_bundles(self, session):
         """Dags whose bundle is no longer active should be marked stale even without a parse signal."""
         session.add(DagBundleModel(name="gone-bundle"))


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

#### The Issue:

When deactivating DAGs, airflow compares the `DagFileStat` generated by the manager to a DAG's fileloc in order to identify DAGs which were not seen on the most recent file parse. 

However, when processing zip-packaged DAGs, the DAG's relative_fileloc will be the value of `__file__` reported by zipfile, which includes the inner path within the zip archive (ex: `path/to/some/dag_package.zip/my_dag.py`).

Meanwhile the parsing stats used to index the `last_parsed` dictionary use the path of the archive file itself (ex:  `path/to/some/dag_package.zip`) since there is a single entry per file-parsed.

As a result, when looking at zip-packaged DAGs the `last_parsed.get()` lookup here will never return a value:
https://github.com/apache/airflow/blob/1438ea3587031417cc85d74323235cf087a058fb/airflow-core/src/airflow/dag_processing/manager.py#L481-L489

And thus zip-packaged DAGs are never properly deactivated. 

This issue doesn't surface too often, since most DAGs will also be caught by the `deactivate_deleted_dags` function which properly evaluates them based on inner paths. However for files which produce multiple DAGs ("dag factories") or DAGs which are renamed within a file, this second mechanism won't work either, since DAGs can be removed without the source file being removed.

As a result, certain DAGs within a zip file will never be removed and airflow will continue to attempt to schedule and run them. I have reproduced this issue in breeze on the latest version of `main`.

#### The Fix:

Within the `deactivate_stale_dags` function, we can just remove the inner part of the fileloc for zip-packaged DAGs to obtain the actual filepath of the archive itself. I've added this as a private method on the class, but it could also be added as a property on the `DAG` model itself.

---

##### Was generative AI tooling used to co-author this PR?

No
