### PR TITLE
Mask nested entities when writing bulk audit-log entries

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -102,7 +102,11 @@ def _mask_connection_entity(extra_fields):
                     result[k] = {ek: "***" for ek in parsed_extra}
                 else:
                     result[k] = "Expected JSON object in `extra` field, got non-dict JSON"
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, TypeError):
+                # ``extra`` is declared as a string, but this runs on the raw body before
+                # validation, so it can arrive as any JSON type -- a number or an already-decoded
+                # object makes ``json.loads`` raise TypeError rather than JSONDecodeError. Both
+                # are recorded without the value, instead of raising out of the audit-log path.
                 result[k] = "Encountered non-JSON in `extra` field"
         else:
             result[k] = secrets_masker.redact(v, k)

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -45,8 +45,51 @@ def _sanitize_for_stdlib_log(value: str) -> str:
     return value.replace("\r", " ").replace("\n", " ")
 
 
+def _mask_bulk_entities(extra_fields, mask_entity):
+    """
+    Apply per-entity masking to a bulk request body.
+
+    A ``BulkBody`` has exactly one top-level field, ``actions``; the entities carrying the
+    secrets sit two levels down, in ``actions[].entities[]``. The per-entity maskers below
+    inspect top-level key names, so handing them a bulk body means they see only the key
+    ``actions`` and pass its whole payload through untouched. Reach the entities first.
+
+    Returns ``None`` when the body is not bulk-shaped, so callers fall back to flat masking.
+    """
+    actions = extra_fields.get("actions")
+    if not isinstance(actions, list):
+        return None
+
+    masked_actions = []
+    for action in actions:
+        if not isinstance(action, dict):
+            masked_actions.append(action)
+            continue
+        entities = action.get("entities")
+        if not isinstance(entities, list):
+            masked_actions.append(action)
+            continue
+        # ``delete`` actions may list bare id/key strings rather than entity objects;
+        # those carry no secret and are left as they are.
+        masked_actions.append(
+            {
+                **action,
+                "entities": [mask_entity(e) if isinstance(e, dict) else e for e in entities],
+            }
+        )
+    return {**extra_fields, "actions": masked_actions}
+
+
 def _mask_connection_fields(extra_fields):
-    """Mask connection fields."""
+    """Mask connection fields, for either a single-entity or a bulk request body."""
+    bulk = _mask_bulk_entities(extra_fields, _mask_connection_entity)
+    if bulk is not None:
+        return bulk
+    return _mask_connection_entity(extra_fields)
+
+
+def _mask_connection_entity(extra_fields):
+    """Mask the fields of one connection."""
     result = {}
     for k, v in extra_fields.items():
         if k == "extra" and v:
@@ -67,6 +110,14 @@ def _mask_connection_fields(extra_fields):
 
 
 def _mask_variable_fields(extra_fields):
+    """Mask variable values, for either a single-entity or a bulk request body."""
+    bulk = _mask_bulk_entities(extra_fields, _mask_variable_entity)
+    if bulk is not None:
+        return bulk
+    return _mask_variable_entity(extra_fields)
+
+
+def _mask_variable_entity(extra_fields):
     """
     Mask the variable value.
 

--- a/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
@@ -131,14 +131,7 @@ class TestMaskVariableFields:
 
 
 class TestMaskBulkFields:
-    """The bulk endpoints nest their entities, and the masking has to reach them.
-
-    A ``BulkBody`` has exactly one top-level field, ``actions``; the entities carrying the
-    secrets sit two levels down, in ``actions[].entities[]``. Both maskers dispatch on
-    top-level key names, so a bulk body previously presented them with the single key
-    ``actions`` -- neither ``val``/``value`` for variables, nor ``extra`` for connections --
-    and the payload was written to the audit log as supplied.
-    """
+    """The bulk endpoints nest their entities, and the masking has to reach them."""
 
     def test_bulk_variable_values_are_masked(self):
         result = _mask_variable_fields(
@@ -260,6 +253,28 @@ class TestMaskBulkFields:
         """The masker runs on request bodies before validation, so it must not add a failure mode."""
         _mask_variable_fields(body)
         _mask_connection_fields(body)
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            pytest.param({"token": "CONN_LEAK_token"}, id="already-decoded-object"),
+            pytest.param(["CONN_LEAK_token"], id="already-decoded-array"),
+            pytest.param(123, id="number"),
+            pytest.param(True, id="bool"),
+        ],
+    )
+    def test_non_string_extra_does_not_raise_and_does_not_leak(self, extra):
+        """``extra`` reaches this before validation, so it need not be a string.
+
+        ``json.loads`` raises ``TypeError`` rather than ``JSONDecodeError`` for a non-string, which
+        would otherwise escape the audit-log decorator.
+        """
+        body = {"actions": [{"action": "create", "entities": [{"connection_id": "c1", "extra": extra}]}]}
+
+        result = _mask_connection_fields(body)
+
+        assert "CONN_LEAK_token" not in json.dumps(result)
+        assert result["actions"][0]["entities"][0]["connection_id"] == "c1"
 
     def test_flat_body_still_takes_the_single_entity_path(self):
         assert _mask_variable_fields({"key": "k", "value": "secret"}) == {"key": "k", "value": "***"}

--- a/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
@@ -130,6 +130,141 @@ class TestMaskVariableFields:
         assert result == {"value": "***"}
 
 
+class TestMaskBulkFields:
+    """The bulk endpoints nest their entities, and the masking has to reach them.
+
+    A ``BulkBody`` has exactly one top-level field, ``actions``; the entities carrying the
+    secrets sit two levels down, in ``actions[].entities[]``. Both maskers dispatch on
+    top-level key names, so a bulk body previously presented them with the single key
+    ``actions`` -- neither ``val``/``value`` for variables, nor ``extra`` for connections --
+    and the payload was written to the audit log as supplied.
+    """
+
+    def test_bulk_variable_values_are_masked(self):
+        result = _mask_variable_fields(
+            {
+                "actions": [
+                    {
+                        "action": "create",
+                        "entities": [
+                            {"key": "campaign_signing_material", "value": "VARVAL_LEAK_token"},
+                            {"key": "other", "val": "VARVAL_LEAK_alias"},
+                        ],
+                        "action_on_existence": "overwrite",
+                    }
+                ]
+            }
+        )
+        assert result == {
+            "actions": [
+                {
+                    "action": "create",
+                    "entities": [
+                        {"key": "campaign_signing_material", "value": "***"},
+                        {"key": "other", "val": "***"},
+                    ],
+                    "action_on_existence": "overwrite",
+                }
+            ]
+        }
+
+    def test_bulk_connection_extra_is_masked(self):
+        """``extra`` is the load-bearing case for connections.
+
+        Key-name redaction already covered a nested ``password`` -- but only while
+        ``hide_sensitive_var_conn_fields`` is enabled, which is a deployment setting and is off
+        in this test environment. ``extra`` was never covered by it at all: the name is not a
+        recognised sensitive field, and the value is a JSON *string*, which ``redact`` returns
+        unchanged. Masking ``extra`` is structural here, so it does not depend on that setting.
+        """
+        result = _mask_connection_fields(
+            {
+                "actions": [
+                    {
+                        "action": "create",
+                        "entities": [
+                            {
+                                "connection_id": "c1",
+                                "conn_type": "http",
+                                "password": "CONN_LEAK_pw",
+                                "extra": json.dumps({"token": "CONN_LEAK_token", "region": "eu"}),
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        entity = result["actions"][0]["entities"][0]
+        assert entity["extra"] == {"token": "***", "region": "***"}
+        assert entity["connection_id"] == "c1"
+        # every value is gone, only the key names of ``extra`` remain
+        assert "CONN_LEAK_token" not in json.dumps(result)
+
+    @pytest.mark.parametrize(
+        ("body", "masker"),
+        [
+            (
+                {"actions": [{"action": "create", "entities": [{"key": "k", "value": "LEAK_v"}]}]},
+                _mask_variable_fields,
+            ),
+            (
+                {
+                    "actions": [
+                        {
+                            "action": "update",
+                            "entities": [{"connection_id": "c", "extra": json.dumps({"t": "LEAK_v"})}],
+                        }
+                    ]
+                },
+                _mask_connection_fields,
+            ),
+        ],
+        ids=["variables", "connections"],
+    )
+    def test_no_secret_survives_in_the_serialized_entry(self, body, masker):
+        """The audit entry is serialized whole, so assert on the serialization, not one field."""
+        assert "LEAK_v" not in json.dumps(masker(body))
+
+    def test_multiple_actions_and_entities_are_all_masked(self):
+        result = _mask_variable_fields(
+            {
+                "actions": [
+                    {
+                        "action": "create",
+                        "entities": [{"key": "a", "value": "s1"}, {"key": "b", "value": "s2"}],
+                    },
+                    {"action": "update", "entities": [{"key": "c", "value": "s3"}]},
+                ]
+            }
+        )
+        values = [e["value"] for a in result["actions"] for e in a["entities"]]
+        assert values == ["***", "***", "***"]
+
+    def test_delete_by_key_entities_are_left_alone(self):
+        """``delete`` may list bare keys rather than entity objects; those carry no secret."""
+        body = {"actions": [{"action": "delete", "entities": ["key_one", "key_two"]}]}
+        assert _mask_variable_fields(body) == body
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {"key": "k", "value": "secret"},
+            {"actions": "not-a-list"},
+            {"actions": [{"action": "create"}]},
+            {"actions": [{"action": "create", "entities": "not-a-list"}]},
+            {"actions": ["not-a-dict"]},
+        ],
+        ids=["flat-body", "actions-not-list", "no-entities", "entities-not-list", "action-not-dict"],
+    )
+    def test_non_bulk_and_malformed_shapes_do_not_raise(self, body):
+        """The masker runs on request bodies before validation, so it must not add a failure mode."""
+        _mask_variable_fields(body)
+        _mask_connection_fields(body)
+
+    def test_flat_body_still_takes_the_single_entity_path(self):
+        assert _mask_variable_fields({"key": "k", "value": "secret"}) == {"key": "k", "value": "***"}
+
+
 class TestActionLoggingUserFields:
     """The audit Log records the raw identifier in ``owner`` and the human-friendly
     ``get_display_name()`` in ``owner_display_name``."""


### PR DESCRIPTION
The audit-log maskers for Variables and Connections dispatch on top-level key
names -- `val`/`value` for variables, `extra` for connections. A bulk request
body has exactly one top-level key, `actions`, and the entities sit two levels
down in `actions[].entities[]`, so neither masker ever saw a key it recognised
and the payload was recorded as supplied. The single-entity endpoints mask the
same fields correctly; only the bulk paths diverged.

### Approach

`_mask_bulk_entities` walks `actions[].entities[]` and applies the existing
per-entity masking to each entry, so the two shapes now agree. The per-entity
logic is unchanged and simply factored out (`_mask_connection_entity`,
`_mask_variable_entity`) so both call sites share it.

- A `delete` action may list bare id/key strings rather than entity objects;
  those carry nothing to mask and are passed through.
- The helper returns `None` for a non-bulk body so the flat path is untouched.
- It runs on the request body *before* validation, so malformed shapes
  (`actions` not a list, missing `entities`, non-dict actions) must not raise --
  each is covered by a test.

Worth noting for connections: a nested `password` was already covered, but only
while `hide_sensitive_var_conn_fields` is enabled, since that is key-name
redaction. `extra` was never covered by it -- the name is not a recognised
sensitive field and the value is a JSON *string*, which `redact` returns
unchanged. Masking `extra` here is structural and so does not depend on that
setting.

### Test plan

- [x] `TestMaskBulkFields` -- bulk variables, bulk connection `extra`, multiple
      actions/entities, delete-by-key, and five malformed shapes
- [x] Verified against unmodified code: 5 of the new tests **fail**, and the
      guard tests correctly pass either way
- [x] `test_decorators.py` -- 30 passed
- [x] `test_variables.py` + `test_connections.py` -- 230 passed
- [x] `ruff check` / `ruff format` clean

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
