### PR TITLE
Fix Breeze type errors that fail static checks on every PR

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/custom_param_types.py
+++ b/dev/breeze/src/airflow_breeze/utils/custom_param_types.py
@@ -192,9 +192,9 @@ class CacheableChoice(click.Choice):
         if not current_value:
             current_choices = self.choices
         else:
-            current_choices = [
+            current_choices = tuple(
                 f">{choice}<" if choice == current_value else choice for choice in self.choices
-            ]
+            )
         choices_str = " | ".join(current_choices)
         # Use curly braces to indicate a required argument.
         if param.required and param.param_type_name == "argument":

--- a/dev/breeze/src/airflow_breeze/utils/github.py
+++ b/dev/breeze/src/airflow_breeze/utils/github.py
@@ -25,7 +25,7 @@ import zipfile
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from rich.markup import escape
 
@@ -237,7 +237,9 @@ def get_active_airflow_versions(
     repo = Repo(AIRFLOW_ROOT_PATH)
     all_active_tags: list[str] = []
     try:
-        ref_tags = repo.git.ls_remote("--tags", remote_name).splitlines()
+        # `git.ls_remote` is typed as returning the full union of git-command return shapes;
+        # with plain args it is always the command output.
+        ref_tags = cast("str", repo.git.ls_remote("--tags", remote_name)).splitlines()
     except GitCommandError as ex:
         console_print(
             f"[error]Could not fetch tags from `{remote_name}` remote! Make sure to have it configured.\n"


### PR DESCRIPTION
`dev/breeze` has five mypy errors on `v3-3-test` that fail `CI image checks / Static checks`
on every PR against the branch, regardless of what the PR changes:

```
dev/breeze/src/airflow_breeze/utils/custom_param_types.py:195  list[str | Any] assigned to tuple[Any, ...]
dev/breeze/src/airflow_breeze/utils/github.py:240,256,258,260  cascading from ls_remote's union return type
```

The four `github.py` errors all cascade from the first, so one `cast` clears them.
Both spellings are taken verbatim from `main`, which already carries these fixes.

Currently blocking #70872 and #70845.

Verified with `mypy-dev`, `mypy-airflow-ctl`, `mypy-airflow-e2e-tests`, `mypy-docker-tests`
and `mypy-kubernetes-tests`.

Dev-tooling only, not user-facing, so no newsfragment.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)