### PR TITLE
Move CloudComposerExternalTaskSensor template-field logic to execute()

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -596,25 +596,26 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
 
     def execute(self, context: Context) -> None:
         # Validate and normalize the target only after its template fields have been rendered.
+        # Treat an empty list the same as an unset value before the exclusivity checks.
+        if not self.composer_external_task_ids:
+            self.composer_external_task_ids = None
+
         if self.composer_external_task_id is not None and self.composer_external_task_ids is not None:
             raise ValueError(
                 "Only one of `composer_external_task_id` or `composer_external_task_ids` may "
                 "be provided to CloudComposerExternalTaskSensor; "
                 "use `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id`."
             )
-        if self.composer_external_task_group_id is not None and (
-            self.composer_external_task_id is not None or self.composer_external_task_ids is not None
-        ):
+
+        if self.composer_external_task_id is not None:
+            self.composer_external_task_ids = [self.composer_external_task_id]
+
+        if self.composer_external_task_group_id is not None and self.composer_external_task_ids is not None:
             raise ValueError(
                 "Only one of `composer_external_task_group_id` or `composer_external_task_ids` may "
                 "be provided to CloudComposerExternalTaskSensor; "
                 "use `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id`."
             )
-
-        if not self.composer_external_task_ids:
-            self.composer_external_task_ids = None
-        if self.composer_external_task_id is not None:
-            self.composer_external_task_ids = [self.composer_external_task_id]
 
         total_states = set(self.allowed_states + self.skipped_states + self.failed_states)
         if self.composer_external_task_ids or self.composer_external_task_group_id:

--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -391,6 +391,11 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
         self.project_id = project_id
         self.region = region
         self.environment_id = environment_id
+        self.composer_external_dag_id = composer_external_dag_id
+        self.composer_external_task_id = composer_external_task_id
+        self.composer_external_task_ids = composer_external_task_ids
+        self.composer_external_task_group_id = composer_external_task_group_id
+        self.impersonation_chain = impersonation_chain
 
         self.allowed_states = list(allowed_states) if allowed_states else [TaskInstanceState.SUCCESS.value]
         self.skipped_states = list(skipped_states) if skipped_states else []
@@ -403,50 +408,8 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
                 "Duplicate values provided across allowed_states, skipped_states and failed_states."
             )
 
-        # convert [] to None
-        if not composer_external_task_ids:
-            composer_external_task_ids = None
-
-        # can't set both single task id and a list of task ids
-        if composer_external_task_id is not None and composer_external_task_ids is not None:
-            raise ValueError(
-                "Only one of `composer_external_task_id` or `composer_external_task_ids` may "
-                "be provided to CloudComposerExternalTaskSensor; "
-                "use `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id`."
-            )
-
-        # since both not set, convert the single id to a 1-elt list - from here on, we only consider the list
-        if composer_external_task_id is not None:
-            composer_external_task_ids = [composer_external_task_id]
-
-        if composer_external_task_group_id is not None and composer_external_task_ids is not None:
-            raise ValueError(
-                "Only one of `composer_external_task_group_id` or `composer_external_task_ids` may "
-                "be provided to CloudComposerExternalTaskSensor; "
-                "use `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id`."
-            )
-
-        # check the requested states are all valid states for the target type, be it dag or task
-        if composer_external_task_ids or composer_external_task_group_id:
-            if not total_states <= set(State.task_states):
-                raise ValueError(
-                    "Valid values for `allowed_states`, `skipped_states` and `failed_states` "
-                    "when `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id` "
-                    f"is not `None`: {State.task_states}"
-                )
-        elif not total_states <= set(State.dag_states):
-            raise ValueError(
-                "Valid values for `allowed_states`, `skipped_states` and `failed_states` "
-                f"when `composer_external_task_id` and `composer_external_task_group_id` is `None`: {State.dag_states}"
-            )
-
         self.execution_range = execution_range
-        self.composer_external_dag_id = composer_external_dag_id
-        self.composer_external_task_id = composer_external_task_id
-        self.composer_external_task_ids = composer_external_task_ids
-        self.composer_external_task_group_id = composer_external_task_group_id
         self.gcp_conn_id = gcp_conn_id
-        self.impersonation_chain = impersonation_chain
         self.deferrable = deferrable
         self.poll_interval = poll_interval
 
@@ -632,6 +595,42 @@ class CloudComposerExternalTaskSensor(BaseSensorOperator):
             )
 
     def execute(self, context: Context) -> None:
+        # Validate and normalize the target only after its template fields have been rendered.
+        if self.composer_external_task_id is not None and self.composer_external_task_ids is not None:
+            raise ValueError(
+                "Only one of `composer_external_task_id` or `composer_external_task_ids` may "
+                "be provided to CloudComposerExternalTaskSensor; "
+                "use `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id`."
+            )
+        if self.composer_external_task_group_id is not None and (
+            self.composer_external_task_id is not None or self.composer_external_task_ids is not None
+        ):
+            raise ValueError(
+                "Only one of `composer_external_task_group_id` or `composer_external_task_ids` may "
+                "be provided to CloudComposerExternalTaskSensor; "
+                "use `composer_external_task_id` or `composer_external_task_ids` or `composer_external_task_group_id`."
+            )
+
+        if not self.composer_external_task_ids:
+            self.composer_external_task_ids = None
+        if self.composer_external_task_id is not None:
+            self.composer_external_task_ids = [self.composer_external_task_id]
+
+        total_states = set(self.allowed_states + self.skipped_states + self.failed_states)
+        if self.composer_external_task_ids or self.composer_external_task_group_id:
+            if not total_states <= set(State.task_states):
+                raise ValueError(
+                    "Valid values for `allowed_states`, `skipped_states` and `failed_states` "
+                    "when `composer_external_task_id` or `composer_external_task_ids` or "
+                    f"`composer_external_task_group_id` is not `None`: {State.task_states}"
+                )
+        elif not total_states <= set(State.dag_states):
+            raise ValueError(
+                "Valid values for `allowed_states`, `skipped_states` and `failed_states` "
+                f"when `composer_external_task_id` and `composer_external_task_group_id` is `None`: "
+                f"{State.dag_states}"
+            )
+
         self._composer_airflow_version = self._get_composer_airflow_version()
 
         if self.composer_external_task_ids and len(self.composer_external_task_ids) > len(

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
@@ -241,6 +241,26 @@ class TestCloudComposerExternalTaskSensor:
         with pytest.raises(ValueError, match="composer_external_task_id.*is `None`"):
             task.execute(context={})
 
+    def test_empty_task_ids_list_normalizes_before_exclusivity_check(self):
+        task = CloudComposerExternalTaskSensor(
+            task_id="task-id",
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            environment_id=TEST_ENVIRONMENT_ID,
+            composer_external_dag_id="test_dag_id",
+            composer_external_task_group_id=TEST_COMPOSER_EXTERNAL_TASK_GROUP_ID,
+            composer_external_task_ids=[],
+        )
+
+        with (
+            mock.patch.object(task, "_get_composer_airflow_version", return_value=3),
+            mock.patch.object(task, "poke", return_value=True),
+        ):
+            task.execute(context={})
+
+        assert task.composer_external_task_ids is None
+        assert task.composer_external_task_group_id == TEST_COMPOSER_EXTERNAL_TASK_GROUP_ID
+
     @pytest.mark.parametrize("composer_airflow_version", [2, 3])
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
     def test_wait_ready(self, mock_hook, composer_airflow_version):

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_composer.py
@@ -201,6 +201,46 @@ class TestCloudComposerDAGRunSensor:
 
 
 class TestCloudComposerExternalTaskSensor:
+    def test_templated_task_id_is_normalized_after_rendering(self):
+        task = CloudComposerExternalTaskSensor(
+            task_id="task-id",
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            environment_id=TEST_ENVIRONMENT_ID,
+            composer_external_dag_id="test_dag_id",
+            composer_external_task_id="{{ target_task_id }}",
+        )
+
+        assert task.composer_external_task_ids is None
+        task.render_template_fields(context={"target_task_id": TEST_COMPOSER_EXTERNAL_TASK_ID})
+        assert task.composer_external_task_id == TEST_COMPOSER_EXTERNAL_TASK_ID
+        assert task.composer_external_task_ids is None
+
+        with (
+            mock.patch.object(task, "_get_composer_airflow_version", return_value=3),
+            mock.patch.object(task, "poke", return_value=True),
+        ):
+            task.execute(context={})
+
+        assert task.composer_external_task_ids == [TEST_COMPOSER_EXTERNAL_TASK_ID]
+
+    def test_state_validation_uses_rendered_target(self):
+        task = CloudComposerExternalTaskSensor(
+            task_id="task-id",
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            environment_id=TEST_ENVIRONMENT_ID,
+            composer_external_dag_id="test_dag_id",
+            composer_external_task_id=lambda *, context, jinja_env: None,
+            allowed_states=["up_for_retry"],
+        )
+
+        task.render_template_fields(context={})
+        assert task.composer_external_task_id is None
+
+        with pytest.raises(ValueError, match="composer_external_task_id.*is `None`"):
+            task.execute(context={})
+
     @pytest.mark.parametrize("composer_airflow_version", [2, 3])
     @mock.patch("airflow.providers.google.cloud.sensors.cloud_composer.CloudComposerHook")
     def test_wait_ready(self, mock_hook, composer_airflow_version):

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -19,7 +19,6 @@ providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::Datap
 providers/google/src/airflow/providers/google/cloud/operators/functions.py::CloudFunctionDeployFunctionOperator
 providers/google/src/airflow/providers/google/cloud/operators/gcs.py::GCSFileTransformOperator
 providers/google/src/airflow/providers/google/cloud/sensors/bigquery_dts.py::BigQueryDataTransferServiceTransferRunSensor
-providers/google/src/airflow/providers/google/cloud/sensors/cloud_composer.py::CloudComposerExternalTaskSensor
 providers/google/src/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py::AzureFileShareToGCSOperator
 providers/google/src/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py::BigQueryToMsSqlOperator
 providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py::GCSToBigQueryOperator


### PR DESCRIPTION
Fixes the Google provider's `CloudComposerExternalTaskSensor` entry from the #70296 exemption-list burn-down.

Several of the sensor's template fields (`composer_external_task_id`, `composer_external_task_ids`, `composer_external_task_group_id`) were normalized and validated inside `__init__`. Because template fields are only rendered *after* the constructor runs, that logic operated on the raw, un-rendered Jinja expressions, and the `validate-operators-init` prek hook flagged the class.

Changes:

- Assign every template field directly in `__init__` (`self.field = field`) with no transformation, so the constructor no longer applies logic to un-rendered values.
- Moved the following into `execute()`, where they act on the rendered values:
  - the empty-list → `None` normalization,
  - the single `composer_external_task_id` → one-element `composer_external_task_ids` conversion,
  - the `allowed_states` / `skipped_states` / `failed_states` validity check against dag- vs task-states,
  - the mutual-exclusivity checks between `composer_external_task_id`, `composer_external_task_ids`, and `composer_external_task_group_id`.
- Removed the operator's entry from `scripts/ci/prek/validate_operators_init_exemptions.txt`.
- Added unit tests covering post-render normalization and rendered-target state validation.

The public constructor signature is unchanged, so this is not a breaking change for existing DAGs. The `DuplicateStateError` check on the non-templated `allowed_states`/`skipped_states`/`failed_states` remains in `__init__`.

Verified locally that `scripts/ci/prek/validate_operators_init.py` reports zero findings for `CloudComposerExternalTaskSensor` after the change.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes [Claude]

<!--
Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->
