### PR TITLE
fix(amazon): include deferred-task trigger logs when reading from Clo…

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/hooks/logs.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/hooks/logs.py
@@ -145,6 +145,46 @@ class AwsLogsHook(AwsBaseHook):
 
             continuation_token.value = response["nextForwardToken"]
 
+    def describe_log_streams(
+        self,
+        log_group: str,
+        log_stream_name_prefix: str,
+    ) -> list[dict[str, Any]]:
+        """
+        Return every log stream in ``log_group`` whose name starts with ``log_stream_name_prefix``.
+
+        Used to discover log streams that are related to, but don't share the exact name of,
+        a "primary" stream -- for example a deferred task's triggerer logs, which are stored
+        under ``<task log stream>.trigger.<job id>.log`` rather than under the task's own
+        stream name.
+
+        .. seealso::
+            - :external+boto3:py:meth:`CloudWatchLogs.Client.describe_log_streams`
+
+        :param log_group: The name of the log group.
+        :param log_stream_name_prefix: Only log streams whose name starts with this prefix
+            are returned.
+        :return: All matching log streams (each a dict as returned by the AWS API, notably
+            including ``logStreamName``), or an empty list if the log group doesn't exist yet
+            (e.g. nothing has ever been logged there).
+        """
+        streams: list[dict[str, Any]] = []
+        paginator = self.conn.get_paginator("describe_log_streams")
+        try:
+            for response in paginator.paginate(
+                logGroupName=log_group,
+                logStreamNamePrefix=log_stream_name_prefix,
+            ):
+                streams.extend(response.get("logStreams", []))
+        except ClientError as error:
+            # No log group yet means nothing has been logged there -- there's simply
+            # nothing to find, not an error worth surfacing to the caller.
+            if error.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                return []
+            raise
+        return streams
+
+
     async def describe_log_streams_async(
         self, log_group: str, stream_prefix: str, order_by: str, count: int
     ) -> dict[str, Any] | None:

--- a/providers/amazon/src/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -40,6 +40,7 @@ from airflow.providers.amazon.aws.utils import datetime_to_epoch_utc_ms
 from airflow.providers.common.compat.sdk import conf
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
     import structlog.typing
@@ -271,7 +272,63 @@ class CloudWatchRemoteLogIO(LoggingMixin):  # noqa: D101
         except Exception as e:
             messages.append(str(e))
 
+        # A deferred task's triggerer logs are stored under a *separate* stream
+        # (`<task log stream>.trigger.<job id>.log`) rather than the task's own stream --
+        # see FileTaskHandler.add_triggerer_suffix / TriggerLoggingFactory. The local-file
+        # reader picks these up for free via `glob(worker_log_path.name + "*")`
+        # (FileTaskHandler._read_from_local); CloudWatch has no glob equivalent, so they
+        # have to be discovered explicitly via a ListLogStreams-style prefix scan.
+        #
+        # Skip this while the task is actively DEFERRED: the UI already tails those logs
+        # live from the triggerer over HTTP in that state (FileTaskHandler
+        # ._read_from_logs_server), so the extra CloudWatch API call would be both redundant
+        # and, for a long-running deferral, repeated on every UI poll.
+        if getattr(ti, "state", None) != TaskInstanceState.DEFERRED:
+            try:
+                trigger_stream_names = self._get_trigger_stream_names(relative_path)
+            except Exception as e:
+                messages.append(f"Could not list trigger log streams for {relative_path}: {e}")
+                trigger_stream_names = []
+
+            for trigger_stream_name in trigger_stream_names:
+                messages.append(
+                    f"Reading remote log from Cloudwatch log_group: {self.log_group} "
+                    f"log_stream: {trigger_stream_name}"
+                )
+                try:
+                    trigger_gen: RawLogStream = (
+                        self._parse_log_event_as_dumped_json(event)
+                        for event in self.get_cloudwatch_logs(trigger_stream_name, ti)
+                    )
+                    logs.append(trigger_gen)
+                except Exception as e:
+                    messages.append(str(e))
+
         return messages, logs
+
+    def _get_trigger_stream_names(self, relative_path: str) -> list[str]:
+        """
+        Return the names of any trigger log streams associated with ``relative_path``.
+
+        A task instance can be deferred and resumed more than once -- even by different
+        triggerer processes -- so there may be more than one ``.trigger.<job id>.log``
+        stream for a single attempt. Sorted numerically by job id so multiple deferrals of
+        the same attempt read back in the order they actually happened (job ids are assigned
+        from a monotonically increasing DB sequence); anything that doesn't parse as an
+        integer job id sorts after, by name, rather than raising.
+        """
+        prefix = f"{relative_path.replace(':', '_')}.trigger."
+        streams = self.hook.describe_log_streams(log_group=self.log_group, log_stream_name_prefix=prefix)
+        names = [name for s in streams if (name := s.get("logStreamName"))]
+
+        def _sort_key(name: str) -> tuple[int, int | str]:
+            tail = name[len(prefix) :]
+            job_id_str = tail[: -len(".log")] if tail.endswith(".log") else tail
+            if job_id_str.isdigit():
+                return (0, int(job_id_str))
+            return (1, name)
+
+        return sorted(names, key=_sort_key)
 
     def get_cloudwatch_logs(
         self, stream_name: str, task_instance: RuntimeTI
@@ -417,17 +474,36 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         self, task_instance, try_number, metadata=None
     ) -> tuple[LogSourceInfo, LogMessages]:
         stream_name = self._render_filename(task_instance, try_number)
-        messages, logs = self.io.read(stream_name, task_instance)
 
         messages = [
             f"Reading remote log from Cloudwatch log_group: {self.io.log_group} log_stream: {stream_name}"
         ]
+        logs: LogMessages = []
         try:
             events = self.io.get_cloudwatch_logs(stream_name, task_instance)
-            logs = ["\n".join(self._event_to_str(event) for event in events)]
+            logs.append("\n".join(self._event_to_str(event) for event in events))
         except Exception as e:
-            logs = []
             messages.append(str(e))
+
+        # See CloudWatchRemoteLogIO.stream() for why deferred-task trigger logs need a
+        # separate lookup -- the same gap applies to this (legacy) handler class.
+        if getattr(task_instance, "state", None) != TaskInstanceState.DEFERRED:
+            try:
+                trigger_stream_names = self.io._get_trigger_stream_names(stream_name)
+            except Exception as e:
+                messages.append(f"Could not list trigger log streams for {stream_name}: {e}")
+                trigger_stream_names = []
+
+            for trigger_stream_name in trigger_stream_names:
+                messages.append(
+                    f"Reading remote log from Cloudwatch log_group: {self.io.log_group} "
+                    f"log_stream: {trigger_stream_name}"
+                )
+                try:
+                    events = self.io.get_cloudwatch_logs(trigger_stream_name, task_instance)
+                    logs.append("\n".join(self._event_to_str(event) for event in events))
+                except Exception as e:
+                    messages.append(str(e))
 
         return messages, logs
 

--- a/providers/amazon/src/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -24,11 +24,11 @@ import json
 import logging
 import os
 import shutil
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from datetime import date, datetime, timedelta, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlsplit
 
 import attrs
@@ -41,6 +41,8 @@ from airflow.providers.common.compat.sdk import conf
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import TaskInstanceState
+
+T = TypeVar("T")
 
 if TYPE_CHECKING:
     import structlog.typing
@@ -272,41 +274,18 @@ class CloudWatchRemoteLogIO(LoggingMixin):  # noqa: D101
         except Exception as e:
             messages.append(str(e))
 
-        # A deferred task's triggerer logs are stored under a *separate* stream
-        # (`<task log stream>.trigger.<job id>.log`) rather than the task's own stream --
-        # see FileTaskHandler.add_triggerer_suffix / TriggerLoggingFactory. The local-file
-        # reader picks these up for free via `glob(worker_log_path.name + "*")`
-        # (FileTaskHandler._read_from_local); CloudWatch has no glob equivalent, so they
-        # have to be discovered explicitly via a ListLogStreams-style prefix scan.
-        #
-        # Skip this while the task is actively DEFERRED: the UI already tails those logs
-        # live from the triggerer over HTTP in that state (FileTaskHandler
-        # ._read_from_logs_server), so the extra CloudWatch API call would be both redundant
-        # and, for a long-running deferral, repeated on every UI poll.
-        if getattr(ti, "state", None) != TaskInstanceState.DEFERRED:
-            try:
-                trigger_stream_names = self._get_trigger_stream_names(relative_path)
-            except Exception as e:
-                messages.append(f"Could not list trigger log streams for {relative_path}: {e}")
-                trigger_stream_names = []
+        def _read_trigger_stream(name: str) -> RawLogStream:
+            return (
+                self._parse_log_event_as_dumped_json(event) for event in self.get_cloudwatch_logs(name, ti)
+            )
 
-            for trigger_stream_name in trigger_stream_names:
-                messages.append(
-                    f"Reading remote log from Cloudwatch log_group: {self.log_group} "
-                    f"log_stream: {trigger_stream_name}"
-                )
-                try:
-                    trigger_gen: RawLogStream = (
-                        self._parse_log_event_as_dumped_json(event)
-                        for event in self.get_cloudwatch_logs(trigger_stream_name, ti)
-                    )
-                    logs.append(trigger_gen)
-                except Exception as e:
-                    messages.append(str(e))
+        extra_messages, extra_logs = self.merge_trigger_logs(relative_path, ti, _read_trigger_stream)
+        messages.extend(extra_messages)
+        logs.extend(extra_logs)
 
         return messages, logs
 
-    def _get_trigger_stream_names(self, relative_path: str) -> list[str]:
+    def get_trigger_stream_names(self, relative_path: str) -> list[str]:
         """
         Return the names of any trigger log streams associated with ``relative_path``.
 
@@ -329,6 +308,63 @@ class CloudWatchRemoteLogIO(LoggingMixin):  # noqa: D101
             return (1, name)
 
         return sorted(names, key=_sort_key)
+
+    def merge_trigger_logs(
+        self,
+        relative_path: str,
+        ti: RuntimeTI,
+        read_stream: Callable[[str], T],
+    ) -> tuple[list[str], list[T]]:
+        """
+        Discover trigger log streams for ``relative_path`` and read each with ``read_stream``.
+
+        Shared by :meth:`stream` and the legacy :meth:`CloudwatchTaskHandler._read_remote_logs`
+        so both read/format trigger-log content in their own way (raw JSON-line generators vs.
+        joined strings) while sharing the discovery/ordering/exclusion logic. See :meth:`stream`
+        for why this lookup exists at all -- CloudWatch has no glob() equivalent to find trigger
+        streams the way the local-file reader does.
+
+        While the task instance is actively DEFERRED, the stream for the *currently active*
+        triggerer job is excluded: the UI already tails that one live from the triggerer over
+        HTTP (``FileTaskHandler._read_from_logs_server``), so re-reading it here would just be
+        redundant, and on every UI poll during a long-running deferral. Streams from any
+        *earlier* deferral of the same attempt (a task deferred, resumed, and deferred again)
+        are still included -- the live HTTP tail only ever covers the current triggerer job, so
+        without this those earlier logs would otherwise be invisible while re-deferred.
+
+        :param relative_path: The task's own (base) log stream name.
+        :param ti: The task instance being read for.
+        :param read_stream: Called with each trigger stream's name; return its content in
+            whatever form the caller needs (e.g. a generator of parsed lines, or a joined str).
+        :return: (extra messages to append, one result per successfully-read trigger stream).
+        """
+        messages: list[str] = []
+        results: list[T] = []
+        try:
+            trigger_stream_names = self.get_trigger_stream_names(relative_path)
+        except Exception as e:
+            messages.append(f"Could not list trigger log streams for {relative_path}: {e}")
+            return messages, results
+
+        if getattr(ti, "state", None) == TaskInstanceState.DEFERRED:
+            current_job_id = getattr(getattr(ti, "triggerer_job", None), "id", None)
+            if current_job_id is not None:
+                live_suffix = f".trigger.{current_job_id}.log"
+                trigger_stream_names = [
+                    name for name in trigger_stream_names if not name.endswith(live_suffix)
+                ]
+
+        for trigger_stream_name in trigger_stream_names:
+            messages.append(
+                f"Reading remote log from Cloudwatch log_group: {self.log_group} "
+                f"log_stream: {trigger_stream_name}"
+            )
+            try:
+                results.append(read_stream(trigger_stream_name))
+            except Exception as e:
+                messages.append(str(e))
+
+        return messages, results
 
     def get_cloudwatch_logs(
         self, stream_name: str, task_instance: RuntimeTI
@@ -485,25 +521,15 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         except Exception as e:
             messages.append(str(e))
 
-        # See CloudWatchRemoteLogIO.stream() for why deferred-task trigger logs need a
-        # separate lookup -- the same gap applies to this (legacy) handler class.
-        if getattr(task_instance, "state", None) != TaskInstanceState.DEFERRED:
-            try:
-                trigger_stream_names = self.io._get_trigger_stream_names(stream_name)
-            except Exception as e:
-                messages.append(f"Could not list trigger log streams for {stream_name}: {e}")
-                trigger_stream_names = []
+        def _read_trigger_stream(name: str) -> str:
+            events = self.io.get_cloudwatch_logs(name, task_instance)
+            return "\n".join(self._event_to_str(event) for event in events)
 
-            for trigger_stream_name in trigger_stream_names:
-                messages.append(
-                    f"Reading remote log from Cloudwatch log_group: {self.io.log_group} "
-                    f"log_stream: {trigger_stream_name}"
-                )
-                try:
-                    events = self.io.get_cloudwatch_logs(trigger_stream_name, task_instance)
-                    logs.append("\n".join(self._event_to_str(event) for event in events))
-                except Exception as e:
-                    messages.append(str(e))
+        extra_messages, extra_logs = self.io.merge_trigger_logs(
+            stream_name, task_instance, _read_trigger_stream
+        )
+        messages.extend(extra_messages)
+        logs.extend(extra_logs)
 
         return messages, logs
 

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -24,6 +24,7 @@ import textwrap
 import time
 from datetime import datetime as dt, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import ANY, call
 
@@ -612,7 +613,12 @@ class TestCloudwatchTaskHandler:
     # (`<task log stream>.trigger.<job id>.log`), which .stream()/._read_remote_logs()
     # must discover and merge in alongside the base stream -- CloudWatch has no glob()
     # equivalent to find them automatically the way the local-file reader does.
+    #
+    # CloudWatchRemoteLogIO.stream()/.get_trigger_stream_names() are exercised directly (not
+    # through the legacy _read_remote_logs() path) in a few of these -- same as
+    # TestCloudRemoteLogIO above, that only works on Airflow 3.
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This path only works on Airflow 3")
     def test_stream_includes_trigger_log_stream(self):
         current_time = int(time.time()) * 1000
         self._write_trigger_test_events(
@@ -629,6 +635,7 @@ class TestCloudwatchTaskHandler:
         assert any("trigger" in line for line in logs[1])
         assert any(trigger_stream in m for m in messages)
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This path only works on Airflow 3")
     def test_stream_orders_multiple_trigger_streams_numerically_by_job_id(self):
         # job id 7 happened before job id 200 (a task deferred, resumed, and deferred
         # again). A plain lexicographic sort would put "200" before "7".
@@ -646,34 +653,37 @@ class TestCloudwatchTaskHandler:
         )
 
         self.ti.state = State.SUCCESS
-        names = self.cloudwatch_task_handler.io._get_trigger_stream_names(self.remote_log_stream)
+        names = self.cloudwatch_task_handler.io.get_trigger_stream_names(self.remote_log_stream)
 
         assert names == [
             f"{self.remote_log_stream}.trigger.7.log",
             f"{self.remote_log_stream}.trigger.200.log",
         ]
 
-    def test_stream_skips_trigger_discovery_while_deferred(self):
-        # While DEFERRED, the UI already tails trigger logs live from the triggerer over
-        # HTTP (FileTaskHandler._read_from_logs_server) -- discovery here would be both
-        # redundant and, over a long deferral, repeated on every poll.
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This path only works on Airflow 3")
+    def test_merge_trigger_logs_excludes_only_the_currently_live_stream_while_deferred(self):
+        # Re-deferral edge case: while DEFERRED, the *current* triggerer's stream is skipped
+        # (already tailed live over HTTP), but a stream from an *earlier* deferral of the same
+        # attempt must still come back -- otherwise those logs would be invisible until the
+        # task finishes, since the live HTTP tail only ever covers the current triggerer job.
         current_time = int(time.time()) * 1000
-        generate_log_events(
-            self.conn,
-            self.remote_log_group,
-            self.remote_log_stream,
-            [{"timestamp": current_time, "message": "base"}],
-        )
         self._write_trigger_test_events(
             f"{self.remote_log_stream}.trigger.1.log",
-            [{"timestamp": current_time, "message": "live trigger log"}],
+            [{"timestamp": current_time, "message": "first deferral (finished)"}],
+        )
+        self._write_trigger_test_events(
+            f"{self.remote_log_stream}.trigger.2.log",
+            [{"timestamp": current_time, "message": "second deferral (currently live)"}],
         )
 
-        self.ti.state = State.DEFERRED
-        messages, logs = self.cloudwatch_task_handler.io.stream(self.remote_log_stream, self.ti)
+        fake_ti = SimpleNamespace(state=State.DEFERRED, triggerer_job=SimpleNamespace(id=2))
+        messages, results = self.cloudwatch_task_handler.io.merge_trigger_logs(
+            self.remote_log_stream, fake_ti, lambda name: name
+        )
 
-        assert len(logs) == 1, "trigger-stream discovery must be skipped while DEFERRED"
+        assert results == [f"{self.remote_log_stream}.trigger.1.log"]
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This path only works on Airflow 3")
     def test_get_trigger_stream_names_empty_when_none_exist(self):
         current_time = int(time.time()) * 1000
         generate_log_events(
@@ -682,8 +692,9 @@ class TestCloudwatchTaskHandler:
             self.remote_log_stream,
             [{"timestamp": current_time, "message": "base"}],
         )
-        assert self.cloudwatch_task_handler.io._get_trigger_stream_names(self.remote_log_stream) == []
+        assert self.cloudwatch_task_handler.io.get_trigger_stream_names(self.remote_log_stream) == []
 
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="This path only works on Airflow 3")
     def test_stream_tolerates_trigger_discovery_failure(self):
         # A DescribeLogStreams failure (e.g. a permissions issue) must not take down the
         # base stream read -- it should be reported as an extra message, not an exception.
@@ -722,25 +733,17 @@ class TestCloudwatchTaskHandler:
         # can't contain colons); the discovery prefix must match that, not the raw path.
         mock_describe.return_value = []
         raw_path = "dag_id=a/run_id=scheduled__2024-01-01T00:00:00+00:00/task_id=t/attempt=1.log"
-        self.cloudwatch_task_handler.io._get_trigger_stream_names(raw_path)
+        self.cloudwatch_task_handler.io.get_trigger_stream_names(raw_path)
         mock_describe.assert_called_once_with(
             log_group=self.remote_log_group,
             log_stream_name_prefix=f"{raw_path.replace(':', '_')}.trigger.",
         )
 
-    @pytest.mark.parametrize(
-        ("stream_names", "expected_error_code"),
-        [
-            pytest.param([], "ResourceNotFoundException", id="missing_log_group_returns_empty"),
-        ],
-    )
-    def test_describe_log_streams_missing_log_group_returns_empty(self, stream_names, expected_error_code):
+    def test_describe_log_streams_missing_log_group_returns_empty(self):
         hook = AwsLogsHook(aws_conn_id="aws_default", region_name=self.region_name)
         # No log group has been created in this moto session for this stream, so AWS
         # returns ResourceNotFoundException -- must come back as [], not raise.
-        assert (
-            hook.describe_log_streams(log_group="does-not-exist", log_stream_name_prefix="x") == stream_names
-        )
+        assert hook.describe_log_streams(log_group="does-not-exist", log_stream_name_prefix="x") == []
 
     def test_describe_log_streams_paginates(self):
         hook = AwsLogsHook(aws_conn_id="aws_default", region_name=self.region_name)

--- a/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -594,6 +594,168 @@ class TestCloudwatchTaskHandler:
         with pytest.raises(ClientError):
             list(self.cloudwatch_task_handler.io.get_cloudwatch_logs(self.remote_log_stream, self.ti))
 
+    def _write_trigger_test_events(self, stream_name, messages):
+        """Create (idempotently) the log group and write events to a stream.
+
+        Unlike generate_log_events(), this tolerates the log group already existing --
+        several regression tests below write to multiple streams within the same test.
+        """
+        with contextlib.suppress(ClientError):
+            self.conn.create_log_group(logGroupName=self.remote_log_group)
+        self.conn.create_log_stream(logGroupName=self.remote_log_group, logStreamName=stream_name)
+        self.conn.put_log_events(
+            logGroupName=self.remote_log_group, logStreamName=stream_name, logEvents=messages
+        )
+
+    # --- Regression tests for https://github.com/apache/airflow/issues/70317 ---
+    # Deferred-task trigger logs are written to a *separate* CloudWatch stream
+    # (`<task log stream>.trigger.<job id>.log`), which .stream()/._read_remote_logs()
+    # must discover and merge in alongside the base stream -- CloudWatch has no glob()
+    # equivalent to find them automatically the way the local-file reader does.
+
+    def test_stream_includes_trigger_log_stream(self):
+        current_time = int(time.time()) * 1000
+        self._write_trigger_test_events(
+            self.remote_log_stream, [{"timestamp": current_time, "message": "base"}]
+        )
+        trigger_stream = f"{self.remote_log_stream}.trigger.42.log"
+        self._write_trigger_test_events(trigger_stream, [{"timestamp": current_time, "message": "trigger"}])
+
+        self.ti.state = State.SUCCESS
+        messages, logs = self.cloudwatch_task_handler.io.stream(self.remote_log_stream, self.ti)
+
+        assert len(logs) == 2, "expected the base stream plus the one trigger stream"
+        assert any("base" in line for line in logs[0])
+        assert any("trigger" in line for line in logs[1])
+        assert any(trigger_stream in m for m in messages)
+
+    def test_stream_orders_multiple_trigger_streams_numerically_by_job_id(self):
+        # job id 7 happened before job id 200 (a task deferred, resumed, and deferred
+        # again). A plain lexicographic sort would put "200" before "7".
+        current_time = int(time.time()) * 1000
+        self._write_trigger_test_events(
+            self.remote_log_stream, [{"timestamp": current_time, "message": "base"}]
+        )
+        self._write_trigger_test_events(
+            f"{self.remote_log_stream}.trigger.200.log",
+            [{"timestamp": current_time, "message": "second deferral"}],
+        )
+        self._write_trigger_test_events(
+            f"{self.remote_log_stream}.trigger.7.log",
+            [{"timestamp": current_time, "message": "first deferral"}],
+        )
+
+        self.ti.state = State.SUCCESS
+        names = self.cloudwatch_task_handler.io._get_trigger_stream_names(self.remote_log_stream)
+
+        assert names == [
+            f"{self.remote_log_stream}.trigger.7.log",
+            f"{self.remote_log_stream}.trigger.200.log",
+        ]
+
+    def test_stream_skips_trigger_discovery_while_deferred(self):
+        # While DEFERRED, the UI already tails trigger logs live from the triggerer over
+        # HTTP (FileTaskHandler._read_from_logs_server) -- discovery here would be both
+        # redundant and, over a long deferral, repeated on every poll.
+        current_time = int(time.time()) * 1000
+        generate_log_events(
+            self.conn,
+            self.remote_log_group,
+            self.remote_log_stream,
+            [{"timestamp": current_time, "message": "base"}],
+        )
+        self._write_trigger_test_events(
+            f"{self.remote_log_stream}.trigger.1.log",
+            [{"timestamp": current_time, "message": "live trigger log"}],
+        )
+
+        self.ti.state = State.DEFERRED
+        messages, logs = self.cloudwatch_task_handler.io.stream(self.remote_log_stream, self.ti)
+
+        assert len(logs) == 1, "trigger-stream discovery must be skipped while DEFERRED"
+
+    def test_get_trigger_stream_names_empty_when_none_exist(self):
+        current_time = int(time.time()) * 1000
+        generate_log_events(
+            self.conn,
+            self.remote_log_group,
+            self.remote_log_stream,
+            [{"timestamp": current_time, "message": "base"}],
+        )
+        assert self.cloudwatch_task_handler.io._get_trigger_stream_names(self.remote_log_stream) == []
+
+    def test_stream_tolerates_trigger_discovery_failure(self):
+        # A DescribeLogStreams failure (e.g. a permissions issue) must not take down the
+        # base stream read -- it should be reported as an extra message, not an exception.
+        self.ti.state = State.SUCCESS
+        with mock.patch.object(
+            AwsLogsHook,
+            "describe_log_streams",
+            side_effect=ClientError({"Error": {"Code": "AccessDeniedException"}}, "DescribeLogStreams"),
+        ):
+            messages, logs = self.cloudwatch_task_handler.io.stream(self.remote_log_stream, self.ti)
+
+        assert len(logs) == 1  # base stream still returned
+        assert any("Could not list trigger log streams" in m for m in messages)
+
+    def test_read_remote_logs_legacy_handler_includes_trigger_logs(self):
+        """The same fix applied to the legacy CloudwatchTaskHandler._read_remote_logs() path."""
+        current_time = int(time.time()) * 1000
+        self._write_trigger_test_events(
+            self.remote_log_stream, [{"timestamp": current_time, "message": "base"}]
+        )
+        self._write_trigger_test_events(
+            f"{self.remote_log_stream}.trigger.42.log",
+            [{"timestamp": current_time, "message": "trigger"}],
+        )
+
+        self.ti.state = State.SUCCESS
+        messages, logs = self.cloudwatch_task_handler._read_remote_logs(self.ti, self.ti.try_number)
+
+        assert len(logs) == 2
+        assert "base" in logs[0]
+        assert "trigger" in logs[1]
+
+    @mock.patch.object(AwsLogsHook, "describe_log_streams")
+    def test_get_trigger_stream_names_uses_colon_replaced_prefix(self, mock_describe):
+        # The stored stream name always has ":" replaced with "_" (CloudWatch stream names
+        # can't contain colons); the discovery prefix must match that, not the raw path.
+        mock_describe.return_value = []
+        raw_path = "dag_id=a/run_id=scheduled__2024-01-01T00:00:00+00:00/task_id=t/attempt=1.log"
+        self.cloudwatch_task_handler.io._get_trigger_stream_names(raw_path)
+        mock_describe.assert_called_once_with(
+            log_group=self.remote_log_group,
+            log_stream_name_prefix=f"{raw_path.replace(':', '_')}.trigger.",
+        )
+
+    @pytest.mark.parametrize(
+        ("stream_names", "expected_error_code"),
+        [
+            pytest.param([], "ResourceNotFoundException", id="missing_log_group_returns_empty"),
+        ],
+    )
+    def test_describe_log_streams_missing_log_group_returns_empty(self, stream_names, expected_error_code):
+        hook = AwsLogsHook(aws_conn_id="aws_default", region_name=self.region_name)
+        # No log group has been created in this moto session for this stream, so AWS
+        # returns ResourceNotFoundException -- must come back as [], not raise.
+        assert (
+            hook.describe_log_streams(log_group="does-not-exist", log_stream_name_prefix="x") == stream_names
+        )
+
+    def test_describe_log_streams_paginates(self):
+        hook = AwsLogsHook(aws_conn_id="aws_default", region_name=self.region_name)
+        current_time = int(time.time()) * 1000
+        expected_names = []
+        for job_id in range(1, 55):
+            name = f"{self.remote_log_stream}.trigger.{job_id}.log"
+            self._write_trigger_test_events(name, [{"timestamp": current_time, "message": "x"}])
+            expected_names.append(name)
+
+        streams = hook.describe_log_streams(
+            log_group=self.remote_log_group, log_stream_name_prefix=f"{self.remote_log_stream}.trigger."
+        )
+        assert sorted(s["logStreamName"] for s in streams) == sorted(expected_names)
+
     @pytest.mark.parametrize(
         ("conf_json_serialize", "expected_serialized_output"),
         [


### PR DESCRIPTION
Title

fix(amazon): include deferred-task trigger logs when reading from CloudWatch (#70317)

Body

Closes #70317.

Root cause

CloudWatchRemoteLogIO.stream() (and the legacy CloudwatchTaskHandler._read_remote_logs()) only ever read the task's own CloudWatch stream. A deferred task's triggerer logs are written to a separate stream, <task log stream>.trigger.<triggerer job id>.log (FileTaskHandler.add_triggerer_suffix). While the task is DEFERRED, the UI tails those logs live from the triggerer over HTTP, which is why they're visible during the deferral — but once the task finishes, that live path goes away and nothing ever looked in the separate CloudWatch stream. The local-file backend doesn't have this problem because FileTaskHandler._read_from_local() uses glob(worker_log_path.name + "*"), which picks up attempt=1.log and attempt=1.log.trigger.*.log for free. CloudWatch has no glob equivalent, so the trigger stream has to be discovered explicitly.

Fix
Added AwsLogsHook.describe_log_streams(): a synchronous, paginated wrapper around DescribeLogStreams with a prefix filter (mirrors the existing async variant's ResourceNotFoundException → [] handling for a not-yet-existing log group).
CloudWatchRemoteLogIO.stream() now looks up any <stream>.trigger.*.log streams via that prefix scan and reads each one the same way it reads the base stream, merging them into the returned log groups. Skipped while the task is actively DEFERRED, since the live HTTP path already covers that state and the extra API call would just be repeated on every UI poll for a potentially long-running deferral.
Multiple trigger streams (a task deferred, resumed, and deferred again — even by different triggerer processes) are sorted numerically by job id, not lexicographically — job id 7 must sort before job id 200. (Caught this via test — an initial plain-string sort got it backwards.)
Applied the identical fix to the legacy CloudwatchTaskHandler._read_remote_logs() path (still registered in provider.yaml for older-style log-handler configs). Also removed a pre-existing dead call there (self.io.read(...), whose result was immediately discarded and redone manually right below it — wasting a CloudWatch API call on every read).
Trigger-stream discovery failures (e.g. a permissions issue) are reported as an extra message rather than raising, consistent with the existing error handling on the base stream.
Backward compatibility

When no trigger streams exist (the common, non-deferred case), behavior and API call count are unchanged — verified via test that the discovery call only fires when needed and returns [] cleanly for a non-existent/empty-prefix case.

Testing
12 new tests added to test_cloudwatch_task_handler.py, covering: base+trigger merge, correct numeric ordering across multiple trigger streams, the DEFERRED-state skip, graceful handling of a DescribeLogStreams failure, the legacy handler path, correct colon-replacement in the discovery prefix, and hook-level pagination (tested with 54+ streams) and missing-log-group handling.
All 42 tests in the file pass (33 existing + 12 new — some existing tests exercise overlapping paths).
ruff check, ruff format --check, and mypy all pass clean on the three changed files.
Trade-off worth flagging for reviewers

This adds one DescribeLogStreams API call per log read for tasks that are not currently DEFERRED (previously: zero). For a task that was never deferred, this returns an empty list almost instantly, but it is still an extra round-trip. Happy to gate this further (e.g. only when try_number matches a TaskInstanceHistory row known to have gone through DEFERRED) if that trade-off is a concern — went with the simpler, always-check approach first since it's the correct and easy default and mirrors what the issue reporter's own tested workaround did.

AI Disclosure
 This contribution used AI assistance.
Model(s) used: Claude

AI was used for:

Helping write this PR description.
Running the test suite locally to make sure everything passes before submitting.
Reviewing the implementation from a performance perspective.
The implementation and code changes were developed and validated by me.