### PR TITLE
Correct the uv.lock versions and keycloak changelog after the 2026-08-01 wave

### DIFF
--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -41,6 +41,7 @@ Features
 
 * ``Implement bulk authorization methods in KeycloakAuthManager (#70647)``
 * ``Move keycloak JWT tokens to separate cookies (#70550)``
+* ``Add KeycloakJWTMiddleware to KeycloakAuthManager (#70800)``
 * ``Add IMPORT_ERRORS_ALL permission for import errors of files with no registered Dag (#69790)``
 
 .. Below changes are excluded from the changelog. Move them to

--- a/uv.lock
+++ b/uv.lock
@@ -4223,7 +4223,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-clickhousedb"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "providers/clickhousedb" }
 dependencies = [
     { name = "apache-airflow" },
@@ -6231,7 +6231,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-keycloak"
-version = "0.8.2"
+version = "0.9.0"
 source = { editable = "providers/keycloak" }
 dependencies = [
     { name = "apache-airflow" },


### PR DESCRIPTION
Two corrections to #70932, both found by auditing the merged wave against what it
actually shipped.

### `uv.lock` kept the pre-release versions for two providers

The wave bumped `clickhousedb` to 1.0.1 and `keycloak` to 0.9.0, but the lock file
was not updated for either:

```
clickhousedb   provider.yaml=1.0.1   uv.lock=1.0.0
keycloak       provider.yaml=0.9.0   uv.lock=0.8.2
```

The other 46 released providers are correct — these two were bumped in the wave's
final commit, where the regenerated lock ended up unstaged and never made it in.
Resolving the workspace therefore pins both below what their `provider.yaml`
declares.

### The Keycloak JWT middleware is missing from the keycloak changelog

`Add KeycloakJWTMiddleware to KeycloakAuthManager` (#70800, `607df55498`) merged
between the wave being classified and merged, so it is an ancestor of the release
commit and ships in 0.9.0 — but it was not in the snapshot the changelog was
written from, so nothing mentions it.

It is not incidental: it adds `KeycloakJWTMiddleware` across five source files and
is what reads and refreshes the `_access_token` / `_refresh_token` cookies that
#70550 introduced in the same release. Without it the notes describe the storage
change with no sign of the half that consumes it.

### Verification

Every commit touching each released provider between its previous release tag and
the release commit was checked against that provider's changelog. Across all 48
providers, #70800 was the only omission; the release commit itself is the only
remaining unlisted entry, which is expected — it goes to the excluded block of the
next wave.

After this change every provider's `provider.yaml` version matches its
`changelog.rst`, `__init__.py`, `pyproject.toml` and `uv.lock` entries.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
