### PR TITLE
Fix Cloud Build operator template preparation

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py
@@ -190,8 +190,6 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.build = build
-        # Not template fields to keep original value
-        self.build_raw = build
         self.project_id = project_id
         self.wait = wait
         self.retry = retry
@@ -205,12 +203,13 @@ class CloudBuildCreateBuildOperator(GoogleCloudBaseOperator):
 
     def prepare_template(self) -> None:
         # if no file is specified, skip
-        if not isinstance(self.build_raw, str):
+        if not isinstance(self.build, str):
             return
-        with open(self.build_raw) as file:
-            if self.build_raw.endswith((".yaml", ".yml")):
+        build_path = self.build
+        with open(build_path) as file:
+            if build_path.endswith((".yaml", ".yml")):
                 self.build = yaml.safe_load(file.read())
-            if self.build_raw.endswith(".json"):
+            if build_path.endswith(".json"):
                 self.build = json.loads(file.read())
 
     @property

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -9,7 +9,6 @@ providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneS
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
-providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py::CloudDataTransferServiceCreateJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocCreateClusterOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocSubmitJobOperator

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -12,7 +12,6 @@ providers/amazon/src/airflow/providers/amazon/aws/operators/sagemaker.py::SageMa
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator
-providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py::CloudDataTransferServiceCreateJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocCreateClusterOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocSubmitJobOperator


### PR DESCRIPTION
`CloudBuildCreateBuildOperator` stores a second copy of the templated `build` argument in `build_raw` during construction. This additional value read requires the operator to remain exempt from template-field constructor validation.

This change removes `build_raw` and uses a local `build_path` inside `prepare_template()` while loading JSON or YAML into `self.build`. Existing template-loading behavior remains unchanged, while the constructor now only assigns the argument to its corresponding instance field.

The obsolete constructor-validation exemption is removed in the same change.

related: #70296
cc @potiuk — taking `CloudBuildCreateBuildOperator` from the burn-down list.

### Validation

* Cloud Build operator unit tests: 36 passed
* Operator constructor validation: passed
* Ruff formatting and lint checks: passed
* Git diff whitespace validation: passed

---

##### Was generative AI tooling used to co-author this PR?

* [x] Yes — OpenAI Codex

Generated-by: OpenAI Codex following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
