### PR TITLE
Document the 409 from XCom create and drop a duplicated condition

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -7027,6 +7027,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPExceptionResponse'
           description: Not Found
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPExceptionResponse'
+          description: Conflict
         '422':
           description: Validation Error
           content:

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/xcom.py
@@ -237,6 +237,7 @@ def get_xcom_entries(
         [
             status.HTTP_400_BAD_REQUEST,
             status.HTTP_404_NOT_FOUND,
+            status.HTTP_409_CONFLICT,
         ]
     ),
     dependencies=[
@@ -269,10 +270,9 @@ def create_xcom_entry(
 
     # Validate Dag Run ID
     if not dag_run:
-        if not dag_run:
-            raise HTTPException(
-                status.HTTP_404_NOT_FOUND, f"Dag Run with ID: `{dag_run_id}` not found for dag: `{dag_id}`"
-            )
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"Dag Run with ID: `{dag_run_id}` not found for dag: `{dag_id}`"
+        )
 
     # Check existing XCom
     already_existing_query = XComModel.get_many(

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -4291,6 +4291,7 @@ export class XcomService {
                 401: 'Unauthorized',
                 403: 'Forbidden',
                 404: 'Not Found',
+                409: 'Conflict',
                 422: 'Validation Error'
             }
         });

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -8082,6 +8082,10 @@ export type $OpenApiTs = {
                  */
                 404: HTTPExceptionResponse;
                 /**
+                 * Conflict
+                 */
+                409: HTTPExceptionResponse;
+                /**
                  * Validation Error
                  */
                 422: HTTPValidationError;


### PR DESCRIPTION
## Sumarry

Two small fixes to `POST /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/xcomEntries`.

**The 409 was undocumented.** The handler returns `409 Conflict` when an XCom with
that key already exists for the task instance, but `create_openapi_http_exception_doc`
only declared `400` and `404`. Clients generated from the spec therefore had no
model for a status the endpoint really does return. Same class of fix as #67570
and #67571.

**A duplicated condition.** The Dag-run check was nested inside an identical copy of
itself:

```python
if not dag_run:
    if not dag_run:
        raise HTTPException(status.HTTP_404_NOT_FOUND, ...)
```
Dead code, no behaviour change.

`v2-rest-api-generated.yaml` and `ui/openapi-gen/` are regenerated from the changed
`responses=` declaration.
