### PR TITLE
Skip log accumulator disk spill when reading finished task logs

### DIFF
--- a/airflow-core/src/airflow/utils/log/file_task_handler.py
+++ b/airflow-core/src/airflow/utils/log/file_task_handler.py
@@ -683,6 +683,18 @@ class FileTaskHandler(logging.Handler):
             TaskInstanceState.DEFERRED,
         )
 
+        if end_of_log:
+            # No continuation token will be issued, so the total line count is not
+            # needed: stream straight through instead of paying the accumulator's
+            # eager full drain to memory/disk. Memory stays bounded by the merge
+            # heap in _interleave_logs either way.
+            if metadata and "log_pos" in metadata:
+                out_stream = islice(out_stream, metadata["log_pos"], None)
+            else:
+                # first time reading log, add messages before interleaved log stream
+                out_stream = chain(header, out_stream)
+            return out_stream, {"end_of_log": end_of_log}
+
         with LogStreamAccumulator(out_stream, HEAP_DUMP_SIZE) as stream_accumulator:
             log_pos = stream_accumulator.total_lines
             out_stream = stream_accumulator.stream

--- a/airflow-core/tests/unit/utils/log/test_log_reader.py
+++ b/airflow-core/tests/unit/utils/log/test_log_reader.py
@@ -136,7 +136,7 @@ class TestLogView:
         )
         assert logs[2].event == "::endgroup::"
         assert logs[3].event == "try_number=1."
-        assert metadata == {"end_of_log": True, "log_pos": 1}
+        assert metadata == {"end_of_log": True}
 
     def test_test_read_log_chunks_should_read_latest_files(self):
         task_log_reader = TaskLogReader()
@@ -151,7 +151,7 @@ class TestLogView:
         )
         assert logs[2].event == "::endgroup::"
         assert logs[3].event == f"try_number={ti.try_number}."
-        assert metadata == {"end_of_log": True, "log_pos": 1}
+        assert metadata == {"end_of_log": True}
 
     def test_test_test_read_log_stream_should_read_one_try(self):
         task_log_reader = TaskLogReader()

--- a/airflow-core/tests/unit/utils/test_log_handlers.py
+++ b/airflow-core/tests/unit/utils/test_log_handlers.py
@@ -474,7 +474,7 @@ class TestFileTaskLogHandler:
         log_handler_output_stream, metadata = fth._read(ti=local_log_file_read, try_number=1)
         mock_read_local.assert_called_with(path)
         assert extract_events(log_handler_output_stream) == ["the log"]
-        assert metadata == {"end_of_log": True, "log_pos": 1}
+        assert metadata == {"end_of_log": True}
 
     @patch("airflow.utils.log.file_task_handler.FileTaskHandler._read_from_local")
     def test__read_when_local_respects_log_pos_metadata(self, mock_read_local, create_task_instance):
@@ -503,7 +503,34 @@ class TestFileTaskLogHandler:
 
         # Should resume from the third line only.
         assert extract_events(log_handler_output_stream) == ["line 3"]
-        assert metadata == {"end_of_log": True, "log_pos": 3}
+        assert metadata == {"end_of_log": True}
+
+    @pytest.mark.parametrize("ti_state", [TaskInstanceState.SUCCESS, TaskInstanceState.FAILED])
+    @patch("airflow.utils.log.file_task_handler.LogStreamAccumulator")
+    @patch("airflow.utils.log.file_task_handler.FileTaskHandler._read_from_local")
+    def test__read_end_of_log_skips_accumulator(
+        self, mock_read_local, mock_accumulator, ti_state, create_task_instance
+    ):
+        """A terminal-state read issues no continuation token, so the stream must pass
+        through without the accumulator's eager full drain to memory/disk."""
+        mock_read_local.return_value = (
+            ["the messages"],
+            [convert_list_to_stream(["line 1", "line 2", "line 3"])],
+        )
+        ti = create_task_instance(
+            dag_id="dag_for_testing_local_log_read",
+            task_id="task_for_testing_local_log_read",
+            run_type=DagRunType.SCHEDULED,
+            logical_date=DEFAULT_DATE,
+            state=ti_state,
+        )
+        fth = FileTaskHandler("")
+
+        log_handler_output_stream, metadata = fth._read(ti=ti, try_number=1)
+
+        assert extract_events(log_handler_output_stream) == ["line 1", "line 2", "line 3"]
+        assert metadata == {"end_of_log": True}
+        mock_accumulator.assert_not_called()
 
     @patch("airflow.utils.log.file_task_handler.FileTaskHandler._read_from_local")
     def test_read_respects_log_pos_metadata(self, mock_read_local, create_task_instance):
@@ -528,7 +555,7 @@ class TestFileTaskLogHandler:
 
         # Should resume from the third line only.
         assert extract_events(log_handler_output_stream) == ["line 3"]
-        assert metadata == {"end_of_log": True, "log_pos": 3}
+        assert metadata == {"end_of_log": True}
 
     def test__read_from_local(self, tmp_path):
         """Tests the behavior of method _read_from_local"""
@@ -623,7 +650,7 @@ class TestFileTaskLogHandler:
         else:
             fth._read_from_logs_server.assert_not_called()
         assert extract_events(logs, False) == expected_logs
-        assert metadata == {"end_of_log": True, "log_pos": 3}
+        assert metadata == {"end_of_log": True}
 
     @pytest.mark.parametrize("is_tih", [False, True])
     def test_read_served_logs(self, is_tih, create_task_instance):

--- a/devel-common/src/tests_common/test_utils/version_compat.py
+++ b/devel-common/src/tests_common/test_utils/version_compat.py
@@ -42,6 +42,7 @@ AIRFLOW_V_3_1_9_PLUS = get_base_airflow_version_tuple() >= (3, 1, 9)
 AIRFLOW_V_3_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 0)
 AIRFLOW_V_3_2_2_PLUS = get_base_airflow_version_tuple() >= (3, 2, 2)
 AIRFLOW_V_3_3_PLUS = get_base_airflow_version_tuple() >= (3, 3, 0)
+AIRFLOW_V_3_4_0_PLUS = get_base_airflow_version_tuple() >= (3, 4, 0)
 
 if AIRFLOW_V_3_1_PLUS:
     from airflow.sdk import PokeReturnValue, timezone
@@ -64,6 +65,7 @@ __all__ = [
     "AIRFLOW_V_3_1_PLUS",
     "AIRFLOW_V_3_2_PLUS",
     "AIRFLOW_V_3_3_PLUS",
+    "AIRFLOW_V_3_4_0_PLUS",
     "NOTSET",
     "XCOM_RETURN_KEY",
     "ArgNotSet",

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -39,7 +39,11 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.taskinstance import create_task_instance
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_2_PLUS,
+    AIRFLOW_V_3_4_0_PLUS,
+)
 
 try:
     from airflow.sdk.timezone import datetime
@@ -418,7 +422,10 @@ class TestS3TaskHandler:
             assert log[5].event == "Line 2"
             assert log[6].event == "Log line 3"
             assert log[7].event == "Line 4"
-            assert metadata == {"end_of_log": True, "log_pos": 4}
+            if AIRFLOW_V_3_4_0_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 4}
         elif AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"
@@ -443,7 +450,10 @@ class TestS3TaskHandler:
         if AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert len(log) == 2
-            assert metadata == {"end_of_log": True, "log_pos": 0}
+            if AIRFLOW_V_3_4_0_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 0}
         else:
             assert len(log) == 1
             assert len(log) == len(metadata)

--- a/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
+++ b/providers/amazon/tests/unit/amazon/aws/log/test_s3_task_handler.py
@@ -40,7 +40,11 @@ from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.dag import sync_dag_to_db
 from tests_common.test_utils.db import clear_db_dag_bundles, clear_db_dags, clear_db_runs
 from tests_common.test_utils.taskinstance import create_task_instance
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_2_PLUS,
+    AIRFLOW_V_3_4_PLUS,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -467,7 +471,10 @@ class TestS3TaskHandler:
             assert log[5].event == "Line 2"
             assert log[6].event == "Log line 3"
             assert log[7].event == "Line 4"
-            assert metadata == {"end_of_log": True, "log_pos": 4}
+            if AIRFLOW_V_3_4_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 4}
         elif AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"
@@ -492,7 +499,10 @@ class TestS3TaskHandler:
         if AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert len(log) == 2
-            assert metadata == {"end_of_log": True, "log_pos": 0}
+            if AIRFLOW_V_3_4_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 0}
         else:
             assert len(log) == 1
             assert len(log) == len(metadata)

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -35,7 +35,11 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_2_PLUS,
+    AIRFLOW_V_3_4_0_PLUS,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -465,7 +469,10 @@ class TestGCSTaskHandler:
             assert logs[1].event == expected_gs_uri
             assert logs[2].event == "::endgroup::"
             assert logs[3].event == "CONTENT"
-            assert metadata == {"end_of_log": True, "log_pos": 1}
+            if AIRFLOW_V_3_4_0_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 1}
         elif AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
@@ -503,7 +510,10 @@ class TestGCSTaskHandler:
             assert log[1].event == expected_gs_uri
             assert log[2].event == f"{self.gcs_task_handler.local_base}/1.log"
             assert log[3].event == "::endgroup::"
-            assert metadata == {"end_of_log": True, "log_pos": 0}
+            if AIRFLOW_V_3_4_0_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 0}
         elif AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"

--- a/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_gcs_task_handler.py
@@ -34,7 +34,11 @@ from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_2_PLUS,
+    AIRFLOW_V_3_4_PLUS,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -464,7 +468,10 @@ class TestGCSTaskHandler:
             assert logs[1].event == expected_gs_uri
             assert logs[2].event == "::endgroup::"
             assert logs[3].event == "CONTENT"
-            assert metadata == {"end_of_log": True, "log_pos": 1}
+            if AIRFLOW_V_3_4_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 1}
         elif AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"
@@ -502,7 +509,10 @@ class TestGCSTaskHandler:
             assert log[1].event == expected_gs_uri
             assert log[2].event == f"{self.gcs_task_handler.local_base}/1.log"
             assert log[3].event == "::endgroup::"
-            assert metadata == {"end_of_log": True, "log_pos": 0}
+            if AIRFLOW_V_3_4_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 0}
         elif AIRFLOW_V_3_0_PLUS:
             log = list(log)
             assert log[0].event == "::group::Log message source details"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -33,7 +33,11 @@ from airflow.utils.timezone import datetime
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_2_PLUS,
+    AIRFLOW_V_3_4_0_PLUS,
+)
 
 pytestmark = pytest.mark.db_test
 
@@ -127,7 +131,10 @@ class TestWasbTaskHandler:
             )
             assert logs[2].event == "::endgroup::"
             assert logs[3].event == "Log line"
-            assert metadata == {"end_of_log": True, "log_pos": 1}
+            if AIRFLOW_V_3_4_0_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 1}
         elif AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/log/test_wasb_task_handler.py
@@ -33,7 +33,11 @@ from airflow.utils.state import TaskInstanceState
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.db import clear_db_dags, clear_db_runs
-from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS, AIRFLOW_V_3_2_2_PLUS
+from tests_common.test_utils.version_compat import (
+    AIRFLOW_V_3_0_PLUS,
+    AIRFLOW_V_3_2_2_PLUS,
+    AIRFLOW_V_3_4_PLUS,
+)
 
 pytestmark = pytest.mark.db_test
 
@@ -210,7 +214,10 @@ class TestWasbTaskHandler:
             )
             assert logs[2].event == "::endgroup::"
             assert logs[3].event == "Log line"
-            assert metadata == {"end_of_log": True, "log_pos": 1}
+            if AIRFLOW_V_3_4_PLUS:
+                assert metadata == {"end_of_log": True}
+            else:
+                assert metadata == {"end_of_log": True, "log_pos": 1}
         elif AIRFLOW_V_3_0_PLUS:
             logs = list(logs)
             assert logs[0].event == "::group::Log message source details"

--- a/ui-continue-token-plan.md
+++ b/ui-continue-token-plan.md
@@ -1,0 +1,124 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+# Plan: make the Airflow UI respect the log continuation token
+
+**Status:** design / not yet implemented
+**Context:** follow-up to the streaming task-log series (`#69299`, `#69300`, and the
+"Skip log accumulator disk spill when reading finished task logs" commit on this branch).
+
+## Problem
+
+The React UI ignores the log continuation token entirely. `useLogs`
+(`airflow-core/src/airflow/ui/src/queries/useLogs.tsx`) calls
+`useTaskInstanceServiceGetLog` with only
+`{accept, dagId, dagRunId, mapIndex, taskId, tryNumber}` — **no `token`** — and on
+every `refetchInterval` tick React Query discards the previous data and re-fetches the
+**entire log from line 0**. It reads only `data.content`; the returned
+`continuation_token` (JSON body) / `Airflow-Continuation-Token` (NDJSON header) is never
+consumed. Client-side `truncateData` slices to the last `limit` lines only *after*
+pulling everything.
+
+Cost model today: for a task that runs across N polls while its log grows to L lines, the
+server does **O(L × N)** work — read + `_interleave_logs` merge + serialize + ship the
+whole log every tick — and the browser re-parses the whole log every tick.
+
+## What already exists (no backend change needed)
+
+- Endpoint `GET .../logs/{try_number}` (`api_fastapi/core_api/routes/public/log.py`)
+  already accepts `token: str | None`, decodes it back into `metadata` (carrying
+  `log_pos`), and returns the next token **only while the log is unfinished**:
+  - `application/json` → `continuation_token` in the body.
+  - `application/x-ndjson` (current UI default) → `Airflow-Continuation-Token` **response
+    header**.
+- Generated client `GetLogData` already has `token?: string | null`, and `getLog`
+  forwards it.
+
+So the entire change is on the React side: capture the returned token, send it back, and
+**append** deltas instead of **replacing** the whole buffer.
+
+## Design
+
+### A. Where to read the token
+
+- **Recommended: switch the UI request to `accept: "application/json"`** so the token
+  arrives in the body (`continuation_token`) — the generated client already deserializes
+  the body, so no header plumbing is required.
+- Keeping NDJSON streaming would require extending the generated request layer to surface
+  the `Airflow-Continuation-Token` **response header**, which the client currently
+  discards. More work; defer.
+
+### B. Accumulate instead of replace
+
+Convert `useLogs` from a replace-query to an accumulate-query (a `useInfiniteQuery`, or a
+manual reducer):
+
+- `queryFn` calls `getLog({ ..., token: pageParam })`.
+- `getNextPageParam` returns the response `continuation_token`; when it is `null`/absent
+  (`end_of_log`), return `undefined` so React Query stops paging.
+- Concatenate `content` across pages into one buffer and feed **that** buffer to
+  `parseLogs`, `truncateData`, search, and download — all already operate on a flat
+  content array.
+- Drive polling with `refetchInterval` only while `hasNextPage && isStatePending(state)`,
+  replacing the current "refetch everything while pending" behavior.
+
+### C. Reset on try-number / restart
+
+Reset the accumulated buffer + token when `tryNumber` changes or the TI transitions to a
+fresh run, so stale lines are not appended. Key the infinite query on `tryNumber`.
+
+### D. Keep "download full log" honest
+
+Download currently relies on `fetchedData` being the whole log. With incremental fetch,
+either reuse the accumulated buffer, or for download specifically issue a one-shot
+`fullContent: true` request (the endpoint already supports `full_content`).
+
+No backend change required — this is a `useLogs.tsx` refactor plus (optionally, only for
+the NDJSON path) response-header exposure in the request layer.
+
+## Does it reduce API-server pressure?
+
+**Yes — per-request cost during the running-task window drops from O(L) to O(Δ)** (only
+new lines since `log_pos`); total server work over the task life becomes **O(L) instead of
+O(L × N)**. Concretely it cuts:
+
+- **Response payload / egress** — biggest, clearest win; only the delta ships each tick.
+- **CPU** — JSON/structlog serialization and the `_interleave_logs` merge scale with lines
+  emitted, so they shrink to the delta.
+- **Browser cost** — only new lines are parsed/rendered each tick instead of the whole log.
+
+### Caveats (be realistic)
+
+1. **Request count is unchanged** — still one poll per interval per open log view. Token
+   use lowers per-request cost, not the number of requests. Cutting request count needs
+   server-push (SSE/streaming), a separate effort.
+2. **Savings apply only while the task runs.** Once finished the UI already stops polling,
+   and the accumulator-bypass commit on this branch already streams terminal reads without
+   the accumulator.
+3. **Log-backend reads may shrink less than egress.** For remote object stores that cannot
+   seek, the handler still pulls the object and `islice`s past `log_pos`, so backend I/O
+   improves less than payload size; local files fare better.
+4. **Shifts running-task reads onto the accumulator path** (which computes `log_pos`) —
+   inherent to producing a token, bounded by `HEAP_DUMP_SIZE`. This is the opposite
+   optimization from the finished-task fast path in the last commit.
+
+**Net:** a solid efficiency win (egress + CPU) for deployments with many users watching
+long-running tasks with large logs. It is *not* a remedy for "too many concurrent
+pollers" — real streaming is the lever there; token-based incremental fetch is the lever
+for eliminating wasted re-transfer.


### PR DESCRIPTION
**part of the streaming task log series**
- related: #69299 (merged core plumbing), #69300 (merged KubernetesExecutor counterpart)

## Why

`FileTaskHandler._read` wraps every read in `LogStreamAccumulator`, which eagerly drains the whole merged log stream (5000 lines to memory, the rest to a tempfile on the API server) *before the first byte reaches the client* — only to get the `total_lines` for the continuation token.

For a finished task no continuation token is ever issued (`end_of_log=True` on both the JSON and NDJSON paths), so the count is dead weight: every terminal-task read full-log downloads — pays a full-log disk write + read-back + re-parse and a time-to-first-byte equal to the whole drain, for nothing.

## What

- Early-return in `FileTaskHandler._read` bypassing `LogStreamAccumulator` when `end_of_log` is `True`.
- **Memory stays bounded either way** — the k-way merge heap in `_interleave_logs` (capped at `HEAP_DUMP_SIZE`, flushing half when full) is what bounds the read path, not the accumulator.


---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Sonnet 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
