### PR TITLE
Rename dag serialization metrics.

### DIFF
--- a/airflow-core/newsfragments/70838.feature.rst
+++ b/airflow-core/newsfragments/70838.feature.rst
@@ -1,0 +1,1 @@
+Added the ``dag.serialization.version_created`` and ``dag.serialization.version_updated`` metrics, which count Dag serializations in each of the two situations where serialization happens: when a new Dag version is created, and when the latest Dag version is updated in place.

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -763,7 +763,10 @@ class SerializedDagModel(Base):
             session.merge(dag_version)
             # Update the latest DagCode
             DagCode.update_source_code(dag_id=dag.dag_id, fileloc=dag.fileloc, session=session)
-            stats.incr("dag.serialization_writes", tags={"dag_id": dag.dag_id, "bundle_name": bundle_name})
+            stats.incr(
+                "dag.serialization.version_updated",
+                tags={"dag_id": dag.dag_id, "bundle_name": bundle_name},
+            )
             return True
 
         dagv = DagVersion.write_dag(
@@ -786,7 +789,10 @@ class SerializedDagModel(Base):
         cls._create_deadline_alert_records(new_serialized_dag, deadline_uuid_mapping)
         log.debug("DAG: %s written to the DB", dag.dag_id)
         DagCode.write_code(dagv, dag.fileloc, session=session)
-        stats.incr("dag.serialization_writes", tags={"dag_id": dag.dag_id, "bundle_name": bundle_name})
+        stats.incr(
+            "dag.serialization.version_created",
+            tags={"dag_id": dag.dag_id, "bundle_name": bundle_name},
+        )
         return True
 
     @classmethod

--- a/airflow-core/tests/unit/models/test_serialized_dag.py
+++ b/airflow-core/tests/unit/models/test_serialized_dag.py
@@ -206,18 +206,18 @@ class TestSerializedDagModel:
         assert dag_updated is True
 
     def test_serialization_metric_incremented_on_new_write(self, testing_dag_bundle):
-        """A brand new serialized DAG write emits the ``dag.serialization_writes`` metric."""
+        """A brand new serialized DAG write emits the ``dag.serialization.version_created`` metric."""
         dag = make_example_dags(example_dags_module).get("example_params_trigger_ui")
         with mock.patch(self.SERIALIZED_DAG_STATS) as mock_stats:
             assert SDM.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=self.TEST_BUNDLE_NAME) is True
 
         mock_stats.incr.assert_called_once_with(
-            "dag.serialization_writes",
+            "dag.serialization.version_created",
             tags={"dag_id": dag.dag_id, "bundle_name": self.TEST_BUNDLE_NAME},
         )
 
     def test_serialization_metric_not_incremented_when_unchanged(self, testing_dag_bundle):
-        """Re-writing an unchanged DAG must not emit the ``dag.serialization_writes`` metric."""
+        """Re-writing an unchanged DAG must not emit any serialization metric."""
         dag = make_example_dags(example_dags_module).get("example_params_trigger_ui")
         assert SDM.write_dag(LazyDeserializedDAG.from_dag(dag), bundle_name=self.TEST_BUNDLE_NAME) is True
 
@@ -240,7 +240,7 @@ class TestSerializedDagModel:
 
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 1
         mock_stats.incr.assert_called_once_with(
-            "dag.serialization_writes",
+            "dag.serialization.version_updated",
             tags={"dag_id": "metric_dag", "bundle_name": self.TEST_BUNDLE_NAME},
         )
 
@@ -256,14 +256,14 @@ class TestSerializedDagModel:
 
         assert session.scalar(select(func.count()).select_from(DagVersion)) == 2
         mock_stats.incr.assert_called_once_with(
-            "dag.serialization_writes",
+            "dag.serialization.version_created",
             tags={"dag_id": "metric_dag", "bundle_name": self.TEST_BUNDLE_NAME},
         )
 
     @mock.patch("airflow._shared.observability.metrics.stats._export_legacy_names", True)
     @mock.patch("airflow._shared.observability.metrics.stats._get_backend")
     def test_serialization_metric_exports_new_and_legacy_names(self, mock_get_backend, testing_dag_bundle):
-        """Serializing a DAG emits both the modern ``dag.serialization_writes`` metric and its legacy name."""
+        """Serializing a DAG emits both the tagged serialization metric and its legacy name."""
         mock_backend = mock.MagicMock(spec=StatsLogger)
         mock_get_backend.return_value = mock_backend
         dag = make_example_dags(example_dags_module).get("example_params_trigger_ui")
@@ -272,9 +272,9 @@ class TestSerializedDagModel:
 
         mock_backend.incr.assert_has_calls(
             [
-                mock.call(f"dag.serialization_writes.{dag.dag_id}.{self.TEST_BUNDLE_NAME}"),
+                mock.call(f"dag.serialization.version_created.{dag.dag_id}.{self.TEST_BUNDLE_NAME}"),
                 mock.call(
-                    "dag.serialization_writes",
+                    "dag.serialization.version_created",
                     tags={"dag_id": dag.dag_id, "bundle_name": self.TEST_BUNDLE_NAME},
                 ),
             ]

--- a/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
+++ b/shared/observability/src/airflow_shared/observability/metrics/metrics_template.yaml
@@ -227,11 +227,19 @@ metrics:
     legacy_name: "-"
     name_variables: []
 
-  - name: "dag.serialization_writes"
-    description: "Number of times a Dag was serialized and written to the metadata DB.
-    Metric with dag_id and bundle_name tagging."
+  - name: "dag.serialization.version_created"
+    description: "Number of times a Dag was serialized into a new Dag version, on its first serialization
+    or when its latest version already has task instances. Metric with dag_id and bundle_name tagging."
     type: "counter"
-    legacy_name: "dag.serialization_writes.{dag_id}.{bundle_name}"
+    legacy_name: "dag.serialization.version_created.{dag_id}.{bundle_name}"
+    name_variables: ["dag_id", "bundle_name"]
+
+  - name: "dag.serialization.version_updated"
+    description: "Number of times a Dag was serialized over its latest Dag version in place, without
+    creating a new version, because that version has no task instances. Metric with dag_id and
+    bundle_name tagging."
+    type: "counter"
+    legacy_name: "dag.serialization.version_updated.{dag_id}.{bundle_name}"
     name_variables: ["dag_id", "bundle_name"]
 
   - name: "celery.task_timeout_error"


### PR DESCRIPTION
## Description

Follow-up to #68906, which added a single `dag.serialization_writes` counter emitted from two different branches of `SerializedDagModel.write_dag`. Sharing one name means the metric can't distinguish the two ways a Dag gets serialized, and they have very different consequences:

- a new `DagVersion` row is inserted — unbounded growth across `dag_version`, `dag_code` and `serialized_dag`
- the latest `DagVersion` is overwritten in place — bounded churn on a single row

A Dag that re-serializes on every parse (for example one whose template holds a callable, with no actual change to the Dag) shows up in either path depending on whether its current version has task instances, but only the first grows the metadata DB. Splitting the counter lets the two be alerted on with different thresholds.

`dag.serialization_writes` is replaced by:

| metric | emitted when |
|---|---|
| `dag.serialization.version_created` | a new Dag version is written — first serialization, or the latest version already has task instances |
| `dag.serialization.version_updated` | the latest Dag version is overwritten in place, having no task instances |

The metric has not been released yet, so there is no deprecation path and no newsfragment.

The paths that write no serialized data — a bundle-metadata refresh, or a parse where nothing changed — are still uncounted. 

related: #68906

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Co-authored-by: [Claude Opus 5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
