### PR TITLE
Add `--min-completed-minutes` to `cleanup-pods` to prevent KPO race condition

### DIFF
--- a/providers/cncf/kubernetes/docs/changelog.rst
+++ b/providers/cncf/kubernetes/docs/changelog.rst
@@ -33,7 +33,7 @@ Changelog
 New features
 ~~~~~~~~~~~~
 
-* ``Add --min-completed-minutes to cleanup-pods to prevent KPO race condition (#XXXXX)``
+* ``Add --min-completed-minutes to cleanup-pods to prevent KPO race condition (#70595)``
 
 10.20.0
 .......

--- a/providers/cncf/kubernetes/docs/changelog.rst
+++ b/providers/cncf/kubernetes/docs/changelog.rst
@@ -27,14 +27,6 @@
 Changelog
 ---------
 
-10.21.0
-.......
-
-New features
-~~~~~~~~~~~~
-
-* ``Add --min-completed-minutes to cleanup-pods to prevent KPO race condition (#70595)``
-
 10.20.0
 .......
 

--- a/providers/cncf/kubernetes/docs/changelog.rst
+++ b/providers/cncf/kubernetes/docs/changelog.rst
@@ -27,6 +27,14 @@
 Changelog
 ---------
 
+10.21.0
+.......
+
+New features
+~~~~~~~~~~~~
+
+* ``Add --min-completed-minutes to cleanup-pods to prevent KPO race condition (#XXXXX)``
+
 10.20.0
 .......
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
@@ -68,6 +68,19 @@ ARG_MIN_PENDING_MINUTES = Arg(
     ),
 )
 
+ARG_MIN_COMPLETED_MINUTES = Arg(
+    ("--min-completed-minutes",),
+    default=0,
+    type=positive_int(allow_zero=True),
+    help=(
+        "Minimum age in minutes of a completed (Succeeded/Failed/Evicted) pod before it is deleted. "
+        "Defaults to 0 (delete immediately, preserving current behaviour). "
+        "Set this to a value greater than the KubernetesPodOperator poll interval (~2 s) to prevent "
+        "a race where the cleanup job removes a pod before KPO observes its terminal phase, "
+        "causing a spurious task failure despite the pod having succeeded."
+    ),
+)
+
 ARG_TEAM = Arg(
     ("--team",),
     default=None,
@@ -84,7 +97,7 @@ KUBERNETES_COMMANDS = (
             "in evicted/failed/succeeded/pending states"
         ),
         func=lazy_load_command("airflow.providers.cncf.kubernetes.cli.kubernetes_command.cleanup_pods"),
-        args=(ARG_NAMESPACE, ARG_MIN_PENDING_MINUTES, ARG_VERBOSE),
+        args=(ARG_NAMESPACE, ARG_MIN_PENDING_MINUTES, ARG_MIN_COMPLETED_MINUTES, ARG_VERBOSE),
     ),
     ActionCommand(
         name="generate-dag-yaml",

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
@@ -70,14 +70,11 @@ ARG_MIN_PENDING_MINUTES = Arg(
 
 ARG_MIN_COMPLETED_MINUTES = Arg(
     ("--min-completed-minutes",),
-    default=0,
+    default=1,
     type=positive_int(allow_zero=True),
     help=(
         "Minimum age in minutes of a completed (Succeeded/Failed/Evicted) pod before it is deleted. "
-        "Defaults to 0 (delete immediately, preserving current behaviour). "
-        "Set this to a positive value to prevent a race condition where the cleanup job removes a "
-        "just-completed pod before KubernetesPodOperator has polled its terminal phase, "
-        "causing a spurious task failure despite the pod having succeeded."
+        "Default is 1. Set to 0 to delete immediately."
     ),
 )
 

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
@@ -75,8 +75,8 @@ ARG_MIN_COMPLETED_MINUTES = Arg(
     help=(
         "Minimum age in minutes of a completed (Succeeded/Failed/Evicted) pod before it is deleted. "
         "Defaults to 0 (delete immediately, preserving current behaviour). "
-        "Set this to a value greater than the KubernetesPodOperator poll interval (2 s, see ``await_pod_completion``) to prevent "
-        "a race where the cleanup job removes a pod before KPO observes its terminal phase, "
+        "Set this to a positive value to prevent a race condition where the cleanup job removes a "
+        "just-completed pod before KubernetesPodOperator has polled its terminal phase, "
         "causing a spurious task failure despite the pod having succeeded."
     ),
 )

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/definition.py
@@ -75,7 +75,7 @@ ARG_MIN_COMPLETED_MINUTES = Arg(
     help=(
         "Minimum age in minutes of a completed (Succeeded/Failed/Evicted) pod before it is deleted. "
         "Defaults to 0 (delete immediately, preserving current behaviour). "
-        "Set this to a value greater than the KubernetesPodOperator poll interval (~2 s) to prevent "
+        "Set this to a value greater than the KubernetesPodOperator poll interval (2 s, see ``await_pod_completion``) to prevent "
         "a race where the cleanup job removes a pod before KPO observes its terminal phase, "
         "causing a spurious task failure despite the pod having succeeded."
     ),

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -120,7 +120,8 @@ def generate_pod_yaml(args):
 
 
 def _get_pod_completion_time(pod):
-    """Return the time the pod entered a terminal state, or its creation time as fallback.
+    """
+    Return the time the pod entered a terminal state, or its creation time as fallback.
 
     Uses the latest ``finished_at`` timestamp across all container statuses so that pods
     with multiple containers (e.g. an init container + a base container) are judged by

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -209,10 +209,11 @@ def cleanup_pods(args):
                 min_completed_minutes == 0
                 or current_time - _get_pod_completion_time(pod) > timedelta(minutes=min_completed_minutes)
             )
-            if is_terminal_old_enough or (
+            is_pending_too_long = (
                 pod_phase == pod_pending
                 and current_time - pod.metadata.creation_timestamp > timedelta(minutes=min_pending_minutes)
-            ):
+            )
+            if is_terminal_old_enough or is_pending_too_long:
                 print(
                     f'Deleting pod "{pod_name}" phase "{pod_phase}" and reason "{pod_reason}", '
                     f'restart policy "{pod_restart_policy}"'

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -119,6 +119,20 @@ def generate_pod_yaml(args):
     print(f"YAML output can be found at {yaml_output_path}")
 
 
+def _get_pod_completion_time(pod):
+    """Return the time the pod entered a terminal state, or its creation time as fallback.
+
+    Uses the latest ``finished_at`` timestamp across all container statuses so that pods
+    with multiple containers (e.g. an init container + a base container) are judged by
+    the time the *last* container finished, not by when the pod was created.
+    """
+    times = []
+    for status in pod.status.container_statuses or []:
+        if status.state and status.state.terminated and status.state.terminated.finished_at:
+            times.append(status.state.terminated.finished_at)
+    return max(times) if times else pod.metadata.creation_timestamp
+
+
 @cli_utils.action_cli(check_db=False)
 @providers_configuration_loaded
 def cleanup_pods(args):
@@ -129,6 +143,8 @@ def cleanup_pods(args):
     # protect newly created pods from deletion
     if min_pending_minutes < 5:
         min_pending_minutes = 5
+
+    min_completed_minutes = args.min_completed_minutes
 
     # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
     # All Containers in the Pod have terminated in success, and will not be restarted.
@@ -173,10 +189,18 @@ def cleanup_pods(args):
             pod_restart_policy = pod.spec.restart_policy.lower()
             current_time = datetime.now(pod.metadata.creation_timestamp.tzinfo)
 
-            if (
+            terminal = (
                 pod_phase == pod_succeeded
                 or (pod_phase == pod_failed and pod_restart_policy == pod_restart_policy_never)
                 or (pod_reason == pod_reason_evicted)
+            )
+            terminal_old_enough = terminal and (
+                min_completed_minutes == 0
+                or current_time - _get_pod_completion_time(pod)
+                > timedelta(minutes=min_completed_minutes)
+            )
+            if (
+                terminal_old_enough
                 or (
                     pod_phase == pod_pending
                     and current_time - pod.metadata.creation_timestamp

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -121,17 +121,29 @@ def generate_pod_yaml(args):
 
 def _get_pod_completion_time(pod):
     """
-    Return the time the pod entered a terminal state, or its creation time as fallback.
+    Return the time the pod's last container finished.
 
-    Uses the latest ``finished_at`` timestamp across all container statuses so that pods
-    with multiple containers (e.g. an init container + a base container) are judged by
-    the time the *last* container finished, not by when the pod was created.
+    Scans both ``container_statuses`` and ``init_container_statuses`` and returns the
+    latest ``finished_at`` timestamp. Falls back to the latest condition
+    ``last_transition_time`` (which is updated at the terminal transition), and finally
+    to ``creation_timestamp`` as a last resort.
     """
-    times = []
-    for status in pod.status.container_statuses or []:
-        if status.state and status.state.terminated and status.state.terminated.finished_at:
-            times.append(status.state.terminated.finished_at)
-    return max(times) if times else pod.metadata.creation_timestamp
+    statuses = [*(pod.status.container_statuses or []), *(pod.status.init_container_statuses or [])]
+    times = [
+        s.state.terminated.finished_at
+        for s in statuses
+        if s.state and s.state.terminated and s.state.terminated.finished_at
+    ]
+    if times:
+        return max(times)
+    condition_times = [
+        c.last_transition_time
+        for c in (pod.status.conditions or [])
+        if c.last_transition_time
+    ]
+    if condition_times:
+        return max(condition_times)
+    return pod.metadata.creation_timestamp
 
 
 @cli_utils.action_cli(check_db=False)

--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/cli/kubernetes_command.py
@@ -137,9 +137,7 @@ def _get_pod_completion_time(pod):
     if times:
         return max(times)
     condition_times = [
-        c.last_transition_time
-        for c in (pod.status.conditions or [])
-        if c.last_transition_time
+        c.last_transition_time for c in (pod.status.conditions or []) if c.last_transition_time
     ]
     if condition_times:
         return max(condition_times)
@@ -202,23 +200,18 @@ def cleanup_pods(args):
             pod_restart_policy = pod.spec.restart_policy.lower()
             current_time = datetime.now(pod.metadata.creation_timestamp.tzinfo)
 
-            terminal = (
+            is_terminal = (
                 pod_phase == pod_succeeded
                 or (pod_phase == pod_failed and pod_restart_policy == pod_restart_policy_never)
                 or (pod_reason == pod_reason_evicted)
             )
-            terminal_old_enough = terminal and (
+            is_terminal_old_enough = is_terminal and (
                 min_completed_minutes == 0
-                or current_time - _get_pod_completion_time(pod)
-                > timedelta(minutes=min_completed_minutes)
+                or current_time - _get_pod_completion_time(pod) > timedelta(minutes=min_completed_minutes)
             )
-            if (
-                terminal_old_enough
-                or (
-                    pod_phase == pod_pending
-                    and current_time - pod.metadata.creation_timestamp
-                    > timedelta(minutes=min_pending_minutes)
-                )
+            if is_terminal_old_enough or (
+                pod_phase == pod_pending
+                and current_time - pod.metadata.creation_timestamp > timedelta(minutes=min_pending_minutes)
             ):
                 print(
                     f'Deleting pod "{pod_name}" phase "{pod_phase}" and reason "{pod_reason}", '

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
@@ -329,7 +329,7 @@ class TestCleanUpPodsCommand:
         load_incluster_config.assert_called_once()
 
     @pytest.mark.parametrize(
-        "pod_kwargs, min_completed_minutes, expect_deleted",
+        ("pod_kwargs", "min_completed_minutes", "expect_deleted"),
         [
             pytest.param(
                 {"phase": "Succeeded", "finished_at": NOW - timedelta(seconds=3)},

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
@@ -39,23 +39,16 @@ pytestmark = pytest.mark.db_test
 
 NOW = parse("2024-01-01T13:15:17Z")
 
-CONTAINER_STATUS_ATTRS = {
-    "name": "base",
-    "ready": False,
-    "restart_count": 0,
-    "image": "img",
-    "image_id": "id",
-}
 
-
-def make_container_status(finished_at):
+def make_container_status(state):
     return k8s.V1ContainerStatus(
-        **CONTAINER_STATUS_ATTRS,
-        state=k8s.V1ContainerState(
-            terminated=k8s.V1ContainerStateTerminated(exit_code=0, finished_at=finished_at)
-            if finished_at
-            else None
-        ),
+        name="base", ready=False, restart_count=0, image="img", image_id="id", state=state
+    )
+
+
+def make_terminated_status(finished_at):
+    return make_container_status(
+        k8s.V1ContainerState(terminated=k8s.V1ContainerStateTerminated(exit_code=0, finished_at=finished_at))
     )
 
 
@@ -79,8 +72,8 @@ def make_terminal_pod(
         status=k8s.V1PodStatus(
             phase=phase,
             reason=reason,
-            container_statuses=[make_container_status(finished_at)] if finished_at else [],
-            init_container_statuses=[make_container_status(init_finished_at)] if init_finished_at else [],
+            container_statuses=[make_terminated_status(finished_at)] if finished_at else [],
+            init_container_statuses=[make_terminated_status(init_finished_at)] if init_finished_at else [],
             conditions=conditions,
         ),
     )
@@ -433,25 +426,31 @@ class TestGetPodCompletionTime:
         )
 
     def test_single_main_container(self):
-        pod = self._pod(container_statuses=[make_container_status(self.T1)])
+        pod = self._pod(container_statuses=[make_terminated_status(self.T1)])
         assert kubernetes_command._get_pod_completion_time(pod) == self.T1
 
     def test_single_init_container_no_main(self):
-        pod = self._pod(container_statuses=[], init_container_statuses=[make_container_status(self.T1)])
+        pod = self._pod(container_statuses=[], init_container_statuses=[make_terminated_status(self.T1)])
         assert kubernetes_command._get_pod_completion_time(pod) == self.T1
 
     def test_main_and_init_returns_max(self):
         pod = self._pod(
-            container_statuses=[make_container_status(self.T1)],
-            init_container_statuses=[make_container_status(self.T2)],
+            container_statuses=[make_terminated_status(self.T1)],
+            init_container_statuses=[make_terminated_status(self.T2)],
         )
         assert kubernetes_command._get_pod_completion_time(pod) == self.T2
 
     @pytest.mark.parametrize(
         "container_status",
         [
-            pytest.param(k8s.V1ContainerStatus(**CONTAINER_STATUS_ATTRS, state=None), id="no-state"),
-            pytest.param(make_container_status(finished_at=None), id="not-terminated"),
+            pytest.param(make_container_status(state=None), id="no-state"),
+            pytest.param(
+                make_container_status(
+                    k8s.V1ContainerState(waiting=k8s.V1ContainerStateWaiting(reason="ContainerCreating"))
+                ),
+                id="never-terminated",
+            ),
+            pytest.param(make_terminated_status(finished_at=None), id="terminated-without-finished-at"),
         ],
     )
     def test_falls_back_to_conditions(self, container_status):

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
@@ -18,11 +18,13 @@ from __future__ import annotations
 
 import importlib
 import os
+from datetime import timedelta
 from unittest import mock
 from unittest.mock import MagicMock, call
 
 import kubernetes
 import pytest
+import time_machine
 from dateutil.parser import parse
 from kubernetes.client import models as k8s
 
@@ -34,6 +36,54 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 pytestmark = pytest.mark.db_test
+
+NOW = parse("2024-01-01T13:15:17Z")
+
+CONTAINER_STATUS_ATTRS = {
+    "name": "base",
+    "ready": False,
+    "restart_count": 0,
+    "image": "img",
+    "image_id": "id",
+}
+
+
+def make_container_status(finished_at):
+    return k8s.V1ContainerStatus(
+        **CONTAINER_STATUS_ATTRS,
+        state=k8s.V1ContainerState(
+            terminated=k8s.V1ContainerStateTerminated(exit_code=0, finished_at=finished_at)
+            if finished_at
+            else None
+        ),
+    )
+
+
+def make_terminal_pod(
+    name,
+    phase,
+    reason=None,
+    restart_policy="Never",
+    finished_at=None,
+    init_finished_at=None,
+    condition_time=None,
+):
+    conditions = (
+        [k8s.V1PodCondition(type="Ready", status="False", last_transition_time=condition_time)]
+        if condition_time
+        else []
+    )
+    return k8s.V1Pod(
+        metadata=k8s.V1ObjectMeta(name=name, creation_timestamp=NOW - timedelta(hours=1)),
+        spec=k8s.V1PodSpec(containers=[], restart_policy=restart_policy),
+        status=k8s.V1PodStatus(
+            phase=phase,
+            reason=reason,
+            container_statuses=[make_container_status(finished_at)] if finished_at else [],
+            init_container_statuses=[make_container_status(init_finished_at)] if init_finished_at else [],
+            conditions=conditions,
+        ),
+    )
 
 
 class TestGenerateDagYamlCommand:
@@ -285,32 +335,69 @@ class TestCleanUpPodsCommand:
         delete_pod.assert_called_with("dummy", "awesome-namespace")
         load_incluster_config.assert_called_once()
 
-    # -- min-completed-minutes tests --
-
-    def _make_pod(self, name, phase, finished_at, reason=None, restart_policy="Never"):
-        """Build a minimal pod mock for min-completed-minutes tests."""
-        pod = MagicMock()
-        pod.metadata.name = name
-        pod.metadata.creation_timestamp = parse("2021-12-20T08:00:00Z")
-        pod.status.phase = phase
-        pod.status.reason = reason
-        pod.spec.restart_policy = restart_policy
-        container_status = MagicMock()
-        container_status.state.terminated.finished_at = finished_at
-        pod.status.container_statuses = [container_status]
-        return pod
-
+    @pytest.mark.parametrize(
+        "pod_kwargs, min_completed_minutes, expect_deleted",
+        [
+            pytest.param(
+                {"phase": "Succeeded", "finished_at": NOW - timedelta(seconds=3)},
+                1,
+                False,
+                id="succeeded-just-finished-kept",
+            ),
+            pytest.param(
+                {"phase": "Succeeded", "finished_at": NOW - timedelta(minutes=5)},
+                1,
+                True,
+                id="succeeded-old-enough-deleted",
+            ),
+            pytest.param(
+                {"phase": "Succeeded", "finished_at": NOW - timedelta(seconds=3)},
+                0,
+                True,
+                id="zero-disables-guard",
+            ),
+            pytest.param(
+                {"phase": "Failed", "finished_at": NOW - timedelta(seconds=3)},
+                1,
+                False,
+                id="failed-just-finished-kept",
+            ),
+            pytest.param(
+                {"phase": "Failed", "init_finished_at": NOW - timedelta(seconds=3)},
+                1,
+                False,
+                id="init-container-failed-just-finished-kept",
+            ),
+            pytest.param(
+                {"phase": "Failed", "reason": "Evicted", "condition_time": NOW - timedelta(seconds=3)},
+                1,
+                False,
+                id="evicted-before-containers-started-kept",
+            ),
+            pytest.param(
+                {"phase": "Failed", "reason": "Evicted", "condition_time": NOW - timedelta(minutes=5)},
+                1,
+                True,
+                id="evicted-old-enough-deleted",
+            ),
+        ],
+    )
+    @time_machine.travel(NOW, tick=False)
     @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
     @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
     @mock.patch("kubernetes.config.load_incluster_config")
-    def test_cleanup_succeeded_pod_too_young_not_deleted(
-        self, load_incluster_config, list_namespaced_pod, delete_pod
+    def test_cleanup_pods_min_completed_minutes(
+        self,
+        load_incluster_config,
+        list_namespaced_pod,
+        delete_pod,
+        pod_kwargs,
+        min_completed_minutes,
+        expect_deleted,
     ):
-        # finished_at far in the future → age is negative → less than 1 min → skip
-        pod = self._make_pod("run-o1sxc2on", "Succeeded", parse("2099-12-20T08:01:07Z"))
         pods = MagicMock()
         pods.metadata._continue = None
-        pods.items = [pod]
+        pods.items = [make_terminal_pod("run-o1sxc2on", **pod_kwargs)]
         list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(
@@ -320,147 +407,60 @@ class TestCleanUpPodsCommand:
                     "--namespace",
                     "awesome-namespace",
                     "--min-completed-minutes",
-                    "1",
+                    str(min_completed_minutes),
                 ]
             )
         )
-        delete_pod.assert_not_called()
-
-    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
-    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
-    @mock.patch("kubernetes.config.load_incluster_config")
-    def test_cleanup_succeeded_pod_old_enough_deleted(
-        self, load_incluster_config, list_namespaced_pod, delete_pod
-    ):
-        # finished_at far in the past → age > 1 min → delete
-        pod = self._make_pod("run-oldpod", "Succeeded", parse("2021-12-20T08:01:07Z"))
-        pods = MagicMock()
-        pods.metadata._continue = None
-        pods.items = [pod]
-        list_namespaced_pod.return_value = pods
-        kubernetes_command.cleanup_pods(
-            self.parser.parse_args(
-                [
-                    "kubernetes",
-                    "cleanup-pods",
-                    "--namespace",
-                    "awesome-namespace",
-                    "--min-completed-minutes",
-                    "1",
-                ]
-            )
-        )
-        delete_pod.assert_called_with("run-oldpod", "awesome-namespace")
-
-    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
-    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
-    @mock.patch("kubernetes.config.load_incluster_config")
-    def test_cleanup_min_completed_zero_deletes_immediately(
-        self, load_incluster_config, list_namespaced_pod, delete_pod
-    ):
-        # explicit 0 disables the age check: delete Succeeded pods regardless of age
-        pod = self._make_pod("run-newpod", "Succeeded", parse("2099-12-20T08:01:07Z"))
-        pods = MagicMock()
-        pods.metadata._continue = None
-        pods.items = [pod]
-        list_namespaced_pod.return_value = pods
-        kubernetes_command.cleanup_pods(
-            self.parser.parse_args(
-                [
-                    "kubernetes",
-                    "cleanup-pods",
-                    "--namespace",
-                    "awesome-namespace",
-                    "--min-completed-minutes",
-                    "0",
-                ]
-            )
-        )
-        delete_pod.assert_called_with("run-newpod", "awesome-namespace")
-
-    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
-    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
-    @mock.patch("kubernetes.config.load_incluster_config")
-    def test_cleanup_failed_pod_too_young_not_deleted(
-        self, load_incluster_config, list_namespaced_pod, delete_pod
-    ):
-        # Failed + restart_policy=Never, but finished too recently → skip
-        pod = self._make_pod(
-            "run-failpod", "Failed", parse("2099-12-20T08:01:07Z"), restart_policy="Never"
-        )
-        pods = MagicMock()
-        pods.metadata._continue = None
-        pods.items = [pod]
-        list_namespaced_pod.return_value = pods
-        kubernetes_command.cleanup_pods(
-            self.parser.parse_args(
-                [
-                    "kubernetes",
-                    "cleanup-pods",
-                    "--namespace",
-                    "awesome-namespace",
-                    "--min-completed-minutes",
-                    "1",
-                ]
-            )
-        )
-        delete_pod.assert_not_called()
+        if expect_deleted:
+            delete_pod.assert_called_once_with("run-o1sxc2on", "awesome-namespace")
+        else:
+            delete_pod.assert_not_called()
 
 
 class TestGetPodCompletionTime:
     T1 = parse("2024-01-01T10:00:00Z")
     T2 = parse("2024-01-01T10:05:00Z")
-    T3 = parse("2024-01-01T09:00:00Z")  # earlier than T1/T2, used as creation_timestamp
+    CREATED_AT = parse("2024-01-01T09:00:00Z")  # earlier than T1/T2
 
-    def _cs(self, finished_at=None):
-        """Real V1ContainerStatus with optional finished_at."""
-        return k8s.V1ContainerStatus(
-            name="base",
-            ready=False,
-            restart_count=0,
-            image="img",
-            image_id="id",
-            state=k8s.V1ContainerState(
-                terminated=k8s.V1ContainerStateTerminated(exit_code=0, finished_at=finished_at)
-                if finished_at
-                else None
+    def _pod(self, container_statuses=None, init_container_statuses=None, conditions=None):
+        return k8s.V1Pod(
+            metadata=k8s.V1ObjectMeta(name="run-o1sxc2on", creation_timestamp=self.CREATED_AT),
+            status=k8s.V1PodStatus(
+                container_statuses=container_statuses,
+                init_container_statuses=init_container_statuses,
+                conditions=conditions,
             ),
         )
 
-    def _cond(self, last_transition_time):
-        return k8s.V1PodCondition(type="Ready", status="False", last_transition_time=last_transition_time)
-
-    def _pod(self, container_statuses=None, init_container_statuses=None, conditions=None):
-        pod = MagicMock()
-        pod.status.container_statuses = container_statuses
-        pod.status.init_container_statuses = init_container_statuses
-        pod.status.conditions = conditions
-        pod.metadata.creation_timestamp = self.T3
-        return pod
-
     def test_single_main_container(self):
-        pod = self._pod(container_statuses=[self._cs(self.T1)])
+        pod = self._pod(container_statuses=[make_container_status(self.T1)])
         assert kubernetes_command._get_pod_completion_time(pod) == self.T1
 
     def test_single_init_container_no_main(self):
-        pod = self._pod(container_statuses=[], init_container_statuses=[self._cs(self.T1)])
+        pod = self._pod(container_statuses=[], init_container_statuses=[make_container_status(self.T1)])
         assert kubernetes_command._get_pod_completion_time(pod) == self.T1
 
     def test_main_and_init_returns_max(self):
         pod = self._pod(
-            container_statuses=[self._cs(self.T1)],
-            init_container_statuses=[self._cs(self.T2)],
+            container_statuses=[make_container_status(self.T1)],
+            init_container_statuses=[make_container_status(self.T2)],
         )
         assert kubernetes_command._get_pod_completion_time(pod) == self.T2
 
-    def test_no_finished_at_falls_back_to_conditions(self):
-        # container status present but no finished_at → conditions fallback
+    @pytest.mark.parametrize(
+        "container_status",
+        [
+            pytest.param(k8s.V1ContainerStatus(**CONTAINER_STATUS_ATTRS, state=None), id="no-state"),
+            pytest.param(make_container_status(finished_at=None), id="not-terminated"),
+        ],
+    )
+    def test_falls_back_to_conditions(self, container_status):
         pod = self._pod(
-            container_statuses=[self._cs(finished_at=None)],
-            conditions=[self._cond(self.T1)],
+            container_statuses=[container_status],
+            conditions=[k8s.V1PodCondition(type="Ready", status="False", last_transition_time=self.T1)],
         )
         assert kubernetes_command._get_pod_completion_time(pod) == self.T1
 
     def test_no_containers_no_conditions_falls_back_to_creation_timestamp(self):
         pod = self._pod(container_statuses=[], init_container_statuses=[], conditions=[])
-        assert kubernetes_command._get_pod_completion_time(pod) == self.T3
+        assert kubernetes_command._get_pod_completion_time(pod) == self.CREATED_AT

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, call
 import kubernetes
 import pytest
 from dateutil.parser import parse
+from kubernetes.client import models as k8s
 
 from airflow.cli import cli_parser
 from airflow.executors import executor_loader
@@ -357,14 +358,23 @@ class TestCleanUpPodsCommand:
     def test_cleanup_min_completed_zero_deletes_immediately(
         self, load_incluster_config, list_namespaced_pod, delete_pod
     ):
-        # default (0) preserves existing behaviour: delete Succeeded pods regardless of age
+        # explicit 0 disables the age check: delete Succeeded pods regardless of age
         pod = self._make_pod("run-newpod", "Succeeded", parse("2099-12-20T08:01:07Z"))
         pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod]
         list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
-            self.parser.parse_args(["kubernetes", "cleanup-pods", "--namespace", "awesome-namespace"])
+            self.parser.parse_args(
+                [
+                    "kubernetes",
+                    "cleanup-pods",
+                    "--namespace",
+                    "awesome-namespace",
+                    "--min-completed-minutes",
+                    "0",
+                ]
+            )
         )
         delete_pod.assert_called_with("run-newpod", "awesome-namespace")
 
@@ -395,3 +405,62 @@ class TestCleanUpPodsCommand:
             )
         )
         delete_pod.assert_not_called()
+
+
+class TestGetPodCompletionTime:
+    T1 = parse("2024-01-01T10:00:00Z")
+    T2 = parse("2024-01-01T10:05:00Z")
+    T3 = parse("2024-01-01T09:00:00Z")  # earlier than T1/T2, used as creation_timestamp
+
+    def _cs(self, finished_at=None):
+        """Real V1ContainerStatus with optional finished_at."""
+        return k8s.V1ContainerStatus(
+            name="base",
+            ready=False,
+            restart_count=0,
+            image="img",
+            image_id="id",
+            state=k8s.V1ContainerState(
+                terminated=k8s.V1ContainerStateTerminated(exit_code=0, finished_at=finished_at)
+                if finished_at
+                else None
+            ),
+        )
+
+    def _cond(self, last_transition_time):
+        return k8s.V1PodCondition(type="Ready", status="False", last_transition_time=last_transition_time)
+
+    def _pod(self, container_statuses=None, init_container_statuses=None, conditions=None):
+        pod = MagicMock()
+        pod.status.container_statuses = container_statuses
+        pod.status.init_container_statuses = init_container_statuses
+        pod.status.conditions = conditions
+        pod.metadata.creation_timestamp = self.T3
+        return pod
+
+    def test_single_main_container(self):
+        pod = self._pod(container_statuses=[self._cs(self.T1)])
+        assert kubernetes_command._get_pod_completion_time(pod) == self.T1
+
+    def test_single_init_container_no_main(self):
+        pod = self._pod(container_statuses=[], init_container_statuses=[self._cs(self.T1)])
+        assert kubernetes_command._get_pod_completion_time(pod) == self.T1
+
+    def test_main_and_init_returns_max(self):
+        pod = self._pod(
+            container_statuses=[self._cs(self.T1)],
+            init_container_statuses=[self._cs(self.T2)],
+        )
+        assert kubernetes_command._get_pod_completion_time(pod) == self.T2
+
+    def test_no_finished_at_falls_back_to_conditions(self):
+        # container status present but no finished_at → conditions fallback
+        pod = self._pod(
+            container_statuses=[self._cs(finished_at=None)],
+            conditions=[self._cond(self.T1)],
+        )
+        assert kubernetes_command._get_pod_completion_time(pod) == self.T1
+
+    def test_no_containers_no_conditions_falls_back_to_creation_timestamp(self):
+        pod = self._pod(container_statuses=[], init_container_statuses=[], conditions=[])
+        assert kubernetes_command._get_pod_completion_time(pod) == self.T3

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py
@@ -283,3 +283,115 @@ class TestCleanUpPodsCommand:
         list_namespaced_pod.assert_has_calls(calls)
         delete_pod.assert_called_with("dummy", "awesome-namespace")
         load_incluster_config.assert_called_once()
+
+    # -- min-completed-minutes tests --
+
+    def _make_pod(self, name, phase, finished_at, reason=None, restart_policy="Never"):
+        """Build a minimal pod mock for min-completed-minutes tests."""
+        pod = MagicMock()
+        pod.metadata.name = name
+        pod.metadata.creation_timestamp = parse("2021-12-20T08:00:00Z")
+        pod.status.phase = phase
+        pod.status.reason = reason
+        pod.spec.restart_policy = restart_policy
+        container_status = MagicMock()
+        container_status.state.terminated.finished_at = finished_at
+        pod.status.container_statuses = [container_status]
+        return pod
+
+    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
+    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
+    @mock.patch("kubernetes.config.load_incluster_config")
+    def test_cleanup_succeeded_pod_too_young_not_deleted(
+        self, load_incluster_config, list_namespaced_pod, delete_pod
+    ):
+        # finished_at far in the future → age is negative → less than 1 min → skip
+        pod = self._make_pod("run-o1sxc2on", "Succeeded", parse("2099-12-20T08:01:07Z"))
+        pods = MagicMock()
+        pods.metadata._continue = None
+        pods.items = [pod]
+        list_namespaced_pod.return_value = pods
+        kubernetes_command.cleanup_pods(
+            self.parser.parse_args(
+                [
+                    "kubernetes",
+                    "cleanup-pods",
+                    "--namespace",
+                    "awesome-namespace",
+                    "--min-completed-minutes",
+                    "1",
+                ]
+            )
+        )
+        delete_pod.assert_not_called()
+
+    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
+    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
+    @mock.patch("kubernetes.config.load_incluster_config")
+    def test_cleanup_succeeded_pod_old_enough_deleted(
+        self, load_incluster_config, list_namespaced_pod, delete_pod
+    ):
+        # finished_at far in the past → age > 1 min → delete
+        pod = self._make_pod("run-oldpod", "Succeeded", parse("2021-12-20T08:01:07Z"))
+        pods = MagicMock()
+        pods.metadata._continue = None
+        pods.items = [pod]
+        list_namespaced_pod.return_value = pods
+        kubernetes_command.cleanup_pods(
+            self.parser.parse_args(
+                [
+                    "kubernetes",
+                    "cleanup-pods",
+                    "--namespace",
+                    "awesome-namespace",
+                    "--min-completed-minutes",
+                    "1",
+                ]
+            )
+        )
+        delete_pod.assert_called_with("run-oldpod", "awesome-namespace")
+
+    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
+    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
+    @mock.patch("kubernetes.config.load_incluster_config")
+    def test_cleanup_min_completed_zero_deletes_immediately(
+        self, load_incluster_config, list_namespaced_pod, delete_pod
+    ):
+        # default (0) preserves existing behaviour: delete Succeeded pods regardless of age
+        pod = self._make_pod("run-newpod", "Succeeded", parse("2099-12-20T08:01:07Z"))
+        pods = MagicMock()
+        pods.metadata._continue = None
+        pods.items = [pod]
+        list_namespaced_pod.return_value = pods
+        kubernetes_command.cleanup_pods(
+            self.parser.parse_args(["kubernetes", "cleanup-pods", "--namespace", "awesome-namespace"])
+        )
+        delete_pod.assert_called_with("run-newpod", "awesome-namespace")
+
+    @mock.patch("airflow.providers.cncf.kubernetes.cli.kubernetes_command._delete_pod")
+    @mock.patch("kubernetes.client.CoreV1Api.list_namespaced_pod")
+    @mock.patch("kubernetes.config.load_incluster_config")
+    def test_cleanup_failed_pod_too_young_not_deleted(
+        self, load_incluster_config, list_namespaced_pod, delete_pod
+    ):
+        # Failed + restart_policy=Never, but finished too recently → skip
+        pod = self._make_pod(
+            "run-failpod", "Failed", parse("2099-12-20T08:01:07Z"), restart_policy="Never"
+        )
+        pods = MagicMock()
+        pods.metadata._continue = None
+        pods.items = [pod]
+        list_namespaced_pod.return_value = pods
+        kubernetes_command.cleanup_pods(
+            self.parser.parse_args(
+                [
+                    "kubernetes",
+                    "cleanup-pods",
+                    "--namespace",
+                    "awesome-namespace",
+                    "--min-completed-minutes",
+                    "1",
+                ]
+            )
+        )
+        delete_pod.assert_not_called()


### PR DESCRIPTION
## Problem

`KubernetesPodOperator` in synchronous (`deferrable=False`) mode calls `PodManager.await_pod_completion` to confirm the pod reached a terminal phase. This method polls `read_pod` every **2 seconds** ([`pod_manager.py:839`](https://github.com/apache/airflow/blob/main/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/utils/pod_manager.py#L839), hardcoded `time.sleep(2)`).

When a pod transitions to `Succeeded`, there is up to a 2-second window before `PodManager.await_pod_completion` observes the terminal phase. The `airflow kubernetes cleanup-pods` command currently deletes Succeeded/Failed/Evicted pods **immediately** — there is no minimum-age guard for terminal states.

If the cleanup job fires during that window, `PodManager.await_pod_completion`'s next `read_pod` call returns 404 and the task is marked **FAILED**, even though the pod completed successfully (exit code 0).

A `--min-pending-minutes` guard already exists for Pending pods (default 30 m, minimum 5 m). No equivalent exists for terminal states.

### Real-world reproduction

Confirmed via Kubernetes API server audit logs on a production EKS cluster running `apache-airflow-providers-cncf-kubernetes==10.19.0` on Airflow 3.2.2. The cleanup CronJob was set to run every 5 minutes.

Timeline of a representative failure:

```
13:15:12Z  PodManager polls pod       → phase Running
13:15:14Z  Container exits            → exit code 0 (pod phase → Succeeded)
13:15:17Z  cleanup-pods deletes pod   → 3 s after completion
13:15:18Z  PodManager polls pod       → 404 Not Found → task FAILED
```

Airflow task log excerpt:
```
[INFO]  Pod run-o1sxc2on has phase Running
[ERROR] Task failed with exception
ApiException: (404) Reason: Not Found
HTTP response body: {"message":"pods \"run-o1sxc2on\" not found","reason":"NotFound","code":404}
```

Audit log at deletion time confirmed `phase: Succeeded`, `containerStatuses[0].state.terminated.exitCode: 0`, `finishedAt: 13:15:14Z`.

### Related

PR #69269 fixed a similar 404 race in `is_istio_enabled` for the deferrable `trigger_reentry` path (10.20.0). This PR addresses the complementary gap: preventing the race at source by not deleting recently-completed pods.

## Solution

Add `--min-completed-minutes` (default `1`) to the `cleanup-pods` command. When set, Succeeded/Failed/Evicted pods are skipped unless their completion time exceeds the threshold. Set to `0` to restore the previous immediate-deletion behaviour.

Completion time is derived from the latest `finished_at` across both `container_statuses` **and** `init_container_statuses`. Falls back to the latest `conditions[*].last_transition_time` (updated at the terminal transition), then to `creation_timestamp` as a last resort.

## Changes

| File | Change |
|---|---|
| `cli/definition.py` | Add `ARG_MIN_COMPLETED_MINUTES` (default `1`, `allow_zero=True`) |
| `cli/kubernetes_command.py` | Add `_get_pod_completion_time()`; gate terminal-pod deletion by age |
| `tests/.../test_kubernetes_command.py` | `TestGetPodCompletionTime` with real k8s model objects; 4 integration-style tests for the new flag |
| `docs/changelog.rst` | Not modified — maintained by release manager |

CLI reference docs (`cli-ref.rst`) use `.. argparse::` and pick up the new flag automatically.

## Testing

```bash
pytest providers/cncf/kubernetes/tests/unit/cncf/kubernetes/cli/test_kubernetes_command.py -q
# 19 passed
```

## Usage

```bash
# Helm chart — keep default of 1 minute:
cleanup:
  args: ["bash", "-c", "exec airflow kubernetes cleanup-pods --namespace {{ .Release.Namespace }}"]

# Or set explicitly:
airflow kubernetes cleanup-pods --namespace airflow --min-completed-minutes 5
```

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Sonnet 4.6, Opus 5)

Generated-by: Claude Sonnet 4.6 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.