### PR TITLE
Fix Slack failure alerts going silent when several jobs fail

### DIFF
--- a/.github/workflows/ci-amd.yml
+++ b/.github/workflows/ci-amd.yml
@@ -1190,6 +1190,9 @@ jobs:
           echo "failed-jobs<<EOF" >> "${GITHUB_OUTPUT}"
           echo "${FAILED_JOBS}" >> "${GITHUB_OUTPUT}"
           echo "EOF" >> "${GITHUB_OUTPUT}"
+          # A literal newline would end the double-quoted YAML scalar the Slack payload
+          # interpolates job names into, and the action would reject the whole payload.
+          echo "failed-jobs-text=${FAILED_JOBS//$'\n'/\\n}" >> "${GITHUB_OUTPUT}"
           if [[ -n "${FAILED_JOBS}" ]]; then
             echo "has-failures=true" >> "${GITHUB_OUTPUT}"
           else
@@ -1224,12 +1227,12 @@ jobs:
           # yamllint disable rule:line-length
           payload: |
             channel: "internal-airflow-ci-cd"
-            text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+            text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+                  text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
           # yamllint enable rule:line-length
       - name: "Notify Slack (still not fixed)"
         if: steps.notification.outputs.action == 'notify_reminder'
@@ -1240,12 +1243,12 @@ jobs:
           # yamllint disable rule:line-length
           payload: |
             channel: "internal-airflow-ci-cd"
-            text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+            text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+                  text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
           # yamllint enable rule:line-length
       - name: "Notify Slack (all tests passing)"
         if: steps.notification.outputs.action == 'notify_recovery'

--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -1179,6 +1179,9 @@ jobs:
           echo "failed-jobs<<EOF" >> "${GITHUB_OUTPUT}"
           echo "${FAILED_JOBS}" >> "${GITHUB_OUTPUT}"
           echo "EOF" >> "${GITHUB_OUTPUT}"
+          # A literal newline would end the double-quoted YAML scalar the Slack payload
+          # interpolates job names into, and the action would reject the whole payload.
+          echo "failed-jobs-text=${FAILED_JOBS//$'\n'/\\n}" >> "${GITHUB_OUTPUT}"
           if [[ -n "${FAILED_JOBS}" ]]; then
             echo "has-failures=true" >> "${GITHUB_OUTPUT}"
           else
@@ -1213,12 +1216,12 @@ jobs:
           # yamllint disable rule:line-length
           payload: |
             channel: "internal-airflow-ci-cd"
-            text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+            text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+                  text: "🚨 Failure Alert: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
           # yamllint enable rule:line-length
       - name: "Notify Slack (still not fixed)"
         if: steps.notification.outputs.action == 'notify_reminder'
@@ -1229,12 +1232,12 @@ jobs:
           # yamllint disable rule:line-length
           payload: |
             channel: "internal-airflow-ci-cd"
-            text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+            text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on branch *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
             blocks:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
+                  text: "🚨🔁 Still not fixed: Scheduled CI (${{ needs.build-info.outputs.platform }}) on *${{ github.ref_name }}*\n\nFailing jobs:\n${{ steps.get-failures.outputs.failed-jobs-text }}\n\n*Details:* <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View the failure log>"
           # yamllint enable rule:line-length
       - name: "Notify Slack (all tests passing)"
         if: steps.notification.outputs.action == 'notify_recovery'


### PR DESCRIPTION
## Why

Scheduled canary failures have gone unreported on Slack since 2026-07-25 whenever more than one job failed in a run. The `get-failures` writes the failing job names into a multi-line step output inside a double-quoted YAML scalar. With one failing job there is no newline and it works. With two or more, the literal newline ends the scalar.

https://github.com/apache/airflow/actions/runs/30161651631/job/89694403096

Example payload:
```
  channel: "internal-airflow-ci-cd"
  text: "🚨 Failure Alert: Scheduled CI (linux/amd64) on branch *main*\n\nFailing jobs:\nBuild PROD images / Build Airflow and provider distributions
  Helm tests / Unit tests Helm: airflow_aux (K8S 1.35.0)\n\n*Details:* <https://github.com/apache/airflow/actions/runs/30161651631|View the failure log>"
  blocks:
    - type: "section"
      text:
        type: "mrkdwn"
        text: "🚨 Failure Alert: Scheduled CI (linux/amd64) on *main*\n\nFailing jobs:\nBuild PROD images / Build Airflow and provider distributions
  Helm tests / Unit tests Helm: airflow_aux (K8S 1.35.0)\n\n*Details:* <https://github.com/apache/airflow/actions/runs/30161651631|View the failure log>"
```

Error message:
```
Error: Invalid input! Failed to parse contents of the provided payload
SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
```

Other CI example:
* https://github.com/apache/airflow/actions/runs/30185325862/job/89754191567
* https://github.com/apache/airflow/actions/runs/30394416274/job/90412450542
* https://github.com/apache/airflow/actions/runs/30418119641/job/90481449309

## How

Use `${FAILED_JOBS_TEXT//$'\n'/\\n}` to decode `\n` as a literal `n` instead of a line break.

## Verification

Download  the action:

```
SHA=dcb1066f776dd043e64d0e8ba94ca15cc7e1875d
mkdir -p act && cd act
for f in index.js sourcemap-register.cjs package.json; do
  gh api "repos/slackapi/slack-github-action/contents/dist/$f?ref=$SHA" \
     -H "Accept: application/vnd.github.raw" > "$f"
done
```

### On main branch

This will show error message like above
```
FAILED_JOBS=$(printf '%s\n' \
  'Airflow CTL tests / airflow-ctl:P3.10 tests' \
  'Airflow CTL tests / airflow-ctl:P3.11 tests' \
  'Airflow CTL tests / airflow-ctl:P3.12 tests' \
  'Airflow CTL tests / airflow-ctl:P3.13 tests' \
  'Airflow CTL tests / airflow-ctl:P3.14 tests')

.venv/bin/python - .github/workflows/ci-amd.yml "$FAILED_JOBS" > act/old-payload.txt <<'PY'
import re, sys, yaml
wf = yaml.safe_load(open(sys.argv[1]))
step = next(s for s in wf["jobs"]["notify-slack"]["steps"] if "payload" in s.get("with", {}))
ctx = {"steps.get-failures.outputs.failed-jobs": sys.argv[2],
       "needs.build-info.outputs.platform": "linux/amd64", "github.ref_name": "main",
       "github.repository": "apache/airflow", "github.run_id": "30552911470"}
print(re.sub(r"\$\{\{\s*(.+?)\s*\}\}", lambda m: ctx.get(m.group(1), ""), step["with"]["payload"]), end="")
PY

cd act

env INPUT_METHOD="chat.postMessage" INPUT_TOKEN="xoxb-fake" \
    INPUT_PAYLOAD="$(cat old-payload.txt)" \
    INPUT_ERRORS="true" INPUT_RETRIES="0" "INPUT_PAYLOAD-TEMPLATED=false" \
    GITHUB_OUTPUT=/tmp/o GITHUB_ENV=/tmp/e node index.js
```

## On this branch

The error message change to "fetch failed", because we don't really have this server in local. The failure is not decoding error.
```
FAILED_JOBS=$(printf '%s\n' \
  'Airflow CTL tests / airflow-ctl:P3.10 tests' \
  'Airflow CTL tests / airflow-ctl:P3.11 tests' \
  'Airflow CTL tests / airflow-ctl:P3.12 tests' \
  'Airflow CTL tests / airflow-ctl:P3.13 tests' \
  'Airflow CTL tests / airflow-ctl:P3.14 tests')

FAILED_JOBS_TEXT=${FAILED_JOBS//$'\n'/\\n}

.venv/bin/python - .github/workflows/ci-amd.yml "$FAILED_JOBS_TEXT" > act/new-payload.txt <<'PY'
import re, sys, yaml
wf = yaml.safe_load(open(sys.argv[1]))
step = next(s for s in wf["jobs"]["notify-slack"]["steps"] if "payload" in s.get("with", {}))
ctx = {"steps.get-failures.outputs.failed-jobs-text": sys.argv[2],
       "needs.build-info.outputs.platform": "linux/amd64", "github.ref_name": "main",
       "github.repository": "apache/airflow", "github.run_id": "30552911470"}
print(re.sub(r"\$\{\{\s*(.+?)\s*\}\}", lambda m: ctx.get(m.group(1), ""), step["with"]["payload"]), end="")
PY

cd act

env INPUT_METHOD="chat.postMessage" INPUT_TOKEN="xoxb-fake" \
    INPUT_API="http://127.0.0.1:9/" \
    INPUT_PAYLOAD="$(cat new-payload.txt)" \
    INPUT_ERRORS="true" INPUT_RETRIES="0" "INPUT_PAYLOAD-TEMPLATED=false" \
    GITHUB_OUTPUT=/tmp/o GITHUB_ENV=/tmp/e node index.js
```


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
