### PR TITLE
Resolve backfill_id in the access dependency with the type the routes declare

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -27,6 +27,7 @@ from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer, OAuth2PasswordBearer
 from itsdangerous import BadSignature, URLSafeSerializer
 from jwt import ExpiredSignatureError, InvalidTokenError
+from pydantic import NonNegativeInt, TypeAdapter, ValidationError
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
@@ -390,6 +391,12 @@ ReadableBackfillsFilterDep = Annotated[
 ]
 
 
+# The type the backfill routes declare for the `backfill_id` path parameter. Shared with
+# `requires_access_backfill` so the authorization decision parses the id exactly as the handler
+# does; see the comment there for why any divergence is a cross-Dag authorization bypass.
+_BACKFILL_ID_ADAPTER: TypeAdapter[NonNegativeInt] = TypeAdapter(NonNegativeInt)
+
+
 def requires_access_backfill(
     method: ResourceMethod,
 ) -> Callable[[Request, BaseUser, Session], Coroutine[Any, Any, None]]:
@@ -405,8 +412,20 @@ def requires_access_backfill(
         # Try to retrieve the dag_id from the backfill_id path param
         backfill_id_raw = request.path_params.get("backfill_id")
         try:
-            backfill_id = int(backfill_id_raw) if backfill_id_raw is not None else None
-        except ValueError:
+            # Parse with the *same* type the endpoints declare for this path parameter, so this
+            # dependency and the handler always resolve the same backfill -- and therefore the
+            # same Dag.
+            #
+            # `int()` is not that parser: pydantic's lax mode accepts strings `int()` rejects,
+            # so "1.0" and "1.00" validate to 1 for the handler while `int()` raised here. Since
+            # dependencies resolve before the endpoint's own parameter validation, that left
+            # `dag_id` unresolved for a request the handler went on to serve against backfill 1.
+            backfill_id = (
+                _BACKFILL_ID_ADAPTER.validate_python(backfill_id_raw) if backfill_id_raw is not None else None
+            )
+        except ValidationError:
+            # Rejected by the endpoint's parser too, so the handler cannot run: FastAPI answers
+            # 422 before it is reached. Left as None, preserving that response.
             backfill_id = None
 
         if backfill_id is not None:

--- a/airflow-core/src/airflow/api_fastapi/core_api/security.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/security.py
@@ -412,14 +412,8 @@ def requires_access_backfill(
         # Try to retrieve the dag_id from the backfill_id path param
         backfill_id_raw = request.path_params.get("backfill_id")
         try:
-            # Parse with the *same* type the endpoints declare for this path parameter, so this
-            # dependency and the handler always resolve the same backfill -- and therefore the
-            # same Dag.
-            #
-            # `int()` is not that parser: pydantic's lax mode accepts strings `int()` rejects,
-            # so "1.0" and "1.00" validate to 1 for the handler while `int()` raised here. Since
-            # dependencies resolve before the endpoint's own parameter validation, that left
-            # `dag_id` unresolved for a request the handler went on to serve against backfill 1.
+            # Must parse exactly as the handler does (e.g. pydantic's lax mode coerces "1.0" to 1
+            # where int() raises), or the two can authorize and act on different backfills.
             backfill_id = (
                 _BACKFILL_ID_ADAPTER.validate_python(backfill_id_raw) if backfill_id_raw is not None else None
             )
@@ -433,6 +427,10 @@ def requires_access_backfill(
             dag_id = backfill.dag_id if backfill else None
 
         # Try to retrieve the dag_id from the request body (POST backfill)
+        # TODO: a backfill_id that parses but matches no row also lands here, so an unknown
+        # backfill is authorized against the body's dag_id and answers 404 where an unauthorized
+        # one answers 403 - disclosing which ids exist. Not exploitable for a cross-Dag action;
+        # tracked at https://github.com/apache/airflow/issues/71080
         if dag_id is None:
             # Not a json body, ignore
             with suppress(JSONDecodeError):

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -433,10 +433,7 @@ class TestFastApiSecurity:
     async def test_requires_access_backfill_backfill_not_found_falls_back_to_body(
         self, mock_get_auth_manager, mock_get_team_name
     ):
-        """When backfill_id is int but Backfill not found, dag_id from body is used.
-
-        Not exploitable: the handler answers 404 before acting, so no cross-Dag action follows.
-        """
+        """When backfill_id is int but Backfill not found, dag_id from body is used."""
         auth_manager = Mock()
         auth_manager.is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -367,7 +367,7 @@ class TestFastApiSecurity:
     async def test_requires_access_backfill_authorized_from_body(
         self, mock_get_auth_manager, mock_get_team_name
     ):
-        """When backfill_id is missing or not int, dag_id can come from request body (POST backfill)."""
+        """With no backfill_id in the path, dag_id comes from the request body (POST backfill)."""
         auth_manager = Mock()
         auth_manager.is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager
@@ -430,7 +430,10 @@ class TestFastApiSecurity:
     async def test_requires_access_backfill_backfill_not_found_falls_back_to_body(
         self, mock_get_auth_manager, mock_get_team_name
     ):
-        """When backfill_id is int but Backfill not found, dag_id from body is used."""
+        """When backfill_id is int but Backfill not found, dag_id from body is used.
+
+        Not exploitable: the handler answers 404 before acting, so no cross-Dag action follows.
+        """
         auth_manager = Mock()
         auth_manager.is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager
@@ -452,6 +455,48 @@ class TestFastApiSecurity:
             method="POST",
             access_entity=DagAccessEntity.RUN,
             details=DagDetails(id="fallback_dag_id", team_name="team1"),
+            user=user,
+        )
+
+    @pytest.mark.db_test
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backfill_id", ["42", "42.0", "42.00"])
+    @patch.object(DagModel, "get_team_name")
+    @patch("airflow.api_fastapi.core_api.security.get_auth_manager")
+    async def test_requires_access_backfill_authorizes_the_backfill_the_handler_will_act_on(
+        self, mock_get_auth_manager, mock_get_team_name, backfill_id
+    ):
+        """The dependency must resolve the same backfill the handler does, for every spelling.
+
+        The endpoints declare ``backfill_id: NonNegativeInt``, and pydantic's lax mode coerces
+        ``"42.0"`` and ``"42.00"`` to ``42`` -- both are spellings the handler accepts and serves
+        against backfill 42. Parsing with ``int()`` here rejected them and left ``dag_id``
+        unresolved, so the two disagreed about which Dag the request concerned.
+        """
+        auth_manager = Mock()
+        auth_manager.is_authorized_dag.return_value = True
+        mock_get_auth_manager.return_value = auth_manager
+        mock_get_team_name.return_value = "team1"
+
+        backfill = Mock()
+        backfill.dag_id = "backfill_dag"
+        session = Mock()
+        session.scalars.return_value.one_or_none.return_value = backfill
+
+        request = Mock()
+        request.path_params = {"backfill_id": backfill_id}
+        request.query_params = {"dag_id": "some_other_dag"}
+        request.json = AsyncMock(return_value={"dag_id": "some_other_dag"})
+
+        user = Mock()
+
+        await requires_access_backfill("PUT")(request, user, session)
+
+        # the backfill's own Dag, not the one supplied on the request
+        auth_manager.is_authorized_dag.assert_called_once_with(
+            method="PUT",
+            access_entity=DagAccessEntity.RUN,
+            details=DagDetails(id="backfill_dag", team_name="team1"),
             user=user,
         )
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/test_security.py
@@ -20,12 +20,14 @@ from json import JSONDecodeError
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from jwt import ExpiredSignatureError, InvalidTokenError
+from sqlalchemy.orm import Session
 
 from airflow import settings
 from airflow.api_fastapi.app import create_app
-from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN
+from airflow.api_fastapi.auth.managers.base_auth_manager import COOKIE_NAME_JWT_TOKEN, BaseAuthManager
+from airflow.api_fastapi.auth.managers.models.base_user import BaseUser
 from airflow.api_fastapi.auth.managers.models.resource_details import (
     AccessView,
     ConnectionDetails,
@@ -55,6 +57,7 @@ from airflow.api_fastapi.core_api.security import (
     resolve_user_from_token,
 )
 from airflow.models import Connection, Pool, Variable
+from airflow.models.backfill import Backfill
 from airflow.models.dag import DagModel
 from airflow.models.dagbundle import DagBundleModel
 from airflow.models.team import Team
@@ -473,22 +476,22 @@ class TestFastApiSecurity:
         against backfill 42. Parsing with ``int()`` here rejected them and left ``dag_id``
         unresolved, so the two disagreed about which Dag the request concerned.
         """
-        auth_manager = Mock()
+        auth_manager = Mock(spec=BaseAuthManager)
         auth_manager.is_authorized_dag.return_value = True
         mock_get_auth_manager.return_value = auth_manager
         mock_get_team_name.return_value = "team1"
 
-        backfill = Mock()
+        backfill = Mock(spec=Backfill)
         backfill.dag_id = "backfill_dag"
-        session = Mock()
+        session = Mock(spec=Session)
         session.scalars.return_value.one_or_none.return_value = backfill
 
-        request = Mock()
+        request = Mock(spec=Request)
         request.path_params = {"backfill_id": backfill_id}
         request.query_params = {"dag_id": "some_other_dag"}
         request.json = AsyncMock(return_value={"dag_id": "some_other_dag"})
 
-        user = Mock()
+        user = Mock(spec=BaseUser)
 
         await requires_access_backfill("PUT")(request, user, session)
 


### PR DESCRIPTION
The backfill routes declare `backfill_id: NonNegativeInt`, but
`requires_access_backfill` parsed the raw path value with `int()` and swallowed
the failure. Those two parsers do not agree.

### The divergence

| supplied `backfill_id` | `NonNegativeInt` (the handler) | `int()` (the dependency) |
|---|---|---|
| `"42"` | 42 | 42 |
| `"42.0"` | **42** | ValueError |
| `"42.00"` | **42** | ValueError |
| `"42."`, `"42e0"`, `"42.5"`, `"0x2a"` | rejected | ValueError |

pydantic's lax mode accepts the two decimal spellings and coerces them to an
int; `int()` rejects them.

FastAPI resolves route dependencies *before* the endpoint's own parameter
validation, so for those spellings the dependency's parse failed, it left the
Dag unresolved, and the request went on to be served by the handler against
backfill 42. The dependency and the handler disagreed about which backfill --
and therefore which Dag -- the request concerned.

### Approach

Parse with the same `TypeAdapter(NonNegativeInt)` the routes declare, so the
two cannot diverge by construction. The adapter is module-level and named, so
the coupling to the route signature is explicit rather than re-derived.

This deliberately does **not** introduce a stricter parser. An earlier revision
used `int()` with an explicit 400, which changed the public API contract: a
malformed path value such as `/backfills/invalid_id` previously produced
FastAPI's structured **422** (`loc: ["path", "backfill_id"]`), and a 400 from
the dependency preempted it. Five existing route tests caught that. Matching
the declared type keeps every existing status code and body shape intact --
values both parsers reject still yield the handler's 422, and an unknown
backfill still yields each route's own 404 wording.

### Test plan

- [x] `test_requires_access_backfill_authorizes_the_backfill_the_handler_will_act_on`
      -- parametrized over `42`, `42.0`, `42.00`; asserts the Dag comes from the
      resolved backfill and not from a value supplied on the request
- [x] Verified against unmodified code: `42.0` and `42.00` **fail**, `42` passes --
      so the test pins the divergence and not the plumbing
- [x] `airflow-core/tests/unit/api_fastapi/core_api/test_security.py` -- 111 passed
- [x] `airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_backfills.py`
      -- 63 passed, including the four `test_invalid_id` 422 cases and `test_no_exist`
- [x] `ruff check` / `ruff format` clean

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
