### PR TITLE
Batch upstream map-length lookups when resolving mapped kwargs

### DIFF
--- a/airflow-core/src/airflow/models/expandinput.py
+++ b/airflow-core/src/airflow/models/expandinput.py
@@ -136,7 +136,7 @@ class SchedulerDictOfListsExpandInput:
 
         def _get_length(v: ExpandArgument) -> int | None:
             if isinstance(v, SchedulerXComArg):
-                return get_task_map_length(v, run_id, session=session, lengths=lengths)
+                return get_task_map_length(v, run_id, lengths=lengths, session=session)
 
             # Unfortunately a user-defined TypeGuard cannot apply negative type
             # narrowing. https://github.com/python/typing/discussions/1013
@@ -189,7 +189,7 @@ class SchedulerListOfDictsExpandInput:
         if isinstance(self.value, Sized):
             return len(self.value)
         lengths = prefetch_map_lengths([self.value], run_id, session=session)
-        length = get_task_map_length(self.value, run_id, session=session, lengths=lengths)
+        length = get_task_map_length(self.value, run_id, lengths=lengths, session=session)
         if length is None:
             raise NotFullyPopulated({"expand_kwargs() argument"})
         return length

--- a/airflow-core/src/airflow/models/expandinput.py
+++ b/airflow-core/src/airflow/models/expandinput.py
@@ -124,13 +124,19 @@ class SchedulerDictOfListsExpandInput:
         If any arguments are not known right now (upstream task not finished),
         they will not be present in the dict.
         """
-        from airflow.serialization.definitions.xcom_arg import SchedulerXComArg, get_task_map_length
+        from airflow.serialization.definitions.xcom_arg import (
+            SchedulerXComArg,
+            get_task_map_length,
+            prefetch_map_lengths,
+        )
 
-        # TODO: This initiates one database call for each XComArg. Would it be
-        # more efficient to do one single db call and unpack the value here?
+        lengths = prefetch_map_lengths(
+            (v for v in self.value.values() if isinstance(v, SchedulerXComArg)), run_id, session=session
+        )
+
         def _get_length(v: ExpandArgument) -> int | None:
             if isinstance(v, SchedulerXComArg):
-                return get_task_map_length(v, run_id, session=session)
+                return get_task_map_length(v, run_id, session=session, lengths=lengths)
 
             # Unfortunately a user-defined TypeGuard cannot apply negative type
             # narrowing. https://github.com/python/typing/discussions/1013
@@ -178,11 +184,12 @@ class SchedulerListOfDictsExpandInput:
         raise NotFullyPopulated({"expand_kwargs() argument"})
 
     def get_total_map_length(self, run_id: str, *, session: Session) -> int:
-        from airflow.serialization.definitions.xcom_arg import get_task_map_length
+        from airflow.serialization.definitions.xcom_arg import get_task_map_length, prefetch_map_lengths
 
         if isinstance(self.value, Sized):
             return len(self.value)
-        length = get_task_map_length(self.value, run_id, session=session)
+        lengths = prefetch_map_lengths([self.value], run_id, session=session)
+        length = get_task_map_length(self.value, run_id, session=session, lengths=lengths)
         if length is None:
             raise NotFullyPopulated({"expand_kwargs() argument"})
         return length

--- a/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
+++ b/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from functools import singledispatch
 from typing import TYPE_CHECKING, Any
 
@@ -31,12 +31,21 @@ from airflow.serialization.definitions.notset import NOTSET, is_arg_set
 from airflow.utils.db import exists_query
 from airflow.utils.state import State
 
-__all__ = ["SchedulerXComArg", "deserialize_xcom_arg", "get_task_map_length"]
+__all__ = [
+    "SchedulerXComArg",
+    "deserialize_xcom_arg",
+    "get_task_map_length",
+    "prefetch_map_lengths",
+]
 
 if TYPE_CHECKING:
     from airflow.serialization.definitions.dag import SerializedDAG
     from airflow.serialization.definitions.mappedoperator import Operator
     from airflow.typing_compat import Self
+
+# Map length of each referenced task, keyed by ``(dag_id, task_id)``. A task whose
+# length is not known yet (upstream unfinished) is absent rather than mapped to None.
+MapLengths = Mapping[tuple[str, str], int]
 
 
 class SchedulerXComArg:
@@ -145,14 +154,102 @@ class SchedulerZipXComArg(SchedulerXComArg):
             yield from arg.iter_references()
 
 
+def _match_referenced_tasks(model: Any, keys: Iterable[tuple[str, str]]) -> tuple[Any, Any]:
+    """
+    Build filters selecting rows of ``model`` for any of the given ``(dag_id, task_id)``.
+
+    Matching the two columns independently rather than as a row value keeps the query
+    portable. That is wider than the key set only if the keys span several Dags, which
+    the callers never do, and callers read results back by exact key regardless.
+    """
+    dag_ids, task_ids = zip(*keys)
+    return model.dag_id.in_(set(dag_ids)), model.task_id.in_(set(task_ids))
+
+
+def prefetch_map_lengths(
+    xcom_args: Iterable[SchedulerXComArg], run_id: str, *, session: Session
+) -> dict[tuple[str, str], int]:
+    """
+    Resolve the map length of every task referenced by ``xcom_args`` in bulk.
+
+    Passing the result to :func:`get_task_map_length` as ``lengths`` keeps the number of
+    queries constant no matter how many arguments -- and how many tasks nested inside
+    ``zip()``/``concat()`` arguments -- have to be resolved.
+
+    Tasks whose length is not known yet are absent from the result, mirroring the
+    ``None`` that :func:`get_task_map_length` returns for them.
+    """
+    from airflow.models.taskinstance import TaskInstance
+    from airflow.models.taskmap import TaskMap
+    from airflow.models.xcom import XComModel
+    from airflow.serialization.definitions.mappedoperator import is_mapped
+
+    operators = {(op.dag_id, op.task_id): op for arg in xcom_args for op, _ in arg.iter_references()}
+    if not operators:
+        return {}
+    mapped = {key for key, op in operators.items() if is_mapped(op)}
+    unmapped = operators.keys() - mapped
+
+    lengths: dict[tuple[str, str], int] = {}
+    if unmapped:
+        rows = session.execute(
+            select(TaskMap.dag_id, TaskMap.task_id, TaskMap.length).where(
+                TaskMap.run_id == run_id,
+                TaskMap.map_index < 0,
+                *_match_referenced_tasks(TaskMap, unmapped),
+            )
+        )
+        lengths.update({(dag_id, task_id): length for dag_id, task_id, length in rows})
+    if mapped:
+        unfinished = set(
+            session.execute(
+                select(TaskInstance.dag_id, TaskInstance.task_id)
+                .where(
+                    TaskInstance.run_id == run_id,
+                    *_match_referenced_tasks(TaskInstance, mapped),
+                    # Special NULL treatment is needed because 'state' can be NULL.
+                    # The "IN" part would produce "NULL NOT IN ..." and eventually
+                    # "NULl = NULL", which is a big no-no in SQL.
+                    or_(
+                        TaskInstance.state.is_(None),
+                        TaskInstance.state.in_(s.value for s in State.unfinished if s is not None),
+                    ),
+                )
+                .distinct()
+            )
+        )
+        if finished := mapped - unfinished:
+            counts = {
+                (dag_id, task_id): count
+                for dag_id, task_id, count in session.execute(
+                    select(XComModel.dag_id, XComModel.task_id, func.count(XComModel.map_index))
+                    .where(
+                        XComModel.run_id == run_id,
+                        XComModel.map_index >= 0,
+                        XComModel.key == XCOM_RETURN_KEY,
+                        *_match_referenced_tasks(XComModel, finished),
+                    )
+                    .group_by(XComModel.dag_id, XComModel.task_id)
+                )
+            }
+            # A finished mapped task that pushed nothing has no row to group, but its
+            # length is a known zero rather than an unresolved value.
+            lengths.update({key: counts.get(key, 0) for key in finished})
+    return lengths
+
+
 @singledispatch
-def get_task_map_length(xcom_arg: SchedulerXComArg, run_id: str, *, session: Session) -> int | None:
+def get_task_map_length(
+    xcom_arg: SchedulerXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+) -> int | None:
     # The base implementation -- specific XComArg subclasses have specialised implementations
     raise NotImplementedError(f"get_task_map_length not implemented for {type(xcom_arg)}")
 
 
 @get_task_map_length.register
-def _(xcom_arg: SchedulerPlainXComArg, run_id: str, *, session: Session) -> int | None:
+def _(
+    xcom_arg: SchedulerPlainXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+) -> int | None:
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.taskmap import TaskMap
     from airflow.models.xcom import XComModel
@@ -160,6 +257,9 @@ def _(xcom_arg: SchedulerPlainXComArg, run_id: str, *, session: Session) -> int 
 
     dag_id = xcom_arg.operator.dag_id
     task_id = xcom_arg.operator.task_id
+
+    if lengths is not None:
+        return lengths.get((dag_id, task_id))
 
     if is_mapped(xcom_arg.operator):
         unfinished_ti_exists = exists_query(
@@ -195,13 +295,19 @@ def _(xcom_arg: SchedulerPlainXComArg, run_id: str, *, session: Session) -> int 
 
 
 @get_task_map_length.register
-def _(xcom_arg: SchedulerMapXComArg, run_id: str, *, session: Session) -> int | None:
-    return get_task_map_length(xcom_arg.arg, run_id, session=session)
+def _(
+    xcom_arg: SchedulerMapXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+) -> int | None:
+    return get_task_map_length(xcom_arg.arg, run_id, session=session, lengths=lengths)
 
 
 @get_task_map_length.register
-def _(xcom_arg: SchedulerZipXComArg, run_id: str, *, session: Session) -> int | None:
-    all_lengths = (get_task_map_length(arg, run_id, session=session) for arg in xcom_arg.args)
+def _(
+    xcom_arg: SchedulerZipXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+) -> int | None:
+    all_lengths = (
+        get_task_map_length(arg, run_id, session=session, lengths=lengths) for arg in xcom_arg.args
+    )
     ready_lengths = [length for length in all_lengths if length is not None]
     if len(ready_lengths) != len(xcom_arg.args):
         return None  # If any of the referenced XComs is not ready, we are not ready either.
@@ -211,8 +317,12 @@ def _(xcom_arg: SchedulerZipXComArg, run_id: str, *, session: Session) -> int | 
 
 
 @get_task_map_length.register
-def _(xcom_arg: SchedulerConcatXComArg, run_id: str, *, session: Session) -> int | None:
-    all_lengths = (get_task_map_length(arg, run_id, session=session) for arg in xcom_arg.args)
+def _(
+    xcom_arg: SchedulerConcatXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+) -> int | None:
+    all_lengths = (
+        get_task_map_length(arg, run_id, session=session, lengths=lengths) for arg in xcom_arg.args
+    )
     ready_lengths = [length for length in all_lengths if length is not None]
     if len(ready_lengths) != len(xcom_arg.args):
         return None  # If any of the referenced XComs is not ready, we are not ready either.

--- a/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
+++ b/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
@@ -238,7 +238,7 @@ def prefetch_map_lengths(
 
 @singledispatch
 def get_task_map_length(
-    xcom_arg: SchedulerXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+    xcom_arg: SchedulerXComArg, run_id: str, *, lengths: MapLengths | None = None, session: Session
 ) -> int | None:
     # The base implementation -- specific XComArg subclasses have specialised implementations
     raise NotImplementedError(f"get_task_map_length not implemented for {type(xcom_arg)}")

--- a/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
+++ b/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
@@ -22,7 +22,7 @@ from functools import singledispatch
 from typing import TYPE_CHECKING, Any
 
 import attrs
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, tuple_
 from sqlalchemy.orm import Session
 
 from airflow.models.referencemixin import ReferenceMixin
@@ -157,18 +157,6 @@ class SchedulerZipXComArg(SchedulerXComArg):
             yield from arg.iter_references()
 
 
-def _match_referenced_tasks(model: Any, keys: Iterable[tuple[str, str]]) -> tuple[Any, Any]:
-    """
-    Build filters selecting rows of ``model`` for any of the given ``(dag_id, task_id)``.
-
-    Matching the two columns independently rather than as a row value keeps the query
-    portable. That is wider than the key set only if the keys span several Dags, which
-    the callers never do, and callers read results back by exact key regardless.
-    """
-    dag_ids, task_ids = zip(*keys)
-    return model.dag_id.in_(set(dag_ids)), model.task_id.in_(set(task_ids))
-
-
 def prefetch_map_lengths(
     xcom_args: Iterable[SchedulerXComArg], run_id: str, *, session: Session
 ) -> dict[tuple[str, str], int]:
@@ -194,7 +182,7 @@ def prefetch_map_lengths(
             select(TaskMap.dag_id, TaskMap.task_id, TaskMap.length).where(
                 TaskMap.run_id == run_id,
                 TaskMap.map_index < 0,
-                *_match_referenced_tasks(TaskMap, unmapped),
+                tuple_(TaskMap.dag_id, TaskMap.task_id).in_(sorted(unmapped)),
             )
         )
         lengths.update(((dag_id, task_id), length) for dag_id, task_id, length in rows)
@@ -204,7 +192,7 @@ def prefetch_map_lengths(
                 select(TaskInstance.dag_id, TaskInstance.task_id)
                 .where(
                     TaskInstance.run_id == run_id,
-                    *_match_referenced_tasks(TaskInstance, mapped),
+                    tuple_(TaskInstance.dag_id, TaskInstance.task_id).in_(sorted(mapped)),
                     # Special NULL treatment is needed because 'state' can be NULL.
                     # The "IN" part would produce "NULL NOT IN ..." and eventually
                     # "NULl = NULL", which is a big no-no in SQL.
@@ -225,7 +213,7 @@ def prefetch_map_lengths(
                         XComModel.run_id == run_id,
                         XComModel.map_index >= 0,
                         XComModel.key == XCOM_RETURN_KEY,
-                        *_match_referenced_tasks(XComModel, finished),
+                        tuple_(XComModel.dag_id, XComModel.task_id).in_(sorted(finished)),
                     )
                     .group_by(XComModel.dag_id, XComModel.task_id)
                 )

--- a/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
+++ b/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
@@ -246,7 +246,7 @@ def get_task_map_length(
 
 @get_task_map_length.register
 def _(
-    xcom_arg: SchedulerPlainXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+    xcom_arg: SchedulerPlainXComArg, run_id: str, *, lengths: MapLengths | None = None, session: Session
 ) -> int | None:
     dag_id = xcom_arg.operator.dag_id
     task_id = xcom_arg.operator.task_id
@@ -289,17 +289,17 @@ def _(
 
 @get_task_map_length.register
 def _(
-    xcom_arg: SchedulerMapXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+    xcom_arg: SchedulerMapXComArg, run_id: str, *, lengths: MapLengths | None = None, session: Session
 ) -> int | None:
-    return get_task_map_length(xcom_arg.arg, run_id, session=session, lengths=lengths)
+    return get_task_map_length(xcom_arg.arg, run_id, lengths=lengths, session=session)
 
 
 @get_task_map_length.register
 def _(
-    xcom_arg: SchedulerZipXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+    xcom_arg: SchedulerZipXComArg, run_id: str, *, lengths: MapLengths | None = None, session: Session
 ) -> int | None:
     all_lengths = (
-        get_task_map_length(arg, run_id, session=session, lengths=lengths) for arg in xcom_arg.args
+        get_task_map_length(arg, run_id, lengths=lengths, session=session) for arg in xcom_arg.args
     )
     ready_lengths = [length for length in all_lengths if length is not None]
     if len(ready_lengths) != len(xcom_arg.args):
@@ -311,10 +311,10 @@ def _(
 
 @get_task_map_length.register
 def _(
-    xcom_arg: SchedulerConcatXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
+    xcom_arg: SchedulerConcatXComArg, run_id: str, *, lengths: MapLengths | None = None, session: Session
 ) -> int | None:
     all_lengths = (
-        get_task_map_length(arg, run_id, session=session, lengths=lengths) for arg in xcom_arg.args
+        get_task_map_length(arg, run_id, lengths=lengths, session=session) for arg in xcom_arg.args
     )
     ready_lengths = [length for length in all_lengths if length is not None]
     if len(ready_lengths) != len(xcom_arg.args):

--- a/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
+++ b/airflow-core/src/airflow/serialization/definitions/xcom_arg.py
@@ -26,7 +26,10 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from airflow.models.referencemixin import ReferenceMixin
-from airflow.models.xcom import XCOM_RETURN_KEY
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskmap import TaskMap
+from airflow.models.xcom import XCOM_RETURN_KEY, XComModel
+from airflow.serialization.definitions.mappedoperator import is_mapped
 from airflow.serialization.definitions.notset import NOTSET, is_arg_set
 from airflow.utils.db import exists_query
 from airflow.utils.state import State
@@ -179,11 +182,6 @@ def prefetch_map_lengths(
     Tasks whose length is not known yet are absent from the result, mirroring the
     ``None`` that :func:`get_task_map_length` returns for them.
     """
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.models.taskmap import TaskMap
-    from airflow.models.xcom import XComModel
-    from airflow.serialization.definitions.mappedoperator import is_mapped
-
     operators = {(op.dag_id, op.task_id): op for arg in xcom_args for op, _ in arg.iter_references()}
     if not operators:
         return {}
@@ -199,7 +197,7 @@ def prefetch_map_lengths(
                 *_match_referenced_tasks(TaskMap, unmapped),
             )
         )
-        lengths.update({(dag_id, task_id): length for dag_id, task_id, length in rows})
+        lengths.update(((dag_id, task_id), length) for dag_id, task_id, length in rows)
     if mapped:
         unfinished = set(
             session.execute(
@@ -234,7 +232,7 @@ def prefetch_map_lengths(
             }
             # A finished mapped task that pushed nothing has no row to group, but its
             # length is a known zero rather than an unresolved value.
-            lengths.update({key: counts.get(key, 0) for key in finished})
+            lengths.update((key, counts.get(key, 0)) for key in finished)
     return lengths
 
 
@@ -250,11 +248,6 @@ def get_task_map_length(
 def _(
     xcom_arg: SchedulerPlainXComArg, run_id: str, *, session: Session, lengths: MapLengths | None = None
 ) -> int | None:
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.models.taskmap import TaskMap
-    from airflow.models.xcom import XComModel
-    from airflow.serialization.definitions.mappedoperator import is_mapped
-
     dag_id = xcom_arg.operator.dag_id
     task_id = xcom_arg.operator.task_id
 

--- a/airflow-core/tests/unit/serialization/definitions/test_xcom_arg.py
+++ b/airflow-core/tests/unit/serialization/definitions/test_xcom_arg.py
@@ -101,6 +101,30 @@ def test_map_lengths_resolve_nested_zip_leaves_in_one_batch(dag_maker, session):
     assert lengths == {"a": 2}
 
 
+def test_expand_kwargs_resolves_concatenated_upstreams_in_one_batch(dag_maker, session):
+    with dag_maker(dag_id="expand_kwargs_upstreams", session=session, serialized=True) as dag:
+
+        @dag.task
+        def emit_a(): ...
+
+        @dag.task
+        def emit_b(): ...
+
+        @dag.task
+        def show(a): ...
+
+        show.expand_kwargs(emit_a().concat(emit_b()))
+
+    dag_run = dag_maker.create_dagrun()
+    for task_id, length in (("emit_a", 2), ("emit_b", 3)):
+        _add_task_map(session, dag_run, task_id, length)
+    session.commit()
+
+    expand_input = _get_expand_input(dag_maker)
+    with assert_queries_count(1, session=session):
+        assert expand_input.get_total_map_length(dag_run.run_id, session=session) == 5
+
+
 def _make_mapped_upstream_dag(dag_maker, session):
     """Build ``show.expand(a=<mapped task>, b=<unmapped task>)`` with ``a`` expanded to 2 instances."""
     with dag_maker(dag_id="mapped_upstream", session=session, serialized=True) as dag:

--- a/airflow-core/tests/unit/serialization/definitions/test_xcom_arg.py
+++ b/airflow-core/tests/unit/serialization/definitions/test_xcom_arg.py
@@ -1,0 +1,190 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from airflow.models.expandinput import NotFullyPopulated
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskmap import TaskMap
+from airflow.models.xcom import XCOM_RETURN_KEY, XComModel
+from airflow.serialization.definitions.xcom_arg import prefetch_map_lengths
+from airflow.utils.state import TaskInstanceState
+
+from tests_common.test_utils.asserts import assert_queries_count
+
+pytestmark = pytest.mark.db_test
+
+
+def _add_task_map(session, dag_run, task_id, length):
+    session.add(
+        TaskMap(
+            dag_id=dag_run.dag_id,
+            task_id=task_id,
+            run_id=dag_run.run_id,
+            map_index=-1,
+            length=length,
+            keys=None,
+        )
+    )
+
+
+def _get_expand_input(dag_maker, task_id="show"):
+    return dag_maker.serialized_dag.get_task(task_id)._get_specified_expand_input()
+
+
+def test_map_lengths_over_unmapped_upstreams_use_a_single_query(dag_maker, session):
+    with dag_maker(dag_id="unmapped_upstreams", session=session, serialized=True) as dag:
+
+        @dag.task
+        def emit_a(): ...
+
+        @dag.task
+        def emit_b(): ...
+
+        @dag.task
+        def emit_c(): ...
+
+        @dag.task
+        def show(a, b, c): ...
+
+        show.expand(a=emit_a(), b=emit_b(), c=emit_c())
+
+    dag_run = dag_maker.create_dagrun()
+    for task_id, length in (("emit_a", 2), ("emit_b", 3), ("emit_c", 4)):
+        _add_task_map(session, dag_run, task_id, length)
+    session.commit()
+
+    expand_input = _get_expand_input(dag_maker)
+    with assert_queries_count(1, session=session):
+        lengths = expand_input._get_map_lengths(dag_run.run_id, session=session)
+    assert lengths == {"a": 2, "b": 3, "c": 4}
+
+
+def test_map_lengths_resolve_nested_zip_leaves_in_one_batch(dag_maker, session):
+    with dag_maker(dag_id="zipped_upstreams", session=session, serialized=True) as dag:
+
+        @dag.task
+        def emit_a(): ...
+
+        @dag.task
+        def emit_b(): ...
+
+        @dag.task
+        def show(a): ...
+
+        show.expand(a=emit_a().zip(emit_b()))
+
+    dag_run = dag_maker.create_dagrun()
+    for task_id, length in (("emit_a", 2), ("emit_b", 3)):
+        _add_task_map(session, dag_run, task_id, length)
+    session.commit()
+
+    expand_input = _get_expand_input(dag_maker)
+    with assert_queries_count(1, session=session):
+        lengths = expand_input._get_map_lengths(dag_run.run_id, session=session)
+    assert lengths == {"a": 2}
+
+
+def _make_mapped_upstream_dag(dag_maker, session):
+    """Build ``show.expand(a=<mapped task>, b=<unmapped task>)`` with ``a`` expanded to 2 instances."""
+    with dag_maker(dag_id="mapped_upstream", session=session, serialized=True) as dag:
+
+        @dag.task
+        def emit(): ...
+
+        @dag.task
+        def double(x): ...
+
+        @dag.task
+        def emit_other(): ...
+
+        @dag.task
+        def show(a, b): ...
+
+        show.expand(a=double.expand(x=emit()), b=emit_other())
+
+    dag_run = dag_maker.create_dagrun()
+    _add_task_map(session, dag_run, "emit", 2)
+    _add_task_map(session, dag_run, "emit_other", 4)
+    session.flush()
+    TaskMap.expand_mapped_task(dag_maker.serialized_dag.get_task("double"), dag_run.run_id, session=session)
+    session.flush()
+    return dag_run
+
+
+def _set_upstream_state(session, dag_run, task_id, state):
+    for ti in session.scalars(
+        select(TaskInstance).where(
+            TaskInstance.dag_id == dag_run.dag_id,
+            TaskInstance.run_id == dag_run.run_id,
+            TaskInstance.task_id == task_id,
+        )
+    ):
+        ti.state = state
+
+
+@pytest.mark.parametrize(
+    ("pushed_map_indexes", "expected"),
+    [
+        pytest.param([0, 1], {"a": 2, "b": 4}, id="counts-pushed-xcoms"),
+        pytest.param([], {"a": 0, "b": 4}, id="finished-without-xcoms-is-zero"),
+    ],
+)
+def test_map_lengths_over_a_finished_mapped_upstream(dag_maker, session, pushed_map_indexes, expected):
+    dag_run = _make_mapped_upstream_dag(dag_maker, session)
+    _set_upstream_state(session, dag_run, "double", TaskInstanceState.SUCCESS)
+    for map_index in pushed_map_indexes:
+        XComModel.set(
+            key=XCOM_RETURN_KEY,
+            value=map_index,
+            dag_id=dag_run.dag_id,
+            task_id="double",
+            run_id=dag_run.run_id,
+            map_index=map_index,
+            session=session,
+        )
+    session.commit()
+
+    expand_input = _get_expand_input(dag_maker)
+    # One query per upstream kind: the unmapped lengths, the unfinished-instance
+    # probe for the mapped upstream, and its pushed-XCom count.
+    with assert_queries_count(3, session=session):
+        lengths = expand_input._get_map_lengths(dag_run.run_id, session=session)
+    assert lengths == expected
+
+
+def test_map_lengths_over_an_unfinished_mapped_upstream(dag_maker, session):
+    dag_run = _make_mapped_upstream_dag(dag_maker, session)
+    _set_upstream_state(session, dag_run, "double", TaskInstanceState.RUNNING)
+    session.commit()
+
+    expand_input = _get_expand_input(dag_maker)
+    with pytest.raises(NotFullyPopulated) as exc_info:
+        expand_input._get_map_lengths(dag_run.run_id, session=session)
+    assert exc_info.value.missing == {"a"}
+
+
+def test_prefetch_map_lengths_without_references_runs_no_query(dag_maker, session):
+    with dag_maker(dag_id="no_references", session=session, serialized=True):
+        pass
+    dag_run = dag_maker.create_dagrun()
+    session.commit()
+
+    with assert_queries_count(0, session=session):
+        assert prefetch_map_lengths([], dag_run.run_id, session=session) == {}


### PR DESCRIPTION
## Summary

Resolving mapped task kwargs previously issued one database query per `XComArg`, causing N+1 queries for expanded kwargs (especially with nested `zip()`/`concat()`). This change replaces those repeated lookups with a bulk prefetch, addressing the long-standing TODO in `SchedulerDictOfListsExpandInput._get_map_lengths`.

Upstream map lengths are now resolved in a fixed number of queries, improving both scheduler expansion and execution API argument binding.

## Changes

- Add `prefetch_map_lengths()` to resolve all referenced upstream map lengths in bulk.
- Add an optional `lengths` parameter to `get_task_map_length()` and use prefetched results when available.
- Prefetch once in `SchedulerDictOfListsExpandInput` and `SchedulerListOfDictsExpandInput`.
- Add tests covering query counts and behavior for mapped, unmapped, zipped, and unfinished upstreams.

## Testing

- Added query-count tests to verify the optimization.
- Existing scheduler and mapping tests pass.
- `mypy-airflow-core` and pre-commit checks pass.

* related: #70548
* related: #69757
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)
Drafted-by: Claude Code (Opus 5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
