### PR TITLE
Fix DateTimeSensorAsync crash when target_time is a template with start_from_trigger=True

### DIFF
--- a/providers/standard/src/airflow/providers/standard/sensors/date_time.py
+++ b/providers/standard/src/airflow/providers/standard/sensors/date_time.py
@@ -115,10 +115,13 @@ class DateTimeSensorAsync(DateTimeSensor):
 
         self.start_from_trigger = start_from_trigger
         if self.start_from_trigger:
-            self.start_trigger_args.trigger_kwargs = dict(
-                moment=self._moment,
-                end_from_trigger=self.end_from_trigger,
-            )
+            if isinstance(self.target_time, str) and "{{" in self.target_time:
+                self.start_from_trigger = False
+            else:
+                self.start_trigger_args.trigger_kwargs = dict(
+                    moment=self._moment,
+                    end_from_trigger=self.end_from_trigger,
+                )
 
     def execute(self, context: Context) -> NoReturn:
         self.defer(


### PR DESCRIPTION
When `DateTimeSensorAsync` is used with `start_from_trigger=True` and `target_time` is a Jinja template string (e.g. `"{{ data_interval_end.tomorrow().replace(hour=1) }}"`), the operator crashes at DAG-parse time because `__init__` eagerly accesses `self._moment`, which calls `timezone.parse()` on the unresolved template string.

This fix detects template strings (containing `{{`) in `target_time` and disables `start_from_trigger` for that task instance, falling back to the normal `execute()` path. Template resolution happens at execution time in the worker, after which the task defers to the triggerer correctly.

- [X] Yes (specify the tool below)

Generated-by: OpenCode
