### PR TITLE
Fix airflowctl showing a traceback instead of the server error on 5xx

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -119,15 +119,9 @@ class ServerResponseError(httpx.HTTPStatusError):
         # pulled in explicitly here or ``.json()`` raises ``httpx.ResponseNotRead``.
         response.read()
 
-        if 400 <= response.status_code < 500:
-            return cls(
-                message=f"Client error message: {response.json()}",
-                request=response.request,
-                response=response,
-            )
-
+        error_kind = "Client" if response.status_code < 500 else "Server"
         return cls(
-            message=f"Server error message: {response.json()}",
+            message=f"{error_kind} error message: {response.json()}",
             request=response.request,
             response=response,
         )

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -115,18 +115,22 @@ class ServerResponseError(httpx.HTTPStatusError):
         if response.headers.get("content-type") != "application/json":
             return None
 
+        # httpx runs response event hooks before it reads the body, so the body has to be
+        # pulled in explicitly here or ``.json()`` raises ``httpx.ResponseNotRead``.
+        response.read()
+
         if 400 <= response.status_code < 500:
-            response.read()
             return cls(
                 message=f"Client error message: {response.json()}",
                 request=response.request,
                 response=response,
             )
 
-        msg = response.json()
-
-        self = cls(message=msg, request=response.request, response=response)
-        return self
+        return cls(
+            message=f"Server error message: {response.json()}",
+            request=response.request,
+            response=response,
+        )
 
 
 def _check_flag_and_exit_if_server_response_error(func):

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -53,6 +53,22 @@ def make_client_w_responses(responses: list[httpx.Response]) -> Client:
     return Client(base_url="", token="", mounts={"'http://": httpx.MockTransport(handle_request)})
 
 
+def make_unread_json_response(status_code: int, payload: dict, **kwargs) -> httpx.Response:
+    """
+    Build a JSON response whose body has not been read yet.
+
+    ``httpx.Response(json=...)`` eagerly loads the body, which hides the fact that response
+    event hooks run before httpx reads a real server's body. Passing an iterator keeps the
+    body streaming, matching what the hooks see against a live API server.
+    """
+    return httpx.Response(
+        status_code,
+        headers={"content-type": "application/json"},
+        content=iter([json.dumps(payload).encode()]),
+        **kwargs,
+    )
+
+
 @pytest.fixture(autouse=True)
 def unique_config_dir():
     temp_dir = tempfile.mkdtemp()
@@ -106,6 +122,23 @@ class TestClient:
         with pytest.raises(ServerResponseError) as err:
             client.get("http://error")
         assert err.value.args == ("Client error message: {'detail': 'Not found'}",)
+
+    @pytest.mark.parametrize(
+        ("status_code", "expected_message"),
+        [
+            pytest.param(404, "Client error message: {'detail': 'boom'}", id="client-error"),
+            pytest.param(500, "Server error message: {'detail': 'boom'}", id="server-error"),
+        ],
+    )
+    def test_error_parsing_with_unread_body(self, status_code, expected_message):
+        response = make_unread_json_response(
+            status_code, {"detail": "boom"}, request=httpx.Request("GET", "http://error")
+        )
+
+        with pytest.raises(ServerResponseError) as err:
+            get_json_error(response)
+
+        assert err.value.args == (expected_message,)
 
     @pytest.mark.parametrize(
         ("suppress_error_log", "expected_warning_count"),
@@ -398,6 +431,19 @@ class TestSaveKeyringPatching:
         with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
             responses: list[httpx.Response] = [
                 *[httpx.Response(500, text="Internal Server Error")] * 2,
+                httpx.Response(200, json={"detail": "Recovered from error"}),
+                httpx.Response(400, json={"detail": "Should not get here"}),
+            ]
+            client = make_client_w_responses(responses)
+
+            response = client.get("http://error")
+            assert response.status_code == 200
+            assert len(responses) == 1
+
+    def test_retry_handling_server_error_with_unread_body(self):
+        with time_machine.travel("2023-01-01T00:00:00Z", tick=False):
+            responses: list[httpx.Response] = [
+                make_unread_json_response(500, {"detail": "boom"}),
                 httpx.Response(200, json={"detail": "Recovered from error"}),
                 httpx.Response(400, json={"detail": "Should not get here"}),
             ]


### PR DESCRIPTION
## Summary

`ServerResponseError.from_response()` parsed JSON from `5xx` responses before reading the body, causing `httpx.ResponseNotRead` in response hooks. 
This prevented the intended `ServerResponseError` from being raised and broke retries for server errors.

## Changes

- Read the response body before handling `4xx`/`5xx` responses.
- Format `5xx` JSON errors consistently with `4xx`.
- Add a streaming-response test helper to reproduce unread-body behavior.
- Add tests covering JSON `5xx` error parsing and retry behavior.

## Notes

The JSON `5xx` path previously had no test coverage because existing tests used `text=`responses. The new tests fail on `main` with `httpx.ResponseNotRead`.

---

##### Was generative AI tooling used to co-author this PR?
- [X] Yes (please specify the tool below)
Generated-by: Claude Code (Opus 5)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
