### PR TITLE
Fix BteqOperator declaring template_fields as a bare string

### DIFF
--- a/providers/teradata/src/airflow/providers/teradata/operators/bteq.py
+++ b/providers/teradata/src/airflow/providers/teradata/operators/bteq.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
 from airflow.providers.teradata.utils.bteq_util import (
@@ -75,7 +76,7 @@ class BteqOperator(BaseOperator):
     :param timeout_rc: Return code to use if the BTEQ execution fails due to a timeout. To allow DAG execution to continue after a timeout, include this value in `bteq_quit_rc`. If not specified, a timeout will raise an exception and stop the DAG.
     """
 
-    template_fields = "sql"
+    template_fields: Sequence[str] = ("sql",)
     ui_color = "#ff976d"
 
     def __init__(

--- a/providers/teradata/tests/unit/teradata/operators/test_bteq.py
+++ b/providers/teradata/tests/unit/teradata/operators/test_bteq.py
@@ -144,8 +144,7 @@ class TestBteqOperator:
 
     def test_template_fields(self):
         # Verify template fields are defined correctly
-        print(BteqOperator.template_fields)
-        assert BteqOperator.template_fields == "sql"
+        assert BteqOperator.template_fields == ("sql",)
 
     def test_execute_raises_if_no_sql_or_file(self):
         op = BteqOperator(task_id="fail_case", teradata_conn_id="td_conn")


### PR DESCRIPTION
`BteqOperator` declared `template_fields = "sql"`. A bare string is a sequence of
characters, so this declares the fields `"s"`, `"q"` and `"l"` rather than `"sql"`.

Airflow papers over this in `BaseOperator.__init__`, which wraps a string
`template_fields` in a list, but it emits a `UserWarning` every time a task is
built, and any code reading the class attribute directly — the sphinx
`template-fields` doc role, `dry_run()`, `_set_xcomargs_dependencies()` — still
sees the wrong value.

Declaring it as `Sequence[str] = ("sql",)` matches every other operator in the
codebase and drops the warning.

The existing `test_template_fields` asserted the incorrect value, so it is updated
to the corrected one (and a stray `print` removed).

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
