### PR TITLE
[v3-3-test] UI: Wrap long plugin source path in import-error dialog (#69111)

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrorsModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Dashboard/Stats/PluginImportErrorsModal.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Heading, Text, HStack } from "@chakra-ui/react";
+import { Box, ClipboardRoot, Heading, Text, HStack } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuFileWarning } from "react-icons/lu";
@@ -24,7 +24,7 @@ import { PiFilePy } from "react-icons/pi";
 
 import type { PluginImportErrorResponse } from "openapi/requests/types.gen";
 import { SearchBar } from "src/components/SearchBar";
-import { Accordion, Dialog } from "src/components/ui";
+import { Accordion, ClipboardIconButton, Dialog } from "src/components/ui";
 import { Pagination } from "src/components/ui/Pagination";
 
 type PluginImportErrorsModalProps = {
@@ -84,10 +84,21 @@ export const PluginImportErrorsModal: React.FC<PluginImportErrorsModalProps> = (
           <Accordion.Root collapsible multiple size="md" variant="enclosed">
             {visibleItems.map((importError) => (
               <Accordion.Item key={importError.error} value={importError.source}>
-                <Accordion.ItemTrigger cursor="pointer">
-                  <PiFilePy />
-                  {importError.source}
-                </Accordion.ItemTrigger>
+                <HStack align="stretch" gap={0} w="100%">
+                  <Accordion.ItemTrigger cursor="pointer" flex="1">
+                    <HStack alignItems="center" gap={2} minW={0} w="100%">
+                      <PiFilePy />
+                      <Text minW={0} overflowWrap="anywhere">
+                        {importError.source}
+                      </Text>
+                    </HStack>
+                  </Accordion.ItemTrigger>
+                  <Box alignItems="center" display="flex" flexShrink={0} pr={2}>
+                    <ClipboardRoot value={importError.source}>
+                      <ClipboardIconButton variant="outline" />
+                    </ClipboardRoot>
+                  </Box>
+                </HStack>
                 <Accordion.ItemContent>
                   <Text color="fg.error" fontSize="sm" whiteSpace="pre-wrap">
                     <code>{importError.error}</code>


### PR DESCRIPTION
Backport of #69111 to `v3-3-test` for the Airflow 3.3.1 patch release. Clean `git cherry-pick -x` (no conflicts).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — automated cherry-pick backport; code is the original author's, unchanged.
