### PR TITLE
Fix operators declaring template_fields/template_ext as bare strings

### DIFF
--- a/providers/edge3/src/airflow/providers/edge3/example_dags/win_notepad.py
+++ b/providers/edge3/src/airflow/providers/edge3/example_dags/win_notepad.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 class NotepadOperator(BaseOperator):
     """Example Operator Implementation which starts a ``Notepad.exe`` on Windows."""
 
-    template_fields: Sequence[str] = "text"
+    template_fields: Sequence[str] = ("text",)
 
     def __init__(self, text: str, **kwargs):
         self.text = text

--- a/providers/edge3/src/airflow/providers/edge3/example_dags/win_test.py
+++ b/providers/edge3/src/airflow/providers/edge3/example_dags/win_test.py
@@ -140,7 +140,7 @@ class CmdOperator(BaseOperator):
 
     template_fields: Sequence[str] = ("command", "env", "cwd")
     template_fields_renderers = {"command": "bash", "env": "json"}
-    template_ext: Sequence[str] = ".bat"
+    template_ext: Sequence[str] = (".bat",)
 
     subprocess: Popen | None = None
 

--- a/providers/telegram/src/airflow/providers/telegram/operators/telegram.py
+++ b/providers/telegram/src/airflow/providers/telegram/operators/telegram.py
@@ -103,7 +103,7 @@ class TelegramFileOperator(BaseOperator):
     :param telegram_kwargs: Extra args to be passed to telegram client
     """
 
-    template_fields: Sequence[str] = "chat_id"
+    template_fields: Sequence[str] = ("chat_id",)
     ui_color = "#FFBA40"
 
     def __init__(

--- a/providers/telegram/tests/unit/telegram/operators/test_telegram.py
+++ b/providers/telegram/tests/unit/telegram/operators/test_telegram.py
@@ -24,7 +24,7 @@ import telegram
 
 import airflow
 from airflow.models import Connection
-from airflow.providers.telegram.operators.telegram import TelegramOperator
+from airflow.providers.telegram.operators.telegram import TelegramFileOperator, TelegramOperator
 
 TELEGRAM_TOKEN = "xxx:xxx"
 
@@ -171,6 +171,21 @@ class TestTelegramOperator:
             task_id="telegram",
             text="text",
             telegram_kwargs={"custom_arg": "value", "text": "should be ignored"},
+        )
+        operator.render_template_fields({"chat_id": "1234567"})
+        assert operator.chat_id == "1234567"
+
+
+class TestTelegramFileOperator:
+    def test_should_return_template_fields(self):
+        assert TelegramFileOperator.template_fields == ("chat_id",)
+
+    def test_should_return_templatized_chat_id_field(self):
+        operator = TelegramFileOperator(
+            telegram_conn_id="telegram_default",
+            chat_id="{{ chat_id }}",
+            task_id="telegram",
+            file="/tmp/file.txt",
         )
         operator.render_template_fields({"chat_id": "1234567"})
         assert operator.chat_id == "1234567"


### PR DESCRIPTION
A bare string is a sequence of characters, so "chat_id" declares the fields "c", "h", "a"... rather than "chat_id".

Airflow papers over this for template_fields by wrapping a string in a list, at the cost of a UserWarning on every task build. template_ext gets no such fallback: ".bat" expands to (".", "b", "a", "t"), so any templated value ending in one of those characters is mistaken for a script path and its contents silently loaded in its place.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- - [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
