### PR TITLE
Copy 2.11.2 release notes to main

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4015,6 +4015,33 @@ thank everyone who helped shape this release through design discussions, code co
 community feedback. For full details, migration guidance, and upgrade best practices, refer to the official Upgrade
 Guide and join the conversation on the Airflow dev and user mailing lists.
 
+Airflow 2.11.2 (2026-03-11)
+---------------------------
+
+Significant Changes
+^^^^^^^^^^^^^^^^^^^
+
+Bug Fixes
+"""""""""
+
+- Fix Task Instances list view rendering raw HTML instead of clickable links for Dag Id, Task Id, and Run Id columns. (#62533)
+- In 2.11.1 by mistake ``core.use_historical_filename_templates`` was read by Airflow instead of ``logging.use_historical_filename_templates``. The ``core`` option is deprecated in Airflow 2.11.2. Both options are removed in Airflow 3 as historical templates are supported and does not cause low-severity security issue in Airflow 3. (#62647)
+- gracefully handle 404 from worker log server for historical retry attempts (#63002)
+- task_instance_mutation_hook receives a TI with run_id set (#62999)
+- fix missing logs in UI for tasks in ``UP_FOR_RETRY`` and ``UP_FOR_RESCHEDULE`` states (#54547) (#62877)
+- Fixing 500 error on webserver after upgrading to FAB provider 1.5.4 (#62412)
+- Lazily import fs and package_index hook in providers manager #52117 (#62356)
+
+Updated dependencies
+""""""""""""""""""""
+
+- Upgrade airflow UI to latest reasonable dependencies. (#63158)
+- Bump the core-ui-package-updates group across 1 directory with 87 updates (#61091)
+- bump filelock (#62952)
+- Limit Celery Provider to not install 3.17.0 as it breaks airflow 2.11 (#63046)
+- Bump the pip-dependency-updates group across 3 directories with 5 updates (#62808)
+- Upgrade to latest released build dependencies (#62613)
+
 Airflow 2.11.1 (2026-02-20)
 ---------------------------
 

--- a/reproducible_build.yaml
+++ b/reproducible_build.yaml
@@ -1,2 +1,2 @@
-release-notes-hash: 88ac6650c4b957b773ff2be17baaa018
-source-date-epoch: 1783348021
+release-notes-hash: add84c9fdd1cd1565d9e920a19a0fe6a
+source-date-epoch: 1785274037


### PR DESCRIPTION
The 2.11.2 release notes were written on the 2.11 branch but never copied to
`main`, the way [#62271](https://github.com/apache/airflow/pull/62271) did for
2.11.1. `RELEASE_NOTES.rst` therefore jumps straight from 2.11.1 (2026-02-20) to
Airflow 3.0, and every release-notes page built from `main` since inherits the
gap — including the 3.2.2 and 3.3.0 docs, both published well after 2.11.2
shipped on 2026-03-11.

This copies the 2.11.2 section verbatim from the `2.11.2` tag and drops it in
front of 2.11.1, keeping the file's series-then-reverse-chronological order.
`reproducible_build.yaml` is updated by the `update-reproducible-source-date-epoch`
hook, same as the 2.11.1 copy.

The already-published `3.2.2` and `3.3.0` doc archives stay as they are — those
pages are frozen at their release builds, so restoring 2.11.2 there needs a docs
republish from the corresponding release branches, which is a release-manager
action rather than something this PR can do.

closes: #69882

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
