### PR TITLE
Implement FabAuthManager.refresh_user for sliding JWT refresh

### DIFF
--- a/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
+++ b/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py
@@ -315,6 +315,11 @@ class FabAuthManager(BaseAuthManager[User]):
     def serialize_user(self, user: User) -> dict[str, Any]:
         return {"sub": str(user.id)}
 
+    def refresh_user(self, *, user: User) -> User | None:
+        if not user or user.is_anonymous:
+            return None
+        return user
+
     def is_logged_in(self) -> bool:
         """Return whether the user is logged in."""
         user = self.get_user()

--- a/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
+++ b/providers/fab/tests/unit/fab/auth_manager/test_fab_auth_manager.py
@@ -246,6 +246,19 @@ class TestFabAuthManager:
         result = auth_manager_with_appbuilder.serialize_user(user)
         assert result == {"sub": str(user.id)}
 
+    def test_refresh_user_returns_user_for_authenticated(self, auth_manager_with_appbuilder):
+        user = Mock()
+        user.is_anonymous = False
+        assert auth_manager_with_appbuilder.refresh_user(user=user) is user
+
+    def test_refresh_user_returns_none_for_anonymous(self, auth_manager_with_appbuilder):
+        user = Mock()
+        user.is_anonymous = True
+        assert auth_manager_with_appbuilder.refresh_user(user=user) is None
+
+    def test_refresh_user_returns_none_for_no_user(self, auth_manager_with_appbuilder):
+        assert auth_manager_with_appbuilder.refresh_user(user=None) is None
+
     @mock.patch.object(FabAuthManager, "get_user")
     def test_is_logged_in(self, mock_get_user, auth_manager_with_appbuilder):
         user = Mock()


### PR DESCRIPTION
### What?

Implements `FabAuthManager.refresh_user` so `JWTRefreshMiddleware` reissues the `_token` cookie on every request when the user is authenticated.

### Why?

`JWTRefreshMiddleware` (added in #55506, 3.1.4) drives sliding-refresh of the UI JWT by calling `auth_manager.refresh_user(user)`. `BaseAuthManager.refresh_user` is a no-op by default. `KeycloakAuthManager` overrides it — `FabAuthManager` does not. On FAB deployments (the default), the silent-refresh path does nothing, so long-open browser tabs burst 401s from concurrent `/ui/*` and `/api/v2/*` polls every `[api_auth] jwt_expiration_time` interval.

Symptom on our prod (Airflow 3.1.7 + FAB + Google OAuth):

```
[error] JWT token is not valid: Signature has expired
  [airflow.api_fastapi.auth.managers.base_auth_manager] loc=base_auth_manager.py:107
INFO: - "GET /ui/dashboard/dag_stats HTTP/1.1" 401 Unauthorized
INFO: - "GET /ui/dags?dag_runs_limit=14&limit=50&offset=0&exclude_stale=true&order_by=dag_display_name HTTP/1.1" 401 Unauthorized
INFO: - "GET /api/v2/dags/~/dagRuns/~/hitlDetails?state=deferred&response_received=false HTTP/1.1" 401 Unauthorized
```

Related open issue: #57065.

### How?

Return the current user for authenticated (non-anonymous) FAB sessions. `deserialize_user` above already re-fetches the user from DB by `token["sub"]`, so the object is fresh — returning it is safe and adds only one HS512 sign per request (sub-ms).

For anonymous / no user, return `None` to skip the reissue.

### Tests

Three unit tests covering: authenticated user → returns user; anonymous user → returns None; no user → returns None.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines) for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, following [instructions located in the newsfragments README.rst](https://github.com/apache/airflow/blob/main/newsfragments/README.rst)