### PR TITLE
Add Dag ID filtering to Assets search

### DIFF
--- a/airflow-core/newsfragments/70971.feature.rst
+++ b/airflow-core/newsfragments/70971.feature.rst
@@ -1,0 +1,1 @@
+Add a Dag ID filter to the Assets search page.

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.test.tsx
@@ -47,3 +47,24 @@ describe("FilterBar preset filters", () => {
     expect(screen.queryByTestId("preset-filters-button")).not.toBeInTheDocument();
   });
 });
+
+describe("FilterBar URL synchronization", () => {
+  const configs = [{ key: "dag_id", label: "Dag ID", type: "text" as const }];
+
+  it("updates an existing filter when its external value changes", () => {
+    const { rerender } = render(
+      <FilterBar configs={configs} initialValues={{ dag_id: "dag_a" }} onFiltersChange={vi.fn()} />,
+      { wrapper },
+    );
+
+    expect(screen.getByText("Dag ID: dag_a")).toBeInTheDocument();
+
+    rerender(<FilterBar configs={configs} initialValues={{ dag_id: "dag_b" }} onFiltersChange={vi.fn()} />);
+
+    expect(screen.getByText("Dag ID: dag_b")).toBeInTheDocument();
+
+    rerender(<FilterBar configs={configs} initialValues={{}} onFiltersChange={vi.fn()} />);
+
+    expect(screen.queryByText("Dag ID: dag_b")).not.toBeInTheDocument();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.test.tsx
@@ -258,3 +258,24 @@ describe("FilterBar keyboard handling", () => {
     await waitFor(() => expect(document.querySelector('input[id^="react-select"]')).not.toBeNull());
   });
 });
+
+describe("FilterBar URL synchronization", () => {
+  const configs = [{ key: "dag_id", label: "Dag ID", type: "text" as const }];
+
+  it("updates an existing filter when its external value changes", async () => {
+    const { rerender } = render(
+      <FilterBar configs={configs} initialValues={{ dag_id: "dag_a" }} onFiltersChange={vi.fn()} />,
+      { wrapper },
+    );
+
+    expect(screen.getByTestId("dag_id-pill")).toHaveTextContent("Dag ID: dag_a");
+
+    rerender(<FilterBar configs={configs} initialValues={{ dag_id: "dag_b" }} onFiltersChange={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByTestId("dag_id-pill")).toHaveTextContent("Dag ID: dag_b"));
+
+    rerender(<FilterBar configs={configs} initialValues={{}} onFiltersChange={vi.fn()} />);
+
+    await waitFor(() => expect(screen.queryByTestId("dag_id-pill")).not.toBeInTheDocument());
+  });
+});

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.tsx
@@ -90,19 +90,31 @@ export const FilterBar = ({
       const existingKeys = new Set(prevFilters.map((filter) => filter.config.key));
       const toAdd = pillsToAdd.filter((pill) => !existingKeys.has(pill.config.key));
 
-      // Remove pills that had a committed value but whose URL param was cleared externally.
-      const afterRemove = prevFilters.filter((filter) => {
-        const pillHadValue = isValidFilterValue(filter.config.type, filter.value);
-        const urlValue = initialValues[filter.config.key];
+      // Keep committed pills synchronized with external URL changes, including browser history.
+      const synchronizedFilters = prevFilters
+        .filter((filter) => {
+          const pillHadValue = isValidFilterValue(filter.config.type, filter.value);
+          const urlValue = initialValues[filter.config.key];
 
-        return !pillHadValue || isValidFilterValue(filter.config.type, urlValue);
-      });
+          return !pillHadValue || isValidFilterValue(filter.config.type, urlValue);
+        })
+        .map((filter) => {
+          const urlValue = initialValues[filter.config.key];
 
-      if (toAdd.length === 0 && afterRemove.length === prevFilters.length) {
+          return isValidFilterValue(filter.config.type, urlValue) && filter.value !== urlValue
+            ? { ...filter, value: urlValue }
+            : filter;
+        });
+
+      const filtersUnchanged =
+        synchronizedFilters.length === prevFilters.length &&
+        synchronizedFilters.every((filter, index) => filter === prevFilters[index]);
+
+      if (toAdd.length === 0 && filtersUnchanged) {
         return prevFilters;
       }
 
-      return [...afterRemove, ...toAdd];
+      return [...synchronizedFilters, ...toAdd];
     });
     // configs is intentionally omitted — it is structurally stable across renders and including
     // it would risk infinite re-render loops. initialValuesKey captures all relevant URL changes.

--- a/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.tsx
+++ b/airflow-core/src/airflow/ui/src/components/FilterBar/FilterBar.tsx
@@ -94,19 +94,30 @@ export const FilterBar = ({
       const existingKeys = new Set(prevFilters.map((filter) => filter.config.key));
       const toAdd = pillsToAdd.filter((pill) => !existingKeys.has(pill.config.key));
 
-      // Remove pills that had a committed value but whose URL param was cleared externally.
-      const afterRemove = prevFilters.filter((filter) => {
-        const pillHadValue = isValidFilterValue(filter.config.type, filter.value);
-        const urlValue = initialValues[filter.config.key];
+      const synchronizedFilters = prevFilters
+        .filter((filter) => {
+          const pillHadValue = isValidFilterValue(filter.config.type, filter.value);
+          const urlValue = initialValues[filter.config.key];
 
-        return !pillHadValue || isValidFilterValue(filter.config.type, urlValue);
-      });
+          return !pillHadValue || isValidFilterValue(filter.config.type, urlValue);
+        })
+        .map((filter) => {
+          const urlValue = initialValues[filter.config.key];
 
-      if (toAdd.length === 0 && afterRemove.length === prevFilters.length) {
+          return isValidFilterValue(filter.config.type, urlValue) && filter.value !== urlValue
+            ? { ...filter, value: urlValue }
+            : filter;
+        });
+
+      const filtersUnchanged =
+        synchronizedFilters.length === prevFilters.length &&
+        synchronizedFilters.every((filter, index) => filter === prevFilters[index]);
+
+      if (toAdd.length === 0 && filtersUnchanged) {
         return prevFilters;
       }
 
-      return [...afterRemove, ...toAdd];
+      return [...synchronizedFilters, ...toAdd];
     });
     // configs is intentionally omitted — it is structurally stable across renders and including
     // it would risk infinite re-render loops. initialValuesKey captures all relevant URL changes.

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.test.tsx
@@ -1,0 +1,110 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import type * as ReactRouterDom from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as OpenapiQueries from "openapi/queries";
+import type { FilterConfig } from "src/components/FilterBar";
+import { Wrapper } from "src/utils/Wrapper";
+
+import { AssetsList } from "./AssetsList";
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactRouterDom>();
+
+  return {
+    ...actual,
+    useSearchParams: () => [mockSearchParams, vi.fn()] as const,
+  };
+});
+
+vi.mock("openapi/queries", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenapiQueries>();
+
+  return {
+    ...actual,
+    useAssetServiceGetAssetsUi: vi.fn(),
+  };
+});
+
+vi.mock("src/components/DataTable", () => ({
+  DataTable: () => null,
+}));
+
+vi.mock("src/components/FilterBar", () => ({
+  FilterBar: ({ configs }: { readonly configs: Array<FilterConfig> }) => (
+    <div data-testid="asset-filters">
+      {configs.map(({ key, supportsAdvancedSearch }) => (
+        <span
+          data-advanced-search={supportsAdvancedSearch === true}
+          data-testid={`asset-filter-${key}`}
+          key={key}
+        >
+          {key}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("src/components/SearchBar", () => ({
+  SearchBar: () => null,
+}));
+
+vi.mock("src/queries/useConfig", () => ({
+  useConfig: (key: string) => (key === "fallback_page_limit" ? 50 : false),
+}));
+
+const { useAssetServiceGetAssetsUi } = await import("openapi/queries");
+
+const lastAssetsCall = () => vi.mocked(useAssetServiceGetAssetsUi).mock.calls.at(-1)?.[0];
+
+describe("AssetsList filters", () => {
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams();
+    vi.mocked(useAssetServiceGetAssetsUi).mockReturnValue({
+      data: { assets: [], total_entries: 0 },
+      error: null,
+      isLoading: false,
+    } as ReturnType<typeof useAssetServiceGetAssetsUi>);
+  });
+
+  it("offers an exact-match Dag ID filter", () => {
+    render(<AssetsList />, { wrapper: Wrapper });
+
+    expect(screen.getByTestId("asset-filter-dag_id")).toHaveAttribute("data-advanced-search", "false");
+  });
+
+  it("passes the selected Dag ID to the Assets API and omits it after clearing", () => {
+    mockSearchParams = new URLSearchParams("dag_id=consumer_dag");
+
+    const { rerender } = render(<AssetsList />, { wrapper: Wrapper });
+
+    expect(lastAssetsCall()?.dagIds).toEqual(["consumer_dag"]);
+
+    mockSearchParams = new URLSearchParams("dag_id=");
+    rerender(<AssetsList />);
+
+    expect(lastAssetsCall()?.dagIds).toBeUndefined();
+  });
+});

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.test.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 import "@testing-library/jest-dom";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { delay, http, HttpResponse } from "msw";
 import { setupServer, type SetupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -75,5 +75,57 @@ describe("AssetsList filtering", () => {
 
     expect(screen.getByText("asset_with_dependencies")).toBeInTheDocument();
     expect(screen.queryAllByTestId("skeleton")).toHaveLength(0);
+  });
+
+  it("offers Dag ID as an exact-match filter", async () => {
+    render(<AppWrapper initialEntries={["/assets"]} />);
+
+    fireEvent.click(await screen.findByTestId("add-filter-button"));
+    fireEvent.click(await screen.findByTestId("add-filter-dag_id"));
+
+    expect(await screen.findByTestId("filter-pill-input")).toBeInTheDocument();
+    // The page search keeps its own advanced-search toggle. An exact-match Dag ID
+    // filter must not add a second toggle inside its editor.
+    expect(screen.getAllByTestId("advanced-search-toggle")).toHaveLength(1);
+  });
+
+  it("passes the selected Dag ID to the Assets API and omits it after clearing", async () => {
+    const requestedDagIds: Array<Array<string>> = [];
+
+    server.use(
+      http.get("/ui/assets", ({ request }) => {
+        requestedDagIds.push(new URL(request.url).searchParams.getAll("dag_ids"));
+
+        return HttpResponse.json({ assets: [], total_entries: 0 });
+      }),
+    );
+
+    render(<AppWrapper initialEntries={["/assets?dag_id=consumer_dag"]} />);
+
+    await waitFor(() => expect(requestedDagIds.at(-1)).toEqual(["consumer_dag"]));
+
+    const dagIdPill = await screen.findByTestId("dag_id-pill");
+
+    fireEvent.click(within(dagIdPill).getByRole("button", { name: /Remove .* filter/u }));
+
+    await waitFor(() => expect(requestedDagIds.at(-1)).toEqual([]));
+    expect(screen.queryByTestId("dag_id-pill")).not.toBeInTheDocument();
+  });
+
+  it("ignores an empty Dag ID query parameter", async () => {
+    const requestedDagIds: Array<Array<string>> = [];
+
+    server.use(
+      http.get("/ui/assets", ({ request }) => {
+        requestedDagIds.push(new URL(request.url).searchParams.getAll("dag_ids"));
+
+        return HttpResponse.json({ assets: [], total_entries: 0 });
+      }),
+    );
+
+    render(<AppWrapper initialEntries={["/assets?dag_id="]} />);
+
+    await waitFor(() => expect(requestedDagIds.at(-1)).toEqual([]));
+    expect(screen.queryByTestId("dag_id-pill")).not.toBeInTheDocument();
   });
 });

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -38,6 +38,7 @@ import { useDocumentTitle, useFiltersHandler, type FilterableSearchParamsKeys } 
 import { DependencyPopover } from "./DependencyPopover";
 
 const assetsFilterKeys: Array<FilterableSearchParamsKeys> = [
+  SearchParamsKeys.DAG_ID,
   SearchParamsKeys.GROUP_PATTERN,
   SearchParamsKeys.LAST_ASSET_EVENT_TIMESTAMP_RANGE,
 ];
@@ -98,7 +99,7 @@ const createColumns = (translate: (key: string) => string): Array<ColumnDef<Asse
   },
 ];
 
-const { NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
+const { DAG_ID, NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
 
 export const AssetsList = () => {
   const { t: translate } = useTranslation(["assets", "common"]);
@@ -107,6 +108,7 @@ export const AssetsList = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const dagId = searchParams.get(DAG_ID);
   const namePattern = searchParams.get(NAME_PATTERN) ?? "";
   const advancedSearch = useAdvancedSearch("assets");
 
@@ -116,6 +118,9 @@ export const AssetsList = () => {
   const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-last_asset_event_timestamp"];
 
   const { filterConfigs, handleFiltersChange, initialValues } = useFiltersHandler(assetsFilterKeys);
+  const assetsFilterConfigs = filterConfigs.map((config) =>
+    config.key === DAG_ID ? { ...config, supportsAdvancedSearch: false } : config,
+  );
 
   const lastAssetEventTimestampGte = searchParams.get(SearchParamsKeys.LAST_ASSET_EVENT_TIMESTAMP_GTE);
   const lastAssetEventTimestampLte = searchParams.get(SearchParamsKeys.LAST_ASSET_EVENT_TIMESTAMP_LTE);
@@ -128,6 +133,7 @@ export const AssetsList = () => {
 
   const { data, error, isLoading } = useAssetServiceGetAssetsUi({
     ...groupArg,
+    dagIds: dagId === null || dagId === "" ? undefined : [dagId],
     lastAssetEventTimestampGte: lastAssetEventTimestampGte ?? undefined,
     lastAssetEventTimestampLte: lastAssetEventTimestampLte ?? undefined,
     limit: pagination.pageSize,
@@ -164,7 +170,7 @@ export const AssetsList = () => {
         />
 
         <FilterBar
-          configs={filterConfigs}
+          configs={assetsFilterConfigs}
           initialValues={initialValues}
           onFiltersChange={handleFiltersChange}
         />

--- a/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/AssetsList/AssetsList.tsx
@@ -44,6 +44,7 @@ import { useDocumentTitle, useFiltersHandler, type FilterableSearchParamsKeys } 
 import { DependencyPopover } from "./DependencyPopover";
 
 const assetsFilterKeys: Array<FilterableSearchParamsKeys> = [
+  SearchParamsKeys.DAG_ID,
   SearchParamsKeys.GROUP_PATTERN,
   SearchParamsKeys.LAST_ASSET_EVENT_TIMESTAMP_RANGE,
 ];
@@ -128,7 +129,7 @@ const createColumns = (translate: TFunction): Array<ColumnDef<AssetResponse>> =>
   },
 ];
 
-const { NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
+const { DAG_ID, NAME_PATTERN, OFFSET }: SearchParamsKeysType = SearchParamsKeys;
 
 export const AssetsList = () => {
   const { t: translate } = useTranslation(["assets", "common"]);
@@ -137,6 +138,7 @@ export const AssetsList = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const dagId = searchParams.get(DAG_ID);
   const namePattern = searchParams.get(NAME_PATTERN) ?? "";
   const advancedSearch = useAdvancedSearch("assets");
 
@@ -146,6 +148,9 @@ export const AssetsList = () => {
   const orderBy = sort ? [`${sort.desc ? "-" : ""}${sort.id}`] : ["-last_asset_event_timestamp"];
 
   const { filterConfigs, handleFiltersChange, initialValues } = useFiltersHandler(assetsFilterKeys);
+  const assetsFilterConfigs = filterConfigs.map((config) =>
+    config.key === DAG_ID ? { ...config, supportsAdvancedSearch: false } : config,
+  );
 
   const lastAssetEventTimestampGte = searchParams.get(SearchParamsKeys.LAST_ASSET_EVENT_TIMESTAMP_GTE);
   const lastAssetEventTimestampLte = searchParams.get(SearchParamsKeys.LAST_ASSET_EVENT_TIMESTAMP_LTE);
@@ -159,6 +164,7 @@ export const AssetsList = () => {
   const { data, error, isFetching, isLoading } = useAssetServiceGetAssetsUi(
     {
       ...groupArg,
+      dagIds: dagId === null || dagId === "" ? undefined : [dagId],
       lastAssetEventTimestampGte: lastAssetEventTimestampGte ?? undefined,
       lastAssetEventTimestampLte: lastAssetEventTimestampLte ?? undefined,
       limit: pagination.pageSize,
@@ -201,7 +207,7 @@ export const AssetsList = () => {
             placeholder={translate("searchPlaceholder")}
           />
           <FilterBar
-            configs={filterConfigs}
+            configs={assetsFilterConfigs}
             initialValues={initialValues}
             onFiltersChange={handleFiltersChange}
           />


### PR DESCRIPTION
## Summary

Adds an exact-match **Dag ID** filter to the Assets page, allowing users to find Assets related to a specific Dag using the existing filter-pill UI and Assets API.

Related to #53052.

## Changes

- Adds Dag ID to the existing Assets filter menu.
- Passes the selected ID to the existing Assets API.
- Stores the selection in the URL for sharing and reload persistence.
- Keeps existing filter-pill values synchronized with browser Back/Forward navigation.
- Ignores empty Dag IDs and preserves existing pagination-reset behavior.

## Scope

This addresses the Dag relationship-filtering part of #53052, not the entire issue.

The existing API includes Assets that schedule the selected Dag, are produced by its tasks, or are consumed by its tasks. This filter combines those relationships; it does not provide separate Consuming Dag or Producing Task selectors.

## Demo


https://github.com/user-attachments/assets/90db96d5-f2a3-45dc-9dfa-45abcb3f3724


Demonstrates Dag ID filtering, reload persistence, browser Back/Forward synchronization, and resetting filters.

## Testing

- Focused FilterBar and AssetsList tests: **21 passed**.
- Prettier, focused ESLint, TypeScript, and pre-commit hooks passed.
- Verified in the local Airflow UI: filtering, empty/nonexistent IDs, reload, Back/Forward, clearing/reset, pagination reset, combinations with existing name/group filters, and returning from Asset details.

The full manual-stage hook run was not completed.

## AI disclosure

- [x] Generative AI tooling was used to co-author this PR.

Generated-by: OpenAI Codex (GPT-5.6), following the [Airflow contribution guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions).