### PR TITLE
Fix OpenLineage team_name access and other failing paths

### DIFF
--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/listener.py
@@ -21,7 +21,6 @@ import os
 import sys
 import threading
 from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
 from datetime import datetime
 from functools import cache
 from typing import TYPE_CHECKING
@@ -138,8 +137,12 @@ def _run_adapter_method(method_name: str, /, *args, **kwargs):
     background worker threads (e.g. the ``datadog`` transport, which always starts an async
     HTTP worker thread) are never closed, so this leaks one thread per event and steadily
     consumes scheduler CPU and memory until restart.
+
+    Returns nothing: the emitted event is only of use inside the pool worker, and pickling it
+    back to the parent would turn a redacted event the pickler chokes on into a spurious
+    "failed to submit" warning for an emission that actually succeeded.
     """
-    return getattr(_get_process_adapter(), method_name)(*args, **kwargs)
+    getattr(_get_process_adapter(), method_name)(*args, **kwargs)
 
 
 def _emit_manual_state_change_event(adapter_method_name: str, stats_key: str, **kwargs):
@@ -149,11 +152,11 @@ def _emit_manual_state_change_event(adapter_method_name: str, stats_key: str, **
     Module-level so it is picklable across the ProcessPoolExecutor boundary used by
     `_on_task_instance_manual_state_change` for scheduler-side "task state changed
     externally" emissions. The method is resolved on the per-process adapter so the
-    pool worker reuses one client across events (see ``_run_adapter_method``).
+    pool worker reuses one client across events (see ``_run_adapter_method``), and nothing is
+    returned so an unpicklable event cannot fail the future after a successful emission.
     """
     event = getattr(_get_process_adapter(), adapter_method_name)(**kwargs)
     Stats.gauge(stats_key, len(Serde.to_json(event).encode("utf-8")))
-    return event
 
 
 class OpenLineageListener:
@@ -1058,14 +1061,21 @@ class OpenLineageListener:
                 self._terminate_with_wait(process)
             self.log.debug("Process with pid %s finished - parent", pid)
         else:
-            setproctitle(getproctitle() + " - OpenLineage - " + callable_name)
-            if not AIRFLOW_V_3_0_PLUS:
-                configure_orm(disable_connection_pool=True)
-            self.log.debug("Executing OpenLineage process - %s - pid %s", callable_name, os.getpid())
+            # Everything the child does lives in this try, and the exit lives in its finally: a child
+            # that returns instead of exiting becomes a second task runner. It would unwind into the
+            # hook's caller and keep executing task-runner code while sharing the supervisor socket
+            # with the real one, duplicating state writes and interleaving bytes on the channel.
             try:
+                setproctitle(getproctitle() + " - OpenLineage - " + callable_name)
+                if not AIRFLOW_V_3_0_PLUS:
+                    configure_orm(disable_connection_pool=True)
+                self.log.debug("Executing OpenLineage process - %s - pid %s", callable_name, os.getpid())
                 callable()
                 self.log.debug("Process with current pid finishes after %s", callable_name)
-            except Exception:
+            except BaseException:
+                # BaseException, not Exception: a SIGINT delivered to the process group reaches this
+                # child as KeyboardInterrupt, and Airflow's own AirflowTaskTimeout / TaskDeferred
+                # also derive from BaseException.
                 self.log.warning(
                     "OpenLineage %s process failed. This has no impact on actual task execution status.",
                     callable_name,
@@ -1076,8 +1086,13 @@ class OpenLineageListener:
                 # logging so buffered records (including any warnings above) are flushed
                 # before the process exits. Without this, the final log lines are silently
                 # dropped, making failures invisible.
-                logging.shutdown()
-            os._exit(0)
+                # Nest os._exit in its own finally so that a raising logging.shutdown()
+                # (e.g. a remote handler whose close() throws) cannot skip the exit and
+                # unwind back into the task runner as a second process.
+                try:
+                    logging.shutdown()
+                finally:
+                    os._exit(0)
 
     @property
     def executor(self) -> ProcessPoolExecutor:
@@ -1095,8 +1110,26 @@ class OpenLineageListener:
     @hookimpl
     def before_stopping(self, component) -> None:
         self.log.debug("before_stopping: %s", component.__class__.__name__)
-        with timeout(30):
-            self.executor.shutdown(wait=True)
+        if self._executor is None:
+            # Do not build a pool just to tear it down -- on the task runner this hook fires at the
+            # end of every task, where no pool was ever needed.
+            return
+
+        # Detach before shutting down so a later event rebuilds a fresh pool. Left attached, every
+        # subsequent submission would raise "cannot schedule new futures after shutdown" and drop
+        # its event for the remaining lifetime of the process.
+        executor, self._executor = self._executor, None
+        try:
+            with timeout(30):
+                executor.shutdown(wait=True)
+        except BaseException:
+            # `timeout` is SIGALRM-based: it raises AirflowTaskTimeout when shutdown overruns, and
+            # ValueError when called off the main thread. Neither may escape a listener hook --
+            # and BaseException is required, not Exception, because AirflowTaskTimeout derives from
+            # BaseException so that user code cannot swallow it. Every hook call site guards with
+            # `except Exception`, so letting it through would reach the caller.
+            self.log.warning("OpenLineage executor did not shut down cleanly.", exc_info=True)
+            executor.shutdown(wait=False)
 
     @hookimpl
     def on_dag_run_running(self, dag_run: DagRun, msg: str) -> None:
@@ -1258,9 +1291,14 @@ class OpenLineageListener:
     def submit_callable(self, callable, *args, **kwargs):
         try:
             fut = self.executor.submit(callable, *args, **kwargs)
-        except BrokenProcessPool:
-            self.log.warning("ProcessPoolExecutor is broken; recreating and retrying submission.")
-            self._executor.shutdown(wait=False)
+        except RuntimeError:
+            # BrokenProcessPool subclasses RuntimeError, so this also covers a pool that was already
+            # shut down ("cannot schedule new futures after shutdown"). The retry is deliberately
+            # unguarded: every caller wraps this in `except BaseException`, and a second consecutive
+            # failure deserves to surface in their warning rather than be swallowed here.
+            self.log.warning("ProcessPoolExecutor is unusable; recreating and retrying submission.")
+            if self._executor is not None:
+                self._executor.shutdown(wait=False)
             self._executor = None
             fut = self.executor.submit(callable, *args, **kwargs)
         fut.add_done_callback(self.log_submit_error)

--- a/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/utils/utils.py
@@ -1045,15 +1045,18 @@ class DagRunInfo(InfoJsonEncodable):
         dag_versions = safe_getattr(dagrun, "dag_versions", [])
         if not dag_versions:
             return None
+        # The DagVersion rows themselves are lazy-loaded, so reading their columns can still hit
+        # a detached session even though fetching the list above succeeded.
         current_version = dag_versions[-1]
         if key == "bundle_name":
-            return current_version.bundle_name
+            return safe_getattr(current_version, "bundle_name")
         if key == "bundle_version":
-            return current_version.bundle_version
+            return safe_getattr(current_version, "bundle_version")
         if key == "version_id":
-            return str(current_version.id)
+            version_id = safe_getattr(current_version, "id")
+            return str(version_id) if version_id is not None else None
         if key == "version_number":
-            return current_version.version_number
+            return safe_getattr(current_version, "version_number")
         raise ValueError(f"Unsupported key: {key}`")
 
     @classmethod
@@ -1062,13 +1065,30 @@ class DagRunInfo(InfoJsonEncodable):
         if not AIRFLOW_V_3_3_PLUS or not airflow_conf.getboolean("core", "multi_team", fallback=False):
             return None
 
-        from airflow.models.dagbundle import DagBundleModel
+        # The Execution API delivers the team name on the DagRun payload it sends to the task
+        # runner, so task events resolve it from there rather than through the bundle lookup below,
+        # which needs a metadata DB session the task runner does not have.
+        # `hasattr` rather than a None check -- a team-less run legitimately carries None, while
+        # the scheduler's ORM DagRun has no such attribute at all.
+        if hasattr(dagrun, "team_name"):
+            return dagrun.team_name
 
-        bundle_name = cls.dag_version_info(dagrun, "bundle_name")
-        if not isinstance(bundle_name, str):
+        try:
+            bundle_name = cls.dag_version_info(dagrun, "bundle_name")
+            if not isinstance(bundle_name, str):
+                return None
+
+            from airflow.models.dagbundle import DagBundleModel
+
+            return DagBundleModel.get_team_name(bundle_name)
+        except Exception as e:
+            log.warning(
+                "OpenLineage failed to resolve the team name for dag `%s`: %s.",
+                safe_getattr(dagrun, "dag_id"),
+                e,
+            )
+            log.debug("Exception details:", exc_info=True)
             return None
-
-        return DagBundleModel.get_team_name(bundle_name)
 
 
 class TaskInstanceInfo(InfoJsonEncodable):
@@ -1387,23 +1407,28 @@ def get_airflow_job_facet(dag_run: DagRun) -> dict[str, AirflowJobFacet]:
 def get_airflow_state_run_facet(
     dag_id: str, run_id: str, task_ids: list[str], dag_run_state: DagRunState
 ) -> dict[str, AirflowStateRunFacet]:
-    tis = DagRun.fetch_task_instances(dag_id=dag_id, run_id=run_id, task_ids=task_ids)
+    try:
+        tis = DagRun.fetch_task_instances(dag_id=dag_id, run_id=run_id, task_ids=task_ids)
 
-    def get_task_duration(ti):
-        if ti.duration is not None:
-            return ti.duration
-        if ti.end_date is not None and ti.start_date is not None:
-            return (ti.end_date - ti.start_date).total_seconds()
-        # Fallback to 0.0 for tasks with missing timestamps (e.g., skipped/terminated tasks)
-        return 0.0
+        def get_task_duration(ti):
+            if ti.duration is not None:
+                return ti.duration
+            if ti.end_date is not None and ti.start_date is not None:
+                return (ti.end_date - ti.start_date).total_seconds()
+            # Fallback to 0.0 for tasks with missing timestamps (e.g., skipped/terminated tasks)
+            return 0.0
 
-    return {
-        "airflowState": AirflowStateRunFacet(
-            dagRunState=dag_run_state,
-            tasksState={ti.task_id: ti.state for ti in tis},
-            tasksDuration={ti.task_id: get_task_duration(ti) for ti in tis},
-        )
-    }
+        return {
+            "airflowState": AirflowStateRunFacet(
+                dagRunState=dag_run_state,
+                tasksState={ti.task_id: ti.state for ti in tis},
+                tasksDuration={ti.task_id: get_task_duration(ti) for ti in tis},
+            )
+        }
+    except Exception as e:
+        log.warning("Failed to build AirflowStateRunFacet for DagRun %s/%s: %s.", dag_id, run_id, e)
+        log.debug("Exception details:", exc_info=True)
+        return {}
 
 
 def is_dag_run_asset_triggered(

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -36,7 +36,7 @@ from openlineage.client.transport.console import ConsoleConfig
 from uuid6 import uuid7
 
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.providers.common.compat.sdk import BaseOperator
+from airflow.providers.common.compat.sdk import AirflowTaskTimeout, BaseOperator
 from airflow.providers.openlineage.extractors.base import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import OpenLineageAdapter
 from airflow.providers.openlineage.plugins.listener import OpenLineageListener
@@ -163,6 +163,26 @@ class TestProcessAdapterReuse:
 
         assert pid_first == pid_second
         assert adapter_id_first == adapter_id_second
+
+    @patch("airflow.providers.openlineage.plugins.listener.Stats")
+    @patch("airflow.providers.openlineage.plugins.listener.Serde")
+    @patch("airflow.providers.openlineage.plugins.listener._get_process_adapter")
+    def test_pool_wrappers_return_nothing(self, mock_get_adapter, mock_serde, mock_stats):
+        """The emitted event must not be pickled back to the parent.
+
+        An event the pickler chokes on would fail the future and be reported as a submission
+        failure, even though the emission itself succeeded.
+        """
+        from airflow.providers.openlineage.plugins.listener import (
+            _emit_manual_state_change_event,
+            _run_adapter_method,
+        )
+
+        assert _run_adapter_method("dag_started", dag_id="dag") is None
+        assert _emit_manual_state_change_event("fail_task", "ol.event.size.fail.op") is None
+
+        mock_get_adapter.return_value.dag_started.assert_called_once_with(dag_id="dag")
+        mock_get_adapter.return_value.fail_task.assert_called_once_with()
 
 
 class TestExecutorInitializer:
@@ -2729,6 +2749,100 @@ class TestOpenLineageListenerAirflow3:
         assert fut is new_future
         listener.log.warning.assert_called_once()
         assert "recreating" in listener.log.warning.call_args[0][0]
+
+    def test_submit_callable_recreates_executor_after_shutdown(self):
+        """A pool shut down by `before_stopping` must be replaced, not submitted to."""
+        listener = OpenLineageListener()
+        dead_executor = MagicMock()
+        dead_executor.submit.side_effect = RuntimeError("cannot schedule new futures after shutdown")
+        new_executor = MagicMock()
+        listener._executor = dead_executor
+        listener.log = MagicMock()
+
+        with mock.patch(
+            "airflow.providers.openlineage.plugins.listener.ProcessPoolExecutor",
+            return_value=new_executor,
+        ):
+            fut = listener.submit_callable(lambda: None)
+
+        assert fut is new_executor.submit.return_value
+        assert listener._executor is new_executor
+
+    def test_before_stopping_does_not_create_executor(self):
+        """On the task runner this hook fires per task; it must not spawn a pool to tear it down."""
+        listener = OpenLineageListener()
+
+        with mock.patch(
+            "airflow.providers.openlineage.plugins.listener.ProcessPoolExecutor"
+        ) as mock_pool_cls:
+            listener.before_stopping(MagicMock())
+
+        mock_pool_cls.assert_not_called()
+        assert listener._executor is None
+
+    def test_before_stopping_detaches_executor(self):
+        executor = MagicMock()
+        listener = OpenLineageListener()
+        listener._executor = executor
+
+        listener.before_stopping(MagicMock())
+
+        executor.shutdown.assert_called_once_with(wait=True)
+        assert listener._executor is None
+
+    def test_before_stopping_swallows_shutdown_failure(self):
+        """A timed-out or off-main-thread shutdown must not escape the hook.
+
+        `AirflowTaskTimeout` derives from `BaseException`, so the guard cannot be `except Exception`.
+        """
+        executor = MagicMock()
+        executor.shutdown.side_effect = [AirflowTaskTimeout("timed out"), None]
+        listener = OpenLineageListener()
+        listener._executor = executor
+        listener.log = MagicMock()
+
+        listener.before_stopping(MagicMock())
+
+        assert executor.shutdown.call_args_list == [mock.call(wait=True), mock.call(wait=False)]
+        assert listener._executor is None
+        listener.log.warning.assert_called_once()
+
+    @mock.patch("airflow.providers.openlineage.plugins.listener.logging.shutdown")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.os._exit")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.os.fork", return_value=0)
+    def test_fork_execute_child_exits_on_base_exception(self, mock_fork, mock_exit, mock_log_shutdown):
+        """A SIGINT to the process group reaches the child as KeyboardInterrupt.
+
+        The child must never return: doing so leaves a duplicate task runner behind, sharing the
+        supervisor connection with the real one.
+        """
+        listener = OpenLineageListener()
+        listener.log = MagicMock()
+
+        listener._fork_execute(mock.Mock(side_effect=KeyboardInterrupt("ctrl-c")), "on_running")
+
+        mock_exit.assert_called_once_with(0)
+        mock_log_shutdown.assert_called_once()
+        listener.log.warning.assert_called_once()
+
+    @mock.patch("airflow.providers.openlineage.plugins.listener.logging.shutdown")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.os._exit")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.os.fork", return_value=0)
+    def test_fork_execute_child_exits_when_setup_fails(self, mock_fork, mock_exit, mock_log_shutdown):
+        """A failure before the emission call must still exit, not unwind into the caller."""
+        listener = OpenLineageListener()
+        listener.log = MagicMock()
+        callable_ = mock.Mock()
+
+        with mock.patch(
+            "airflow.providers.openlineage.plugins.listener.getproctitle",
+            side_effect=OSError("cannot read proc title"),
+        ):
+            listener._fork_execute(callable_, "on_running")
+
+        callable_.assert_not_called()
+        mock_exit.assert_called_once_with(0)
+        listener.log.warning.assert_called_once()
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 2 tests")

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_listener.py
@@ -17,10 +17,11 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections import defaultdict
 from collections.abc import Callable
-from concurrent.futures import Future
+from concurrent.futures import Future, ProcessPoolExecutor
 from contextlib import suppress
 from datetime import datetime
 from types import SimpleNamespace
@@ -2753,11 +2754,11 @@ class TestOpenLineageListenerAirflow3:
     def test_submit_callable_recreates_executor_after_shutdown(self):
         """A pool shut down by `before_stopping` must be replaced, not submitted to."""
         listener = OpenLineageListener()
-        dead_executor = MagicMock()
+        dead_executor = MagicMock(spec=ProcessPoolExecutor)
         dead_executor.submit.side_effect = RuntimeError("cannot schedule new futures after shutdown")
-        new_executor = MagicMock()
+        new_executor = MagicMock(spec=ProcessPoolExecutor)
         listener._executor = dead_executor
-        listener.log = MagicMock()
+        listener.log = MagicMock(spec=logging.Logger)
 
         with mock.patch(
             "airflow.providers.openlineage.plugins.listener.ProcessPoolExecutor",
@@ -2781,7 +2782,7 @@ class TestOpenLineageListenerAirflow3:
         assert listener._executor is None
 
     def test_before_stopping_detaches_executor(self):
-        executor = MagicMock()
+        executor = MagicMock(spec=ProcessPoolExecutor)
         listener = OpenLineageListener()
         listener._executor = executor
 
@@ -2795,11 +2796,11 @@ class TestOpenLineageListenerAirflow3:
 
         `AirflowTaskTimeout` derives from `BaseException`, so the guard cannot be `except Exception`.
         """
-        executor = MagicMock()
+        executor = MagicMock(spec=ProcessPoolExecutor)
         executor.shutdown.side_effect = [AirflowTaskTimeout("timed out"), None]
         listener = OpenLineageListener()
         listener._executor = executor
-        listener.log = MagicMock()
+        listener.log = MagicMock(spec=logging.Logger)
 
         listener.before_stopping(MagicMock())
 
@@ -2817,9 +2818,11 @@ class TestOpenLineageListenerAirflow3:
         supervisor connection with the real one.
         """
         listener = OpenLineageListener()
-        listener.log = MagicMock()
+        listener.log = MagicMock(spec=logging.Logger)
 
-        listener._fork_execute(mock.Mock(side_effect=KeyboardInterrupt("ctrl-c")), "on_running")
+        listener._fork_execute(
+            mock.Mock(spec=Callable, side_effect=KeyboardInterrupt("ctrl-c")), "on_running"
+        )
 
         mock_exit.assert_called_once_with(0)
         mock_log_shutdown.assert_called_once()
@@ -2831,8 +2834,8 @@ class TestOpenLineageListenerAirflow3:
     def test_fork_execute_child_exits_when_setup_fails(self, mock_fork, mock_exit, mock_log_shutdown):
         """A failure before the emission call must still exit, not unwind into the caller."""
         listener = OpenLineageListener()
-        listener.log = MagicMock()
-        callable_ = mock.Mock()
+        listener.log = MagicMock(spec=logging.Logger)
+        callable_ = mock.Mock(spec=Callable)
 
         with mock.patch(
             "airflow.providers.openlineage.plugins.listener.getproctitle",
@@ -2843,6 +2846,32 @@ class TestOpenLineageListenerAirflow3:
         callable_.assert_not_called()
         mock_exit.assert_called_once_with(0)
         listener.log.warning.assert_called_once()
+
+    @mock.patch(
+        "airflow.providers.openlineage.plugins.listener.logging.shutdown",
+        side_effect=RuntimeError("handler close failed"),
+    )
+    @mock.patch("airflow.providers.openlineage.plugins.listener.os._exit")
+    @mock.patch("airflow.providers.openlineage.plugins.listener.os.fork", return_value=0)
+    def test_fork_execute_child_exits_when_logging_shutdown_raises(
+        self, mock_fork, mock_exit, mock_log_shutdown
+    ):
+        """logging.shutdown() raising must not bypass os._exit(0).
+
+        A remote task-log handler (S3/GCS) whose close() raises, or a handler lock held
+        at fork time, can make logging.shutdown() propagate out of the finally block.
+        Without the nested finally the child unwinds into the task runner and runs as a
+        second process sharing the supervisor connection.
+        """
+        listener = OpenLineageListener()
+        listener.log = MagicMock(spec=logging.Logger)
+
+        # In the real process os._exit(0) terminates execution before the RuntimeError
+        # can propagate; with a mocked os._exit the exception surfaces in the test.
+        with pytest.raises(RuntimeError, match="handler close failed"):
+            listener._fork_execute(mock.Mock(spec=Callable), "on_running")
+
+        mock_exit.assert_called_once_with(0)
 
 
 @pytest.mark.skipif(AIRFLOW_V_3_0_PLUS, reason="Airflow 2 tests")

--- a/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
+++ b/providers/openlineage/tests/unit/openlineage/utils/test_utils.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pendulum
 import pytest
 from openlineage.client.facet_v2 import parent_run
+from sqlalchemy.orm.exc import DetachedInstanceError
 from uuid6 import uuid7
 
 from airflow import DAG
@@ -318,6 +319,19 @@ def test_dag_run_version_no_versions():
 
 
 @pytest.mark.parametrize("key", ["bundle_name", "bundle_version", "version_id", "version_number"])
+def test_dag_run_version_detached_version_row(key):
+    """The DagVersion rows are lazy-loaded, so reading their columns can hit a detached session."""
+    version = MagicMock()
+    type(version).bundle_name = PropertyMock(side_effect=DetachedInstanceError)
+    type(version).bundle_version = PropertyMock(side_effect=DetachedInstanceError)
+    type(version).id = PropertyMock(side_effect=DetachedInstanceError)
+    type(version).version_number = PropertyMock(side_effect=DetachedInstanceError)
+    dag_run = MagicMock()
+    dag_run.dag_versions = [version]
+    assert DagRunInfo.dag_version_info(dag_run, key) is None
+
+
+@pytest.mark.parametrize("key", ["bundle_name", "bundle_version", "version_id", "version_number"])
 @pytest.mark.db_test
 def test_dag_run_version(key):
     dagrun_mock = MagicMock(DagRun)
@@ -357,6 +371,37 @@ def test_dag_run_team_name(
     assert DagRunInfo.team_name(dagrun_mock) == "team_a"
 
     mock_get_team_name.assert_called_once_with("bundle_name")
+
+
+@pytest.mark.db_test
+@pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="multi-team requires Airflow 3.3+")
+@pytest.mark.parametrize("team_name", ["team_a", None])
+@patch("airflow.models.dagbundle.DagBundleModel.get_team_name")
+@patch("airflow.providers.openlineage.utils.utils.airflow_conf.getboolean", return_value=True)
+def test_dag_run_team_name_from_execution_api_dag_run(mock_getboolean, mock_get_team_name, team_name):
+    """The task runner has no DB session, so a DagRun carrying `team_name` must be trusted as-is."""
+    # A resolvable bundle plus a DB answer, so falling through to the lookup would be observable.
+    dagrun_mock = MagicMock(spec_set=["team_name", "dag_versions"])
+    dagrun_mock.team_name = team_name
+    dagrun_mock.dag_versions = [MagicMock(bundle_name="bundle_name")]
+    mock_get_team_name.return_value = "from_db"
+
+    assert DagRunInfo.team_name(dagrun_mock) == team_name
+
+    mock_get_team_name.assert_not_called()
+
+
+@pytest.mark.db_test
+@pytest.mark.skipif(not AIRFLOW_V_3_3_PLUS, reason="multi-team requires Airflow 3.3+")
+@patch("airflow.models.dagbundle.DagBundleModel.get_team_name")
+@patch("airflow.providers.openlineage.utils.utils.airflow_conf.getboolean", return_value=True)
+def test_dag_run_team_name_lookup_failure_does_not_raise(mock_getboolean, mock_get_team_name):
+    """A failed lookup must degrade to None -- `_cast_fields` would otherwise lose the whole event."""
+    dagrun_mock = MagicMock(DagRun)
+    dagrun_mock.dag_versions = [MagicMock(bundle_name="bundle_name")]
+    mock_get_team_name.side_effect = RuntimeError("Session must be set before!")
+
+    assert DagRunInfo.team_name(dagrun_mock) is None
 
 
 @pytest.mark.db_test
@@ -3587,6 +3632,20 @@ class TestGetAirflowStateRunFacet:
         )
 
         assert result["airflowState"].tasksDuration["terminated_task"] == 0.0
+
+    @patch(
+        "airflow.providers.openlineage.utils.utils.DagRun.fetch_task_instances",
+        side_effect=Exception("db hiccup"),
+    )
+    def test_db_failure_returns_empty_facet(self, _mock_fetch):
+        """A DB error in the pool worker should drop only the facet, not the whole event."""
+        result = get_airflow_state_run_facet(
+            dag_id="test_dag",
+            run_id="test_run",
+            task_ids=["test_task"],
+            dag_run_state=DagRunState.SUCCESS,
+        )
+        assert result == {}
 
 
 @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="Airflow 3 specific test")


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Fixes a set of paths in the OpenLineage listener where a single failing detail discards an entire event, or escapes into the caller.

The headline is the team_name attr accessed with DagBundleModel, that was trying to access the DB from the worker. Now it short-circuits to the team_name in DagRun model, that is forwarded to workers.

| Fix | Impact before |
| --- | --- |
| `team_name` reads the Execution API value on workers | All task events dropped when `multi_team` is on |
| Forked emission child always exits | A `BaseException` (e.g. SIGINT to the process group) unwound the child back into the task runner, where it kept running as a second one sharing the supervisor connection |
| `before_stopping` detaches the pool and guards its timeout | Every Dag run event after a job stopped hit an already-shut-down pool; a hung shutdown raised `AirflowTaskTimeout` (a `BaseException`) straight past the caller's `except Exception` |
| `before_stopping` no longer creates a pool to tear down | The task runner built a `ProcessPoolExecutor` at the end of every task purely to shut it down |
| `submit_callable` catches `RuntimeError` | `BrokenProcessPool` subclasses it, so this also covers post-shutdown submissions |
| `get_airflow_state_run_facet` guards its DB query | A DB hiccup in the pool worker discarded the whole terminal Dag run event instead of just the facet |
| `dag_version_info` uses `safe_getattr` | Lazy-loaded `DagVersion` columns could raise on a detached session |
| Pool wrappers no longer return the event | An unpicklable redacted event reported a successful emission as a failed submission |

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
