### PR TITLE
Respect [fab] update_fab_perms when syncing per-DAG permissions during parsing

### DIFF
--- a/airflow-core/newsfragments/70588.improvement.rst
+++ b/airflow-core/newsfragments/70588.improvement.rst
@@ -1,0 +1,1 @@
+The per-DAG permission sync during DAG parsing now honors ``[fab] update_fab_perms``. The default (``True``) keeps the existing behavior; setting it to ``False`` skips the per-DAG permission sync, avoiding the extra per-parse writes for deployments that manage DAG access at the role level.

--- a/airflow-core/src/airflow/dag_processing/collection.py
+++ b/airflow-core/src/airflow/dag_processing/collection.py
@@ -296,7 +296,9 @@ def _serialize_dag_capturing_errors(
         if not dag_was_updated:
             # Check and update DagCode
             DagCode.update_source_code(dag.dag_id, dag.fileloc, session=session)
-        if "FabAuthManager" in conf.get("core", "auth_manager"):
+        if "FabAuthManager" in conf.get("core", "auth_manager") and conf.getboolean(
+            "fab", "update_fab_perms", fallback=True
+        ):
             _sync_dag_perms(dag, session=session)
 
         return []


### PR DESCRIPTION
During DAG parsing, `_serialize_dag_capturing_errors()` calls `_sync_dag_perms()` for every DAG whenever the FAB auth manager is active — regardless of the `[fab] update_fab_perms` setting. `sync_perm_for_dag()` creates/refreshes a per-DAG resource on every parse, which is avoidable DB work for deployments that manage DAG access at the role level and have disabled automatic FAB permission management.

This makes the per-DAG permission sync honor `[fab] update_fab_perms`:

- Default is `True`, so **there is no behavior change for existing configurations**.
- When set to `False` (operator has opted out of automatic FAB permission management), the per-DAG sync is skipped, avoiding the extra per-parse writes.

The flag's documented purpose is "Update FAB permissions and sync security manager roles", so honoring it in this path is consistent with its intent.

<!-- Note: happy to add a config-level toggle or a dedicated setting instead if maintainers prefer that over reusing `update_fab_perms`; and to add a unit test once the approach is agreed. -->
