### PR TITLE
[v3-3-test] Add `has_note` key to the API response for TI to render saved note indicator in Airflow 3 Grid View UI (#68979)

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/ui/grid.py
@@ -34,6 +34,7 @@ class LightGridTaskInstanceSummary(BaseModel):
     min_start_date: datetime | None
     max_end_date: datetime | None
     dag_version_number: int | None = None
+    has_note: bool = False
 
 
 class GridTISummaries(BaseModel):

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/_private_ui.yaml
@@ -3130,6 +3130,10 @@ components:
           - type: integer
           - type: 'null'
           title: Dag Version Number
+        has_note:
+          type: boolean
+          title: Has Note
+          default: false
       type: object
       required:
       - task_id

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/ui/grid.py
@@ -72,7 +72,7 @@ from airflow.models.dag_version import DagVersion
 from airflow.models.dagrun import DagRun
 from airflow.models.deadline import Deadline
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, TaskInstanceNote
 from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
@@ -419,6 +419,7 @@ def _build_ti_summaries(
             start_date=ti.start_date,
             end_date=ti.end_date,
             dag_version_number=getattr(ti, "version_number", None),
+            has_note=bool(getattr(ti, "has_note", False)),
         )
     if not ti_details:
         return None
@@ -513,6 +514,13 @@ def get_grid_ti_summaries_stream(
         # database connection open for the entire stream duration.
         # See https://github.com/apache/airflow/issues/65010.
 
+        has_note_subq = (
+            exists()
+            .where(TaskInstanceNote.ti_id == TaskInstance.id)
+            .correlate(TaskInstance)
+            .label("has_note")
+        )
+
         for run_id in run_ids or []:
             with create_session(scoped=False) as session:
                 tis = session.execute(
@@ -523,6 +531,7 @@ def get_grid_ti_summaries_stream(
                         TaskInstance.start_date,
                         TaskInstance.end_date,
                         DagVersion.version_number,
+                        has_note_subq,
                     )
                     .outerjoin(DagVersion, TaskInstance.dag_version_id == DagVersion.id)
                     .where(TaskInstance.dag_id == dag_id)

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/grid.py
@@ -43,6 +43,7 @@ class GridNodeAgg:
     min_start_date: datetime | None = None
     max_end_date: datetime | None = None
     dag_version_number: int | None = None
+    has_note: bool = False
 
     def add_ti(
         self,
@@ -51,6 +52,7 @@ class GridNodeAgg:
         start_date: datetime | None,
         end_date: datetime | None,
         dag_version_number: int | None,
+        has_note: bool = False,
     ) -> None:
         """Merge one task instance row into the summary."""
         self.child_states[state] += 1
@@ -62,6 +64,7 @@ class GridNodeAgg:
             self.dag_version_number is None or dag_version_number > self.dag_version_number
         ):
             self.dag_version_number = dag_version_number
+        self.has_note = self.has_note or has_note
 
     def merge(self, other: GridNodeAgg) -> None:
         """Merge another summary into this one."""
@@ -78,6 +81,7 @@ class GridNodeAgg:
             self.dag_version_number is None or other.dag_version_number > self.dag_version_number
         ):
             self.dag_version_number = other.dag_version_number
+        self.has_note = self.has_note or other.has_note
 
     def with_placeholder_state(self) -> GridNodeAgg:
         """Represent mapped tasks without rows as a single no-status square in the grid."""
@@ -133,6 +137,7 @@ def _get_aggs_for_node(summary: GridNodeAgg) -> dict[str, Any]:
         "max_end_date": summary.max_end_date,
         "child_states": _serialize_child_states(summary.child_states),
         "dag_version_number": summary.dag_version_number,
+        "has_note": summary.has_note,
     }
 
 

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -9870,6 +9870,11 @@ export const $LightGridTaskInstanceSummary = {
                 }
             ],
             title: 'Dag Version Number'
+        },
+        has_note: {
+            type: 'boolean',
+            title: 'Has Note',
+            default: false
         }
     },
     type: 'object',

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -2497,6 +2497,7 @@ export type LightGridTaskInstanceSummary = {
     min_start_date: string | null;
     max_end_date: string | null;
     dag_version_number?: number | null;
+    has_note?: boolean;
 };
 
 /**

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/GridTI.tsx
@@ -24,8 +24,12 @@ import { StateIcon } from "src/components/StateIcon";
 import TaskInstanceTooltip from "src/components/TaskInstanceTooltip";
 import { buildTaskInstanceUrl } from "src/utils/links";
 
+const NOTE_GRADIENT =
+  "linear-gradient(45deg, var(--chakra-colors-color-palette-solid) 65%, var(--chakra-colors-color-palette-emphasized) 65%)";
+
 type Props = {
   readonly dagId: string;
+  readonly hasNote?: boolean;
   readonly instance: LightGridTaskInstanceSummary;
   readonly isGroup?: boolean;
   readonly isMapped?: boolean | null;
@@ -35,7 +39,16 @@ type Props = {
   readonly taskId: string;
 };
 
-export const GridTI = ({ dagId, instance, isGroup, isMapped, onClick, runId, taskId }: Props) => {
+export const GridTI = ({
+  dagId,
+  hasNote = false,
+  instance,
+  isGroup,
+  isMapped,
+  onClick,
+  runId,
+  taskId,
+}: Props) => {
   const { groupId: selectedGroupId, taskId: selectedTaskId } = useParams();
   const location = useLocation();
 
@@ -101,6 +114,7 @@ export const GridTI = ({ dagId, instance, isGroup, isMapped, onClick, runId, tas
               justifyContent="center"
               minH={0}
               p={0}
+              style={hasNote ? { background: NOTE_GRADIENT } : undefined}
               variant="solid"
               width="14px"
             >

--- a/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
+++ b/airflow-core/src/airflow/ui/src/layouts/Details/Grid/TaskInstancesColumn.tsx
@@ -145,6 +145,7 @@ export const TaskInstancesColumn = ({
             )}
             <GridTI
               dagId={dagId}
+              hasNote={taskInstance.has_note ?? false}
               instance={taskInstance}
               isGroup={node.isGroup}
               isMapped={node.is_mapped}

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_grid.py
@@ -30,7 +30,7 @@ from airflow._shared.timezones import timezone
 from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.models.dagbag import DBDagBag
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, TaskInstanceNote
 from airflow.providers.standard.operators.empty import EmptyOperator
 from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import task_group
@@ -771,6 +771,7 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "t1",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:00Z",
                     "min_start_date": "2025-03-01T23:59:58Z",
                 },
@@ -780,6 +781,7 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "t2",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:02Z",
                     "min_start_date": "2025-03-02T00:00:00Z",
                 },
@@ -789,12 +791,14 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "t7",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:04Z",
                     "min_start_date": "2025-03-02T00:00:02Z",
                 },
                 {
                     "child_states": {"success": 4},
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:12Z",
                     "min_start_date": "2025-03-02T00:00:04Z",
                     "state": "success",
@@ -807,12 +811,14 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "task_group-1.t6",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:06Z",
                     "min_start_date": "2025-03-02T00:00:04Z",
                 },
                 {
                     "child_states": {"success": 3},
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:12Z",
                     "min_start_date": "2025-03-02T00:00:06Z",
                     "state": "success",
@@ -825,6 +831,7 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "task_group-1.task_group-2.t3",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:08Z",
                     "min_start_date": "2025-03-02T00:00:06Z",
                 },
@@ -834,6 +841,7 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "task_group-1.task_group-2.t4",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:10Z",
                     "min_start_date": "2025-03-02T00:00:08Z",
                 },
@@ -843,6 +851,7 @@ class TestGetGridDataEndpoint:
                     "task_display_name": "task_group-1.task_group-2.t5",
                     "child_states": None,
                     "dag_version_number": 1,
+                    "has_note": False,
                     "max_end_date": "2025-03-02T00:00:12Z",
                     "min_start_date": "2025-03-02T00:00:10Z",
                 },
@@ -875,6 +884,7 @@ class TestGetGridDataEndpoint:
             {
                 "child_states": {"none": 1},
                 "dag_version_number": 1,
+                "has_note": False,
                 "task_id": "mapped_task_2",
                 "task_display_name": "mapped_task_2",
                 "max_end_date": None,
@@ -884,6 +894,7 @@ class TestGetGridDataEndpoint:
             {
                 "child_states": {"success": 1, "running": 1, "none": 1},
                 "dag_version_number": 1,
+                "has_note": False,
                 "max_end_date": "2024-12-30T01:02:03Z",
                 "min_start_date": "2024-12-30T01:00:00Z",
                 "state": "running",
@@ -896,6 +907,7 @@ class TestGetGridDataEndpoint:
                 "task_display_name": "mapped_task_group.subtask",
                 "child_states": None,
                 "dag_version_number": 1,
+                "has_note": False,
                 "max_end_date": "2024-12-30T01:02:03Z",
                 "min_start_date": "2024-12-30T01:00:00Z",
             },
@@ -905,12 +917,14 @@ class TestGetGridDataEndpoint:
                 "task_display_name": "A Beautiful Task Name \U0001f680",
                 "child_states": None,
                 "dag_version_number": 1,
+                "has_note": False,
                 "max_end_date": None,
                 "min_start_date": None,
             },
             {
                 "child_states": {"none": 6},
                 "dag_version_number": 1,
+                "has_note": False,
                 "task_id": "task_group",
                 "task_display_name": "task_group",
                 "max_end_date": None,
@@ -920,6 +934,7 @@ class TestGetGridDataEndpoint:
             {
                 "child_states": {"none": 2},
                 "dag_version_number": 1,
+                "has_note": False,
                 "task_id": "task_group.inner_task_group",
                 "task_display_name": "task_group.inner_task_group",
                 "max_end_date": None,
@@ -929,6 +944,7 @@ class TestGetGridDataEndpoint:
             {
                 "child_states": {"none": 2},
                 "dag_version_number": 1,
+                "has_note": False,
                 "task_id": "task_group.inner_task_group.inner_task_group_sub_task",
                 "task_display_name": "Inner Task Group Sub Task Label",
                 "max_end_date": None,
@@ -938,6 +954,7 @@ class TestGetGridDataEndpoint:
             {
                 "child_states": {"none": 4},
                 "dag_version_number": 1,
+                "has_note": False,
                 "task_id": "task_group.mapped_task",
                 "task_display_name": "task_group.mapped_task",
                 "max_end_date": None,
@@ -1175,6 +1192,22 @@ class TestGetGridDataEndpoint:
         nodes = response.json()
         task_ids = sorted([node["id"] for node in nodes])
         assert task_ids == expected_task_ids, description
+
+    def test_grid_ti_summaries_has_note(self, session, test_client):
+        """has_note is true when a TaskInstanceNote exists for a TI, false otherwise."""
+        ti = session.scalar(
+            select(TaskInstance).where(TaskInstance.run_id == "run_1", TaskInstance.task_id == TASK_ID)
+        )
+        ti.task_instance_note = TaskInstanceNote(content="test note")
+        session.commit()
+
+        response = test_client.get(f"/grid/ti_summaries/{DAG_ID}?run_ids=run_1")
+        assert response.status_code == 200
+        [data] = self._parse_ndjson(response)
+        by_task_id = {ti["task_id"]: ti for ti in data["task_instances"]}
+
+        assert by_task_id[TASK_ID]["has_note"] is True
+        assert all(not ti["has_note"] for task_id, ti in by_task_id.items() if task_id != TASK_ID)
 
     @staticmethod
     def _parse_ndjson(response) -> list[dict]:


### PR DESCRIPTION
Backport of #68979 to `v3-3-test`.

One conflict in `GridTI.tsx`: the `GridTI` destructure differed (v3-3-test is single-line and is followed by `useParams()`, whereas main's follows with a `useHover()` line that isn't on this branch). Resolved by adopting the multi-line destructure with `hasNote = false` and keeping v3-3-test's existing `useParams()` line — the `useHover` line was dropped as it belongs to a separate main-only feature. All other hunks applied cleanly.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — cherry-pick backport with one manual conflict resolution (documented above).