### PR TITLE
Fix insecure HTTP links in documentation

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -68,7 +68,7 @@ media - this is important for the PMC to be aware of such activities. If PMC is 
 have no chance to spot and promote such candidates.
 
 Guidelines from ASF are listed at ASF:
-`New Candidates for Committership <http://community.apache.org/newcommitter.html#guidelines-for-assessing-new-candidates-for-committership>`_
+`New Candidates for Committership <https://community.apache.org/newcommitter.html#guidelines-for-assessing-new-candidates-for-committership>`_
 
 
 Prerequisites

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ pip install 'apache-airflow[postgres,google]==3.3.0' \
 ```
 
 For information on installing provider distributions, check
-[providers](http://airflow.apache.org/docs/apache-airflow-providers/index.html).
+[providers](https://airflow.apache.org/docs/apache-airflow-providers/index.html).
 
 <!-- END Installing from PyPI, please keep comment here to allow auto update of PyPI readme.md -->
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -25,7 +25,7 @@
 
 ## Introduction
 
-This chart will bootstrap an [Airflow](https://airflow.apache.org) deployment on a [Kubernetes](http://kubernetes.io)
+This chart will bootstrap an [Airflow](https://airflow.apache.org) deployment on a [Kubernetes](https://kubernetes.io)
 cluster using the [Helm](https://helm.sh) package manager.
 
 ## Requirements

--- a/generated/PYPI_README.md
+++ b/generated/PYPI_README.md
@@ -135,7 +135,7 @@ pip install 'apache-airflow[postgres,google]==3.3.0' \
 ```
 
 For information on installing provider distributions, check
-[providers](http://airflow.apache.org/docs/apache-airflow-providers/index.html).
+[providers](https://airflow.apache.org/docs/apache-airflow-providers/index.html).
 
 ## Official source code
 


### PR DESCRIPTION
## Summary

Update insecure HTTP links to HTTPS in README.md, chart/README.md, and COMMITTERS.rst.

## Changes

- README.md: Update airflow.apache.org provider docs link to HTTPS
- chart/README.md: Update kubernetes.io link to HTTPS
- COMMITTERS.rst: Update community.apache.org link to HTTPS

## Testing

N/A — documentation link updates only. Verified all target URLs resolve over HTTPS.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)