### PR TITLE
Add regression test for SERVER_TERMINATED precedence over retry

### DIFF
--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -160,6 +160,7 @@ from airflow.sdk.execution_time.comms import (
     _ResponseFrame,
 )
 from airflow.sdk.execution_time.supervisor import (
+    SERVER_TERMINATED,
     ActivitySubprocess,
     InProcessSupervisorComms,
     InProcessTestSupervisor,
@@ -3824,6 +3825,22 @@ class TestSignalRetryLogic:
         mock_watched_subprocess._should_retry = True
 
         assert mock_watched_subprocess.final_state == TaskInstanceState.UP_FOR_RETRY
+
+    def test_server_terminated_takes_precedence_over_retry(self, mocker):
+        """Test that a server-terminated task stays SERVER_TERMINATED even with retries enabled."""
+        mock_watched_subprocess = ActivitySubprocess(
+            process_log=mocker.MagicMock(),
+            id=TI_ID,
+            pid=12345,
+            stdin=mocker.Mock(),
+            process=mocker.Mock(),
+            client=mocker.Mock(),
+        )
+        mock_watched_subprocess._exit_code = 1
+        mock_watched_subprocess._should_retry = True
+        mock_watched_subprocess._terminal_state = SERVER_TERMINATED
+
+        assert mock_watched_subprocess.final_state == SERVER_TERMINATED
 
     def test_non_signal_exit_code_without_retry_goes_to_failed(self, mocker):
         """Test that non-signal exit codes without retries enabled go to FAILED."""


### PR DESCRIPTION
## Why

`ActivitySubprocess.final_state` resolves a task's final state through an ordered
chain of checks. The `SERVER_TERMINATED` check deliberately sits before the
`_should_retry` check: once the API server has told the supervisor to stop
(heartbeat returning 404 / 409 / 410), that TaskInstance is no longer the worker's
to decide on, so the worker must not independently mark it `UP_FOR_RETRY` even
when retries are configured.

That ordering is load-bearing, but nothing currently guards it. `TestSignalRetryLogic`
covers the retry and no-retry outcomes, and a separate integration test covers
`SERVER_TERMINATED`, but no test sets `_terminal_state = SERVER_TERMINATED` together
with `_should_retry = True` and a non-zero exit code — the only input combination
that distinguishes the current ordering from the reverse one. Reordering those two
branches would change behaviour silently.

## What

Adds `test_server_terminated_takes_precedence_over_retry` to `TestSignalRetryLogic`
in `task-sdk/tests/task_sdk/execution_time/test_supervisor.py`, asserting that
`final_state` returns `SERVER_TERMINATED` for a non-zero exit code with
`_should_retry = True`. Also imports `SERVER_TERMINATED` from
`airflow.sdk.execution_time.supervisor`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)
