### PR TITLE
Clarify How to upgrade docs for PyPI installs

### DIFF
--- a/airflow-core/docs/installation/installing-from-pypi.rst
+++ b/airflow-core/docs/installation/installing-from-pypi.rst
@@ -260,6 +260,8 @@ Airflow version. Whenever we release a new version of Airflow, we upgrade all de
 applicable versions and test them together, so if you want to keep up with those tests - staying up-to-date
 with latest version of Airflow is the easiest way to update those dependencies.
 
+.. _installing-from-pypi-installation-and-upgrade-scenarios:
+
 Installation and upgrade scenarios
 ''''''''''''''''''''''''''''''''''
 

--- a/airflow-core/docs/installation/upgrading.rst
+++ b/airflow-core/docs/installation/upgrading.rst
@@ -59,13 +59,9 @@ How to upgrade
 
 Reinstall Apache Airflow®, specifying the desired new version.
 
-To upgrade a bootstrapped local instance, you can set the ``AIRFLOW_VERSION`` environment variable to the
-intended version prior to rerunning the installation command. Upgrade incrementally by patch version: e.g.,
-if upgrading from version 2.8.2 to 2.8.4, upgrade first to 2.8.3. For more detailed guidance, see
-:doc:`/start`.
-
 To upgrade a PyPI package, rerun the ``pip install`` command in your environment using the desired version
-as a constraint. For more detailed guidance, see :doc:`/installation/installing-from-pypi`.
+as a constraint. For detailed installation and upgrade scenarios, see
+:ref:`installing-from-pypi-installation-and-upgrade-scenarios`.
 
 In order to manually migrate the database you should run the ``airflow db migrate`` command in your
 environment. It can be run either in your virtual environment or in the containers that give


### PR DESCRIPTION
## Description

Closes #47539

Follows maintainer guidance on the issue:

1. Remove the confusing "bootstrapped local instance" paragraph (undefined term, unclear incremental-upgrade advice).
2. Point the PyPI upgrade sentence at the Installation and upgrade scenarios section in `installing-from-pypi.rst` via a Sphinx `:ref:` (previous attempts that used an HTML fragment inside `:doc:` failed the docs build).

## Type

- [x] Documentation only

## Testing

- Manual check: no trailing whitespace / CRLF / missing final newline
- `pre-commit run trailing-whitespace|end-of-file-fixer|rst-backticks|mixed-line-ending --files ...` on the touched RST files (passed)