### PR TITLE
Fix flaky secrets masking test in LLMRetryPolicy

### DIFF
--- a/providers/common/ai/tests/unit/common/ai/policies/test_retry.py
+++ b/providers/common/ai/tests/unit/common/ai/policies/test_retry.py
@@ -29,6 +29,7 @@ from airflow.providers.common.ai.policies.retry import (
     ErrorClassification,
     LLMRetryPolicy,
 )
+from airflow.sdk._shared.secrets_masker import reset_secrets_masker
 from airflow.sdk.definitions.retry_policy import RetryAction, RetryRule
 from airflow.sdk.log import mask_secret
 
@@ -112,6 +113,7 @@ class TestLLMClassifyDecisions:
     @pytest.mark.enable_redact
     @patch("airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook", autospec=True)
     def test_prompt_redacts_known_secrets(self, mock_hook_cls):
+        reset_secrets_masker()
         secret_value = "super-secret-conn-password"
         mask_secret(secret_value)
 
@@ -135,7 +137,7 @@ class TestLLMClassifyDecisions:
     @pytest.mark.enable_redact
     @patch("airflow.providers.common.ai.hooks.pydantic_ai.PydanticAIHook", autospec=True)
     def test_prompt_keeps_raw_message_when_redaction_disabled(self, mock_hook_cls):
-
+        reset_secrets_masker()
         secret_value = "super-secret-conn-password"
         mask_secret(secret_value)
 


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Noticed in https://github.com/apache/airflow/actions/runs/30607586996/job/91085236442?pr=68997

Error:
```shell
FAILED providers/common/ai/tests/unit/common/ai/policies/test_retry.py::TestLLMClassifyDecisions::test_prompt_redacts_known_secrets - AssertionError: assert equals failed
  'Classify this error from a data pipeline task (attempt 1 of 3):\n\nConnectionError: could n  'Classify this error from a data pipeline task (attempt 1 of 3):\n\nConnectionError: could n 
  ot authenticate with *** ***'                                                                 ot authenticate with password ***'
```

`test_prompt_redacts_known_secrets` and `test_prompt_keeps_raw_message_when_redaction_disabled` register a secret against the process wide secrets masker singleton, which persists for the lifetime of the test process. When another test earlier in the same worker registers "password" as a masked value (a very common test fixture default), it leaks into these tests and masks more than the secret they registered, breaking the exact-match assertion. Resetting the masker at the start of each test isolates it from whatever ran before it in the same process.



---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
