### PR TITLE
Run CI on airflow-ctl release-branch pull requests and pushes

### DIFF
--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -24,12 +24,18 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - v[0-9]+-[0-9]+-test
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+      - chart/v[0-9]+-[0-9]+x-test
+      - airflow-ctl/v[0-9]+-[0-9]+-test
   pull_request:
     branches:
       - main
       - v[0-9]+-[0-9]+-test
       - v[0-9]+-[0-9]+-stable
       - providers-[a-z]+-?[a-z]*/v[0-9]+-[0-9]+
+      - chart/v[0-9]+-[0-9]+x-test
+      - chart/v[0-9]+-[0-9]+x-stable
+      - airflow-ctl/v[0-9]+-[0-9]+-test
+      - airflow-ctl/v[0-9]+-[0-9]+-stable
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 permissions:

--- a/.github/workflows/ci-amd-arm.yml
+++ b/.github/workflows/ci-amd-arm.yml
@@ -1011,7 +1011,7 @@ jobs:
           overwrite: true
       - name: "Notify Slack (new/changed failures)"
         if: steps.notification.outputs.action == 'notify_new'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -1027,7 +1027,7 @@ jobs:
           # yamllint enable rule:line-length
       - name: "Notify Slack (still not fixed)"
         if: steps.notification.outputs.action == 'notify_reminder'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -1043,7 +1043,7 @@ jobs:
           # yamllint enable rule:line-length
       - name: "Notify Slack (all tests passing)"
         if: steps.notification.outputs.action == 'notify_recovery'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -264,7 +264,7 @@ jobs:
           inputs.canary-run == 'true' &&
           matrix.flag == '--docs-only' &&
           steps.inventory-notification.outputs.action == 'notify_new'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -280,7 +280,7 @@ jobs:
           inputs.canary-run == 'true' &&
           matrix.flag == '--docs-only' &&
           steps.inventory-notification.outputs.action == 'notify_reminder'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -296,7 +296,7 @@ jobs:
           inputs.canary-run == 'true' &&
           matrix.flag == '--docs-only' &&
           steps.inventory-notification.outputs.action == 'notify_recovery'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci-image-checks.yml
+++ b/.github/workflows/ci-image-checks.yml
@@ -439,7 +439,7 @@ jobs:
           inputs.canary-run == 'true' &&
           (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: "Send Slack notification (new/changed failures)"
         if: steps.notification.outputs.action == 'notify_new'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: "Send Slack notification (still not fixed)"
         if: steps.notification.outputs.action == 'notify_reminder'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: "Send Slack notification (all passing)"
         if: steps.notification.outputs.action == 'notify_recovery'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,9 +20,19 @@ name: "CodeQL"
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable']
+    branches:
+      - main
+      - v[0-9]+-[0-9]+-test
+      - v[0-9]+-[0-9]+-stable
+      - chart/v[0-9]+-[0-9]+x-test
+      - chart/v[0-9]+-[0-9]+x-stable
+      - airflow-ctl/v[0-9]+-[0-9]+-test
+      - airflow-ctl/v[0-9]+-[0-9]+-stable
   push:
-    branches: [main]
+    branches:
+      - main
+      - chart/v[0-9]+-[0-9]+x-test
+      - airflow-ctl/v[0-9]+-[0-9]+-test
   schedule:
     - cron: '0 2 * * *'
 

--- a/.github/workflows/e2e-flaky-tests-report.yml
+++ b/.github/workflows/e2e-flaky-tests-report.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: "Post report to Slack"
         if: always() && steps.analyze.outcome == 'success'
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/workflows/publish-docs-to-s3.yml
+++ b/.github/workflows/publish-docs-to-s3.yml
@@ -409,7 +409,7 @@ jobs:
           sudo /tmp/aws/install --update
           rm -rf /tmp/aws/
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/registry-backfill.yml
+++ b/.github/workflows/registry-backfill.yml
@@ -118,7 +118,7 @@ jobs:
           done
 
       - name: "Install uv"
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
@@ -136,7 +136,7 @@ jobs:
           rm -rf /tmp/aws/
 
       - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
@@ -252,7 +252,7 @@ jobs:
           rm -rf /tmp/aws/
 
       - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/registry-build.yml
+++ b/.github/workflows/registry-build.yml
@@ -133,7 +133,7 @@ jobs:
           rm -rf /tmp/aws/
 
       - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37  # v6.1.0
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b  # v6.2.1
         with:
           aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/registry-tests.yml
+++ b/.github/workflows/registry-tests.yml
@@ -50,7 +50,7 @@ jobs:
           persist-credentials: false
 
       - name: "Install uv"
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/scheduled-verify-release-calendar.yml
+++ b/.github/workflows/scheduled-verify-release-calendar.yml
@@ -50,7 +50,7 @@ jobs:
       # yamllint disable rule:line-length
       - name: "Notify Slack on failure"
         if: failure()
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/update-constraints-on-push-stable.yml
+++ b/.github/workflows/update-constraints-on-push-stable.yml
@@ -156,7 +156,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - name: "Send Slack notification"
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95  # v3.0.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c  # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -103,7 +103,7 @@ jobs:
           [${{ inputs.target-branch }}] Notify Slack on success
         if: success() && steps.find-pr.outputs.pr-url != ''
         uses: >-
-          slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+          slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}
@@ -132,7 +132,7 @@ jobs:
           [${{ inputs.target-branch }}] Notify Slack on failure
         if: failure()
         uses: >-
-          slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
+          slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c
         with:
           method: chat.postMessage
           token: ${{ env.SLACK_BOT_TOKEN }}

--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -64,7 +64,7 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by prek hook
-version = "3.3.0"
+version = "3.2.1"
 
 dependencies = [
     "a2wsgi>=1.10.8",
@@ -149,7 +149,7 @@ dependencies = [
     "typing-extensions>=4.14.1",
     "universal-pathlib>=0.3.8",
     "uuid6>=2024.7.10",
-    "apache-airflow-task-sdk<1.4.0,>=1.3.0",
+    "apache-airflow-task-sdk==1.2.1",
     "apache-airflow-ctl<0.1.6,>=0.1.5",
     # pre-installed providers
     "apache-airflow-providers-common-compat>=1.7.4",
@@ -248,7 +248,6 @@ exclude = [
 "../shared/secrets_backend/src/airflow_shared/secrets_backend" = "src/airflow/_shared/secrets_backend"
 "../shared/secrets_masker/src/airflow_shared/secrets_masker" = "src/airflow/_shared/secrets_masker"
 "../shared/serialization/src/airflow_shared/serialization" = "src/airflow/_shared/serialization"
-"../shared/state/src/airflow_shared/state" = "src/airflow/_shared/state"
 "../shared/timezones/src/airflow_shared/timezones" = "src/airflow/_shared/timezones"
 "../shared/listeners/src/airflow_shared/listeners" = "src/airflow/_shared/listeners"
 "../shared/plugins_manager/src/airflow_shared/plugins_manager" = "src/airflow/_shared/plugins_manager"
@@ -337,7 +336,6 @@ shared_distributions = [
     "apache-airflow-shared-secrets-backend",
     "apache-airflow-shared-secrets-masker",
     "apache-airflow-shared-serialization",
-    "apache-airflow-shared-state",
     "apache-airflow-shared-timezones",
     "apache-airflow-shared-plugins-manager",
     "apache-airflow-shared-providers-discovery",

--- a/airflow-ctl/.pre-commit-config.yaml
+++ b/airflow-ctl/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: mypy-airflow-ctl
         name: Run mypy for airflow-ctl
         language: python
-        entry: ../scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py airflow-ctl
+        entry: ../scripts/ci/prek/mypy_local_folder.py airflow-ctl
         pass_filenames: false
         files: ^.*\.py$
         require_serial: true

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -49,27 +49,6 @@ class AssetAliasResponse(BaseModel):
     group: Annotated[str, Field(title="Group")]
 
 
-class AssetStateBody(BaseModel):
-    """
-    Request body for setting an asset state value.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    value: Annotated[str, Field(max_length=65535, title="Value")]
-
-
-class AssetStateResponse(BaseModel):
-    """
-    A single asset state key/value pair with metadata.
-    """
-
-    key: Annotated[str, Field(title="Key")]
-    value: Annotated[str, Field(title="Value")]
-    updated_at: Annotated[datetime, Field(title="Updated At")]
-
-
 class AssetWatcherResponse(BaseModel):
     """
     Asset watcher serializer for responses.
@@ -129,32 +108,6 @@ class BulkActionResponse(BaseModel):
     ] = []
 
 
-class BulkDAGRunBody(BaseModel):
-    """
-    Request body for bulk delete operations on Dag Runs.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dag_run_id: Annotated[str, Field(title="Dag Run Id")]
-    dag_id: Annotated[str | None, Field(title="Dag Id")] = None
-
-
-class BulkDeleteActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | BulkDAGRunBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
 class BulkResponse(BaseModel):
     """
     Serializer for responses to bulk entity operations.
@@ -180,26 +133,6 @@ class BulkResponse(BaseModel):
 
 class Note(RootModel[str]):
     root: Annotated[str, Field(max_length=1000, title="Note")]
-
-
-class BulkUpdateActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["update"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[BulkDAGRunBody], Field(description="A list of entities to be updated.", title="Entities")
-    ]
-    update_mask: Annotated[
-        list[str] | None,
-        Field(
-            description="A list of field names to update for each entity.Only these fields will be applied from the request body to the database model.Any extra fields provided will be ignored.",
-            title="Update Mask",
-        ),
-    ] = None
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class TaskIds(RootModel[list]):
@@ -235,12 +168,11 @@ class ClearTaskInstancesBody(BaseModel):
     run_on_latest_version: Annotated[
         bool | None,
         Field(
-            description="(Experimental) Run on the latest bundle version of the dag after clearing the task instances. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).",
+            description="(Experimental) Run on the latest bundle version of the dag after clearing the task instances.",
             title="Run On Latest Version",
         ),
-    ] = None
+    ] = False
     prevent_running_task: Annotated[bool | None, Field(title="Prevent Running Task")] = False
-    note: Annotated[Note | None, Field(title="Note")] = None
 
 
 class Value(RootModel[list]):
@@ -355,20 +287,23 @@ class DAGRunClearBody(BaseModel):
     )
     dry_run: Annotated[bool | None, Field(title="Dry Run")] = True
     only_failed: Annotated[bool | None, Field(title="Only Failed")] = False
-    only_new: Annotated[
-        bool | None,
-        Field(
-            description="Only queue newly added tasks in the latest Dag version without clearing existing tasks.",
-            title="Only New",
-        ),
-    ] = False
     run_on_latest_version: Annotated[
         bool | None,
         Field(
-            description="(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).",
+            description="(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run.",
             title="Run On Latest Version",
         ),
-    ] = None
+    ] = False
+
+
+class DAGRunPatchStates(str, Enum):
+    """
+    Enum for Dag Run states when updating a Dag Run.
+    """
+
+    QUEUED = "queued"
+    SUCCESS = "success"
+    FAILED = "failed"
 
 
 class DAGSourceResponse(BaseModel):
@@ -421,16 +356,6 @@ class DagRunAssetReference(BaseModel):
     partition_key: Annotated[str | None, Field(title="Partition Key")] = None
 
 
-class DagRunMutableStates(str, Enum):
-    """
-    Dag Run states from which the run may be mutated (patched, deleted).
-    """
-
-    QUEUED = "queued"
-    SUCCESS = "success"
-    FAILED = "failed"
-
-
 class DagRunState(str, Enum):
     """
     All possible states that a DagRun can be in.
@@ -469,7 +394,6 @@ class DagRunType(str, Enum):
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
-    OPERATOR_TRIGGERED = "operator_triggered"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 
@@ -712,15 +636,6 @@ class MaterializeAssetBody(BaseModel):
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     note: Annotated[str | None, Field(title="Note")] = None
     partition_key: Annotated[str | None, Field(title="Partition Key")] = None
-
-
-class NewTaskResponse(BaseModel):
-    """
-    Lightweight response for new tasks that don't have TaskInstances yet.
-    """
-
-    task_id: Annotated[str, Field(title="Task Id")]
-    task_display_name: Annotated[str, Field(title="Task Display Name")]
 
 
 class PluginImportErrorResponse(BaseModel):
@@ -973,28 +888,6 @@ class TaskOutletAssetReference(BaseModel):
     updated_at: Annotated[datetime, Field(title="Updated At")]
 
 
-class TaskStateBody(BaseModel):
-    """
-    Request body for setting a task state value.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    value: Annotated[str, Field(max_length=65535, title="Value")]
-
-
-class TaskStateResponse(BaseModel):
-    """
-    A single task state key/value pair with metadata.
-    """
-
-    key: Annotated[str, Field(title="Key")]
-    value: Annotated[str, Field(title="Value")]
-    updated_at: Annotated[datetime, Field(title="Updated At")]
-    expires_at: Annotated[datetime | None, Field(title="Expires At")] = None
-
-
 class TimeDelta(BaseModel):
     """
     TimeDelta can be used to interact with datetime.timedelta objects.
@@ -1225,15 +1118,6 @@ class AssetResponse(BaseModel):
     last_asset_event: LastAssetEventResponse | None = None
 
 
-class AssetStateCollectionResponse(BaseModel):
-    """
-    All asset state entries for an asset.
-    """
-
-    asset_states: Annotated[list[AssetStateResponse], Field(title="Asset States")]
-    total_entries: Annotated[int, Field(title="Total Entries")]
-
-
 class BackfillPostBody(BaseModel):
     """
     Object used for create backfill request.
@@ -1246,16 +1130,10 @@ class BackfillPostBody(BaseModel):
     from_date: Annotated[datetime, Field(title="From Date")]
     to_date: Annotated[datetime, Field(title="To Date")]
     run_backwards: Annotated[bool | None, Field(title="Run Backwards")] = False
-    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")] = None
+    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")] = {}
     reprocess_behavior: ReprocessBehavior | None = "none"
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = 10
-    run_on_latest_version: Annotated[
-        bool | None,
-        Field(
-            description="Run on the latest bundle version of the Dag for each backfilled run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``True`` (the historical default for backfills).",
-            title="Run On Latest Version",
-        ),
-    ] = None
+    run_on_latest_version: Annotated[bool | None, Field(title="Run On Latest Version")] = True
 
 
 class BackfillResponse(BaseModel):
@@ -1275,19 +1153,6 @@ class BackfillResponse(BaseModel):
     completed_at: Annotated[datetime | None, Field(title="Completed At")] = None
     updated_at: Annotated[datetime, Field(title="Updated At")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
-
-
-class BulkCreateActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["create"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[BulkDAGRunBody], Field(description="A list of entities to be created.", title="Entities")
-    ]
-    action_on_existence: BulkActionOnExistence | None = "fail"
 
 
 class BulkCreateActionConnectionBody(BaseModel):
@@ -1511,7 +1376,6 @@ class DAGDetailsResponse(BaseModel):
     timetable_summary: Annotated[str | None, Field(title="Timetable Summary")] = None
     timetable_description: Annotated[str | None, Field(title="Timetable Description")] = None
     timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")]
-    timetable_periodic: Annotated[bool, Field(title="Timetable Periodic")]
     tags: Annotated[list[DagTagResponse], Field(title="Tags")]
     max_active_tasks: Annotated[int, Field(title="Max Active Tasks")]
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = None
@@ -1541,13 +1405,9 @@ class DAGDetailsResponse(BaseModel):
     timezone: Annotated[str | None, Field(title="Timezone")] = None
     last_parsed: Annotated[datetime | None, Field(title="Last Parsed")] = None
     default_args: Annotated[dict[str, Any] | None, Field(title="Default Args")] = None
-    rerun_with_latest_version: Annotated[bool | None, Field(title="Rerun With Latest Version")] = None
     owner_links: Annotated[dict[str, str] | None, Field(title="Owner Links")] = None
     is_favorite: Annotated[bool | None, Field(title="Is Favorite")] = False
     active_runs_count: Annotated[int | None, Field(title="Active Runs Count")] = 0
-    is_backfillable: Annotated[
-        bool, Field(description="Whether this Dag's schedule supports backfilling.", title="Is Backfillable")
-    ]
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
     concurrency: Annotated[
         int,
@@ -1581,7 +1441,6 @@ class DAGResponse(BaseModel):
     timetable_summary: Annotated[str | None, Field(title="Timetable Summary")] = None
     timetable_description: Annotated[str | None, Field(title="Timetable Description")] = None
     timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")]
-    timetable_periodic: Annotated[bool, Field(title="Timetable Periodic")]
     tags: Annotated[list[DagTagResponse], Field(title="Tags")]
     max_active_tasks: Annotated[int, Field(title="Max Active Tasks")]
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = None
@@ -1598,9 +1457,6 @@ class DAGResponse(BaseModel):
     next_dagrun_run_after: Annotated[datetime | None, Field(title="Next Dagrun Run After")] = None
     allowed_run_types: Annotated[list[DagRunType] | None, Field(title="Allowed Run Types")] = None
     owners: Annotated[list[str], Field(title="Owners")]
-    is_backfillable: Annotated[
-        bool, Field(description="Whether this Dag's schedule supports backfilling.", title="Is Backfillable")
-    ]
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
 
 
@@ -1612,7 +1468,7 @@ class DAGRunPatchBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    state: DagRunMutableStates | None = None
+    state: DAGRunPatchStates | None = None
     note: Annotated[Note | None, Field(title="Note")] = None
 
 
@@ -1775,7 +1631,7 @@ class JobCollectionResponse(BaseModel):
 
 class PatchTaskInstanceBody(BaseModel):
     """
-    Request body for patching task instance state.
+    Request body for Clear Task Instances endpoint.
     """
 
     model_config = ConfigDict(
@@ -1972,15 +1828,6 @@ class TaskResponse(BaseModel):
     ]
 
 
-class TaskStateCollectionResponse(BaseModel):
-    """
-    All task state entries for a task instance.
-    """
-
-    task_states: Annotated[list[TaskStateResponse], Field(title="Task States")]
-    total_entries: Annotated[int, Field(title="Total Entries")]
-
-
 class VariableCollectionResponse(BaseModel):
     """
     Variable Collection serializer for responses.
@@ -2024,18 +1871,6 @@ class BackfillCollectionResponse(BaseModel):
 
     backfills: Annotated[list[BackfillResponse], Field(title="Backfills")]
     total_entries: Annotated[int, Field(title="Total Entries")]
-
-
-class BulkBodyBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[
-            BulkCreateActionBulkDAGRunBody | BulkUpdateActionBulkDAGRunBody | BulkDeleteActionBulkDAGRunBody
-        ],
-        Field(title="Actions"),
-    ]
 
 
 class BulkBodyConnectionBody(BaseModel):
@@ -2097,15 +1932,6 @@ class BulkDeleteActionBulkTaskInstanceBody(BaseModel):
     action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
-class ClearTaskInstanceCollectionResponse(BaseModel):
-    """
-    Response for clear dag run dry run, which may contain new tasks without full TaskInstance data.
-    """
-
-    task_instances: Annotated[list[TaskInstanceResponse | NewTaskResponse], Field(title="Task Instances")]
-    total_entries: Annotated[int, Field(title="Total Entries")]
-
-
 class DAGCollectionResponse(BaseModel):
     """
     Dag Collection serializer for responses.
@@ -2117,38 +1943,11 @@ class DAGCollectionResponse(BaseModel):
 
 class DAGRunCollectionResponse(BaseModel):
     """
-    Dag Run collection response supporting both offset and cursor pagination.
-
-    A single flat model is used instead of a discriminated union
-    (``Annotated[Offset | Cursor, Field(discriminator=...)]``) because
-    the OpenAPI ``oneOf`` + ``discriminator`` construct is not handled
-    correctly by ``@hey-api/openapi-ts`` / ``@7nohe/openapi-react-query-codegen``:
-    return types degrade to ``unknown`` in JSDoc and can produce
-    incorrect TypeScript types (see hey-api/openapi-ts#1613, #3270).
+    Dag Run Collection serializer for responses.
     """
 
     dag_runs: Annotated[list[DAGRunResponse], Field(title="Dag Runs")]
-    total_entries: Annotated[
-        int | None,
-        Field(
-            description="Total number of matching items. Populated for offset pagination, ``null`` when using cursor pagination.",
-            title="Total Entries",
-        ),
-    ] = None
-    next_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the next page. Populated for cursor pagination, ``null`` when using offset pagination or when there is no next page.",
-            title="Next Cursor",
-        ),
-    ] = None
-    previous_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the previous page. Populated for cursor pagination, ``null`` when using offset pagination or when on the first page.",
-            title="Previous Cursor",
-        ),
-    ] = None
+    total_entries: Annotated[int, Field(title="Total Entries")]
 
 
 class DAGWarningCollectionResponse(BaseModel):
@@ -2240,38 +2039,11 @@ class TaskCollectionResponse(BaseModel):
 
 class TaskInstanceCollectionResponse(BaseModel):
     """
-    Task instance collection response supporting both offset and cursor pagination.
-
-    A single flat model is used instead of a discriminated union
-    (``Annotated[Offset | Cursor, Field(discriminator=...)]``) because
-    the OpenAPI ``oneOf`` + ``discriminator`` construct is not handled
-    correctly by ``@hey-api/openapi-ts`` / ``@7nohe/openapi-react-query-codegen``:
-    return types degrade to ``unknown`` in JSDoc and can produce
-    incorrect TypeScript types (see hey-api/openapi-ts#1613, #3270).
+    Task Instance Collection serializer for responses.
     """
 
     task_instances: Annotated[list[TaskInstanceResponse], Field(title="Task Instances")]
-    total_entries: Annotated[
-        int | None,
-        Field(
-            description="Total number of matching items. Populated for offset pagination, ``null`` when using cursor pagination.",
-            title="Total Entries",
-        ),
-    ] = None
-    next_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the next page. Populated for cursor pagination, ``null`` when using offset pagination or when there is no next page.",
-            title="Next Cursor",
-        ),
-    ] = None
-    previous_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the previous page. Populated for cursor pagination, ``null`` when using offset pagination or when on the first page.",
-            title="Previous Cursor",
-        ),
-    ] = None
+    total_entries: Annotated[int, Field(title="Total Entries")]
 
 
 class TaskInstanceHistoryCollectionResponse(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -101,9 +101,9 @@ apache-airflow-providers-mongo = false
 apache-airflow-providers-apprise = false
 apache-airflow-providers-apache-impala = false
 apache-airflow-ctl = false
-apache-airflow-providers-zendesk = false
 apache-airflow-providers-github = false
 apache-airflow-providers-snowflake = false
+apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
@@ -1735,6 +1735,7 @@ dependencies = [
     { name = "a2wsgi" },
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "apache-airflow-ctl" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-io" },
     { name = "apache-airflow-providers-common-sql" },
@@ -1744,6 +1745,7 @@ dependencies = [
     { name = "argcomplete" },
     { name = "asgiref" },
     { name = "attrs" },
+    { name = "cachetools" },
     { name = "cadwyn" },
     { name = "colorlog" },
     { name = "cron-descriptor" },
@@ -1846,9 +1848,13 @@ dev = [
     { name = "apache-airflow-providers-fab" },
     { name = "apache-airflow-providers-ftp" },
     { name = "apache-airflow-providers-git" },
+    { name = "apache-airflow-task-sdk" },
 ]
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
+]
+mypy = [
+    { name = "apache-airflow-devel-common", extra = ["mypy"] },
 ]
 
 [package.metadata]
@@ -1857,6 +1863,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0,<0.22.0" },
     { name = "alembic", specifier = ">=1.13.1,<2.0" },
     { name = "apache-airflow-core", extras = ["graphviz", "gunicorn", "kerberos", "otel", "statsd"], marker = "extra == 'all'", editable = "airflow-core" },
+    { name = "apache-airflow-ctl", editable = "airflow-ctl" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-io", editable = "providers/common/io" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
@@ -1867,6 +1874,7 @@ requires-dist = [
     { name = "asgiref", marker = "python_full_version < '3.14'", specifier = ">=2.3.0" },
     { name = "asgiref", marker = "python_full_version >= '3.14'", specifier = ">=3.11.1" },
     { name = "attrs", specifier = ">=22.1.0,!=25.2.0" },
+    { name = "cachetools", specifier = ">=6.0.0" },
     { name = "cadwyn", specifier = ">=6.0.4" },
     { name = "colorlog", specifier = ">=6.8.2" },
     { name = "cron-descriptor", specifier = ">=1.2.24" },
@@ -1921,7 +1929,7 @@ requires-dist = [
     { name = "rich-argparse", specifier = ">=1.0.0" },
     { name = "setproctitle", specifier = ">=1.3.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.48" },
-    { name = "starlette", specifier = ">=0.45.0,<1" },
+    { name = "starlette", specifier = ">=0.45.0" },
     { name = "statsd", marker = "extra == 'statsd'", specifier = ">=3.3.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "svcs", specifier = ">=25.1.0" },
@@ -1948,8 +1956,10 @@ dev = [
     { name = "apache-airflow-providers-fab", editable = "providers/fab" },
     { name = "apache-airflow-providers-ftp", editable = "providers/ftp" },
     { name = "apache-airflow-providers-git", editable = "providers/git" },
+    { name = "apache-airflow-task-sdk", editable = "task-sdk" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
+mypy = [{ name = "apache-airflow-devel-common", extras = ["mypy"], editable = "devel-common" }]
 
 [[package]]
 name = "apache-airflow-ctl"
@@ -1987,6 +1997,9 @@ dev = [
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
 ]
+mypy = [
+    { name = "apache-airflow-devel-common", extra = ["mypy"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2017,6 +2030,7 @@ dev = [
     { name = "apache-airflow-devel-common", editable = "devel-common" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
+mypy = [{ name = "apache-airflow-devel-common", extras = ["mypy"], editable = "devel-common" }]
 
 [[package]]
 name = "apache-airflow-ctl-tests"


### PR DESCRIPTION
Pull requests targeting this branch receive no CI at all today: the
`airflow-ctl/` release-branch patterns are missing from this branch's workflow
trigger filters, so only branch-independent bot checks report and a PR can show
all-green without any tests or CodeQL ever running.

GitHub resolves trigger filters from the workflow files on the *target* branch,
so the equivalent fix on `main` (#69626) is a no-op here and has to land on the
release branch itself.

Same change as the companion PR against `airflow-ctl/v0-1-test` (#70724).

related: #69626

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)