### PR TITLE
Clarify Elasticsearch remote-logging scheme needs Airflow 3.3.0+

### DIFF
--- a/providers/elasticsearch/docs/logging/index.rst
+++ b/providers/elasticsearch/docs/logging/index.rst
@@ -37,9 +37,7 @@ First, to use the handler, ``airflow.cfg`` must be configured as follows:
     [elasticsearch]
     host = <host>:<port>
 
-On Airflow 3.x you can also route remote logging to Elasticsearch through the provider
-dispatch mechanism by adding an ``elasticsearch://`` scheme to
-``[logging] remote_base_log_folder``:
+On Airflow 3.3.0 or above you can also route remote logging to Elasticsearch through the provider dispatch mechanism by adding an ``elasticsearch://`` scheme to ``[logging] remote_base_log_folder``:
 
 .. code-block:: ini
 


### PR DESCRIPTION
- related: #70525
- related: https://github.com/apache/airflow/pull/70295#discussion_r3696081992

Follow-up to #70525, which documented routing Elasticsearch remote logging through the provider dispatch mechanism (the ``elasticsearch://`` scheme in ``[logging] remote_base_log_folder``).


- Replace the vague "On Airflow 3.x" with the precise **"On Airflow 3.3.0 or above"** — the provider dispatch / scheme-registration mechanism this paragraph describes is only available from 3.3.0 onward.
- Collapse the paragraph onto a single line.

Docs-only change; no runtime behaviour is affected.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below) Opus 4.8

Generated-by: Opus 4.8 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
