### PR TITLE
Mask list-shaped Variable values on deserialization

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -323,9 +323,22 @@ def _mask_and_deserialize_variable(raw: str, key: str, deserialize_json: bool) -
         return raw
     val = json.loads(raw)
     if isinstance(val, str):
+        # No key names of its own, so the variable's key decides whether it is masked.
         mask_secret(val, key)
     elif isinstance(val, dict):
+        # ``add_mask`` walks a dict per key and masks by the *inner* key name, ignoring the
+        # name passed here.
         mask_secret(val)
+    elif isinstance(val, list):
+        # A list was previously skipped entirely, even though ``add_mask`` walks iterables --
+        # the same list nested one level inside a dict was masked, only a top-level one was not.
+        #
+        # It is passed under the variable's key, not anonymously: a list has no key names of
+        # its own, so bare values inside follow the same rule as the plain-string case above.
+        # Masking them unconditionally would add every element to the global pattern set, so a
+        # list of ordinary values such as region names would be redacted everywhere it appeared.
+        # Dicts *inside* the list are still masked by their own key names.
+        mask_secret(val, key)
     return val
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/context.py
+++ b/task-sdk/src/airflow/sdk/execution_time/context.py
@@ -323,21 +323,13 @@ def _mask_and_deserialize_variable(raw: str, key: str, deserialize_json: bool) -
         return raw
     val = json.loads(raw)
     if isinstance(val, str):
-        # No key names of its own, so the variable's key decides whether it is masked.
         mask_secret(val, key)
     elif isinstance(val, dict):
-        # ``add_mask`` walks a dict per key and masks by the *inner* key name, ignoring the
-        # name passed here.
+        # Masked by the dict's own inner key names, which is what ``add_mask`` uses.
         mask_secret(val)
     elif isinstance(val, list):
-        # A list was previously skipped entirely, even though ``add_mask`` walks iterables --
-        # the same list nested one level inside a dict was masked, only a top-level one was not.
-        #
-        # It is passed under the variable's key, not anonymously: a list has no key names of
-        # its own, so bare values inside follow the same rule as the plain-string case above.
-        # Masking them unconditionally would add every element to the global pattern set, so a
-        # list of ordinary values such as region names would be redacted everywhere it appeared.
-        # Dicts *inside* the list are still masked by their own key names.
+        # Pass the Variable's key so list elements inherit the Variable's sensitivity
+        # instead of being added to the global mask patterns.
         mask_secret(val, key)
     return val
 

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -430,12 +430,7 @@ class TestVariableAccessor:
 
     @mock.patch("airflow.sdk.execution_time.context.mask_secret")
     def test_var_json_masks_list_values(self, mock_mask_secret, mock_supervisor_comms):
-        """A JSON list is handed to the masker whole, exactly as a dict is.
-
-        ``add_mask`` walks dicts and iterables itself, so the top-level type dispatch was the
-        only thing deciding whether nested values were reached: a list at the top level matched
-        no branch and was skipped, while the same list nested inside a dict was masked.
-        """
+        """A JSON list is handed to the masker whole, exactly as a dict is."""
         accessor = VariableAccessor(deserialize_json=True)
         raw_json = '[{"password": "s3cr3t"}, {"password": "s3cr3t2"}]'
         mock_supervisor_comms.send.return_value = VariableResult(key="db_configs", value=raw_json)
@@ -491,14 +486,7 @@ class TestVariableAccessor:
 
     @mock.patch("airflow.sdk.execution_time.context.mask_secret")
     def test_var_json_list_value_does_not_over_mask(self, mock_mask_secret, mock_supervisor_comms):
-        """var.json with a non-sensitive list variable does not mask individual list elements.
-
-        The list is handed to the masker **under the variable's key**, which is what preserves
-        this: bare values inside a list have no key names of their own, so they follow the
-        variable key's sensitivity. Passing the list anonymously instead would add every element
-        to the global pattern set, and an ordinary value such as a region name would then be
-        redacted everywhere it appeared in the logs.
-        """
+        """var.json with a non-sensitive list variable does not mask individual list elements."""
         accessor = VariableAccessor(deserialize_json=True)
         raw_json = '["us-east-1", "eu-west-1"]'
         mock_supervisor_comms.send.return_value = VariableResult(key="aws_regions", value=raw_json)

--- a/task-sdk/tests/task_sdk/execution_time/test_context.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_context.py
@@ -429,6 +429,41 @@ class TestVariableAccessor:
         mock_mask_secret.assert_any_call({"password": "s3cr3t", "host": "db.example.com"})
 
     @mock.patch("airflow.sdk.execution_time.context.mask_secret")
+    def test_var_json_masks_list_values(self, mock_mask_secret, mock_supervisor_comms):
+        """A JSON list is handed to the masker whole, exactly as a dict is.
+
+        ``add_mask`` walks dicts and iterables itself, so the top-level type dispatch was the
+        only thing deciding whether nested values were reached: a list at the top level matched
+        no branch and was skipped, while the same list nested inside a dict was masked.
+        """
+        accessor = VariableAccessor(deserialize_json=True)
+        raw_json = '[{"password": "s3cr3t"}, {"password": "s3cr3t2"}]'
+        mock_supervisor_comms.send.return_value = VariableResult(key="db_configs", value=raw_json)
+
+        val = accessor.db_configs
+
+        assert val == [{"password": "s3cr3t"}, {"password": "s3cr3t2"}]
+        mock_mask_secret.assert_any_call(raw_json, "db_configs")
+        # under the variable's key; dicts inside are still masked by their own key names
+        mock_mask_secret.assert_any_call([{"password": "s3cr3t"}, {"password": "s3cr3t2"}], "db_configs")
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            pytest.param("12345", 12345, id="int"),
+            pytest.param("true", True, id="bool"),
+            pytest.param("null", None, id="null"),
+            pytest.param("1.5", 1.5, id="float"),
+        ],
+    )
+    def test_var_json_scalar_values_pass_through(self, raw, expected, mock_supervisor_comms):
+        """Handing a scalar to the masker is a no-op and must not change the value returned."""
+        accessor = VariableAccessor(deserialize_json=True)
+        mock_supervisor_comms.send.return_value = VariableResult(key="some_number", value=raw)
+
+        assert accessor.some_number == expected
+
+    @mock.patch("airflow.sdk.execution_time.context.mask_secret")
     def test_var_json_sensitive_key_masks_raw_json(self, mock_mask_secret, mock_supervisor_comms):
         """var.json.<sensitive_key> masks the entire raw JSON string because the variable key is sensitive."""
         accessor = VariableAccessor(deserialize_json=True)
@@ -456,7 +491,14 @@ class TestVariableAccessor:
 
     @mock.patch("airflow.sdk.execution_time.context.mask_secret")
     def test_var_json_list_value_does_not_over_mask(self, mock_mask_secret, mock_supervisor_comms):
-        """var.json with a non-sensitive list variable does not mask individual list elements."""
+        """var.json with a non-sensitive list variable does not mask individual list elements.
+
+        The list is handed to the masker **under the variable's key**, which is what preserves
+        this: bare values inside a list have no key names of their own, so they follow the
+        variable key's sensitivity. Passing the list anonymously instead would add every element
+        to the global pattern set, and an ordinary value such as a region name would then be
+        redacted everywhere it appeared in the logs.
+        """
         accessor = VariableAccessor(deserialize_json=True)
         raw_json = '["us-east-1", "eu-west-1"]'
         mock_supervisor_comms.send.return_value = VariableResult(key="aws_regions", value=raw_json)
@@ -464,7 +506,10 @@ class TestVariableAccessor:
         val = accessor.aws_regions
 
         assert val == ["us-east-1", "eu-west-1"]
-        mock_mask_secret.assert_called_once_with(raw_json, "aws_regions")
+        mock_mask_secret.assert_any_call(raw_json, "aws_regions")
+        mock_mask_secret.assert_any_call(["us-east-1", "eu-west-1"], "aws_regions")
+        # never anonymously -- that is what would mask the elements globally
+        assert mock.call(["us-east-1", "eu-west-1"]) not in mock_mask_secret.call_args_list
 
     @mock.patch("airflow.sdk.execution_time.context.mask_secret")
     def test_var_json_invalid_json_raises(self, mock_mask_secret):


### PR DESCRIPTION
`_mask_and_deserialize_variable` dispatched on the top-level type of the
deserialized value and handled only `str` and `dict`. A Variable whose JSON is a
list therefore matched no branch and was returned with nothing inside it masked.

`add_mask` walks dicts and iterables itself, so the same list nested one level
inside a dict was already masked -- the top-level dispatch was the only thing
deciding whether the nested values were reached at all.

### Approach

Add the `list` branch, passing the value **under the variable's key** rather
than anonymously.

That distinction is the whole design of the change. Elements of a list have no
key names of their own, so they follow the variable key's sensitivity -- the same
rule already applied to a plain string value. Passing the list anonymously would
mask every element unconditionally and add each to the global pattern set, so a
Variable holding `["us-east-1", "eu-west-1"]` would cause `us-east-1` to be
redacted everywhere it appeared in any log. `test_var_json_list_value_does_not_over_mask`
already guarded that, and this keeps it true. Dicts *inside* the list are still
masked by their own key names.

Verified against the real masker:

| variable | key | result |
|---|---|---|
| `[{"password": "…"}]` | `db_configs` | `[{"password": "***"}]` |
| `["us-east-1", "eu-west-1"]` | `aws_regions` | unchanged |
| `["…"]` | `my_password` | `***` |
| `{"password": "…"}` | `db_config` | `{"password": "***"}` (unchanged path) |

`test_var_json_list_value_does_not_over_mask` is updated: it asserted
`mask_secret` was called exactly once, and there are now two calls. The property
it guards is unchanged and the assertion is now stated directly -- the list is
passed under the variable's key, and never anonymously.

### Test plan

- [x] `test_var_json_masks_list_values` -- list handed to the masker under the
      variable's key
- [x] `test_var_json_list_value_does_not_over_mask` -- updated to assert the
      no-over-masking property rather than the call count
- [x] `test_var_json_scalar_values_pass_through` -- int/bool/null/float returned
      unchanged
- [x] Verified against unmodified code: both list tests **fail**
- [x] `test_context.py` -- 170 passed
- [x] `ruff check` / `ruff format` clean

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
