### PR TITLE
Drop connection headers on cross-host redirect in HttpAsyncHook (#70164)

### DIFF
--- a/devel-common/src/tests_common/test_utils/aiohttp.py
+++ b/devel-common/src/tests_common/test_utils/aiohttp.py
@@ -40,6 +40,7 @@ class MockAiohttpClientResponse:
         method: str = "GET",
         url: str = "http://example.com",
         reason: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         self.status = status
         self._payload = payload
@@ -47,6 +48,11 @@ class MockAiohttpClientResponse:
         self._method = method
         self._url = url
         self._reason = reason
+        self.headers = headers or {}
+
+    async def release(self) -> None:
+        """No-op for unit tests; aiohttp frees the underlying connection."""
+        pass
 
     @property
     def reason(self) -> str:

--- a/providers/http/src/airflow/providers/http/hooks/http.py
+++ b/providers/http/src/airflow/providers/http/hooks/http.py
@@ -512,19 +512,63 @@ class AsyncHttpSession(LoggingMixin):
         url = _url_from_endpoint(self.base_url, endpoint)
         merged_headers = {**(self.headers or {}), **(headers or {})}
         extra_options = {**(self.extra_options or {}), **(extra_options or {})}
+        # Track which headers came from the connection so they can be dropped
+        # on a cross-host redirect (aiohttp only strips Authorization).
+        connection_header_names = set(self.headers.keys()) if self.headers else set()
 
         async def request_func() -> ClientResponse:
-            response = await self._request(
-                url,
-                params=data if self.method == "GET" else None,
-                data=data if self.method in {"POST", "PUT", "PATCH"} else None,
-                json=json,
-                headers=merged_headers,
-                auth=self.auth,
-                **extra_options,
+            nonlocal url
+            # aiohttp does not drop custom headers on cross-host redirects,
+            # so we disable automatic redirect following and walk the chain
+            # manually, dropping connection-supplied headers when the target
+            # changes host.
+            max_redirects = 5
+            current_headers = merged_headers
+            remaining_connection_headers = connection_header_names.copy()
+
+            for _ in range(max_redirects):
+                response = await self._request(
+                    url,
+                    params=data if self.method == "GET" else None,
+                    data=data if self.method in {"POST", "PUT", "PATCH"} else None,
+                    json=json,
+                    headers=current_headers,
+                    auth=self.auth,
+                    allow_redirects=False,
+                    **extra_options,
+                )
+
+                if response.status in (301, 302, 303, 307, 308):
+                    redirect_url = response.headers.get("Location")
+                    if not redirect_url:
+                        response.raise_for_status()
+                        return response
+
+                    # Resolve relative Location URLs against the current URL.
+                    redirect_url = _url_from_endpoint(url, redirect_url)
+                    redirect_parsed = urlparse(redirect_url)
+                    current_parsed = urlparse(url)
+
+                    if current_parsed.netloc != redirect_parsed.netloc:
+                        # Cross-host redirect: drop connection-supplied headers,
+                        # keeping only headers the caller explicitly passed in.
+                        current_headers = {k: v for k, v in merged_headers.items() if k not in remaining_connection_headers}
+                        remaining_connection_headers.clear()
+
+                    url = redirect_url
+                    await response.release()
+                    continue
+
+                response.raise_for_status()
+                return response
+
+            raise ClientResponseError(
+                request_info=response.request_info,
+                history=(),
+                status=599,
+                message=f"Too many redirects ({max_redirects})",
+                headers=response.headers,
             )
-            response.raise_for_status()
-            return response
 
         async for attempt in AsyncRetrying(
             stop=stop_after_attempt(self.retry_limit),

--- a/providers/http/tests/unit/http/hooks/test_http.py
+++ b/providers/http/tests/unit/http/hooks/test_http.py
@@ -898,3 +898,52 @@ class TestHttpAsyncHook:
             async with aiohttp.ClientSession() as session:
                 await hook.run(session=session, endpoint="test.com:8080/v1/test")
                 assert mocked_function.call_args.args[0] == "http://test.com:8080/v1/test"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("location", "expected_forwarded_key"),
+        [
+            pytest.param("http://other.host/v1/redirected", None, id="cross-host"),
+            pytest.param("http://test:8080/v1/redirected", "secret-key", id="same-host"),
+        ],
+    )
+    async def test_async_connection_header_is_only_forwarded_on_a_same_host_redirect(
+        self, create_connection_without_db, location, expected_forwarded_key
+    ):
+        """Connection extra headers must not be forwarded on a cross-host redirect (async)."""
+        create_connection_without_db(
+            Connection(
+                conn_id="http_conn_with_api_key",
+                conn_type="http",
+                host="test:8080/",
+                extra='{"X-API-Key": "secret-key"}',
+            )
+        )
+        hook = HttpAsyncHook(http_conn_id="http_conn_with_api_key")
+
+        with mock.patch("aiohttp.ClientSession.get", new_callable=mock.AsyncMock) as mocked_get:
+            redirect_response = MockAiohttpClientResponse(
+                status=302,
+                method="GET",
+                url="http://test:8080/v1/test",
+                headers={"Location": location},
+            )
+            final_response = MockAiohttpClientResponse(
+                status=200,
+                payload={"message": "OK"},
+                method="GET",
+                url=location,
+            )
+            mocked_get.side_effect = [redirect_response, final_response]
+
+            async with aiohttp.ClientSession() as session:
+                resp = await hook.run(session=session, endpoint="v1/test")
+                assert resp.status == 200
+
+            # First request should carry the connection header
+            first_headers = mocked_get.call_args_list[0].kwargs["headers"]
+            assert first_headers.get("X-API-Key") == "secret-key"
+
+            # Second request should only carry it on a same-host redirect
+            second_headers = mocked_get.call_args_list[1].kwargs["headers"]
+            assert second_headers.get("X-API-Key") == expected_forwarded_key


### PR DESCRIPTION
### Summary

`HttpAsyncHook` forwards Connection `extra` headers (e.g. `X-API-Key`, `Private-Token`) across cross-host redirects because `aiohttp` only strips the `Authorization` header. This is a security issue — a secret held under any other header name is replayed verbatim to the redirect target.

PR #70000 fixed the synchronous `HttpHook` by subclassing `requests.Session` and extending `rebuild_auth`. This PR fixes the async side.

### Approach

`aiohttp` has no per-redirect callback equivalent to `requests.Session.rebuild_auth()`, so the fix disables automatic redirect following (`allow_redirects=False`) and walks the redirect chain manually. When the redirect target changes host, connection-supplied headers are dropped from subsequent requests. Same-host redirects are unaffected.

### Changes

1. **`providers/http/src/airflow/providers/http/hooks/http.py`** — `AsyncHttpSession.run()` now handles redirects manually:
   - Tracks which headers originated from the connection
   - Disables `aiohttp`'s auto-redirect
   - On cross-host redirect: drops connection headers, keeps caller-supplied headers
   - On same-host redirect: retains all headers
   - Max 5 redirects followed (matching `requests` default)

2. **`devel-common/src/tests_common/test_utils/aiohttp.py`** — Added `headers` and `release()` to `MockAiohttpClientResponse` to support redirect tests.

3. **`providers/http/tests/unit/http/hooks/test_http.py`** — Added `test_async_connection_header_is_only_forwarded_on_a_same_host_redirect` parametrized for cross-host and same-host redirects.

### Verification

- Cross-host redirect: `X-API-Key` present on first request, absent on second
- Same-host redirect: `X-API-Key` present on both requests
- Existing tests pass unchanged

### Related

- Fixes #70164
- Sync hook fix: #70000
