### PR TITLE
Fix dynamic task mapping timeout leaving unfinished tasks marked successful

### DIFF
--- a/airflow-core/newsfragments/70795.bugfix.rst
+++ b/airflow-core/newsfragments/70795.bugfix.rst
@@ -1,0 +1,1 @@
+Fix dynamic task mapping timeout leaving unfinished tasks marked successful

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2948,7 +2948,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 default=None,
             )
             for task_instance in unfinished_task_instances:
-                task_instance.state = TaskInstanceState.SKIPPED
+                task_instance.state = TaskInstanceState.FAILED
                 session.merge(task_instance)
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -6620,7 +6620,7 @@ class TestSchedulerJob:
         run1 = session.merge(run1)
         session.refresh(run1)
         assert run1.state == State.FAILED
-        assert run1_ti.state == State.SKIPPED
+        assert run1_ti.state == State.FAILED
         session.flush()
         # Run relevant part of scheduling again to assert run2 has been scheduled
         self.job_runner._start_queued_dagruns(session)


### PR DESCRIPTION
When a Dag run times out while a mapped task is still expanding, the scheduler marked its unfinished mapped task instances SKIPPED. Because SKIPPED does not count as a failure, the mapped task itself could still be reported as successful even though the Dag run that owned it timed out, misleading users about whether the run actually completed its work. Mark these task instances FAILED instead, so a timed-out Dag run is reflected consistently in the state of the tasks it left unfinished.

closes: #37332