### PR TITLE
[v3-3-test] UI: Make the Dag pause toggle distinguishable in dark mode (#70203)

### DIFF
--- a/airflow-core/src/airflow/ui/src/theme.ts
+++ b/airflow-core/src/airflow/ui/src/theme.ts
@@ -382,6 +382,12 @@ const defaultAirflowTheme: ThemingConfig = {
     },
     switch: {
       slots: [],
+      base: {
+        control: {
+          shadow: "inset 0 0 0px 1px var(--shadow-color)",
+          shadowColor: { _dark: "gray.500", _light: "gray.400" },
+        },
+      },
       defaultVariants: { size: "sm" } as Record<string, string>,
     },
     // size="sm" gives px/py:2 on cell and columnHeader vs px/py:3 for "md".


### PR DESCRIPTION
Backport of #70203 to `v3-3-test` for the Airflow 3.3.1 patch release. Clean `git cherry-pick -x` (no conflicts).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — automated cherry-pick backport; code is the original author's, unchanged.
