### PR TITLE
UI: Add button to find run on Grid from run header

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -72,7 +72,7 @@
       "mode": "Mode"
     },
     "expectedDuration": "Expected Duration",
-    "findOnGrid": "Find this run on the Grid",
+    "showInGrid": "Show in Grid View",
     "lastSchedulingDecision": "Last Scheduling Decision",
     "mappedPartitionKey": "Mapped Partition Key",
     "partitionDate": "Partition Date",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -72,7 +72,6 @@
       "mode": "Mode"
     },
     "expectedDuration": "Expected Duration",
-    "showInGrid": "Show in Grid View",
     "lastSchedulingDecision": "Last Scheduling Decision",
     "mappedPartitionKey": "Mapped Partition Key",
     "partitionDate": "Partition Date",
@@ -80,6 +79,7 @@
     "queuedAt": "Queued At",
     "runAfter": "Run After",
     "runType": "Run Type",
+    "showInGrid": "Show in Grid View",
     "sourceAssetEvent": "Source Asset Event",
     "triggeredBy": "Triggered By",
     "triggeringUser": "Triggering User"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/common.json
@@ -72,6 +72,7 @@
       "mode": "Mode"
     },
     "expectedDuration": "Expected Duration",
+    "findOnGrid": "Find this run on the Grid",
     "lastSchedulingDecision": "Last Scheduling Decision",
     "mappedPartitionKey": "Mapped Partition Key",
     "partitionDate": "Partition Date",

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -49,7 +49,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
 
-  const findOnGrid = () =>
+  const showInGrid = () =>
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
@@ -69,7 +69,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
       <HeaderCard
         actions={
           <>
-            <IconButton label={translate("dagRun.findOnGrid")} onClick={findOnGrid} variant="outline">
+            <IconButton label={translate("dagRun.showInGrid")} onClick={showInGrid} variant="outline">
               <LuScanSearch />
             </IconButton>
             <NeedsReviewButtonWithModal dagId={dagId} runId={dagRunId} />

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -19,6 +19,8 @@
 import { HStack, Text, Box } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
 import { FiBarChart } from "react-icons/fi";
+import { LuScanSearch } from "react-icons/lu";
+import { useSearchParams } from "react-router-dom";
 
 import { useDeadlinesServiceGetDagDeadlineAlerts } from "openapi/queries";
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -31,7 +33,7 @@ import { NeedsReviewButtonWithModal } from "src/components/NeedsReviewButton";
 import NotePreview from "src/components/NotePreview";
 import { RunTypeIcon } from "src/components/RunTypeIcon";
 import Time from "src/components/Time";
-import { RouterLink } from "src/components/ui";
+import { IconButton, RouterLink } from "src/components/ui";
 import { SearchParamsKeys } from "src/constants/searchParams";
 import DeleteRunButton from "src/pages/DagRuns/DeleteRunButton";
 import { useDagRunNote } from "src/queries/useDagRunNote";
@@ -42,9 +44,22 @@ import { DeadlineStatus } from "./DeadlineStatus";
 export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
   const { t: translate } = useTranslation();
   const { isPending, note, onOpen, onSave, setNote } = useDagRunNote(dagRun);
+  const [, setSearchParams] = useSearchParams();
 
   const dagId = dagRun.dag_id;
   const dagRunId = dagRun.dag_run_id;
+
+  const findOnGrid = () =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+
+        next.set(SearchParamsKeys.RUN_ID_PATTERN, dagRunId);
+
+        return next;
+      },
+      { replace: true },
+    );
 
   const { data: alertData } = useDeadlinesServiceGetDagDeadlineAlerts({ dagId });
   const hasDeadlineAlerts = (alertData?.total_entries ?? 0) > 0;
@@ -54,6 +69,9 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
       <HeaderCard
         actions={
           <>
+            <IconButton label={translate("dagRun.findOnGrid")} onClick={findOnGrid} variant="outline">
+              <LuScanSearch />
+            </IconButton>
             <NeedsReviewButtonWithModal dagId={dagId} runId={dagRunId} />
             <ClearRunButton dagRun={dagRun} isHotkeyEnabled />
             <MarkRunAsButton dagRun={dagRun} isHotkeyEnabled />

--- a/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Run/Header.tsx
@@ -69,7 +69,7 @@ export const Header = ({ dagRun }: { readonly dagRun: DAGRunResponse }) => {
       <HeaderCard
         actions={
           <>
-            <IconButton label={translate("dagRun.showInGrid")} onClick={showInGrid} variant="outline">
+            <IconButton label={translate("dagRun.showInGrid")} onClick={showInGrid}>
               <LuScanSearch />
             </IconButton>
             <NeedsReviewButtonWithModal dagId={dagId} runId={dagRunId} />

--- a/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/TaskInstance/Header.tsx
@@ -19,7 +19,9 @@
 import { Box } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { LuScanSearch } from "react-icons/lu";
 import { MdOutlineTask } from "react-icons/md";
+import { useSearchParams } from "react-router-dom";
 
 import type { TaskInstanceResponse } from "openapi/requests/types.gen";
 import { ClearTaskInstanceButton } from "src/components/Clear";
@@ -29,12 +31,27 @@ import { HeaderCard } from "src/components/HeaderCard";
 import { MarkTaskInstanceAsButton } from "src/components/MarkAs";
 import NotePreview from "src/components/NotePreview";
 import Time from "src/components/Time";
+import { IconButton } from "src/components/ui";
+import { SearchParamsKeys } from "src/constants/searchParams";
 import { useTaskInstanceNote } from "src/queries/useTaskInstanceNote";
 import { getDuration, renderDuration } from "src/utils";
 
 export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceResponse }) => {
   const { t: translate } = useTranslation();
   const { isPending, note, onOpen, onSave, setNote } = useTaskInstanceNote(taskInstance);
+  const [, setSearchParams] = useSearchParams();
+
+  const showInGrid = () =>
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+
+        next.set(SearchParamsKeys.RUN_ID_PATTERN, taskInstance.dag_run_id);
+
+        return next;
+      },
+      { replace: true },
+    );
 
   const stats = [
     { label: translate("task.operator"), value: taskInstance.operator_name },
@@ -70,6 +87,9 @@ export const Header = ({ taskInstance }: { readonly taskInstance: TaskInstanceRe
       <HeaderCard
         actions={
           <>
+            <IconButton label={translate("dagRun.showInGrid")} onClick={showInGrid}>
+              <LuScanSearch />
+            </IconButton>
             <ClearTaskInstanceButton
               isHotkeyEnabled
               onOpen={() => setClearOpen(true)}


### PR DESCRIPTION
**Button Placement and Icon**
**Run View**
<img width="1301" height="116" alt="image" src="https://github.com/user-attachments/assets/797dbbcc-c785-4fd4-9dfe-ed4a508c8631" />
**Task View**
<img width="881" height="77" alt="image" src="https://github.com/user-attachments/assets/b6c5295a-abd6-45dd-a8d6-567fdcb131e2" />


**Effect of Pressing Button**
<img width="496" height="243" alt="image" src="https://github.com/user-attachments/assets/25dbd238-1106-42fd-8928-faf6767ee3a6" />

Adds a "Show in Grid View" button to the DagRun header. Clicking it filters the Grid view down to the current run. This functions even past the window of 50 runs normally visible on the grid view.

The button writes the current `dag_run_id` into the `run_id_pattern` URL search param. The Details/Grid layout already reads that same param, so the co-rendered Grid immediately filters to this run. This reuses the existing search-param filtering convention — no new API calls, just a URL-state update.

Reuses functionality added from [PR #70150](https://github.com/apache/airflow/pull/70150)

Note: `run_id_pattern` is a substring filter, not an exact match. The button sets it to the full run ID, so the target run always matches. If another run's ID happened to contain this one as a substring, both would appear.




 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
