### PR TITLE
Revoke JWT token on provider-level /auth/logout routes

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/api_fastapi/routes/login.py
@@ -102,7 +102,14 @@ def create_token_cli(request: Request, body: dict[str, Any] = Body(...)) -> Logi
 def logout(request: Request) -> RedirectResponse:
     """Clear session cookies and redirect to the login page."""
     with _get_flask_app().app_context():
-        login_url = get_auth_manager().get_url_login()
+        auth_manager = get_auth_manager()
+
+        # Revoke the current token before redirecting, matching the core
+        # /auth/logout route's behavior (see PR #67289).
+        if token_str := request.cookies.get(COOKIE_NAME_JWT_TOKEN):
+            auth_manager.revoke_token(token_str)
+
+        login_url = auth_manager.get_url_login()
         secure = request.base_url.scheme == "https" or bool(conf.get("api", "ssl_cert", fallback=""))
         cookie_path = get_cookie_path()
         response = RedirectResponse(login_url)

--- a/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
+++ b/providers/fab/tests/unit/fab/auth_manager/api_fastapi/routes/test_login.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -82,3 +82,31 @@ class TestLogin:
         token_cookie = next(c for c in cookies if f"{COOKIE_NAME_JWT_TOKEN}=" in c)
         assert f"Path={SUBPATH}" in session_cookie
         assert f"Path={SUBPATH}" in token_cookie
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login._get_flask_app")
+    def test_logout_revokes_token(self, mock_get_flask_app, mock_get_auth_manager, test_client):
+        mock_get_flask_app.return_value.app_context.return_value.__enter__.return_value = None
+        mock_auth_manager = MagicMock()
+        mock_auth_manager.get_url_login.return_value = "/auth/login"
+        mock_get_auth_manager.return_value = mock_auth_manager
+
+        response = test_client.get(
+            "/logout", cookies={COOKIE_NAME_JWT_TOKEN: "the-jwt-token"}, follow_redirects=False
+        )
+        assert response.status_code == 307
+        mock_auth_manager.revoke_token.assert_called_once_with("the-jwt-token")
+
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login.get_auth_manager")
+    @patch("airflow.providers.fab.auth_manager.api_fastapi.routes.login._get_flask_app")
+    def test_logout_without_token_cookie_does_not_revoke(
+        self, mock_get_flask_app, mock_get_auth_manager, test_client
+    ):
+        mock_get_flask_app.return_value.app_context.return_value.__enter__.return_value = None
+        mock_auth_manager = MagicMock()
+        mock_auth_manager.get_url_login.return_value = "/auth/login"
+        mock_get_auth_manager.return_value = mock_auth_manager
+
+        response = test_client.get("/logout", follow_redirects=False)
+        assert response.status_code == 307
+        mock_auth_manager.revoke_token.assert_not_called()

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/routes/login.py
@@ -143,6 +143,12 @@ def login_callback(request: Request):
 def logout(request: Request):
     """Log out the user from Keycloak."""
     auth_manager = cast("KeycloakAuthManager", get_auth_manager())
+
+    # Revoke the current token before redirecting to Keycloak's end-session endpoint,
+    # matching the core /auth/logout route's behavior (see PR #67289).
+    if token_str := request.cookies.get(COOKIE_NAME_JWT_TOKEN):
+        auth_manager.revoke_token(token_str)
+
     keycloak_config = auth_manager.get_keycloak_client().well_known()
     end_session_endpoint = keycloak_config["end_session_endpoint"]
 

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/routes/test_login.py
@@ -204,3 +204,32 @@ class TestLoginRouter:
         assert response.status_code == 307
         assert "location" in response.headers
         assert response.headers["location"] == logout_callback_url
+
+    @patch("airflow.providers.keycloak.auth_manager.routes.login.KeycloakAuthManager.revoke_token")
+    @patch("airflow.providers.keycloak.auth_manager.routes.login.KeycloakAuthManager.get_keycloak_client")
+    def test_logout_revokes_token(self, mock_get_keycloak_client, mock_revoke_token, client):
+        mock_keycloak_client = Mock()
+        mock_keycloak_client.well_known.return_value = {"end_session_endpoint": "logout_url"}
+        mock_get_keycloak_client.return_value = mock_keycloak_client
+        response = client.get(
+            AUTH_MANAGER_FASTAPI_APP_PREFIX + "/logout",
+            cookies={"_token": "the-jwt-token"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        mock_revoke_token.assert_called_once_with("the-jwt-token")
+
+    @patch("airflow.providers.keycloak.auth_manager.routes.login.KeycloakAuthManager.revoke_token")
+    @patch("airflow.providers.keycloak.auth_manager.routes.login.KeycloakAuthManager.get_keycloak_client")
+    def test_logout_without_token_cookie_does_not_revoke(
+        self, mock_get_keycloak_client, mock_revoke_token, client
+    ):
+        mock_keycloak_client = Mock()
+        mock_keycloak_client.well_known.return_value = {"end_session_endpoint": "logout_url"}
+        mock_get_keycloak_client.return_value = mock_keycloak_client
+        response = client.get(
+            AUTH_MANAGER_FASTAPI_APP_PREFIX + "/logout",
+            follow_redirects=False,
+        )
+        assert response.status_code == 307
+        mock_revoke_token.assert_not_called()


### PR DESCRIPTION
Core's `/auth/logout` (#67289) revokes the current JWT before redirecting to the auth manager's logout URL. FabAuthManager's and KeycloakAuthManager's own `/auth/logout` routes don't do the same before redirecting to the IdP, so a token stays valid if that route is reached directly. This adds the same `revoke_token()` call to both, for consistency.

## Test plan
- [x] Added `test_logout_revokes_token` / `test_logout_without_token_cookie_does_not_revoke` for both providers
- [x] Existing logout tests still pass

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)