### PR TITLE
Fix the deadline_reference decorator's no-parentheses form

### DIFF
--- a/airflow-core/docs/howto/deadline-alerts.rst
+++ b/airflow-core/docs/howto/deadline-alerts.rst
@@ -420,6 +420,10 @@ references for specific integrations like calendars or other data sources. To do
 a class that inherits from BaseDeadlineReference, add the ``@deadline_reference`` decorator, and
 implement an ``_evaluate_with()`` method.
 
+The decorator may be used with or without parentheses. Used bare, or with empty parentheses, the
+reference is evaluated when a new Dag run is created; pass a ``DeadlineReference.TYPES`` value to
+choose a different time.
+
 
 **Creating a Custom Reference**
 
@@ -520,6 +524,9 @@ followed by a more urgent escalation if the Dag is still running.
 **Important Notes:**
 
 * **Timezone Awareness**: Always return timezone-aware datetime objects.
+* **No-argument Construction**: Custom references are instantiated during registration, so they must be
+  constructible with no arguments. If your reference takes parameters, decorate it with ``@dataclass``
+  and give every field a default value.
 * **Plugin Placement**: One convenient place for custom references is in the plugins directory.
 * **API Server Restart**: Restart the Airflow API Server after adding or modifying custom references.
 * **Required Parameters**: Use ``required_kwargs`` to specify parameters your reference needs.

--- a/airflow-core/newsfragments/70708.bugfix.rst
+++ b/airflow-core/newsfragments/70708.bugfix.rst
@@ -1,0 +1,1 @@
+The ``@deadline_reference`` decorator can now be used without parentheses. Previously, using it that way silently skipped registration and rebound the decorated class to the decorator's inner function, which surfaced later as an unrelated ``TypeError``.

--- a/airflow-core/tests/unit/models/test_deadline.py
+++ b/airflow-core/tests/unit/models/test_deadline.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest import mock
@@ -912,6 +913,44 @@ class TestDeadlineReferenceDecorator:
                 return timezone.datetime(DEFAULT_DATE)
 
         mock_register.assert_called_once_with(DecoratedCustomRef, timing)
+
+    def test_deadline_reference_decorator_without_parentheses(self):
+        @deadline_reference
+        class BareDecoratedRef(BaseDeadlineReference):
+            def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
+                return timezone.datetime(DEFAULT_DATE)
+
+        # The decorated name must still be the class, not the inner decorator function.
+        assert isinstance(BareDecoratedRef, type)
+        assert issubclass(BareDecoratedRef, BaseDeadlineReference)
+
+        assert hasattr(DeadlineReference, BareDecoratedRef.__name__)
+        assert getattr(DeadlineReference, BareDecoratedRef.__name__).__class__ is BareDecoratedRef
+
+        assert_correct_timing(BareDecoratedRef, DeadlineReference.TYPES.DAGRUN_CREATED)
+        assert_builtin_types_unchanged(
+            DeadlineReference.TYPES.DAGRUN_QUEUED, DeadlineReference.TYPES.DAGRUN_CREATED
+        )
+
+    def test_deadline_reference_decorator_without_parentheses_invalid_class(self):
+        """Test that the bare form must inherit the base class."""
+        with pytest.raises(ValueError, match="InvalidBareRef must inherit from BaseDeadlineReference"):
+
+            @deadline_reference
+            class InvalidBareRef:
+                pass
+
+    def test_deadline_reference_requiring_arguments_raises_helpful_error(self):
+        """Test that a reference which cannot be instantiated with no arguments explains itself."""
+        with pytest.raises(TypeError, match="must be constructible with no arguments"):
+
+            @deadline_reference()
+            @dataclass
+            class RefWithRequiredField(BaseDeadlineReference):
+                required_field: str
+
+                def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
+                    return timezone.datetime(DEFAULT_DATE)
 
 
 @pytest.mark.db_test

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -20,7 +20,7 @@ import logging
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 import attrs
 
@@ -290,7 +290,15 @@ class DeadlineReference:
             raise ValueError(f"{reference_class.__name__} must inherit from BaseDeadlineReference")
 
         # Register the new reference with DeadlineReference for discoverability
-        setattr(cls, reference_class.__name__, reference_class())
+        try:
+            reference_instance = reference_class()
+        except TypeError as e:
+            raise TypeError(
+                f"{reference_class.__name__} must be constructible with no arguments in order to be "
+                f"registered as a deadline reference. If it takes parameters, decorate it with "
+                f"@dataclass and give every field a default value. Original error: {e}"
+            ) from e
+        setattr(cls, reference_class.__name__, reference_instance)
         logger.info("Registered DeadlineReference %s", reference_class.__name__)
 
         # Add to appropriate deadline_reference_type classification
@@ -310,13 +318,32 @@ class DeadlineReference:
         return reference_class
 
 
+@overload
+def deadline_reference(
+    deadline_reference_type: type[BaseDeadlineReference],
+) -> type[BaseDeadlineReference]: ...
+
+
+@overload
 def deadline_reference(
     deadline_reference_type: DeadlineReferenceTypes | None = None,
-) -> Callable[[type[BaseDeadlineReference]], type[BaseDeadlineReference]]:
+) -> Callable[[type[BaseDeadlineReference]], type[BaseDeadlineReference]]: ...
+
+
+def deadline_reference(deadline_reference_type=None):
     """
     Decorate a class to register a custom deadline reference.
 
+    May be used with or without parentheses. Without parentheses the reference is evaluated when a
+    new dagrun is created; pass a ``DeadlineReference.TYPES`` value to choose a different time.
+
     Usage:
+        @deadline_reference
+        class MyBareReference(BaseDeadlineReference):
+            # Equivalent to @deadline_reference(); evaluated when a new dagrun is created.
+            def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
+                return some_datetime
+
         @deadline_reference()
         class MyCustomReference(BaseDeadlineReference):
             # By default, evaluate_with will be called when a new dagrun is created.
@@ -338,6 +365,9 @@ def deadline_reference(
             def serialize_reference(self) -> dict:
                 return {"reference_type": self.reference_name}
     """
+    # Used bare, without parentheses: the decorated class is passed in directly.
+    if isinstance(deadline_reference_type, type):
+        return DeadlineReference.register_custom_reference(deadline_reference_type)
 
     def decorator(
         reference_class: type[BaseDeadlineReference],

--- a/task-sdk/src/airflow/sdk/definitions/deadline.py
+++ b/task-sdk/src/airflow/sdk/definitions/deadline.py
@@ -337,12 +337,14 @@ def deadline_reference(deadline_reference_type=None):
     May be used with or without parentheses. Without parentheses the reference is evaluated when a
     new dagrun is created; pass a ``DeadlineReference.TYPES`` value to choose a different time.
 
-    Usage:
+    .. code-block:: python
+
         @deadline_reference
         class MyBareReference(BaseDeadlineReference):
             # Equivalent to @deadline_reference(); evaluated when a new dagrun is created.
             def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
                 return some_datetime
+
 
         @deadline_reference()
         class MyCustomReference(BaseDeadlineReference):
@@ -350,16 +352,18 @@ def deadline_reference(deadline_reference_type=None):
             def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
                 # Put your business logic here (use deferred imports for Core types)
                 from airflow.models import DagRun
+
                 return some_datetime
 
             def serialize_reference(self) -> dict:
                 return {"reference_type": self.reference_name}
 
+
+        # Optionally, specify when it is calculated by providing a DeadlineReference.TYPES value.
         @deadline_reference(DeadlineReference.TYPES.DAGRUN_QUEUED)
         class MyQueuedRef(BaseDeadlineReference):
-            # Optionally, you can specify when you want it calculated by providing a DeadlineReference.TYPES
             def _evaluate_with(self, *, session: Session, **kwargs) -> datetime:
-                 # Put your business logic here
+                # Put your business logic here
                 return some_datetime
 
             def serialize_reference(self) -> dict:


### PR DESCRIPTION
Found a couple issues with the `@deadline_reference` decorator while working on my Summit workshop.

Docs implied that you could use `@deadline_reference` without parentheses, as was intended behavior, but using it that way would cause a TypeError (without a particularly helpful message) later when it was called.  This PR fixes support for the non-paren version, adds a clearer error message for a related instantiation issue, and cleans up the documentation a little to improve clarity.

This is an additive fix, anything that was working before should still work unchanged.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ x ] Yes (please specify the tool below)

Generated-by: [Kiro-CLI (Claude Opus 5)] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
