### PR TITLE
Make Task SDK supervisor subprocess a session leaderFix supervisor session leader

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -418,7 +418,12 @@ def _fork_main(
     - Catch un-handled exceptions and attempt to show _something_ in case of error
     - Finally, run the actual task runner code (``target`` argument, defaults to ``.task_runner:main`)
     """
-    # TODO: Make this process a session leader
+    # Make this process a session leader
+    if hasattr(os, "setsid"):
+        try:
+            os.setsid()
+        except OSError:
+            pass
 
     # Store original stderr for last-chance exception handling
     last_chance_stderr = _get_last_chance_stderr()


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

### Background & Problem
In `task-sdk/src/airflow/sdk/execution_time/supervisor.py`, the `_subprocess_main` function is the entry point for the child process that runs the user's task code. An existing `TODO` comment indicated that this child process should be made a session leader. 

If the process is not a session leader, it remains in the same process group as the parent supervisor. This means that if a signal (like `SIGINT` or `SIGTERM`) is sent to the parent process group, both the parent and the child would receive it independently, potentially leading to double-firing of signal handlers and race conditions during shutdown or interruption.

### The Solution
This PR resolves the `TODO` by making the child process a session leader immediately upon startup. 

We introduced a call to `os.setsid()` inside a `try...except OSError` block, guarded by `hasattr(os, "setsid")` to ensure cross-platform compatibility (especially for Windows environments where `setsid` might not be available). This isolates the child process into its own session and process group, ensuring that signals are handled explicitly through the supervisor's lifecycle management rather than broadcasted by the OS terminal.

### Impacted Files
[MODIFY] task-sdk/src/airflow/sdk/execution_time/supervisor.py

### Testing & Verification
- The changes gracefully fall back if `os.setsid()` is unavailable or fails.
- CI/CD pipelines (via breeze and pre-commit) will verify that syntax is correct and that process isolation continues to function properly across supported operating systems.

closes: #70949

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Antigravity IDE following the [guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
