### PR TITLE
Fix pytest class-scoped fixture deprecation warning in extract_permissions tests

### DIFF
--- a/scripts/tests/ci/prek/test_extract_permissions.py
+++ b/scripts/tests/ci/prek/test_extract_permissions.py
@@ -627,7 +627,8 @@ class TestExtractAllPermissions:
     """
 
     @pytest.fixture(scope="class")
-    def all_entries(self) -> list[PermissionEntry]:
+    @classmethod
+    def all_entries(cls) -> list[PermissionEntry]:
         return extract_all_permissions(PUBLIC_ROUTES_DIR)
 
     def test_extracts_non_empty_result(self, all_entries):
@@ -769,7 +770,8 @@ class TestExtractAllPermissions:
 
 class TestRenderRst:
     @pytest.fixture(scope="class")
-    def rst_content(self) -> str:
+    @classmethod
+    def rst_content(cls) -> str:
         entries = extract_all_permissions(PUBLIC_ROUTES_DIR)
         return render_rst(entries)
 


### PR DESCRIPTION
Running `scripts/tests/ci/prek/test_extract_permissions.py` surfaces:

```
=========================================================================================================== warnings summary ============================================================================================================
tests/ci/prek/test_extract_permissions.py::TestExtractAllPermissions::test_extracts_non_empty_result
tests/ci/prek/test_extract_permissions.py::TestRenderRst::test_rst_contains_auto_generated_marker
  /Users/eladkal/Projects/airflow/.venv/lib/python3.12/site-packages/_pytest/fixtures.py:1313: PytestRemovedIn10Warning: Class-scoped fixture defined as instance method is deprecated.
  Instance attributes set in this fixture will NOT be visible to test methods,
  as each test gets a new instance while the fixture runs only once per class.
  Use @classmethod decorator and set attributes on cls instead.
  See https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method
    fixturefunc = resolve_fixture_function(fixturedef, request)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================== 1017 passed, 2 warnings in 10.58s ===================================================================================================

```
for the class-scoped all_entries fixture in TestExtractAllPermissions
and the rst_content fixture in TestRenderRst. pytest 9.1 deprecates
this pattern because attributes set on self in a class-scoped fixture
aren't visible to test methods — pytest creates a new instance per
test while the fixture runs once per class — and the warning will
become an error in pytest 10.

Both fixtures here just return a computed value and never touch self,
so the fix is mechanical: decorate each with `@classmethod` and take
cls instead of self, per pytest's documented migration path.

No test behavior changes — all 70 tests in the file still pass with
no warnings.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude (Sonnet 4.5)

Generated-by: Claude (Sonnet 4.5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)