### PR TITLE
fix(ssh): validate cleanup under custom remote base

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
@@ -353,6 +353,7 @@ class SSHRemoteJobOperator(BaseOperator):
                     "log_file": self._paths.log_file,
                     "exit_code_file": self._paths.exit_code_file,
                     "pid_file": self._paths.pid_file,
+                    "base_dir": self._paths.base_dir,
                     "remote_os": self._detected_os,
                 },
             )
@@ -363,6 +364,7 @@ class SSHRemoteJobOperator(BaseOperator):
                 remote_host=self.remote_host,
                 job_id=self._job_id,
                 job_dir=self._paths.job_dir,
+                base_dir=self._paths.base_dir,
                 log_file=self._paths.log_file,
                 exit_code_file=self._paths.exit_code_file,
                 remote_os=self._detected_os,
@@ -406,6 +408,7 @@ class SSHRemoteJobOperator(BaseOperator):
                     remote_host=self.remote_host,
                     job_id=event["job_id"],
                     job_dir=event["job_dir"],
+                    base_dir=event.get("base_dir"),
                     log_file=event["log_file"],
                     exit_code_file=event["exit_code_file"],
                     remote_os=event["remote_os"],
@@ -423,12 +426,13 @@ class SSHRemoteJobOperator(BaseOperator):
         exit_code = event.get("exit_code")
         job_dir = event.get("job_dir", "")
         remote_os = event.get("remote_os", "posix")
+        base_dir = event.get("base_dir")
 
         self.log.info("Remote job completed with exit code: %s", exit_code)
 
         should_cleanup = self.cleanup == "always" or (self.cleanup == "on_success" and exit_code == 0)
         if should_cleanup and job_dir:
-            self._cleanup_remote_job(job_dir, remote_os)
+            self._cleanup_remote_job(job_dir, remote_os, base_dir)
 
         if exit_code is None:
             raise AirflowException(f"Remote job failed: {event.get('message', 'Unknown error')}")
@@ -441,7 +445,7 @@ class SSHRemoteJobOperator(BaseOperator):
 
         self.log.info("Remote job completed successfully")
 
-    def _cleanup_remote_job(self, job_dir: str, remote_os: str) -> None:
+    def _cleanup_remote_job(self, job_dir: str, remote_os: str, base_dir: str | None = None) -> None:
         """
         Clean up the remote job directory, retrying on transient SSH failures.
 
@@ -452,9 +456,9 @@ class SSHRemoteJobOperator(BaseOperator):
         """
         self.log.info("Cleaning up remote job directory: %s", job_dir)
         if remote_os == "posix":
-            cleanup_cmd = build_posix_cleanup_command(job_dir)
+            cleanup_cmd = build_posix_cleanup_command(job_dir, base_dir)
         else:
-            cleanup_cmd = build_windows_cleanup_command(job_dir)
+            cleanup_cmd = build_windows_cleanup_command(job_dir, base_dir)
 
         last_error: Exception | None = None
         for attempt in range(1, self.cleanup_retries + 1):

--- a/providers/ssh/src/airflow/providers/ssh/triggers/ssh_remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/triggers/ssh_remote_job.py
@@ -66,6 +66,7 @@ class SSHRemoteJobTrigger(BaseTrigger):
     :param remote_host: Optional override for the remote host
     :param job_id: Unique identifier for the remote job
     :param job_dir: Remote directory containing job artifacts
+    :param base_dir: Parent directory used to validate cleanup paths
     :param log_file: Path to the log file on the remote host
     :param exit_code_file: Path to the exit code file on the remote host
     :param remote_os: Operating system of the remote host ('posix' or 'windows')
@@ -86,6 +87,7 @@ class SSHRemoteJobTrigger(BaseTrigger):
         log_file: str,
         exit_code_file: str,
         remote_os: Literal["posix", "windows"],
+        base_dir: str | None = None,
         poll_interval: int = 5,
         log_chunk_size: int = 65536,
         log_offset: int = 0,
@@ -97,6 +99,7 @@ class SSHRemoteJobTrigger(BaseTrigger):
         self.remote_host = remote_host
         self.job_id = job_id
         self.job_dir = job_dir
+        self.base_dir = base_dir
         self.log_file = log_file
         self.exit_code_file = exit_code_file
         self.remote_os = remote_os
@@ -115,6 +118,7 @@ class SSHRemoteJobTrigger(BaseTrigger):
                 "remote_host": self.remote_host,
                 "job_id": self.job_id,
                 "job_dir": self.job_dir,
+                "base_dir": self.base_dir,
                 "log_file": self.log_file,
                 "exit_code_file": self.exit_code_file,
                 "remote_os": self.remote_os,
@@ -224,6 +228,7 @@ class SSHRemoteJobTrigger(BaseTrigger):
             {
                 "job_id": self.job_id,
                 "job_dir": self.job_dir,
+                "base_dir": self.base_dir,
                 "log_file": self.log_file,
                 "exit_code_file": self.exit_code_file,
                 "remote_os": self.remote_os,
@@ -298,6 +303,7 @@ class SSHRemoteJobTrigger(BaseTrigger):
                         {
                             "job_id": self.job_id,
                             "job_dir": self.job_dir,
+                            "base_dir": self.base_dir,
                             "log_file": self.log_file,
                             "exit_code_file": self.exit_code_file,
                             "remote_os": self.remote_os,

--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -30,18 +30,26 @@ POSIX_DEFAULT_BASE_DIR = "/tmp/airflow-ssh-jobs"
 WINDOWS_DEFAULT_BASE_DIR = "$env:TEMP\\airflow-ssh-jobs"
 
 
-def _validate_job_dir(job_dir: str, remote_os: Literal["posix", "windows"]) -> None:
+def _validate_job_dir(
+    job_dir: str,
+    remote_os: Literal["posix", "windows"],
+    base_dir: str | None = None,
+) -> None:
     """
     Validate that job_dir is under the expected base directory.
 
     :param job_dir: The job directory path to validate
     :param remote_os: Operating system type
+    :param base_dir: Expected parent directory. Defaults to the provider's
+        standard job directory.
     :raises ValueError: If job_dir doesn't start with the expected base path
     """
     if remote_os == "posix":
-        expected_prefix = POSIX_DEFAULT_BASE_DIR + "/"
+        expected_base = base_dir or POSIX_DEFAULT_BASE_DIR
+        expected_prefix = expected_base.rstrip("/") + "/"
     else:
-        expected_prefix = WINDOWS_DEFAULT_BASE_DIR + "\\"
+        expected_base = base_dir or WINDOWS_DEFAULT_BASE_DIR
+        expected_prefix = expected_base.rstrip("\\") + "\\"
 
     if not job_dir.startswith(expected_prefix):
         raise ValueError(
@@ -456,27 +464,29 @@ if (Test-Path $path) {{
     return f"powershell.exe -NoProfile -NonInteractive -EncodedCommand {encoded_script}"
 
 
-def build_posix_cleanup_command(job_dir: str) -> str:
+def build_posix_cleanup_command(job_dir: str, base_dir: str | None = None) -> str:
     """
     Build a POSIX command to clean up the job directory.
 
     :param job_dir: Path to the job directory
     :return: Shell command to remove the directory
+    :param base_dir: Expected parent directory. Defaults to the standard base.
     :raises ValueError: If job_dir is not under the expected base directory
     """
-    _validate_job_dir(job_dir, "posix")
+    _validate_job_dir(job_dir, "posix", base_dir)
     return f"rm -rf '{job_dir}'"
 
 
-def build_windows_cleanup_command(job_dir: str) -> str:
+def build_windows_cleanup_command(job_dir: str, base_dir: str | None = None) -> str:
     """
     Build a PowerShell command to clean up the job directory.
 
     :param job_dir: Path to the job directory
     :return: PowerShell command to remove the directory
+    :param base_dir: Expected parent directory. Defaults to the standard base.
     :raises ValueError: If job_dir is not under the expected base directory
     """
-    _validate_job_dir(job_dir, "windows")
+    _validate_job_dir(job_dir, "windows", base_dir)
     escaped_path = job_dir.replace("'", "''")
     script = f"Remove-Item -Recurse -Force -Path '{escaped_path}' -ErrorAction SilentlyContinue"
     script_bytes = script.encode("utf-16-le")

--- a/providers/ssh/tests/unit/ssh/operators/test_ssh_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/operators/test_ssh_remote_job.py
@@ -393,6 +393,34 @@ class TestSSHRemoteJobOperator:
         call_args = self.mock_hook.exec_ssh_client_command.call_args
         assert "rm -rf" in call_args[0][1]
 
+    def test_execute_complete_with_custom_cleanup_base(self):
+        """Cleanup uses the custom base directory carried by the trigger event."""
+        op = SSHRemoteJobOperator(
+            task_id="test_task",
+            ssh_conn_id="test_conn",
+            command="/path/to/script.sh",
+            cleanup="on_success",
+        )
+
+        event = {
+            "done": True,
+            "status": "success",
+            "exit_code": 0,
+            "job_id": "test_job_123",
+            "base_dir": "/opt/custom-airflow-jobs",
+            "job_dir": "/opt/custom-airflow-jobs/test_job_123",
+            "log_file": "/opt/custom-airflow-jobs/test_job_123/stdout.log",
+            "exit_code_file": "/opt/custom-airflow-jobs/test_job_123/exit_code",
+            "log_chunk": "",
+            "log_offset": 0,
+            "remote_os": "posix",
+        }
+
+        op.execute_complete({}, event)
+
+        call_args = self.mock_hook.exec_ssh_client_command.call_args
+        assert "/opt/custom-airflow-jobs/test_job_123" in call_args[0][1]
+
     def test_on_kill(self):
         """Test on_kill attempts to kill remote process."""
         op = SSHRemoteJobOperator(

--- a/providers/ssh/tests/unit/ssh/triggers/test_ssh_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/triggers/test_ssh_remote_job.py
@@ -30,6 +30,7 @@ def _make_trigger(**overrides):
         remote_host=None,
         job_id="test_job",
         job_dir="/tmp/job",
+        base_dir="/tmp",
         log_file="/tmp/job/stdout.log",
         exit_code_file="/tmp/job/exit_code",
         remote_os="posix",
@@ -46,6 +47,7 @@ class TestSSHRemoteJobTrigger:
             remote_host="test.example.com",
             job_id="test_job_123",
             job_dir="/tmp/airflow-ssh-jobs/test_job_123",
+            base_dir="/tmp/airflow-ssh-jobs",
             log_file="/tmp/airflow-ssh-jobs/test_job_123/stdout.log",
             exit_code_file="/tmp/airflow-ssh-jobs/test_job_123/exit_code",
             remote_os="posix",
@@ -62,6 +64,7 @@ class TestSSHRemoteJobTrigger:
         assert kwargs["remote_host"] == "test.example.com"
         assert kwargs["job_id"] == "test_job_123"
         assert kwargs["job_dir"] == "/tmp/airflow-ssh-jobs/test_job_123"
+        assert kwargs["base_dir"] == "/tmp/airflow-ssh-jobs"
         assert kwargs["log_file"] == "/tmp/airflow-ssh-jobs/test_job_123/stdout.log"
         assert kwargs["exit_code_file"] == "/tmp/airflow-ssh-jobs/test_job_123/exit_code"
         assert kwargs["remote_os"] == "posix"
@@ -104,6 +107,7 @@ class TestSSHRemoteJobTrigger:
         assert events[0].payload["done"] is True
         assert events[0].payload["exit_code"] == 0
         assert events[0].payload["log_chunk"] == "Final output\n"
+        assert events[0].payload["base_dir"] == "/tmp"
 
     @pytest.mark.asyncio
     async def test_run_job_completed_failure(self):

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -449,7 +449,20 @@ class TestCleanupCommands:
         with pytest.raises(ValueError, match="Invalid job directory"):
             build_posix_cleanup_command("/tmp/other_dir")
 
+    def test_posix_cleanup_accepts_custom_base_directory(self):
+        """Cleanup accepts a job directory under the operator's custom base."""
+        cmd = build_posix_cleanup_command("/opt/custom-airflow-jobs/job_123", "/opt/custom-airflow-jobs")
+        assert "/opt/custom-airflow-jobs/job_123" in cmd
+
     def test_windows_cleanup_rejects_invalid_path(self):
         """Test Windows cleanup rejects paths outside expected base directory."""
         with pytest.raises(ValueError, match="Invalid job directory"):
             build_windows_cleanup_command("C:\\temp\\other_dir")
+
+    def test_windows_cleanup_accepts_custom_base_directory(self):
+        """Cleanup accepts a job directory under the operator's custom base."""
+        cmd = build_windows_cleanup_command(
+            "D:\\airflow-jobs\\job_123",
+            "D:\\airflow-jobs",
+        )
+        assert "Remove-Item" in base64.b64decode(cmd.split("-EncodedCommand ")[1]).decode("utf-16-le")


### PR DESCRIPTION
## Summary

- Carry the configured `remote_base_dir` through `SSHRemoteJobTrigger` serialization and completion events.
- Validate cleanup paths against that configured base instead of always requiring `/tmp/airflow-ssh-jobs` (or the default Windows path).
- Add POSIX, Windows, trigger-serialization, and deferred-cleanup regression coverage.

## Issue

Closes #69813

## Validation

- `python -m py_compile` passes for all changed source and test modules.
- AST parsing and `git diff --check` pass.
- The focused pytest command is blocked in this sparse Windows checkout because Airflow's `tests_common` test dependency is not installed; CI should run the provider suite.