### PR TITLE
UI: add toggle to restore DagRun total count

### DIFF
--- a/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/DagRuns/DagRuns.tsx
@@ -21,6 +21,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
+import { useLocalStorage } from "usehooks-ts";
 
 import { useDagRunServiceGetDagRuns } from "openapi/queries";
 import type { DAGRunResponse } from "openapi/requests/types.gen";
@@ -46,6 +47,7 @@ import Time from "src/components/Time";
 import { TruncatedText } from "src/components/TruncatedText";
 import { RouterLink } from "src/components/ui";
 import { ActionBar } from "src/components/ui/ActionBar";
+import { Switch } from "src/components/ui";
 import { SearchParamsKeys, type SearchParamsKeysType } from "src/constants/searchParams";
 import { useAdvancedSearchArg } from "src/hooks/useAdvancedSearch";
 import { useConfig } from "src/queries/useConfig";
@@ -259,7 +261,10 @@ export const DagRuns = () => {
   const [sort] = sorting;
   const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-run_after"];
 
-  const { pageSize } = pagination;
+  // Cursor pagination (default) skips COUNT(*) for performance (#65604).
+  // Offset mode restores the total DagRun count heading (#70856).
+  const [showExactCount, setShowExactCount] = useLocalStorage("dagRuns:showExactCount", false);
+  const { pageIndex, pageSize } = pagination;
   const filteredState = searchParams.get(STATE_PARAM);
   const filteredType = searchParams.get(RUN_TYPE_PARAM);
   const filteredRunIdPattern = searchParams.get(RUN_ID_PATTERN_PARAM);
@@ -314,7 +319,7 @@ export const DagRuns = () => {
       bundleVersion: bundleVersion ?? undefined,
       confContains: confContains !== null && confContains !== "" ? confContains : undefined,
       consumingAssetPattern: filteredConsumingAsset ?? undefined,
-      cursor: cursor ?? "",
+      ...(showExactCount ? { offset: pageIndex * pageSize } : { cursor: cursor ?? "" }),
       dagId: dagId ?? "~",
       ...dagIdPatternArg,
       dagVersion:
@@ -346,8 +351,9 @@ export const DagRuns = () => {
     },
   );
 
-  const nextCursor = data?.next_cursor ?? undefined;
-  const previousCursor = data?.previous_cursor ?? undefined;
+  const nextCursor = showExactCount ? undefined : (data?.next_cursor ?? undefined);
+  const previousCursor = showExactCount ? undefined : (data?.previous_cursor ?? undefined);
+  const totalEntries = showExactCount ? (data?.total_entries ?? 0) : undefined;
 
   const { allRowsSelected, clearSelections, deselectKeys, handleRowSelect, handleSelectAll, selectedRows } =
     useRowSelection({
@@ -373,13 +379,26 @@ export const DagRuns = () => {
     >
       <Flex alignItems="center" justifyContent="space-between">
         <DagRunsFilters dagId={dagId} />
-        <ExpandCollapseButtons
-          collapseLabel={translate("common:collapseAllExtra")}
-          expandLabel={translate("common:expandAllExtra")}
-          isExpanded={open}
-          onCollapse={onClose}
-          onExpand={onOpen}
-        />
+        <HStack gap={3}>
+          <Switch
+            checked={showExactCount}
+            onCheckedChange={(details) => {
+              setShowExactCount(details.checked);
+              if (details.checked) {
+                setTableURLState({ ...tableURLState, cursor: undefined });
+              }
+            }}
+          >
+            {translate("dagRun.showExactCount", { defaultValue: "Show total count" })}
+          </Switch>
+          <ExpandCollapseButtons
+            collapseLabel={translate("common:collapseAllExtra")}
+            expandLabel={translate("common:expandAllExtra")}
+            isExpanded={open}
+            onCollapse={onClose}
+            onExpand={onOpen}
+          />
+        </HStack>
       </Flex>
       <DataTable
         columns={columns}
@@ -391,6 +410,7 @@ export const DagRuns = () => {
         nextCursor={nextCursor}
         onStateChange={setTableURLState}
         previousCursor={previousCursor}
+        total={totalEntries}
       />
       <ActionBar.Root closeOnInteractOutside={false} open={Boolean(selectedRows.size)}>
         <ActionBar.Content>


### PR DESCRIPTION
## What this PR does / why we need it

Closes #70856

After #65604, the Dag Runs UI always uses cursor pagination, so the API
no longer returns \`total_entries\` and the DataTable count heading
disappeared between 3.2.1 and 3.2.2.

This keeps cursor pagination as the default (fast path) and adds an
opt-in **Show total count** switch that uses offset pagination to restore
\`total_entries\` / the row count heading.

## Preference for how this is reviewed

- [x] I prefer that this PR is reviewed as a whole

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## How was this tested

Manual reasoning against \`DataTable\` / \`get_dag_runs\` cursor vs offset
contracts. Prefer UI review in breeze/dev UI.

## Docs

N/A (UI affordance with defaultValue label)

Made with [Cursor](https://cursor.com)