### PR TITLE
reject mixed-separator path traversal in imap attachment names

### DIFF
--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -332,7 +332,11 @@ class ImapHook(BaseHook):
         return os.path.islink(self._correct_path(name, local_output_directory))
 
     def _is_escaping_current_directory(self, name: str) -> bool:
-        return f"..{os.sep}" in name
+        # Windows also accepts "/" as a path separator, so a "../" attachment name
+        # traverses there even though os.sep is a backslash and the old
+        # f"..{os.sep}" check missed it. Normalise both separators and reject any
+        # ".." path component.
+        return any(part == ".." for part in name.replace("\\", "/").split("/"))
 
     def _correct_path(self, name: str, local_output_directory: str) -> str:
         return (

--- a/providers/imap/src/airflow/providers/imap/hooks/imap.py
+++ b/providers/imap/src/airflow/providers/imap/hooks/imap.py
@@ -332,11 +332,15 @@ class ImapHook(BaseHook):
         return os.path.islink(self._correct_path(name, local_output_directory))
 
     def _is_escaping_current_directory(self, name: str) -> bool:
-        # Windows also accepts "/" as a path separator, so a "../" attachment name
-        # traverses there even though os.sep is a backslash and the old
-        # f"..{os.sep}" check missed it. Normalise both separators and reject any
-        # ".." path component.
-        return any(part == ".." for part in name.replace("\\", "/").split("/"))
+        # On Windows os.altsep is "/", so a "../" attachment name traverses even
+        # though os.sep is a backslash and the old f"..{os.sep}" check missed it.
+        # Split on every separator the host recognises and reject any ".."
+        # component. Using os.altsep keeps backslashes as ordinary characters on
+        # POSIX, where they are legal in filenames.
+        normalised = name.replace(os.sep, "/")
+        if os.altsep:
+            normalised = normalised.replace(os.altsep, "/")
+        return any(part == ".." for part in normalised.split("/"))
 
     def _correct_path(self, name: str, local_output_directory: str) -> str:
         return (

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -409,6 +409,21 @@ class TestImapHook:
         mock_open_method.assert_not_called()
         mock_open_method.return_value.write.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("../test1.csv", True),
+            ("subdir/../../test1.csv", True),
+            ("..\\..\\test1.csv", True),
+            ("subdir\\..\\..\\test1.csv", True),
+            ("..", True),
+            ("test1.csv", False),
+            ("report..final.csv", False),
+        ],
+    )
+    def test_is_escaping_current_directory_handles_both_separators(self, name, expected):
+        assert ImapHook()._is_escaping_current_directory(name) is expected
+
     @patch("airflow.providers.imap.hooks.imap.os.path.islink", return_value=True)
     @patch(open_string, new_callable=mock_open)
     @patch(imaplib_string)

--- a/providers/imap/tests/unit/imap/hooks/test_imap.py
+++ b/providers/imap/tests/unit/imap/hooks/test_imap.py
@@ -409,19 +409,37 @@ class TestImapHook:
         mock_open_method.assert_not_called()
         mock_open_method.return_value.write.assert_not_called()
 
+    @patch("airflow.providers.imap.hooks.imap.os.altsep", None)
+    @patch("airflow.providers.imap.hooks.imap.os.sep", "/")
     @pytest.mark.parametrize(
         ("name", "expected"),
         [
             ("../test1.csv", True),
             ("subdir/../../test1.csv", True),
+            ("..", True),
+            ("test1.csv", False),
+            ("report..final.csv", False),
+            # On POSIX a backslash is an ordinary filename character, not a separator.
+            ("..\\..\\test1.csv", False),
+        ],
+    )
+    def test_is_escaping_current_directory_on_posix(self, name, expected):
+        assert ImapHook()._is_escaping_current_directory(name) is expected
+
+    @patch("airflow.providers.imap.hooks.imap.os.altsep", "/")
+    @patch("airflow.providers.imap.hooks.imap.os.sep", "\\")
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
             ("..\\..\\test1.csv", True),
+            ("../../test1.csv", True),
             ("subdir\\..\\..\\test1.csv", True),
             ("..", True),
             ("test1.csv", False),
             ("report..final.csv", False),
         ],
     )
-    def test_is_escaping_current_directory_handles_both_separators(self, name, expected):
+    def test_is_escaping_current_directory_on_windows(self, name, expected):
         assert ImapHook()._is_escaping_current_directory(name) is expected
 
     @patch("airflow.providers.imap.hooks.imap.os.path.islink", return_value=True)


### PR DESCRIPTION
`_is_escaping_current_directory` in the imap hook rejects a traversing attachment name with `f"..{os.sep}" in name`, which is tied to the host separator. On Windows `os.sep` is a backslash but a forward slash is also a valid path separator, so an attachment named `../../evil` slips past the check and, once joined onto the output directory in `_correct_path`, resolves outside it, letting whoever sent the mail write an arbitrary file. This normalises both separators and rejects any `..` path component instead.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.