### PR TITLE
Add tests for Keycloak token models

### DIFF
--- a/airflow-core/tests/unit/always/test_project_structure.py
+++ b/airflow-core/tests/unit/always/test_project_structure.py
@@ -172,7 +172,6 @@ class TestProjectStructure:
             "providers/google/tests/unit/google/common/hooks/test_operation_helpers.py",
             "providers/google/tests/unit/google/test_go_module_utils.py",
             "providers/http/tests/unit/http/test_exceptions.py",
-            "providers/keycloak/tests/unit/keycloak/auth_manager/datamodels/test_token.py",
             "providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_adls.py",
             "providers/snowflake/tests/unit/snowflake/triggers/test_snowflake_trigger.py",
             "providers/standard/tests/unit/standard/operators/test_branch.py",

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/datamodels/__init__.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/datamodels/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/datamodels/test_token.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/datamodels/test_token.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from pydantic import ValidationError
+
+from airflow.providers.keycloak.auth_manager.datamodels.token import (
+    TokenBody,
+    TokenClientCredentialsBody,
+    TokenPasswordBody,
+    TokenResponse,
+)
+
+
+class TestTokenResponse:
+    def test_model_validate_and_dump(self):
+        token = TokenResponse.model_validate({"access_token": "token"})
+
+        assert token.access_token == "token"
+        assert token.model_dump() == {"access_token": "token"}
+
+    def test_requires_access_token(self):
+        with pytest.raises(ValidationError):
+            TokenResponse.model_validate({})
+
+
+class TestTokenBody:
+    @pytest.mark.parametrize(
+        ("payload", "expected_type", "expected_dump"),
+        [
+            (
+                {"username": "username", "password": "password"},
+                TokenPasswordBody,
+                {"grant_type": "password", "username": "username", "password": "password"},
+            ),
+            (
+                {"grant_type": "password", "username": "username", "password": "password"},
+                TokenPasswordBody,
+                {"grant_type": "password", "username": "username", "password": "password"},
+            ),
+            (
+                {
+                    "grant_type": "client_credentials",
+                    "client_id": "client_id",
+                    "client_secret": "client_secret",
+                },
+                TokenClientCredentialsBody,
+                {
+                    "grant_type": "client_credentials",
+                    "client_id": "client_id",
+                    "client_secret": "client_secret",
+                },
+            ),
+        ],
+    )
+    def test_model_validate_and_dump(self, payload, expected_type, expected_dump):
+        token_body = TokenBody.model_validate(payload)
+
+        assert isinstance(token_body.root, expected_type)
+        assert token_body.model_dump() == expected_dump
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"username": None, "password": "password"},
+            {"grant_type": "unsupported", "username": "username", "password": "password"},
+            {"username": "username", "password": "password", "extra": "value"},
+            {"grant_type": "client_credentials", "client_secret": "client_secret"},
+        ],
+    )
+    def test_rejects_invalid_payload(self, payload):
+        with pytest.raises(ValidationError):
+            TokenBody.model_validate(payload)
+
+
+class TestTokenPasswordBody:
+    @mock.patch("airflow.providers.keycloak.auth_manager.datamodels.token.create_token_for", autospec=True)
+    def test_create_token(self, mock_create_token_for):
+        mock_create_token_for.return_value = "token"
+        body = TokenPasswordBody(username="username", password="password")
+
+        assert body.create_token(expiration_time_in_seconds=60) == "token"
+        mock_create_token_for.assert_called_once_with("username", "password", expiration_time_in_seconds=60)
+
+
+class TestTokenClientCredentialsBody:
+    @mock.patch(
+        "airflow.providers.keycloak.auth_manager.datamodels.token.create_client_credentials_token",
+        autospec=True,
+    )
+    def test_create_token(self, mock_create_client_credentials_token):
+        mock_create_client_credentials_token.return_value = "token"
+        body = TokenClientCredentialsBody(
+            grant_type="client_credentials",
+            client_id="client_id",
+            client_secret="client_secret",
+        )
+
+        assert body.create_token(expiration_time_in_seconds=60) == "token"
+        mock_create_client_credentials_token.assert_called_once_with(
+            "client_id", "client_secret", expiration_time_in_seconds=60
+        )


### PR DESCRIPTION
Add focused unit coverage for the Keycloak token request and response models.

The tests cover password and client-credentials grant discrimination, validation failures, serialization, and delegation to the token service functions. The corresponding temporary exemption is removed from `OVERLOOKED_TESTS`.

Testing:

- `uv run --project providers/keycloak pytest providers/keycloak/tests/unit/keycloak/auth_manager/datamodels/test_token.py --cov=providers/keycloak/src/airflow/providers/keycloak/auth_manager/datamodels --cov-report=term-missing -xvs`
- `uv run --project providers/keycloak pytest providers/keycloak/tests/unit/keycloak -xvs`
- `uv run --project airflow-core pytest airflow-core/tests/unit/always/test_project_structure.py::TestProjectStructure::test_providers_modules_should_have_tests -xvs`
- `prek run --from-ref upstream/main --stage pre-commit`
- `prek run --from-ref upstream/main --stage manual`
- `breeze --answer yes testing providers-tests --parallel-test-types "Providers[common.compat,keycloak]" --run-in-parallel`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
