### PR TITLE
Clarify which signal each duplicated otel_* config option applies to

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1296,7 +1296,8 @@ metrics:
       default: "False"
     otel_on:
       description: |
-        Enables sending metrics to OpenTelemetry.
+        Enables sending Airflow metrics to an OpenTelemetry Collector. This option only affects
+        metrics; sending traces is configured separately in the ``[traces]`` section.
       version_added: 2.6.0
       type: boolean
       example: ~
@@ -1304,7 +1305,7 @@ metrics:
     otel_host:
       description: |
         Specifies the hostname or IP address of the OpenTelemetry Collector to which Airflow sends
-        metrics and traces.
+        metrics.
       version_added: 2.6.0
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1321,7 +1322,7 @@ metrics:
       default: "localhost"
     otel_port:
       description: |
-        Specifies the port of the OpenTelemetry Collector that is listening to.
+        Specifies the port on which the OpenTelemetry Collector listens for metrics.
       version_added: 2.6.0
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1345,7 +1346,7 @@ metrics:
       default: "airflow"
     otel_interval_milliseconds:
       description: |
-        Defines the interval, in milliseconds, at which Airflow sends batches of metrics and traces
+        Defines the interval, in milliseconds, at which Airflow sends batches of metrics
         to the configured OpenTelemetry Collector.
       version_added: 2.6.0
       version_deprecated: 3.2.0
@@ -1380,7 +1381,7 @@ metrics:
       default: "False"
     otel_service:
       description: |
-        The default service name of traces.
+        The default service name under which metrics are emitted.
       version_added: 2.10.3
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1397,7 +1398,7 @@ metrics:
       default: "Airflow"
     otel_ssl_active:
       description: |
-        If ``True``, SSL will be enabled. Defaults to ``False``.
+        If ``True``, SSL will be enabled for the connection used to send metrics. Defaults to ``False``.
         To establish an HTTPS connection to the OpenTelemetry collector,
         you need to configure the SSL certificate and key within the OpenTelemetry collector's
         ``config.yml`` file.
@@ -1421,7 +1422,8 @@ traces:
   options:
     otel_on:
       description: |
-        Enables sending traces to OpenTelemetry.
+        Enables sending Airflow traces to an OpenTelemetry Collector. This option only affects
+        traces; sending metrics is configured separately in the ``[metrics]`` section.
       version_added: 2.10.0
       type: boolean
       example: ~
@@ -1446,7 +1448,7 @@ traces:
       default: "localhost"
     otel_port:
       description: |
-        Specifies the port of the OpenTelemetry Collector that is listening to.
+        Specifies the port on which the OpenTelemetry Collector listens for traces.
       version_added: 2.10.0
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1463,7 +1465,7 @@ traces:
       default: "8889"
     otel_service:
       description: |
-        The default service name of traces.
+        The default service name under which traces are emitted.
       version_added: 2.10.0
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1480,7 +1482,7 @@ traces:
       default: "Airflow"
     otel_debugging_on:
       description: |
-        If True, all traces are also emitted to the console. Defaults to False.
+        If ``True``, all traces are also emitted to the console. Defaults to ``False``.
       version_added: 2.10.0
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1497,10 +1499,10 @@ traces:
       default: "False"
     otel_ssl_active:
       description: |
-        If True, SSL will be enabled.  Defaults to False.
+        If ``True``, SSL will be enabled for the connection used to send traces. Defaults to ``False``.
         To establish an HTTPS connection to the OpenTelemetry collector,
         you need to configure the SSL certificate and key within the OpenTelemetry collector's
-        config.yml file.
+        ``config.yml`` file.
       version_added: 2.10.0
       version_deprecated: 3.2.0
       deprecation_reason: |
@@ -1517,7 +1519,7 @@ traces:
       default: "False"
     otel_debug_traces_on:
       description: |
-        If True, then traces from Airflow internal methods are exported. Defaults to False.
+        If ``True``, then traces from Airflow internal methods are exported. Defaults to ``False``.
       version_added: 3.1.0
       version_deprecated: 3.2.0
       deprecation_reason: |


### PR DESCRIPTION
The ``otel_on``, ``otel_host``, ``otel_port``, ``otel_service``, ``otel_debugging_on`` and ``otel_ssl_active`` options appear in both the ``[metrics]`` and ``[traces]`` sections of the Configuration Reference, and their descriptions did not say which of the two features each copy configures, so users could not tell the duplicated options apart.

Three descriptions were also incorrect: ``[metrics] otel_host`` and ``[metrics] otel_interval_milliseconds`` claimed to also cover traces, and ``[metrics] otel_service`` described only traces — the code reads all of these exclusively for metrics (``observability/metrics/otel_logger.py``).

Each description now names the signal it configures (keeping both sets of options, per the resolution discussed in the issue), and the ``[traces]`` descriptions regain the literal markup (``True``/``False``/``config.yml``) used elsewhere so they render properly again.

closes: #43366

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code, following [the Gen-AI assisted contributions guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst); all changes were verified against the code that reads these options and fully human-reviewed.
