### PR TITLE
Fix leaked triggerer thread in test_trigger_logger_fd_closed_when_removed

### DIFF
--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -1125,21 +1125,22 @@ def test_trigger_logger_fd_closed_when_removed(session):
         mock_init_log_file.return_value.open.return_value = mock_file
 
         trigger_runner_supervisor = TriggerRunnerSupervisor.start(job=Job(id=123456), capacity=10)
-        trigger_runner_supervisor.load_triggers()
+        try:
+            trigger_runner_supervisor.load_triggers()
 
-        # The 0.5s trigger must fire and its finished-trigger cleanup must run before the log FD is
-        # closed. How many service iterations that takes depends on real wall-clock timing and runner
-        # speed (_service_subprocess returns as soon as there is I/O, not after a full 0.1s), so poll
-        # until the close happens rather than relying on a fixed iteration count -- a fixed count is
-        # flaky on slow/loaded runners where the trigger has not fired yet within the window.
-        for _ in range(300):
-            trigger_runner_supervisor._service_subprocess(0.1)
-            if mock_file.close.called:
-                break
+            # The 0.5s trigger must fire and its finished-trigger cleanup must run before the log FD is
+            # closed. How many service iterations that takes depends on real wall-clock timing and runner
+            # speed (_service_subprocess returns as soon as there is I/O, not after a full 0.1s), so poll
+            # until the close happens rather than relying on a fixed iteration count -- a fixed count is
+            # flaky on slow/loaded runners where the trigger has not fired yet within the window.
+            for _ in range(300):
+                trigger_runner_supervisor._service_subprocess(0.1)
+                if mock_file.close.called:
+                    break
+        finally:
+            trigger_runner_supervisor.kill(force=False)
 
     mock_file.close.assert_called_once()
-
-    trigger_runner_supervisor.kill(force=False)
 
 
 def test_trigger_logger_fd_closed_when_upload_to_remote_raises(jobless_supervisor):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Noticed in https://github.com/apache/airflow/actions/runs/30739444883

Error:
```shell
____________________________________________________________________________ test_update_triggers_delegates_workload_creation ____________________________________________________________________________
/usr/python/lib/python3.10/unittest/mock.py:940: in assert_called_once_with
    raise AssertionError(msg)
E   AssertionError: Expected 'monotonic' to be called once. Called 9 times.
E   Calls: [call(), call(), call(), call(), call(), call(), call(), call(), call()].

During handling of the above exception, another exception occurred:
airflow-core/tests/unit/jobs/test_triggerer_job.py:2487: in test_update_triggers_delegates_workload_creation
    monotonic.assert_called_once_with()
E   AssertionError: Expected 'monotonic' to be called once. Called 9 times.
E   Calls: [call(), call(), call(), call(), call(), call(), call(), call(), call()].
------------------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------------------
--- Supervised process Last chance exception handler ---
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1266, in arun
    await self.sync_state_to_supervisor(finished_ids)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1551, in sync_state_to_supervisor
    resp = await self.asend(msg)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1564, in asend
    response = await self.comms_decoder.asend(msg)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1152, in asend
    return self._from_frame(await future)
asyncio.exceptions.CancelledError: Reader loop exited

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 462, in _fork_main
    target()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1061, in run_in_process
    TriggerRunner().run()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1232, in run
    asyncio.run(self.arun())
  File "/usr/python/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/python/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1289, in arun
    await reader_task
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1102, in _reader_loop
    frame = await self._aread_frame()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1089, in _aread_frame
    len_bytes = await self._async_reader.readexactly(4)
  File "/usr/python/lib/python3.10/asyncio/streams.py", line 708, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/python/lib/python3.10/asyncio/streams.py", line 501, in _wait_for_data
    await self._waiter
  File "/usr/python/lib/python3.10/asyncio/selector_events.py", line 862, in _read_ready__data_received
    data = self._sock.recv(self.max_size)
ConnectionResetError: [Errno 104] Connection reset by peer
--- Supervised process Last chance exception handler ---
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1266, in arun
    await self.sync_state_to_supervisor(finished_ids)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1551, in sync_state_to_supervisor
    resp = await self.asend(msg)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1564, in asend
    response = await self.comms_decoder.asend(msg)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1152, in asend
    return self._from_frame(await future)
asyncio.exceptions.CancelledError: Reader loop exited

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 462, in _fork_main
    target()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1061, in run_in_process
    TriggerRunner().run()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1232, in run
    asyncio.run(self.arun())
  File "/usr/python/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/python/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1289, in arun
    await reader_task
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1102, in _reader_loop
    frame = await self._aread_frame()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1089, in _aread_frame
    len_bytes = await self._async_reader.readexactly(4)
  File "/usr/python/lib/python3.10/asyncio/streams.py", line 708, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/python/lib/python3.10/asyncio/streams.py", line 501, in _wait_for_data
    await self._waiter
  File "/usr/python/lib/python3.10/asyncio/selector_events.py", line 862, in _read_ready__data_received
    data = self._sock.recv(self.max_size)
ConnectionResetError: [Errno 104] Connection reset by peer
--- Supervised process Last chance exception handler ---
Traceback (most recent call last):
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1266, in arun
    await self.sync_state_to_supervisor(finished_ids)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1551, in sync_state_to_supervisor
    resp = await self.asend(msg)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1564, in asend
    response = await self.comms_decoder.asend(msg)
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1152, in asend
    return self._from_frame(await future)
asyncio.exceptions.CancelledError: Reader loop exited

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/airflow/task-sdk/src/airflow/sdk/execution_time/supervisor.py", line 462, in _fork_main
    target()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1061, in run_in_process
    TriggerRunner().run()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1232, in run
    asyncio.run(self.arun())
  File "/usr/python/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/python/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1289, in arun
    await reader_task
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1102, in _reader_loop
    frame = await self._aread_frame()
  File "/opt/airflow/airflow-core/src/airflow/jobs/triggerer_job_runner.py", line 1089, in _aread_frame
    len_bytes = await self._async_reader.readexactly(4)
  File "/usr/python/lib/python3.10/asyncio/streams.py", line 708, in readexactly
    await self._wait_for_data('readexactly')
  File "/usr/python/lib/python3.10/asyncio/streams.py", line 501, in _wait_for_data
    await self._waiter
  File "/usr/python/lib/python3.10/asyncio/selector_events.py", line 862, in _read_ready__data_received
    data = self._sock.recv(self.max_size)
ConnectionResetError: [Errno 104] Connection reset by peer
```


The test started a real TriggerRunnerSupervisor subprocess but only killed it after the final assertion, so a failed or slow assertion left the subprocess running. The leaked process kept calling `time.monotonic()` in the background, polluting mock call counts in unrelated tests that patch the same target later in the same run.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
