### PR TITLE
Add synchronous Vertex AI Agent Engine query operator

### DIFF
--- a/providers/google/docs/operators/cloud/vertex_ai.rst
+++ b/providers/google/docs/operators/cloud/vertex_ai.rst
@@ -51,15 +51,15 @@ To get an Agent Engine you can use
     :end-before: [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
 To query an Agent Engine synchronously you can use
-:class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.QueryAgentEngineOperator`.
+:class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunAgentQueryOperator`.
 The operator calls the public ``query_reasoning_engine`` GAPIC method and returns
 the Agent Engine output directly without using Google Cloud Storage.
 
 .. exampleinclude:: /../../google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
     :language: python
     :dedent: 4
-    :start-after: [START how_to_cloud_vertex_ai_query_agent_engine_operator]
-    :end-before: [END how_to_cloud_vertex_ai_query_agent_engine_operator]
+    :start-after: [START how_to_cloud_vertex_ai_run_agent_query_operator]
+    :end-before: [END how_to_cloud_vertex_ai_run_agent_query_operator]
 
 To run a query job on an Agent Engine you can use
 :class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunQueryJobOperator`.

--- a/providers/google/docs/operators/cloud/vertex_ai.rst
+++ b/providers/google/docs/operators/cloud/vertex_ai.rst
@@ -50,6 +50,17 @@ To get an Agent Engine you can use
     :start-after: [START how_to_cloud_vertex_ai_get_agent_engine_operator]
     :end-before: [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
+To query an Agent Engine synchronously you can use
+:class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.QueryAgentEngineOperator`.
+The operator calls the public ``query_reasoning_engine`` GAPIC method and returns
+the Agent Engine output directly without using Google Cloud Storage.
+
+.. exampleinclude:: /../../google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
+    :language: python
+    :dedent: 4
+    :start-after: [START how_to_cloud_vertex_ai_query_agent_engine_operator]
+    :end-before: [END how_to_cloud_vertex_ai_query_agent_engine_operator]
+
 To run a query job on an Agent Engine you can use
 :class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunQueryJobOperator`.
 The operator uses the public ``run_query_job`` SDK method. The ``config`` parameter

--- a/providers/google/docs/operators/cloud/vertex_ai.rst
+++ b/providers/google/docs/operators/cloud/vertex_ai.rst
@@ -53,7 +53,7 @@ To get an Agent Engine you can use
 To query an Agent Engine synchronously you can use
 :class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunAgentQueryOperator`.
 The operator calls the public ``query_reasoning_engine`` GAPIC method and returns
-the Agent Engine output directly without using Google Cloud Storage.
+the serialized response without using Google Cloud Storage.
 
 .. exampleinclude:: /../../google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
     :language: python

--- a/providers/google/docs/operators/cloud/vertex_ai.rst
+++ b/providers/google/docs/operators/cloud/vertex_ai.rst
@@ -51,15 +51,15 @@ To get an Agent Engine you can use
     :end-before: [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
 To query an Agent Engine synchronously you can use
-:class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunAgentQueryOperator`.
+:class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunReasoningEngineQueryOperator`.
 The operator calls the public ``query_reasoning_engine`` GAPIC method and returns
 the serialized response without using Google Cloud Storage.
 
 .. exampleinclude:: /../../google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
     :language: python
     :dedent: 4
-    :start-after: [START how_to_cloud_vertex_ai_run_agent_query_operator]
-    :end-before: [END how_to_cloud_vertex_ai_run_agent_query_operator]
+    :start-after: [START how_to_cloud_vertex_ai_run_reasoning_engine_query_operator]
+    :end-before: [END how_to_cloud_vertex_ai_run_reasoning_engine_query_operator]
 
 To run a query job on an Agent Engine you can use
 :class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunQueryJobOperator`.

--- a/providers/google/docs/operators/cloud/vertex_ai.rst
+++ b/providers/google/docs/operators/cloud/vertex_ai.rst
@@ -50,7 +50,7 @@ To get an Agent Engine you can use
     :start-after: [START how_to_cloud_vertex_ai_get_agent_engine_operator]
     :end-before: [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
-To query an Agent Engine synchronously you can use
+To query a Reasoning Engine synchronously you can use
 :class:`~airflow.providers.google.cloud.operators.vertex_ai.agent_engine.RunReasoningEngineQueryOperator`.
 The operator calls the public ``query_reasoning_engine`` GAPIC method and returns
 the serialized response without using Google Cloud Storage.

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
@@ -25,7 +25,6 @@ from typing import TYPE_CHECKING, Any
 
 import google.auth.transport.requests
 from asgiref.sync import sync_to_async
-from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.cloud.aiplatform_v1 import ReasoningEngineExecutionServiceClient
 from vertexai import Client
 
@@ -171,7 +170,7 @@ class AgentEngineHook(GoogleBaseHook):
         reasoning_engine_id: str,
         input_data: dict[str, Any] | None = None,
         class_method: str = "query",
-        retry: Retry | _MethodDefault = DEFAULT,
+        retry: Retry | None = None,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         project_id: str = PROVIDE_PROJECT_ID,
@@ -184,7 +183,7 @@ class AgentEngineHook(GoogleBaseHook):
         :param input_data: Optional. Input for the Reasoning Engine class method in JSON object format.
             Defaults to ``None``.
         :param class_method: Optional. The Reasoning Engine class method to invoke. Defaults to ``query``.
-        :param retry: Designation of what errors, if any, should be retried. Defaults to ``DEFAULT``.
+        :param retry: Designation of what errors, if any, should be retried. Defaults to ``None``.
         :param timeout: The timeout for this request. Defaults to ``None``.
         :param metadata: Strings which should be sent along with the request as metadata. Defaults
             to an empty tuple.

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
@@ -182,10 +182,12 @@ class AgentEngineHook(GoogleBaseHook):
         :param location: Required. The ID of the Google Cloud location that the service belongs to.
         :param agent_engine_id: Required. The Agent Engine ID.
         :param input_data: Optional. Input for the Agent Engine class method in JSON object format.
+            Defaults to ``None``.
         :param class_method: Optional. The Agent Engine class method to invoke. Defaults to ``query``.
-        :param retry: Designation of what errors, if any, should be retried.
-        :param timeout: The timeout for this request.
-        :param metadata: Strings which should be sent along with the request as metadata.
+        :param retry: Designation of what errors, if any, should be retried. Defaults to ``DEFAULT``.
+        :param timeout: The timeout for this request. Defaults to ``None``.
+        :param metadata: Strings which should be sent along with the request as metadata. Defaults
+            to an empty tuple.
         :param project_id: Optional. The ID of the Google Cloud project. Defaults to the project
             configured in the connection.
         """

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
@@ -177,13 +177,13 @@ class AgentEngineHook(GoogleBaseHook):
         project_id: str = PROVIDE_PROJECT_ID,
     ) -> QueryReasoningEngineResponse:
         """
-        Query an Agent Engine synchronously.
+        Query a Reasoning Engine synchronously.
 
         :param location: Required. The ID of the Google Cloud location that the service belongs to.
-        :param reasoning_engine_id: Required. The Reasoning Engine resource ID for the Agent Engine.
-        :param input_data: Optional. Input for the Agent Engine class method in JSON object format.
+        :param reasoning_engine_id: Required. The Reasoning Engine resource ID.
+        :param input_data: Optional. Input for the Reasoning Engine class method in JSON object format.
             Defaults to ``None``.
-        :param class_method: Optional. The Agent Engine class method to invoke. Defaults to ``query``.
+        :param class_method: Optional. The Reasoning Engine class method to invoke. Defaults to ``query``.
         :param retry: Designation of what errors, if any, should be retried. Defaults to ``DEFAULT``.
         :param timeout: The timeout for this request. Defaults to ``None``.
         :param metadata: Strings which should be sent along with the request as metadata. Defaults

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
@@ -165,10 +165,10 @@ class AgentEngineHook(GoogleBaseHook):
         return client.get(name=name, config=config)
 
     @GoogleBaseHook.fallback_to_default_project_id
-    def query_agent_engine(
+    def query_reasoning_engine(
         self,
         location: str,
-        agent_engine_id: str,
+        reasoning_engine_id: str,
         input_data: dict[str, Any] | None = None,
         class_method: str = "query",
         retry: Retry | _MethodDefault = DEFAULT,
@@ -180,7 +180,7 @@ class AgentEngineHook(GoogleBaseHook):
         Query an Agent Engine synchronously.
 
         :param location: Required. The ID of the Google Cloud location that the service belongs to.
-        :param agent_engine_id: Required. The Agent Engine ID.
+        :param reasoning_engine_id: Required. The Reasoning Engine resource ID for the Agent Engine.
         :param input_data: Optional. Input for the Agent Engine class method in JSON object format.
             Defaults to ``None``.
         :param class_method: Optional. The Agent Engine class method to invoke. Defaults to ``query``.
@@ -192,7 +192,7 @@ class AgentEngineHook(GoogleBaseHook):
             configured in the connection.
         """
         client = self.get_reasoning_engine_execution_service_client(location=location)
-        name = client.reasoning_engine_path(project_id, location, agent_engine_id)
+        name = client.reasoning_engine_path(project_id, location, reasoning_engine_id)
         request: dict[str, Any] = {"name": name, "class_method": class_method}
         if input_data is not None:
             request["input"] = input_data

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
@@ -191,8 +191,11 @@ class AgentEngineHook(GoogleBaseHook):
         """
         client = self.get_reasoning_engine_execution_service_client(location=location)
         name = client.reasoning_engine_path(project_id, location, agent_engine_id)
+        request: dict[str, Any] = {"name": name, "class_method": class_method}
+        if input_data is not None:
+            request["input"] = input_data
         return client.query_reasoning_engine(
-            request={"name": name, "input": input_data, "class_method": class_method},
+            request=request,
             retry=retry,
             timeout=timeout,
             metadata=metadata,

--- a/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/vertex_ai/agent_engine.py
@@ -25,8 +25,11 @@ from typing import TYPE_CHECKING, Any
 
 import google.auth.transport.requests
 from asgiref.sync import sync_to_async
+from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
+from google.cloud.aiplatform_v1 import ReasoningEngineExecutionServiceClient
 from vertexai import Client
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import (
     PROVIDE_PROJECT_ID,
     GoogleBaseAsyncHook,
@@ -34,6 +37,8 @@ from airflow.providers.google.common.hooks.base_google import (
 )
 
 if TYPE_CHECKING:
+    from google.api_core.retry import Retry
+    from google.cloud.aiplatform_v1.types import QueryReasoningEngineResponse
     from vertexai._genai import types
 
 
@@ -66,7 +71,8 @@ class AgentEngineHook(GoogleBaseHook):
     """
     Hook for Google Cloud Vertex AI Agent Engine APIs.
 
-    Wraps the ``agent_engines`` module of the Vertex AI SDK client:
+    Wraps the ``agent_engines`` module of the Vertex AI SDK client and the
+    Reasoning Engine Execution Service GAPIC client:
     https://docs.cloud.google.com/python/docs/reference/agentplatform/latest/vertexai._genai.agent_engines.AgentEngines
     """
 
@@ -89,6 +95,23 @@ class AgentEngineHook(GoogleBaseHook):
             location=location,
             credentials=self.get_credentials(),
         ).agent_engines
+
+    def _get_api_endpoint(self, location: str | None = None) -> str | None:
+        if location and location != "global" and self.is_default_universe():
+            return f"{location}-aiplatform.googleapis.com:443"
+        return None
+
+    def get_reasoning_engine_execution_service_client(
+        self, location: str | None = None
+    ) -> ReasoningEngineExecutionServiceClient:
+        """Return the Reasoning Engine Execution Service client."""
+        return ReasoningEngineExecutionServiceClient(
+            credentials=self.get_credentials(),
+            client_info=CLIENT_INFO,
+            client_options=self.get_client_options(
+                api_endpoint_override=self._get_api_endpoint(location=location)
+            ),
+        )
 
     @staticmethod
     def build_agent_engine_name(project_id: str, location: str, agent_engine_id: str) -> str:
@@ -140,6 +163,40 @@ class AgentEngineHook(GoogleBaseHook):
         client = self.get_agent_engine_client(project_id=project_id, location=location)
         name = self.build_agent_engine_name(project_id, location, agent_engine_id)
         return client.get(name=name, config=config)
+
+    @GoogleBaseHook.fallback_to_default_project_id
+    def query_agent_engine(
+        self,
+        location: str,
+        agent_engine_id: str,
+        input_data: dict[str, Any] | None = None,
+        class_method: str = "query",
+        retry: Retry | _MethodDefault = DEFAULT,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] = (),
+        project_id: str = PROVIDE_PROJECT_ID,
+    ) -> QueryReasoningEngineResponse:
+        """
+        Query an Agent Engine synchronously.
+
+        :param location: Required. The ID of the Google Cloud location that the service belongs to.
+        :param agent_engine_id: Required. The Agent Engine ID.
+        :param input_data: Optional. Input for the Agent Engine class method in JSON object format.
+        :param class_method: Optional. The Agent Engine class method to invoke. Defaults to ``query``.
+        :param retry: Designation of what errors, if any, should be retried.
+        :param timeout: The timeout for this request.
+        :param metadata: Strings which should be sent along with the request as metadata.
+        :param project_id: Optional. The ID of the Google Cloud project. Defaults to the project
+            configured in the connection.
+        """
+        client = self.get_reasoning_engine_execution_service_client(location=location)
+        name = client.reasoning_engine_path(project_id, location, agent_engine_id)
+        return client.query_reasoning_engine(
+            request={"name": name, "input": input_data, "class_method": class_method},
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
     @GoogleBaseHook.fallback_to_default_project_id
     def run_query_job(

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
@@ -172,18 +172,17 @@ class GetAgentEngineOperator(GoogleCloudBaseOperator):
 
 class RunReasoningEngineQueryOperator(GoogleCloudBaseOperator):
     """
-    Query a Vertex AI Agent Engine synchronously.
+    Query a Vertex AI Reasoning Engine synchronously.
 
     :param project_id: Required (templated). The ID of the Google Cloud project that the service
         belongs to.
     :param location: Required (templated). The ID of the Google Cloud location that the service
         belongs to.
-    :param reasoning_engine_id: Required (templated). The Reasoning Engine resource ID for the
-        Agent Engine.
-    :param input_data: Optional (templated). Input for the Agent Engine class method in JSON object
-        format. Defaults to ``None``.
-    :param class_method: Optional (templated). The Agent Engine class method to invoke. Defaults to
-        ``query``.
+    :param reasoning_engine_id: Required (templated). The Reasoning Engine resource ID.
+    :param input_data: Optional (templated). Input for the Reasoning Engine class method in JSON
+        object format. Defaults to ``None``.
+    :param class_method: Optional (templated). The Reasoning Engine class method to invoke. Defaults
+        to ``query``.
     :param retry: Designation of what errors, if any, should be retried. Defaults to ``DEFAULT``.
     :param timeout: The timeout for this request. Defaults to ``None``.
     :param metadata: Strings which should be sent along with the request as metadata. Defaults to
@@ -239,7 +238,7 @@ class RunReasoningEngineQueryOperator(GoogleCloudBaseOperator):
         )
 
     def execute(self, context: Context) -> dict[str, JsonValue]:
-        self.log.info("Querying Agent Engine %s.", self.reasoning_engine_id)
+        self.log.info("Querying Reasoning Engine %s.", self.reasoning_engine_id)
         response = self.hook.query_reasoning_engine(
             project_id=self.project_id,
             location=self.location,
@@ -250,7 +249,7 @@ class RunReasoningEngineQueryOperator(GoogleCloudBaseOperator):
             timeout=self.timeout,
             metadata=self.metadata,
         )
-        self.log.info("Agent Engine %s returned a response.", self.reasoning_engine_id)
+        self.log.info("Reasoning Engine %s returned a response.", self.reasoning_engine_id)
         return QueryReasoningEngineResponse.to_dict(response)
 
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
@@ -170,7 +170,7 @@ class GetAgentEngineOperator(GoogleCloudBaseOperator):
         return result
 
 
-class RunAgentQueryOperator(GoogleCloudBaseOperator):
+class RunReasoningEngineQueryOperator(GoogleCloudBaseOperator):
     """
     Query a Vertex AI Agent Engine synchronously.
 
@@ -178,7 +178,8 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
         belongs to.
     :param location: Required (templated). The ID of the Google Cloud location that the service
         belongs to.
-    :param agent_engine_id: Required (templated). The Agent Engine ID.
+    :param reasoning_engine_id: Required (templated). The Reasoning Engine resource ID for the
+        Agent Engine.
     :param input_data: Optional (templated). Input for the Agent Engine class method in JSON object
         format. Defaults to ``None``.
     :param class_method: Optional (templated). The Agent Engine class method to invoke. Defaults to
@@ -196,7 +197,7 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
     template_fields = (
         "project_id",
         "location",
-        "agent_engine_id",
+        "reasoning_engine_id",
         "input_data",
         "class_method",
         "gcp_conn_id",
@@ -208,7 +209,7 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
         *,
         project_id: str,
         location: str,
-        agent_engine_id: str,
+        reasoning_engine_id: str,
         input_data: dict[str, Any] | None = None,
         class_method: str = "query",
         retry: Retry | _MethodDefault = DEFAULT,
@@ -221,7 +222,7 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
         super().__init__(**kwargs)
         self.project_id = project_id
         self.location = location
-        self.agent_engine_id = agent_engine_id
+        self.reasoning_engine_id = reasoning_engine_id
         self.input_data = input_data
         self.class_method = class_method
         self.retry = retry
@@ -238,18 +239,18 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
         )
 
     def execute(self, context: Context) -> dict[str, JsonValue]:
-        self.log.info("Querying Agent Engine %s.", self.agent_engine_id)
-        response = self.hook.query_agent_engine(
+        self.log.info("Querying Agent Engine %s.", self.reasoning_engine_id)
+        response = self.hook.query_reasoning_engine(
             project_id=self.project_id,
             location=self.location,
-            agent_engine_id=self.agent_engine_id,
+            reasoning_engine_id=self.reasoning_engine_id,
             input_data=self.input_data,
             class_method=self.class_method,
             retry=self.retry,
             timeout=self.timeout,
             metadata=self.metadata,
         )
-        self.log.info("Agent Engine %s returned a response.", self.agent_engine_id)
+        self.log.info("Agent Engine %s returned a response.", self.reasoning_engine_id)
         return QueryReasoningEngineResponse.to_dict(response)
 
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
@@ -23,6 +23,9 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
+from google.cloud.aiplatform_v1.types import QueryReasoningEngineResponse
+
 from airflow.providers.common.compat.sdk import conf
 from airflow.providers.google.cloud.hooks.vertex_ai.agent_engine import (
     AgentEngineHook,
@@ -33,6 +36,7 @@ from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseO
 from airflow.providers.google.cloud.triggers.vertex_ai import AgentEngineQueryJobTrigger
 
 if TYPE_CHECKING:
+    from google.api_core.retry import Retry
     from vertexai._genai import types
 
     from airflow.providers.common.compat.sdk import Context
@@ -163,6 +167,82 @@ class GetAgentEngineOperator(GoogleCloudBaseOperator):
         result = _serialize_agent_engine(agent_engine)
         self.log.info("Agent Engine %s was retrieved.", self.agent_engine_id)
         return result
+
+
+class QueryAgentEngineOperator(GoogleCloudBaseOperator):
+    """
+    Query a Vertex AI Agent Engine synchronously.
+
+    :param project_id: Required. The ID of the Google Cloud project that the service belongs to.
+    :param location: Required. The ID of the Google Cloud location that the service belongs to.
+    :param agent_engine_id: Required. The Agent Engine ID.
+    :param input_data: Optional. Input for the Agent Engine class method in JSON object format.
+    :param class_method: Optional. The Agent Engine class method to invoke. Defaults to ``query``.
+    :param retry: Designation of what errors, if any, should be retried.
+    :param timeout: The timeout for this request.
+    :param metadata: Strings which should be sent along with the request as metadata.
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
+    :param impersonation_chain: Optional service account to impersonate using short-term credentials.
+    """
+
+    template_fields = (
+        "project_id",
+        "location",
+        "agent_engine_id",
+        "input_data",
+        "class_method",
+        "gcp_conn_id",
+        "impersonation_chain",
+    )
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        location: str,
+        agent_engine_id: str,
+        input_data: dict[str, Any] | None = None,
+        class_method: str = "query",
+        retry: Retry | _MethodDefault = DEFAULT,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] = (),
+        gcp_conn_id: str = "google_cloud_default",
+        impersonation_chain: str | Sequence[str] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.project_id = project_id
+        self.location = location
+        self.agent_engine_id = agent_engine_id
+        self.input_data = input_data
+        self.class_method = class_method
+        self.retry = retry
+        self.timeout = timeout
+        self.metadata = metadata
+        self.gcp_conn_id = gcp_conn_id
+        self.impersonation_chain = impersonation_chain
+
+    @cached_property
+    def hook(self) -> AgentEngineHook:
+        return AgentEngineHook(
+            gcp_conn_id=self.gcp_conn_id,
+            impersonation_chain=self.impersonation_chain,
+        )
+
+    def execute(self, context: Context) -> Any:
+        self.log.info("Querying Agent Engine %s.", self.agent_engine_id)
+        response = self.hook.query_agent_engine(
+            project_id=self.project_id,
+            location=self.location,
+            agent_engine_id=self.agent_engine_id,
+            input_data=self.input_data,
+            class_method=self.class_method,
+            retry=self.retry,
+            timeout=self.timeout,
+            metadata=self.metadata,
+        )
+        self.log.info("Agent Engine %s returned a response.", self.agent_engine_id)
+        return QueryReasoningEngineResponse.to_dict(response).get("output")
 
 
 class RunQueryJobOperator(GoogleCloudBaseOperator):

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
@@ -237,7 +237,7 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
             impersonation_chain=self.impersonation_chain,
         )
 
-    def execute(self, context: Context) -> JsonValue:
+    def execute(self, context: Context) -> dict[str, JsonValue]:
         self.log.info("Querying Agent Engine %s.", self.agent_engine_id)
         response = self.hook.query_agent_engine(
             project_id=self.project_id,
@@ -250,7 +250,7 @@ class RunAgentQueryOperator(GoogleCloudBaseOperator):
             metadata=self.metadata,
         )
         self.log.info("Agent Engine %s returned a response.", self.agent_engine_id)
-        return QueryReasoningEngineResponse.to_dict(response).get("output")
+        return QueryReasoningEngineResponse.to_dict(response)
 
 
 class RunQueryJobOperator(GoogleCloudBaseOperator):

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
@@ -23,7 +23,6 @@ from collections.abc import Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.cloud.aiplatform_v1.types import QueryReasoningEngineResponse
 
 from airflow.providers.common.compat.sdk import conf
@@ -183,7 +182,7 @@ class RunReasoningEngineQueryOperator(GoogleCloudBaseOperator):
         object format. Defaults to ``None``.
     :param class_method: Optional (templated). The Reasoning Engine class method to invoke. Defaults
         to ``query``.
-    :param retry: Designation of what errors, if any, should be retried. Defaults to ``DEFAULT``.
+    :param retry: Designation of what errors, if any, should be retried. Defaults to ``None``.
     :param timeout: The timeout for this request. Defaults to ``None``.
     :param metadata: Strings which should be sent along with the request as metadata. Defaults to
         an empty tuple.
@@ -211,7 +210,7 @@ class RunReasoningEngineQueryOperator(GoogleCloudBaseOperator):
         reasoning_engine_id: str,
         input_data: dict[str, Any] | None = None,
         class_method: str = "query",
-        retry: Retry | _MethodDefault = DEFAULT,
+        retry: Retry | None = None,
         timeout: float | None = None,
         metadata: Sequence[tuple[str, str]] = (),
         gcp_conn_id: str = "google_cloud_default",

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/agent_engine.py
@@ -37,6 +37,7 @@ from airflow.providers.google.cloud.triggers.vertex_ai import AgentEngineQueryJo
 
 if TYPE_CHECKING:
     from google.api_core.retry import Retry
+    from pydantic import JsonValue
     from vertexai._genai import types
 
     from airflow.providers.common.compat.sdk import Context
@@ -169,20 +170,27 @@ class GetAgentEngineOperator(GoogleCloudBaseOperator):
         return result
 
 
-class QueryAgentEngineOperator(GoogleCloudBaseOperator):
+class RunAgentQueryOperator(GoogleCloudBaseOperator):
     """
     Query a Vertex AI Agent Engine synchronously.
 
-    :param project_id: Required. The ID of the Google Cloud project that the service belongs to.
-    :param location: Required. The ID of the Google Cloud location that the service belongs to.
-    :param agent_engine_id: Required. The Agent Engine ID.
-    :param input_data: Optional. Input for the Agent Engine class method in JSON object format.
-    :param class_method: Optional. The Agent Engine class method to invoke. Defaults to ``query``.
-    :param retry: Designation of what errors, if any, should be retried.
-    :param timeout: The timeout for this request.
-    :param metadata: Strings which should be sent along with the request as metadata.
-    :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
-    :param impersonation_chain: Optional service account to impersonate using short-term credentials.
+    :param project_id: Required (templated). The ID of the Google Cloud project that the service
+        belongs to.
+    :param location: Required (templated). The ID of the Google Cloud location that the service
+        belongs to.
+    :param agent_engine_id: Required (templated). The Agent Engine ID.
+    :param input_data: Optional (templated). Input for the Agent Engine class method in JSON object
+        format. Defaults to ``None``.
+    :param class_method: Optional (templated). The Agent Engine class method to invoke. Defaults to
+        ``query``.
+    :param retry: Designation of what errors, if any, should be retried. Defaults to ``DEFAULT``.
+    :param timeout: The timeout for this request. Defaults to ``None``.
+    :param metadata: Strings which should be sent along with the request as metadata. Defaults to
+        an empty tuple.
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud (templated). Defaults
+        to ``google_cloud_default``.
+    :param impersonation_chain: Optional service account to impersonate using short-term credentials
+        (templated). Defaults to ``None``.
     """
 
     template_fields = (
@@ -229,7 +237,7 @@ class QueryAgentEngineOperator(GoogleCloudBaseOperator):
             impersonation_chain=self.impersonation_chain,
         )
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context: Context) -> JsonValue:
         self.log.info("Querying Agent Engine %s.", self.agent_engine_id)
         response = self.hook.query_agent_engine(
             project_id=self.project_id,

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
@@ -60,8 +60,8 @@ from airflow.providers.google.cloud.operators.vertex_ai.agent_engine import (
     CreateAgentEngineOperator,
     DeleteAgentEngineOperator,
     GetAgentEngineOperator,
-    RunAgentQueryOperator,
     RunQueryJobOperator,
+    RunReasoningEngineQueryOperator,
     UpdateAgentEngineOperator,
 )
 
@@ -192,16 +192,16 @@ with DAG(
     )
     # [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
-    # [START how_to_cloud_vertex_ai_run_agent_query_operator]
-    run_agent_query = RunAgentQueryOperator(
-        task_id="run_agent_query",
+    # [START how_to_cloud_vertex_ai_run_reasoning_engine_query_operator]
+    run_reasoning_engine_query = RunReasoningEngineQueryOperator(
+        task_id="run_reasoning_engine_query",
         project_id=PROJECT_ID,
         location=LOCATION,
-        agent_engine_id=AGENT_ENGINE_ID,
+        reasoning_engine_id=AGENT_ENGINE_ID,
         input_data={"input": "hello from Airflow"},
         timeout=300,
     )
-    # [END how_to_cloud_vertex_ai_run_agent_query_operator]
+    # [END how_to_cloud_vertex_ai_run_reasoning_engine_query_operator]
 
     # [START how_to_cloud_vertex_ai_run_query_job_operator]
     run_query_job = RunQueryJobOperator(
@@ -271,7 +271,7 @@ with DAG(
         [create_bucket, build_agent_image]
         >> create_agent_engine
         >> get_agent_engine
-        >> run_agent_query
+        >> run_reasoning_engine_query
         >> run_query_job
         >> run_query_job_deferrable
         >> update_agent_engine

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
@@ -60,7 +60,7 @@ from airflow.providers.google.cloud.operators.vertex_ai.agent_engine import (
     CreateAgentEngineOperator,
     DeleteAgentEngineOperator,
     GetAgentEngineOperator,
-    QueryAgentEngineOperator,
+    RunAgentQueryOperator,
     RunQueryJobOperator,
     UpdateAgentEngineOperator,
 )
@@ -192,16 +192,16 @@ with DAG(
     )
     # [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
-    # [START how_to_cloud_vertex_ai_query_agent_engine_operator]
-    query_agent_engine = QueryAgentEngineOperator(
-        task_id="query_agent_engine",
+    # [START how_to_cloud_vertex_ai_run_agent_query_operator]
+    run_agent_query = RunAgentQueryOperator(
+        task_id="run_agent_query",
         project_id=PROJECT_ID,
         location=LOCATION,
         agent_engine_id=AGENT_ENGINE_ID,
         input_data={"input": "hello from Airflow"},
         timeout=300,
     )
-    # [END how_to_cloud_vertex_ai_query_agent_engine_operator]
+    # [END how_to_cloud_vertex_ai_run_agent_query_operator]
 
     # [START how_to_cloud_vertex_ai_run_query_job_operator]
     run_query_job = RunQueryJobOperator(
@@ -271,7 +271,7 @@ with DAG(
         [create_bucket, build_agent_image]
         >> create_agent_engine
         >> get_agent_engine
-        >> query_agent_engine
+        >> run_agent_query
         >> run_query_job
         >> run_query_job_deferrable
         >> update_agent_engine

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py
@@ -60,6 +60,7 @@ from airflow.providers.google.cloud.operators.vertex_ai.agent_engine import (
     CreateAgentEngineOperator,
     DeleteAgentEngineOperator,
     GetAgentEngineOperator,
+    QueryAgentEngineOperator,
     RunQueryJobOperator,
     UpdateAgentEngineOperator,
 )
@@ -191,6 +192,17 @@ with DAG(
     )
     # [END how_to_cloud_vertex_ai_get_agent_engine_operator]
 
+    # [START how_to_cloud_vertex_ai_query_agent_engine_operator]
+    query_agent_engine = QueryAgentEngineOperator(
+        task_id="query_agent_engine",
+        project_id=PROJECT_ID,
+        location=LOCATION,
+        agent_engine_id=AGENT_ENGINE_ID,
+        input_data={"input": "hello from Airflow"},
+        timeout=300,
+    )
+    # [END how_to_cloud_vertex_ai_query_agent_engine_operator]
+
     # [START how_to_cloud_vertex_ai_run_query_job_operator]
     run_query_job = RunQueryJobOperator(
         task_id="run_query_job",
@@ -259,6 +271,7 @@ with DAG(
         [create_bucket, build_agent_image]
         >> create_agent_engine
         >> get_agent_engine
+        >> query_agent_engine
         >> run_query_job
         >> run_query_job_deferrable
         >> update_agent_engine

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
@@ -20,8 +20,10 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.agent_engine import AgentEngineAsyncHook, AgentEngineHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 
 from unit.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
@@ -39,6 +41,7 @@ OPERATION_ID = "delete-123"
 QUERY_OPERATION_ID = "query-123"
 CONFIG = {"display_name": "test-agent-engine"}
 QUERY_CONFIG = {"query": "hello", "output_gcs_uri": "gs://test-bucket/query-output/"}
+QUERY_INPUT = {"input": "hello"}
 CHECK_QUERY_CONFIG = {"retrieve_result": True}
 
 
@@ -61,6 +64,38 @@ class TestAgentEngineHookWithDefaultProjectId:
             credentials=mock.sentinel.credentials,
         )
         assert result == mock_client.return_value.agent_engines
+
+    @pytest.mark.parametrize(
+        ("location", "is_default_universe", "expected"),
+        [
+            (GCP_LOCATION, True, f"{GCP_LOCATION}-aiplatform.googleapis.com:443"),
+            ("global", True, None),
+            (GCP_LOCATION, False, None),
+        ],
+    )
+    def test_get_api_endpoint(self, location, is_default_universe, expected):
+        self.hook.is_default_universe = mock.create_autospec(
+            AgentEngineHook.is_default_universe, return_value=is_default_universe
+        )
+
+        assert self.hook._get_api_endpoint(location=location) == expected
+
+    @mock.patch(AGENT_ENGINE_STRING.format("ReasoningEngineExecutionServiceClient"), autospec=True)
+    def test_get_reasoning_engine_execution_service_client(self, mock_client):
+        self.hook.get_credentials = mock.Mock(return_value=mock.sentinel.credentials, spec=())
+        self.hook.get_client_options = mock.Mock(return_value=mock.sentinel.client_options, spec=())
+
+        result = self.hook.get_reasoning_engine_execution_service_client(location=GCP_LOCATION)
+
+        self.hook.get_client_options.assert_called_once_with(
+            api_endpoint_override=f"{GCP_LOCATION}-aiplatform.googleapis.com:443"
+        )
+        mock_client.assert_called_once_with(
+            credentials=mock.sentinel.credentials,
+            client_info=CLIENT_INFO,
+            client_options=mock.sentinel.client_options,
+        )
+        assert result == mock_client.return_value
 
     @mock.patch(AGENT_ENGINE_STRING.format("AgentEngineHook.get_agent_engine_client"), autospec=True)
     def test_create_agent_engine(self, mock_get_client):
@@ -99,6 +134,34 @@ class TestAgentEngineHookWithDefaultProjectId:
 
         mock_get_client.return_value.get.assert_called_once_with(name=AGENT_ENGINE_NAME, config=CONFIG)
         assert result == mock_get_client.return_value.get.return_value
+
+    @mock.patch(
+        AGENT_ENGINE_STRING.format("AgentEngineHook.get_reasoning_engine_execution_service_client"),
+        autospec=True,
+    )
+    def test_query_agent_engine(self, mock_get_client):
+        result = self.hook.query_agent_engine(
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            agent_engine_id=AGENT_ENGINE_ID,
+            input_data=QUERY_INPUT,
+        )
+
+        mock_get_client.assert_called_once_with(self.hook, location=GCP_LOCATION)
+        mock_get_client.return_value.reasoning_engine_path.assert_called_once_with(
+            GCP_PROJECT, GCP_LOCATION, AGENT_ENGINE_ID
+        )
+        mock_get_client.return_value.query_reasoning_engine.assert_called_once_with(
+            request={
+                "name": mock_get_client.return_value.reasoning_engine_path.return_value,
+                "input": QUERY_INPUT,
+                "class_method": "query",
+            },
+            retry=DEFAULT,
+            timeout=None,
+            metadata=(),
+        )
+        assert result == mock_get_client.return_value.query_reasoning_engine.return_value
 
     @mock.patch(AGENT_ENGINE_STRING.format("AgentEngineHook.get_agent_engine_client"), autospec=True)
     def test_run_query_job(self, mock_get_client):

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
@@ -139,11 +139,11 @@ class TestAgentEngineHookWithDefaultProjectId:
         AGENT_ENGINE_STRING.format("AgentEngineHook.get_reasoning_engine_execution_service_client"),
         autospec=True,
     )
-    def test_query_agent_engine(self, mock_get_client):
-        result = self.hook.query_agent_engine(
+    def test_query_reasoning_engine(self, mock_get_client):
+        result = self.hook.query_reasoning_engine(
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,
-            agent_engine_id=AGENT_ENGINE_ID,
+            reasoning_engine_id=AGENT_ENGINE_ID,
             input_data=QUERY_INPUT,
             class_method="custom_query",
             retry=mock.sentinel.retry,
@@ -171,11 +171,11 @@ class TestAgentEngineHookWithDefaultProjectId:
         AGENT_ENGINE_STRING.format("AgentEngineHook.get_reasoning_engine_execution_service_client"),
         autospec=True,
     )
-    def test_query_agent_engine_without_input_data(self, mock_get_client):
-        self.hook.query_agent_engine(
+    def test_query_reasoning_engine_without_input_data(self, mock_get_client):
+        self.hook.query_reasoning_engine(
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,
-            agent_engine_id=AGENT_ENGINE_ID,
+            reasoning_engine_id=AGENT_ENGINE_ID,
         )
 
         mock_get_client.return_value.query_reasoning_engine.assert_called_once_with(

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
@@ -163,6 +163,27 @@ class TestAgentEngineHookWithDefaultProjectId:
         )
         assert result == mock_get_client.return_value.query_reasoning_engine.return_value
 
+    @mock.patch(
+        AGENT_ENGINE_STRING.format("AgentEngineHook.get_reasoning_engine_execution_service_client"),
+        autospec=True,
+    )
+    def test_query_agent_engine_without_input_data(self, mock_get_client):
+        self.hook.query_agent_engine(
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            agent_engine_id=AGENT_ENGINE_ID,
+        )
+
+        mock_get_client.return_value.query_reasoning_engine.assert_called_once_with(
+            request={
+                "name": mock_get_client.return_value.reasoning_engine_path.return_value,
+                "class_method": "query",
+            },
+            retry=DEFAULT,
+            timeout=None,
+            metadata=(),
+        )
+
     @mock.patch(AGENT_ENGINE_STRING.format("AgentEngineHook.get_agent_engine_client"), autospec=True)
     def test_run_query_job(self, mock_get_client):
         result = self.hook.run_query_job(

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
-from google.api_core.gapic_v1.method import DEFAULT
 
 from airflow.providers.google.cloud.hooks.vertex_ai.agent_engine import AgentEngineAsyncHook, AgentEngineHook
 from airflow.providers.google.common.consts import CLIENT_INFO
@@ -183,7 +182,7 @@ class TestAgentEngineHookWithDefaultProjectId:
                 "name": mock_get_client.return_value.reasoning_engine_path.return_value,
                 "class_method": "query",
             },
-            retry=DEFAULT,
+            retry=None,
             timeout=None,
             metadata=(),
         )

--- a/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/hooks/vertex_ai/test_agent_engine.py
@@ -145,6 +145,10 @@ class TestAgentEngineHookWithDefaultProjectId:
             location=GCP_LOCATION,
             agent_engine_id=AGENT_ENGINE_ID,
             input_data=QUERY_INPUT,
+            class_method="custom_query",
+            retry=mock.sentinel.retry,
+            timeout=60,
+            metadata=(("key", "value"),),
         )
 
         mock_get_client.assert_called_once_with(self.hook, location=GCP_LOCATION)
@@ -155,11 +159,11 @@ class TestAgentEngineHookWithDefaultProjectId:
             request={
                 "name": mock_get_client.return_value.reasoning_engine_path.return_value,
                 "input": QUERY_INPUT,
-                "class_method": "query",
+                "class_method": "custom_query",
             },
-            retry=DEFAULT,
-            timeout=None,
-            metadata=(),
+            retry=mock.sentinel.retry,
+            timeout=60,
+            metadata=(("key", "value"),),
         )
         assert result == mock_get_client.return_value.query_reasoning_engine.return_value
 

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
@@ -27,7 +27,7 @@ from airflow.providers.google.cloud.operators.vertex_ai.agent_engine import (
     CreateAgentEngineOperator,
     DeleteAgentEngineOperator,
     GetAgentEngineOperator,
-    QueryAgentEngineOperator,
+    RunAgentQueryOperator,
     RunQueryJobOperator,
     UpdateAgentEngineOperator,
 )
@@ -151,14 +151,14 @@ class TestGetAgentEngineOperator:
         )
 
 
-class TestQueryAgentEngineOperator:
+class TestRunAgentQueryOperator:
     @mock.patch(AGENT_ENGINE_PATH.format("AgentEngineHook"), autospec=True)
     def test_execute(self, mock_hook, context):
         query_output = {"message": "Hello from Agent Engine"}
         mock_hook.return_value.query_agent_engine.return_value = QueryReasoningEngineResponse(
             output=query_output
         )
-        op = QueryAgentEngineOperator(
+        op = RunAgentQueryOperator(
             task_id=TASK_ID,
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
@@ -187,6 +187,29 @@ class TestRunReasoningEngineQueryOperator:
         )
         assert result == {"output": query_output}
 
+    @mock.patch(AGENT_ENGINE_PATH.format("AgentEngineHook"), autospec=True)
+    def test_execute_uses_no_retry_by_default(self, mock_hook, context):
+        mock_hook.return_value.query_reasoning_engine.return_value = QueryReasoningEngineResponse()
+        op = RunReasoningEngineQueryOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            reasoning_engine_id=AGENT_ENGINE_ID,
+        )
+
+        op.execute(context=context)
+
+        mock_hook.return_value.query_reasoning_engine.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            reasoning_engine_id=AGENT_ENGINE_ID,
+            input_data=None,
+            class_method="query",
+            retry=None,
+            timeout=None,
+            metadata=(),
+        )
+
 
 class TestRunQueryJobOperator:
     @mock.patch(AGENT_ENGINE_PATH.format("AgentEngineHook"), autospec=True)

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
@@ -27,8 +27,8 @@ from airflow.providers.google.cloud.operators.vertex_ai.agent_engine import (
     CreateAgentEngineOperator,
     DeleteAgentEngineOperator,
     GetAgentEngineOperator,
-    RunAgentQueryOperator,
     RunQueryJobOperator,
+    RunReasoningEngineQueryOperator,
     UpdateAgentEngineOperator,
 )
 
@@ -151,18 +151,18 @@ class TestGetAgentEngineOperator:
         )
 
 
-class TestRunAgentQueryOperator:
+class TestRunReasoningEngineQueryOperator:
     @mock.patch(AGENT_ENGINE_PATH.format("AgentEngineHook"), autospec=True)
     def test_execute(self, mock_hook, context):
         query_output = {"message": "Hello from Agent Engine"}
-        mock_hook.return_value.query_agent_engine.return_value = QueryReasoningEngineResponse(
+        mock_hook.return_value.query_reasoning_engine.return_value = QueryReasoningEngineResponse(
             output=query_output
         )
-        op = RunAgentQueryOperator(
+        op = RunReasoningEngineQueryOperator(
             task_id=TASK_ID,
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,
-            agent_engine_id=AGENT_ENGINE_ID,
+            reasoning_engine_id=AGENT_ENGINE_ID,
             input_data=QUERY_INPUT,
             class_method="custom_query",
             retry=mock.sentinel.retry,
@@ -175,10 +175,10 @@ class TestRunAgentQueryOperator:
         result = op.execute(context=context)
 
         assert_hook_created(mock_hook)
-        mock_hook.return_value.query_agent_engine.assert_called_once_with(
+        mock_hook.return_value.query_reasoning_engine.assert_called_once_with(
             project_id=GCP_PROJECT,
             location=GCP_LOCATION,
-            agent_engine_id=AGENT_ENGINE_ID,
+            reasoning_engine_id=AGENT_ENGINE_ID,
             input_data=QUERY_INPUT,
             class_method="custom_query",
             retry=mock.sentinel.retry,

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
@@ -185,7 +185,7 @@ class TestRunAgentQueryOperator:
             timeout=60,
             metadata=(("key", "value"),),
         )
-        assert result == query_output
+        assert result == {"output": query_output}
 
 
 class TestRunQueryJobOperator:

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_agent_engine.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from google.cloud.aiplatform_v1.types import QueryReasoningEngineResponse
 
 from airflow.providers.common.compat.sdk import TaskDeferred
 from airflow.providers.google.cloud.operators.vertex_ai.agent_engine import (
     CreateAgentEngineOperator,
     DeleteAgentEngineOperator,
     GetAgentEngineOperator,
+    QueryAgentEngineOperator,
     RunQueryJobOperator,
     UpdateAgentEngineOperator,
 )
@@ -41,6 +43,7 @@ AGENT_ENGINE_ID = "123"
 AGENT_ENGINE_NAME = "projects/test-project/locations/us-central1/reasoningEngines/123"
 CONFIG = {"display_name": "test-agent-engine"}
 QUERY_CONFIG = {"query": "hello", "output_gcs_uri": "gs://test-bucket/query-output/"}
+QUERY_INPUT = {"input": "hello"}
 CHECK_QUERY_CONFIG = {"retrieve_result": True}
 OPERATION = {"name": "operations/delete-123", "done": False}
 QUERY_OPERATION_NAME = "operations/query-123"
@@ -146,6 +149,43 @@ class TestGetAgentEngineOperator:
             agent_engine_id=AGENT_ENGINE_ID,
             config=CONFIG,
         )
+
+
+class TestQueryAgentEngineOperator:
+    @mock.patch(AGENT_ENGINE_PATH.format("AgentEngineHook"), autospec=True)
+    def test_execute(self, mock_hook, context):
+        query_output = {"message": "Hello from Agent Engine"}
+        mock_hook.return_value.query_agent_engine.return_value = QueryReasoningEngineResponse(
+            output=query_output
+        )
+        op = QueryAgentEngineOperator(
+            task_id=TASK_ID,
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            agent_engine_id=AGENT_ENGINE_ID,
+            input_data=QUERY_INPUT,
+            class_method="custom_query",
+            retry=mock.sentinel.retry,
+            timeout=60,
+            metadata=(("key", "value"),),
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        result = op.execute(context=context)
+
+        assert_hook_created(mock_hook)
+        mock_hook.return_value.query_agent_engine.assert_called_once_with(
+            project_id=GCP_PROJECT,
+            location=GCP_LOCATION,
+            agent_engine_id=AGENT_ENGINE_ID,
+            input_data=QUERY_INPUT,
+            class_method="custom_query",
+            retry=mock.sentinel.retry,
+            timeout=60,
+            metadata=(("key", "value"),),
+        )
+        assert result == query_output
 
 
 class TestRunQueryJobOperator:


### PR DESCRIPTION
Add `RunReasoningEngineQueryOperator` for direct synchronous Agent Engine invocations through the public `ReasoningEngineExecutionService` GAPIC. This complements `RunQueryJobOperator` when a Google Cloud Storage-backed asynchronous job is not needed.

The hook configures the regional endpoint and forwards retry, timeout, metadata, input, and class method options. The operator returns the complete JSON-serializable GAPIC response, without first fetching the runtime or creating a query job.

The new path is covered by hook and operator unit tests, provider documentation, and the existing Agent Engine system-test example.

related: #68479

## Validation

- Targeted unit tests: `44 passed`.
- Full Google provider suite: `4973 passed, 59 skipped`.
- Provider mypy checks passed.
- Pre-commit and manual prek checks passed.
- Google provider documentation build and spellcheck passed.
- End-to-end GCP system test: `1 passed` (details and reproduction steps below).
- AI-assisted Magpie self-review (`pr-management-code-review`, dry-run) at `dfdd1a9`: no blocking, major, minor, or nit findings. The public GAPIC surface was cross-checked against the minimum supported `google-cloud-aiplatform==1.155.0`. No GitHub review was posted.

The complete system test was also run end-to-end against a real GCP environment. It can be reproduced from the Airflow checkout with GCP credentials forwarded to Breeze, `SYSTEM_TESTS_GCP_PROJECT` configured in `files/airflow-breeze-config/environment_variables.env`, and a unique environment ID:

```bash
SYSTEM_TESTS_ENV_ID=<unique-id> \
BREEZE_INIT_COMMAND='export GOOGLE_CLOUD_PROJECT="${SYSTEM_TESTS_GCP_PROJECT}"' \
breeze testing system-tests \
  --forward-credentials \
  --test-timeout 2400 \
  providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_agent_engine.py \
  -q
```

Latest result: `1 passed in 747.16s`. The run exercised create, get, synchronous query, synchronous and deferrable query jobs, update, and delete flows, and completed resource teardown successfully.

The one-time GCP project setup required by the test remains documented in the system test module docstring.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

