### PR TITLE
Return only the latest Dag version from iter_all_latest_version_dags

### DIFF
--- a/airflow-core/src/airflow/models/dagbag.py
+++ b/airflow-core/src/airflow/models/dagbag.py
@@ -229,7 +229,7 @@ class DBDagBag:
         """
         from airflow.models.serialized_dag import SerializedDagModel
 
-        for sdm in session.scalars(select(SerializedDagModel)):
+        for sdm in SerializedDagModel.get_latest_serialized_dags(session=session):
             sdm.load_op_links = self.load_op_links
             if dag := sdm.dag:
                 yield dag

--- a/airflow-core/src/airflow/models/serialized_dag.py
+++ b/airflow-core/src/airflow/models/serialized_dag.py
@@ -846,12 +846,12 @@ class SerializedDagModel(Base):
     @classmethod
     @provide_session
     def get_latest_serialized_dags(
-        cls, *, dag_ids: list[str], session: Session = NEW_SESSION
+        cls, *, dag_ids: list[str] | None = None, session: Session = NEW_SESSION
     ) -> Sequence[SerializedDagModel]:
         """
         Get the latest serialized dags of given DAGs.
 
-        :param dag_ids: The list of DAG IDs.
+        :param dag_ids: The list of DAG IDs. If ``None``, cover all dags.
         :param session: The database session.
         :return: The latest serialized dag of the DAGs.
         """

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -244,29 +244,36 @@ class TestDBDagBag:
         db.clear_db_dag_bundles()
 
     def test_iter_all_latest_version_dags_yields_only_the_latest_version(self, dag_maker):
-        dag_id = "versioned_dag"
         db.clear_db_runs()
         db.clear_db_dags()
         db.clear_db_serialized_dags()
         db.clear_db_dag_bundles()
 
-        with dag_maker(dag_id, schedule=None):
+        with dag_maker("versioned_dag", schedule=None):
             EmptyOperator(task_id="a")
         # A version with task instances is kept rather than updated in place, so the next
         # write adds a second version instead of overwriting the first.
         dag_maker.create_dagrun()
 
-        with DAG(dag_id, schedule=None) as dag:
+        with DAG("versioned_dag", schedule=None) as dag:
             EmptyOperator(task_id="a")
             EmptyOperator(task_id="b")
         sync_dag_to_db(dag)
 
+        # Left at version 1, below the highest version_number in the table.
+        with dag_maker("single_version_dag", schedule=None):
+            EmptyOperator(task_id="only")
+
         with create_session() as session:
-            assert DagVersion.get_latest_version(dag_id, session=session).version_number == 2
+            assert DagVersion.get_latest_version("versioned_dag", session=session).version_number == 2
+            assert DagVersion.get_latest_version("single_version_dag", session=session).version_number == 1
             dags = list(DBDagBag().iter_all_latest_version_dags(session=session))
 
-        assert [dag.dag_id for dag in dags] == [dag_id]
-        assert set(dags[0].task_ids) == {"a", "b"}
+        assert sorted(d.dag_id for d in dags) == ["single_version_dag", "versioned_dag"]
+        assert {d.dag_id: set(d.task_ids) for d in dags} == {
+            "versioned_dag": {"a", "b"},
+            "single_version_dag": {"only"},
+        }
 
         db.clear_db_runs()
         db.clear_db_dags()

--- a/airflow-core/tests/unit/models/test_dagbag.py
+++ b/airflow-core/tests/unit/models/test_dagbag.py
@@ -35,6 +35,7 @@ from airflow.serialization.serialized_objects import LazyDeserializedDAG, Serial
 from airflow.utils.session import create_session
 
 from tests_common.test_utils import db
+from tests_common.test_utils.dag import sync_dag_to_db
 
 pytestmark = pytest.mark.db_test
 
@@ -242,6 +243,36 @@ class TestDBDagBag:
         db.clear_db_serialized_dags()
         db.clear_db_dag_bundles()
 
+    def test_iter_all_latest_version_dags_yields_only_the_latest_version(self, dag_maker):
+        dag_id = "versioned_dag"
+        db.clear_db_runs()
+        db.clear_db_dags()
+        db.clear_db_serialized_dags()
+        db.clear_db_dag_bundles()
+
+        with dag_maker(dag_id, schedule=None):
+            EmptyOperator(task_id="a")
+        # A version with task instances is kept rather than updated in place, so the next
+        # write adds a second version instead of overwriting the first.
+        dag_maker.create_dagrun()
+
+        with DAG(dag_id, schedule=None) as dag:
+            EmptyOperator(task_id="a")
+            EmptyOperator(task_id="b")
+        sync_dag_to_db(dag)
+
+        with create_session() as session:
+            assert DagVersion.get_latest_version(dag_id, session=session).version_number == 2
+            dags = list(DBDagBag().iter_all_latest_version_dags(session=session))
+
+        assert [dag.dag_id for dag in dags] == [dag_id]
+        assert set(dags[0].task_ids) == {"a", "b"}
+
+        db.clear_db_runs()
+        db.clear_db_dags()
+        db.clear_db_serialized_dags()
+        db.clear_db_dag_bundles()
+
 
 class TestDBDagBagCache:
     """Tests for DBDagBag optional caching behavior."""
@@ -379,17 +410,17 @@ class TestDBDagBagCache:
         assert result == mock_sdm.dag
         assert "test_version" in dag_bag._dags
 
-    def test_iter_all_latest_version_dags_does_not_cache(self):
+    @patch.object(SerializedDagModel, "get_latest_serialized_dags")
+    def test_iter_all_latest_version_dags_does_not_cache(self, mock_get_latest_serialized_dags):
         """Test that iter_all_latest_version_dags does not cache to prevent thrashing."""
         dag_bag = DBDagBag(cache_size=10, cache_ttl=60)
 
-        mock_session = MagicMock()
         mock_sdm = MagicMock()
         mock_sdm.dag = MagicMock()
         mock_sdm.dag_version_id = "test_version"
-        mock_session.scalars.return_value = [mock_sdm]
+        mock_get_latest_serialized_dags.return_value = [mock_sdm]
 
-        list(dag_bag.iter_all_latest_version_dags(session=mock_session))
+        list(dag_bag.iter_all_latest_version_dags(session=MagicMock()))
 
         # Cache should be empty -- iter doesn't cache to prevent thrashing
         assert len(dag_bag._dags) == 0


### PR DESCRIPTION
## The method promised latest-version dags in its name and docstring but read every serialized_dag row, so FAB permission syncing processed each Dag once per version and could apply an outdated access_control last.

 `DBDagBag.iter_all_latest_version_dags` promises latest-version Dags in both its
name and its docstring, but it read every `serialized_dag` row without filtering
by version.

Its only production caller is FAB's `create_dag_specific_permissions`, so DAG-level
permission syncing iterated each Dag once per version. Besides the wasted work, the
query has no `ORDER BY`, so when versions carry different `access_control` the one
applied last is undefined and an outdated policy can win.

`SerializedDagModel._latest_by_version_select()` already supported "all dags" via
`dag_ids=None`; this exposes that through the public `get_latest_serialized_dags()`
wrapper, which keeps the existing `load_op_links` hook in the loop intact. All five
existing callers pass `dag_ids=` explicitly, so the signature change is backwards
compatible.

The existing test mocked `session.scalars`, so it could not catch a wrong query.
Added a regression test that writes two real versions to the database.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
