### PR TITLE
Run CodeQL on chart release-branch pull requests and pushes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,9 +20,19 @@ name: "CodeQL"
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
-    branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable']
+    branches:
+      - main
+      - v[0-9]+-[0-9]+-test
+      - v[0-9]+-[0-9]+-stable
+      - chart/v[0-9]+-[0-9]+x-test
+      - chart/v[0-9]+-[0-9]+x-stable
+      - airflow-ctl/v[0-9]+-[0-9]+-test
+      - airflow-ctl/v[0-9]+-[0-9]+-stable
   push:
-    branches: [main]
+    branches:
+      - main
+      - chart/v[0-9]+-[0-9]+x-test
+      - airflow-ctl/v[0-9]+-[0-9]+-test
   schedule:
     - cron: '0 2 * * *'
 


### PR DESCRIPTION
Pull requests targeting this branch never run CodeQL: the `chart/`
release-branch patterns are missing from this branch's CodeQL trigger filters,
so the security analysis that gates `main` is silently absent here while the
rest of the test suite reports normally. Verified on the most recent merged PR
into this branch — a full green test suite, zero CodeQL checks.

The test pipeline itself is unaffected and already runs, so `ci-amd-arm.yml` is
deliberately left alone. Only the CodeQL filters change.

GitHub resolves trigger filters from the workflow files on the *target* branch,
so the equivalent fix on `main` (#69626) is a no-op here and has to land on the
release branch itself.

related: #69626

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)