### PR TITLE
Fix SSHRemoteJobOperator cleanup rejecting a custom remote_base_dir

### DIFF
--- a/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/operators/ssh_remote_job.py
@@ -452,9 +452,9 @@ class SSHRemoteJobOperator(BaseOperator):
         """
         self.log.info("Cleaning up remote job directory: %s", job_dir)
         if remote_os == "posix":
-            cleanup_cmd = build_posix_cleanup_command(job_dir)
+            cleanup_cmd = build_posix_cleanup_command(job_dir, self.remote_base_dir)
         else:
-            cleanup_cmd = build_windows_cleanup_command(job_dir)
+            cleanup_cmd = build_windows_cleanup_command(job_dir, self.remote_base_dir)
 
         last_error: Exception | None = None
         for attempt in range(1, self.cleanup_retries + 1):

--- a/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
+++ b/providers/ssh/src/airflow/providers/ssh/utils/remote_job.py
@@ -30,18 +30,26 @@ POSIX_DEFAULT_BASE_DIR = "/tmp/airflow-ssh-jobs"
 WINDOWS_DEFAULT_BASE_DIR = "$env:TEMP\\airflow-ssh-jobs"
 
 
-def _validate_job_dir(job_dir: str, remote_os: Literal["posix", "windows"]) -> None:
+def _validate_job_dir(
+    job_dir: str, remote_os: Literal["posix", "windows"], base_dir: str | None = None
+) -> None:
     """
     Validate that job_dir is under the expected base directory.
 
+    The base directory is configurable via ``SSHRemoteJobOperator(remote_base_dir=...)``,
+    so validating against the platform default would reject every custom one.
+
     :param job_dir: The job directory path to validate
     :param remote_os: Operating system type
+    :param base_dir: Base directory the job dir must be under; defaults to the
+        platform default when not set
     :raises ValueError: If job_dir doesn't start with the expected base path
     """
-    if remote_os == "posix":
-        expected_prefix = POSIX_DEFAULT_BASE_DIR + "/"
-    else:
-        expected_prefix = WINDOWS_DEFAULT_BASE_DIR + "\\"
+    sep = "\\" if remote_os == "windows" else "/"
+    if base_dir is None:
+        base_dir = POSIX_DEFAULT_BASE_DIR if remote_os == "posix" else WINDOWS_DEFAULT_BASE_DIR
+    # RemoteJobPaths joins with a single separator, so tolerate a trailing one here.
+    expected_prefix = base_dir.rstrip(sep) + sep
 
     if not job_dir.startswith(expected_prefix):
         raise ValueError(
@@ -456,27 +464,29 @@ if (Test-Path $path) {{
     return f"powershell.exe -NoProfile -NonInteractive -EncodedCommand {encoded_script}"
 
 
-def build_posix_cleanup_command(job_dir: str) -> str:
+def build_posix_cleanup_command(job_dir: str, base_dir: str | None = None) -> str:
     """
     Build a POSIX command to clean up the job directory.
 
     :param job_dir: Path to the job directory
+    :param base_dir: Base directory the job dir must be under; defaults to the platform default
     :return: Shell command to remove the directory
     :raises ValueError: If job_dir is not under the expected base directory
     """
-    _validate_job_dir(job_dir, "posix")
+    _validate_job_dir(job_dir, "posix", base_dir)
     return f"rm -rf '{job_dir}'"
 
 
-def build_windows_cleanup_command(job_dir: str) -> str:
+def build_windows_cleanup_command(job_dir: str, base_dir: str | None = None) -> str:
     """
     Build a PowerShell command to clean up the job directory.
 
     :param job_dir: Path to the job directory
+    :param base_dir: Base directory the job dir must be under; defaults to the platform default
     :return: PowerShell command to remove the directory
     :raises ValueError: If job_dir is not under the expected base directory
     """
-    _validate_job_dir(job_dir, "windows")
+    _validate_job_dir(job_dir, "windows", base_dir)
     escaped_path = job_dir.replace("'", "''")
     script = f"Remove-Item -Recurse -Force -Path '{escaped_path}' -ErrorAction SilentlyContinue"
     script_bytes = script.encode("utf-16-le")

--- a/providers/ssh/tests/unit/ssh/operators/test_ssh_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/operators/test_ssh_remote_job.py
@@ -504,6 +504,37 @@ class TestSSHRemoteJobOperator:
         assert self.mock_hook.exec_ssh_client_command.call_count == 2
         mock_sleep.assert_called_once()
 
+    def test_cleanup_uses_configured_remote_base_dir(self):
+        """A custom remote_base_dir must survive cleanup, which runs after deferral (#69813)."""
+        self.mock_hook.exec_ssh_client_command.return_value = (0, b"", b"")
+        job_dir = "/tmp-data/airflow-ssh-jobs/test_job_123"
+
+        op = SSHRemoteJobOperator(
+            task_id="test_task",
+            ssh_conn_id="test_conn",
+            command="/path/to/script.sh",
+            remote_base_dir="/tmp-data/airflow-ssh-jobs",
+        )
+
+        op._cleanup_remote_job(job_dir, "posix")
+
+        assert self.mock_hook.exec_ssh_client_command.call_count == 1
+        assert job_dir in self.mock_hook.exec_ssh_client_command.call_args.args[1]
+
+    def test_cleanup_still_rejects_job_dir_outside_remote_base_dir(self):
+        """The guard must narrow to the configured base dir rather than being lifted."""
+        op = SSHRemoteJobOperator(
+            task_id="test_task",
+            ssh_conn_id="test_conn",
+            command="/path/to/script.sh",
+            remote_base_dir="/tmp-data/airflow-ssh-jobs",
+        )
+
+        with pytest.raises(ValueError, match="Invalid job directory"):
+            op._cleanup_remote_job("/tmp-data/elsewhere/test_job_123", "posix")
+
+        self.mock_hook.exec_ssh_client_command.assert_not_called()
+
     def test_cleanup_gives_up_after_retries_without_raising(self):
         """When every cleanup attempt fails the task is not failed; the dir is left in place."""
         self.mock_hook.exec_ssh_client_command.side_effect = Exception("connection refused")

--- a/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
+++ b/providers/ssh/tests/unit/ssh/utils/test_remote_job.py
@@ -453,3 +453,50 @@ class TestCleanupCommands:
         """Test Windows cleanup rejects paths outside expected base directory."""
         with pytest.raises(ValueError, match="Invalid job directory"):
             build_windows_cleanup_command("C:\\temp\\other_dir")
+
+    @pytest.mark.parametrize(
+        "base_dir, job_dir",
+        [
+            pytest.param("/tmp-data/airflow-ssh-jobs", "/tmp-data/airflow-ssh-jobs/job_123", id="custom"),
+            pytest.param(
+                "/tmp-data/airflow-ssh-jobs/", "/tmp-data/airflow-ssh-jobs/job_123", id="trailing-sep"
+            ),
+            pytest.param("/opt/jobs", "/opt/jobs/job_123", id="unrelated-to-default"),
+        ],
+    )
+    def test_posix_cleanup_accepts_configured_base_dir(self, base_dir, job_dir):
+        """A remote_base_dir outside the platform default must not be rejected at cleanup."""
+        cmd = build_posix_cleanup_command(job_dir, base_dir)
+        assert cmd == f"rm -rf '{job_dir}'"
+
+    def test_windows_cleanup_accepts_configured_base_dir(self):
+        """A Windows remote_base_dir outside the platform default must not be rejected."""
+        cmd = build_windows_cleanup_command("D:\\jobs\\job_123", "D:\\jobs")
+        encoded_script = cmd.split("-EncodedCommand ")[1]
+        decoded_script = base64.b64decode(encoded_script).decode("utf-16-le")
+        assert "D:\\jobs\\job_123" in decoded_script
+
+    @pytest.mark.parametrize(
+        "builder, base_dir, job_dir",
+        [
+            pytest.param(build_posix_cleanup_command, "/opt/jobs", "/opt/other/job_123", id="posix-sibling"),
+            pytest.param(
+                build_posix_cleanup_command,
+                "/opt/jobs",
+                "/tmp/airflow-ssh-jobs/job_123",
+                id="posix-platform-default",
+            ),
+            pytest.param(
+                build_windows_cleanup_command, "D:\\jobs", "D:\\other\\job_123", id="windows-sibling"
+            ),
+        ],
+    )
+    def test_cleanup_rejects_paths_outside_configured_base_dir(self, builder, base_dir, job_dir):
+        """Passing a base dir must narrow the guard to it, not disable the guard."""
+        with pytest.raises(ValueError, match="Invalid job directory"):
+            builder(job_dir, base_dir)
+
+    def test_posix_cleanup_rejects_prefix_lookalike(self):
+        """A sibling directory sharing the base dir's name prefix is not under it."""
+        with pytest.raises(ValueError, match="Invalid job directory"):
+            build_posix_cleanup_command("/opt/jobs-evil/job_123", "/opt/jobs")


### PR DESCRIPTION
`SSHRemoteJobOperator(remote_base_dir=...)` ran the job to completion and then failed the task on the last step, while removing the job directory:

```text
Invalid job directory: '/tmp-data/airflow-ssh-jobs/af_ ....'. Expected Path under '/tmp/airflow-ssh-jobs' for safety.
```

The cleanup guard in `_validate_job_dir` compared the job directory against the platform default base dir, but the base dir is configurable through `remote_base_dir`. The operator's own `_validate_base_dir` accepts any non-traversal path, so a custom value passed validation at submit time and only blew up at cleanup, after an hour-long job had already finished. The job directory was also left behind.

Validating against the *configured* base dir keeps the guard doing its job. Cleanup runs `rm -rf` / `Remove-Item -Recurse -Force`, so it must only ever target a directory the operator created, and it still can.

`base_dir` is threaded as an optional argument through `build_posix_cleanup_command` / `build_windows_cleanup_command` to `_validate_job_dir`, defaulting to the platform default so existing callers and behaviour are unchanged. The operator passes `self.remote_base_dir` rather than `self._paths.base_dir`, because cleanup happens in `execute_complete` after deferral, on a fresh operator instance where `_paths` is `None`.

A configured base dir with a trailing separator is also tolerated, since `RemoteJobPaths` joins with a single separator and the prefix would otherwise never match.

closes: #69813

### Tests

10 new tests, all reverted-and-checked: 9 of them fail without the source change.

- `build_posix_cleanup_command` / `build_windows_cleanup_command` accept a custom base dir, including one with a trailing separator and one unrelated to the platform default.
- The guard is narrowed to the configured base dir, not lifted: a sibling directory, and the platform default itself, are both still rejected once a custom base dir is set.
- A sibling that shares the base dir's name prefix (`/opt/jobs-evil` against `/opt/jobs`) is rejected, since the check appends the separator before comparing.
- At the operator level, `_cleanup_remote_job` with a custom `remote_base_dir` now issues the cleanup command, and still refuses a job dir outside that base dir without contacting the host.

The tenth test, `test_cleanup_still_rejects_job_dir_outside_remote_base_dir`, passes before and after by design. It is not a regression test for this bug but a guard against fixing it by removing the check, which is the obvious wrong fix here.

`providers/ssh/tests/unit/ssh/utils/test_remote_job.py` and `.../operators/test_ssh_remote_job.py` in full: 57 passed, 2 skipped. The 2 skips are the process-group teardown tests, which need a POSIX host with `setsid`; they skip on macOS regardless of this change. `ruff format --check` and `ruff check` are clean.

I did not add a changelog entry, since provider changelogs are regenerated from `git log` at release time. Happy to add one to `providers/ssh/docs/changelog.rst` if you would prefer it explicit.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
