### PR TITLE
Store non-string Variable API values as JSON instead of a Python repr

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/variables.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 
-from pydantic import Field, JsonValue, model_validator
+from pydantic import Field, JsonValue, field_validator, model_validator
 
 from airflow._shared.secrets_masker import redact
 from airflow.api_fastapi.core_api.base import BaseModel, StrictBaseModel, make_partial_model
@@ -60,6 +60,13 @@ class VariableBody(StrictBaseModel):
     value: JsonValue = Field(serialization_alias="val")
     description: str | None = Field(default=None)
     team_name: str | None = Field(max_length=50, default=None)
+
+    @field_validator("value")
+    @classmethod
+    def serialize_non_string_value(cls, value: JsonValue) -> JsonValue:
+        if isinstance(value, str):
+            return value
+        return json.dumps(value, indent=2)
 
     @model_validator(mode="after")
     def validate_team_name(self) -> VariableBody:

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/public/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/public/variables.py
@@ -126,13 +126,11 @@ class BulkVariableService(BulkService[VariableBody]):
 
             for variable in action.entities:
                 if variable.key in create_keys:
-                    should_serialize_json = isinstance(variable.value, (dict, list))
                     Variable.set(
                         key=variable.key,
                         value=variable.value,
                         description=variable.description,
                         session=self.session,
-                        serialize_json=should_serialize_json,
                     )
                     results.success.append(variable.key)
 

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_variables.py
@@ -1528,3 +1528,74 @@ class TestBulkVariables(TestVariableEndpoint):
 
         session.commit()
         assert session.scalars(select(Variable.key).where(Variable.key.in_(keys))).all() == []
+
+
+class TestVariableJsonValueSerialization(TestVariableEndpoint):
+    """``value`` accepts any JSON type, so every write path must store it as JSON, not a Python repr."""
+
+    JSON_VALUES = [
+        (["a", "b"], '[\n  "a",\n  "b"\n]'),
+        ({"k": 1}, '{\n  "k": 1\n}'),
+        (True, "true"),
+        (7, "7"),
+        (None, "null"),
+    ]
+    IDS = ["list", "dict", "bool", "int", "null"]
+
+    @pytest.mark.parametrize(("value", "expected_stored"), JSON_VALUES, ids=IDS)
+    def test_post_stores_json(self, test_client, session, value, expected_stored):
+        response = test_client.post("/variables", json={"key": "json_var", "value": value})
+        assert response.status_code == 201
+
+        stored = session.scalar(select(Variable).where(Variable.key == "json_var"))
+        assert stored.val == expected_stored
+        assert json.loads(stored.val) == value
+
+    @pytest.mark.parametrize(("value", "expected_stored"), JSON_VALUES, ids=IDS)
+    def test_patch_stores_json(self, test_client, session, value, expected_stored):
+        Variable.set(key="json_var", value="original", session=session)
+        session.commit()
+
+        response = test_client.patch("/variables/json_var", json={"key": "json_var", "value": value})
+        assert response.status_code == 200
+
+        session.expire_all()
+        stored = session.scalar(select(Variable).where(Variable.key == "json_var"))
+        assert stored.val == expected_stored
+        assert json.loads(stored.val) == value
+
+    @pytest.mark.parametrize(("value", "expected_stored"), JSON_VALUES, ids=IDS)
+    def test_bulk_create_stores_json(self, test_client, session, value, expected_stored):
+        response = test_client.patch(
+            "/variables",
+            json={"actions": [{"action": "create", "entities": [{"key": "json_var", "value": value}]}]},
+        )
+        assert response.status_code == 200
+        assert response.json()["create"]["success"] == ["json_var"]
+
+        stored = session.scalar(select(Variable).where(Variable.key == "json_var"))
+        assert stored.val == expected_stored
+        assert json.loads(stored.val) == value
+
+    @pytest.mark.parametrize("verb", ["post", "patch", "bulk"])
+    def test_string_value_is_stored_verbatim(self, test_client, session, verb):
+        """A string is already the stored form -- it must not be re-encoded into a quoted JSON string."""
+        if verb == "post":
+            test_client.post("/variables", json={"key": "str_var", "value": "plain string"})
+        elif verb == "patch":
+            Variable.set(key="str_var", value="original", session=session)
+            session.commit()
+            test_client.patch("/variables/str_var", json={"key": "str_var", "value": "plain string"})
+        else:
+            test_client.patch(
+                "/variables",
+                json={
+                    "actions": [
+                        {"action": "create", "entities": [{"key": "str_var", "value": "plain string"}]}
+                    ]
+                },
+            )
+
+        session.expire_all()
+        stored = session.scalar(select(Variable).where(Variable.key == "str_var"))
+        assert stored.val == "plain string"


### PR DESCRIPTION
closes: #71010

## Sumarry

`VariableBody.value` is typed `JsonValue`, so the Variables API accepts any JSON type
— that was deliberate, added in #49844 so the API could take the same files the CLI
imports. What that PR did not change is the storage path, which still assumes a
string. Three write paths, three different outcomes:

```console
# create — 201, silently stores a Python repr
$ curl -X POST .../variables -d '{"key":"v","value":["a","b"]}'
201  stored: ['a', 'b']          # json.loads() raises

# patch — 500
$ curl -X PATCH .../variables/v -d '{"key":"v","value":["a","b"]}'
500  TypeError: encoding without a string argument

# bulk (what the UI's "import variables" uses) — dicts and lists are fine, the rest are not
stored: true -> "True"           # Python capital T
```

The create case is the dangerous one: it reports success, the UI shows something that
looks plausible, and the failure only surfaces days later when a Dag calls
`Variable.get(key, deserialize_json=True)` and hits a `JSONDecodeError` with nothing
pointing back at the write.

Beyond the report, `bool` and `null` are corrupted too (`True` / `None` rather than
`true` / `null`), and `int` is only correct by coincidence — `str(7)` happens to be
valid JSON.

## Fix

`Variable.set` falls back to `str(value)` and `Variable.val`'s setter calls
`bytes(value, "utf-8")`; both already assume a string. So rather than teaching each
consumer to serialize, the body serializes once and every consumer keeps its existing
assumption:

```python
@field_validator("value")
@classmethod
def serialize_non_string_value(cls, value: JsonValue) -> JsonValue:
    if isinstance(value, str):
        return value
    return json.dumps(value, indent=2)
```

Strings pass through untouched — they are already the stored form, and re-encoding
one would add a layer of quotes on every write.

`indent=2` is what the bulk path was already producing for dicts and lists, so the
bytes it writes are unchanged; only the two broken paths move. That also makes the
`serialize_json` branch in `BulkVariableService` redundant — it has to go, or the
value would be encoded twice.

The issue suggests narrowing the field to `str | None` instead. That would undo
#49844 and reopen #49837, so this keeps JSON values accepted and stores them properly.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)
