### PR TITLE
Refuse a separator-bearing secret id before the team scoped lookup

### DIFF
--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -36,11 +36,8 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
 
     def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
         if TEAM_SEP in conn_id:
-            # Refused ahead of the team scoped lookup, not only ahead of the team agnostic
-            # one. The scoped lookup builds PREFIX + _<TEAM>___ + <ID>, so an id that itself
-            # contains the separator makes that string ambiguous: a caller in team `team_a`
-            # asking for `prod___dbconn` builds exactly what team `team_a___prod` builds for
-            # id `dbconn`. That lookup *hits*, so a guard placed after it never runs.
+            # An id containing the separator could collide with another team's namespace
+            # even on the scoped lookup below, so it must be refused before either runs.
             return None
 
         if team_name and (
@@ -60,11 +57,7 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         :return: Variable Value
         """
         if TEAM_SEP in key:
-            # Refused ahead of the team scoped lookup, not only ahead of the team agnostic
-            # one. The scoped lookup builds PREFIX + _<TEAM>___ + <ID>, so an id that itself
-            # contains the separator makes that string ambiguous: a caller in team `team_a`
-            # asking for `prod___dbconn` builds exactly what team `team_a___prod` builds for
-            # id `dbconn`. That lookup *hits*, so a guard placed after it never runs.
+            # Same collision risk as get_conn_value, see its code comment.
             return None
 
         if team_name and (

--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -20,26 +20,34 @@
 from __future__ import annotations
 
 import os
-import re
 
 from airflow.secrets import BaseSecretsBackend
 
 CONN_ENV_PREFIX = "AIRFLOW_CONN_"
 VAR_ENV_PREFIX = "AIRFLOW_VAR_"
 
+# Separates the team name from the secret id in a team namespaced environment variable
+# name: AIRFLOW_CONN__<TEAM>___<ID>.
+TEAM_SEP = "___"
+
 
 class EnvironmentVariablesBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from environment variable."""
 
     def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
+        if TEAM_SEP in conn_id:
+            # Refused ahead of the team scoped lookup, not only ahead of the team agnostic
+            # one. The scoped lookup builds PREFIX + _<TEAM>___ + <ID>, so an id that itself
+            # contains the separator makes that string ambiguous: a caller in team `team_a`
+            # asking for `prod___dbconn` builds exactly what team `team_a___prod` builds for
+            # id `dbconn`. That lookup *hits*, so a guard placed after it never runs.
+            return None
+
         if team_name and (
             team_var := os.environ.get(f"{CONN_ENV_PREFIX}_{team_name.upper()}___" + conn_id.upper())
         ):
             # Format to set a team specific connection: AIRFLOW_CONN__<TEAM_ID>___<CONN_ID>
             return team_var
-
-        if self._names_a_team_namespace(conn_id):
-            return None
 
         return os.environ.get(CONN_ENV_PREFIX + conn_id.upper())
 
@@ -51,39 +59,18 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         :param team_name: Team name associated to the task trying to access the variable (if any)
         :return: Variable Value
         """
+        if TEAM_SEP in key:
+            # Refused ahead of the team scoped lookup, not only ahead of the team agnostic
+            # one. The scoped lookup builds PREFIX + _<TEAM>___ + <ID>, so an id that itself
+            # contains the separator makes that string ambiguous: a caller in team `team_a`
+            # asking for `prod___dbconn` builds exactly what team `team_a___prod` builds for
+            # id `dbconn`. That lookup *hits*, so a guard placed after it never runs.
+            return None
+
         if team_name and (
             team_var := os.environ.get(f"{VAR_ENV_PREFIX}_{team_name.upper()}___" + key.upper())
         ):
             # Format to set a team specific variable: AIRFLOW_VAR__<TEAM_ID>___<VAR_KEY>
             return team_var
 
-        if self._names_a_team_namespace(key):
-            return None
-
         return os.environ.get(VAR_ENV_PREFIX + key.upper())
-
-    @staticmethod
-    def _names_a_team_namespace(secret_id: str) -> bool:
-        """
-        Whether ``secret_id`` spells out a team namespaced environment variable name.
-
-        A team specific secret lives in the ``_<TEAM_NAME>___<SECRET_ID>`` namespace of the
-        environment. An id of that shape therefore makes the team agnostic lookup -- which
-        prepends only ``AIRFLOW_CONN_`` / ``AIRFLOW_VAR_`` -- land inside some team's namespace,
-        so that lookup is refused for such an id.
-
-        **The id is never attributed to a particular team**, because it cannot be: a team name
-        may itself contain the ``___`` separator, so ``_a___b___c`` is both team ``a`` with id
-        ``b___c`` and team ``a___b`` with id ``c``, and nothing in the string distinguishes them.
-        Only the caller's own namespace is ever constructed, never parsed.
-
-        This is why the check is not "does the id belong to some team other than the caller's".
-        Comparing the id against the prefix the caller's team builds looks equivalent and is not:
-        for a caller in team ``a`` the id ``_a___b___c`` starts with ``_A___``, yet the variable
-        it resolves, ``AIRFLOW_CONN__A___B___C``, is team ``a___b``'s. Treating a prefix match as
-        ownership hands one team the secrets of every team whose name extends it. Callers reach
-        their own team's secrets with the bare id plus their team scope -- handled above, and safe
-        because that path can only ever build the caller's own namespace -- so nothing legitimate
-        needs a namespaced id here.
-        """
-        return re.fullmatch(r"_.+___.+", secret_id) is not None

--- a/airflow-core/tests/unit/always/test_secrets_environment_variables.py
+++ b/airflow-core/tests/unit/always/test_secrets_environment_variables.py
@@ -21,6 +21,7 @@ import pytest
 
 from airflow.secrets.environment_variables import (
     CONN_ENV_PREFIX,
+    TEAM_SEP,
     VAR_ENV_PREFIX,
     EnvironmentVariablesBackend,
 )
@@ -135,6 +136,49 @@ class TestEnvironmentVariablesBackendTeamScope:
         monkeypatch.setenv(env_prefix + SECRET_ID.upper(), GLOBAL_VALUE)
 
         assert lookup(env_prefix, method, SECRET_ID, team_name) == GLOBAL_VALUE
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    def test_a_bare_id_containing_the_separator_is_not_resolved(self, monkeypatch, env_prefix, method):
+        """The scoped lookup can build another team's variable name from a *bare* id.
+
+        Caller in ``team_a`` supplies ``prod___dbconn``. The team scoped lookup builds
+        ``<PREFIX>_TEAM_A___PROD___DBCONN`` -- byte-identical to what team ``team_a___prod``
+        builds for its own id ``dbconn``. That lookup **hits**, so refusing only the team
+        agnostic fall-through never sees this: the fall-through is never reached.
+        """
+        target_team, target_id = "team_a___prod", "dbconn"
+        monkeypatch.setenv(team_env_var(env_prefix, target_team, target_id), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, f"prod{TEAM_SEP}{target_id}", "team_a") is None
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])
+    def test_an_id_containing_the_separator_is_refused_in_every_scope(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        """One rule, applied the same way with or without a team scope.
+
+        An id carrying the separator cannot be resolved unambiguously in either direction, so
+        there is no scope in which it is safe to look up.
+        """
+        monkeypatch.setenv(env_prefix + f"A{TEAM_SEP}B".upper(), GLOBAL_VALUE)
+
+        assert lookup(env_prefix, method, f"a{TEAM_SEP}b", team_name) is None
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    def test_the_owning_team_cannot_reach_a_separator_bearing_id_either(
+        self, monkeypatch, env_prefix, method, team_name
+    ):
+        """Documents the cost of the rule, so a future change does not reintroduce the hole.
+
+        A team's *own* secret whose id contains the separator is unreachable too. That is
+        deliberate: the string it builds is the same one another team's name could build, and
+        nothing in it says which reading is intended.
+        """
+        monkeypatch.setenv(team_env_var(env_prefix, team_name, f"prod{TEAM_SEP}dbconn"), TEAM_VALUE)
+
+        assert lookup(env_prefix, method, f"prod{TEAM_SEP}dbconn", team_name) is None
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])


### PR DESCRIPTION
The team scoped lookup builds `PREFIX + _<TEAM>___ + <ID>`, so a secret id that
itself contains `___` makes that string ambiguous:

```
caller in team "team_a", bare id "prod___dbconn"
  AIRFLOW_CONN_ + _TEAM_A + ___ + PROD___DBCONN   ->  AIRFLOW_CONN__TEAM_A___PROD___DBCONN

team "team_a___prod", its own id "dbconn"
  AIRFLOW_CONN_ + _TEAM_A___PROD + ___ + DBCONN   ->  AIRFLOW_CONN__TEAM_A___PROD___DBCONN
```

Byte-identical — and the **scoped** lookup hits, so the existing guard, which ran
only ahead of the team agnostic fall-through, was never reached for this shape.

### Approach

Two changes, both small:

1. **Move the check ahead of both lookups** rather than only the fall-through.
2. **Widen it** from "spells out a team namespace" (`_<TEAM>___<ID>`) to simply
   "contains the separator".

The narrower form had to reason about *which* team an id might name. That is
unanswerable while a team name may itself contain the separator, and it made the
guard depend on every stored team name being valid — which `teams sync` has never
enforced. Asking only "does this contain `___`" removes both problems, and drops
`_names_a_team_namespace` entirely.

This is also what the provider secrets backends already do (`TEAM_SEP in
secret_id`, applied to every getter). Core was the outlier.

### Behaviour change

A Connection or Variable whose **id** contains `___` is no longer resolvable from
the environment backend — in either scope, including for its owning team.

That is deliberate. The name such an id builds is one another team's name could
build, and nothing in the string says which reading was meant. The owning team
reaches its own secret the normal way, with the bare id plus its team scope, which
is unaffected. Ids without the separator are unaffected in every scope.

### Test plan

- [x] `test_a_bare_id_containing_the_separator_is_not_resolved` — the collision
      above, both lookups
- [x] `test_an_id_containing_the_separator_is_refused_in_every_scope` — one rule,
      with and without a team scope
- [x] `test_the_owning_team_cannot_reach_a_separator_bearing_id_either` — pins the
      cost, so a later relaxation cannot quietly reopen the hole
- [x] Verified against the code with only the two guards removed (constant kept, so
      the failure is behavioural not an import error): **26 failed**; with them,
      **46 passed**
- [x] All 34 pre-existing tests in the file pass unchanged
- [x] `ruff check` / `ruff format` clean

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
