### PR TITLE
Fix DAGs list page Last Run/Next Run going stale after runs complete

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -327,6 +327,7 @@ export const DagsList = () => {
 
   const { data: runStateCountsData, isLoading: runStateCountsLoading } = useDagRunStateCounts({
     dagIds: data?.dags.map((dag) => dag.dag_id) ?? [],
+    dags: data?.dags,
   });
   const runStateContext: RunStateCountsContext = {
     countsByDag: Object.fromEntries(

--- a/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagsList/DagsList.tsx
@@ -327,7 +327,6 @@ export const DagsList = () => {
 
   const { data: runStateCountsData, isLoading: runStateCountsLoading } = useDagRunStateCounts({
     dagIds: data?.dags.map((dag) => dag.dag_id) ?? [],
-    dags: data?.dags,
   });
   const runStateContext: RunStateCountsContext = {
     countsByDag: Object.fromEntries(

--- a/airflow-core/src/airflow/ui/src/queries/useDagRunStateCounts.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDagRunStateCounts.tsx
@@ -17,12 +17,22 @@
  * under the License.
  */
 import { useDagServiceGetDagRunStateCountsUi } from "openapi/queries";
-import { useAutoRefresh } from "src/utils";
+import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
-export const useDagRunStateCounts = ({ dagIds }: { readonly dagIds: ReadonlyArray<string> }) => {
-  // checkPendingRuns: true checks for pending runs across *all* dags and scales the interval back
-  // rather than disabling polling outright once the currently displayed page has nothing pending.
+export const useDagRunStateCounts = ({
+  dagIds,
+  dags,
+}: {
+  readonly dagIds: ReadonlyArray<string>;
+  // Refresh predicate is derived from useDags' data so the counts query doesn't
+  // need to be loaded before it knows whether to poll — avoids a chicken-and-egg.
+  readonly dags: ReadonlyArray<DAGWithLatestDagRunsResponse> | undefined;
+}) => {
   const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
+  const hasPendingRun =
+    dags?.some((dag) => !dag.is_paused && dag.latest_dag_runs.some((run) => isStatePending(run.state))) ??
+    false;
 
   // Stable key: sort the dag_ids so pagination/sort order changes don't churn the cache.
   const sortedDagIds = [...dagIds].sort();
@@ -30,6 +40,6 @@ export const useDagRunStateCounts = ({ dagIds }: { readonly dagIds: ReadonlyArra
   return useDagServiceGetDagRunStateCountsUi({ dagIds: sortedDagIds }, undefined, {
     enabled: sortedDagIds.length > 0,
     placeholderData: (prev) => prev,
-    refetchInterval,
+    refetchInterval: refetchInterval === false ? false : hasPendingRun ? refetchInterval : refetchInterval * 10,
   });
 };

--- a/airflow-core/src/airflow/ui/src/queries/useDagRunStateCounts.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDagRunStateCounts.tsx
@@ -40,6 +40,7 @@ export const useDagRunStateCounts = ({
   return useDagServiceGetDagRunStateCountsUi({ dagIds: sortedDagIds }, undefined, {
     enabled: sortedDagIds.length > 0,
     placeholderData: (prev) => prev,
-    refetchInterval: refetchInterval === false ? false : hasPendingRun ? refetchInterval : refetchInterval * 10,
+    refetchInterval:
+      refetchInterval === false ? false : hasPendingRun ? refetchInterval : refetchInterval * 10,
   });
 };

--- a/airflow-core/src/airflow/ui/src/queries/useDagRunStateCounts.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDagRunStateCounts.tsx
@@ -17,22 +17,12 @@
  * under the License.
  */
 import { useDagServiceGetDagRunStateCountsUi } from "openapi/queries";
-import type { DAGWithLatestDagRunsResponse } from "openapi/requests/types.gen";
-import { isStatePending, useAutoRefresh } from "src/utils";
+import { useAutoRefresh } from "src/utils";
 
-export const useDagRunStateCounts = ({
-  dagIds,
-  dags,
-}: {
-  readonly dagIds: ReadonlyArray<string>;
-  // Refresh predicate is derived from useDags' data so the counts query doesn't
-  // need to be loaded before it knows whether to poll — avoids a chicken-and-egg.
-  readonly dags: ReadonlyArray<DAGWithLatestDagRunsResponse> | undefined;
-}) => {
-  const refetchInterval = useAutoRefresh({});
-  const hasPendingRun =
-    dags?.some((dag) => !dag.is_paused && dag.latest_dag_runs.some((run) => isStatePending(run.state))) ??
-    false;
+export const useDagRunStateCounts = ({ dagIds }: { readonly dagIds: ReadonlyArray<string> }) => {
+  // checkPendingRuns: true checks for pending runs across *all* dags and scales the interval back
+  // rather than disabling polling outright once the currently displayed page has nothing pending.
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
 
   // Stable key: sort the dag_ids so pagination/sort order changes don't churn the cache.
   const sortedDagIds = [...dagIds].sort();
@@ -40,6 +30,6 @@ export const useDagRunStateCounts = ({
   return useDagServiceGetDagRunStateCountsUi({ dagIds: sortedDagIds }, undefined, {
     enabled: sortedDagIds.length > 0,
     placeholderData: (prev) => prev,
-    refetchInterval: hasPendingRun ? refetchInterval : false,
+    refetchInterval,
   });
 };

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -18,7 +18,7 @@
  */
 import { useDagServiceGetDagsUi } from "openapi/queries";
 import type { DagRunState } from "openapi/requests/types.gen";
-import { useAutoRefresh } from "src/utils";
+import { isStatePending, useAutoRefresh } from "src/utils";
 
 export const useDags = ({
   advancedSearch = false,
@@ -80,7 +80,16 @@ export const useDags = ({
       teams,
     },
     undefined,
-    { refetchInterval },
+    {
+      refetchInterval: (query) =>
+        refetchInterval === false
+          ? false
+          : query.state.data?.dags.some(
+              (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
+            )
+            ? refetchInterval
+            : refetchInterval * 10,
+    },
   );
 
   return {

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -85,8 +85,8 @@ export const useDags = ({
         refetchInterval === false
           ? false
           : query.state.data?.dags.some(
-              (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
-            )
+                (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
+              )
             ? refetchInterval
             : refetchInterval * 10,
     },

--- a/airflow-core/src/airflow/ui/src/queries/useDags.tsx
+++ b/airflow-core/src/airflow/ui/src/queries/useDags.tsx
@@ -18,7 +18,7 @@
  */
 import { useDagServiceGetDagsUi } from "openapi/queries";
 import type { DagRunState } from "openapi/requests/types.gen";
-import { isStatePending, useAutoRefresh } from "src/utils";
+import { useAutoRefresh } from "src/utils";
 
 export const useDags = ({
   advancedSearch = false,
@@ -57,7 +57,7 @@ export const useDags = ({
   tagsMatchMode?: "all" | "any";
   teams?: Array<string>;
 }) => {
-  const refetchInterval = useAutoRefresh({});
+  const refetchInterval = useAutoRefresh({ checkPendingRuns: true });
 
   const { data, error, isFetching, isLoading } = useDagServiceGetDagsUi(
     {
@@ -80,14 +80,7 @@ export const useDags = ({
       teams,
     },
     undefined,
-    {
-      refetchInterval: (query) =>
-        query.state.data?.dags.some(
-          (dag) => !dag.is_paused && dag.latest_dag_runs.some((dr) => isStatePending(dr.state)),
-        )
-          ? refetchInterval
-          : false,
-    },
+    { refetchInterval },
   );
 
   return {


### PR DESCRIPTION
**Summary**
The DAGs list page (`/dags`) stops auto-refreshing once none of the visible
DAGs has a run in a pending state. Since that's the normal resting
condition, "Last Run" and "Next Run" (and the Recent Tasks counts) go stale
and never update again until a manual page reload.

**Root cause**
`useDags` and `useDagRunStateCounts` each set `refetchInterval: false`
whenever no DAG on the current page is mid-run, permanently killing
polling. Every other page in the UI instead uses
`useAutoRefresh({ checkPendingRuns: true })`, which checks pending runs
globally and scales the interval back instead of disabling it.

**Fix**
Route both hooks through the same `checkPendingRuns: true` mechanism
already used elsewhere, instead of their own divergent, page-local gate.
No visual/markup changes — purely a polling-behavior fix.

closes: #70663

Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)