### PR TITLE
Stop variables export/import from silently corrupting values

### DIFF
--- a/airflow-core/src/airflow/cli/commands/variable_command.py
+++ b/airflow-core/src/airflow/cli/commands/variable_command.py
@@ -186,11 +186,16 @@ def variables_export(args):
 
         data = json.JSONDecoder()
         for var in qry:
+            # Emit a form variables_import turns back into var.val: it stores strings verbatim,
+            # JSON-encodes everything else, and unwraps any dict carrying a "value" key.
             try:
                 val = data.decode(var.val)
             except Exception:
                 val = var.val
-            if var.description:
+            else:
+                if isinstance(val, str):
+                    val = var.val
+            if var.description or (isinstance(val, dict) and "value" in val):
                 var_dict[var.key] = {
                     "value": val,
                     "description": var.description,

--- a/airflow-core/src/airflow/cli/commands/variable_command.py
+++ b/airflow-core/src/airflow/cli/commands/variable_command.py
@@ -186,15 +186,13 @@ def variables_export(args):
 
         data = json.JSONDecoder()
         for var in qry:
-            # Emit a form variables_import turns back into var.val: it stores strings verbatim,
-            # JSON-encodes everything else, and unwraps any dict carrying a "value" key.
+            # Mirror variables_import's reconstruction so export/import round-trips.
             try:
                 val = data.decode(var.val)
             except Exception:
                 val = var.val
-            else:
-                if isinstance(val, str):
-                    val = var.val
+            if isinstance(val, str):
+                val = var.val
             if var.description or (isinstance(val, dict) and "value" in val):
                 var_dict[var.key] = {
                     "value": val,

--- a/airflow-core/tests/unit/cli/commands/test_variable_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_variable_command.py
@@ -360,6 +360,40 @@ class TestCliVariables:
         """Test variables_export command"""
         variable_command.variables_export(self.parser.parse_args(["variables", "export", os.devnull]))
 
+    @pytest.mark.parametrize(
+        ("stored_value", "expected_export"),
+        [
+            pytest.param(
+                '{"value": "a", "description": "b"}',
+                {"value": {"value": "a", "description": "b"}, "description": None},
+                id="envelope_lookalike",
+            ),
+            pytest.param(
+                '{"value": 1, "other": 2}',
+                {"value": {"value": 1, "other": 2}, "description": None},
+                id="envelope_lookalike_with_extra_keys",
+            ),
+            pytest.param('"hello"', '"hello"', id="json_string"),
+        ],
+    )
+    def test_variables_export_survives_reimport(self, tmp_path, stored_value, expected_export):
+        """Values that collide with the export format must round-trip through export/import."""
+        path = tmp_path / "variables.json"
+        variable_command.variables_set(self.parser.parse_args(["variables", "set", "k", stored_value]))
+        variable_command.variables_export(self.parser.parse_args(["variables", "export", os.fspath(path)]))
+
+        assert json.loads(path.read_text()) == {"k": expected_export}
+
+        variable_command.variables_delete(self.parser.parse_args(["variables", "delete", "k"]))
+        with create_session() as session:
+            variable_command.variables_import(
+                self.parser.parse_args(["variables", "import", os.fspath(path)]), session=session
+            )
+
+        assert Variable.get("k", deserialize_json=True) == json.loads(stored_value)
+        with create_session() as session:
+            assert session.scalar(select(Variable.description).where(Variable.key == "k")) is None
+
     def test_variables_isolation(self, tmp_path):
         """Test isolation of variables"""
         path1 = tmp_path / "testfile1.json"


### PR DESCRIPTION
`airflow variables export` followed by `airflow variables import` can silently rewrite a variable's value and invent a description for it.

Export writes a bare value when a variable has no description, while import treats any dict carrying a `"value"` key as a `{"value": ..., "description": ...}` envelope — nothing distinguishes the envelope from a value that happens to look like one. Export also decodes the stored JSON, losing the difference between raw text and a JSON-encoded string.

Round-tripping through a file on `main` :

| DB value before | exported as | after re-import |
|---|---|---|
| `{"value": "a", "description": "b"}` | `{"value": "a", "description": "b"}` | value → `a`, description → `b` |
| `{"value": 1, "other": 2}` | `{"value": 1, "other": 2}` | value → `1`, `other` dropped |
| `"hello"` | `hello` | `hello` — no longer valid JSON, so `deserialize_json=True` starts raising |

Import's reconstruction is deterministic — strings are stored verbatim, everything else is JSON-encoded, and one envelope layer is unwrapped — so export alone can be made lossless, leaving hand-written import files behaving exactly as before. Export now emits the stored form when the decoded value is a string, and wraps values that are themselves envelope-shaped so import's unwrap consumes our envelope rather than the user's data.

Exported files are unchanged for values that were never ambiguous. One visible change worth flagging: a variable stored as a JSON-encoded string (`Variable.set(k, "text", serialize_json=True)`) now exports as `"\"text\""` rather than `"text"`. The old output could not be re-imported without corruption, so there is no lossless way to keep it.

Left for follow-up PRs: import still truncates a hand-written `{"value": 1, "other": 2}` to `1`, and the UI import path does not unwrap the envelope at all.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)