### PR TITLE
i18n(Ko): add missing translations (Jul 30)

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
@@ -42,7 +42,10 @@
     "title": "{{name}}에 대한 에셋 이벤트 생성"
   },
   "events": "이벤트",
-  "extra": "추가 정보",
+  "filters": {
+    "groupPlaceholder": "그룹 검색",
+    "lastEventDateRange": "마지막 이벤트 날짜"
+  },
   "group": "그룹",
   "lastAssetEvent": "마지막 에셋 이벤트",
   "name": "이름",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/assets.json
@@ -44,7 +44,7 @@
   "events": "이벤트",
   "filters": {
     "groupPlaceholder": "그룹 검색",
-    "lastEventDateRange": "마지막 이벤트 날짜"
+    "lastEventDateRange": "마지막 이벤트 기간"
   },
   "group": "그룹",
   "lastAssetEvent": "마지막 에셋 이벤트",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/ko/common.json
@@ -8,6 +8,7 @@
     "Variables": "변수들"
   },
   "allOperators": "모든 오퍼레이터",
+  "allTeams": "모든 팀",
   "appearance": {
     "appearance": "외관",
     "darkMode": "다크 모드",
@@ -85,6 +86,7 @@
   "dagRun_one": "Dag 실행",
   "dagRun_other": "Dag 실행들",
   "dagRunId": "Dag 실행 ID",
+  "dagRunState": "Dag 실행 상태",
   "dagWarnings": "Dag 경고/오류",
   "defaultToGraphView": "그래프 뷰 기본 보기",
   "defaultToGridView": "그리드 뷰 기본 보기",
@@ -287,6 +289,9 @@
   },
   "showDetailsPanel": "세부 정보 패널 펼치기",
   "signedInAs": "로그인한 사용자",
+  "slot": "슬롯",
+  "slot_one": "슬롯",
+  "slot_other": "슬롯",
   "source": {
     "hide": "소스 숨기기",
     "hotkey": "s",


### PR DESCRIPTION
Add two missing Korean translations

| File | 
|---|
| `assets.json` | 
| `common.json` | 

## Test

`breeze ui check-translation-completeness --language ko`

<img width="792" height="675" alt="스크린샷 2026-07-30 오후 9 33 08" src="https://github.com/user-attachments/assets/13bbb792-93ff-4bb8-ac0d-cd274f5c7342" />


Please review this translation.
cc @onestn @noeunkim