### PR TITLE
Fix wtforms-mocking condition

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/connections.py
@@ -153,14 +153,14 @@ class HookMetaService:
         ]:
             try:
                 if not find_spec(mod_name):
-                    raise ModuleNotFoundError
+                    raise ModuleNotFoundError(f"No module named {mod_name!r}", name=mod_name)
             except ModuleNotFoundError:
                 sys.modules[mod_name] = MagicMock()
 
         # We conditionally inject mock classes for missing dependencies
         # to ensure `ProvidersManager` can initialize hook connection widgets
         # without crashing when FAB/WTForms are not installed.
-        if "wtforms.StringField" not in sys.modules:
+        if isinstance(sys.modules.get("wtforms"), MagicMock):
             # Only apply mocks if the actual module wasn't loaded beforehand.
             # This avoids thread-safety issues caused by `unittest.mock.patch` mutating global states.
             with (


### PR DESCRIPTION
The previous code (introduced in #63986)

    "wtforms.StringField" not in sys.modules

always evaluates to True because StringField is not a module, and is never present in sys.modules even if wtforms IS installed and imported.

Judging from surrounding code, I think the original intention is to only patch if wtforms is not installed (and thuse a MagicMock was injected in the previous block). This changes the check to reflect my assumed intention.

I also tightened the custom ModuleNotFoundError a bit to carry more useful information.

cc @Subham-KRLX