### PR TITLE
Fix Windows compatibility in prek scripts and POSIX-only test skip gu…

### DIFF
--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -118,7 +118,7 @@ def run_command(*args, **kwargs) -> None:
 
 
 def read_airflow_version() -> str:
-    ast_obj = ast.parse((AIRFLOW_CORE_SOURCES_PATH / "airflow" / "__init__.py").read_text())
+    ast_obj = ast.parse((AIRFLOW_CORE_SOURCES_PATH / "airflow" / "__init__.py").read_text(encoding="utf-8"))
     for node in ast_obj.body:
         if isinstance(node, ast.Assign):
             if node.targets[0].id == "__version__":  # type: ignore[attr-defined]
@@ -139,7 +139,7 @@ def _read_global_constants_assignment(name: str) -> Any:
     (``NAME: type = ...``). The value must be a literal so it can be safely
     evaluated with ``ast.literal_eval``.
     """
-    tree = ast.parse(GLOBAL_CONSTANTS_PATH.read_text())
+    tree = ast.parse(GLOBAL_CONSTANTS_PATH.read_text(encoding="utf-8"))
     for node in tree.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
@@ -226,7 +226,7 @@ def insert_documentation(
     extra_information: str | None = None,
 ) -> bool:
     found = False
-    old_content = file_path.read_text()
+    old_content = file_path.read_text(encoding="utf-8")
     lines = old_content.splitlines(keepends=True)
     replacing = False
     result: list[str] = []
@@ -274,7 +274,7 @@ def read_uv_required_min_version() -> tuple[str, tuple[int, ...]]:
     Parses ``[tool.uv] required-version = ">=X.Y.Z"`` and returns ``(raw, tuple)``.
     We parse by regex to avoid pulling a TOML dep into every prek script.
     """
-    pyproject = (AIRFLOW_ROOT_PATH / "pyproject.toml").read_text()
+    pyproject = (AIRFLOW_ROOT_PATH / "pyproject.toml").read_text(encoding="utf-8")
     # Narrow to the [tool.uv] section so we don't match a different required-version.
     match = re.search(r"^\[tool\.uv\]\s*$(?P<body>.*?)(?=^\[|\Z)", pyproject, re.MULTILINE | re.DOTALL)
     if not match:
@@ -789,7 +789,7 @@ def get_imports_from_file(file_path: Path, *, only_top_level: bool) -> list[str]
     When only_top_level = False then returns
         ['os', 'collections.defaultdict', 'numpy', 'pandas.DataFrame', 'json', 'pathlib.Path', 'pathlib.PurePath']
     """
-    root = ast.parse(file_path.read_text(), file_path.name)
+    root = ast.parse(file_path.read_text(encoding="utf-8"), file_path.name)
     imports: list[str] = []
 
     nodes = ast.iter_child_nodes(root) if only_top_level else ast.walk(root)

--- a/shared/observability/src/airflow_shared/observability/metrics/stats.py
+++ b/shared/observability/src/airflow_shared/observability/metrics/stats.py
@@ -65,7 +65,8 @@ def _reset_backend_after_fork() -> None:
     _backend = None
 
 
-os.register_at_fork(after_in_child=_reset_backend_after_fork)
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_backend_after_fork)
 
 
 def normalize_name_for_stats(name: str, log_warning: bool = True) -> str:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -181,6 +181,10 @@ if TYPE_CHECKING:
 
     from airflow.sdk.definitions.context import Context
 
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="Supervisor uses POSIX-only process primitives"
+)
+
 log = logging.getLogger(__name__)
 TI_ID = uuid7()
 

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -22,6 +22,7 @@ import contextvars
 import functools
 import json
 import os
+import sys
 import textwrap
 import time
 from collections.abc import Iterable
@@ -191,6 +192,10 @@ from tests_common.test_utils.mock_operators import AirflowLink
 if TYPE_CHECKING:
     from kgb import SpyAgency
 import time_machine
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="Task runner uses POSIX-only process primitives"
+)
 
 
 def get_inline_dag(dag_id: str, task: BaseOperator) -> DAG:


### PR DESCRIPTION
Close: #69464 (follow-up)

Three Windows-compatibility fixes split out from #69504 per maintainer review:

common_prek_utils.py: explicit encoding="utf-8" on all read_text() calls prevents UnicodeDecodeError on Windows where the default codec is cp1252
shared/observability/.../stats.py: guard os.register_at_fork with hasattr since it is POSIX-only
test_supervisor.py / test_task_runner.py: skip on Windows with pytestmark rather than stubbing out POSIX syscalls — CI on Linux runs all tests as normal