### PR TITLE
Wait for vector index to stabilize

### DIFF
--- a/providers/amazon/tests/system/amazon/aws/example_bedrock_retrieve_and_generate.py
+++ b/providers/amazon/tests/system/amazon/aws/example_bedrock_retrieve_and_generate.py
@@ -32,7 +32,9 @@ from opensearchpy import (
     AWSV4SignerAuth,
     OpenSearch,
     RequestsHttpConnection,
+    TransportError,
 )
+from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from airflow.providers.amazon.aws.hooks.bedrock import BedrockAgentHook
 from airflow.providers.amazon.aws.hooks.opensearch_serverless import OpenSearchServerlessHook
@@ -271,6 +273,23 @@ def create_vector_index(index_name: str, collection_id: str, region: str):
                 sleep(2)
             else:
                 raise
+
+    # An acknowledged index-creation call does not guarantee the index is ready for use;
+    # OpenSearch Serverless materializes it asynchronously and exposes no status API for it.
+    # Poll a trivial search as a readiness probe so downstream Bedrock ingestion does not
+    # start (and fail) before the index can serve requests.
+    @retry(
+        retry=retry_if_exception_type(TransportError),
+        stop=stop_after_attempt(30),
+        wait=wait_fixed(5),
+        before_sleep=before_sleep_log(log, logging.INFO),
+        reraise=True,
+    )
+    def _wait_for_index_readiness():
+        oss_client.search(index=index_name, body={"query": {"match_all": {}}, "size": 0})
+
+    _wait_for_index_readiness()
+    log.info("Index %s is ready.", index_name)
 
 
 @task


### PR DESCRIPTION
  The Bedrock retrieve-and-generate system test creates an OpenSearch
  Serverless vector index and then immediately proceeds to Bedrock
  Knowledge Base ingestion. However, an acknowledged index-creation call
  does not guarantee the index is ready for use: OpenSearch Serverless
  materializes the index asynchronously and exposes no status API to
  check on its progress. When ingestion starts before the index can
  serve requests, the test fails intermittently.
  
  Since there is no status API for the index, this change polls a
  trivial `match_all` search against the new index as a readiness probe
  (retrying `TransportError` up to 30 times at 5-second intervals)
  before allowing downstream tasks to run, eliminating the race.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
