### PR TITLE
Upgrade react-resizable-panels to v4

### DIFF
--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -63,7 +63,7 @@
     "react-icons": "^5.7.0",
     "react-innertext": "^1.1.5",
     "react-markdown": "^10.1.0",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "^4.12.1",
     "react-router-dom": "^7.18.2",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-katex": "^7.0.1",

--- a/airflow-core/src/airflow/ui/package.json
+++ b/airflow-core/src/airflow/ui/package.json
@@ -63,7 +63,7 @@
     "react-icons": "^5.7.0",
     "react-innertext": "^1.1.5",
     "react-markdown": "^9.1.0",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "^4.12.1",
     "react-router-dom": "^7.18.1",
     "react-syntax-highlighter": "^15.6.1",
     "rehype-katex": "^7.0.1",

--- a/airflow-core/src/airflow/ui/pnpm-lock.yaml
+++ b/airflow-core/src/airflow/ui/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
       react-resizable-panels:
-        specifier: ^3.0.6
-        version: 3.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^4.12.1
+        version: 4.12.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-router-dom:
         specifier: ^7.18.2
         version: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3839,11 +3839,11 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-resizable-panels@3.0.6:
-    resolution: {integrity: sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==}
+  react-resizable-panels@4.12.3:
+    resolution: {integrity: sha512-GHMJWnDXui/3RX4bT+cgBP+N3N2nkwcoZATr/2xLFpqQQe7TlBrE0cGM0dUa9ceT7A90tUrSRsiqgRG+g0/2AA==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-router-dom@7.18.2:
     resolution: {integrity: sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==}
@@ -8969,7 +8969,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-resizable-panels@3.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-resizable-panels@4.12.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)

--- a/airflow-core/src/airflow/ui/pnpm-lock.yaml
+++ b/airflow-core/src/airflow/ui/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0(@types/react@19.2.17)(react@19.2.8)
       react-resizable-panels:
-        specifier: ^3.0.6
-        version: 3.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^4.12.1
+        version: 4.12.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-router-dom:
         specifier: ^7.18.1
         version: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -3887,11 +3887,11 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
-  react-resizable-panels@3.0.6:
-    resolution: {integrity: sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==}
+  react-resizable-panels@4.12.2:
+    resolution: {integrity: sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
@@ -9152,7 +9152,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-resizable-panels@3.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-resizable-panels@4.12.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -24,12 +24,7 @@ import { useReactFlow } from "@xyflow/react";
 import { useTranslation } from "react-i18next";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { LuFileWarning } from "react-icons/lu";
-import {
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-  type ImperativePanelGroupHandle,
-} from "react-resizable-panels";
+import { Group, Panel, Separator, useDefaultLayout, useGroupRef } from "react-resizable-panels";
 import { Outlet, useParams, useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
@@ -97,7 +92,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
   const { dagId = "", runId } = useParams();
   const { data: dag } = useDagServiceGetDag({ dagId });
   const [dagView, setDagView] = useLocalStorage<DagView>(DEFAULT_DAG_VIEW_KEY, "grid");
-  const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
+  const panelGroupRef = useGroupRef();
   // Root for the delegated grid/gantt crosshair-hover handler (covers both the
   // grid and the gantt so their shared row highlight stays in sync, with no
   // React re-render on hover).
@@ -222,6 +217,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
   const panelViewKey = dagView === "gantt" ? "grid" : dagView;
   const minSize = dagView === "gantt" && Boolean(runId) ? 35 : 6;
   const defaultSize = Math.max(dagView === "graph" ? 70 : 20, minSize);
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({ id: `${panelViewKey}-${direction}` });
 
   return (
     <GroupsProvider dagId={dagId}>
@@ -271,14 +267,24 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
               {direction === "ltr" ? <FaChevronLeft /> : <FaChevronRight />}
             </IconButton>
           ) : undefined}
-          <PanelGroup
-            autoSaveId={`${panelViewKey}-${direction}`}
+          <Group
+            defaultLayout={defaultLayout}
             dir={direction}
-            direction="horizontal"
+            groupRef={panelGroupRef}
             key={`${panelViewKey}-${direction}`}
-            ref={panelGroupRef}
+            onLayoutChanged={(layout, meta) => {
+              onLayoutChanged(layout, meta);
+              // Programmatic setLayout() from PanelButtons handles its own fit-view; only
+              // fit here for user-driven resizes, otherwise the two callers double-fit.
+              if (meta.isUserInteraction) {
+                const zoom = getZoom();
+
+                void fitView({ maxZoom: zoom, minZoom: zoom });
+              }
+            }}
+            orientation="horizontal"
           >
-            <Panel defaultSize={defaultSize} id="main-panel" minSize={minSize} order={1}>
+            <Panel defaultSize={defaultSize} id="main-panel" minSize={minSize}>
               <Flex
                 bg={dagView === "graph" ? undefined : "bg.muted"}
                 borderColor="bg.muted"
@@ -374,16 +380,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
             </Panel>
             {!isRightPanelCollapsed && (
               <>
-                <PanelResizeHandle
-                  className="resize-handle"
-                  onDragging={(isDragging) => {
-                    if (!isDragging) {
-                      const zoom = getZoom();
-
-                      void fitView({ maxZoom: zoom, minZoom: zoom });
-                    }
-                  }}
-                >
+                <Separator className="resize-handle">
                   <Box
                     _hover={{ bg: "info.solid" }}
                     alignItems="center"
@@ -412,9 +409,9 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                       {direction === "ltr" ? <FaChevronRight /> : <FaChevronLeft />}
                     </IconButton>
                   </Box>
-                </PanelResizeHandle>
+                </Separator>
 
-                <Panel defaultSize={dagView === "graph" ? 30 : 80} id="details-panel" minSize={20} order={2}>
+                <Panel defaultSize={dagView === "graph" ? 30 : 80} id="details-panel" minSize={20}>
                   <Box
                     display="flex"
                     flexDirection="column"
@@ -454,7 +451,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                 </Panel>
               </>
             )}
-          </PanelGroup>
+          </Group>
         </Box>
       </Box>
     </GroupsProvider>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/DetailsLayout.tsx
@@ -23,12 +23,7 @@ import type { PropsWithChildren, ReactNode, RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { LuFileWarning } from "react-icons/lu";
-import {
-  type ImperativePanelGroupHandle,
-  Panel,
-  PanelGroup,
-  PanelResizeHandle,
-} from "react-resizable-panels";
+import { Group, Panel, Separator, useDefaultLayout, useGroupRef } from "react-resizable-panels";
 import { Outlet, useParams, useSearchParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
@@ -93,7 +88,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
   const { dagId = "", runId } = useParams();
   const { data: dag } = useDagServiceGetDag({ dagId });
   const [dagView, setDagView] = useLocalStorage<DagView>(DEFAULT_DAG_VIEW_KEY, "grid");
-  const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
+  const panelGroupRef = useGroupRef();
   // Root for the delegated grid/gantt crosshair-hover handler (covers both the
   // grid and the gantt so their shared row highlight stays in sync, with no
   // React re-render on hover).
@@ -218,6 +213,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
   const panelViewKey = dagView === "gantt" ? "grid" : dagView;
   const minSize = dagView === "gantt" && Boolean(runId) ? 35 : 6;
   const defaultSize = Math.max(dagView === "graph" ? 70 : 20, minSize);
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({ id: `${panelViewKey}-${direction}` });
 
   return (
     <GroupsProvider dagId={dagId}>
@@ -260,14 +256,24 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
               {direction === "ltr" ? <FaChevronLeft /> : <FaChevronRight />}
             </IconButton>
           ) : undefined}
-          <PanelGroup
-            autoSaveId={`${panelViewKey}-${direction}`}
+          <Group
+            defaultLayout={defaultLayout}
             dir={direction}
-            direction="horizontal"
+            groupRef={panelGroupRef}
             key={`${panelViewKey}-${direction}`}
-            ref={panelGroupRef}
+            onLayoutChanged={(layout, meta) => {
+              onLayoutChanged(layout, meta);
+              // Programmatic setLayout() from PanelButtons handles its own fit-view; only
+              // fit here for user-driven resizes, otherwise the two callers double-fit.
+              if (meta.isUserInteraction) {
+                const zoom = getZoom();
+
+                void fitView({ maxZoom: zoom, minZoom: zoom });
+              }
+            }}
+            orientation="horizontal"
           >
-            <Panel defaultSize={defaultSize} id="main-panel" minSize={minSize} order={1}>
+            <Panel defaultSize={defaultSize} id="main-panel" minSize={minSize}>
               <Flex flexDirection="column" height="100%">
                 <PanelButtons
                   dagView={dagView}
@@ -342,16 +348,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
             </Panel>
             {!isRightPanelCollapsed && (
               <>
-                <PanelResizeHandle
-                  className="resize-handle"
-                  onDragging={(isDragging) => {
-                    if (!isDragging) {
-                      const zoom = getZoom();
-
-                      void fitView({ maxZoom: zoom, minZoom: zoom });
-                    }
-                  }}
-                >
+                <Separator className="resize-handle">
                   <Box
                     alignItems="center"
                     bg="border.emphasized"
@@ -379,9 +376,9 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                       {direction === "ltr" ? <FaChevronRight /> : <FaChevronLeft />}
                     </IconButton>
                   </Box>
-                </PanelResizeHandle>
+                </Separator>
 
-                <Panel defaultSize={dagView === "graph" ? 30 : 80} id="details-panel" minSize={20} order={2}>
+                <Panel defaultSize={dagView === "graph" ? 30 : 80} id="details-panel" minSize={20}>
                   <Box
                     display="flex"
                     flexDirection="column"
@@ -421,7 +418,7 @@ export const DetailsLayout = ({ children, error, isLoading, outletContext, tabs 
                 </Panel>
               </>
             )}
-          </PanelGroup>
+          </Group>
         </Box>
       </Box>
     </GroupsProvider>

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -33,7 +33,7 @@ import { useTranslation } from "react-i18next";
 import { FiGrid } from "react-icons/fi";
 import { LuChartGantt } from "react-icons/lu";
 import { MdOutlineAccountTree, MdSettings } from "react-icons/md";
-import type { ImperativePanelGroupHandle } from "react-resizable-panels";
+import type { GroupImperativeHandle } from "react-resizable-panels";
 import { useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
@@ -66,7 +66,7 @@ import { VersionIndicatorSelect } from "./VersionIndicatorSelect";
 type Props = {
   readonly dagView: DagView;
   readonly limit: number;
-  readonly panelGroupRef: RefObject<ImperativePanelGroupHandle | null>;
+  readonly panelGroupRef: RefObject<GroupImperativeHandle | null>;
   readonly setDagView: (value: DagView) => void;
   readonly setLimit: (value: number) => void;
   readonly setShowVersionIndicatorMode: Dispatch<SetStateAction<VersionIndicatorOptions>>;
@@ -150,7 +150,10 @@ export const PanelButtons = ({
 
   const handleFocus = (view: string) => {
     if (panelGroupRef.current) {
-      const newLayout = view === "graph" ? [70, 30] : [30, 70];
+      const newLayout =
+        view === "graph"
+          ? { "details-panel": 30, "main-panel": 70 }
+          : { "details-panel": 70, "main-panel": 30 };
 
       panelGroupRef.current.setLayout(newLayout);
       // Used setTimeout to ensure DOM has been updated

--- a/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/PanelButtons.tsx
@@ -32,7 +32,7 @@ import { useTranslation } from "react-i18next";
 import { FiGrid } from "react-icons/fi";
 import { LuChartGantt } from "react-icons/lu";
 import { MdOutlineAccountTree, MdSettings } from "react-icons/md";
-import type { ImperativePanelGroupHandle } from "react-resizable-panels";
+import type { GroupImperativeHandle } from "react-resizable-panels";
 import { useParams } from "react-router-dom";
 import { useLocalStorage } from "usehooks-ts";
 
@@ -58,7 +58,7 @@ import { VersionIndicatorSelect } from "./VersionIndicatorSelect";
 type Props = {
   readonly dagView: DagView;
   readonly limit: number;
-  readonly panelGroupRef: React.RefObject<ImperativePanelGroupHandle | null>;
+  readonly panelGroupRef: React.RefObject<GroupImperativeHandle | null>;
   readonly setDagView: (value: DagView) => void;
   readonly setLimit: (value: number) => void;
   readonly setShowVersionIndicatorMode: React.Dispatch<React.SetStateAction<VersionIndicatorOptions>>;
@@ -125,7 +125,10 @@ export const PanelButtons = ({
 
   const handleFocus = (view: string) => {
     if (panelGroupRef.current) {
-      const newLayout = view === "graph" ? [70, 30] : [30, 70];
+      const newLayout =
+        view === "graph"
+          ? { "details-panel": 30, "main-panel": 70 }
+          : { "details-panel": 70, "main-panel": 30 };
 
       panelGroupRef.current.setLayout(newLayout);
       // Used setTimeout to ensure DOM has been updated

--- a/airflow-core/src/airflow/ui/src/pages/Asset/AssetLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/AssetLayout.tsx
@@ -22,7 +22,7 @@ import { Box, Code, HStack, Text } from "@chakra-ui/react";
 import { useReactFlow } from "@xyflow/react";
 import { useTranslation } from "react-i18next";
 import { MdOutlineStorage, MdTimeline } from "react-icons/md";
-import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { Outlet, useParams } from "react-router-dom";
 
 import { useAssetServiceGetAsset } from "openapi/queries";
@@ -60,6 +60,8 @@ export const AssetLayout = () => {
 
   const { fitView, getZoom } = useReactFlow();
 
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({ id: `asset-${direction}` });
+
   const externalTabs = usePluginTabs("asset");
 
   const tabs = [
@@ -88,13 +90,21 @@ export const AssetLayout = () => {
       </HStack>
       <ProgressBar size="xs" visibility={Boolean(isLoading) ? "visible" : "hidden"} />
       <Box flex={1} minH={0}>
-        <PanelGroup
-          autoSaveId={`asset-${direction}`}
+        <Group
+          defaultLayout={defaultLayout}
           dir={direction}
-          direction="horizontal"
           key={`asset-${direction}`}
+          onLayoutChanged={(layout, meta) => {
+            onLayoutChanged(layout, meta);
+            if (meta.isUserInteraction) {
+              const zoom = getZoom();
+
+              void fitView({ maxZoom: zoom, minZoom: zoom });
+            }
+          }}
+          orientation="horizontal"
         >
-          <Panel defaultSize={70} minSize={6}>
+          <Panel defaultSize={70} id="asset-graph" minSize={6}>
             <Box
               borderColor="bg.muted"
               borderRadius="md"
@@ -109,16 +119,7 @@ export const AssetLayout = () => {
               </GroupsProvider>
             </Box>
           </Panel>
-          <PanelResizeHandle
-            className="resize-handle"
-            onDragging={(isDragging) => {
-              if (!isDragging) {
-                const zoom = getZoom();
-
-                void fitView({ maxZoom: zoom, minZoom: zoom });
-              }
-            }}
-          >
+          <Separator className="resize-handle">
             <Box
               _hover={{ bg: "info.solid" }}
               borderRadius="full"
@@ -127,8 +128,8 @@ export const AssetLayout = () => {
               mb={3}
               w={1}
             />
-          </PanelResizeHandle>
-          <Panel defaultSize={30} minSize={20}>
+          </Separator>
+          <Panel defaultSize={30} id="asset-details" minSize={20}>
             <Box
               display="flex"
               flexDirection="column"
@@ -160,7 +161,7 @@ export const AssetLayout = () => {
               <Outlet />
             </Box>
           </Panel>
-        </PanelGroup>
+        </Group>
       </Box>
     </>
   );

--- a/airflow-core/src/airflow/ui/src/pages/Asset/AssetLayout.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/AssetLayout.tsx
@@ -21,7 +21,7 @@ import { useReactFlow } from "@xyflow/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MdOutlineStorage, MdTimeline } from "react-icons/md";
-import { PanelGroup, Panel, PanelResizeHandle } from "react-resizable-panels";
+import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { Outlet, useParams } from "react-router-dom";
 
 import { useAssetServiceGetAsset } from "openapi/queries";
@@ -63,6 +63,8 @@ export const AssetLayout = () => {
 
   const { fitView, getZoom } = useReactFlow();
 
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({ id: `asset-${direction}` });
+
   const externalTabs = usePluginTabs("asset");
 
   const tabs = [
@@ -83,13 +85,21 @@ export const AssetLayout = () => {
       </HStack>
       <ProgressBar size="xs" visibility={Boolean(isLoading) ? "visible" : "hidden"} />
       <Box flex={1} minH={0}>
-        <PanelGroup
-          autoSaveId={`asset-${direction}`}
+        <Group
+          defaultLayout={defaultLayout}
           dir={direction}
-          direction="horizontal"
           key={`asset-${direction}`}
+          onLayoutChanged={(layout, meta) => {
+            onLayoutChanged(layout, meta);
+            if (meta.isUserInteraction) {
+              const zoom = getZoom();
+
+              void fitView({ maxZoom: zoom, minZoom: zoom });
+            }
+          }}
+          orientation="horizontal"
         >
-          <Panel defaultSize={70} minSize={6}>
+          <Panel defaultSize={70} id="asset-graph" minSize={6}>
             <Box height="100%" position="relative" pr={2}>
               <AssetPanelButtons dependencyType={dependencyType} setDependencyType={setDependencyType} />
               <GroupsProvider dagId="~">
@@ -97,19 +107,10 @@ export const AssetLayout = () => {
               </GroupsProvider>
             </Box>
           </Panel>
-          <PanelResizeHandle
-            className="resize-handle"
-            onDragging={(isDragging) => {
-              if (!isDragging) {
-                const zoom = getZoom();
-
-                void fitView({ maxZoom: zoom, minZoom: zoom });
-              }
-            }}
-          >
+          <Separator className="resize-handle">
             <Box bg="fg.subtle" cursor="col-resize" h="100%" transition="background 0.2s" w={0.5} />
-          </PanelResizeHandle>
-          <Panel defaultSize={30} minSize={20}>
+          </Separator>
+          <Panel defaultSize={30} id="asset-details" minSize={20}>
             <Header asset={asset} />
             {asset?.extra && Object.keys(asset.extra).length > 0 ? (
               <Box mb={3} mt={3} px={3}>
@@ -134,7 +135,7 @@ export const AssetLayout = () => {
             <NavTabs tabs={tabs} />
             <Outlet />
           </Panel>
-        </PanelGroup>
+        </Group>
       </Box>
     </>
   );


### PR DESCRIPTION
Third of the deferred items from #70777.

v4 rewrites the public API: `PanelGroup` → `Group`, `PanelResizeHandle` → `Separator`, `direction` → `orientation`, `autoSaveId` → the `useDefaultLayout({ id })` hook, `ref` → `groupRef` (via `useGroupRef`), `ImperativePanelGroupHandle` → `GroupImperativeHandle`. `onDragging` is gone from `Separator` — the drag-end "refit graph zoom" behavior in `DetailsLayout` and `AssetLayout` now runs from `Group`'s `onLayoutChanged`, branching on `meta.isUserInteraction` so `PanelButtons`' programmatic `setLayout` doesn't double-fit. `Panel`'s `order` prop is gone (source order is used). `setLayout` now takes a `{ [panelId]: percentage }` map instead of an ordered array.

v4's `readLegacyLayout` transparently migrates the v3 `localStorage` entries on first load, so users' remembered panel widths survive the upgrade.

`AssetLayout` panels get stable `id="asset-graph"` / `id="asset-details"` because v4 keys persistence by panel id — without explicit ids, `useId`-generated values change across reloads and layout wouldn't restore.

## Screenshots

Verified locally (breeze + `react-resizable-panels@4`) that the resizable panels still work in every place that uses the lib — Dag details (`DetailsLayout` / `PanelButtons`) and the Asset detail page (`AssetLayout`):

**Dag details — grid view (resizable split)**

![Dag details grid view split](https://raw.githubusercontent.com/astronomer/airflow/pr-70820-screenshots/01-dag-grid-split.png)

**Dag details — graph view (resizable split)**

![Dag details graph view split](https://raw.githubusercontent.com/astronomer/airflow/pr-70820-screenshots/02-dag-graph-split.png)

**Dragging the divider resizes the panels, and the graph re-fits via `onLayoutChanged`**

![Dag details after resize](https://raw.githubusercontent.com/astronomer/airflow/pr-70820-screenshots/03-dag-graph-resized.png)

**Asset detail — dependency graph / details (resizable split)**

![Asset detail split](https://raw.githubusercontent.com/astronomer/airflow/pr-70820-screenshots/04-asset-split.png)

**RTL (Arabic) — the layout mirrors correctly (graph/main panel on the right, details on the left, collapse chevrons flipped) and resizing still works**

`useDefaultLayout`'s id includes the direction (`${view}-${direction}` / `asset-${direction}`), so LTR and RTL persist independent layouts.

![Dag details graph view, RTL](https://raw.githubusercontent.com/astronomer/airflow/pr-70820-screenshots/rtl-01-graph.png)

![Asset detail split, RTL](https://raw.githubusercontent.com/astronomer/airflow/pr-70820-screenshots/rtl-03-asset.png)

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.7)

Generated-by: Claude Code (Opus 4.7) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
