### PR TITLE
Complete the Traditional Chinese UI translations

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/assets.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/assets.json
@@ -42,7 +42,10 @@
     "title": "為 {{name}} 建立資源事件"
   },
   "events": "資源事件",
-  "extra": "額外資源資訊",
+  "filters": {
+    "groupPlaceholder": "搜尋群組",
+    "lastEventDateRange": "最後事件時間"
+  },
   "group": "群組",
   "lastAssetEvent": "最後資源事件",
   "name": "名稱",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/common.json
@@ -86,6 +86,7 @@
   "dagRun_one": "Dag 執行",
   "dagRun_other": "Dag 執行",
   "dagRunId": "Dag 執行 ID",
+  "dagRunState": "Dag 執行狀態",
   "dagWarnings": "Dag 警告 / 錯誤",
   "defaultToGraphView": "預設使用圖形檢視",
   "defaultToGridView": "預設使用網格檢視",
@@ -288,6 +289,9 @@
   },
   "showDetailsPanel": "顯示詳細資訊",
   "signedInAs": "登入身分：",
+  "slot": "配額",
+  "slot_one": "配額",
+  "slot_other": "配額",
   "source": {
     "hide": "隱藏來源",
     "hotkey": "s",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/components.json
@@ -7,9 +7,15 @@
     "backwards": "反向執行",
     "dateRange": "日期範圍",
     "errorStartDateBeforeEndDate": "開始日期必須早於結束日期。",
+    "exceptionReason": {
+      "alreadyExists": "已存在",
+      "inFlight": "進行中",
+      "unknown": "未知"
+    },
     "maxRuns": "活躍執行數上限",
     "missingAndErroredRuns": "遺漏和錯誤的執行",
     "missingRuns": "遺漏的執行",
+    "notCreatedReason": "未建立原因",
     "overrideExistingParams": "覆寫既有執行的參數",
     "permissionDenied": "試執行失敗：使用者沒有建立回填的權限。",
     "reprocessBehavior": "重新處理行為",
@@ -29,7 +35,8 @@
     "validation": {
       "datesRequired": "必須提供資料區間的開始與結束日期。",
       "startBeforeEnd": "資料區間起始日期必須早於或等於結束日期。"
-    }
+    },
+    "viewSlots": "檢視回填 #{{id}} 的配額"
   },
   "banner": {
     "backfillInProgress": "回填正在進行中",
@@ -113,6 +120,10 @@
     "location": "第 {{line}} 行，位於 {{name}}"
   },
   "reparseDag": "重新解析 Dag",
+  "slowestTaskInstances": {
+    "empty": "此範圍內沒有已完成的任務實例",
+    "title": "最慢的任務實例"
+  },
   "sortedAscending": "遞增排序",
   "sortedDescending": "遞減排序",
   "sortedUnsorted": "未排序",
@@ -130,7 +141,7 @@
   "triggerDag": {
     "button": "觸發",
     "dataInterval": "資料區間",
-    "dataIntervalAuto": "依邏輯日期與時間表推斷",
+    "dataIntervalAuto": "依邏輯日期與排程規則推斷",
     "dataIntervalManual": "手動指定",
     "intervalEnd": "結束",
     "intervalStart": "開始",

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dag.json
@@ -144,13 +144,7 @@
       "label": "Dag 執行次數"
     },
     "dependencies": {
-      "label": "相依性 (Dependencies)",
-      "options": {
-        "allDagDependencies": "所有 Dag 相依性",
-        "externalConditions": "外部條件",
-        "onlyTasks": "僅限任務"
-      },
-      "placeholder": "相依性 (Dependencies)"
+      "allDagDependencies": "所有 Dag 相依性"
     },
     "graphDirection": {
       "label": "圖表方向"

--- a/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/zh-TW/dags.json
@@ -17,12 +17,14 @@
       "unfavorite": "未加為最愛"
     },
     "lastRunState": "最後執行狀態",
+    "noTimetableTypesFound": "找不到排程規則類型",
     "paused": {
       "active": "啟用中",
       "all": "全部",
       "paused": "暫停"
     },
-    "runIdPatternFilter": "搜尋 Dag 執行"
+    "runIdPatternFilter": "搜尋 Dag 執行",
+    "timetableType": "排程規則類型"
   },
   "ownerLink": "擁有者 {{owner}} 的連結",
   "runAndTaskActions": {


### PR DESCRIPTION
## Sumarry

Complete the Traditional Chinese UI translations

- Adds the 16 missing keys
- Removes 6 keys English no longer defines

`breeze ui check-translation-completeness --language zh-TW` now reports 1009/1009,
0 missing, 0 unused, 0 TODOs.