### PR TITLE
Stop airflow config update from writing a backup during dry-run

### DIFF
--- a/airflow-core/src/airflow/cli/commands/config_command.py
+++ b/airflow-core/src/airflow/cli/commands/config_command.py
@@ -933,8 +933,8 @@ def update_config(args) -> None:
     the breaking configuration changes by scanning the current configuration file for parameters that have
     been renamed, removed, or had their default values changed in Airflow 3.0. To see or fix all recommended
     changes, use the --all-recommendations argument. To automatically update your airflow.cfg file, use
-    the --fix argument. This command cleans up the existing comments in airflow.cfg but creates a backup of
-    the old airflow.cfg file.
+    the --fix argument. Applying --fix cleans up the existing comments in airflow.cfg, so a backup of the
+    old airflow.cfg file is written first. A dry-run leaves the filesystem untouched.
 
     CLI Arguments:
         --fix: flag (optional)
@@ -1058,14 +1058,6 @@ def update_config(args) -> None:
                 modifications.add_remove(conf_section, conf_option)
                 changes_applied.append(f"{prefix} Removed '{conf_section}/{conf_option}' from configuration.")
 
-    backup_path = f"{AIRFLOW_CONFIG}.bak"
-    try:
-        shutil.copy2(AIRFLOW_CONFIG, backup_path)
-        console.print(f"Backup saved as '{backup_path}'.")
-    except Exception as e:
-        console.print(f"Failed to create backup: {e}")
-        raise AirflowConfigException("Backup creation failed. Aborting update_config operation.")
-
     if dry_run:
         console.print("[blue]Dry-run mode enabled. No changes will be written to airflow.cfg.[/blue]")
         with StringIO() as config_output:
@@ -1078,6 +1070,14 @@ def update_config(args) -> None:
             new_config = config_output.getvalue()
         console.print(new_config)
     else:
+        backup_path = f"{AIRFLOW_CONFIG}.bak"
+        try:
+            shutil.copy2(AIRFLOW_CONFIG, backup_path)
+            console.print(f"Backup saved as '{backup_path}'.")
+        except Exception as e:
+            console.print(f"Failed to create backup: {e}")
+            raise AirflowConfigException("Backup creation failed. Aborting update_config operation.")
+
         with open(AIRFLOW_CONFIG, "w") as config_file:
             conf.write_custom_config(
                 file=config_file,

--- a/airflow-core/tests/unit/cli/commands/test_config_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_config_command.py
@@ -566,6 +566,29 @@ class TestCliConfigUpdate:
         assert initial_config in current_cfg, "Dry-run should not modify the config file."
 
     @conf_vars({("core", "executor"): "SequentialExecutor"})
+    def test_update_config_dry_run_does_not_touch_filesystem(self, tmp_path, monkeypatch, capsys):
+        cfg_file = tmp_path / "airflow.cfg"
+        cfg_file.write_text("[core]\nexecutor = SequentialExecutor\n")
+
+        monkeypatch.setattr(config_command, "AIRFLOW_CONFIG", str(cfg_file))
+        monkeypatch.setattr(conf, "write_custom_config", lambda file, **kwargs: file.write("preview_config"))
+
+        def read_only_copy2(src, dst):
+            raise OSError("Read-only file system")
+
+        monkeypatch.setattr(shutil, "copy2", read_only_copy2)
+
+        parser = cli_parser.get_parser()
+        args = parser.parse_args(["config", "update", "--all-recommendations"])
+
+        config_command.update_config(args)
+
+        output = capsys.readouterr().out
+        assert "preview_config" in output
+        assert "Backup saved as" not in output
+        assert not (tmp_path / "airflow.cfg.bak").exists()
+
+    @conf_vars({("core", "executor"): "SequentialExecutor"})
     def test_update_config_all_options_fix(self, tmp_path, monkeypatch, capsys):
         cfg_file = tmp_path / "airflow.cfg"
         initial_config = "[core]\nexecutor = SequentialExecutor\n"


### PR DESCRIPTION
`airflow config update` without `--fix` is documented as a dry-run, but it created the `airflow.cfg.bak` backup unconditionally before the dry-run branch. That meant a pure-preview command mutated the filesystem, and when the config directory is not writable the command aborted with `AirflowConfigException` before printing anything — so the preview the user asked for was never shown.

The backup now happens only on the `--fix` path, next to the write it protects.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
