### PR TITLE
Fix broken OpenAI batch trigger test blocking main

### DIFF
--- a/providers/openai/tests/unit/openai/triggers/test_openai.py
+++ b/providers/openai/tests/unit/openai/triggers/test_openai.py
@@ -228,7 +228,7 @@ class TestOpenAIBatchTrigger:
             conn_id=self.CONN_ID,
             batch_id=self.BATCH_ID,
             poll_interval=self.POLL_INTERVAL,
-            end_time=self.END_TIME,
+            timeout=self.TIMEOUT,
         )
         events = [event async for event in trigger.run()]
         assert events == [


### PR DESCRIPTION
## Summary

`providers/openai/tests/unit/openai/triggers/test_openai.py` still references
`self.END_TIME`, which was renamed to `LEGACY_END_TIME` in #69534. As a result,
`test_openai_batch_yields_single_terminal_event` fails with `AttributeError`.

The stale reference is the result of a semantic merge conflict with #69506,
which introduced the test using `self.END_TIME`.

## Change

Switch the test to `timeout=self.TIMEOUT`, matching every other behavioral test
in the file.

The deprecated `end_time` path remains covered by
`test_serialization_with_legacy_end_time`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
