### PR TITLE
Record the relaxed types-paramiko bound in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2712,7 +2712,7 @@ requires-dist = [
     { name = "types-deprecated", marker = "extra == 'mypy'", specifier = ">=1.2.9.20240311" },
     { name = "types-docutils", marker = "extra == 'mypy'", specifier = ">=0.21.0.20240704" },
     { name = "types-markdown", marker = "extra == 'mypy'", specifier = ">=3.6.0.20240316" },
-    { name = "types-paramiko", marker = "extra == 'mypy'", specifier = ">=4.0.0.20260402,<5.0.0" },
+    { name = "types-paramiko", marker = "extra == 'mypy'", specifier = ">=4.0.0.20260402" },
     { name = "types-protobuf", marker = "extra == 'mypy'", specifier = ">=5.26.0.20240422" },
     { name = "types-pymysql", marker = "extra == 'mypy'", specifier = ">=1.1.0.20240425" },
     { name = "types-python-dateutil", marker = "extra == 'mypy'", specifier = ">=2.9.0.20240316" },


### PR DESCRIPTION
`devel-common/pyproject.toml` dropped the `<5.0.0` cap on `types-paramiko` in #71009, but `uv.lock` still records `>=4.0.0.20260402,<5.0.0`. The `update-uv-lock` prek hook rewrites the file for anyone who touches the repo, so every branch cut from `main` picks up this one-line change and then has to either carry it as an unrelated diff or drop it before pushing.

Note that `uv lock --check` passes on `main` despite the drift — it validates that the lock resolves, not that the recorded `requires-dist` metadata matches the project files. Running the hook is what surfaces it.

Regenerated with the repo's own `update-uv-lock` hook, so the pinned uv version was used and the diff is exactly the one line.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)