### PR TITLE
Fix encrypted private keys in async SFTP hook

### DIFF
--- a/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
+++ b/providers/sftp/src/airflow/providers/sftp/hooks/sftp.py
@@ -786,8 +786,10 @@ class SFTPHookAsync(BaseHook):
             self.key_file = extra_options["key_file"]
         if "known_hosts" in extra_options and self.known_hosts != self.default_known_hosts:
             self.known_hosts = extra_options["known_hosts"]
-        if ("passphrase" or "private_key_passphrase") in extra_options:
-            self.passphrase = extra_options["passphrase"]
+        if "passphrase" in extra_options or "private_key_passphrase" in extra_options:
+            self.passphrase = extra_options.get("passphrase") or extra_options.get(
+                "private_key_passphrase", ""
+            )
         if "private_key" in extra_options:
             self.private_key = extra_options["private_key"]
 

--- a/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
+++ b/providers/sftp/tests/unit/sftp/hooks/test_sftp.py
@@ -774,13 +774,13 @@ class MockAirflowConnectionWithPrivate:
                 {
                     "private_key": "~/keys/my_key",
                     "known_hosts": "unused",
-                    "passphrase": "mypassphrase"
+                    "private_key_passphrase": "mypassphrase"
                 }
                 """
         self.extra_dejson = {
             "private_key": "~/keys/my_key",
             "known_hosts": None,
-            "passphrase": "mypassphrase",
+            "private_key_passphrase": "mypassphrase",
         }
 
 
@@ -945,6 +945,7 @@ class TestSFTPHookAsync:
         hook = SFTPHookAsync()
         await hook._get_conn()
 
+        mock_import_private_key.assert_called_once_with("~/keys/my_key", "mypassphrase")
         expected_connection_details = {
             "host": "localhost",
             "port": 22,


### PR DESCRIPTION
The async SFTP hook only read the legacy `passphrase` connection extra because its condition always evaluated to that key. As a result, encrypted private keys configured with the documented `private_key_passphrase` extra could not be imported.

This accepts the documented extra while preserving the existing `passphrase` behavior and precedence, matching the async SSH hook. The regression test verifies that the configured passphrase is passed when importing a private key.

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)