### PR TITLE
Do not import the stored path when rebuilding a Callback from serialized data

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/callback.py
+++ b/task-sdk/src/airflow/sdk/definitions/callback.py
@@ -28,6 +28,20 @@ from airflow.sdk._shared.module_loading import import_string, is_valid_dotpath
 log = structlog.getLogger(__name__)
 
 
+class _SerializedCallbackPath(str):
+    """
+    A callback path which was read back from serialized data.
+
+    The path of a ``Callback`` is checked when the ``Callback`` is first created. Rebuilding
+    that ``Callback`` from its serialized form carries the path in this wrapper so that
+    :meth:`Callback.get_callback_path` keeps it as-is instead of resolving it a second time.
+
+    :meta private:
+    """
+
+    __slots__ = ()
+
+
 class Callback(ABC):
     """
     Base class for Deadline Alert callbacks.
@@ -66,6 +80,14 @@ class Callback(ABC):
 
         stripped_callback = _callback.strip()
 
+        if isinstance(_callback, _SerializedCallbackPath):
+            # This path was already checked when the Callback it belongs to was created, so
+            # rebuilding that Callback keeps it as it is. Reconstruction happens in components
+            # which never call the callback themselves, and resolving the path there is neither
+            # needed nor wanted: the module it names is not necessarily importable in that
+            # process, and importing it has no bearing on the path we return either way.
+            return stripped_callback
+
         try:
             # The provided callback is a string which appears to be a valid dotpath, attempt to import it.
             callback = import_string(stripped_callback)
@@ -95,6 +117,10 @@ class Callback(ABC):
     @classmethod
     def deserialize(cls, data: dict, version):
         path = data.pop("path")
+        if isinstance(path, str):
+            # Mark the path as coming from serialized data, so that it is taken as it was
+            # stored rather than resolved again. See ``get_callback_path``.
+            path = _SerializedCallbackPath(path)
         return cls(callback_callable=path, **data)
 
     @classmethod

--- a/task-sdk/src/airflow/sdk/definitions/callback.py
+++ b/task-sdk/src/airflow/sdk/definitions/callback.py
@@ -32,9 +32,7 @@ class _SerializedCallbackPath(str):
     """
     A callback path which was read back from serialized data.
 
-    The path of a ``Callback`` is checked when the ``Callback`` is first created. Rebuilding
-    that ``Callback`` from its serialized form carries the path in this wrapper so that
-    :meth:`Callback.get_callback_path` keeps it as-is instead of resolving it a second time.
+    See :meth:`Callback.get_callback_path` for what the marker buys.
 
     :meta private:
     """
@@ -118,8 +116,6 @@ class Callback(ABC):
     def deserialize(cls, data: dict, version):
         path = data.pop("path")
         if isinstance(path, str):
-            # Mark the path as coming from serialized data, so that it is taken as it was
-            # stored rather than resolved again. See ``get_callback_path``.
             path = _SerializedCallbackPath(path)
         return cls(callback_callable=path, **data)
 

--- a/task-sdk/tests/task_sdk/definitions/test_callback.py
+++ b/task-sdk/tests/task_sdk/definitions/test_callback.py
@@ -16,11 +16,15 @@
 # under the License.
 from __future__ import annotations
 
+import importlib
+import sys
+from pathlib import Path
 from typing import cast
 
 import pytest
 
 from airflow.sdk._shared.module_loading import qualname
+from airflow.sdk._shared.serialization import DATA
 from airflow.sdk.definitions.callback import AsyncCallback, Callback, SyncCallback
 from airflow.sdk.serde import deserialize, serialize
 
@@ -38,6 +42,45 @@ def empty_sync_callback_for_deadline_tests():
 TEST_CALLBACK_PATH = qualname(empty_async_callback_for_deadline_tests)
 TEST_CALLBACK_KWARGS = {"arg1": "value1"}
 UNIMPORTABLE_DOT_PATH = "valid.but.nonexistent.path"
+
+# A module which leaves a trace when its body is executed, so that a test can tell whether
+# it was imported. Written to a temporary directory by the `callback_module` fixture below.
+CALLBACK_MODULE_SOURCE = '''
+from pathlib import Path
+
+Path(__file__).with_suffix(".imported").touch()
+
+
+def sync_callback():
+    """A callback which can be reached by dot path once this module is importable."""
+
+
+async def async_callback():
+    """An awaitable callback which can be reached by dot path once this module is importable."""
+'''
+
+
+@pytest.fixture
+def callback_module(tmp_path, monkeypatch):
+    """
+    Provide a factory which makes a named module importable for the duration of a test.
+
+    The factory returns the module name and the path of a marker file which the module
+    creates when it is imported; the marker only exists if the module body has been run.
+    """
+    monkeypatch.syspath_prepend(str(tmp_path))
+    created: list[str] = []
+
+    def _create(module_name: str) -> tuple[str, Path]:
+        (tmp_path / f"{module_name}.py").write_text(CALLBACK_MODULE_SOURCE)
+        importlib.invalidate_caches()
+        created.append(module_name)
+        return module_name, tmp_path / f"{module_name}.imported"
+
+    yield _create
+
+    for module_name in created:
+        sys.modules.pop(module_name, None)
 
 
 class TestCallback:
@@ -227,6 +270,90 @@ class TestSyncCallback:
         serialized = serialize(callback)
         deserialized = cast("Callback", deserialize(serialized.copy()))
         assert callback == deserialized
+
+
+class TestCallbackPathHandling:
+    """Cover how a callback path is treated when it is supplied, versus read back from storage."""
+
+    def test_init_imports_the_module_named_by_the_path(self, callback_module):
+        """A Callback created from a dot path resolves it, so its author gets feedback on it."""
+        module_name, marker = callback_module("callback_module_resolved_on_creation")
+        path = f"{module_name}.sync_callback"
+
+        callback = SyncCallback(path)
+
+        assert marker.exists(), "the module named by the path should have been imported"
+        assert callback.path == path
+
+    def test_deserialize_does_not_import_the_module_named_by_the_stored_path(self, callback_module):
+        """Rebuilding a Callback keeps the stored path without resolving it again."""
+        module_name, marker = callback_module("callback_module_not_resolved_on_deserialize")
+        path = f"{module_name}.sync_callback"
+
+        callback = SyncCallback.deserialize({"path": path, "kwargs": {}, "executor": None}, 0)
+
+        assert not marker.exists(), "the module named by the stored path should not have been imported"
+        assert module_name not in sys.modules
+        assert callback.path == path
+        assert type(callback.path) is str
+
+    def test_deserialize_async_does_not_import_the_module_named_by_the_stored_path(self, callback_module):
+        module_name, marker = callback_module("async_callback_module_not_resolved_on_deserialize")
+        path = f"{module_name}.async_callback"
+
+        callback = AsyncCallback.deserialize({"path": path, "kwargs": {}}, 0)
+
+        assert not marker.exists(), "the module named by the stored path should not have been imported"
+        assert module_name not in sys.modules
+        assert callback.path == path
+
+    def test_serde_deserialize_does_not_import_the_module_named_by_the_stored_path(self, callback_module):
+        """The same holds when the Callback is rebuilt through serde, as it is from stored data."""
+        module_name, marker = callback_module("callback_module_not_resolved_through_serde")
+        path = f"{module_name}.sync_callback"
+
+        serialized = serialize(SyncCallback(TEST_CALLBACK_PATH, kwargs=TEST_CALLBACK_KWARGS))
+        serialized[DATA]["path"] = path
+
+        deserialized = cast("Callback", deserialize(serialized))
+
+        assert not marker.exists(), "the module named by the stored path should not have been imported"
+        assert module_name not in sys.modules
+        assert deserialized.path == path
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            pytest.param("not a dot path", id="not_a_dot_path"),
+            pytest.param("", id="empty_string"),
+            pytest.param(None, id="none"),
+            pytest.param(42, id="not_a_string"),
+        ],
+    )
+    def test_deserialize_rejects_a_path_which_is_not_a_dot_path(self, path):
+        """A stored value which is not shaped like a dot path is still rejected."""
+        with pytest.raises(ImportError, match="doesn't look like a valid dot path."):
+            SyncCallback.deserialize({"path": path, "kwargs": {}, "executor": None}, 0)
+
+    def test_deserialize_keeps_a_stored_path_which_no_longer_points_at_a_callable(self):
+        """
+        The stored path is taken as it was stored.
+
+        Unlike a path handed to the constructor, it is not checked against what it currently
+        resolves to; that check belongs to the moment the Callback is created.
+        """
+        callback = SyncCallback.deserialize({"path": "os.path", "kwargs": {}, "executor": None}, 0)
+
+        assert callback.path == "os.path"
+
+    def test_deserialize_round_trip_keeps_kwargs_and_executor(self):
+        callback = SyncCallback(TEST_CALLBACK_PATH, kwargs=TEST_CALLBACK_KWARGS, executor="local")
+
+        deserialized = cast("SyncCallback", deserialize(serialize(callback)))
+
+        assert deserialized == callback
+        assert deserialized.kwargs == TEST_CALLBACK_KWARGS
+        assert deserialized.executor == "local"
 
 
 # While DeadlineReference lives in the SDK package, the unit tests to confirm it


### PR DESCRIPTION
`Callback.get_callback_path` imports the module named by a dotted-path string in
order to check that it resolves to a callable. That check is deliberately best
effort — the `ImportError` is logged and swallowed and the path is returned
either way, because the callable may only exist on the host that will eventually
run it.

Rebuilding a `Callback` from its serialized form went through that same path, so
deserializing one imported the module named in the stored data. The path was
already checked when the `Callback` was first created, and reconstruction happens
in components that never invoke the callback themselves, so importing there is
neither needed nor wanted — it runs module-level code of whatever the stored
string happens to name.

This carries a path read back from serialized data in a private `str` subclass
and returns it unchanged instead of resolving it a second time.

Construction from a Dag author's callable or dotted path is unaffected, including
the existing import-based callable check. The dot-path shape check still applies
to stored paths too, so a malformed stored path is still rejected.

### Test plan

- [x] `test_init_imports_the_module_named_by_the_path` — positive control: Dag-author construction still resolves the path
- [x] `test_deserialize_does_not_import_the_module_named_by_the_stored_path` — and the `AsyncCallback` equivalent
- [x] `test_serde_deserialize_does_not_import_the_module_named_by_the_stored_path` — full route through serde
- [x] `test_deserialize_rejects_a_path_which_is_not_a_dot_path` — shape check preserved on stored paths
- [x] `test_deserialize_keeps_a_stored_path_which_no_longer_points_at_a_callable`
- [x] Tests use a real fixture module whose import has an observable side effect, rather than mocking `import_string`

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
