### PR TITLE
Rewrite SnowparkContainerJobOperator exclusivity check and move back …

### DIFF
--- a/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_containers.py
+++ b/providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_containers.py
@@ -144,6 +144,8 @@ class SnowparkContainerJobOperator(BaseOperator):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+        if spec_text is not None and (spec is not None or spec_stage is not None):
+            raise ValueError("Cannot specify both 'spec_text' and 'spec'/'spec_stage'")
         self.compute_pool = compute_pool
         self.container_name = container_name
         self.spec = spec
@@ -232,8 +234,6 @@ class SnowparkContainerJobOperator(BaseOperator):
 
     def execute(self, context: Context) -> str:
         """Submit and optionally wait for a Snowpark Container Services job."""
-        if self.spec_text and (self.spec or self.spec_stage):
-            raise ValueError("Cannot specify both 'spec_text' and 'spec'/'spec_stage'")
         if not self.spec_text and not (self.spec and self.spec_stage):
             raise ValueError("Must provide either 'spec_text' or both 'spec' and 'spec_stage'")
 

--- a/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
+++ b/providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py
@@ -46,6 +46,10 @@ def _make_operator(**kwargs):
 
 
 class TestSnowparkContainerJobOperator:
+    def test_invalid_spec_combinations_at_init(self):
+        with pytest.raises(ValueError, match=r"Cannot specify both"):
+            _make_operator(spec=SPEC, spec_stage=SPEC_STAGE, spec_text=SPEC_TEXT)
+
     @pytest.mark.parametrize(
         ("kwargs", "match"),
         (
@@ -53,11 +57,6 @@ class TestSnowparkContainerJobOperator:
                 {"spec": None, "spec_stage": None, "spec_text": None},
                 "Must provide either",
                 id="no_spec_provided",
-            ),
-            pytest.param(
-                {"spec": SPEC, "spec_stage": SPEC_STAGE, "spec_text": SPEC_TEXT},
-                "Cannot specify both",
-                id="both_spec_and_spec_text",
             ),
             pytest.param(
                 {"spec": SPEC, "spec_stage": None, "spec_text": None},
@@ -71,7 +70,7 @@ class TestSnowparkContainerJobOperator:
             ),
         ),
     )
-    def test_invalid_spec_combinations(self, kwargs, match):
+    def test_invalid_spec_combinations_at_execute(self, kwargs, match):
         op = _make_operator(**kwargs)
         with pytest.raises(ValueError, match=match):
             op.execute(context=None)


### PR DESCRIPTION
…to __init__

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Description

This PR moves template_field exclusivity check back to `__init__` from `execute()` so the `self.spec_text and (self.spec or self.spec_stage) ` while keeping it's inverse in `execute()` since it is a required-argument check (see #70503) for the `SnowparkContainerJobOperator` operators in the providers/snowflake/src/airflow/providers/snowflake/operators/snowpark_containers.py.

The check is updated to use `is not None` polarity rather than a truthiness check, so this is not a straight revert of the original code.

These are pure provision checks ("was this argument passed?") which belong in `__init__` per the updated guidance in #70296, as moving them to execute() risks false positives when `render_template_as_native_obj=True` renders a provided field to None.

## Tests

- Separated tests under providers/snowflake/tests/unit/snowflake/operators/test_snowpark_containers.py to validate the new behaviour.

related: #70296 and #70503 

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Antigravity IDE and Claude Web] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
