### PR TITLE
[v3-3-test] Fix sphinx build error (#69505)

### DIFF
--- a/airflow-core/docs/best-practices.rst
+++ b/airflow-core/docs/best-practices.rst
@@ -852,7 +852,7 @@ You can use environment variables to parameterize the Dag.
 Mocking variables and connections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When you write tests for code that uses variables or a connection, you must ensure that they exist when you run the tests. The obvious solution is to save these objects to the database so they can be read while your code is executing. However, reading and writing objects to the database are burdened with additional time overhead. In order to speed up the test execution, it is worth simulating the existence of these objects without saving them to the database. For this, you can create environment variables with mocking :any:`os.environ` using :meth:`unittest.mock.patch.dict`.
+When you write tests for code that uses variables or a connection, you must ensure that they exist when you run the tests. The obvious solution is to save these objects to the database so they can be read while your code is executing. However, reading and writing objects to the database are burdened with additional time overhead. In order to speed up the test execution, it is worth simulating the existence of these objects without saving them to the database. For this, you can create environment variables with mocking :data:`os.environ` using :meth:`unittest.mock.patch.dict`.
 
 For variable, use :envvar:`AIRFLOW_VAR_{KEY}`.
 


### PR DESCRIPTION
Backport of #69505 to `v3-3-test`. Clean `git cherry-pick -x`.

**Unblocks CI on the branch:** `v3-3-test`'s `best-practices.rst` uses `:any:\`os.environ\``, which the warnings-as-errors docs build rejects (`Error, no command xref target from best-practices:os.environ`) — failing the "Build documentation (--spellcheck-only)" job for **every** PR targeting `v3-3-test`. #69505 changed it to `:data:\`os.environ\`` on main; this backports that one-line fix.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — cherry-pick backport of a one-line docs xref fix.