### PR TITLE
Limit Dependabot Go module updates to security advisories only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -373,7 +373,9 @@ updates:
 
   - package-ecosystem: "gomod"
     cooldown:
-      default-days: 4
+      # Longer than other ecosystems: distributed Go releases are not pre-scanned by a
+      # central registry, so we give any malicious release more time to be flagged.
+      default-days: 14
     directory: "/go-sdk"
     schedule:
       interval: "weekly"
@@ -404,16 +406,21 @@ updates:
           - "*"
         applies-to: security-updates
 
+  # Go modules resolve straight to upstream repositories: there is no central registry
+  # (unlike PyPI/npm) that pre-scans a release, and whoever controls a module's namespace
+  # can publish a version at any time. To keep an unreviewed upstream Go release from being
+  # auto-merged into our dev/CI chain, we do NOT raise automatic version-update PRs here
+  # (`open-pull-requests-limit: 0`); routine Go bumps are done manually. We still accept
+  # advisory-driven security updates, which require a published GHSA advisory and so cannot
+  # be triggered by an upstream release self-declaring itself a "security" fix.
   - package-ecosystem: "gomod"
     cooldown:
-      default-days: 4
+      default-days: 14
     directory: "/go-sdk"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
-      go-sdk-dependency-updates:
-        patterns:
-          - "*"
       go-sdk-security-updates:
         patterns:
           - "*"


### PR DESCRIPTION
## Why

The Go SDK's dependencies resolve directly to upstream repositories. Unlike PyPI or npm, there is no central registry that pre-scans a release before it is published, and whoever controls a module's namespace can cut a release at any time.

Go's checksum database (`go.sum` + `sum.golang.org`) makes existing pins immutable, so the risk is not the *current* pin — it is the *next* automatic bump.

## What

For the `gomod` ecosystem rooted at `/go-sdk`:

- **Default branch:** disable automatic version-update PRs (`open-pull-requests-limit: 0`) and keep only the advisory-driven `go-sdk-security-updates` group. Dependabot security updates require a published GHSA advisory, so they cannot be triggered by an upstream release self-declaring itself a "security" fix. Routine Go dependency bumps are now done manually when we actually need them.
- **Both gomod blocks:** raise the cooldown from 4 to 14 days, giving any release a longer window to be flagged before it is auto-considered (the `v3-3-test` branch still does grouped minor/patch bumps).

This only changes the automation posture for Go modules — no dependency versions change, and security fixes still flow automatically.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)