### PR TITLE
Add `type` field sort prek hook for Helm `values.schema.json` file

### DIFF
--- a/chart/.pre-commit-config.yaml
+++ b/chart/.pre-commit-config.yaml
@@ -95,6 +95,13 @@ repos:
         pass_filenames: false
         files: ^kustomize-overlays/.*\.(yaml|yml)$|^kustomize-overlays/.*/STATUS$
         require_serial: true
+      - id: sort-helm-values-schema-file-type-field
+        name: Sort Helm Values Schema File (type field)
+        entry: ../scripts/ci/prek/sort_helm_values_schema_file_type_field.py
+        language: python
+        pass_filenames: false
+        files: ^values\.schema\.json$
+        require_serial: true
       - id: lint-json-schema
         name: Lint chart/values.schema.json
         entry: ../scripts/ci/prek/lint_json_schema.py

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -84,8 +84,8 @@
         "defaultAirflowDigest": {
             "description": "Default airflow digest to deploy. Overrides tag.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "default": null,
             "x-docsSection": "Common"
@@ -197,8 +197,8 @@
         "schedulerName": {
             "description": "Specify kube scheduler name for Pods.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "default": null,
             "x-docsSection": "Common"
@@ -221,8 +221,8 @@
         "ipFamilyPolicy": {
             "description": "Specify the ip family policy to configure dual-stack networking for all Services. See https://kubernetes.io/docs/concepts/services-networking/dual-stack/",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "enum": [
                 "SingleStack",
@@ -679,8 +679,8 @@
         "airflowLocalSettings": {
             "description": "`airflow_local_settings` file as a string (templated). You can bake an `airflow_local_settings.py` into your image instead. In that case, set this value to null.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Common",
             "default": "See values.yaml"
@@ -735,24 +735,24 @@
                         "repository": {
                             "description": "The airflow image repository.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "tag": {
                             "description": "The airflow image tag.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "digest": {
                             "description": "The airflow image digest. If set, it will override the tag.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -788,24 +788,24 @@
                         "repository": {
                             "description": "The pod_template image repository. If ``config.kubernetes.worker_container_repository`` is set, k8s executor will use config value instead.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "tag": {
                             "description": "The pod_template image tag. If ``config.kubernetes.worker_container_tag`` is set, k8s executor will use config value instead.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "digest": {
                             "description": "The pod_template image digest. If set, it will override the tag. If ``config.kubernetes_executor.worker_container_repository`` and ``config.kubernetes_executor.worker_container_tag`` are set, the k8s executor will use those instead.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -829,16 +829,16 @@
                         "repository": {
                             "description": "The flower image repository.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "tag": {
                             "description": "The flower image tag.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -1318,40 +1318,40 @@
                 "metadataSecretName": {
                     "description": "Metadata connection string secret.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "metadataSecretKey": {
                     "description": "Key in the metadata connection secret containing the connection string. Only used when `metadataSecretName` is set.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "resultBackendSecretName": {
                     "description": "Result backend connection string secret.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "resultBackendSecretKey": {
                     "description": "Key in the result backend connection secret containing the connection string. Only used when `resultBackendSecretName` is set.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "brokerUrlSecretName": {
                     "description": "Redis broker URL secret.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "x-docsSection": "Redis",
                     "default": null
@@ -1359,8 +1359,8 @@
                 "brokerUrlSecretKey": {
                     "description": "Key in the broker URL secret containing the broker URL. Only used when `brokerUrlSecretName` is set.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "x-docsSection": "Redis",
                     "default": null
@@ -1388,8 +1388,8 @@
                         "host": {
                             "description": "The database host.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -1421,8 +1421,8 @@
                 "resultBackendConnection": {
                     "description": "Result backend connection configuration.",
                     "type": [
-                        "object",
-                        "null"
+                        "null",
+                        "object"
                     ],
                     "default": null,
                     "additionalProperties": false,
@@ -1445,8 +1445,8 @@
                         "host": {
                             "description": "The database host.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -1487,8 +1487,8 @@
                 "brokerUrl": {
                     "description": "Direct url to the redis broker (when using an external redis instance) (can only be set during install, not upgrade).",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "x-docsSection": "Redis",
                     "default": null
@@ -1506,8 +1506,8 @@
         "fernetKey": {
             "description": "The Fernet key used to encrypt passwords (can only be set during install, not upgrade).",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Common",
             "default": null
@@ -1515,8 +1515,8 @@
         "fernetKeySecretName": {
             "description": "The Fernet key secret name.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Airflow",
             "default": null
@@ -1533,8 +1533,8 @@
         "apiSecretKey": {
             "description": "The Flask secret key for Airflow Api to encrypt browser session.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Common",
             "default": null
@@ -1551,8 +1551,8 @@
         "apiSecretKeySecretName": {
             "description": "The Secret name containing Flask secret_key for the Api.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Airflow",
             "default": null
@@ -1560,8 +1560,8 @@
         "jwtSecret": {
             "description": "Secret key used to encode and decode JWTs to authenticate to public and private APIs. Note: It is not recommended to use in production as during helm upgrade it will be changed which can cause dag failures during component rollover.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Common",
             "default": null
@@ -1569,8 +1569,8 @@
         "jwtSecretName": {
             "description": "The JWT secret name.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Airflow",
             "default": null
@@ -1612,8 +1612,8 @@
                 "keytabBase64Content": {
                     "description": "Kerberos keytab base64 encoded content.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -1902,8 +1902,8 @@
                                 "name": {
                                     "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                                     "type": [
-                                        "string",
-                                        "null"
+                                        "null",
+                                        "string"
                                     ],
                                     "default": null
                                 },
@@ -2057,8 +2057,8 @@
                                 "storageClassName": {
                                     "description": "If using a custom StorageClass, pass name ref to all StatefulSets here (templated).",
                                     "type": [
-                                        "string",
-                                        "null"
+                                        "null",
+                                        "string"
                                     ],
                                     "default": null
                                 },
@@ -2346,16 +2346,16 @@
                         "runtimeClassName": {
                             "description": "Specify runtime for Airflow Celery worker pods.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "priorityClassName": {
                             "description": "Specify priority for Airflow Celery worker pods.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -2728,8 +2728,8 @@
                         "schedulerName": {
                             "description": "Specify kube scheduler name for Airflow Celery worker pods.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null,
                             "x-docsSection": "Common"
@@ -2834,8 +2834,8 @@
                                 "name": {
                                     "description": "The name of the ServiceAccount to use. If not set and ``create`` is 'true', a name is generated using the release name with kubernetes dedicated name.",
                                     "type": [
-                                        "string",
-                                        "null"
+                                        "null",
+                                        "string"
                                     ],
                                     "default": null
                                 },
@@ -3086,16 +3086,16 @@
                         "runtimeClassName": {
                             "description": "Specify runtime for pods created with pod-template-file.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "priorityClassName": {
                             "description": "Specify priority for pods created with pod-template-file.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -3221,8 +3221,8 @@
                         "schedulerName": {
                             "description": "Specify kube scheduler name for pods created with pod-template-file.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null,
                             "x-docsSection": "Common"
@@ -3298,8 +3298,8 @@
                             "default": null,
                             "items": {
                                 "type": [
-                                    "string",
-                                    "null"
+                                    "null",
+                                    "string"
                                 ]
                             }
                         }
@@ -3339,8 +3339,8 @@
                             "default": null,
                             "items": {
                                 "type": [
-                                    "string",
-                                    "null"
+                                    "null",
+                                    "string"
                                 ]
                             }
                         }
@@ -3446,8 +3446,8 @@
                                 "audience": {
                                     "description": "Intended audience of the token. Optional - defaults to the identifier of the Kubernetes API server.",
                                     "type": [
-                                        "string",
-                                        "null"
+                                        "null",
+                                        "string"
                                     ],
                                     "default": null
                                 }
@@ -3461,8 +3461,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -3577,8 +3577,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for scheduler pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -3884,8 +3884,8 @@
                             "default": null,
                             "items": {
                                 "type": [
-                                    "string",
-                                    "null"
+                                    "null",
+                                    "string"
                                 ]
                             }
                         }
@@ -3970,8 +3970,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -4007,8 +4007,8 @@
                         "storageClassName": {
                             "description": "If using a custom StorageClass, pass name ref to all StatefulSets here (templated).",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -4128,8 +4128,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for triggerer pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -4491,10 +4491,10 @@
                                 "default": {},
                                 "additionalProperties": {
                                     "type": [
-                                        "string",
-                                        "number",
                                         "boolean",
-                                        "null"
+                                        "null",
+                                        "number",
+                                        "string"
                                     ]
                                 }
                             }
@@ -4535,8 +4535,8 @@
                             "default": null,
                             "items": {
                                 "type": [
-                                    "string",
-                                    "null"
+                                    "null",
+                                    "string"
                                 ]
                             }
                         }
@@ -4613,8 +4613,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -4729,8 +4729,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for dag processor pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -5118,8 +5118,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -5285,8 +5285,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for the create user job pod.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -5454,8 +5454,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -5621,8 +5621,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for the migrate database job pod.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -5924,8 +5924,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -6101,8 +6101,8 @@
                 "apiServerConfig": {
                     "description": "This string (templated) will be mounted into the Airflow API Server as a custom `webserver_config.py`. You can bake a `webserver_config.py` in to your image instead or specify a configmap containing the webserver_config.py.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "x-docsSection": "Common",
                     "default": null,
@@ -6113,8 +6113,8 @@
                 "apiServerConfigConfigMapName": {
                     "description": "The configmap name containing the webserver_config.py.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "x-docsSection": "Common",
                     "default": null,
@@ -6184,20 +6184,20 @@
                                     },
                                     "port": {
                                         "type": [
-                                            "string",
-                                            "integer"
+                                            "integer",
+                                            "string"
                                         ]
                                     },
                                     "targetPort": {
                                         "type": [
-                                            "string",
-                                            "integer"
+                                            "integer",
+                                            "string"
                                         ]
                                     },
                                     "nodePort": {
                                         "type": [
-                                            "string",
-                                            "integer"
+                                            "integer",
+                                            "string"
                                         ]
                                     },
                                     "protocol": {
@@ -6227,8 +6227,8 @@
                         "loadBalancerIP": {
                             "description": "API server Service loadBalancerIP.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -6256,8 +6256,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for API server pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -6634,8 +6634,8 @@
                 "secretName": {
                     "description": "A secret containing the user and password pair.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -6650,16 +6650,16 @@
                 "username": {
                     "description": "Username use to access Flower.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "password": {
                     "description": "Password use to access Flower.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -6693,14 +6693,14 @@
                                     },
                                     "port": {
                                         "type": [
-                                            "string",
-                                            "integer"
+                                            "integer",
+                                            "string"
                                         ]
                                     },
                                     "targetPort": {
                                         "type": [
-                                            "string",
-                                            "integer"
+                                            "integer",
+                                            "string"
                                         ]
                                     },
                                     "protocol": {
@@ -6725,8 +6725,8 @@
                         "loadBalancerIP": {
                             "description": "Flower Service loadBalancerIP.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -6760,8 +6760,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -6810,8 +6810,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for Flower pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -7103,8 +7103,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -7134,8 +7134,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for StatsD pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -7325,8 +7325,8 @@
                 "config": {
                     "description": "Override the OTel Collector `config.yml`. When set (non-empty), this string replaces the chart's default collector config. The value is rendered with `tpl`, so values like `{{ .Values.ports.otelCollectorOtlpHttp }}` or `{{ include \"airflow.fullname\" . }}` can be referenced from inside the string. Leave empty to use the chart default.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -7472,8 +7472,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for OTel Collector pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -7540,8 +7540,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -7688,8 +7688,8 @@
                 "configSecretName": {
                     "description": "The PgBouncer config Secret name (templated).",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -7855,8 +7855,8 @@
                         "clusterIp": {
                             "description": "Specific ClusterIP for the PgBouncer Service.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         }
@@ -7912,24 +7912,24 @@
                         "ca": {
                             "description": "Certificate Authority for server side",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "cert": {
                             "description": "Server Certificate for server side",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "key": {
                             "description": "Private key used to authenticate with the server",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         }
@@ -7938,24 +7938,24 @@
                 "extraIniMetadata": {
                     "description": "Add extra metadata database specific PgBouncer ini configuration: https://www.pgbouncer.org/config.html#section-databases",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "extraIniResultBackend": {
                     "description": "Add extra result backend database specific PgBouncer ini configuration: https://www.pgbouncer.org/config.html#section-databases",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "extraIni": {
                     "description": "Add extra general PgBouncer ini configuration: https://www.pgbouncer.org/config.html",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8000,8 +8000,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -8026,8 +8026,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for PgBouncer pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8087,16 +8087,16 @@
                         "statsSecretName": {
                             "description": "Name of an existing Secrets object containing PgBouncer Metrics secrets.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "statsSecretKey": {
                             "description": "Key referencing the PGBouncer Metrics connection URI within an existing Secrets object. Defaults to `connection` if left null.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -8262,8 +8262,8 @@
                         "clusterIP": {
                             "description": "If using `ClusterIP` service type, custom IP address can be specified.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -8295,8 +8295,8 @@
                         "storageClassName": {
                             "description": "If using a custom StorageClass, pass name ref to all StatefulSets here (templated).",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -8311,8 +8311,8 @@
                         "existingClaim": {
                             "description": "The name of an existing PVC to use.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -8349,16 +8349,16 @@
                 "passwordSecretName": {
                     "description": "Redis password secret.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
                 "password": {
                     "description": "If password is set, create secret with it, else generate a new one on install (can only be set during install, not upgrade).",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8410,8 +8410,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for redis pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8432,8 +8432,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -8554,8 +8554,8 @@
                 "secretName": {
                     "description": "Name of the Kubernetes secret containing Base64 encoded credentials to connect to a private registry (will get passed to imagePullSecrets) (Deprecated - renamed to `registry.secretNames`).",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8611,8 +8611,8 @@
                 "secretName": {
                     "description": "A secret containing the connection string.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8682,8 +8682,8 @@
                 "secretName": {
                     "description": "A secret containing the connection string.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8908,8 +8908,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for cleanup pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -8987,8 +8987,8 @@
                                 "audience": {
                                     "description": "Intended audience of the token. Optional - defaults to the identifier of the Kubernetes API server.",
                                     "type": [
-                                        "string",
-                                        "null"
+                                        "null",
+                                        "string"
                                     ],
                                     "default": null
                                 }
@@ -9002,8 +9002,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -9284,8 +9284,8 @@
                 "priorityClassName": {
                     "description": "Specify priority for database cleanup pods.",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -9341,8 +9341,8 @@
                         "name": {
                             "description": "The name of the ServiceAccount to use. If not set and create is true, a name is generated using the release name.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -9532,24 +9532,24 @@
                         "postgresPassword": {
                             "description": "Password for the 'postgres' admin user.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": "postgres"
                         },
                         "username": {
                             "description": "Name for a custom user to create",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": ""
                         },
                         "password": {
                             "description": "Password for the custom user to create.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": ""
                         }
@@ -9600,8 +9600,8 @@
         "podTemplate": {
             "description": "The content of ``pod_template_file.yaml`` used for KubernetesExecutor workers (templated). The default (see ``files/pod-template-file.kubernetes-helm-yaml``) already takes into account normal ``workers`` configuration parameters (e.g. ``workers.resources``), so you normally won't need to override this directly.",
             "type": [
-                "string",
-                "null"
+                "null",
+                "string"
             ],
             "x-docsSection": "Airflow",
             "default": null,
@@ -9618,8 +9618,8 @@
                 "mountPath": {
                     "description": "Where dags volume will be mounted. Works for both `persistence` and `gitSync`. If not specified, dags mount path will be set to `$AIRFLOW_HOME/dags`",
                     "type": [
-                        "string",
-                        "null"
+                        "null",
+                        "string"
                     ],
                     "default": null
                 },
@@ -9641,8 +9641,8 @@
                         "storageClassName": {
                             "description": "If using a custom StorageClass, pass name here (templated).",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -9659,8 +9659,8 @@
                         "existingClaim": {
                             "description": "The name of an existing PVC to use.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -9675,8 +9675,8 @@
                         "subPath": {
                             "description": "Subpath within the PVC where dags are located.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         }
@@ -9899,32 +9899,32 @@
                         "credentialsSecret": {
                             "description": "Name of a Secret containing the repo `GIT_SYNC_USERNAME` and `GIT_SYNC_PASSWORD`.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "sshKey": {
                             "description": "SSH private key",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "sshKeySecret": {
                             "description": "Name of a Secret containing the repo `sshKeySecret`.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "knownHosts": {
                             "description": "When using a ssh private key, the contents of your `known_hosts` file.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null,
                             "examples": [
@@ -10013,8 +10013,8 @@
                         "storageClassName": {
                             "description": "If using a custom StorageClass, pass name here (templated).",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
@@ -10029,16 +10029,16 @@
                         "existingClaim": {
                             "description": "The name of an existing PVC to use.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "subPath": {
                             "description": "The subpath of the existing PVC to use.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         }
@@ -13567,8 +13567,8 @@
         "persistentVolumeClaimRetentionPolicy": {
             "description": "PersistentVolumeClaim retention policy to be used in the lifecycle of a StatefulSet",
             "type": [
-                "object",
-                "null"
+                "null",
+                "object"
             ],
             "default": null,
             "additionalProperties": false,

--- a/scripts/ci/prek/sort_helm_values_schema_file_type_field.py
+++ b/scripts/ci/prek/sort_helm_values_schema_file_type_field.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import json
+import sys
+
+from common_prek_utils import AIRFLOW_ROOT_PATH
+
+_VALUES_SCHEMA_FILE = AIRFLOW_ROOT_PATH / "chart/values.schema.json"
+
+
+if __name__ != "__main__":
+    raise SystemExit(
+        "This file is intended to be executed as an executable program. You cannot use it as a module."
+    )
+
+
+def _sort(data: dict | list) -> None:
+    "Sort all elements in `type` fields in json file"
+    if isinstance(data, dict):
+        if "type" in data and isinstance(data["type"], list):
+            data["type"].sort()
+
+        temp = list(data.values())
+    elif isinstance(data, list):
+        temp = data
+
+    for val in (val for val in temp if isinstance(val, (dict, list))):
+        _sort(val)
+
+
+def main() -> int:
+    with open(_VALUES_SCHEMA_FILE, encoding="utf-8") as schema_file:
+        schema = json.loads(schema_file.read())
+
+    _sort(schema)
+
+    with open(_VALUES_SCHEMA_FILE, "w", encoding="utf-8") as schema_file:
+        json.dump(schema, schema_file, indent=4)
+        schema_file.write("\n")
+
+    return 0
+
+
+sys.exit(main())

--- a/scripts/ci/prek/sort_helm_values_schema_file_type_field.py
+++ b/scripts/ci/prek/sort_helm_values_schema_file_type_field.py
@@ -38,7 +38,9 @@ def _sort(data: dict | list) -> None:
         if "type" in data and isinstance(data["type"], list):
             data["type"].sort()
 
-        temp = list(data.values())
+        # Skip potential `type` fields inside `default` fields as defaults are not
+        # part of the schema file verification process
+        temp = list((v for k, v in data.items() if k != "default"))
     elif isinstance(data, list):
         temp = data
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

Adds a pre-hook which will sort all of the `type` fields in the `values.schema.json` file used for validation of Helm `values.yaml`. Part of #68596, which aims to fix `values.schema.json` validation and make it more precise.

For proper matching during the validation where we are looking at the object type in the schema, we need to have exact type matches and e.g. `["null", "string"]` and `["string", "null"]` are not matched by one rule, e.g. `["null", "string"]`. In theory, we could just add all currently existing options, but in the end I think that it will be more efficient when we have as few matching rules as possible.

As a follow-up, I will do another pre-hook which will check if all type fields defined in `values.schema.json` are defined in the matching rule for validation of the `values.schema.json` file.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
