### PR TITLE
[v3-3-test] Drop colored logging from the Go SDK edge worker (#70824)

### DIFF
--- a/go-sdk/go.mod
+++ b/go-sdk/go.mod
@@ -51,10 +51,9 @@ require (
 )
 
 require (
-	github.com/MatusOllah/slogcolor v1.6.0
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/evanphx/go-hclog-slog v0.0.0-20240717231540-be48fc4c4df5
-	github.com/fatih/color v1.18.0
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/google/uuid v1.6.0
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/go-sdk/go.sum
+++ b/go-sdk/go.sum
@@ -1,5 +1,3 @@
-github.com/MatusOllah/slogcolor v1.6.0 h1:JAKer0xj5l1jYTXyQvs5ggqmJqYDuLnxgR9jfMAd+sI=
-github.com/MatusOllah/slogcolor v1.6.0/go.mod h1:5y1H50XuQIBvuYTJlmokWi+4FuPiJN5L7Z0jM4K4bYA=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=

--- a/go-sdk/pkg/config/config.go
+++ b/go-sdk/pkg/config/config.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MatusOllah/slogcolor"
-	"github.com/fatih/color"
 	cc "github.com/ivanpirog/coloredcobra"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -90,7 +88,6 @@ func Configure(cmd *cobra.Command) error {
 }
 
 func makeLogger(v *viper.Viper) *slog.Logger {
-	opts := *slogcolor.DefaultOptions
 	leveler := &slog.LevelVar{}
 
 	// TODO: Should we have consistency with Airflow's config option? That would mean "logging.logging_level" here
@@ -106,17 +103,20 @@ func makeLogger(v *viper.Viper) *slog.Logger {
 		cobra.CheckErr(err)
 	}
 
-	opts.Level = leveler
-	opts.LevelTags = map[slog.Level]string{
-		logging.LevelTrace: color.New(color.FgHiGreen).Sprint("TRACE"),
-		slog.LevelDebug:    color.New(color.BgCyan, color.FgHiWhite).Sprint("DEBUG"),
-		slog.LevelInfo:     color.New(color.BgGreen, color.FgHiWhite).Sprint("INFO "),
-		slog.LevelWarn:     color.New(color.BgYellow, color.FgHiWhite).Sprint("WARN "),
-		slog.LevelError:    color.New(color.BgRed, color.FgHiWhite).Sprint("ERROR"),
+	opts := &slog.HandlerOptions{
+		Level: leveler,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// Render our custom TRACE level by name rather than "DEBUG-4"
+			if a.Key == slog.LevelKey {
+				if level, ok := a.Value.Any().(slog.Level); ok && level == logging.LevelTrace {
+					a.Value = slog.StringValue("TRACE")
+				}
+			}
+			return a
+		},
 	}
 
-	log := slog.New(slogcolor.NewHandler(os.Stderr, &opts))
-	return log
+	return slog.New(slog.NewTextHandler(os.Stderr, opts))
 }
 
 func SetupViper(cfgFile string) (*viper.Viper, error) {

--- a/kubernetes-tests/lang_sdk/go_example/go.mod
+++ b/kubernetes-tests/lang_sdk/go_example/go.mod
@@ -7,7 +7,6 @@ toolchain go1.24.6
 require github.com/apache/airflow/go-sdk v0.0.0
 
 require (
-	github.com/MatusOllah/slogcolor v1.6.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/evanphx/go-hclog-slog v0.0.0-20240717231540-be48fc4c4df5 // indirect
 	github.com/fatih/color v1.18.0 // indirect

--- a/kubernetes-tests/lang_sdk/go_example/go.sum
+++ b/kubernetes-tests/lang_sdk/go_example/go.sum
@@ -1,5 +1,3 @@
-github.com/MatusOllah/slogcolor v1.6.0 h1:JAKer0xj5l1jYTXyQvs5ggqmJqYDuLnxgR9jfMAd+sI=
-github.com/MatusOllah/slogcolor v1.6.0/go.mod h1:5y1H50XuQIBvuYTJlmokWi+4FuPiJN5L7Z0jM4K4bYA=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=


### PR DESCRIPTION
* Drop colored logging from the Go SDK edge worker

The Go SDK edge worker was the only Edge Worker that colorized its console logs. The Python Edge Worker (edge3 provider) does not support colored logging, so the Go side aligns with it and drops the feature rather than maintaining coloring the rest of the Edge Worker surface does not offer.

Dropping colored logging removes the sole use of the github.com/MatusOllah/ slogcolor dependency; the edge worker now logs via the standard library slog text handler, preserving log levels including the custom TRACE level. The lang-SDK Go example module, which resolves the SDK via a replace directive, is re-tidied to drop the now-unused indirect slogcolor entry.

* Reconcile lang-SDK Go example go.sum before building the bundle

The K8S Lang-SDK test always builds the Go bundle from upstream main's go-sdk, while go_example is a branch fixture whose go.sum is tidied against the in-repo go-sdk. When a branch changes go-sdk's dependency graph the two go-sdks diverge, and Go refuses to build the bundle on the resulting go.sum drift ("missing go.sum entry ..."), turning the bundle-build step red on the pull request. Re-tidy the scratch go_example against the go-sdk it is actually compiled against before packing so the build reconciles the drift itself; the committed go.sum is left untouched and stays guarded by the check-go-example-mod-tidy prek hook.
(cherry picked from commit 802ffa7b3c6ea34a69dd7df0f42c9dc26d5bb883)
