### PR TITLE
Stop batching major version bumps in the edge UI Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -166,10 +166,16 @@ updates:
       edge-ui-package-updates:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
       edge-ui-security-updates:
         patterns:
           - "*"
         applies-to: security-updates
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     cooldown:


### PR DESCRIPTION
The `edge-ui-package-updates` Dependabot group had no restriction on update types, so a `typescript` major bump (6.x → 7.x) kept riding along with routine minor/patch updates. TypeScript 7 dropped the legacy JS Compiler API that `unplugin-dts` (used via `vite-plugin-dts`) still depends on, which breaks `pnpm build` and fails the `compile-edge-assets` prek hook — seen in #70616 and #70848.

This restricts the group to `minor`/`patch` and ignores major updates, matching the pattern already used by `core-ui-package-updates` (airflow-core UI) and the `3-3-edge-ui-package-updates` sibling group that already covers this same directory on `v3-3-test`.

related: #70616, #70848

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)