### PR TITLE
Avoid backlink noise when notifying PRs of uv.lock conflicts

### DIFF
--- a/scripts/ci/notify_uv_lock_conflicts.py
+++ b/scripts/ci/notify_uv_lock_conflicts.py
@@ -237,6 +237,15 @@ def resolve_source_pr(
         return None
 
 
+def avoid_backlink(url: str) -> str:
+    """Swap ``github.com`` for ``redirect.github.com`` so linking to the source
+    PR/commit doesn't generate an automatic backlink comment on it.
+
+    See: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#avoiding-backlinks-to-linked-references
+    """
+    return url.replace("https://github.com/", "https://redirect.github.com/", 1)
+
+
 def build_body(source_ref_md: str) -> str:
     return "\n".join(
         [
@@ -424,13 +433,16 @@ def main() -> int:
     with GitHubGraphQL(token) as client:
         source_pr = resolve_source_pr(client, owner, repo, sha, short_sha)
         if source_pr:
+            # Use redirect.github.com for both links: they point at the PR/commit
+            # that caused this notice, and a plain github.com link would generate
+            # an unwanted backlink comment there.
             source_ref_md = (
-                f"[#{source_pr['number']}]({source_pr['url']}) "
-                f'("{source_pr["title"]}"), commit [`{short_sha}`]({commit_url})'
+                f"[#{source_pr['number']}]({avoid_backlink(source_pr['url'])}) "
+                f'("{source_pr["title"]}"), commit [`{short_sha}`]({avoid_backlink(commit_url)})'
             )
             source_ref_plain = f"#{source_pr['number']} ({source_pr['url']}) — commit {short_sha}"
         else:
-            source_ref_md = f"commit [`{short_sha}`]({commit_url})"
+            source_ref_md = f"commit [`{short_sha}`]({avoid_backlink(commit_url)})"
             source_ref_plain = f"commit {short_sha}"
 
         log(f"Source of uv.lock change: {source_ref_plain}")

--- a/scripts/tests/ci/test_notify_uv_lock_conflicts.py
+++ b/scripts/tests/ci/test_notify_uv_lock_conflicts.py
@@ -161,6 +161,35 @@ class TestClassify:
         assert entry["existing"] == {"id": "C1", "body": f"{mod.MARKER}\nolder notice for deadbee"}
 
 
+class TestAvoidBacklink:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (
+                "https://github.com/apache/airflow/pull/42",
+                "https://redirect.github.com/apache/airflow/pull/42",
+            ),
+            (
+                "https://github.com/apache/airflow/commit/deadbeef",
+                "https://redirect.github.com/apache/airflow/commit/deadbeef",
+            ),
+        ],
+    )
+    def test_rewrites_github_com(self, mod, url, expected):
+        assert mod.avoid_backlink(url) == expected
+
+    def test_leaves_non_github_url_untouched(self, mod):
+        url = "https://example.com/pull/42"
+        assert mod.avoid_backlink(url) == url
+
+    def test_only_rewrites_leading_occurrence(self, mod):
+        """Only the URL's own host is rewritten, not incidental later occurrences."""
+        url = "https://github.com/apache/airflow/pull/42#see-https://github.com/other"
+        assert mod.avoid_backlink(url) == (
+            "https://redirect.github.com/apache/airflow/pull/42#see-https://github.com/other"
+        )
+
+
 class TestBuildBody:
     def test_includes_marker_source_and_instructions(self, mod):
         body = mod.build_body("[#42](https://example/pr/42)")


### PR DESCRIPTION
The uv.lock conflict notifier (scripts/ci/notify_uv_lock_conflicts.py)
posts a comment on conflicting PRs linking back to the PR/commit that
bumped uv.lock on main. Because GitHub auto-generates a backlink
comment on any issue/PR referenced this way, every notification also
produced an unwanted comment on the original PR — noise unrelated to
its own discussion.

GitHub's docs describe using the redirect.github.com host instead of
github.com to suppress this automatic backlink behavior:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#avoiding-backlinks-to-linked-references

This adds an `avoid_backlink()` helper and applies it to both links
embedded in the notice body (the source PR link and the commit link).
The plain-text log/summary output is left untouched since it's never
posted to GitHub.

without this change we are getting too many useless refrences:
<img width="887" height="632" alt="Screenshot 2026-08-03 at 18 52 36" src="https://github.com/user-attachments/assets/52b20666-4ce7-4d78-8af7-fcfaeb73d01c" />


---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude (Sonnet 4.5)

Generated-by: Claude (Sonnet 4.5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)