### PR TITLE
Validate DatabricksSQLStatementsSensor exclusivity at __init__

### DIFF
--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -179,7 +179,7 @@ providers/databricks/src/airflow/providers/databricks/operators/databricks_repos
 providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py::8
 providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py::4
 providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py::7
-providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::4
+providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::3
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_partition.py::4
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_sql.py::1
 providers/databricks/src/airflow/providers/databricks/utils/databricks.py::3

--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -179,7 +179,7 @@ providers/databricks/src/airflow/providers/databricks/operators/databricks_repos
 providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py::8
 providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py::4
 providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py::7
-providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::3
+providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::1
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_partition.py::4
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_sql.py::1
 providers/databricks/src/airflow/providers/databricks/utils/databricks.py::3

--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -181,7 +181,7 @@ providers/databricks/src/airflow/providers/databricks/operators/databricks_repos
 providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py::8
 providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py::4
 providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py::7
-providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::4
+providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::3
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_partition.py::4
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_sql.py::1
 providers/databricks/src/airflow/providers/databricks/utils/databricks.py::3

--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -181,7 +181,7 @@ providers/databricks/src/airflow/providers/databricks/operators/databricks_repos
 providers/databricks/src/airflow/providers/databricks/operators/databricks_sql.py::8
 providers/databricks/src/airflow/providers/databricks/operators/databricks_workflow.py::4
 providers/databricks/src/airflow/providers/databricks/plugins/databricks_workflow.py::7
-providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::3
+providers/databricks/src/airflow/providers/databricks/sensors/databricks.py::1
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_partition.py::4
 providers/databricks/src/airflow/providers/databricks/sensors/databricks_sql.py::1
 providers/databricks/src/airflow/providers/databricks/utils/databricks.py::3

--- a/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
@@ -71,7 +71,7 @@ class DatabricksSQLStatementsSensor(DatabricksSQLStatementsMixin, BaseSensorOper
     ):
         # Handle the scenario where both statement and statement_id are set
         if statement is not None and statement_id is not None:
-            raise AirflowException("Cannot provide both statement and statement_id.")
+            raise ValueError("Cannot provide both statement and statement_id.")
 
         if not warehouse_id:
             raise AirflowException("warehouse_id must be provided.")

--- a/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
@@ -69,12 +69,11 @@ class DatabricksSQLStatementsSensor(DatabricksSQLStatementsMixin, BaseSensorOper
         include_airflow_query_tags: bool = True,
         **kwargs,
     ):
-        # Handle the scenario where both statement and statement_id are set
         if statement is not None and statement_id is not None:
             raise ValueError("Cannot provide both statement and statement_id.")
 
         if not warehouse_id:
-            raise AirflowException("warehouse_id must be provided.")
+            raise ValueError("warehouse_id must be provided.")
 
         super().__init__(**kwargs)
 
@@ -110,9 +109,11 @@ class DatabricksSQLStatementsSensor(DatabricksSQLStatementsMixin, BaseSensorOper
         )
 
     def execute(self, context: Context):
-        # Handle the scenario where both statement and statement_id are not set
+        # Both fields are templated, so "neither resolves to a value" is only knowable
+        # after rendering — __init__ cannot catch it. The both-provided case is a pure
+        # provision error and is checked there instead.
         if not self.statement and not self.statement_id:
-            raise AirflowException("One of either statement or statement_id must be provided.")
+            raise ValueError("One of either statement or statement_id must be provided.")
         if not self.statement_id:
             # Otherwise, we'll go ahead and "submit" the statement
             tags = build_query_tags(context, self.query_tags, self.include_airflow_query_tags)

--- a/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
@@ -69,7 +69,10 @@ class DatabricksSQLStatementsSensor(DatabricksSQLStatementsMixin, BaseSensorOper
         include_airflow_query_tags: bool = True,
         **kwargs,
     ):
-        # Handle the scenario where either both statement and statement_id are set/not set
+        # Handle the scenario where both statement and statement_id are set
+        if statement is not None and statement_id is not None:
+            raise AirflowException("Cannot provide both statement and statement_id.")
+
         if not warehouse_id:
             raise AirflowException("warehouse_id must be provided.")
 
@@ -107,8 +110,7 @@ class DatabricksSQLStatementsSensor(DatabricksSQLStatementsMixin, BaseSensorOper
         )
 
     def execute(self, context: Context):
-        if self.statement and self.statement_id:
-            raise AirflowException("Cannot provide both statement and statement_id.")
+        # Handle the scenario where both statement and statement_id are not set
         if not self.statement and not self.statement_id:
             raise AirflowException("One of either statement or statement_id must be provided.")
         if not self.statement_id:

--- a/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
+++ b/providers/databricks/src/airflow/providers/databricks/sensors/databricks.py
@@ -70,7 +70,7 @@ class DatabricksSQLStatementsSensor(DatabricksSQLStatementsMixin, BaseSensorOper
         **kwargs,
     ):
         if statement is not None and statement_id is not None:
-            raise ValueError("Cannot provide both statement and statement_id.")
+            raise ValueError("Provide exactly one of statement or statement_id.")
 
         if not warehouse_id:
             raise ValueError("warehouse_id must be provided.")

--- a/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
@@ -69,7 +69,7 @@ class TestDatabricksSQLStatementsSensor:
         assert op.warehouse_id == WAREHOUSE_ID
 
     def test_both_statements_included_validated_at_init(self):
-        with pytest.raises(AirflowException, match="Cannot provide both"):
+        with pytest.raises(ValueError, match="Cannot provide both"):
             DatabricksSQLStatementsSensor(
                 statement=STATEMENT,
                 statement_id=STATEMENT_ID,

--- a/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
@@ -68,16 +68,18 @@ class TestDatabricksSQLStatementsSensor:
         assert op.statement_id == STATEMENT_ID
         assert op.warehouse_id == WAREHOUSE_ID
 
-    @pytest.mark.parametrize(
-        ("kwargs", "match"),
-        [
-            ({"statement": STATEMENT, "statement_id": STATEMENT_ID}, "Cannot provide both"),
-            ({}, "One of either statement or statement_id"),
-        ],
-    )
-    def test_statement_combination_validated_at_execute(self, kwargs, match):
-        op = DatabricksSQLStatementsSensor(task_id=TASK_ID, warehouse_id=WAREHOUSE_ID, **kwargs)
-        with pytest.raises(AirflowException, match=match):
+    def test_both_statements_included_validated_at_init(self):
+        with pytest.raises(AirflowException, match="Cannot provide both"):
+            DatabricksSQLStatementsSensor(
+                statement=STATEMENT,
+                statement_id=STATEMENT_ID,
+                task_id=TASK_ID,
+                warehouse_id=WAREHOUSE_ID,
+            )
+
+    def test_both_statements_missing_validated_at_execute(self):
+        op = DatabricksSQLStatementsSensor(task_id=TASK_ID, warehouse_id=WAREHOUSE_ID)
+        with pytest.raises(AirflowException, match="One of either statement or statement_id"):
             op.execute(None)
 
     @mock.patch("airflow.providers.databricks.sensors.databricks.DatabricksHook")

--- a/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
@@ -68,18 +68,34 @@ class TestDatabricksSQLStatementsSensor:
         assert op.statement_id == STATEMENT_ID
         assert op.warehouse_id == WAREHOUSE_ID
 
-    def test_both_statements_included_validated_at_init(self):
+    @pytest.mark.parametrize(
+        ("statement", "statement_id"),
+        [
+            (STATEMENT, STATEMENT_ID),
+            (STATEMENT, ""),
+        ],
+    )
+    def test_both_statements_included_validated_at_init(self, statement, statement_id):
         with pytest.raises(ValueError, match="Cannot provide both"):
             DatabricksSQLStatementsSensor(
-                statement=STATEMENT,
-                statement_id=STATEMENT_ID,
+                statement=statement,
+                statement_id=statement_id,
                 task_id=TASK_ID,
                 warehouse_id=WAREHOUSE_ID,
             )
 
-    def test_both_statements_missing_validated_at_execute(self):
-        op = DatabricksSQLStatementsSensor(task_id=TASK_ID, warehouse_id=WAREHOUSE_ID)
-        with pytest.raises(AirflowException, match="One of either statement or statement_id"):
+    @pytest.mark.parametrize(
+        ("statement", "statement_id"),
+        [
+            (None, None),
+            ("", None),
+        ],
+    )
+    def test_both_statements_missing_validated_at_execute(self, statement, statement_id):
+        op = DatabricksSQLStatementsSensor(
+            task_id=TASK_ID, warehouse_id=WAREHOUSE_ID, statement=statement, statement_id=statement_id
+        )
+        with pytest.raises(ValueError, match="One of either statement or statement_id"):
             op.execute(None)
 
     @mock.patch("airflow.providers.databricks.sensors.databricks.DatabricksHook")

--- a/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
+++ b/providers/databricks/tests/unit/databricks/sensors/test_databricks.py
@@ -22,7 +22,8 @@ from unittest import mock
 import pytest
 from tenacity import stop_after_attempt, wait_incrementing
 
-from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred
+from airflow.models.dag import DAG
+from airflow.providers.common.compat.sdk import AirflowException, TaskDeferred, timezone
 from airflow.providers.databricks.hooks.databricks import SQLStatementState
 from airflow.providers.databricks.sensors.databricks import DatabricksSQLStatementsSensor
 from airflow.providers.databricks.triggers.databricks import DatabricksSQLStatementExecutionTrigger
@@ -73,15 +74,49 @@ class TestDatabricksSQLStatementsSensor:
         [
             (STATEMENT, STATEMENT_ID),
             (STATEMENT, ""),
+            ("", ""),
         ],
     )
     def test_both_statements_included_validated_at_init(self, statement, statement_id):
-        with pytest.raises(ValueError, match="Cannot provide both"):
+        with pytest.raises(ValueError, match="Provide exactly one of"):
             DatabricksSQLStatementsSensor(
                 statement=statement,
                 statement_id=statement_id,
                 task_id=TASK_ID,
                 warehouse_id=WAREHOUSE_ID,
+            )
+
+    @pytest.mark.parametrize(
+        ("statement", "statement_id"),
+        [
+            ("{{ None }}", STATEMENT_ID),
+            (STATEMENT, "{{ None }}"),
+            ("{{ None }}", "{{ None }}"),
+        ],
+    )
+    def test_both_provided_with_template_renders_to_none_validated_at_init(self, statement, statement_id):
+        """
+        Both statement and statement_id are provided; at least one is a template that
+        would render to None under render_template_as_native_obj=True. The constructor
+        must raise before any rendering occurs, so the check is pinned to __init__.
+        If the exclusivity check were moved to execute(), this test would fail because
+        the constructor would succeed and if rendered before execute() the template
+        would render to None making it appear only one value was provided so the moved
+        check would not catch the exclusivity violation
+        """
+        dag = DAG(
+            dag_id="test_native_obj_dag",
+            start_date=timezone.datetime(2025, 1, 1),
+            schedule=None,
+            render_template_as_native_obj=True,
+        )
+        with pytest.raises(ValueError, match="Provide exactly one of"):
+            DatabricksSQLStatementsSensor(
+                task_id=TASK_ID,
+                warehouse_id=WAREHOUSE_ID,
+                statement=statement,
+                statement_id=statement_id,
+                dag=dag,
             )
 
     @pytest.mark.parametrize(
@@ -97,6 +132,32 @@ class TestDatabricksSQLStatementsSensor:
         )
         with pytest.raises(ValueError, match="One of either statement or statement_id"):
             op.execute(None)
+
+    @pytest.mark.parametrize(
+        ("statement", "statement_id"),
+        [
+            (None, "{{ None }}"),
+            ("{{ None }}", None),
+        ],
+    )
+    def test_both_missing_after_template_rendered_validated_at_execute(self, statement, statement_id):
+        dag = DAG(
+            dag_id="test_native_obj_dag",
+            start_date=timezone.datetime(2025, 1, 1),
+            schedule=None,
+            render_template_as_native_obj=True,
+        )
+        op = DatabricksSQLStatementsSensor(
+            task_id=TASK_ID,
+            warehouse_id=WAREHOUSE_ID,
+            statement=statement,
+            statement_id=statement_id,
+            dag=dag,
+        )
+        context = {"dag": dag}
+        op.render_template_fields(context)
+        with pytest.raises(ValueError, match="One of either statement or statement_id"):
+            op.execute(context)
 
     @mock.patch("airflow.providers.databricks.sensors.databricks.DatabricksHook")
     def test_exec_success(self, db_mock_class):


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Description

This PR moves template_field exclusivity check back to `__init__` from `execute()` while keeping the `not statement and not statement_id` sibling in `execute()` since it is a required-argument check (see #70503) for the `DatabricksSQLStatementsSensor` operators in the providers/databricks/src/airflow/providers/databricks/sensors/databricks.py.

The check is updated to use `is not None` polarity rather than a truthiness check, so this is not a straight revert of the original code. This is a genuine improvement over current main: when a provided field renders to `None` under `render_template_as_native_obj=True`, the exclusivity check still fires rather than silently running the non-None argument undetected.

These are pure provision checks ("was this argument passed?") which belong in `__init__` per the updated guidance in #70296, as moving them to `execute()` risks false positives when `render_template_as_native_obj=True` renders a provided field to `None`.

**User-visible behaviour change:** `statement_id=""` alongside a `statement` (and vice versa) previously succeeded end-to-end and now raises at DAG parse time. Empty-string values are `is not None` and are correctly treated as provided. This is deliberate.

Following the logic of "you're already touching this function" argument the PR also converts 3 `AirflowException` to `ValueError` under both `__init__` and `execute()` to increase consistency and follow guidance to narrow when changing a line. 

## Tests

- Separated tests under providers/databricks/tests/unit/databricks/sensors/test_databricks.py added as part of the previous PR #70340 to validate the new behaviour.
- Added parameterised testcases to cover the specific reasons the `is not None` polarity is used in `__init__` while the `is None` polarity is not used in `execute()` for the sibling testcase.

related: #70296 and #70503 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Antigravity IDE] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
