### PR TITLE
Fix Dag callbacks silently dropped when version inflation check blocks parsing

### DIFF
--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -237,7 +237,12 @@ def _parse_file(msg: DagFileParseRequest, log: FilteringBoundLogger) -> DagFileP
 
     stability_check_result = check_dag_file_stability(os.fspath(msg.file))
 
-    if stability_check_error_dict := stability_check_result.get_error_format_dict(msg.file, msg.bundle_path):
+    # Callback runs must not be blocked by the stability check: callbacks for
+    # already-scheduled runs still have to execute, and they never produce a
+    # parsing result anyway.
+    if not msg.callback_requests and (
+        stability_check_error_dict := stability_check_result.get_error_format_dict(msg.file, msg.bundle_path)
+    ):
         # If Dag stability check level is error, we shouldn't parse the Dags and return the result early
         return DagFileParsingResult(
             fileloc=msg.file,

--- a/airflow-core/tests/unit/dag_processing/test_processor.py
+++ b/airflow-core/tests/unit/dag_processing/test_processor.py
@@ -681,6 +681,48 @@ def test_parse_file_static_check_with_error():
     assert "Don't use the variables as arguments" in next(iter(result.import_errors.values()))
 
 
+@conf_vars({("dag_processor", "dag_version_inflation_check_level"): "error"})
+def test_parse_file_static_check_error_still_executes_callbacks(spy_agency):
+    """Callbacks for already-scheduled runs must run even when the stability check blocks parsing."""
+    from airflow import DAG
+
+    called = False
+
+    def on_failure(context):
+        nonlocal called
+        called = True
+
+    dag = DAG(dag_id="a", on_failure_callback=on_failure)
+
+    def fake_collect_dags(self, *args, **kwargs):
+        self.dags[dag.dag_id] = dag
+
+    spy_agency.spy_on(DagBag.collect_dags, call_fake=fake_collect_dags, owner=DagBag)
+
+    requests = [
+        DagCallbackRequest(
+            filepath="test_dag_version_inflation_check.py",
+            msg="Message",
+            dag_id="a",
+            run_id="b",
+            bundle_name="testing",
+            bundle_version=None,
+        )
+    ]
+    result = _parse_file(
+        DagFileParseRequest(
+            file=f"{TEST_DAG_FOLDER}/test_dag_version_inflation_check.py",
+            bundle_path=TEST_DAG_FOLDER,
+            bundle_name="testing",
+            callback_requests=requests,
+        ),
+        log=structlog.get_logger(),
+    )
+
+    assert result is None
+    assert called is True
+
+
 def test_parse_file_static_check_with_default_warning():
     result = _parse_file(
         DagFileParseRequest(


### PR DESCRIPTION
The Dag version inflation stability check returns early from _parse_file before the callback branch runs. With dag_version_inflation_check_level set to "error", any file that trips the check never executes its pending callback requests (on_failure_callback, on_retry_callback, failure emails), and since the manager already popped them from its queue they are lost permanently with no log. Callbacks belong to already-scheduled runs and are independent of whether new Dag versions may be serialized, so they must still execute.

 