### PR TITLE
Allow templating GCS and BigQuery URIs in Vertex AI batch prediction

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -168,7 +168,6 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         "gcs_source",
         "bigquery_source",
         "gcs_destination_prefix",
-        "gcs_destination_prefix",
         "bigquery_destination_prefix",
     )
     operator_extra_links = (VertexAIBatchPredictionJobLink(),)

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -159,7 +159,18 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
     :param poll_interval: Interval size which defines how often job status is checked in deferrable mode.
     """
 
-    template_fields = ("region", "project_id", "model_name", "impersonation_chain", "job_display_name")
+    template_fields = (
+        "region",
+        "project_id",
+        "model_name",
+        "impersonation_chain",
+        "job_display_name",
+        "gcs_source",
+        "bigquery_source",
+        "gcs_destination_prefix",
+        "gcs_destination_prefix",
+        "bigquery_destination_prefix",
+    )
     operator_extra_links = (VertexAIBatchPredictionJobLink(),)
 
     def __init__(


### PR DESCRIPTION
Allow callers to template both gcs, bq inputs and outputs for batch jobs. I am adding this in after swapping from using the vertex batch ai job operator to writing my own custom operator due to the inability to template destinations and outputs to both gcs and bq.

This seems like normal airflow behaviour to me to allow templating for different inputs/outputs, i.e. in dev environment you would inject a dev bigquery project from the config and then template that to build `<dev-project>.<dataset>` whereas in prod you would have `<prod-project>.<dataset>`. Lacking the ability to do this in my experience pretty much breaks this operator for multi-stage work environments where you want the same code to run across dev/staging/prod.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

No

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
