### PR TITLE
[v3-3-test] Remove duplicate tests in Task SDK (#68504)

### DIFF
--- a/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
+++ b/task-sdk/tests/task_sdk/definitions/test_taskgroup.py
@@ -272,40 +272,6 @@ def test_taskgroup_getitem_returns_child_by_label(prefix: bool):
         group1["nonexistent"]
 
 
-def test_build_task_group_with_prefix_functionality():
-    """
-    Tests TaskGroup prefix_group_id functionality - additional test for comprehensive coverage.
-    """
-    logical_date = pendulum.parse("20200101")
-    with DAG("test_prefix_functionality", start_date=logical_date):
-        task1 = EmptyOperator(task_id="task1")
-        with TaskGroup("group234", prefix_group_id=False) as group234:
-            task2 = EmptyOperator(task_id="task2")
-
-            with TaskGroup("group34") as group34:
-                task3 = EmptyOperator(task_id="task3")
-
-                with TaskGroup("group4", prefix_group_id=False) as group4:
-                    task4 = EmptyOperator(task_id="task4")
-
-        task5 = EmptyOperator(task_id="task5")
-        task1 >> group234
-        group34 >> task5
-
-    # Test prefix_group_id behavior
-    assert task2.task_id == "task2"  # prefix_group_id=False, so no prefix
-    assert group34.group_id == "group34"  # nested group gets prefixed
-    assert task3.task_id == "group34.task3"  # task in nested group gets full prefix
-    assert group4.group_id == "group34.group4"  # nested group gets parent prefix
-    assert task4.task_id == "task4"  # prefix_group_id=False, so no prefix
-    assert task5.task_id == "task5"  # root level task, no prefix
-
-    # Test group hierarchy and child access
-    assert group234.get_child_by_label("task2") == task2
-    assert group234.get_child_by_label("group34") == group34
-    assert group4.get_child_by_label("task4") == task4
-
-
 def test_build_task_group_with_task_decorator():
     """
     Test that TaskGroup can be used with the @task decorator.
@@ -577,24 +543,6 @@ def test_iter_tasks():
         "section_2.task3",
         "section_2.bash_task",
     ]
-
-
-def test_override_dag_default_args():
-    logical_date = pendulum.parse("20201109")
-    with DAG(
-        dag_id="example_task_group_default_args",
-        schedule=None,
-        start_date=logical_date,
-        default_args={"owner": "dag"},
-    ):
-        with TaskGroup("group1", default_args={"owner": "group"}):
-            task_1 = EmptyOperator(task_id="task_1")
-            task_2 = EmptyOperator(task_id="task_2", owner="task")
-            task_3 = EmptyOperator(task_id="task_3", default_args={"owner": "task"})
-
-            assert task_1.owner == "group"
-            assert task_2.owner == "task"
-            assert task_3.owner == "task"
 
 
 def test_override_dag_default_args_in_nested_tg():

--- a/task-sdk/tests/task_sdk/execution_time/test_comms.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_comms.py
@@ -61,16 +61,6 @@ class TestCommsModels:
         mask_secret_object = MaskSecret(value=object_to_mask, name="test_secret")
         assert mask_secret_object.value == object_to_mask
 
-    def test_mask_secret_with_list(self):
-        example_dict = ["test"]
-        mask_secret_object = MaskSecret(value=example_dict, name="test_secret")
-        assert mask_secret_object.value == example_dict
-
-    def test_mask_secret_with_iterable(self):
-        example_dict = ["test"]
-        mask_secret_object = MaskSecret(value=example_dict, name="test_secret")
-        assert mask_secret_object.value == example_dict
-
 
 class TestCommsDecoder:
     """Test the communication between the subprocess and the "supervisor"."""


### PR DESCRIPTION
Backport of #68504 to `v3-3-test`. Clean `git cherry-pick -x`. Removes exact/near-exact duplicate tests in the Task SDK (test-only, `changelog:skip`); keeps the branches' test suites in sync to reduce future cherry-pick drift.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — clean cherry-pick backport.