### PR TITLE
Give each mypy prek hook its own file list in CI

### DIFF
--- a/scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
+++ b/scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py
@@ -303,8 +303,8 @@ if CI:
         print("No files to test. Quitting")
         sys.exit(0)
 
-    write_file_list(all_files_to_check)
-    file_argument_ci = "@/files/mypy_files.txt"
+    mypy_file_list = write_file_list(all_files_to_check, suffix=mypy_folders[0].replace("/", "-"))
+    file_argument_ci = f"@/files/{mypy_file_list.name}"
 
     mypy_cmd = (
         f"TERM=ansi mypy --follow-imports=silent {shlex.quote(file_argument_ci)} {' '.join(mypy_extra_args)}"


### PR DESCRIPTION
## Why
- prek runs hooks from different prek projects concurrently. Every one of them wrote its mypy file list to the same `files/mypy_files.txt`.
- On `v3-3-test` [run 30279407098](https://github.com/apache/airflow/actions/runs/30279407098/job/90050868483), `mypy-shared-configuration`, `mypy-shared-dagnode` and `mypy-shared-listeners` all failed on non-existent path.

Their writing file time are close.
```
2026-07-27T17:28:58.9980347Z     Running mypy for folders: ['shared/configuration']
2026-07-27T17:28:58.9981475Z     You can check the list of files in: /home/runner/work/airflow/airflow/files/mypy_files.txt

2026-07-27T17:28:59.0832479Z     Running mypy for folders: ['shared/dagnode']
2026-07-27T17:28:59.0833606Z     You can check the list of files in: /home/runner/work/airflow/airflow/files/mypy_files.txt

2026-07-27T17:28:59.1323493Z     Running mypy for folders: ['shared/listeners']
2026-07-27T17:28:59.1324120Z     You can check the list of files in: /home/runner/work/airflow/airflow/files/mypy_files.txt
```

```
2026-07-27T17:28:59.0455195Z     mypy: Cannot read file 'shared/dagnode/tests/dagnode/__init__.pyteners/spec/taskinstance.py': No such file or directory

2026-07-27T17:28:59.1199107Z     mypy: Cannot read file 'shared/dagnode/tests/dagnode/__init__.pyteners/spec/taskinstance.py': No such file or directory

2026-07-27T17:28:59.1521972Z     mypy: Cannot read file 'shared/dagnode/tests/dagnode/__init__.pyteners/spec/taskinstance.py': No such file or directory
```

## How

- `run_mypy_full_dist_local_venv_or_breeze_in_ci.py`: Use `suffix` argument in `write_file_list()` to avoid overwriting same file.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
