### PR TITLE
Assert the refusal log with getMessage so the compat tests pass

### DIFF
--- a/providers/amazon/tests/unit/amazon/aws/secrets/test_secrets_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/secrets/test_secrets_manager.py
@@ -142,10 +142,12 @@ class TestSecretsManagerBackend:
         assert backend.get_variable(key="prod--hello") is None
         assert backend.get_config(key="prod--sql_alchemy_conn") is None
 
-        # Airflow logs through structlog, which renders the format args into ``msg`` before the
-        # stdlib record is built -- ``record.args`` is empty, so there is no structured payload
-        # to assert on. Assert on level, logger and the refused id (the load-bearing data)
-        # rather than the wording, so rephrasing the warning does not break this.
+        # ``getMessage()`` rather than ``msg``: how a record carries its payload depends on the
+        # Airflow version. Here structlog renders the format args into ``msg`` before the stdlib
+        # record exists, so ``args`` is empty; on the versions the provider compat tests run
+        # against, plain stdlib logging leaves ``msg`` as the format string with the values in
+        # ``args``. ``getMessage()`` renders in both. Assert on level, logger and the refused id
+        # (the load-bearing data) rather than the wording, so rephrasing the warning is free.
         refusals = [
             r
             for r in caplog.records
@@ -153,8 +155,8 @@ class TestSecretsManagerBackend:
         ]
         assert len(refusals) == 3
         for refused_id in ("prod--test_postgres", "prod--hello", "prod--sql_alchemy_conn"):
-            assert sum(refused_id in r.msg for r in refusals) == 1
-        assert all(TEAM_SEP in r.msg for r in refusals)
+            assert sum(refused_id in r.getMessage() for r in refusals) == 1
+        assert all(TEAM_SEP in r.getMessage() for r in refusals)
 
     @mock_aws
     def test_team_caller_falls_back_to_global_connection(self):

--- a/providers/amazon/tests/unit/amazon/aws/secrets/test_systems_manager.py
+++ b/providers/amazon/tests/unit/amazon/aws/secrets/test_systems_manager.py
@@ -185,10 +185,12 @@ class TestSsmSecrets:
         assert backend.get_variable(key="prod--hello") is None
         assert backend.get_config(key="prod--sql_alchemy_conn") is None
 
-        # Airflow logs through structlog, which renders the format args into ``msg`` before the
-        # stdlib record is built -- ``record.args`` is empty, so there is no structured payload
-        # to assert on. Assert on level, logger and the refused id (the load-bearing data)
-        # rather than the wording, so rephrasing the warning does not break this.
+        # ``getMessage()`` rather than ``msg``: how a record carries its payload depends on the
+        # Airflow version. Here structlog renders the format args into ``msg`` before the stdlib
+        # record exists, so ``args`` is empty; on the versions the provider compat tests run
+        # against, plain stdlib logging leaves ``msg`` as the format string with the values in
+        # ``args``. ``getMessage()`` renders in both. Assert on level, logger and the refused id
+        # (the load-bearing data) rather than the wording, so rephrasing the warning is free.
         refusals = [
             r
             for r in caplog.records
@@ -196,8 +198,8 @@ class TestSsmSecrets:
         ]
         assert len(refusals) == 3
         for refused_id in ("prod--test_postgres", "prod--hello", "prod--sql_alchemy_conn"):
-            assert sum(refused_id in r.msg for r in refusals) == 1
-        assert all(TEAM_SEP in r.msg for r in refusals)
+            assert sum(refused_id in r.getMessage() for r in refusals) == 1
+        assert all(TEAM_SEP in r.getMessage() for r in refusals)
 
     @mock_aws
     def test_team_caller_falls_back_to_global_connection(self):


### PR DESCRIPTION
`main` is currently red on the provider compat jobs. The refusal-logging
assertions in the Amazon secrets tests read `record.msg` directly, and how a
record carries its payload depends on the Airflow version:

```python
# main — structlog renders the format args before the stdlib record exists
LogRecord(msg="Connection id 'prod--x' contains '--'", args=())
    "prod--x" in r.msg          -> True

# the versions the compat jobs run against — plain stdlib logging
LogRecord(msg="%s id %r contains %r", args=("Connection", "prod--x", "--"))
    "prod--x" in r.msg          -> False        <- the failure
    "prod--x" in r.getMessage() -> True
```

So the assertions pass on `main` and fail under `Compat 2.11.1:P3.10` and
`Compat 3.0.6:P3.10`:

```
assert 0 == 1
  where 0 = sum(refused_id in r.msg for r in refusals)
```

`getMessage()` renders in both shapes. The assertion still targets the refused
**id** rather than the wording, which was the point of moving off the rendered
sentence in the first place — that intent is unchanged, only the accessor.

This is a regression from #70878, where I moved these assertions off
`getMessage()` while addressing review feedback and verified only against `main`.
Compat runs on provider PRs, so it surfaced on the next provider PR rather than
on the one that introduced it.

Kept separate from #70899 (the Azure `get_config` follow-up) so the repair to
`main` can land on its own.

### Test plan

- [x] `providers/amazon/tests/unit/amazon/aws/secrets/` — 73 passed locally
- [x] Both record shapes checked directly: `r.msg` matches only the pre-rendered
      one, `getMessage()` matches both
- [x] Test-only change; no production code touched
- [x] `ruff format` clean

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following the guidelines at
https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
