### PR TITLE
Fix airflowctl list operations ignoring the requested offset

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -220,7 +220,7 @@ class BaseOperations:
                 raw = fill_missing_fields(json.loads(content), data_model)
                 return data_model.model_validate(raw)  # type: ignore[union-attr]
 
-        self.response = self.client.get(path, params=shared_params)
+        self.response = self.client.get(path, params={**shared_params, "offset": offset})
         first_pass = safe_validate(self.response.content)
         total_entries = first_pass.total_entries  # type: ignore[attr-defined]
         if total_entries < limit:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -252,19 +252,27 @@ class TestBaseOperations:
 
     def test_execute_list_sends_offset_to_server(self):
         """``offset`` must reach the server on the first request, not only on subsequent pages."""
+        rows = [{"name": name} for name in "abcdef"]
+
+        def paged(path, params):
+            # An absent ``offset`` is what the server would see as its own default of 0.
+            start = params.get("offset", 0)
+            return Mock(
+                content=json.dumps(
+                    {"hellos": rows[start : start + params["limit"]], "total_entries": len(rows)}
+                )
+            )
+
         mock_client = Mock()
-        mock_client.get.side_effect = [
-            Mock(content=json.dumps({"hellos": [{"name": "c"}, {"name": "d"}], "total_entries": 6})),
-            Mock(content=json.dumps({"hellos": [{"name": "e"}, {"name": "f"}], "total_entries": 6})),
-        ]
+        mock_client.get.side_effect = paged
         base_operation = BaseOperations(client=mock_client)
 
         response = base_operation.execute_list(
             path="hello", data_model=HelloCollectionResponse, offset=2, limit=2
         )
 
-        assert [call.kwargs["params"]["offset"] for call in mock_client.get.call_args_list] == [2, 4]
-        # The paging loop resumes at offset + limit, so a dropped offset also skips rows 2-3.
+        assert [hello.name for hello in response.hellos] == ["c", "d", "e", "f"]
+
         assert [hello.name for hello in response.hellos] == ["c", "d", "e", "f"]
 
     @pytest.mark.parametrize("limit", [0, -1])

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -273,8 +273,6 @@ class TestBaseOperations:
 
         assert [hello.name for hello in response.hellos] == ["c", "d", "e", "f"]
 
-        assert [hello.name for hello in response.hellos] == ["c", "d", "e", "f"]
-
     @pytest.mark.parametrize("limit", [0, -1])
     def test_execute_list_rejects_non_positive_limit(self, limit):
         mock_client = Mock()

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -250,6 +250,23 @@ class TestBaseOperations:
         for call in mock_client.get.call_args_list:
             assert call.kwargs["params"]["limit"] == 2
 
+    def test_execute_list_sends_offset_to_server(self):
+        """``offset`` must reach the server on the first request, not only on subsequent pages."""
+        mock_client = Mock()
+        mock_client.get.side_effect = [
+            Mock(content=json.dumps({"hellos": [{"name": "c"}, {"name": "d"}], "total_entries": 6})),
+            Mock(content=json.dumps({"hellos": [{"name": "e"}, {"name": "f"}], "total_entries": 6})),
+        ]
+        base_operation = BaseOperations(client=mock_client)
+
+        response = base_operation.execute_list(
+            path="hello", data_model=HelloCollectionResponse, offset=2, limit=2
+        )
+
+        assert [call.kwargs["params"]["offset"] for call in mock_client.get.call_args_list] == [2, 4]
+        # The paging loop resumes at offset + limit, so a dropped offset also skips rows 2-3.
+        assert [hello.name for hello in response.hellos] == ["c", "d", "e", "f"]
+
     @pytest.mark.parametrize("limit", [0, -1])
     def test_execute_list_rejects_non_positive_limit(self, limit):
         mock_client = Mock()


### PR DESCRIPTION
## Summary

`BaseOperations.execute_list` accepts an `offset` but never sent it on the first request, so paging started at the server default while the loop still resumed at `offset + limit` — a non-zero offset both returned the wrong first page and skipped the rows in between. `offset=100, limit=2` returned rows 0-1, then jumped to row 102.

Nothing released is affected: no caller passes `offset`, and `jobs list` takes a separate path when one is given. But the parameter is public on the signature and silently discarded, so the first caller to use it gets wrong results rather than an error.

## Compatibility

Sending `offset=0` is equivalent to omitting it — the API's `QueryOffset` already defaults to `0`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)