### PR TITLE
Scan Go SDK dependencies for known vulnerabilities in CI

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -1017,6 +1017,15 @@ jobs:
       - name: Run Go tests
         working-directory: ./go-sdk
         run: gotestsum --format github-actions ./...
+      # Go modules have no central registry that pre-scans releases, so we scan our own
+      # dependency graph against the Go vulnerability database. govulncheck is reachability
+      # based, so it only fails on advisories that actually affect code we call. The version
+      # tag is immutable (Go modules are content-addressed via the checksum database).
+      - name: Scan Go dependencies for known vulnerabilities
+        working-directory: ./go-sdk
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+          govulncheck ./...
 
   tests-java-sdk:
     name: "Java SDK tests"

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -1006,6 +1006,15 @@ jobs:
       - name: Run Go tests
         working-directory: ./go-sdk
         run: gotestsum --format github-actions ./...
+      # Go modules have no central registry that pre-scans releases, so we scan our own
+      # dependency graph against the Go vulnerability database. govulncheck is reachability
+      # based, so it only fails on advisories that actually affect code we call. The version
+      # tag is immutable (Go modules are content-addressed via the checksum database).
+      - name: Scan Go dependencies for known vulnerabilities
+        working-directory: ./go-sdk
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+          govulncheck ./...
 
   tests-java-sdk:
     name: "Java SDK tests"


### PR DESCRIPTION
## Why

Go modules resolve directly to upstream repositories. Unlike PyPI or npm — where releases are now scanned at publish time — there is no central registry that pre-scans a Go release, so a known-vulnerable or compromised dependency can enter the Go SDK's graph without any external scanner flagging it first. 

We already limit Dependabot to advisory-driven security updates for Go modules (#70914) and CodeQL scans our own Go source daily, but neither continuously checks the *dependency graph* against known advisories.

## What

Add a `govulncheck` step to the `Go SDK tests` job on both the amd and arm CI workflows (kept in sync). `govulncheck`:

- checks the module graph against the [Go vulnerability database](https://pkg.go.dev/vuln), and
- is **reachability based**, so it only fails the build on advisories that affect code the SDK actually calls — keeping the signal low-noise rather than alerting on every transitively-present CVE.

The `@v1.6.0` pin is immutable: Go module versions are content-addressed through the checksum database, unlike mutable Git tags used for `uses:` actions.

This runs whenever the Go SDK job runs (i.e. when Go files change), catching a vulnerable dependency at the moment it is added or bumped.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)