### PR TITLE
Dispatch the highest priority tasks first in the executor

### DIFF
--- a/airflow-core/newsfragments/70942.bugfix.rst
+++ b/airflow-core/newsfragments/70942.bugfix.rst
@@ -1,0 +1,1 @@
+Executors now dispatch the highest ``priority_weight`` tasks first. When more tasks were queued than there were open slots, the lowest priority ones were sent to workers and the highest priority ones were held back.

--- a/airflow-core/src/airflow/executors/base_executor.py
+++ b/airflow-core/src/airflow/executors/base_executor.py
@@ -428,7 +428,10 @@ class BaseExecutor(LoggingMixin):
 
     def order_queued_tasks_by_priority(self) -> list[tuple[TaskInstanceKey, workloads.ExecuteTask]]:
         """
-        Orders the queued tasks by priority.
+        Orders the queued tasks by priority, highest ``priority_weight`` first.
+
+        Consumers take workloads from the front of this list, so the highest priority
+        tasks must come first for them to be scheduled before the rest.
 
         :return: List of workloads from the queued_tasks according to the priority.
         """
@@ -439,7 +442,7 @@ class BaseExecutor(LoggingMixin):
         return sorted(
             self.queued_tasks.items(),
             key=lambda x: x[1].ti.priority_weight,
-            reverse=False,
+            reverse=True,
         )
 
     def trigger_tasks(self, open_slots: int) -> None:

--- a/airflow-core/tests/unit/executors/test_base_executor.py
+++ b/airflow-core/tests/unit/executors/test_base_executor.py
@@ -360,6 +360,29 @@ def test_trigger_running_tasks(dag_maker):
     executor._process_workloads.assert_called_once()
 
 
+@pytest.mark.db_test
+def test_trigger_tasks_schedules_highest_priority_first(dag_maker):
+    """When there are fewer open slots than queued tasks, the lowest priority ones wait."""
+    date = timezone.utcnow()
+
+    with dag_maker("test_trigger_tasks_priority_order"):
+        BaseOperator(task_id="low", priority_weight=1)
+        BaseOperator(task_id="medium", priority_weight=5)
+        BaseOperator(task_id="high", priority_weight=10)
+
+    dagrun = dag_maker.create_dagrun(logical_date=date)
+
+    executor = BaseExecutor()
+    executor._process_workloads = mock.Mock(spec=lambda workloads: None)
+    for task_instance in dagrun.task_instances:
+        executor.queued_tasks[task_instance.key] = workloads.ExecuteTask.make(task_instance)
+
+    executor.trigger_tasks(open_slots=2)
+
+    scheduled = [workload.ti.task_id for workload in executor._process_workloads.call_args[0][0]]
+    assert scheduled == ["high", "medium"]
+
+
 def test_debug_dump(caplog):
     executor = BaseExecutor()
     with caplog.at_level(logging.INFO):


### PR DESCRIPTION
`BaseExecutor` sorts its queued tasks by `priority_weight` ascending, then dispatches from the front of that list. So when more tasks are queued than there are open slots, the **lowest priority tasks are the ones sent to workers**, and the highest priority ones are held back.

For example, with weights 1, 5 and 10 and one slot freeing up per loop, they run in the order 1, 5, 10; the most important task runs last.

It also does not even out over time, because the queue is re-sorted on every call. 

This only affects an executor that has more queued tasks than open slots, so deployments that stay under their `parallelism` ceiling, or that never set `priority_weight`, see no difference either way.

<details>
<summary> Where it happens </summary>

In `airflow-core/src/airflow/executors/base_executor.py`:

```python
# order_queued_tasks_by_priority(): lowest weight first
return sorted(self.queued_tasks.items(), key=lambda x: x[1].ti.priority_weight, reverse=False)

# _get_workloads_to_schedule(): reads from the front, stops at open_slots
for task_key, task_workload in self.order_queued_tasks_by_priority():
    if len(workloads_to_schedule) >= open_slots:
        break
    workloads_to_schedule.append((task_key, task_workload))
```

</details>


<details>
<summary> How it got here </summary>

The sort and the way it is consumed used to match. They drifted apart in two steps:

- #61376 (`fd4fd67c0f`) switched the sort from descending to ascending and, in the same commit, changed `sorted_queue.pop(0)` to `sorted_queue.pop()`. An ascending list popped from the back still gives the highest priority first, so this was correct, and O(1) instead of O(n).
- #61153 (`9fa13c82ff`) refactored `trigger_tasks` to support callback workloads and replaced that `pop()` with the front-to-back loop above. The sort was left ascending.

</details>

What this PR does:
  - `base_executor.py`: sorts descending again, and notes on the method that consumers read from the front.
  - `test_base_executor.py`: adds a test with three weights and fewer open slots than tasks. The existing tests all run with more slots than tasks, so none of them reach the truncating branch.
  - Adds a bugfix newsfragment.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes, Claude Code (Opus 5)

Used to trace the ordering back through the history of the two commits above, and to check that nothing else in the repo overrides the sort or depends on it being ascending.
