### PR TITLE
Fix template-field validation timing in BigQueryToMsSqlOperator

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
@@ -80,20 +80,27 @@ class BigQueryToMsSqlOperator(BigQueryToSqlBaseOperator):
                 )
 
             target_table_name = mssql_table
-
-        try:
-            _, dataset_id, table_id = source_project_dataset_table.split(".")
-        except ValueError:
-            raise ValueError(
-                f"Could not parse {source_project_dataset_table} as <project>.<dataset>.<table>"
-            ) from None
         super().__init__(
             target_table_name=target_table_name,
-            dataset_table=f"{dataset_id}.{table_id}",
+            dataset_table=source_project_dataset_table,
             **kwargs,
         )
         self.mssql_conn_id = mssql_conn_id
         self.source_project_dataset_table = source_project_dataset_table
+        self.dataset_id = None
+        self.table_id = None
+
+    def execute(self, context: Context) -> None:
+        try:
+            _, dataset_id, table_id = self.source_project_dataset_table.split(".")
+        except ValueError:
+            raise ValueError(
+                f"Could not parse {self.source_project_dataset_table} as "
+                "<project>.<dataset>.<table>"
+            ) from None
+        self.dataset_id = dataset_id
+        self.table_id = table_id
+        return super().execute(context)
 
     @cached_property
     def mssql_hook(self) -> MsSqlHook:

--- a/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
@@ -80,13 +80,13 @@ class BigQueryToMsSqlOperator(BigQueryToSqlBaseOperator):
                 )
 
             target_table_name = mssql_table
+        self.source_project_dataset_table = source_project_dataset_table
         super().__init__(
             target_table_name=target_table_name,
-            dataset_table=source_project_dataset_table,
+            dataset_table=self.source_project_dataset_table,
             **kwargs,
         )
         self.mssql_conn_id = mssql_conn_id
-        self.source_project_dataset_table = source_project_dataset_table
         self.dataset_id = None
         self.table_id = None
 
@@ -95,8 +95,7 @@ class BigQueryToMsSqlOperator(BigQueryToSqlBaseOperator):
             _, dataset_id, table_id = self.source_project_dataset_table.split(".")
         except ValueError:
             raise ValueError(
-                f"Could not parse {self.source_project_dataset_table} as "
-                "<project>.<dataset>.<table>"
+                f"Could not parse {self.source_project_dataset_table} as <project>.<dataset>.<table>"
             ) from None
         self.dataset_id = dataset_id
         self.table_id = table_id

--- a/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_mssql.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_bigquery_to_mssql.py
@@ -195,3 +195,25 @@ class TestBigQueryToMsSqlOperator:
         assert "columnLineage" in output_ds.facets
         col_lineage = output_ds.facets["columnLineage"]
         assert set(col_lineage.fields.keys()) == {"id", "name"}
+
+    def test_init_does_not_parse_templated_source_table(self):
+        op = BigQueryToMsSqlOperator(
+            task_id="t",
+            source_project_dataset_table="{{ params.project }}.{{ params.dataset }}.{{ params.table }}",
+            target_table_name="dest",
+        )
+        assert op.source_project_dataset_table == (
+            "{{ params.project }}.{{ params.dataset }}.{{ params.table }}"
+        )
+
+    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_mssql.MsSqlHook")
+    @mock.patch("airflow.providers.google.cloud.transfers.bigquery_to_sql.BigQueryHook")
+    def test_execute_parses_rendered_source_table(self, mock_hook, mock_link):
+        op = BigQueryToMsSqlOperator(
+            task_id="t",
+            source_project_dataset_table="proj.dataset.table",
+            target_table_name="dest",
+        )
+        op.execute(context=None)
+        assert op.dataset_id == "dataset"
+        assert op.table_id == "table"

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -24,7 +24,6 @@ providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSListObj
 providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py::BigQueryDataTransferServiceTransferRunSensor
 providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py::CloudComposerExternalTaskSensor
 providers/google/src/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py::AzureFileShareToGCSOperator
-providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py::BigQueryToMsSqlOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py::GCSToBigQueryOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_gcs.py::GCSToGCSOperator
 providers/google/src/airflow/providers/google/marketing_platform/operators/campaign_manager.py::GoogleCampaignManagerDeleteReportOperator


### PR DESCRIPTION
**Summary**
`BigQueryToMsSqlOperator` parsed its templated `source_project_dataset_table`
field inside `__init__`, before Jinja rendering runs. Fixes this entry from
the #70296 exemption-list burn-down.

**Root cause**
`source_project_dataset_table` is listed in `template_fields`, but `__init__`
called `.split(".")` on it immediately to derive `dataset_id`/`table_id`.
Template fields are only rendered after the constructor returns, so this
ran against the raw, un-rendered string — a templated value like
`"{{ params.project }}.{{ params.dataset }}.{{ params.table }}"` either
fails to parse or produces garbage components.

**Fix**
- `__init__` now does a plain assignment of `source_project_dataset_table`
  and initializes `dataset_id`/`table_id` to `None`.
- The `.split(".")` parsing moved to `execute()`, where it runs against the
  rendered value before delegating to `super().execute(context)`.
- The existing `mssql_table` vs. `target_table_name` provision check was
  left untouched in `__init__`, since it only checks whether an argument
  was supplied, not its content.

Related to #70296

Gen-AI disclosure: I used a generative AI tool to help identify the root
cause, write tests, and draft the PR description. I reviewed, tested, and
verified all changes locally before submitting.


- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)