### PR TITLE
Remove the dead CFullLoader branch from the YAML helpers

### DIFF
--- a/airflow-core/src/airflow/utils/yaml.py
+++ b/airflow-core/src/airflow/utils/yaml.py
@@ -66,8 +66,6 @@ def __getattr__(name):
     # Delegate anything else to the yaml module
     import yaml
 
-    if name == "FullLoader":
-        # Try to use CFullLoader by default
-        getattr(yaml, "CFullLoader", yaml.FullLoader)
-
+    # FullLoader stays pyyaml's on purpose: CFullLoader does not see add_constructor
+    # registrations, so custom tags would raise ConstructorError instead of resolving.
     return getattr(yaml, name)

--- a/airflow-ctl/src/airflowctl/ctl/utils/yaml.py
+++ b/airflow-ctl/src/airflowctl/ctl/utils/yaml.py
@@ -67,8 +67,6 @@ def __getattr__(name):
     # Delegate anything else to the yaml module
     import yaml
 
-    if name == "FullLoader":
-        # Try to use CFullLoader by default
-        getattr(yaml, "CFullLoader", yaml.FullLoader)
-
+    # FullLoader stays pyyaml's on purpose: CFullLoader does not see add_constructor
+    # registrations, so custom tags would raise ConstructorError instead of resolving.
     return getattr(yaml, name)

--- a/task-sdk/src/airflow/sdk/yaml.py
+++ b/task-sdk/src/airflow/sdk/yaml.py
@@ -66,8 +66,6 @@ def __getattr__(name):
     # Delegate anything else to the yaml module
     import yaml
 
-    if name == "FullLoader":
-        # Try to use CFullLoader by default
-        getattr(yaml, "CFullLoader", yaml.FullLoader)
-
+    # FullLoader stays pyyaml's on purpose: CFullLoader does not see add_constructor
+    # registrations, so custom tags would raise ConstructorError instead of resolving.
     return getattr(yaml, name)


### PR DESCRIPTION
## Summary

All three copies of the YAML wrapper carry a branch in `__getattr__` meant to swap in libyaml's `FullLoader`. It discards the value it looks up, so it has never taken effect.

## Change

Deleting the branch rather than adding the missing `return`. `CFullLoader` is not a `FullLoader` subclass, and `yaml.add_constructor` registers only on the pure-Python loaders, so activating it would turn tags registered through the same wrapper into `ConstructorError` — a surface Dag authors reach as `macros.yaml`. `safe_load` and `dump` keep the C implementations, where Airflow controls both ends.

No runtime change: `FullLoader` resolved to pyyaml's loader before, and still does.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
