### PR TITLE
[v3-3-test] Fix getsection() dropping env-var overrides on lazy-regis…

### DIFF
--- a/airflow-core/tests/unit/core/test_configuration.py
+++ b/airflow-core/tests/unit/core/test_configuration.py
@@ -2060,6 +2060,36 @@ class TestProviderConfigPriority:
         with conf_vars({("celery", "celery_app_name"): custom_value}):
             assert conf.get("celery", "celery_app_name") == custom_value
 
+    def test_getsection_returns_env_var_only_provider_section(self, monkeypatch):
+        """Env vars are picked up for a provider section whose keys all default to None."""
+        from airflow.settings import conf
+
+        monkeypatch.setenv("AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__VISIBILITY_TIMEOUT", "21600")
+        monkeypatch.setenv("AIRFLOW__CELERY_BROKER_TRANSPORT_OPTIONS__MASTER_NAME", "mymaster")
+
+        section = conf.getsection("celery_broker_transport_options")
+
+        assert section is not None
+        assert section["visibility_timeout"] == 21600
+        assert section["master_name"] == "mymaster"
+
+    def test_getsection_returns_env_var_only_provider_section_via_cfg_fallback(self, monkeypatch):
+        """Env vars are picked up for a section that lives only in provider cfg fallback defaults."""
+        from airflow.settings import conf
+
+        monkeypatch.setenv("AIRFLOW__ELASTICSEARCH__END_OF_LOG_MARK", "env_override_mark")
+
+        section = conf.getsection("elasticsearch")
+
+        assert section is not None
+        assert section["end_of_log_mark"] == "env_override_mark"
+
+    def test_getsection_returns_none_for_truly_unknown_section(self):
+        """Sections not declared anywhere and with no env vars still return None."""
+        from airflow.settings import conf
+
+        assert conf.getsection("section_that_does_not_exist_anywhere") is None
+
 
 # Technically it's not a DB test, but we want to make sure it's not interfering with xdist non-db tests
 # Because the `_cleanup` method might cause side-effect for parallel-run tests

--- a/shared/configuration/src/airflow_shared/configuration/parser.py
+++ b/shared/configuration/src/airflow_shared/configuration/parser.py
@@ -1879,7 +1879,7 @@ class AirflowConfigParser(ConfigParser):
         # Handle team-specific section lookup for config file
         config_section = f"{team_name}={section}" if team_name else section
 
-        if not self.has_section(config_section) and not self._default_values.has_section(config_section):
+        if not self.has_section(config_section) and not self._has_section_in_any_defaults(config_section):
             return None
         if self._default_values.has_section(config_section):
             _section: ConfigOptionsDictType = dict(self._default_values.items(config_section))


### PR DESCRIPTION
…tered provider sections (#68895)

(cherry picked from commit d11422ee0c6aa95f73af90f9296e543a7727e4a4)

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
