### PR TITLE
Sensors should be consistent about whether or not they return a value

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -465,57 +465,56 @@ class ExternalTaskSensor(BaseSensorOperator):
     def execute(self, context: Context) -> None:
         """Run on the worker and defer using the triggers if deferrable is set to True."""
         if not self.deferrable:
-            super().execute(context)
+            return super().execute(context)
+        # Determine the timeout to use: prefer timeout parameter, fallback to execution_timeout
+        timeout_value = self.timeout
+        if not timeout_value and self.execution_timeout:
+            timeout_value = self.execution_timeout.total_seconds()
+
+        dttm_filter = self._get_dttm_filter(context)
+        if AIRFLOW_V_3_0_PLUS:
+            self.defer(
+                timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
+                trigger=WorkflowTrigger(
+                    external_dag_id=self.external_dag_id,
+                    external_task_group_id=self.external_task_group_id,
+                    external_task_ids=self.external_task_ids,
+                    allowed_states=self.allowed_states,
+                    failed_states=self.failed_states,
+                    skipped_states=self.skipped_states,
+                    poke_interval=self.poll_interval,
+                    soft_fail=self.soft_fail,
+                    logical_dates=list(dttm_filter),
+                    run_ids=None,
+                    execution_dates=None,
+                ),
+                method_name="execute_complete",
+            )
         else:
-            # Determine the timeout to use: prefer timeout parameter, fallback to execution_timeout
-            timeout_value = self.timeout
-            if not timeout_value and self.execution_timeout:
-                timeout_value = self.execution_timeout.total_seconds()
+            # TODO: Remove this block when Airflow 2 support is dropped
+            if self.check_existence and not self._has_checked_existence:
+                from airflow.utils.session import create_session
 
-            dttm_filter = self._get_dttm_filter(context)
-            if AIRFLOW_V_3_0_PLUS:
-                self.defer(
-                    timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
-                    trigger=WorkflowTrigger(
-                        external_dag_id=self.external_dag_id,
-                        external_task_group_id=self.external_task_group_id,
-                        external_task_ids=self.external_task_ids,
-                        allowed_states=self.allowed_states,
-                        failed_states=self.failed_states,
-                        skipped_states=self.skipped_states,
-                        poke_interval=self.poke_interval,
-                        soft_fail=self.soft_fail,
-                        logical_dates=list(dttm_filter),
-                        run_ids=None,
-                        execution_dates=None,
-                    ),
-                    method_name="execute_complete",
-                )
-            else:
-                # TODO: Remove this block when Airflow 2 support is dropped
-                if self.check_existence and not self._has_checked_existence:
-                    from airflow.utils.session import create_session
+                with create_session() as session:
+                    self._check_for_existence(session=session)
 
-                    with create_session() as session:
-                        self._check_for_existence(session=session)
-
-                self.defer(
-                    timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
-                    trigger=WorkflowTrigger(
-                        external_dag_id=self.external_dag_id,
-                        external_task_group_id=self.external_task_group_id,
-                        external_task_ids=self.external_task_ids,
-                        allowed_states=self.allowed_states,
-                        failed_states=self.failed_states,
-                        skipped_states=self.skipped_states,
-                        poke_interval=self.poke_interval,
-                        soft_fail=self.soft_fail,
-                        execution_dates=list(dttm_filter),
-                        logical_dates=None,
-                        run_ids=None,
-                    ),
-                    method_name="execute_complete",
-                )
+            self.defer(
+                timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
+                trigger=WorkflowTrigger(
+                    external_dag_id=self.external_dag_id,
+                    external_task_group_id=self.external_task_group_id,
+                    external_task_ids=self.external_task_ids,
+                    allowed_states=self.allowed_states,
+                    failed_states=self.failed_states,
+                    skipped_states=self.skipped_states,
+                    poke_interval=self.poll_interval,
+                    soft_fail=self.soft_fail,
+                    execution_dates=list(dttm_filter),
+                    logical_dates=None,
+                    run_ids=None,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: dict[str, typing.Any] | None = None) -> None:
         """Execute when the trigger fires - return immediately."""

--- a/providers/standard/src/airflow/providers/standard/sensors/external_task.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/external_task.py
@@ -434,57 +434,56 @@ class ExternalTaskSensor(BaseSensorOperator):
     def execute(self, context: Context) -> None:
         """Run on the worker and defer using the triggers if deferrable is set to True."""
         if not self.deferrable:
-            super().execute(context)
+            return super().execute(context)
+        # Determine the timeout to use: prefer timeout parameter, fallback to execution_timeout
+        timeout_value = self.timeout
+        if not timeout_value and self.execution_timeout:
+            timeout_value = self.execution_timeout.total_seconds()
+
+        dttm_filter = self._get_dttm_filter(context)
+        if AIRFLOW_V_3_0_PLUS:
+            self.defer(
+                timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
+                trigger=WorkflowTrigger(
+                    external_dag_id=self.external_dag_id,
+                    external_task_group_id=self.external_task_group_id,
+                    external_task_ids=self.external_task_ids,
+                    allowed_states=self.allowed_states,
+                    failed_states=self.failed_states,
+                    skipped_states=self.skipped_states,
+                    poke_interval=self.poll_interval,
+                    soft_fail=self.soft_fail,
+                    logical_dates=list(dttm_filter),
+                    run_ids=None,
+                    execution_dates=None,
+                ),
+                method_name="execute_complete",
+            )
         else:
-            # Determine the timeout to use: prefer timeout parameter, fallback to execution_timeout
-            timeout_value = self.timeout
-            if not timeout_value and self.execution_timeout:
-                timeout_value = self.execution_timeout.total_seconds()
+            # TODO: Remove this block when Airflow 2 support is dropped
+            if self.check_existence and not self._has_checked_existence:
+                from airflow.utils.session import create_session
 
-            dttm_filter = self._get_dttm_filter(context)
-            if AIRFLOW_V_3_0_PLUS:
-                self.defer(
-                    timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
-                    trigger=WorkflowTrigger(
-                        external_dag_id=self.external_dag_id,
-                        external_task_group_id=self.external_task_group_id,
-                        external_task_ids=self.external_task_ids,
-                        allowed_states=self.allowed_states,
-                        failed_states=self.failed_states,
-                        skipped_states=self.skipped_states,
-                        poke_interval=self.poll_interval,
-                        soft_fail=self.soft_fail,
-                        logical_dates=list(dttm_filter),
-                        run_ids=None,
-                        execution_dates=None,
-                    ),
-                    method_name="execute_complete",
-                )
-            else:
-                # TODO: Remove this block when Airflow 2 support is dropped
-                if self.check_existence and not self._has_checked_existence:
-                    from airflow.utils.session import create_session
+                with create_session() as session:
+                    self._check_for_existence(session=session)
 
-                    with create_session() as session:
-                        self._check_for_existence(session=session)
-
-                self.defer(
-                    timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
-                    trigger=WorkflowTrigger(
-                        external_dag_id=self.external_dag_id,
-                        external_task_group_id=self.external_task_group_id,
-                        external_task_ids=self.external_task_ids,
-                        allowed_states=self.allowed_states,
-                        failed_states=self.failed_states,
-                        skipped_states=self.skipped_states,
-                        poke_interval=self.poll_interval,
-                        soft_fail=self.soft_fail,
-                        execution_dates=list(dttm_filter),
-                        logical_dates=None,
-                        run_ids=None,
-                    ),
-                    method_name="execute_complete",
-                )
+            self.defer(
+                timeout=datetime.timedelta(seconds=timeout_value) if timeout_value else None,
+                trigger=WorkflowTrigger(
+                    external_dag_id=self.external_dag_id,
+                    external_task_group_id=self.external_task_group_id,
+                    external_task_ids=self.external_task_ids,
+                    allowed_states=self.allowed_states,
+                    failed_states=self.failed_states,
+                    skipped_states=self.skipped_states,
+                    poke_interval=self.poll_interval,
+                    soft_fail=self.soft_fail,
+                    execution_dates=list(dttm_filter),
+                    logical_dates=None,
+                    run_ids=None,
+                ),
+                method_name="execute_complete",
+            )
 
     def execute_complete(self, context: Context, event: dict[str, typing.Any] | None = None) -> None:
         """Execute when the trigger fires - return immediately."""


### PR DESCRIPTION
Maybe more of a discussion topic here - but included one example change.

Many sensors will define their own `execute()` method, which then conditionally calls out to the deferable / non-deferable path. 

However, we're pretty inconsistent about whether or not that value should be returned or not. Some sensors will return the value of `execute()`:

https://github.com/apache/airflow/blob/cd3a7e1a5f6bbe9f6536ab593b06a5728deb0271/providers/http/src/airflow/providers/http/sensors/http.py#L160-L162

but most sensors will not, implicitly returning `None`: 
https://github.com/apache/airflow/blob/8dd76f1624bc28fdef8630684a06914891526578/providers/standard/src/airflow/providers/standard/sensors/filesystem.py#L120-L122

This makes for a really confusing experience when trying to subclass or extend an existing sensor. For example, trying to subclass the ExternalTaskSensor to add a delayed timestamp XCOM output:

```python
class ExternalTaskSensorWithCompletionDelay(ExternalTaskSensor):
    """Return a stable delay target when the upstream task is first observed."""

    def poke(self, context):
        is_done = super().poke(context)
        delay_target = timezone.utcnow() + timedelta(minutes=30).isoformat()
        
        return PokeReturnValue(is_done=bool(is_done), xcom_value=delay_target)
 ```
 
The XCOM value here will not actually be written, because the parent's class execute method ignores the return value and `task.execute()` returns nothing.
 
Is this expected behaviour? Or should we always be returning the value of `super().execute()`? I am open to discussion here but in my mind this sort of thing quietly breaks the extensibility and flexibility of builtin or provided operators.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=93ba2ee action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @SamWheating** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
