### PR TITLE
Only resolve a team namespaced environment secret for its own team

### DIFF
--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -64,4 +64,21 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
 
     @staticmethod
     def _is_team_specific_accessed_as_global(secret_id: str, team_name: str | None = None) -> bool:
-        return team_name is None and bool(re.fullmatch(r"_[^_]+___.+", secret_id))
+        """
+        Whether ``secret_id`` names a team specific secret outside of the team it is looked up for.
+
+        A team specific secret lives in the ``_<TEAM_NAME>___<SECRET_ID>`` namespace of the
+        environment, so an id that already spells such a namespace out resolves the team specific
+        environment variable through the team agnostic lookup. That is only correct when the
+        namespace is the one the lookup is made for -- ``team_name``.
+
+        The namespace of a stored id is deliberately not parsed out of it: a team name may itself
+        contain underscores, so ``_a___b___c`` is both team ``a`` with id ``b___c`` and team
+        ``a___b`` with id ``c``, and no pattern can tell the two apart. Only the namespace prefix
+        that ``team_name`` itself builds is compared, which is unambiguous.
+        """
+        if not re.fullmatch(r"_.+___.+", secret_id):
+            return False
+        if not team_name:
+            return True
+        return not secret_id.upper().startswith(f"_{team_name.upper()}___")

--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -32,14 +32,14 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from environment variable."""
 
     def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
-        if self._is_team_specific_accessed_as_global(conn_id, team_name):
-            return None
-
         if team_name and (
             team_var := os.environ.get(f"{CONN_ENV_PREFIX}_{team_name.upper()}___" + conn_id.upper())
         ):
             # Format to set a team specific connection: AIRFLOW_CONN__<TEAM_ID>___<CONN_ID>
             return team_var
+
+        if self._names_a_team_namespace(conn_id):
+            return None
 
         return os.environ.get(CONN_ENV_PREFIX + conn_id.upper())
 
@@ -51,34 +51,39 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         :param team_name: Team name associated to the task trying to access the variable (if any)
         :return: Variable Value
         """
-        if self._is_team_specific_accessed_as_global(key, team_name):
-            return None
-
         if team_name and (
             team_var := os.environ.get(f"{VAR_ENV_PREFIX}_{team_name.upper()}___" + key.upper())
         ):
             # Format to set a team specific variable: AIRFLOW_VAR__<TEAM_ID>___<VAR_KEY>
             return team_var
 
+        if self._names_a_team_namespace(key):
+            return None
+
         return os.environ.get(VAR_ENV_PREFIX + key.upper())
 
     @staticmethod
-    def _is_team_specific_accessed_as_global(secret_id: str, team_name: str | None = None) -> bool:
+    def _names_a_team_namespace(secret_id: str) -> bool:
         """
-        Whether ``secret_id`` names a team specific secret outside of the team it is looked up for.
+        Whether ``secret_id`` spells out a team namespaced environment variable name.
 
         A team specific secret lives in the ``_<TEAM_NAME>___<SECRET_ID>`` namespace of the
-        environment, so an id that already spells such a namespace out resolves the team specific
-        environment variable through the team agnostic lookup. That is only correct when the
-        namespace is the one the lookup is made for -- ``team_name``.
+        environment. An id of that shape therefore makes the team agnostic lookup -- which
+        prepends only ``AIRFLOW_CONN_`` / ``AIRFLOW_VAR_`` -- land inside some team's namespace,
+        so that lookup is refused for such an id.
 
-        The namespace of a stored id is deliberately not parsed out of it: a team name may itself
-        contain underscores, so ``_a___b___c`` is both team ``a`` with id ``b___c`` and team
-        ``a___b`` with id ``c``, and no pattern can tell the two apart. Only the namespace prefix
-        that ``team_name`` itself builds is compared, which is unambiguous.
+        **The id is never attributed to a particular team**, because it cannot be: a team name
+        may itself contain the ``___`` separator, so ``_a___b___c`` is both team ``a`` with id
+        ``b___c`` and team ``a___b`` with id ``c``, and nothing in the string distinguishes them.
+        Only the caller's own namespace is ever constructed, never parsed.
+
+        This is why the check is not "does the id belong to some team other than the caller's".
+        Comparing the id against the prefix the caller's team builds looks equivalent and is not:
+        for a caller in team ``a`` the id ``_a___b___c`` starts with ``_A___``, yet the variable
+        it resolves, ``AIRFLOW_CONN__A___B___C``, is team ``a___b``'s. Treating a prefix match as
+        ownership hands one team the secrets of every team whose name extends it. Callers reach
+        their own team's secrets with the bare id plus their team scope -- handled above, and safe
+        because that path can only ever build the caller's own namespace -- so nothing legitimate
+        needs a namespaced id here.
         """
-        if not re.fullmatch(r"_.+___.+", secret_id):
-            return False
-        if not team_name:
-            return True
-        return not secret_id.upper().startswith(f"_{team_name.upper()}___")
+        return re.fullmatch(r"_.+___.+", secret_id) is not None

--- a/airflow-core/tests/unit/always/test_secrets_environment_variables.py
+++ b/airflow-core/tests/unit/always/test_secrets_environment_variables.py
@@ -85,12 +85,36 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
-    def test_id_spelling_out_its_own_team_namespace_is_resolved(
+    def test_id_spelling_out_a_team_namespace_is_never_resolved(
         self, monkeypatch, env_prefix, method, team_name
     ):
+        """Even for the team that owns it: an id of that shape is not attributable to a team.
+
+        A caller reaches its own team's secret with the bare id plus its team scope. Allowing
+        the namespaced spelling as well is what made the caller's own prefix look like proof of
+        ownership, which it is not -- see the collision test below.
+        """
         monkeypatch.setenv(team_env_var(env_prefix, team_name), TEAM_VALUE)
 
-        assert lookup(env_prefix, method, team_scoped_id(team_name), team_name) == TEAM_VALUE
+        assert lookup(env_prefix, method, team_scoped_id(team_name), team_name) is None
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    def test_team_whose_name_extends_the_callers_is_not_readable(self, monkeypatch, env_prefix, method):
+        """A team name may contain the ``___`` separator, so one team's namespace can start with another's.
+
+        Caller in ``team_a`` supplies ``_team_a___prod___dbconn``. That id starts with the
+        ``_TEAM_A___`` prefix the caller's own team builds, so a prefix-equals-ownership check
+        clears it; the team scoped lookup then misses and the team agnostic lookup lands on
+        ``AIRFLOW_CONN__TEAM_A___PROD___DBCONN`` -- team ``team_a___prod``'s secret.
+        """
+        caller_team, target_team = "team_a", "team_a___prod"
+        monkeypatch.setenv(team_env_var(env_prefix, target_team), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, team_scoped_id(target_team), caller_team) is None
+        # and the owning team still cannot reach it by the namespaced spelling either
+        assert lookup(env_prefix, method, team_scoped_id(target_team), target_team) is None
+        # while the owning team reaches it normally, with the bare id
+        assert lookup(env_prefix, method, SECRET_ID, target_team) == TEAM_VALUE
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)

--- a/airflow-core/tests/unit/always/test_secrets_environment_variables.py
+++ b/airflow-core/tests/unit/always/test_secrets_environment_variables.py
@@ -1,0 +1,120 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow.secrets.environment_variables import (
+    CONN_ENV_PREFIX,
+    VAR_ENV_PREFIX,
+    EnvironmentVariablesBackend,
+)
+
+# A team specific secret is stored as ``<PREFIX>_<TEAM_NAME>___<SECRET_ID>``. Team names may contain
+# underscores (they are validated against ``^[a-zA-Z0-9_-]{3,50}$``), so both shapes are exercised.
+TEAM_NAMES = ["team_a", "teama"]
+OTHER_TEAM_NAME = "team_b"
+SECRET_ID = "dbconn"
+TEAM_VALUE = "team-scoped-value"
+GLOBAL_VALUE = "team-agnostic-value"
+
+# ``(env prefix, backend method)`` of the two lookups sharing the team scoping rules.
+LOOKUPS = [
+    pytest.param(CONN_ENV_PREFIX, "get_conn_value", id="connection"),
+    pytest.param(VAR_ENV_PREFIX, "get_variable", id="variable"),
+]
+
+
+def team_env_var(env_prefix: str, team_name: str, secret_id: str = SECRET_ID) -> str:
+    return f"{env_prefix}_{team_name.upper()}___{secret_id.upper()}"
+
+
+def team_scoped_id(team_name: str, secret_id: str = SECRET_ID) -> str:
+    """Spell the ``_<TEAM_NAME>___<SECRET_ID>`` namespace out as a secret id."""
+    return f"_{team_name}___{secret_id}"
+
+
+def lookup(env_prefix: str, method: str, secret_id: str, team_name: str | None) -> str | None:
+    return getattr(EnvironmentVariablesBackend(), method)(secret_id, team_name)
+
+
+class TestEnvironmentVariablesBackendTeamScope:
+    """A team specific secret must only be resolvable for the team it is stored for."""
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    def test_team_scoped_secret_is_not_resolved_without_a_team_scope(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        monkeypatch.setenv(team_env_var(env_prefix, team_name), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, team_scoped_id(team_name), None) is None
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    def test_team_scoped_secret_is_not_resolved_for_another_team(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        monkeypatch.setenv(team_env_var(env_prefix, team_name), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, team_scoped_id(team_name), OTHER_TEAM_NAME) is None
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    def test_team_scoped_secret_is_resolved_for_its_own_team(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        monkeypatch.setenv(team_env_var(env_prefix, team_name), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, SECRET_ID, team_name) == TEAM_VALUE
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    def test_id_spelling_out_its_own_team_namespace_is_resolved(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        monkeypatch.setenv(team_env_var(env_prefix, team_name), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, team_scoped_id(team_name), team_name) == TEAM_VALUE
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    def test_team_scoped_secret_wins_over_the_team_agnostic_one(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        monkeypatch.setenv(team_env_var(env_prefix, team_name), TEAM_VALUE)
+        monkeypatch.setenv(env_prefix + SECRET_ID.upper(), GLOBAL_VALUE)
+
+        assert lookup(env_prefix, method, SECRET_ID, team_name) == TEAM_VALUE
+        assert lookup(env_prefix, method, SECRET_ID, None) == GLOBAL_VALUE
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])
+    def test_team_agnostic_secret_is_resolved_for_any_team_scope(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        monkeypatch.setenv(env_prefix + SECRET_ID.upper(), GLOBAL_VALUE)
+
+        assert lookup(env_prefix, method, SECRET_ID, team_name) == GLOBAL_VALUE
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])
+    def test_unset_secret_is_not_resolved(self, monkeypatch, env_prefix, method, team_name):
+        monkeypatch.delenv(env_prefix + SECRET_ID.upper(), raising=False)
+
+        assert lookup(env_prefix, method, SECRET_ID, team_name) is None


### PR DESCRIPTION
A team specific Connection or Variable lives in the `_<TEAM_NAME>___<SECRET_ID>`
namespace of the environment. An id that already spells such a namespace out
therefore reaches that variable through the team agnostic lookup, which is only
correct when the namespace is the one the lookup is made for.

`_is_team_specific_accessed_as_global` guarded that, and had two gaps:

- its pattern `_[^_]+___.+` could not span an underscore in the team name, and
  team names may contain underscores (`^[a-zA-Z0-9_-]{3,50}$`);
- it only applied when no team was in scope (`team_name is None`), so with a team
  in scope it did nothing. The team scoped probe above it only returns on a *hit*,
  so a miss fell through to `os.environ.get(PREFIX + id.upper())` — byte identical
  to another team's variable name.

### Approach

The lookup order is inverted, and the guard stops trying to attribute an id to a
team:

1. the **team scoped** lookup runs first. It is safe by construction — it can only
   ever build `PREFIX + "_" + <caller's team> + "___" + id`, the caller's own
   namespace;
2. after it misses, an id that spells out *any* team namespace (`_.+___.+`) is
   refused, because the team agnostic lookup would land inside one;
3. otherwise the team agnostic lookup proceeds as before.

**The id is never parsed to decide which team it belongs to, because that question
has no answer.** A team name may itself contain the `___` separator, so
`_a___b___c` is simultaneously team `a` with id `b___c` and team `a___b` with id
`c`, and nothing in the string distinguishes them.

An earlier revision of this PR did try to answer it, by comparing the id against
the namespace prefix the caller's own team builds and treating a match as proof of
ownership. That is not sound, and it left the cross-team read open for a whole
class of team names: for a caller in team `a`, the id `_a___b___c` starts with
`_A___`, so the guard cleared it — but the variable it resolves,
`AIRFLOW_CONN__A___B___C`, is team `a___b`'s. The prefix matched, the team scoped
lookup missed, and the team agnostic lookup returned the other team's secret. Any
team whose name extends the caller's was readable. The regression test
`test_team_whose_name_extends_the_callers_is_not_readable` covers exactly that
shape.

Both `get_conn_value` and `get_variable` share the helper, so this covers
Connections and Variables together.

### Behaviour change

Ids of the shape `_<something>___<something>` are no longer resolvable through the
team agnostic environment variable name from **any** scope — including the team
that owns the namespace, which previously could reach its own secret through the
namespaced spelling. That spelling is exactly what made a prefix match look like
ownership. Callers reach their own team's secrets the normal way, with the bare id
plus their team scope, which is unaffected.

Practically: a deployment that stored a *team agnostic* connection or variable
whose id begins with `_` and contains `___` loses that lookup. Legitimate global
ids and same team lookups are unaffected.

### Test plan

- [x] `airflow-core/tests/unit/always/test_secrets_environment_variables.py`, 34 cases —
      every test parametrized over both lookups and over an underscore-bearing (`team_a`)
      and underscore-free (`teama`) team name
- [x] Negative: not resolved without a team scope; not resolved for another team; not
      resolved through the namespaced spelling by any caller **including the owning team**
- [x] `test_team_whose_name_extends_the_callers_is_not_readable` — caller `team_a`,
      target `team_a___prod`, id `_team_a___prod___dbconn`; asserts the read is refused
      and that `team_a___prod` still reaches its own secret with the bare id
- [x] Positive: resolved for its own team; team scoped wins over team agnostic; team
      agnostic still resolves for any team scope
- [x] The 6 cases covering the collision fail against the previous revision of this PR
- [x] Separately, an exhaustive property check over 6 team names (including the
      collision-prone `team_a` / `team_a___prod` and `a` / `a___b`), both lookups, every
      caller scope including none, and both bare and namespaced ids: **0 cross-team
      resolutions** with this change, **4** with the previous revision
- [x] `ruff check` / `ruff format --check` clean on both files

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
