### PR TITLE
Add the Taiwanese Mandarin string for variable-interval deadlines

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
@@ -42,6 +42,7 @@
   },
   "deadlineAlerts": {
     "completionRule": "必須在 {{reference}}後 {{interval}} 內完成",
+    "completionRuleDynamic": "必須在 {{reference}}後的一段變動期間內完成",
     "count_one": "{{count}} 個期限",
     "count_other": "{{count}} 個期限",
     "referenceType": {


### PR DESCRIPTION
<!--## Why
the main branch is failing with

```pytb
src/pages/Dag/DeadlineAlertsBadge.tsx:38:35 - error TS2345: Argument of type 'number | null | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'.

38   const interval = dayjs.duration(alert.interval, "seconds").humanize();
                                     ~~~~~~~~~~~~~~

src/pages/Dag/Overview/DeadlineRow.tsx:46:43 - error TS2345: Argument of type 'number | null | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'.

46   const interval = alert ? dayjs.duration(alert.interval, "seconds").humanize() : undefined;
                                             ~~~~~~~~~~~~~~

src/pages/Run/DeadlineStatus.tsx:88:40 - error TS2345: Argument of type 'number | null | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'.

88               interval: dayjs.duration(deadlineAlert.interval, "seconds").humanize(),
                                          ~~~~~~~~~~~~~~~~~~~~~~

src/pages/Run/DeadlineStatus.tsx:191:38 - error TS2345: Argument of type 'number | null | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'.

191             interval: dayjs.duration(alert.interval, "seconds").humanize(),
                                         ~~~~~~~~~~~~~~

src/pages/Run/DeadlineStatusModal.tsx:134:52 - error TS2345: Argument of type 'number | null | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'.

134                           interval: dayjs.duration(alert.interval, "seconds").humanize(),
                                                       ~~~~~~~~~~~~~~


Found 5 errors in 4 files.

Errors  Files
     1  src/pages/Dag/DeadlineAlertsBadge.tsx:38
     1  src/pages/Dag/Overview/DeadlineRow.tsx:46
     2  src/pages/Run/DeadlineStatus.tsx:88
     1  src/pages/Run/DeadlineStatusModal.tsx:134
```

when running `prek run ts-compile-lint-ui --all-files`,

#68919 made `DeadlineAlertResponse.interval` nullable (`float | None`) for deadlines whose interval is dynamic (e.g., `VariableInterval`) because its value doesn't exist until the scheduler evaluates it. The UI's generated OpenAPI client was never regenerated after that change: `types.gen.ts` still declared `interval` as a required `number`, so every call site fed `null` `undefined` straight into `dayjs.duration(interval, "seconds").humanize()`. That renders `null` as "a few seconds" and `undefined` as "a month" — a plausible-looking but wrong duration for a deadline that has no resolved interval at all.

## What
Regenerate the UI OpenAPI client so `interval` matches the API contract (`number | null`, optional). Extract the duplicated interval/reference-type/completion-rule formatting out of the four call sites (`DeadlineAlertsBadge`, `Overview/DeadlineRow`, `Run/DeadlineStatus`, `Run/DeadlineStatusModal`) into a single `src/utils/deadlineAlert.ts`. `getIntervalLabel` now renders a new `deadlineAlerts.dynamicInterval` i18n string ("a dynamic interval" / 動態間隔) instead of humanizing `null`/`undefined`, and the guard lives in one place so a future call site inherits it instead of having to remember it.-->


as title


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
