### PR TITLE
Flag `execute_tasks_new_python_interpreter` as Edge-only in docs and lint

### DIFF
--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -95,9 +95,9 @@ code you will need to restart those processes. However, it will not be reflected
 By default, task execution uses forking. This avoids the slowdown associated with creating a new Python interpreter
 and re-parsing all of Airflow's code and startup routines. This approach offers significant benefits, especially for shorter tasks.
 This does mean that if you use plugins in your tasks, and want them to update you will either
-need to restart the worker (if using CeleryExecutor) or scheduler (LocalExecutor). The other
-option is you can accept the speed hit at start up set the ``core.execute_tasks_new_python_interpreter``
-config setting to True, resulting in launching a whole new python interpreter for tasks.
+need to restart the worker (if using CeleryExecutor) or scheduler (LocalExecutor). The
+``core.execute_tasks_new_python_interpreter`` setting used to offer a way around that, but since
+Airflow 3.0 it is only honoured by the Edge executor.
 
 (Modules only imported by Dag files on the other hand do not suffer this problem, as Dag files are not
 loaded/parsed in any long-running Airflow process.)

--- a/airflow-core/docs/administration-and-deployment/plugins.rst
+++ b/airflow-core/docs/administration-and-deployment/plugins.rst
@@ -97,7 +97,7 @@ and re-parsing all of Airflow's code and startup routines. This approach offers 
 This does mean that if you use plugins in your tasks, and want them to update you will either
 need to restart the worker (if using CeleryExecutor) or scheduler (LocalExecutor). The
 ``core.execute_tasks_new_python_interpreter`` setting used to offer a way around that, but since
-Airflow 3.0 it is only honoured by the Edge executor.
+Airflow 3.0 it is only read by the Edge worker.
 
 (Modules only imported by Dag files on the other hand do not suffer this problem, as Dag files are not
 loaded/parsed in any long-running Airflow process.)

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -285,9 +285,8 @@ CONFIGS_CHANGES = [
         config=ConfigParameter("core", "execute_tasks_new_python_interpreter"),
         was_removed=False,
         is_invalid_if="True",
-        suggestion="Only the Edge executor still honours this setting. CeleryExecutor and "
-        "LocalExecutor always fork the task from the worker, so tasks no longer start in a fresh "
-        "Python interpreter.",
+        suggestion="Only the Edge worker still reads this setting. CeleryExecutor and "
+        "LocalExecutor no longer consult it.",
     ),
     # api
     ConfigChange(

--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -281,6 +281,14 @@ CONFIGS_CHANGES = [
         is_invalid_if="0",
         suggestion="Please set the `parallelism` configuration parameter to a value greater than 0.",
     ),
+    ConfigChange(
+        config=ConfigParameter("core", "execute_tasks_new_python_interpreter"),
+        was_removed=False,
+        is_invalid_if="True",
+        suggestion="Only the Edge executor still honours this setting. CeleryExecutor and "
+        "LocalExecutor always fork the task from the worker, so tasks no longer start in a fresh "
+        "Python interpreter.",
+    ),
     # api
     ConfigChange(
         config=ConfigParameter("api", "access_control_allow_origin"),

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -223,6 +223,12 @@ core:
         * ``False``: Execute via forking of the parent process
         * ``True``: Spawning a new python process, slower than fork, but means plugin changes picked
           up by tasks straight away
+
+        .. note::
+
+            Since Airflow 3.0 only the Edge executor honours this option. Executors that run tasks
+            through the task SDK supervisor, including ``CeleryExecutor`` and ``LocalExecutor``,
+            always fork the task from the worker.
       default: "False"
       example: ~
       version_added: 2.0.0

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -226,9 +226,9 @@ core:
 
         .. note::
 
-            Since Airflow 3.0 only the Edge executor honours this option. Executors that run tasks
-            through the task SDK supervisor, including ``CeleryExecutor`` and ``LocalExecutor``,
-            always fork the task from the worker.
+            Since Airflow 3.0 this option is only read by the Edge worker. Executors that run
+            tasks through the task SDK supervisor, including ``CeleryExecutor`` and
+            ``LocalExecutor``, no longer consult it.
       default: "False"
       example: ~
       version_added: 2.0.0

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -544,7 +544,7 @@ class TestConfigLint:
             "Invalid value `True` set for `execute_tasks_new_python_interpreter` "
             "configuration parameter in `core` section." in normalized_output
         )
-        assert "Only the Edge executor still honours this setting." in normalized_output
+        assert "Only the Edge worker still reads this setting." in normalized_output
 
     @conf_vars({("core", "execute_tasks_new_python_interpreter"): "False"})
     def test_lint_ignores_execute_tasks_new_python_interpreter(self, stdout_capture):

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -531,6 +531,32 @@ class TestConfigLint:
 
         assert "Invalid value" not in normalized_output
 
+    @conf_vars({("core", "execute_tasks_new_python_interpreter"): "True"})
+    def test_lint_detects_execute_tasks_new_python_interpreter(self, stdout_capture):
+        with stdout_capture as temp_stdout:
+            config_command.lint_config(cli_parser.get_parser().parse_args(["config", "lint"]))
+
+        output = temp_stdout.getvalue()
+
+        normalized_output = re.sub(r"\s+", " ", output.strip())
+
+        assert (
+            "Invalid value `True` set for `execute_tasks_new_python_interpreter` "
+            "configuration parameter in `core` section." in normalized_output
+        )
+        assert "Only the Edge executor still honours this setting." in normalized_output
+
+    @conf_vars({("core", "execute_tasks_new_python_interpreter"): "False"})
+    def test_lint_ignores_execute_tasks_new_python_interpreter(self, stdout_capture):
+        with stdout_capture as temp_stdout:
+            config_command.lint_config(cli_parser.get_parser().parse_args(["config", "lint"]))
+
+        output = temp_stdout.getvalue()
+
+        normalized_output = re.sub(r"\s+", " ", output.strip())
+
+        assert "execute_tasks_new_python_interpreter" not in normalized_output
+
 
 class TestCliConfigUpdate:
     @conf_vars({("core", "executor"): "SequentialExecutor"})


### PR DESCRIPTION
`[core] execute_tasks_new_python_interpreter` is still documented as a live option, but since Airflow 3.0 CeleryExecutor and LocalExecutor ignore it. The only thing left that reads it is the Edge worker.

That happened in https://github.com/apache/airflow/pull/46265 (I _think_ as an unintended side effect), as the code that reads the variable is behind a `if not AIRFLOW_V_3_0_PLUS:` gate. What is left is somewhat inconsistent.

<details>
<summary> Why it's inconsistent </summary>

-  CeleryExecutor and LocalExecutor silently ignore `execute_tasks_new_python_interpreter`. (Note: The Edge worker does honour it on Airflow 3, added in #65943 ).
- `config.yml` documents the option under `[core]` with no deprecation marker.
- `plugins.rst` still tells users to set it to pick up plugin changes without restarting the worker.
- `airflow config lint`, the designated 2 to 3 upgrade check, does not mention it, so an upgrade gives no signal at all.

</details>

What this PR does:
  - `config.yml`:  adds a note to the option saying that since Airflow 3.0 only the Edge worker reads it.
  - `plugins.rst`: removes the advice to set it (that workaround no longer works on Celery or Local).
  - `airflow config lint`: adds an entry so the 2-to-3 upgrade check flags the option when it is set, with a pointer to what changed.

No behaviour changes. The goal is just that an Airflow 2->3 upgrade gives some signal instead of none.

If that's OK I leave restoring the functionality of `execute_tasks_new_python_interpreter` to a separate discussion (#70280 looks like the right place).

<details>
<summary> Optional context: how we ran into it </summary>

We hit this upgrading a CeleryExecutor deployment from 2.11 to 3.3. We had the option set to `True`, so every task ran in a fresh interpreter. On 3.3 tasks are forked from the Celery prefork worker instead, and any task that starts a `multiprocessing` child now inherits the worker's daemon flag and dies with `daemonic processes are not allowed to have children`. Nothing in the upgrade told us the option had stopped working; we found it by reading the provider source.

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Used to map the blast radius: which code paths, docs, and CLI checks still reference the option, and which components still read it.