### PR TITLE
Skip redundant dag.exceeds_max_non_backfill writes to reduce scheduler/DAG-processor lock contention

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -4212,7 +4212,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
             active_non_backfill_runs = runs_dict.get(dag_model.dag_id, 0)
 
-        dag_model.exceeds_max_non_backfill = active_non_backfill_runs >= (dag_model.max_active_runs or 0)
+        exceeds_max = active_non_backfill_runs >= (dag_model.max_active_runs or 0)
+        if dag_model.exceeds_max_non_backfill != exceeds_max:
+            dag_model.exceeds_max_non_backfill = exceeds_max
 
 
 # Backcompat for older versions of task sdk import SchedulerDagBag from here

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10987,6 +10987,22 @@ def test_create_dag_runs_partitioned_timetable_skips_when_next_fields_none(sessi
 
 
 @pytest.mark.db_test
+def test_set_exceeds_max_active_runs_skips_write_when_unchanged(session, dag_maker):
+    with dag_maker(session=session):
+        pass
+    dag_model = dag_maker.dag_model
+    dag_model.exceeds_max_non_backfill = False
+    session.flush()
+    session.expire(dag_model)
+
+    scheduler_job = SchedulerJobRunner(job=Job())
+    scheduler_job._set_exceeds_max_active_runs(
+        dag_model=dag_model, active_non_backfill_runs=0, session=session
+    )
+    assert dag_model not in session.dirty
+
+
+@pytest.mark.db_test
 def test_create_dag_runs_partitioned_timetable_proceeds_when_partition_key_set(session):
     runner = SchedulerJobRunner(
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]


### PR DESCRIPTION
## Summary
`_set_exceeds_max_active_runs` in `scheduler_job_runner.py` now only
writes `dag_model.exceeds_max_non_backfill` when the value actually
changes, instead of writing it unconditionally on every call.

## Root Cause
As described in #70614, this write can block behind the DAG
processor's `SELECT ... FOR UPDATE` lock (`find_orm_dags` in
`collection.py`), which is held for the whole per-file parse
transaction. Since the flag only flips to `True` when a DAG is at its
`max_active_runs` limit, most dagrun completions don't actually change
it — skipping the write in that case avoids the lock contention for
the common case.

This reduces how often the contention happens; it doesn't remove it
entirely, since the write (and the possible block) still happens when
the flag genuinely transitions. The DAG processor's lock scope itself
is untouched — that's a separate, bigger fix.


related: #70614

##### Was generative AI tooling used to co-author this PR?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)