### PR TITLE
Fix airflowctl commands failing against older Airflow servers

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -18,12 +18,17 @@
 from __future__ import annotations
 
 import datetime
+import functools
 import json
-from typing import TYPE_CHECKING, Any, TypeVar, get_args
+import operator
+import types
+import typing
+from typing import TYPE_CHECKING, Any, TypeVar, cast, get_args, get_origin
 
 import httpx
 import structlog
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, RootModel, ValidationError, create_model
+from pydantic.fields import FieldInfo
 
 from airflowctl.api.datamodels.auth_generated import LoginBody, LoginResponse
 from airflowctl.api.datamodels.generated import (
@@ -148,41 +153,105 @@ def _check_flag_and_exit_if_server_response_error(func):
     return wrapped
 
 
-TYPE_DEFAULTS = {
-    bool: False,
-    int: 0,
-    float: 0.0,
-    str: "",
-    list: [],
-    dict: {},
-}
+# Cache of tolerant twins, keyed by the strict model they were built from.
+_TOLERANT_MODELS: dict[type[BaseModel], type[BaseModel]] = {}
 
 
-def get_field_default(annotation) -> Any:
+def _is_polymorphic_union(annotation: Any) -> bool:
+    """
+    Return whether ``annotation`` is a union with two or more non-``None`` members.
+
+    E.g. ``AssetExpressionAsset | AssetExpressionAlias``. ``X | None`` (one real member) is a
+    plain optional and must still be rewritten. A union of two or more models is different:
+    pydantic's smart-union picks whichever member the payload merely *fits*, and every field
+    of a tolerant twin fits trivially (they are all optional). Put a twin in such a union and
+    a payload shaped for member B can silently validate as an empty member A instead of
+    raising -- the wrong-shape response is swallowed rather than surfaced. The cost of
+    leaving such a union strict is that a field missing anywhere beneath it is not
+    tolerated: it surfaces as a validation error rather than degrading to ``None``.
+    """
+    if get_origin(annotation) not in (typing.Union, types.UnionType):
+        return False
+    return len([arg for arg in get_args(annotation) if arg is not type(None)]) >= 2
+
+
+def _tolerate_missing(annotation: Any) -> Any:
+    """Rewrite ``annotation``, swapping any nested response model for its tolerant twin."""
+    if _is_polymorphic_union(annotation):
+        return annotation
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return _tolerant_model(annotation)
+    origin = get_origin(annotation)
+    if origin is None:
+        return annotation
     args = get_args(annotation)
-    if args:
-        non_none = [a for a in args if a is not type(None)]
-        if non_none:
-            return get_field_default(non_none[0])
-    return TYPE_DEFAULTS.get(annotation, None)
+    rewritten = [_tolerate_missing(arg) for arg in args]
+    if all(new_arg is old_arg for new_arg, old_arg in zip(rewritten, args)):
+        return annotation
+    if origin in (typing.Union, types.UnionType):
+        return functools.reduce(operator.or_, rewritten)
+    return origin[tuple(rewritten)]
 
 
-def fill_missing_fields(data: dict, model: type[BaseModel]) -> dict:
-    for field_name, field_info in model.model_fields.items():
-        annotation = field_info.annotation
-        args = get_args(annotation)
-        if field_name not in data and field_info.is_required():
-            data[field_name] = get_field_default(annotation)
-        elif field_name in data and isinstance(data[field_name], dict):
-            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-                data[field_name] = fill_missing_fields(data[field_name], annotation)
-        elif field_name in data and isinstance(data[field_name], list) and args:
-            if isinstance(args[0], type) and issubclass(args[0], BaseModel):
-                data[field_name] = [
-                    fill_missing_fields(item, args[0]) if isinstance(item, dict) else item
-                    for item in data[field_name]
-                ]
-    return data
+def _tolerant_model(model: type[BaseModel]) -> type[BaseModel]:
+    """
+    Build (or fetch the cached) tolerant twin of ``model``.
+
+    The twin is a ``pydantic.create_model`` subclass of ``model`` with every required field
+    -- including ones nested inside it, recursively -- widened to ``X | None`` defaulting to
+    ``None``. A field an older server omits is then left honestly unset instead of being
+    synthesized to a type default that would be indistinguishable from a real value. Because
+    the twin subclasses the original model, ``isinstance(twin_instance, model)`` still holds.
+
+    A ``RootModel`` wraps a single scalar rather than named fields, so "a field is missing"
+    has no meaning for it; it is returned unchanged. Polymorphic unions (see
+    ``_is_polymorphic_union``) are never rewritten, so no cycle can form even though the
+    generated datamodels do contain mutually self-referential schemas (``AssetExpressionAll``
+    <-> ``AssetExpressionAny``): every path back to a model already being built runs through
+    such a union.
+    """
+    if model in _TOLERANT_MODELS:
+        return _TOLERANT_MODELS[model]
+    if issubclass(model, RootModel):
+        return model
+    overrides: dict[str, Any] = {}
+    for field_name, field in model.model_fields.items():
+        annotation = _tolerate_missing(field.annotation)
+        if field.is_required():
+            overrides[field_name] = (annotation | None, FieldInfo.merge_field_infos(field, default=None))
+        elif annotation is not field.annotation:
+            overrides[field_name] = (annotation, field)
+    twin = create_model(f"Partial{model.__name__}", __base__=model, **overrides) if overrides else model
+    _TOLERANT_MODELS[model] = twin
+    return twin
+
+
+def validate_response(content: bytes, data_model: type[T]) -> T:
+    """
+    Validate a server response, tolerating fields an older server does not send.
+
+    The datamodels are generated from the newest Airflow API spec, so a server on an
+    older Airflow line can legitimately omit fields the models declare as required. Any
+    such field is left ``None`` -- never synthesized to a type default (``False``, ``0``,
+    ``""``, ...), which would be indistinguishable from a real value the server actually
+    sent. Any other validation error means the response genuinely disagrees with the
+    model, which is a defect on one side or the other and must surface instead of being
+    papered over.
+    """
+    try:
+        return data_model.model_validate_json(content)
+    except ValidationError as validation_error:
+        errors = validation_error.errors()
+        if any(error["type"] != "missing" for error in errors):
+            raise
+        log.warning(
+            "Response omitted fields this airflowctl requires; leaving them unset (None) "
+            "rather than guessing a value. The server is likely on an older Airflow line "
+            "than these datamodels.",
+            model=data_model.__name__,
+            fields=[".".join(str(part) for part in error["loc"]) for error in errors],
+        )
+        return cast("T", _tolerant_model(data_model).model_validate_json(content))
 
 
 class BaseOperations:
@@ -213,17 +282,12 @@ class BaseOperations:
 
         shared_params = {"limit": limit, **(params or {})}
 
-        def safe_validate(content: bytes) -> BaseModel:
-            try:
-                return data_model.model_validate_json(content)  # type: ignore[union-attr]
-            except ValidationError:
-                raw = fill_missing_fields(json.loads(content), data_model)
-                return data_model.model_validate(raw)  # type: ignore[union-attr]
-
         self.response = self.client.get(path, params={**shared_params, "offset": offset})
-        first_pass = safe_validate(self.response.content)
+        first_pass = validate_response(self.response.content, data_model)
         total_entries = first_pass.total_entries  # type: ignore[attr-defined]
-        if total_entries < limit:
+        # An older server that omits total_entries leaves it None; treat that as "no more
+        # pages" rather than raising on the comparison below.
+        if total_entries is None or total_entries < limit:
             return first_pass
         found_key = None
         for key, value in first_pass.model_dump().items():
@@ -234,11 +298,10 @@ class BaseOperations:
         offset = offset + limit
         while offset < total_entries:
             self.response = self.client.get(path, params={**shared_params, "offset": offset})
-            entry = safe_validate(self.response.content)
+            entry = validate_response(self.response.content, data_model)
             offset = offset + limit
             entry_list.extend(getattr(entry, found_key))
-        obj = data_model(**{found_key: entry_list, "total_entries": total_entries})
-        return data_model.model_validate(obj.model_dump())  # type: ignore[union-attr]
+        return data_model(**{found_key: entry_list, "total_entries": total_entries})
 
 
 # Login operations
@@ -262,12 +325,12 @@ class AssetsOperations(BaseOperations):
     def get(self, asset_id: str) -> AssetResponse | ServerResponseError:
         """Get an asset from the API server."""
         self.response = self.client.get(f"assets/{asset_id}")
-        return AssetResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, AssetResponse)
 
     def get_alias(self, asset_alias_id: str) -> AssetAliasResponse | ServerResponseError:
         """Get an asset alias by its ID from the API server."""
         self.response = self.client.get(f"assets/aliases/{asset_alias_id}")
-        return AssetAliasResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, AssetAliasResponse)
 
     def list(self) -> AssetCollectionResponse | ServerResponseError:
         """List all assets from the API server."""
@@ -287,29 +350,29 @@ class AssetsOperations(BaseOperations):
         self.response = self.client.post(
             "assets/events", json=asset_event_body.model_dump(mode="json", exclude_none=True)
         )
-        return AssetEventResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, AssetEventResponse)
 
     def materialize(self, asset_id: str) -> DAGRunResponse | ServerResponseError:
         """Materialize an asset."""
         self.response = self.client.post(f"assets/{asset_id}/materialize")
-        return DAGRunResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunResponse)
 
     def get_queued_events(self, asset_id: str) -> QueuedEventCollectionResponse | ServerResponseError:
         """Get queued events for an asset."""
         self.response = self.client.get(f"assets/{asset_id}/queuedEvents")
-        return QueuedEventCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, QueuedEventCollectionResponse)
 
     def get_dag_queued_events(
         self, dag_id: str, before: str
     ) -> QueuedEventCollectionResponse | ServerResponseError:
         """Get queued events for a dag."""
         self.response = self.client.get(f"dags/{dag_id}/assets/queuedEvents", params={"before": before})
-        return QueuedEventCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, QueuedEventCollectionResponse)
 
     def get_dag_queued_event(self, dag_id: str, asset_id: str) -> QueuedEventResponse | ServerResponseError:
         """Get a queued event for a dag."""
         self.response = self.client.get(f"dags/{dag_id}/assets/{asset_id}/queuedEvents")
-        return QueuedEventResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, QueuedEventResponse)
 
     def delete_queued_events(self, asset_id: str) -> str | ServerResponseError:
         """Delete a queued event for an asset."""
@@ -335,19 +398,19 @@ class BackfillOperations(BaseOperations):
         self.response = self.client.post(
             "backfills", json=backfill.model_dump(mode="json", exclude_none=True)
         )
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def create_dry_run(self, backfill: BackfillPostBody) -> BackfillResponse | ServerResponseError:
         """Create a dry run backfill."""
         self.response = self.client.post(
             "backfills/dry_run", json=backfill.model_dump(mode="json", exclude_none=True)
         )
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def get(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Get a backfill."""
         self.response = self.client.get(f"backfills/{backfill_id}")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def list(self, dag_id: str) -> BackfillCollectionResponse | ServerResponseError:
         """List all backfills."""
@@ -357,17 +420,17 @@ class BackfillOperations(BaseOperations):
     def pause(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Pause a backfill."""
         self.response = self.client.post(f"backfills/{backfill_id}/pause")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def unpause(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Unpause a backfill."""
         self.response = self.client.post(f"backfills/{backfill_id}/unpause")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def cancel(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Cancel a backfill."""
         self.response = self.client.post(f"backfills/{backfill_id}/cancel")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
 
 class ConfigOperations(BaseOperations):
@@ -376,12 +439,12 @@ class ConfigOperations(BaseOperations):
     def get(self, section: str, option: str) -> Config | ServerResponseError:
         """Get a config from the API server."""
         self.response = self.client.get(f"/config/section/{section}/option/{option}")
-        return Config.model_validate_json(self.response.content)
+        return validate_response(self.response.content, Config)
 
     def list(self) -> Config | ServerResponseError:
         """List all configs from the API server."""
         self.response = self.client.get("/config")
-        return Config.model_validate_json(self.response.content)
+        return validate_response(self.response.content, Config)
 
 
 class ConnectionsOperations(BaseOperations):
@@ -390,7 +453,7 @@ class ConnectionsOperations(BaseOperations):
     def get(self, conn_id: str) -> ConnectionResponse | ServerResponseError:
         """Get a connection from the API server."""
         self.response = self.client.get(f"connections/{conn_id}")
-        return ConnectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionResponse)
 
     def list(self) -> ConnectionCollectionResponse | ServerResponseError:
         """List all connections from the API server."""
@@ -404,14 +467,14 @@ class ConnectionsOperations(BaseOperations):
         self.response = self.client.post(
             "connections", json=connection.model_dump(mode="json", by_alias=True, exclude_none=True)
         )
-        return ConnectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionResponse)
 
     def bulk(self, connections: BulkBodyConnectionBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple connections."""
         self.response = self.client.patch(
             "connections", json=connections.model_dump(mode="json", by_alias=True)
         )
-        return BulkResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BulkResponse)
 
     def create_defaults(self) -> None | ServerResponseError:
         """Create default connections."""
@@ -432,7 +495,7 @@ class ConnectionsOperations(BaseOperations):
             f"connections/{connection.connection_id}",
             json=connection.model_dump(mode="json", by_alias=True),
         )
-        return ConnectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionResponse)
 
     def test(
         self,
@@ -442,7 +505,7 @@ class ConnectionsOperations(BaseOperations):
         self.response = self.client.post(
             "connections/test", json=connection.model_dump(mode="json", by_alias=True)
         )
-        return ConnectionTestResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionTestResponse)
 
 
 class DagsOperations(BaseOperations):
@@ -451,12 +514,12 @@ class DagsOperations(BaseOperations):
     def get(self, dag_id: str) -> DAGResponse | ServerResponseError:
         """Get a Dag."""
         self.response = self.client.get(f"dags/{dag_id}")
-        return DAGResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGResponse)
 
     def get_details(self, dag_id: str) -> DAGDetailsResponse | ServerResponseError:
         """Get a Dag details."""
         self.response = self.client.get(f"dags/{dag_id}/details")
-        return DAGDetailsResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGDetailsResponse)
 
     def get_tags(self) -> DAGTagCollectionResponse | ServerResponseError:
         """Get all Dag tags."""
@@ -468,7 +531,7 @@ class DagsOperations(BaseOperations):
 
     def update(self, dag_id: str, dag_body: DAGPatchBody) -> DAGResponse | ServerResponseError:
         self.response = self.client.patch(f"dags/{dag_id}", json=dag_body.model_dump(mode="json"))
-        return DAGResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGResponse)
 
     def delete(self, dag_id: str) -> str | ServerResponseError:
         self.client.delete(f"dags/{dag_id}")
@@ -476,18 +539,18 @@ class DagsOperations(BaseOperations):
 
     def get_import_error(self, import_error_id: str) -> ImportErrorResponse | ServerResponseError:
         self.response = self.client.get(f"importErrors/{import_error_id}")
-        return ImportErrorResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ImportErrorResponse)
 
     def list_import_errors(self) -> ImportErrorCollectionResponse | ServerResponseError:
         return super().execute_list(path="importErrors", data_model=ImportErrorCollectionResponse)
 
     def get_stats(self, dag_ids: list) -> DagStatsCollectionResponse | ServerResponseError:  # type: ignore
         self.response = self.client.get("dagStats", params={"dag_ids": dag_ids})
-        return DagStatsCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DagStatsCollectionResponse)
 
     def get_version(self, dag_id: str, version_number: int) -> DagVersionResponse | ServerResponseError:
         self.response = self.client.get(f"dags/{dag_id}/dagVersions/{version_number}")
-        return DagVersionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DagVersionResponse)
 
     def list_version(self, dag_id: str) -> DAGVersionCollectionResponse | ServerResponseError:
         return super().execute_list(
@@ -506,7 +569,7 @@ class DagsOperations(BaseOperations):
         self.response = self.client.post(
             f"dags/{dag_id}/dagRuns", json=trigger_dag_run.model_dump(mode="json")
         )
-        return DAGRunResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunResponse)
 
 
 class DagRunOperations(BaseOperations):
@@ -520,7 +583,7 @@ class DagRunOperations(BaseOperations):
             f"/dags/{dag_id}/dagRuns/{dag_run_id}",
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return DAGRunResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunResponse)
 
     def list(
         self,
@@ -582,7 +645,7 @@ class DagRunOperations(BaseOperations):
             params=params,
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return DAGRunCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunCollectionResponse)
 
     def delete(self, dag_id: str, dag_run_id: str) -> str | ServerResponseError:
         """Delete a Dag run."""
@@ -618,7 +681,7 @@ class JobsOperations(BaseOperations):
 
         if limit is not None or offset is not None:
             self.response = self.client.get("jobs", params=params)
-            return JobCollectionResponse.model_validate_json(self.response.content)
+            return validate_response(self.response.content, JobCollectionResponse)
 
         return super().execute_list(path="jobs", data_model=JobCollectionResponse, params=params)
 
@@ -629,7 +692,7 @@ class PoolsOperations(BaseOperations):
     def get(self, pool_name: str) -> PoolResponse | ServerResponseError:
         """Get a pool."""
         self.response = self.client.get(f"pools/{pool_name}")
-        return PoolResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PoolResponse)
 
     def list(self) -> PoolCollectionResponse | ServerResponseError:
         """List all pools."""
@@ -638,12 +701,12 @@ class PoolsOperations(BaseOperations):
     def create(self, pool: PoolBody) -> PoolResponse | ServerResponseError:
         """Create a pool."""
         self.response = self.client.post("pools", json=pool.model_dump(mode="json", exclude_none=True))
-        return PoolResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PoolResponse)
 
     def bulk(self, pools: BulkBodyPoolBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple pools."""
         self.response = self.client.patch("pools", json=pools.model_dump(mode="json"))
-        return BulkResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BulkResponse)
 
     def delete(self, pool: str) -> str | ServerResponseError:
         """Delete a pool."""
@@ -653,7 +716,7 @@ class PoolsOperations(BaseOperations):
     def update(self, pool_body: PoolPatchBody) -> PoolResponse | ServerResponseError:
         """Update a pool."""
         self.response = self.client.patch(f"pools/{pool_body.pool}", json=pool_body.model_dump(mode="json"))
-        return PoolResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PoolResponse)
 
 
 class ProvidersOperations(BaseOperations):
@@ -692,7 +755,7 @@ class TaskInstancesOperations(BaseOperations):
             path,
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return TaskInstanceResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, TaskInstanceResponse)
 
     def get_dependencies(
         self,
@@ -711,7 +774,7 @@ class TaskInstancesOperations(BaseOperations):
             f"{path}/dependencies",
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return TaskDependencyCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, TaskDependencyCollectionResponse)
 
     def list(self, dag_id: str, dag_run_id: str) -> TaskInstanceCollectionResponse | ServerResponseError:
         """List task instances for a Dag run."""
@@ -732,7 +795,7 @@ class TasksOperations(BaseOperations):
             f"dags/{dag_id}/clearTaskInstances",
             json=clear_task_instances.model_dump(mode="json", exclude_none=True),
         )
-        return TaskInstanceCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, TaskInstanceCollectionResponse)
 
 
 class VariablesOperations(BaseOperations):
@@ -741,7 +804,7 @@ class VariablesOperations(BaseOperations):
     def get(self, variable_key: str) -> VariableResponse | ServerResponseError:
         """Get a variable."""
         self.response = self.client.get(f"variables/{variable_key}")
-        return VariableResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VariableResponse)
 
     def list(self) -> VariableCollectionResponse | ServerResponseError:
         """List all variables."""
@@ -752,12 +815,12 @@ class VariablesOperations(BaseOperations):
         self.response = self.client.post(
             "variables", json=variable.model_dump(mode="json", exclude_none=True)
         )
-        return VariableResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VariableResponse)
 
     def bulk(self, variables: BulkBodyVariableBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple variables."""
         self.response = self.client.patch("variables", json=variables.model_dump(mode="json"))
-        return BulkResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BulkResponse)
 
     def delete(self, variable_key: str) -> str | ServerResponseError:
         """Delete a variable."""
@@ -767,7 +830,7 @@ class VariablesOperations(BaseOperations):
     def update(self, variable: VariableBody) -> VariableResponse | ServerResponseError:
         """Update a variable."""
         self.response = self.client.patch(f"variables/{variable.key}", json=variable.model_dump(mode="json"))
-        return VariableResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VariableResponse)
 
 
 class VersionOperations(BaseOperations):
@@ -776,7 +839,7 @@ class VersionOperations(BaseOperations):
     def get(self) -> VersionInfo | ServerResponseError:
         """Get the version."""
         self.response = self.client.get("version")
-        return VersionInfo.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VersionInfo)
 
 
 class XComOperations(BaseOperations):
@@ -798,7 +861,7 @@ class XComOperations(BaseOperations):
             f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{key}",
             params=params,
         )
-        return XComResponseNative.model_validate_json(self.response.content)
+        return validate_response(self.response.content, XComResponseNative)
 
     def list(
         self,
@@ -843,7 +906,7 @@ class XComOperations(BaseOperations):
             f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries",
             json=body.model_dump(mode="json", exclude_unset=True, exclude_none=True),
         )
-        return XComResponseNative.model_validate_json(self.response.content)
+        return validate_response(self.response.content, XComResponseNative)
 
     def edit(
         self,
@@ -868,7 +931,7 @@ class XComOperations(BaseOperations):
             f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{key}",
             json=body.model_dump(mode="json", exclude_unset=True, exclude_none=True),
         )
-        return XComResponseNative.model_validate_json(self.response.content)
+        return validate_response(self.response.content, XComResponseNative)
 
     def delete(
         self,
@@ -899,4 +962,4 @@ class PluginsOperations(BaseOperations):
     def list_import_errors(self) -> PluginImportErrorCollectionResponse | ServerResponseError:
         """List plugin import errors from the API server."""
         self.response = self.client.get("plugins/importErrors")
-        return PluginImportErrorCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PluginImportErrorCollectionResponse)

--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -185,6 +185,21 @@ def fill_missing_fields(data: dict, model: type[BaseModel]) -> dict:
     return data
 
 
+def validate_response(content: bytes, data_model: type[T]) -> T:
+    """
+    Validate a server response, tolerating fields an older server does not send.
+
+    The datamodels are generated from the newest Airflow API spec, so a server on an
+    older Airflow line can legitimately omit fields the models declare as required.
+    Fill those with type defaults rather than failing the whole command.
+    """
+    try:
+        return data_model.model_validate_json(content)
+    except ValidationError:
+        raw = fill_missing_fields(json.loads(content), data_model)
+        return data_model.model_validate(raw)
+
+
 class BaseOperations:
     """
     Base class for operations.
@@ -213,15 +228,8 @@ class BaseOperations:
 
         shared_params = {"limit": limit, **(params or {})}
 
-        def safe_validate(content: bytes) -> BaseModel:
-            try:
-                return data_model.model_validate_json(content)  # type: ignore[union-attr]
-            except ValidationError:
-                raw = fill_missing_fields(json.loads(content), data_model)
-                return data_model.model_validate(raw)  # type: ignore[union-attr]
-
         self.response = self.client.get(path, params=shared_params)
-        first_pass = safe_validate(self.response.content)
+        first_pass = validate_response(self.response.content, data_model)
         total_entries = first_pass.total_entries  # type: ignore[attr-defined]
         if total_entries < limit:
             return first_pass
@@ -234,7 +242,7 @@ class BaseOperations:
         offset = offset + limit
         while offset < total_entries:
             self.response = self.client.get(path, params={**shared_params, "offset": offset})
-            entry = safe_validate(self.response.content)
+            entry = validate_response(self.response.content, data_model)
             offset = offset + limit
             entry_list.extend(getattr(entry, found_key))
         obj = data_model(**{found_key: entry_list, "total_entries": total_entries})
@@ -262,12 +270,12 @@ class AssetsOperations(BaseOperations):
     def get(self, asset_id: str) -> AssetResponse | ServerResponseError:
         """Get an asset from the API server."""
         self.response = self.client.get(f"assets/{asset_id}")
-        return AssetResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, AssetResponse)
 
     def get_by_alias(self, alias: str) -> AssetAliasResponse | ServerResponseError:
         """Get an asset by alias from the API server."""
         self.response = self.client.get(f"assets/aliases/{alias}")
-        return AssetAliasResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, AssetAliasResponse)
 
     def list(self) -> AssetCollectionResponse | ServerResponseError:
         """List all assets from the API server."""
@@ -287,29 +295,29 @@ class AssetsOperations(BaseOperations):
         self.response = self.client.post(
             "assets/events", json=asset_event_body.model_dump(mode="json", exclude_none=True)
         )
-        return AssetEventResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, AssetEventResponse)
 
     def materialize(self, asset_id: str) -> DAGRunResponse | ServerResponseError:
         """Materialize an asset."""
         self.response = self.client.post(f"assets/{asset_id}/materialize")
-        return DAGRunResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunResponse)
 
     def get_queued_events(self, asset_id: str) -> QueuedEventCollectionResponse | ServerResponseError:
         """Get queued events for an asset."""
         self.response = self.client.get(f"assets/{asset_id}/queuedEvents")
-        return QueuedEventCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, QueuedEventCollectionResponse)
 
     def get_dag_queued_events(
         self, dag_id: str, before: str
     ) -> QueuedEventCollectionResponse | ServerResponseError:
         """Get queued events for a dag."""
         self.response = self.client.get(f"dags/{dag_id}/assets/queuedEvents", params={"before": before})
-        return QueuedEventCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, QueuedEventCollectionResponse)
 
     def get_dag_queued_event(self, dag_id: str, asset_id: str) -> QueuedEventResponse | ServerResponseError:
         """Get a queued event for a dag."""
         self.response = self.client.get(f"dags/{dag_id}/assets/{asset_id}/queuedEvents")
-        return QueuedEventResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, QueuedEventResponse)
 
     def delete_queued_events(self, asset_id: str) -> str | ServerResponseError:
         """Delete a queued event for an asset."""
@@ -335,19 +343,19 @@ class BackfillOperations(BaseOperations):
         self.response = self.client.post(
             "backfills", json=backfill.model_dump(mode="json", exclude_none=True)
         )
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def create_dry_run(self, backfill: BackfillPostBody) -> BackfillResponse | ServerResponseError:
         """Create a dry run backfill."""
         self.response = self.client.post(
             "backfills/dry_run", json=backfill.model_dump(mode="json", exclude_none=True)
         )
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def get(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Get a backfill."""
         self.response = self.client.get(f"backfills/{backfill_id}")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def list(self, dag_id: str) -> BackfillCollectionResponse | ServerResponseError:
         """List all backfills."""
@@ -357,17 +365,17 @@ class BackfillOperations(BaseOperations):
     def pause(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Pause a backfill."""
         self.response = self.client.post(f"backfills/{backfill_id}/pause")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def unpause(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Unpause a backfill."""
         self.response = self.client.post(f"backfills/{backfill_id}/unpause")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
     def cancel(self, backfill_id: str) -> BackfillResponse | ServerResponseError:
         """Cancel a backfill."""
         self.response = self.client.post(f"backfills/{backfill_id}/cancel")
-        return BackfillResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BackfillResponse)
 
 
 class ConfigOperations(BaseOperations):
@@ -376,12 +384,12 @@ class ConfigOperations(BaseOperations):
     def get(self, section: str, option: str) -> Config | ServerResponseError:
         """Get a config from the API server."""
         self.response = self.client.get(f"/config/section/{section}/option/{option}")
-        return Config.model_validate_json(self.response.content)
+        return validate_response(self.response.content, Config)
 
     def list(self) -> Config | ServerResponseError:
         """List all configs from the API server."""
         self.response = self.client.get("/config")
-        return Config.model_validate_json(self.response.content)
+        return validate_response(self.response.content, Config)
 
 
 class ConnectionsOperations(BaseOperations):
@@ -390,7 +398,7 @@ class ConnectionsOperations(BaseOperations):
     def get(self, conn_id: str) -> ConnectionResponse | ServerResponseError:
         """Get a connection from the API server."""
         self.response = self.client.get(f"connections/{conn_id}")
-        return ConnectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionResponse)
 
     def list(self) -> ConnectionCollectionResponse | ServerResponseError:
         """List all connections from the API server."""
@@ -404,14 +412,14 @@ class ConnectionsOperations(BaseOperations):
         self.response = self.client.post(
             "connections", json=connection.model_dump(mode="json", by_alias=True, exclude_none=True)
         )
-        return ConnectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionResponse)
 
     def bulk(self, connections: BulkBodyConnectionBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple connections."""
         self.response = self.client.patch(
             "connections", json=connections.model_dump(mode="json", by_alias=True)
         )
-        return BulkResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BulkResponse)
 
     def create_defaults(self) -> None | ServerResponseError:
         """Create default connections."""
@@ -432,7 +440,7 @@ class ConnectionsOperations(BaseOperations):
             f"connections/{connection.connection_id}",
             json=connection.model_dump(mode="json", by_alias=True),
         )
-        return ConnectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionResponse)
 
     def test(
         self,
@@ -442,7 +450,7 @@ class ConnectionsOperations(BaseOperations):
         self.response = self.client.post(
             "connections/test", json=connection.model_dump(mode="json", by_alias=True)
         )
-        return ConnectionTestResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ConnectionTestResponse)
 
 
 class DagsOperations(BaseOperations):
@@ -451,12 +459,12 @@ class DagsOperations(BaseOperations):
     def get(self, dag_id: str) -> DAGResponse | ServerResponseError:
         """Get a Dag."""
         self.response = self.client.get(f"dags/{dag_id}")
-        return DAGResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGResponse)
 
     def get_details(self, dag_id: str) -> DAGDetailsResponse | ServerResponseError:
         """Get a Dag details."""
         self.response = self.client.get(f"dags/{dag_id}/details")
-        return DAGDetailsResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGDetailsResponse)
 
     def get_tags(self) -> DAGTagCollectionResponse | ServerResponseError:
         """Get all Dag tags."""
@@ -468,7 +476,7 @@ class DagsOperations(BaseOperations):
 
     def update(self, dag_id: str, dag_body: DAGPatchBody) -> DAGResponse | ServerResponseError:
         self.response = self.client.patch(f"dags/{dag_id}", json=dag_body.model_dump(mode="json"))
-        return DAGResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGResponse)
 
     def delete(self, dag_id: str) -> str | ServerResponseError:
         self.client.delete(f"dags/{dag_id}")
@@ -476,18 +484,18 @@ class DagsOperations(BaseOperations):
 
     def get_import_error(self, import_error_id: str) -> ImportErrorResponse | ServerResponseError:
         self.response = self.client.get(f"importErrors/{import_error_id}")
-        return ImportErrorResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, ImportErrorResponse)
 
     def list_import_errors(self) -> ImportErrorCollectionResponse | ServerResponseError:
         return super().execute_list(path="importErrors", data_model=ImportErrorCollectionResponse)
 
     def get_stats(self, dag_ids: list) -> DagStatsCollectionResponse | ServerResponseError:  # type: ignore
         self.response = self.client.get("dagStats", params={"dag_ids": dag_ids})
-        return DagStatsCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DagStatsCollectionResponse)
 
     def get_version(self, dag_id: str, version_number: int) -> DagVersionResponse | ServerResponseError:
         self.response = self.client.get(f"dags/{dag_id}/dagVersions/{version_number}")
-        return DagVersionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DagVersionResponse)
 
     def list_version(self, dag_id: str) -> DAGVersionCollectionResponse | ServerResponseError:
         return super().execute_list(
@@ -506,7 +514,7 @@ class DagsOperations(BaseOperations):
         self.response = self.client.post(
             f"dags/{dag_id}/dagRuns", json=trigger_dag_run.model_dump(mode="json")
         )
-        return DAGRunResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunResponse)
 
 
 class DagRunOperations(BaseOperations):
@@ -520,7 +528,7 @@ class DagRunOperations(BaseOperations):
             f"/dags/{dag_id}/dagRuns/{dag_run_id}",
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return DAGRunResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunResponse)
 
     def list(
         self,
@@ -582,7 +590,7 @@ class DagRunOperations(BaseOperations):
             params=params,
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return DAGRunCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, DAGRunCollectionResponse)
 
     def delete(self, dag_id: str, dag_run_id: str) -> str | ServerResponseError:
         """Delete a Dag run."""
@@ -618,7 +626,7 @@ class JobsOperations(BaseOperations):
 
         if limit is not None or offset is not None:
             self.response = self.client.get("jobs", params=params)
-            return JobCollectionResponse.model_validate_json(self.response.content)
+            return validate_response(self.response.content, JobCollectionResponse)
 
         return super().execute_list(path="jobs", data_model=JobCollectionResponse, params=params)
 
@@ -629,7 +637,7 @@ class PoolsOperations(BaseOperations):
     def get(self, pool_name: str) -> PoolResponse | ServerResponseError:
         """Get a pool."""
         self.response = self.client.get(f"pools/{pool_name}")
-        return PoolResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PoolResponse)
 
     def list(self) -> PoolCollectionResponse | ServerResponseError:
         """List all pools."""
@@ -638,12 +646,12 @@ class PoolsOperations(BaseOperations):
     def create(self, pool: PoolBody) -> PoolResponse | ServerResponseError:
         """Create a pool."""
         self.response = self.client.post("pools", json=pool.model_dump(mode="json", exclude_none=True))
-        return PoolResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PoolResponse)
 
     def bulk(self, pools: BulkBodyPoolBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple pools."""
         self.response = self.client.patch("pools", json=pools.model_dump(mode="json"))
-        return BulkResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BulkResponse)
 
     def delete(self, pool: str) -> str | ServerResponseError:
         """Delete a pool."""
@@ -653,7 +661,7 @@ class PoolsOperations(BaseOperations):
     def update(self, pool_body: PoolPatchBody) -> PoolResponse | ServerResponseError:
         """Update a pool."""
         self.response = self.client.patch(f"pools/{pool_body.pool}", json=pool_body.model_dump(mode="json"))
-        return PoolResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PoolResponse)
 
 
 class ProvidersOperations(BaseOperations):
@@ -692,7 +700,7 @@ class TaskInstancesOperations(BaseOperations):
             path,
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return TaskInstanceResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, TaskInstanceResponse)
 
     def get_dependencies(
         self,
@@ -711,7 +719,7 @@ class TaskInstancesOperations(BaseOperations):
             f"{path}/dependencies",
             extensions={"airflowctl_suppress_error_log": suppress_error_log},
         )
-        return TaskDependencyCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, TaskDependencyCollectionResponse)
 
     def list(self, dag_id: str, dag_run_id: str) -> TaskInstanceCollectionResponse | ServerResponseError:
         """List task instances for a Dag run."""
@@ -732,7 +740,7 @@ class TasksOperations(BaseOperations):
             f"dags/{dag_id}/clearTaskInstances",
             json=clear_task_instances.model_dump(mode="json", exclude_none=True),
         )
-        return TaskInstanceCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, TaskInstanceCollectionResponse)
 
 
 class VariablesOperations(BaseOperations):
@@ -741,7 +749,7 @@ class VariablesOperations(BaseOperations):
     def get(self, variable_key: str) -> VariableResponse | ServerResponseError:
         """Get a variable."""
         self.response = self.client.get(f"variables/{variable_key}")
-        return VariableResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VariableResponse)
 
     def list(self) -> VariableCollectionResponse | ServerResponseError:
         """List all variables."""
@@ -752,12 +760,12 @@ class VariablesOperations(BaseOperations):
         self.response = self.client.post(
             "variables", json=variable.model_dump(mode="json", exclude_none=True)
         )
-        return VariableResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VariableResponse)
 
     def bulk(self, variables: BulkBodyVariableBody) -> BulkResponse | ServerResponseError:
         """CRUD multiple variables."""
         self.response = self.client.patch("variables", json=variables.model_dump(mode="json"))
-        return BulkResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, BulkResponse)
 
     def delete(self, variable_key: str) -> str | ServerResponseError:
         """Delete a variable."""
@@ -767,7 +775,7 @@ class VariablesOperations(BaseOperations):
     def update(self, variable: VariableBody) -> VariableResponse | ServerResponseError:
         """Update a variable."""
         self.response = self.client.patch(f"variables/{variable.key}", json=variable.model_dump(mode="json"))
-        return VariableResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VariableResponse)
 
 
 class VersionOperations(BaseOperations):
@@ -776,7 +784,7 @@ class VersionOperations(BaseOperations):
     def get(self) -> VersionInfo | ServerResponseError:
         """Get the version."""
         self.response = self.client.get("version")
-        return VersionInfo.model_validate_json(self.response.content)
+        return validate_response(self.response.content, VersionInfo)
 
 
 class XComOperations(BaseOperations):
@@ -798,7 +806,7 @@ class XComOperations(BaseOperations):
             f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{key}",
             params=params,
         )
-        return XComResponseNative.model_validate_json(self.response.content)
+        return validate_response(self.response.content, XComResponseNative)
 
     def list(
         self,
@@ -843,7 +851,7 @@ class XComOperations(BaseOperations):
             f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries",
             json=body.model_dump(mode="json", exclude_unset=True, exclude_none=True),
         )
-        return XComResponseNative.model_validate_json(self.response.content)
+        return validate_response(self.response.content, XComResponseNative)
 
     def edit(
         self,
@@ -868,7 +876,7 @@ class XComOperations(BaseOperations):
             f"dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries/{key}",
             json=body.model_dump(mode="json", exclude_unset=True, exclude_none=True),
         )
-        return XComResponseNative.model_validate_json(self.response.content)
+        return validate_response(self.response.content, XComResponseNative)
 
     def delete(
         self,
@@ -899,4 +907,4 @@ class PluginsOperations(BaseOperations):
     def list_import_errors(self) -> PluginImportErrorCollectionResponse | ServerResponseError:
         """List plugin import errors from the API server."""
         self.response = self.client.get("plugins/importErrors")
-        return PluginImportErrorCollectionResponse.model_validate_json(self.response.content)
+        return validate_response(self.response.content, PluginImportErrorCollectionResponse)

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -26,8 +26,10 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel, ValidationError
+from structlog.testing import capture_logs
 
+import airflowctl.api.datamodels.generated as generated_datamodels
 from airflowctl.api.client import Client, ClientKind
 from airflowctl.api.datamodels.auth_generated import LoginBody, LoginResponse
 from airflowctl.api.datamodels.generated import (
@@ -107,7 +109,7 @@ from airflowctl.api.datamodels.generated import (
     XComResponse,
     XComResponseNative,
 )
-from airflowctl.api.operations import BaseOperations, _build_query_params
+from airflowctl.api.operations import BaseOperations, _build_query_params, _tolerant_model
 from airflowctl.exceptions import AirflowCtlConnectionException
 
 if TYPE_CHECKING:
@@ -1171,6 +1173,93 @@ class TestDagOperations:
         response = client.dags.get_details("dag_id")
         assert response == self.dag_details_response
 
+    @pytest.mark.parametrize(
+        ("operation", "path", "payload_attr"),
+        [
+            (lambda dags, patch_body: dags.get("dag_id"), "/api/v2/dags/dag_id", "dag_response"),
+            (
+                lambda dags, patch_body: dags.get_details("dag_id"),
+                "/api/v2/dags/dag_id/details",
+                "dag_details_response",
+            ),
+            (
+                lambda dags, patch_body: dags.update(dag_id="dag_id", dag_body=patch_body),
+                "/api/v2/dags/dag_id",
+                "dag_response",
+            ),
+        ],
+        ids=["get", "get_details", "update"],
+    )
+    @pytest.mark.parametrize(
+        "omitted_field",
+        ["is_backfillable", "timetable_periodic", "owners", "tags"],
+    )
+    def test_single_object_response_tolerates_field_an_older_server_omits(
+        self, operation, path, payload_attr, omitted_field
+    ):
+        """A server on an older Airflow line omits fields the generated models declare as required.
+
+        The omitted field must be left honestly ``None`` rather than filled with a
+        synthesized type default that would be indistinguishable from a real value.
+        """
+        payload = json.loads(getattr(self, payload_attr).model_dump_json())
+        del payload[omitted_field]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == path
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = operation(client.dags, self.dag_patch_body)
+
+        assert response.dag_id == self.dag_id
+        assert getattr(response, omitted_field) is None
+
+    def test_collection_response_tolerates_field_an_older_server_omits_from_an_item(self):
+        payload = json.loads(self.dag_collection_response.model_dump_json())
+        del payload["dags"][0]["owners"]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/api/v2/dags"
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dags.list()
+
+        assert response.dags[0].owners is None
+
+    def test_single_object_response_warns_about_the_fields_it_leaves_unset(self):
+        payload = json.loads(self.dag_response.model_dump_json())
+        del payload["is_backfillable"]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        with capture_logs() as captured:
+            client.dags.get("dag_id")
+
+        assert [
+            (entry["model"], entry["fields"]) for entry in captured if entry["log_level"] == "warning"
+        ] == [("DAGResponse", ["is_backfillable"])]
+
+    def test_single_object_response_raises_when_a_present_field_mismatches(self):
+        payload = json.loads(self.dag_response.model_dump_json())
+        del payload["is_backfillable"]
+        payload["max_active_tasks"] = "not-an-int"
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        with pytest.raises(ValidationError) as exc_info:
+            client.dags.get("dag_id")
+
+        assert {error["loc"] for error in exc_info.value.errors()} == {
+            ("is_backfillable",),
+            ("max_active_tasks",),
+        }
+
     def test_get_tags(self):
         def handle_request(request: httpx.Request) -> httpx.Response:
             assert request.url.path == "/api/v2/dagTags"
@@ -1511,6 +1600,245 @@ class TestDagRunOperations:
         client = make_api_client(transport=httpx.MockTransport(handle_request))
         response = client.dag_runs.delete(dag_id=self.dag_id, dag_run_id=self.dag_run_id)
         assert response == self.dag_run_id
+
+
+class TestValidateResponseTolerance:
+    """
+    Cross-cutting coverage for ``validate_response``'s tolerant-twin fallback.
+
+    These target failure modes the old type-defaults implementation could not handle at
+    all: it had no default for a required enum or datetime field, so it produced ``None``
+    for them anyway, and the second (real) ``model_validate`` call then raised because
+    ``None`` is not a valid enum member or datetime -- the very omission the fallback was
+    supposed to tolerate blew up one call later instead.
+    """
+
+    dag_id = "dag_id"
+    dag_run_id = "dag_run_id"
+
+    def _dag_run_payload(self, dag_run_id: str | None = None) -> dict:
+        return json.loads(
+            DAGRunResponse(
+                dag_display_name=dag_run_id or self.dag_run_id,
+                dag_run_id=dag_run_id or self.dag_run_id,
+                dag_id=self.dag_id,
+                logical_date=datetime.datetime(2025, 1, 1),
+                queued_at=datetime.datetime(2025, 1, 1),
+                start_date=datetime.datetime(2025, 1, 1),
+                end_date=datetime.datetime(2025, 1, 1),
+                data_interval_start=datetime.datetime(2025, 1, 1),
+                data_interval_end=datetime.datetime(2025, 1, 1),
+                last_scheduling_decision=datetime.datetime(2025, 1, 1),
+                run_after=datetime.datetime(2025, 1, 1),
+                run_type=DagRunType.MANUAL,
+                state=DagRunState.RUNNING,
+                triggered_by=DagRunTriggeredByType.UI,
+                conf={},
+                note=None,
+                dag_versions=[],
+                duration=None,
+                triggering_user_name=None,
+                bundle_version=None,
+                partition_key=None,
+                partition_date=None,
+            ).model_dump_json()
+        )
+
+    def test_missing_required_enum_field_is_left_none(self):
+        """``DAGRunResponse.state`` is a required enum with no default -- the old
+        type-defaults fallback had no entry for it at all and produced ``None``, which the
+        second ``model_validate`` call then rejected as not being a valid enum member."""
+        payload = self._dag_run_payload()
+        del payload["state"]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.get(dag_id=self.dag_id, dag_run_id=self.dag_run_id)
+
+        assert response.state is None
+
+    def test_missing_required_datetime_field_is_left_none(self):
+        """``DAGRunResponse.run_after`` is a required datetime with no default."""
+        payload = self._dag_run_payload()
+        del payload["run_after"]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.get(dag_id=self.dag_id, dag_run_id=self.dag_run_id)
+
+        assert response.run_after is None
+
+    def test_tolerant_twin_instance_is_still_isinstance_of_the_original_model(self):
+        payload = self._dag_run_payload()
+        del payload["state"]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.dag_runs.get(dag_id=self.dag_id, dag_run_id=self.dag_run_id)
+
+        assert isinstance(response, DAGRunResponse)
+
+    def _dag_details_payload(self) -> dict:
+        return json.loads(
+            DAGDetailsResponse(
+                dag_id=self.dag_id,
+                dag_display_name=self.dag_id,
+                is_paused=False,
+                is_stale=False,
+                last_parsed_time=None,
+                last_parse_duration=None,
+                last_expired=None,
+                bundle_name=None,
+                bundle_version=None,
+                relative_fileloc=None,
+                fileloc=None,
+                description=None,
+                timetable_summary=None,
+                timetable_description=None,
+                timetable_partitioned=False,
+                timetable_periodic=True,
+                tags=[],
+                max_active_tasks=1,
+                max_active_runs=None,
+                max_consecutive_failed_dag_runs=1,
+                has_task_concurrency_limits=True,
+                has_import_errors=False,
+                next_dagrun_logical_date=None,
+                next_dagrun_data_interval_start=None,
+                next_dagrun_data_interval_end=None,
+                next_dagrun_run_after=None,
+                allowed_run_types=None,
+                owners=[],
+                catchup=False,
+                dag_run_timeout=None,
+                asset_expression=None,
+                doc_md=None,
+                start_date=None,
+                end_date=None,
+                is_paused_upon_creation=False,
+                params={},
+                render_template_as_native_obj=True,
+                template_search_path=None,
+                timezone=None,
+                last_parsed=None,
+                default_args=None,
+                is_backfillable=True,
+                file_token="file_token",
+                concurrency=1,
+                latest_dag_version=None,
+            ).model_dump_json()
+        )
+
+    def test_polymorphic_union_member_missing_a_required_field_still_raises(self):
+        """
+        Regression test for a real defect a prior version of the tolerant-twin builder had:
+        rewriting every member of a model-valued union (here
+        ``DAGDetailsResponse.asset_expression``) to its all-optional twin let pydantic's
+        smart-union match a payload shaped for one member -- but missing that member's
+        required subfields -- anyway, silently validating to an empty node instead of
+        raising. A polymorphic union (two or more non-``None`` model members) must never be
+        rewritten, so no member can swallow a malformed payload this way; only the field
+        being missing entirely may still fall back to ``None``.
+        """
+        payload = self._dag_details_payload()
+        del payload["timetable_periodic"]  # an unrelated field an older server omits
+        # Shaped like an AssetExpressionAsset leaf but missing its required "uri" and
+        # "group" -- no union member actually matches this payload.
+        payload["asset_expression"] = {"asset": {"name": "n"}}
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        with pytest.raises(ValidationError):
+            client.dags.get_details(dag_id=self.dag_id)
+
+    def test_execute_list_reassembly_tolerates_a_later_page_missing_a_field(self):
+        """
+        ``BaseOperations.execute_list`` reassembles pages by constructing a fresh
+        ``data_model`` and re-validating it. If a later page's item needed the tolerant
+        fallback for a required, non-Optional field (e.g. a missing ``bool``), that
+        reassembly must not re-raise on the very field it just tolerated.
+        """
+
+        class _StrictItem(BaseModel):
+            name: str
+            is_special: bool
+
+        class _StrictItemCollection(BaseModel):
+            items: list[_StrictItem]
+            total_entries: int
+
+        first_page = {"items": [{"name": "a", "is_special": True}], "total_entries": 2}
+        second_page_item = {"name": "b"}  # is_special omitted, as an older server would.
+
+        pages = [
+            Mock(content=json.dumps(first_page)),
+            Mock(content=json.dumps({"items": [second_page_item], "total_entries": 2})),
+        ]
+        mock_client = Mock()
+        mock_client.get.side_effect = pages
+        base_operation = BaseOperations(client=mock_client)
+
+        response = base_operation.execute_list(path="items", data_model=_StrictItemCollection, limit=1)
+
+        assert [item.name for item in response.items] == ["a", "b"]
+        assert response.items[0].is_special is True
+        assert response.items[1].is_special is None
+
+
+class TestTolerantModelBuilderCoversAllGeneratedModels:
+    """
+    Structural smoke test for the tolerant-twin builder itself.
+
+    Every non-``RootModel`` model in the generated datamodels must produce a tolerant twin
+    that validates an empty payload, proving the builder neither explodes nor infinitely
+    recurses on any of them -- including the two that are mutually self-referential
+    (``AssetExpressionAll`` <-> ``AssetExpressionAny``), which no longer needs a cycle guard
+    now that a polymorphic union (the only path back into either model) is never rewritten.
+    """
+
+    def test_every_generated_model_builds_a_tolerant_twin_that_validates_an_empty_payload(self):
+        models = [
+            obj
+            for obj in vars(generated_datamodels).values()
+            if isinstance(obj, type)
+            and issubclass(obj, BaseModel)
+            and not issubclass(obj, RootModel)
+            and obj.__module__ == generated_datamodels.__name__
+        ]
+        # A generous floor, not the exact count: guards against a filter bug (e.g. the
+        # RootModel exclusion swallowing everything) making this loop -- and the assertion
+        # below -- vacuously pass over zero models.
+        assert len(models) > 150
+
+        failures: dict[str, str] = {}
+        for model in models:
+            try:
+                twin = _tolerant_model(model)
+                twin.model_validate({})
+            except Exception as exc:
+                failures[model.__name__] = repr(exc)
+
+        assert failures == {}
+
+    def test_tolerant_twin_preserves_the_original_field_alias(self):
+        """
+        ``FieldInfo.merge_field_infos`` is a semi-public pydantic API; if a future pydantic
+        release changes how it copies metadata, this must fail loudly here rather than
+        silently drop the alias and only surface when a real server payload keyed by the
+        alias (``ConnectionsOperations`` reads/writes ``schema`` on the wire, see
+        ``ConnectionResponse.schema_``) fails to bind to the tolerant twin.
+        """
+        twin = _tolerant_model(ConnectionResponse)
+
+        assert twin.model_fields["schema_"].alias == "schema"
 
 
 class TestJobsOperations:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -1119,6 +1119,41 @@ class TestDagOperations:
         response = client.dags.get_details("dag_id")
         assert response == self.dag_details_response
 
+    @pytest.mark.parametrize(
+        ("operation", "path", "payload_attr"),
+        [
+            (lambda dags, patch_body: dags.get("dag_id"), "/api/v2/dags/dag_id", "dag_response"),
+            (
+                lambda dags, patch_body: dags.get_details("dag_id"),
+                "/api/v2/dags/dag_id/details",
+                "dag_details_response",
+            ),
+            (
+                lambda dags, patch_body: dags.update(dag_id="dag_id", dag_body=patch_body),
+                "/api/v2/dags/dag_id",
+                "dag_response",
+            ),
+        ],
+        ids=["get", "get_details", "update"],
+    )
+    @pytest.mark.parametrize("omitted_field", ["is_backfillable", "timetable_periodic"])
+    def test_single_object_response_tolerates_field_an_older_server_omits(
+        self, operation, path, payload_attr, omitted_field
+    ):
+        """A server on an older Airflow line omits fields the generated models declare as required."""
+        payload = json.loads(getattr(self, payload_attr).model_dump_json())
+        del payload[omitted_field]
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == path
+            return httpx.Response(200, json=payload)
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = operation(client.dags, self.dag_patch_body)
+
+        assert response.dag_id == self.dag_id
+        assert getattr(response, omitted_field) is False
+
     def test_get_tags(self):
         def handle_request(request: httpx.Request) -> httpx.Response:
             assert request.url.path == "/api/v2/dagTags"


### PR DESCRIPTION
airflowctl's datamodels are generated from the newest Airflow API spec, so a server on an older Airflow line legitimately omits fields the models declare as required. Collection responses already tolerated that via fill_missing_fields, added in #63388 for exactly this reason, but only inside execute_list. Every single-object response validated strictly, so commands such as dags get-details, dags unpause and dags update failed:

    ValidationError: 2 validation errors for DAGResponse
      is_backfillable      Field required
      timetable_periodic   Field required

against any Airflow older than the line the models were generated from.

Lift the validation out of execute_list into a shared validate_response() and use it for all 46 single-object responses. LoginOperations keeps strict validation on purpose — a defaulted token should fail loudly rather than be filled in.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
