### PR TITLE
Mark lineage hashes as non-security

### DIFF
--- a/task-sdk/src/airflow/sdk/lineage.py
+++ b/task-sdk/src/airflow/sdk/lineage.py
@@ -125,7 +125,7 @@ class HookLineageCollector(LoggingMixin):
         even if that means a less precise encoding.
         """
         value_str = json.dumps(value, sort_keys=True, default=str)
-        value_hash = hashlib.md5(value_str.encode()).hexdigest()
+        value_hash = hashlib.md5(value_str.encode(), usedforsecurity=False).hexdigest()
         return value_hash
 
     def _generate_asset_entry_id(self, asset: Asset, context: LineageContext) -> str:


### PR DESCRIPTION
Marks the deterministic MD5 lineage identifier as [non-security](https://docs.python.org/3/library/hashlib.html#hashlib.md5), keeping it usable in FIPS-enabled Python environments.

Otherwise, a successful task may fail with this error:
```
Task failed with exception
UnsupportedDigestmodError: [digital envelope routines] unsupported

File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1325 in run
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1825 in _push_xcom_if_needed
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 716 in _xcom_push
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/bases/xcom.py", line 77 in set
File "/opt/airflow/plugins/dd_airflow_xcom_backend/dd_airflow_xcom_backend.py", line 74 in serialize_value
File "/usr/local/lib/python3.12/site-packages/airflow/providers/common/io/xcom/backend.py", line 150 in serialize_value
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/io/path.py", line 59 in wrapper
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/lineage.py", line 250 in add_output_asset
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/lineage.py", line 139 in _generate_asset_entry_id
File "/usr/local/lib/python3.12/site-packages/airflow/sdk/lineage.py", line 128 in _generate_hash
```

I'm also open to swapping it to another algorithm which is FIPS compliant (like sha256).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)