### PR TITLE
Show user display names for triggered runs and HITL responses

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -502,7 +502,7 @@ def materialize_asset(
             conf=params["conf"],
             run_type=DagRunType.ASSET_MATERIALIZATION,
             triggered_by=DagRunTriggeredByType.REST_API,
-            triggering_user_name=user.get_name(),
+            triggering_user_name=user.get_display_name(),
             state=DagRunState.QUEUED,
             partition_key=params["partition_key"],
             partition_date=params["partition_date"],

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/backfills.py
@@ -306,7 +306,7 @@ def create_backfill(
             max_active_runs=backfill_request.max_active_runs,
             reverse=backfill_request.run_backwards,
             dag_run_conf=backfill_request.dag_run_conf,
-            triggering_user_name=user.get_name(),
+            triggering_user_name=user.get_display_name(),
             reprocess_behavior=backfill_request.reprocess_behavior,
             run_on_latest_version=resolved_run_on_latest,
         )

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -800,7 +800,7 @@ def trigger_dag_run(
             conf=params["conf"],
             run_type=DagRunType.MANUAL,
             triggered_by=triggered_by,
-            triggering_user_name=user.get_name(),
+            triggering_user_name=user.get_display_name(),
             state=DagRunState.QUEUED,
             partition_key=params["partition_key"],
             bundle_version=body.bundle_version,

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/hitl.py
@@ -196,7 +196,7 @@ def update_hitl_detail(
     if isinstance(user_id, int):
         # FabAuthManager (ab_user) store user id as integer, but common interface is string type
         user_id = str(user_id)
-    hitl_user = HITLUser(id=user_id, name=user_name)
+    hitl_user = HITLUser(id=user_id, name=user.get_display_name())
     if hitl_detail_model.assigned_users:
         # Convert assigned_users list to set of user IDs for authorization check
         assigned_user_ids = {assigned_user["id"] for assigned_user in hitl_detail_model.assigned_users}

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -1801,6 +1801,16 @@ class TestPostAssetMaterialize(TestAssets):
         session.commit()
 
     @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.simple.user.SimpleAuthManagerUser.get_display_name",
+        return_value="Jane Doe",
+    )
+    def test_materialize_records_triggering_user_display_name(self, mock_display_name, test_client):
+        response = test_client.post("/assets/1/materialize")
+        assert response.status_code == 200
+        assert response.json()["triggering_user_name"] == "Jane Doe"
+
+    @pytest.mark.usefixtures("configure_git_connection_for_dag_bundle")
     def test_should_respond_200(self, test_client):
         response = test_client.post("/assets/1/materialize")
         assert response.status_code == 200

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py
@@ -434,6 +434,29 @@ class TestCreateBackfill(TestBackfillEndpoint):
         }
         check_last_log(session, dag_id="TEST_DAG_1", event="create_backfill", logical_date=None)
 
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.simple.user.SimpleAuthManagerUser.get_display_name",
+        return_value="Jane Doe",
+    )
+    def test_create_backfill_records_triggering_user_display_name(
+        self, mock_display_name, session, dag_maker, test_client
+    ):
+        with dag_maker(session=session, dag_id="TEST_DAG_DISPLAY_NAME", schedule="0 * * * *") as dag:
+            EmptyOperator(task_id="mytask")
+        session.commit()
+        data = {
+            "dag_id": dag.dag_id,
+            "from_date": to_iso(pendulum.parse("2024-01-01")),
+            "to_date": to_iso(pendulum.parse("2024-02-01")),
+            "max_active_runs": 5,
+            "run_backwards": False,
+            "dag_run_conf": {},
+        }
+        response = test_client.post(url="/backfills", json=data)
+        assert response.status_code == 200
+        backfill = session.scalars(select(Backfill).where(Backfill.dag_id == dag.dag_id)).one()
+        assert backfill.triggering_user_name == "Jane Doe"
+
     def test_dag_not_exist(self, session, test_client):
         session.scalars(select(DagModel)).all()
         session.commit()

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -3757,6 +3757,25 @@ class TestTriggerDagRun:
 
         assert response_1.json()["dag_run_id"] != response_2.json()["dag_run_id"]
 
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.simple.user.SimpleAuthManagerUser.get_display_name",
+        return_value="Jane Doe",
+    )
+    def test_trigger_records_triggering_user_display_name(
+        self, mock_display_name, dag_maker, test_client, session
+    ):
+        dag_id = "test_trigger_display_name"
+        with dag_maker(dag_id=dag_id, schedule=None, session=session, serialized=True):
+            EmptyOperator(task_id="task")
+        session.commit()
+        response = test_client.post(
+            f"/dags/{dag_id}/dagRuns",
+            json={"logical_date": "2024-01-01T00:00:00Z"},
+        )
+        assert response.status_code == 200
+        run = session.scalars(select(DagRun).where(DagRun.run_id == response.json()["dag_run_id"])).one()
+        assert run.triggering_user_name == "Jane Doe"
+
     @time_machine.travel("2025-10-02 12:00:00", tick=False)
     @pytest.mark.usefixtures("custom_timetable_plugin")
     def test_custom_timetable_generate_run_id_for_manual_trigger(self, dag_maker, test_client, session):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_hitl.py
@@ -311,6 +311,26 @@ def sample_update_payload() -> dict[str, Any]:
 class TestUpdateHITLDetailEndpoint:
     @time_machine.travel(datetime(2025, 7, 3, 0, 0, 0), tick=False)
     @pytest.mark.usefixtures("sample_hitl_detail")
+    @mock.patch(
+        "airflow.api_fastapi.auth.managers.simple.user.SimpleAuthManagerUser.get_display_name",
+        return_value="Jane Doe",
+    )
+    def test_response_records_responder_display_name(
+        self,
+        mock_display_name: mock.MagicMock,
+        test_client: TestClient,
+        sample_ti_url_identifier: str,
+        sample_update_payload: dict[str, Any],
+    ) -> None:
+        response = test_client.patch(
+            f"{sample_ti_url_identifier}/hitlDetails",
+            json=sample_update_payload,
+        )
+        assert response.status_code == 200
+        assert response.json()["responded_by"] == {"id": "test", "name": "Jane Doe"}
+
+    @time_machine.travel(datetime(2025, 7, 3, 0, 0, 0), tick=False)
+    @pytest.mark.usefixtures("sample_hitl_detail")
     def test_should_respond_200_with_existing_response(
         self,
         test_client: TestClient,


### PR DESCRIPTION
Follow-up to #70583, which added `BaseUser.get_display_name` and used it so audit-log rows show a friendly user name instead of the raw login.

Several other user-facing fields still recorded `get_name()` (the raw login):

- `triggering_user_name` on manually triggered Dag runs, backfills, and asset materializations — shown in the Dag Runs table and the Run header.
- The HITL responder name (`responded_by`) — shown in the HITL table and response form.

These now use `get_display_name()` too, so what the user sees is consistent with the audit log. For auth managers that don't override `get_display_name` (Simple, Keycloak) it falls back to `get_name`, so their behavior is unchanged; FAB users get their full name.

The edge3 worker maintenance-comment site (`get_name()` embedded in a comment string) is intentionally left out and will be a separate follow-up: that provider can run against an older core without the `get_display_name` interface, so it needs a `hasattr(user, "get_display_name")` compatibility guard.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)