### PR TITLE
Resolve the Dag's team when authorizing a Dag found by lookup

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/assets.py
@@ -86,6 +86,7 @@ from airflow.models.asset import (
     AssetWatcherModel,
     TaskOutletAssetReference,
 )
+from airflow.models.dag import DagModel
 from airflow.models.dag_version import DagVersion
 from airflow.typing_compat import Unpack
 from airflow.utils.state import DagRunState
@@ -459,7 +460,10 @@ def materialize_asset(
     if not get_auth_manager().is_authorized_dag(
         method="POST",
         access_entity=DagAccessEntity.RUN,
-        details=DagDetails(id=dag_id),
+        # The Dag is resolved from the asset here rather than named by the caller, so its team has
+        # to be looked up too. A team-aware auth manager distinguishes a team-scoped Dag from a
+        # global one by this field, so leaving it None asks the wrong question.
+        details=DagDetails(id=dag_id, team_name=DagModel.get_team_name(dag_id, session=session)),
         user=user,
     ):
         raise HTTPException(

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/dag_run.py
@@ -869,7 +869,10 @@ def wait_dag_run_until_finished(
     if not get_auth_manager().is_authorized_dag(
         method="GET",
         access_entity=DagAccessEntity.XCOM,
-        details=DagDetails(id=dag_id),
+        # The route dependency above already authorizes RUN access with the Dag's team resolved;
+        # this second, XCom-specific check has to resolve it the same way, or the two checks ask
+        # a team-aware auth manager about differently-scoped resources.
+        details=DagDetails(id=dag_id, team_name=DagModel.get_team_name(dag_id, session=session)),
         user=user,
     ):
         if result_task_ids:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -2154,11 +2154,8 @@ class TestPostAssetMaterialize(TestAssets):
 
     @pytest.mark.parametrize("team_name", ["team_b", None])
     def test_authorizes_against_the_dags_team(self, test_client, session, team_name):
-        """The Dag is resolved from the asset, so its team must be resolved and passed too.
-
-        A team-aware auth manager distinguishes a team-scoped Dag from a global one by this field,
-        so leaving it ``None`` asks about a differently-scoped resource than the one being acted on.
-        """
+"""The Dag is resolved from the asset, so its team must be resolved and passed too — see the
+    call site's comment for why an unresolved team asks about the wrong resource."""
         recorded = []
 
         auth_manager = mock.Mock(spec=BaseAuthManager)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -2151,6 +2151,32 @@ class TestPostAssetMaterialize(TestAssets):
         assert dag_run.partition_key == "2025-06-01T00:00:00"
         assert dag_run.partition_date == timezone.datetime(2025, 6, 1)
 
+    @pytest.mark.parametrize("team_name", ["team_b", None])
+    def test_authorizes_against_the_dags_team(self, test_client, session, team_name):
+        """The Dag is resolved from the asset, so its team must be resolved and passed too.
+
+        A team-aware auth manager distinguishes a team-scoped Dag from a global one by this field,
+        so leaving it ``None`` asks about a differently-scoped resource than the one being acted on.
+        """
+        recorded = []
+
+        auth_manager = mock.Mock()
+        auth_manager.is_authorized_dag.side_effect = lambda **kw: recorded.append(kw) or True
+
+        with (
+            mock.patch(
+                "airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager",
+                return_value=auth_manager,
+            ),
+            mock.patch.object(DagModel, "get_team_name", return_value=team_name),
+        ):
+            test_client.post("/assets/1/materialize")
+
+        assert recorded, "the authorization check did not run"
+        details = recorded[0]["details"]
+        assert details.id == self.DAG_ASSET1_ID
+        assert details.team_name == team_name
+
 
 class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):
     @pytest.mark.usefixtures("time_freezer")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -2154,8 +2154,8 @@ class TestPostAssetMaterialize(TestAssets):
 
     @pytest.mark.parametrize("team_name", ["team_b", None])
     def test_authorizes_against_the_dags_team(self, test_client, session, team_name):
-"""The Dag is resolved from the asset, so its team must be resolved and passed too — see the
-    call site's comment for why an unresolved team asks about the wrong resource."""
+        """The Dag is resolved from the asset, so its team must be resolved and passed too — see the
+        call site's comment for why an unresolved team asks about the wrong resource."""
         recorded = []
 
         auth_manager = mock.Mock(spec=BaseAuthManager)

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_assets.py
@@ -25,6 +25,7 @@ import time_machine
 from sqlalchemy import delete, func, select, update
 
 from airflow._shared.timezones import timezone
+from airflow.api_fastapi.auth.managers.base_auth_manager import BaseAuthManager
 from airflow.api_fastapi.auth.managers.models.resource_details import DagAccessEntity, DagDetails
 from airflow.models import DagModel
 from airflow.models.asset import (
@@ -2160,7 +2161,7 @@ class TestPostAssetMaterialize(TestAssets):
         """
         recorded = []
 
-        auth_manager = mock.Mock()
+        auth_manager = mock.Mock(spec=BaseAuthManager)
         auth_manager.is_authorized_dag.side_effect = lambda **kw: recorded.append(kw) or True
 
         with (
@@ -2168,14 +2169,18 @@ class TestPostAssetMaterialize(TestAssets):
                 "airflow.api_fastapi.core_api.routes.public.assets.get_auth_manager",
                 return_value=auth_manager,
             ),
-            mock.patch.object(DagModel, "get_team_name", return_value=team_name),
+            mock.patch.object(
+                DagModel, "get_team_name", return_value=team_name, autospec=True
+            ) as mock_get_team_name,
         ):
             test_client.post("/assets/1/materialize")
 
-        assert recorded, "the authorization check did not run"
+        assert len(recorded) == 1, "expected exactly one authorization check"
         details = recorded[0]["details"]
         assert details.id == self.DAG_ASSET1_ID
         assert details.team_name == team_name
+        # resolved for the Dag the asset led to, not for some other Dag
+        mock_get_team_name.assert_called_once_with(self.DAG_ASSET1_ID, session=mock.ANY)
 
 
 class TestGetAssetQueuedEvents(TestQueuedEventEndpoint):

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -4396,8 +4396,8 @@ class TestWaitDagRun:
 
     @pytest.mark.parametrize("team_name", ["team_b", None])
     def test_authorizes_xcom_against_the_dags_team(self, test_client, team_name):
-    """The XCom check must carry the Dag's team, matching what the route dependency above already
-    resolves — see the call site's comment for why."""
+        """The XCom check must carry the Dag's team, matching what the route dependency above already
+        resolves — see the call site's comment for why."""
         with (
             mock.patch(
                 "airflow.api_fastapi.core_api.routes.public.dag_run.get_auth_manager",

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -4394,6 +4394,35 @@ class TestWaitDagRun:
                 user=mock.ANY,
             )
 
+    @pytest.mark.parametrize("team_name", ["team_b", None])
+    def test_authorizes_xcom_against_the_dags_team(self, test_client, team_name):
+        """The XCom check must carry the Dag's team, as the route dependency above already does.
+
+        A team-aware auth manager distinguishes a team-scoped Dag from a global one by this field,
+        so leaving it ``None`` asks about a differently-scoped resource than the one being read.
+        """
+        with (
+            mock.patch(
+                "airflow.api_fastapi.core_api.routes.public.dag_run.get_auth_manager",
+                autospec=True,
+            ) as mock_get_auth_manager,
+            mock.patch.object(DagModel, "get_team_name", return_value=team_name, autospec=True),
+        ):
+            mock_get_auth_manager.return_value.is_authorized_dag.return_value = True
+
+            response = test_client.get(
+                f"/dags/{DAG1_ID}/dagRuns/{DAG1_RUN1_ID}/wait",
+                params={"interval": "1", "result": "task_1"},
+            )
+
+            assert response.status_code == 200
+            mock_get_auth_manager.return_value.is_authorized_dag.assert_called_once_with(
+                method="GET",
+                access_entity=DagAccessEntity.XCOM,
+                details=DagDetails(id=DAG1_ID, team_name=team_name),
+                user=mock.ANY,
+            )
+
     def test_should_respond_200_without_result_when_user_lacks_xcom_permission(self, test_client):
         """Waiting without result parameter should not require XCom permissions."""
         with mock.patch(

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_dag_run.py
@@ -4396,11 +4396,8 @@ class TestWaitDagRun:
 
     @pytest.mark.parametrize("team_name", ["team_b", None])
     def test_authorizes_xcom_against_the_dags_team(self, test_client, team_name):
-        """The XCom check must carry the Dag's team, as the route dependency above already does.
-
-        A team-aware auth manager distinguishes a team-scoped Dag from a global one by this field,
-        so leaving it ``None`` asks about a differently-scoped resource than the one being read.
-        """
+    """The XCom check must carry the Dag's team, matching what the route dependency above already
+    resolves — see the call site's comment for why."""
         with (
             mock.patch(
                 "airflow.api_fastapi.core_api.routes.public.dag_run.get_auth_manager",


### PR DESCRIPTION
Two authorization checks build `DagDetails(id=dag_id)` without `team_name`:

- `materialize_asset`, where the Dag is resolved from the asset rather than
  named by the caller;
- the XCom-specific check in `wait_dag_run_until_finished`.

Every other call site resolves the team with `DagModel.get_team_name` and passes
it -- `security.py:194`, `security.py:235`, `security.py:868`,
`import_error.py:314`, `services/public/task_instances.py:405`.

### Why it matters

A team-aware auth manager distinguishes a team-scoped Dag from a global one by
that field. The Keycloak manager, for instance, selects the resource it asks
about from it -- `DAG:<team>` when set, plain `DAG` when not -- so omitting it
asks about a differently-scoped resource than the one being acted on.

`wait_dag_run_until_finished` is the clearer illustration: its route dependency
already resolves the team for the RUN check, so the two checks in the same
handler disagreed about the scope of the same Dag.

### Approach

Resolve the team at both sites with `DagModel.get_team_name(dag_id, session=session)`,
reusing the request session rather than opening a new one.

After this, `grep -rn "DagDetails(id=" airflow-core/src` returns no call site
without `team_name`.

### Test plan

- [x] `test_authorizes_against_the_dags_team` -- parametrized over a team-scoped
      Dag and a global one; asserts the `DagDetails` reaching the auth manager
      carries the resolved team
- [x] Verified against unmodified code: the team-scoped case **fails**, the
      global case passes either way -- so the test pins the resolution, not the
      plumbing
- [x] `test_assets.py` -- 178 passed
- [x] `test_dag_run.py` -- 358 passed; the 2 failures in
      `TestBulkClearDagRuns` / `TestBulkDagRuns` (`UNIQUE constraint failed:
      team.name`) are **pre-existing** and reproduce identically on unmodified
      `main`
- [x] `ruff check` / `ruff format` clean

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
