### PR TITLE
Fix Keycloak access for individual roles

### DIFF
--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -25,6 +25,16 @@
 Changelog
 ---------
 
+.. note::
+    Upgrading the provider does not update existing Keycloak permissions. For each existing team,
+    run ``airflow keycloak-auth-manager create-team <team>`` again to update the team ReadOnly
+    permission. For non-team installations, run
+    ``airflow keycloak-auth-manager create-permissions`` again without ``--teams`` to update the
+    global Admin permission.
+
+    Manually added policies attached to these permissions will also be evaluated under the
+    ``AFFIRMATIVE`` strategy after the update.
+
 0.9.0
 .....
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -792,6 +792,7 @@ def _attach_team_permissions(
         policy_name=_team_role_policy_name(team, "Viewer"),
         scope_names=["GET", "LIST"],
         resource_names=team_readable_resources,
+        decision_strategy="AFFIRMATIVE",
         _dry_run=_dry_run,
     )
     for role_name in ("User", "Op", "Admin"):
@@ -802,6 +803,7 @@ def _attach_team_permissions(
             policy_name=_team_role_policy_name(team, role_name),
             scope_names=["GET", "LIST"],
             resource_names=team_readable_resources,
+            decision_strategy="AFFIRMATIVE",
             _dry_run=_dry_run,
         )
     _attach_policy_to_scope_permission(

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -301,6 +301,7 @@ def _attach_default_role_permissions(
             policy_name=_role_policy_name(role_name),
             scope_names=_get_extended_resource_methods() + ["LIST"],
             resource_names=[],
+            decision_strategy="AFFIRMATIVE",
             _dry_run=_dry_run,
         )
 

--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -929,6 +929,7 @@ def _attach_superadmin_permissions(
         policy_name=_role_policy_name(SUPER_ADMIN_ROLE_NAME),
         scope_names=_get_extended_resource_methods() + ["LIST"],
         resource_names=team_scoped_resources,
+        decision_strategy="AFFIRMATIVE",
         _dry_run=_dry_run,
     )
     _attach_policy_to_scope_permission(

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -567,15 +567,17 @@ class TestCommands:
         mock_update_admin_permission_resources.assert_called_once_with(client, "test-id", _dry_run=False)
         mock_ensure_group_policy.assert_called_once_with(client, "test-id", "team-a", _dry_run=False)
         assert mock_ensure_aggregate_policy.call_count == 4
-        mock_attach_policy.assert_any_call(
-            client,
-            "test-id",
-            permission_name="ReadOnly-team-a",
-            policy_name="Allow-Viewer-team-a",
-            scope_names=["GET", "LIST"],
-            resource_names=["Dag:team-a", "Team:team-a"],
-            _dry_run=False,
-        )
+        for role_name in TEAM_ROLE_NAMES:
+            mock_attach_policy.assert_any_call(
+                client,
+                "test-id",
+                permission_name="ReadOnly-team-a",
+                policy_name=f"Allow-{role_name}-team-a",
+                scope_names=["GET", "LIST"],
+                resource_names=["Dag:team-a", "Team:team-a"],
+                decision_strategy="AFFIRMATIVE",
+                _dry_run=False,
+            )
         mock_attach_policy.assert_any_call(
             client,
             "test-id",

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -472,24 +472,17 @@ class TestCommands:
                 decision_strategy="AFFIRMATIVE",
                 _dry_run=False,
             )
-        mock_attach_scope_policy.assert_any_call(
-            client,
-            "test-id",
-            permission_name="Admin",
-            policy_name="Allow-Admin",
-            scope_names=_get_extended_resource_methods() + ["LIST"],
-            resource_names=[],
-            _dry_run=False,
-        )
-        mock_attach_scope_policy.assert_any_call(
-            client,
-            "test-id",
-            permission_name="Admin",
-            policy_name="Allow-SuperAdmin",
-            scope_names=_get_extended_resource_methods() + ["LIST"],
-            resource_names=[],
-            _dry_run=False,
-        )
+        for role_name in ("Admin", SUPER_ADMIN_ROLE_NAME):
+            mock_attach_scope_policy.assert_any_call(
+                client,
+                "test-id",
+                permission_name="Admin",
+                policy_name=f"Allow-{role_name}",
+                scope_names=_get_extended_resource_methods() + ["LIST"],
+                resource_names=[],
+                decision_strategy="AFFIRMATIVE",
+                _dry_run=False,
+            )
         mock_attach_resource_policy.assert_any_call(
             client,
             "test-id",

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -639,6 +639,7 @@ class TestCommands:
                 "Team:team-a",
                 "Variable:team-a",
             ],
+            decision_strategy="AFFIRMATIVE",
             _dry_run=False,
         )
         mock_attach_policy.assert_any_call(


### PR DESCRIPTION
The Keycloak provisioning commands attached alternative role policies to
scope permissions while retaining an `UNANIMOUS` decision strategy. This
affected both:

- the team ReadOnly permission for Viewer, User, Op, and Admin roles
- the default non-team global Admin permission for Admin and SuperAdmin roles

These roles are alternatives, but `UNANIMOUS` required users to satisfy every
attached role policy. As a result, users holding only one intended role could be
denied access.

Use an `AFFIRMATIVE` strategy for both permissions and extend the existing
regression tests to verify each alternative role policy.

Compatibility note:

Upgrading the provider does not update existing Keycloak permissions. For each
existing team, run `airflow keycloak-auth-manager create-team <team>` again to
update the team ReadOnly permission. For non-team installations, run
`airflow keycloak-auth-manager create-permissions` again without `--teams` to
update the global Admin permission.

Because these commands preserve policies already attached to the permissions,
manually added custom policies will also be evaluated under the `AFFIRMATIVE`
strategy after the update.

Validation:

- `prek run --from-ref upstream/main --stage pre-commit`
- `prek run --from-ref upstream/main --stage manual`
- `breeze ci selective-check --commit-ref HEAD`
- `breeze testing providers-tests --test-type "Providers[common.compat,keycloak]"`
  (`459 passed, 3 skipped`)

closes: #70251

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — OpenAI Codex (GPT-5)

Generated-by: OpenAI Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
