### PR TITLE
[v3-3-test] Fix collapse button overlapping details panel content (#69240)

### DIFF
--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -361,28 +361,34 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                     justifyContent="center"
                     position="relative"
                     w={0.5}
-                  />
-                </PanelResizeHandle>
-
-                {/* Collapse button positioned next to the resize handle */}
-
-                <Panel defaultSize={dagView === "graph" ? 30 : 80} id="details-panel" minSize={20} order={2}>
-                  <Box display="flex" flexDirection="column" h="100%" position="relative">
+                  >
                     <IconButton
                       bg="fg.subtle"
-                      borderRadius={direction === "ltr" ? "0 100% 100% 0" : "100% 0 0 100%"}
+                      borderRadius="full"
                       boxShadow="md"
+                      cursor="pointer"
+                      insetInlineStart="50%"
                       label={translate("common:collapseDetailsPanel")}
-                      left={direction === "ltr" ? "0" : undefined}
                       onClick={() => setIsRightPanelCollapsed(true)}
                       position="absolute"
-                      right={direction === "rtl" ? "0" : undefined}
                       size="2xs"
                       top="50%"
+                      transform={direction === "ltr" ? "translate(-50%, -50%)" : "translate(50%, -50%)"}
                       zIndex={2}
                     >
                       {direction === "ltr" ? <FaChevronRight /> : <FaChevronLeft />}
                     </IconButton>
+                  </Box>
+                </PanelResizeHandle>
+
+                <Panel defaultSize={dagView === "graph" ? 30 : 80} id="details-panel" minSize={20} order={2}>
+                  <Box
+                    display="flex"
+                    flexDirection="column"
+                    h="100%"
+                    paddingInlineStart={4}
+                    position="relative"
+                  >
                     {children}
                     {Boolean(error) || (warningData?.dag_warnings.length ?? 0) > 0 ? (
                       <>


### PR DESCRIPTION
Backport of #69240 to `v3-3-test` for the Airflow 3.3.1 patch release.

`DetailsLayout.tsx` had diverged on `v3-3-test`, so this block conflicted. Resolved by taking #69240's version — move the collapse `IconButton` into the resize-handle `<Box>`, restyle it (`borderRadius="full"`, `insetInlineStart="50%"` + `transform` centering), and add `paddingInlineStart={4}` to the details panel. The UI format/lint prek hook normalized indentation; tags balance and the warning button / `DAGWarningsModal` remain siblings.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — cherry-pick backport with a manually-resolved structural conflict as described above.