### PR TITLE
Improve assets list performance

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import subqueryload
+from sqlalchemy.orm import selectinload
 
 from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel
 
@@ -45,10 +45,10 @@ def generate_assets_with_last_event_query() -> Select:
         .outerjoin(max_asset_event_id_query, AssetModel.id == max_asset_event_id_query.c.asset_id)
         .outerjoin(AssetEvent, AssetEvent.id == max_asset_event_id_query.c.max_asset_event_id)
         .options(
-            subqueryload(AssetModel.scheduled_dags),
-            subqueryload(AssetModel.producing_tasks),
-            subqueryload(AssetModel.consuming_tasks),
-            subqueryload(AssetModel.aliases),
-            subqueryload(AssetModel.watchers).joinedload(AssetWatcherModel.trigger),
+            selectinload(AssetModel.scheduled_dags),
+            selectinload(AssetModel.producing_tasks),
+            selectinload(AssetModel.consuming_tasks),
+            selectinload(AssetModel.aliases),
+            selectinload(AssetModel.watchers).joinedload(AssetWatcherModel.trigger),
         )
     )

--- a/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.test.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.test.tsx
@@ -16,13 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { QueryClient } from "@tanstack/react-query";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type * as OpenapiQueries from "openapi/queries";
-import type { AssetResponse, DAGDetailsResponse } from "openapi/requests/types.gen";
+import type { AssetEventResponse, AssetResponse, DAGDetailsResponse } from "openapi/requests/types.gen";
 import type { DagRunTriggerParams } from "src/components/TriggerDag/types";
 import type * as Ui from "src/components/ui";
 import { Wrapper } from "src/utils/Wrapper";
@@ -90,6 +91,7 @@ vi.mock("openapi/queries", async (importOriginal) => {
 
 const {
   useAssetServiceCreateAssetEvent,
+  useAssetServiceGetAssetsUiKey,
   useAssetServiceMaterializeAsset,
   useDagServiceGetDagDetails,
   useDependenciesServiceGetDependencies,
@@ -167,6 +169,19 @@ describe("CreateAssetEventModal", () => {
     expect(createAssetEvent).toHaveBeenCalledWith({
       requestBody: expect.objectContaining({ partition_key: null }) as unknown,
     });
+  });
+
+  it("invalidates the assets list cache after creating an event", async () => {
+    const invalidateSpy = vi.spyOn(QueryClient.prototype, "invalidateQueries").mockResolvedValue();
+
+    render(<CreateAssetEventModal asset={asset} onClose={vi.fn()} open />, { wrapper: Wrapper });
+
+    const onSuccess = vi.mocked(useAssetServiceCreateAssetEvent).mock.calls.at(-1)?.[0]?.onSuccess as
+      ((data: AssetEventResponse) => Promise<void>) | undefined;
+
+    await onSuccess?.({ id: 1 } as unknown as AssetEventResponse);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: [useAssetServiceGetAssetsUiKey] });
   });
 
   it("sends the entered manual partition key as-is", () => {

--- a/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Asset/CreateAssetEventModal.tsx
@@ -25,6 +25,7 @@ import { FiPlay } from "react-icons/fi";
 import {
   useAssetServiceCreateAssetEvent,
   UseAssetServiceGetAssetEventsKeyFn,
+  useAssetServiceGetAssetsUiKey,
   useAssetServiceMaterializeAsset,
   UseDagRunServiceGetDagRunsKeyFn,
   useDagServiceGetDagDetails,
@@ -78,7 +79,12 @@ export const CreateAssetEventModal = ({ asset, onClose, open }: Props) => {
     setPartitionKey(undefined);
     onClose();
 
-    let queryKeys = [UseAssetServiceGetAssetEventsKeyFn({ assetId: asset.id }, [{ assetId: asset.id }])];
+    let queryKeys = [
+      UseAssetServiceGetAssetEventsKeyFn({ assetId: asset.id }, [{ assetId: asset.id }]),
+      // The Assets list defaults to sorting by last asset event, so a new event changes both the
+      // displayed timestamp and the row's position; refresh it for manual events and materializes.
+      [useAssetServiceGetAssetsUiKey],
+    ];
 
     if ("dag_run_id" in response) {
       const dagId = response.dag_id;

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -31,9 +31,11 @@ from airflow.models.asset import (
     AssetEvent,
     AssetModel,
     AssetPartitionDagRun,
+    AssetWatcherModel,
     DagScheduleAssetReference,
     PartitionedAssetKeyLog,
 )
+from airflow.models.trigger import Trigger
 from airflow.partition_mappers.base import RollupMapper
 from airflow.partition_mappers.temporal import StartOfHourMapper
 from airflow.partition_mappers.window import HourWindow
@@ -746,12 +748,23 @@ class TestGetAssetsUi:
 
     def test_query_count(self, test_client, session):
         """The asset relationships are eager-loaded, so the query count stays fixed regardless of
-        how many assets are returned (a lazy-loading regression would issue queries per asset)."""
-        for i in range(5):
-            asset = AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset")
-            session.add(asset)
-            session.add(AssetActive.for_asset(asset))
+        how many assets are returned (a lazy-loading regression would issue queries per asset).
+
+        At least two assets carry a watcher (with a trigger) and an alias so the count guards the
+        ``selectinload`` of every relationship, including the nested ``watchers -> trigger`` join.
+        """
+        assets = [AssetModel(name=f"asset{i}", uri=f"s3://bucket/asset{i}", group="asset") for i in range(5)]
+        session.add_all(assets)
+        session.add_all(AssetActive.for_asset(asset) for asset in assets)
+        session.flush()
+
+        for i in range(2):
+            trigger = Trigger(classpath=f"airflow.triggers.testing.TestTrigger{i}", kwargs={})
+            session.add(trigger)
+            session.flush()
+            assets[i].watchers.append(AssetWatcherModel(name=f"watcher{i}", trigger_id=trigger.id))
+            assets[i].aliases.append(AssetAliasModel(name=f"alias{i}", group=""))
         session.commit()
 
-        with assert_queries_count(7):
+        with assert_queries_count(8):
             assert test_client.get("/assets").status_code == 200


### PR DESCRIPTION
Follow up of  https://github.com/apache/airflow/pull/69940 to address comments after it was merged.

Swap `subqueryload` for `selectinload`



---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
