### PR TITLE
Helm: Decouple scheduler persistence from Celery workers

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -22,8 +22,12 @@
 ###########################################
 {{- if .Values.scheduler.enabled }}
 {{- $local := contains "Local" .Values.executor }}
+{{- $schedulerPersistence := .Values.scheduler.persistence }}
+{{- if not (has $schedulerPersistence.enabled (list true false)) }}
+{{- $schedulerPersistence = .Values.workers.celery.persistence }}
+{{- end }}
 # This is important because in $local mode, the scheduler assumes the role of the worker
-{{- $stateful := and $local .Values.workers.celery.persistence.enabled }}
+{{- $stateful := and $local $schedulerPersistence.enabled }}
 # We can skip Dags mounts on scheduler if dagProcessor is enabled, except with $local mode
 {{- $localOrDagProcessorDisabled := or (not .Values.dagProcessor.enabled) $local }}
 {{- $remoteLogging := or .Values.elasticsearch.enabled .Values.opensearch.enabled }}
@@ -66,8 +70,8 @@ spec:
   {{- if and $stateful .Values.scheduler.updateStrategy }}
   updateStrategy: {{- toYaml .Values.scheduler.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if and $stateful .Values.workers.celery.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.workers.celery.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- if and $stateful $schedulerPersistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml $schedulerPersistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{- end }}
   {{- if and (not $stateful) .Values.scheduler.strategy }}
   strategy: {{- toYaml .Values.scheduler.strategy | nindent 4 }}
@@ -343,16 +347,16 @@ spec:
       kind: PersistentVolumeClaim
       metadata:
         name: logs
-        {{- if .Values.workers.celery.persistence.annotations }}
-        annotations: {{- toYaml .Values.workers.celery.persistence.annotations | nindent 10 }}
+        {{- if $schedulerPersistence.annotations }}
+        annotations: {{- toYaml $schedulerPersistence.annotations | nindent 10 }}
         {{- end }}
       spec:
-      {{- if .Values.workers.celery.persistence.storageClassName }}
-        storageClassName: {{ tpl .Values.workers.celery.persistence.storageClassName . | quote }}
+      {{- if $schedulerPersistence.storageClassName }}
+        storageClassName: {{ tpl $schedulerPersistence.storageClassName . | quote }}
       {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Values.workers.celery.persistence.size }}
+            storage: {{ $schedulerPersistence.size }}
   {{- end }}
   {{- end }}

--- a/chart/tests/helm_tests/airflow_core/test_scheduler.py
+++ b/chart/tests/helm_tests/airflow_core/test_scheduler.py
@@ -45,8 +45,8 @@ class TestScheduler:
             ("LocalExecutor", {"celery": {"persistence": {"enabled": False}}}, "Deployment"),
         ],
     )
-    def test_scheduler_kind(self, executor, workers_values, kind):
-        """Test scheduler kind is StatefulSet only with a local executor & worker persistence is enabled."""
+    def test_scheduler_kind_falls_back_to_celery_persistence(self, executor, workers_values, kind):
+        """Scheduler kind falls back to Celery persistence when scheduler persistence is unset."""
         docs = render_chart(
             values={
                 "executor": executor,
@@ -56,6 +56,96 @@ class TestScheduler:
         )
 
         assert kind == jmespath.search("kind", docs[0])
+
+    @pytest.mark.parametrize(
+        ("scheduler_persistence", "celery_persistence", "kind"),
+        [
+            (True, False, "StatefulSet"),
+            (False, True, "Deployment"),
+        ],
+    )
+    def test_scheduler_persistence_is_independent_from_celery(
+        self,
+        scheduler_persistence,
+        celery_persistence,
+        kind,
+    ):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "scheduler": {
+                    "persistence": {
+                        "enabled": scheduler_persistence,
+                    }
+                },
+                "workers": {
+                    "celery": {
+                        "persistence": {
+                            "enabled": celery_persistence,
+                        }
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert kind == jmespath.search("kind", docs[0])
+
+    def test_scheduler_persistence_configuration_falls_back_to_celery(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "logs": {
+                    "persistence": {
+                        "enabled": False,
+                    }
+                },
+                "workers": {
+                    "celery": {
+                        "persistence": {
+                            "enabled": True,
+                            "size": "42Gi",
+                            "storageClassName": "legacy-storage",
+                            "annotations": {
+                                "legacy": "true",
+                            },
+                            "persistentVolumeClaimRetentionPolicy": {
+                                "whenDeleted": "Delete",
+                            },
+                        }
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert jmespath.search("kind", docs[0]) == "StatefulSet"
+        assert (
+            jmespath.search(
+                "spec.volumeClaimTemplates[0].spec.resources.requests.storage",
+                docs[0],
+            )
+            == "42Gi"
+        )
+        assert (
+            jmespath.search(
+                "spec.volumeClaimTemplates[0].spec.storageClassName",
+                docs[0],
+            )
+            == "legacy-storage"
+        )
+        assert jmespath.search(
+            "spec.volumeClaimTemplates[0].metadata.annotations",
+            docs[0],
+        ) == {
+            "legacy": "true",
+        }
+        assert jmespath.search(
+            "spec.persistentVolumeClaimRetentionPolicy",
+            docs[0],
+        ) == {
+            "whenDeleted": "Delete",
+        }
 
     def test_should_add_extra_containers(self):
         docs = render_chart(
@@ -673,12 +763,16 @@ class TestScheduler:
     def test_scheduler_update_strategy(
         self, executor, persistence, update_strategy, expected_update_strategy
     ):
-        """UpdateStrategy should only be used when we have a local executor and workers.persistence."""
+        """UpdateStrategy is used only when scheduler is rendered as a StatefulSet."""
         docs = render_chart(
             values={
                 "executor": executor,
-                "workers": {"celery": {"persistence": {"enabled": persistence}}},
-                "scheduler": {"updateStrategy": update_strategy},
+                "scheduler": {
+                    "persistence": {
+                        "enabled": persistence,
+                    },
+                    "updateStrategy": update_strategy,
+                },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
@@ -703,12 +797,16 @@ class TestScheduler:
         ],
     )
     def test_scheduler_strategy(self, executor, persistence, strategy, expected_strategy):
-        """Strategy should be used when we aren't using both a local executor and workers.persistence."""
+        """Strategy is used only when scheduler is rendered as a Deployment."""
         docs = render_chart(
             values={
                 "executor": executor,
-                "workers": {"celery": {"persistence": {"enabled": persistence}}},
-                "scheduler": {"strategy": strategy},
+                "scheduler": {
+                    "persistence": {
+                        "enabled": persistence,
+                    },
+                    "strategy": strategy,
+                },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
@@ -793,7 +891,14 @@ class TestScheduler:
         docs = render_chart(
             values={
                 "executor": "LocalExecutor",
-                "workers": {"celery": {"persistence": {"annotations": {"foo": "bar"}}}},
+                "scheduler": {
+                    "persistence": {
+                        "enabled": True,
+                        "annotations": {
+                            "foo": "bar",
+                        },
+                    }
+                },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
@@ -845,19 +950,23 @@ class TestScheduler:
     def test_scheduler_template_storage_class_name(self):
         docs = render_chart(
             values={
-                "workers": {
-                    "celery": {
+                "executor": "LocalExecutor",
+                "logs": {"persistence": {"enabled": False}},
+                "scheduler": {
+                    "persistence": {
                         "enabled": True,
-                        "persistence": {"storageClassName": "{{ .Release.Name }}-storage-class"},
+                        "storageClassName": "{{ .Release.Name }}-storage-class",
                     }
                 },
-                "logs": {"persistence": {"enabled": False}},
-                "executor": "LocalExecutor",
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
+
         assert (
-            jmespath.search("spec.volumeClaimTemplates[0].spec.storageClassName", docs[0])
+            jmespath.search(
+                "spec.volumeClaimTemplates[0].spec.storageClassName",
+                docs[0],
+            )
             == "release-name-storage-class"
         )
 
@@ -896,14 +1005,24 @@ class TestScheduler:
     def test_scheduler_template_storage_size(self):
         docs = render_chart(
             values={
-                "workers": {"celery": {"persistence": {"size": "50Gi"}}},
-                "logs": {"persistence": {"enabled": False}},
                 "executor": "LocalExecutor",
+                "logs": {"persistence": {"enabled": False}},
+                "scheduler": {
+                    "persistence": {
+                        "enabled": True,
+                        "size": "50Gi",
+                    }
+                },
             },
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
+
         assert (
-            jmespath.search("spec.volumeClaimTemplates[0].spec.resources.requests.storage", docs[0]) == "50Gi"
+            jmespath.search(
+                "spec.volumeClaimTemplates[0].spec.resources.requests.storage",
+                docs[0],
+            )
+            == "50Gi"
         )
 
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3386,8 +3386,54 @@
                         "exec airflow scheduler"
                     ]
                 },
+                "persistence": {
+                    "description": "Persistence configuration for the scheduler when using a local executor. Unset values fall back to workers.celery.persistence for backward compatibility.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable persistent volumes. If unset, workers.celery.persistence.enabled is used.",
+                            "type": [
+                                "boolean",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "persistentVolumeClaimRetentionPolicy": {
+                            "$ref": "#/definitions/persistentVolumeClaimRetentionPolicy",
+                            "description": "PersistentVolumeClaim retention policy for the scheduler StatefulSet. If unset, workers.celery.persistence.persistentVolumeClaimRetentionPolicy is used."
+                        },
+                        "size": {
+                            "description": "Volume size for the scheduler StatefulSet. If unset, workers.celery.persistence.size is used.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": "100Gi"
+                        },
+                        "storageClassName": {
+                            "description": "StorageClass for the scheduler StatefulSet (templated). If unset, workers.celery.persistence.storageClassName is used.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
+                        },
+                        "annotations": {
+                            "description": "Annotations to add to scheduler volumes. If unset, workers.celery.persistence.annotations is used.",
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "updateStrategy": {
-                    "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a StatefulSet (when using LocalExecutor and workers.persistence).",
+                    "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a StatefulSet.",
                     "type": [
                         "null",
                         "object"
@@ -3395,7 +3441,7 @@
                     "default": null
                 },
                 "strategy": {
-                    "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a Deployment (when not using LocalExecutor and workers.persistence).",
+                    "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a Deployment.",
                     "type": [
                         "null",
                         "object"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3412,7 +3412,7 @@
                             "default": "100Gi"
                         },
                         "storageClassName": {
-                            "description": "StorageClass for the scheduler StatefulSet (templated). If unset, workers.celery.persistence.storageClassName is used.",
+                            "description": "StorageClass for the scheduler StatefulSet (templated). If unset, `workers.celery.persistence.storageClassName` is used.",
                             "type": [
                                 "string",
                                 "null"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3406,24 +3406,24 @@
                         "size": {
                             "description": "Volume size for the scheduler StatefulSet. If unset, workers.celery.persistence.size is used.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": "100Gi"
                         },
                         "storageClassName": {
                             "description": "StorageClass for the scheduler StatefulSet (templated). If unset, `workers.celery.persistence.storageClassName` is used.",
                             "type": [
-                                "string",
-                                "null"
+                                "null",
+                                "string"
                             ],
                             "default": null
                         },
                         "annotations": {
                             "description": "Annotations to add to scheduler volumes. If unset, workers.celery.persistence.annotations is used.",
                             "type": [
-                                "object",
-                                "null"
+                                "null",
+                                "object"
                             ],
                             "default": {},
                             "additionalProperties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1224,11 +1224,33 @@ scheduler:
   # Args to use when running the Airflow scheduler (templated).
   args: ["bash", "-c", "exec airflow scheduler"]
 
+  # Persistence configuration for the scheduler when using a local executor.
+  # When enabled is unset, workers.celery.persistence is used for backward compatibility.
+  persistence:
+    # Enable persistent volumes.
+    enabled: ~
+
+    # This policy determines whether PVCs should be deleted
+    # when the StatefulSet is scaled down or removed.
+    persistentVolumeClaimRetentionPolicy: ~
+    # persistentVolumeClaimRetentionPolicy:
+    #   whenDeleted: Delete
+    #   whenScaled: Delete
+
+    # Volume size for the scheduler StatefulSet.
+    size: 100Gi
+
+    # If using a custom StorageClass, pass its name here.
+    storageClassName: ~
+
+    # Annotations to add to scheduler volumes.
+    annotations: {}
+
   # Update Strategy when scheduler is deployed as a StatefulSet
-  # (when using LocalExecutor and `workers.persistence`)
+  # (when using a local executor and `scheduler.persistence.enabled`)
   updateStrategy: ~
   # Update Strategy when scheduler is deployed as a Deployment
-  # (when not using LocalExecutor and `workers.persistence`)
+  # (when not using a local executor or when `scheduler.persistence.enabled` is false)
   strategy: ~
 
   # Detailed default security context for scheduler Deployments for container and pod level


### PR DESCRIPTION
This PR decouples scheduler persistence configuration from
`workers.celery.persistence` by introducing `scheduler.persistence`.

When `scheduler.persistence.enabled` is explicitly set, the scheduler uses its
own persistence configuration to determine whether it should be rendered as a
StatefulSet and to configure its PVC.

For backward compatibility, when `scheduler.persistence.enabled` is unset, the
scheduler continues to use `workers.celery.persistence`.

The scheduler Helm tests were updated to cover:

* Backward compatibility with the existing Celery persistence configuration
* Independence between scheduler and Celery persistence settings
* Scheduler StatefulSet and Deployment strategies
* PVC size, annotations, StorageClass, and retention policy

Tested with:

```bash
breeze run pytest chart/tests/helm_tests/airflow_core/test_scheduler.py -q
```

closes: #70784

---

##### Was generative AI tooling used to co-author this PR?

* [x] Yes 

---

* Read the **[[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([[AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [[ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x)](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [[airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments)](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.