### PR TITLE
Remove dead type-mismatched guard in airflow-ctl command generation

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -671,8 +671,8 @@ class CommandFactory:
         """Create Arg for non-primitive type Pydantic."""
         parameter_type_map = getattr(generated_datamodels, parameter_type)
         commands = []
-        if parameter_type_map not in self.datamodels_extended_map.keys():
-            self.datamodels_extended_map[parameter_type] = []
+        # Rebuilt per visit: datamodels are shared across operations, so appending would duplicate fields.
+        self.datamodels_extended_map[parameter_type] = []
         for field, field_type in parameter_type_map.model_fields.items():
             if field in self.excluded_parameters:
                 continue


### PR DESCRIPTION
## Summary

The condition guarding this initialisation compares a Pydantic model class against a dict keyed by model name, so it has never been true. The branch is dead code, and has been since it was introduced.

It is deleted rather than repaired because repairing it would be a regression. The field loop beneath appends unconditionally, so the always-taken reset is what keeps datamodels that several operations share — `ConnectionBody` across three, `BackfillPostBody` and `VariableBody` across two — from accumulating a duplicate copy of their fields on every visit: a type-correct comparison expands `ConnectionBody` to 27 entries instead of 9.

Nothing changes at runtime, and the duplicates a repair would introduce are consumed idempotently, so this is a readability fix — it removes a condition that reads as live logic and invites the wrong correction.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
