### PR TITLE
Remove no-op exception re-raise and parser override in airflowctl

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -67,7 +67,6 @@ from airflowctl.exceptions import (
     AirflowCtlCredentialNotFoundException,
     AirflowCtlException,
     AirflowCtlKeyringException,
-    AirflowCtlNotFoundException,
 )
 
 if TYPE_CHECKING:
@@ -517,8 +516,6 @@ def get_client(
             kind=kind,
         )
         yield api_client
-    except AirflowCtlNotFoundException as e:
-        raise e
     finally:
         if api_client:
             api_client.close()

--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -111,10 +111,6 @@ def safe_call_command(function: Callable, args: Iterable[Arg]) -> None:
 class DefaultHelpParser(argparse.ArgumentParser):
     """CustomParser to display help message."""
 
-    def _check_value(self, action, value):
-        """Override _check_value and check conditionally added command."""
-        super()._check_value(action, value)
-
     def error(self, message):
         """Override error and use print_help instead of print_usage."""
         self.print_help()


### PR DESCRIPTION
## Refactor: Remove redundant code in `airflow-ctl`

This cleanup removes two pieces of `airflow-ctl` code that did nothing but obscure the surrounding logic. There is **no change in behavior**.

### 1. Remove no-op exception re-raise in `client.py`
* **Location:** `get_client` function.
* **What changed:** Removed an `except AirflowCtlNotFoundException` block that only immediately re-raised the exception.
* **Why it's safe:** The clause was inside a `try/finally` block within a `@contextlib.contextmanager`. Removing the `except` clause allows the exception to propagate naturally identically to before. The `finally` block still executes `api_client.close()`, and `safe_call_command` in `cli_config.py` continues to handle the error.

### 2. Remove redundant parser override
* **Location:** `DefaultHelpParser._check_value`.
* **What changed:** Removed the method override entirely since it only called `super()`. 
* **Why it's safe:** While `airflow-core`'s namesake does real work here (`check_legacy_command`), `airflow-ctl` deliberately has no legacy-command mapping, making this override a degenerate copy. The `error()` override in the same class actually does work and remains untouched.

**Note:** No newsfragment is required. `airflow-ctl` release managers regenerate the changelog directly from `git log`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
