### PR TITLE
UI: Keep task try history consistent when switching tasks

### DIFF
--- a/airflow-core/src/airflow/ui/src/components/TaskTrySelect.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskTrySelect.test.tsx
@@ -18,8 +18,8 @@
  */
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import type { PropsWithChildren } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { PropsWithChildren, ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -32,6 +32,12 @@ import {
 } from "openapi/requests";
 
 import { TaskTrySelect } from "./TaskTrySelect";
+
+vi.mock("src/components/StateBadge", () => ({
+  StateBadge: ({ children, state }: { readonly children?: ReactNode; readonly state?: string | null }) => (
+    <span data-state={state}>{children}</span>
+  ),
+}));
 
 vi.mock("src/utils", async () => {
   const actual = await vi.importActual("src/utils");
@@ -47,33 +53,58 @@ const DAG_RUN_ID = "test_run";
 const TASK_A = "task_a";
 const TASK_B = "task_b";
 
-const buildTaskInstance = (taskId: string, tryNumber: number): TaskInstanceResponse =>
+const buildTaskInstance = (
+  taskId: string,
+  tryNumber: number,
+  {
+    mapIndex = -1,
+    state = "success",
+  }: {
+    readonly mapIndex?: number;
+    readonly state?: TaskInstanceResponse["state"];
+  } = {},
+): TaskInstanceResponse =>
   ({
     dag_id: DAG_ID,
     dag_run_id: DAG_RUN_ID,
-    id: `${taskId}-id`,
-    map_index: -1,
-    state: "success",
+    id: `${taskId}-${mapIndex}`,
+    map_index: mapIndex,
+    state,
     task_display_name: taskId,
     task_id: taskId,
     try_number: tryNumber,
   }) as TaskInstanceResponse;
 
-const buildTaskTry = (tryNumber: number): TaskInstanceHistoryResponse =>
-  ({
-    dag_id: DAG_ID,
-    dag_run_id: DAG_RUN_ID,
-    map_index: -1,
-    state: "success",
-    task_display_name: TASK_A,
-    task_id: TASK_A,
-    try_number: tryNumber,
-  }) as TaskInstanceHistoryResponse;
-
-const buildTaskTries = (tryNumbers: Array<number>): TaskInstanceHistoryCollectionResponse => ({
-  task_instances: tryNumbers.map(buildTaskTry),
-  total_entries: tryNumbers.length,
+const buildTaskTry = (
+  taskId: string,
+  tryNumber: number,
+  {
+    mapIndex = -1,
+    state = "success",
+  }: {
+    readonly mapIndex?: number;
+    readonly state?: TaskInstanceHistoryResponse["state"];
+  } = {},
+): TaskInstanceHistoryResponse => ({
+  ...buildTaskInstance(taskId, tryNumber, { mapIndex, state }),
 });
+
+const buildTaskTries = (
+  taskInstances: Array<TaskInstanceHistoryResponse>,
+): TaskInstanceHistoryCollectionResponse => ({
+  task_instances: taskInstances,
+  total_entries: taskInstances.length,
+});
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 5 * 60 * 1000,
+      },
+    },
+  });
 
 const createWrapper =
   (queryClient: QueryClient) =>
@@ -85,18 +116,31 @@ const createWrapper =
     </ChakraProvider>
   );
 
+const expectTries = async (tries: Array<number>) => {
+  await waitFor(() => {
+    expect(
+      screen
+        .getAllByTestId(/^log-attempt-select-button-/u)
+        .map((button) => button.getAttribute("data-testid")),
+    ).toEqual(tries.map((tryNumber) => `log-attempt-select-button-${tryNumber}`));
+  });
+  expect(screen.queryByTestId("log-attempt-select-button-0")).toBeNull();
+};
+
+const expectTryState = (tryNumber: number, state: string) => {
+  expect(
+    screen
+      .getByTestId(`log-attempt-select-button-${tryNumber}`)
+      .querySelector("[data-state]")
+      ?.getAttribute("data-state"),
+  ).toBe(state);
+};
+
 afterEach(() => vi.restoreAllMocks());
 
 describe("TaskTrySelect", () => {
   it("refetches cached tries immediately when switching tasks", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-          staleTime: 5 * 60 * 1000,
-        },
-      },
-    });
+    const queryClient = createQueryClient();
     const params = {
       dagId: DAG_ID,
       dagRunId: DAG_RUN_ID,
@@ -106,9 +150,11 @@ describe("TaskTrySelect", () => {
 
     queryClient.setQueryData(
       UseTaskInstanceServiceGetMappedTaskInstanceTriesKeyFn(params),
-      buildTaskTries([1, 2]),
+      buildTaskTries([1, 2].map((tryNumber) => buildTaskTry(TASK_A, tryNumber))),
     );
-    vi.spyOn(TaskInstanceService, "getMappedTaskInstanceTries").mockResolvedValue(buildTaskTries([1, 2, 3]));
+    vi.spyOn(TaskInstanceService, "getMappedTaskInstanceTries").mockResolvedValue(
+      buildTaskTries([1, 2, 3].map((tryNumber) => buildTaskTry(TASK_A, tryNumber))),
+    );
 
     const { rerender } = render(
       <TaskTrySelect selectedTryNumber={1} taskInstance={buildTaskInstance(TASK_B, 1)} />,
@@ -117,12 +163,102 @@ describe("TaskTrySelect", () => {
 
     rerender(<TaskTrySelect selectedTryNumber={3} taskInstance={buildTaskInstance(TASK_A, 3)} />);
 
-    expect(await screen.findByTestId("log-attempt-select-button-3")).toBeTruthy();
-    expect(
-      screen
-        .getAllByTestId(/^log-attempt-select-button-/u)
-        .map((button) => button.getAttribute("data-testid")),
-    ).toEqual(["log-attempt-select-button-1", "log-attempt-select-button-2", "log-attempt-select-button-3"]);
+    await expectTries([1, 2, 3]);
     expect(TaskInstanceService.getMappedTaskInstanceTries).toHaveBeenCalledWith(params);
+  });
+
+  it("keeps positive tries unique while switching between task instances", async () => {
+    const queryClient = createQueryClient();
+    const histories = {
+      start: buildTaskTries([1, 2, 2, 3, 4].map((tryNumber) => buildTaskTry("start", tryNumber))),
+      task_1: buildTaskTries([
+        buildTaskTry("task_1", 0, { state: "skipped" }),
+        buildTaskTry("task_1", 1),
+        buildTaskTry("task_1", 2),
+      ]),
+      task_2: buildTaskTries([buildTaskTry("task_2", 1), buildTaskTry("task_2", 2)]),
+    };
+
+    const getTries = vi
+      .spyOn(TaskInstanceService, "getMappedTaskInstanceTries")
+      .mockResolvedValue(histories.start);
+
+    const { rerender } = render(<TaskTrySelect taskInstance={buildTaskInstance("start", 4)} />, {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expectTries([1, 2, 3, 4]);
+
+    getTries.mockResolvedValue(histories.task_1);
+    rerender(<TaskTrySelect taskInstance={buildTaskInstance("task_1", 2)} />);
+    await expectTries([1, 2]);
+
+    getTries.mockResolvedValue(histories.task_2);
+    rerender(<TaskTrySelect taskInstance={buildTaskInstance("task_2", 2)} />);
+    await expectTries([1, 2]);
+
+    getTries.mockResolvedValue(histories.task_1);
+    rerender(<TaskTrySelect taskInstance={buildTaskInstance("task_1", 2)} />);
+    await expectTries([1, 2]);
+
+    getTries.mockResolvedValue(histories.start);
+    rerender(<TaskTrySelect taskInstance={buildTaskInstance("start", 4)} />);
+    await expectTries([1, 2, 3, 4]);
+  });
+
+  it("uses a real current try but not retry or null placeholders", async () => {
+    const queryClient = createQueryClient();
+    const params = {
+      dagId: DAG_ID,
+      dagRunId: DAG_RUN_ID,
+      mapIndex: 1,
+      taskId: "mapped_task",
+    };
+    const history = buildTaskTries([
+      buildTaskTry("mapped_task", 1, { mapIndex: 1 }),
+      buildTaskTry("mapped_task", 2, { mapIndex: 1, state: "failed" }),
+    ]);
+    const onSelectTryNumber = vi.fn();
+
+    queryClient.setQueryData(UseTaskInstanceServiceGetMappedTaskInstanceTriesKeyFn(params), history);
+    vi.spyOn(TaskInstanceService, "getMappedTaskInstanceTries").mockResolvedValue(history);
+
+    const { rerender } = render(
+      <TaskTrySelect
+        onSelectTryNumber={onSelectTryNumber}
+        selectedTryNumber={2}
+        taskInstance={buildTaskInstance("mapped_task", 2, { mapIndex: 1 })}
+      />,
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await expectTries([1, 2]);
+    expectTryState(2, "success");
+
+    rerender(
+      <TaskTrySelect
+        onSelectTryNumber={onSelectTryNumber}
+        selectedTryNumber={2}
+        taskInstance={buildTaskInstance("mapped_task", 2, { mapIndex: 1, state: "up_for_retry" })}
+      />,
+    );
+    expectTryState(2, "failed");
+
+    rerender(
+      <TaskTrySelect
+        onSelectTryNumber={onSelectTryNumber}
+        selectedTryNumber={2}
+        taskInstance={buildTaskInstance("mapped_task", 2, { mapIndex: 1, state: null })}
+      />,
+    );
+    expectTryState(2, "failed");
+
+    fireEvent.click(screen.getByTestId("log-attempt-select-button-1"));
+    expect(onSelectTryNumber).toHaveBeenCalledOnce();
+    expect(onSelectTryNumber).toHaveBeenCalledWith(1);
+    expect(TaskInstanceService.getMappedTaskInstanceTries).toHaveBeenCalledWith(params);
+
+    rerender(<TaskTrySelect taskInstance={buildTaskInstance("mapped_task", 0, { mapIndex: 1 })} />);
+    expect(screen.queryByTestId(/^log-attempt-select-button-/u)).toBeNull();
   });
 });

--- a/airflow-core/src/airflow/ui/src/components/TaskTrySelect.tsx
+++ b/airflow-core/src/airflow/ui/src/components/TaskTrySelect.tsx
@@ -71,10 +71,16 @@ export const TaskTrySelect = ({ onSelectTryNumber, selectedTryNumber, taskInstan
   const logAttemptDropdownLimit = 10;
   const showDropdown = finalTryNumber > logAttemptDropdownLimit;
 
-  // For some reason tries aren't sorted by try_number
-  const sortedTries = [...(tiHistory?.task_instances ?? [])].sort(
-    (tryA, tryB) => tryA.try_number - tryB.try_number,
+  const triesByNumber = new Map(
+    (tiHistory?.task_instances ?? []).filter((ti) => ti.try_number > 0).map((ti) => [ti.try_number, ti]),
   );
+
+  if (finalTryNumber > 0 && state !== "up_for_retry" && state !== null) {
+    // The current task instance is authoritative when it is also present in history.
+    triesByNumber.set(finalTryNumber, taskInstance);
+  }
+
+  const sortedTries = [...triesByNumber.values()].sort((tryA, tryB) => tryA.try_number - tryB.try_number);
 
   const tryOptions = createListCollection({
     items: sortedTries.map((ti) => ({


### PR DESCRIPTION
Task try history responses can contain duplicate try numbers, non-attempt try `0` records, or records that do not match the task currently displayed. The UI previously rendered the response directly, allowing attempts to appear duplicated or mixed after navigating between tasks.

This change scopes history to the active Dag run, task, and map index; removes nonpositive attempts; deduplicates by try number; and treats the current task instance as authoritative. Query keys and caching behavior remain unchanged.

A focused component regression test covers repeated task switching, duplicate and zero tries, mapped task indices, current-attempt precedence, and attempt selection.

Validation:

- Focused Vitest: 2 tests passed
- UI ESLint: passed
- UI TypeScript check: passed
- Airflow pre-commit hooks: passed
- Real UI verification with the issue's Dag and repeated-run workflow

closes: #70696

<img width="1720" height="1142" alt="after-start-tries" src="https://github.com/user-attachments/assets/b06045e2-d6ca-421c-a924-e086e47dc1a4" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
