### PR TITLE
[v3-3-test] Fix mypy failure on datadog timer wrapped by shared observability Timer (#69202)

### DIFF
--- a/shared/observability/src/airflow_shared/observability/metrics/protocols.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/protocols.py
@@ -27,6 +27,14 @@ if TYPE_CHECKING:
 DeltaType = int | float | datetime.timedelta
 
 
+class BackendTimerProtocol(Protocol):
+    """Minimal interface of a backend timer (e.g. pystatsd / dogstatsd) wrapped by :class:`Timer`."""
+
+    def start(self) -> object: ...
+
+    def stop(self) -> object: ...
+
+
 class TimerProtocol(Protocol):
     """Type protocol for StatsLogger.timer."""
 
@@ -100,7 +108,7 @@ class Timer(TimerProtocol):
     _start_time: float | None
     duration: float | None
 
-    def __init__(self, real_timer: Timer | None = None) -> None:
+    def __init__(self, real_timer: BackendTimerProtocol | None = None) -> None:
         self.real_timer = real_timer
 
     def __enter__(self) -> Self:


### PR DESCRIPTION
Cherry-pick of #69202 to `v3-3-test`.

`mypy-shared-observability` fails on every PR targeting `v3-3-test`:
`datadog_logger.py` passes dogstatsd's `TimedContextManagerDecorator` into
`Timer(...)`, whose `real_timer` is typed `Timer | None`. The fix retypes it
against a minimal `BackendTimerProtocol` (`start()`/`stop()`), which is what
the parameter actually accepts. Type-annotation-only, no runtime change.

This unblocks static checks on the branch — e.g. #70855, #70854, #70852.

(cherry picked from commit 594604681b2f0a4d2da66d32f13acbd6e2262850)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)