### PR TITLE
Strip only the literal properties/ prefix from GA property link IDs

### DIFF
--- a/providers/google/src/airflow/providers/google/marketing_platform/operators/analytics_admin.py
+++ b/providers/google/src/airflow/providers/google/marketing_platform/operators/analytics_admin.py
@@ -194,7 +194,7 @@ class GoogleAnalyticsAdminCreatePropertyOperator(GoogleCloudBaseOperator):
         self.log.info("The Google Analytics property %s was created successfully.", prop.name)
         GoogleAnalyticsPropertyLink.persist(
             context=context,
-            property_id=prop.name.lstrip("properties/"),
+            property_id=prop.name.removeprefix("properties/"),
         )
 
         return Property.to_dict(prop)

--- a/providers/google/tests/unit/google/marketing_platform/operators/test_analytics_admin.py
+++ b/providers/google/tests/unit/google/marketing_platform/operators/test_analytics_admin.py
@@ -117,6 +117,31 @@ class TestGoogleAnalyticsAdminCreatePropertyOperator:
         property_to_dict_mock.assert_called_once_with(property_returned)
         assert property_created == property_serialized
 
+    @pytest.mark.parametrize(
+        ("property_name", "expected_property_id"),
+        [
+            (TEST_PROPERTY_NAME, TEST_PROPERTY_ID),
+            # Stripping a character set instead of the literal prefix would also eat the leading "s".
+            ("properties/s123", "s123"),
+        ],
+    )
+    @mock.patch(f"{ANALYTICS_PATH}.GoogleAnalyticsPropertyLink")
+    @mock.patch(f"{ANALYTICS_PATH}.GoogleAnalyticsAdminHook")
+    @mock.patch(f"{ANALYTICS_PATH}.Property.to_dict")
+    def test_execute_persists_link_with_property_id(
+        self, _, hook_mock, property_link_mock, property_name, expected_property_id
+    ):
+        hook_mock.return_value.create_property.return_value.name = property_name
+
+        GoogleAnalyticsAdminCreatePropertyOperator(
+            task_id="test_task",
+            analytics_property=mock.MagicMock(),
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        ).execute(context=None)
+
+        property_link_mock.persist.assert_called_once_with(context=None, property_id=expected_property_id)
+
 
 class TestGoogleAnalyticsAdminDeletePropertyOperator:
     @mock.patch(f"{ANALYTICS_PATH}.GoogleAnalyticsAdminHook")


### PR DESCRIPTION
`GoogleAnalyticsAdminCreatePropertyOperator` builds the property link ID with
`prop.name.lstrip("properties/")`. `str.lstrip` removes any leading character
belonging to the given set — it is not a prefix strip — so it also consumes any
leading `p`, `r`, `o`, `e`, `t`, `i`, `s` or `/` of the property ID itself.

This is correct today only because GA4 property IDs are numeric, so there is no
user-visible behaviour change. The intent is a prefix strip, so `removeprefix`
expresses it directly and removes the latent trap.Improve semantics and readability

The `persist` call had no test coverage; the added parametrized test pins the
exact-prefix semantics and fails on the previous implementation.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)