### PR TITLE
[v3-3-test] Triggerer: Strengthen Triggerer Metric Test Coverage (#68545)

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -2965,7 +2965,12 @@ def test_handle_events_does_not_confirm_seq_when_persist_fails(jobless_superviso
 def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_tags):
     """triggers.succeeded carries the triggerer's team_name (omitted when the triggerer has none)."""
     jobless_supervisor.team_name = team_name
-    jobless_supervisor.events.append(TriggerEventEntry(1, TriggerEvent(True), 7))
+    jobless_supervisor.events.extend(
+        [
+            TriggerEventEntry(1, TriggerEvent(True), 7),
+            TriggerEventEntry(2, TriggerEvent(True), 8),
+        ]
+    )
 
     with (
         mock.patch.object(TriggerRunnerSupervisor, "on_trigger_event", autospec=True),
@@ -2973,7 +2978,13 @@ def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_t
     ):
         jobless_supervisor.handle_events()
 
-    mock_incr.assert_called_once_with("triggers.succeeded", tags=expected_tags)
+    mock_incr.assert_has_calls(
+        [
+            mock.call("triggers.succeeded", tags=expected_tags),
+            mock.call("triggers.succeeded", tags=expected_tags),
+        ]
+    )
+    assert mock_incr.call_count == 2
 
 
 @pytest.mark.parametrize(
@@ -2986,7 +2997,12 @@ def test_handle_events_emits_team_name(jobless_supervisor, team_name, expected_t
 def test_handle_failed_triggers_emits_team_name(jobless_supervisor, team_name, expected_tags):
     """triggers.failed carries the triggerer's team_name (omitted when the triggerer has none)."""
     jobless_supervisor.team_name = team_name
-    jobless_supervisor.failed_triggers.append((1, None))
+    jobless_supervisor.failed_triggers.extend(
+        [
+            (1, Exception("failure one")),
+            (2, Exception("failure two")),
+        ]
+    )
 
     with (
         mock.patch.object(TriggerRunnerSupervisor, "on_trigger_failure", autospec=True),
@@ -2994,7 +3010,13 @@ def test_handle_failed_triggers_emits_team_name(jobless_supervisor, team_name, e
     ):
         jobless_supervisor.handle_failed_triggers()
 
-    mock_incr.assert_called_once_with("triggers.failed", tags=expected_tags)
+    mock_incr.assert_has_calls(
+        [
+            mock.call("triggers.failed", tags=expected_tags),
+            mock.call("triggers.failed", tags=expected_tags),
+        ]
+    )
+    assert mock_incr.call_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Backport of #68545 to `v3-3-test`. Clean `git cherry-pick -x`. Test-only: strengthens triggerer metric test coverage.
##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — clean cherry-pick backport.