### PR TITLE
Fix /ui/assets picking a stale "last event" under concurrent asset writes

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.orm import selectinload
 
 from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel, association_table
@@ -33,8 +33,20 @@ if TYPE_CHECKING:
 
 def generate_assets_with_last_event_query() -> Select:
     """Fetch Assets outer-joined to their latest AssetEvent id/timestamp."""
-    max_asset_event_id_query = (
-        select(AssetEvent.asset_id, func.max(AssetEvent.id).label("max_asset_event_id"))
+    latest_asset_event_timestamps = (
+        select(AssetEvent.asset_id, func.max(AssetEvent.timestamp).label("last_timestamp"))
+        .group_by(AssetEvent.asset_id)
+        .subquery()
+    )
+    latest_asset_event_ids = (
+        select(AssetEvent.asset_id, func.max(AssetEvent.id).label("last_asset_event_id"))
+        .join(
+            latest_asset_event_timestamps,
+            and_(
+                AssetEvent.asset_id == latest_asset_event_timestamps.c.asset_id,
+                AssetEvent.timestamp == latest_asset_event_timestamps.c.last_timestamp,
+            ),
+        )
         .group_by(AssetEvent.asset_id)
         .subquery()
     )
@@ -45,8 +57,8 @@ def generate_assets_with_last_event_query() -> Select:
             AssetEvent.id.label("last_asset_event_id"),
             AssetEvent.timestamp.label("last_asset_event_timestamp"),
         )
-        .outerjoin(max_asset_event_id_query, AssetModel.id == max_asset_event_id_query.c.asset_id)
-        .outerjoin(AssetEvent, AssetEvent.id == max_asset_event_id_query.c.max_asset_event_id)
+        .outerjoin(latest_asset_event_ids, AssetModel.id == latest_asset_event_ids.c.asset_id)
+        .outerjoin(AssetEvent, AssetEvent.id == latest_asset_event_ids.c.last_asset_event_id)
         .options(
             selectinload(AssetModel.scheduled_dags),
             selectinload(AssetModel.producing_tasks),

--- a/airflow-core/src/airflow/api_fastapi/common/db/assets.py
+++ b/airflow-core/src/airflow/api_fastapi/common/db/assets.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.orm import subqueryload
 
 from airflow.models.asset import AssetEvent, AssetModel, AssetWatcherModel
@@ -30,8 +30,20 @@ if TYPE_CHECKING:
 
 def generate_assets_with_last_event_query() -> Select:
     """Fetch Assets outer-joined to their latest AssetEvent id/timestamp."""
-    max_asset_event_id_query = (
-        select(AssetEvent.asset_id, func.max(AssetEvent.id).label("max_asset_event_id"))
+    latest_asset_event_timestamps = (
+        select(AssetEvent.asset_id, func.max(AssetEvent.timestamp).label("last_timestamp"))
+        .group_by(AssetEvent.asset_id)
+        .subquery()
+    )
+    latest_asset_event_ids = (
+        select(AssetEvent.asset_id, func.max(AssetEvent.id).label("last_asset_event_id"))
+        .join(
+            latest_asset_event_timestamps,
+            and_(
+                AssetEvent.asset_id == latest_asset_event_timestamps.c.asset_id,
+                AssetEvent.timestamp == latest_asset_event_timestamps.c.last_timestamp,
+            ),
+        )
         .group_by(AssetEvent.asset_id)
         .subquery()
     )
@@ -42,8 +54,8 @@ def generate_assets_with_last_event_query() -> Select:
             AssetEvent.id.label("last_asset_event_id"),
             AssetEvent.timestamp.label("last_asset_event_timestamp"),
         )
-        .outerjoin(max_asset_event_id_query, AssetModel.id == max_asset_event_id_query.c.asset_id)
-        .outerjoin(AssetEvent, AssetEvent.id == max_asset_event_id_query.c.max_asset_event_id)
+        .outerjoin(latest_asset_event_ids, AssetModel.id == latest_asset_event_ids.c.asset_id)
+        .outerjoin(AssetEvent, AssetEvent.id == latest_asset_event_ids.c.last_asset_event_id)
         .options(
             subqueryload(AssetModel.scheduled_dags),
             subqueryload(AssetModel.producing_tasks),

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -584,6 +584,27 @@ class TestGetAssetsUi:
         assert last_asset_event["id"] == latest_event_id
         assert last_asset_event["timestamp"] == "2024-01-02T00:00:00Z"
 
+    def test_last_asset_event_breaks_timestamp_tie_by_highest_id(self, test_client, session):
+        asset = AssetModel(name="tied_timestamp", uri="s3://bucket/tied_timestamp", group="asset")
+        session.add(asset)
+        session.add(AssetActive.for_asset(asset))
+        session.flush()
+
+        tied_timestamp = pendulum.datetime(2024, 1, 1)
+        lower_id_event = AssetEvent(asset_id=asset.id, timestamp=tied_timestamp)
+        higher_id_event = AssetEvent(asset_id=asset.id, timestamp=tied_timestamp)
+        session.add_all([lower_id_event, higher_id_event])
+        session.flush()
+        higher_id_event_id = higher_id_event.id
+        session.commit()
+
+        assert higher_id_event_id > lower_id_event.id
+
+        response = test_client.get("/assets")
+        assert response.status_code == 200
+        last_asset_event = response.json()["assets"][0]["last_asset_event"]
+        assert last_asset_event["id"] == higher_id_event_id
+
     def test_sort_by_group(self, test_client, session):
         billing = AssetModel(name="billing_asset", uri="s3://bucket/billing_sort", group="billing")
         marketing = AssetModel(name="marketing_asset", uri="s3://bucket/marketing_sort", group="marketing")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -561,6 +561,29 @@ class TestGetAssetsUi:
         assert response.status_code == 200
         assert [a["name"] for a in response.json()["assets"]] == ["newer", "older"]
 
+    def test_last_asset_event_uses_latest_timestamp_not_highest_id(self, test_client, session):
+        asset = AssetModel(name="out_of_order", uri="s3://bucket/out_of_order", group="asset")
+        session.add(asset)
+        session.add(AssetActive.for_asset(asset))
+        session.flush()
+
+        base = pendulum.datetime(2024, 1, 1)
+        latest_event = AssetEvent(asset_id=asset.id, timestamp=base.add(days=1))
+        highest_id_event = AssetEvent(asset_id=asset.id, timestamp=base)
+        session.add_all([latest_event, highest_id_event])
+        session.flush()
+        latest_event_id = latest_event.id
+        highest_id_event_id = highest_id_event.id
+        session.commit()
+
+        assert highest_id_event_id > latest_event_id
+
+        response = test_client.get("/assets")
+        assert response.status_code == 200
+        last_asset_event = response.json()["assets"][0]["last_asset_event"]
+        assert last_asset_event["id"] == latest_event_id
+        assert last_asset_event["timestamp"] == "2024-01-02T00:00:00Z"
+
     def test_sort_by_group(self, test_client, session):
         billing = AssetModel(name="billing_asset", uri="s3://bucket/billing_sort", group="billing")
         marketing = AssetModel(name="marketing_asset", uri="s3://bucket/marketing_sort", group="marketing")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -572,6 +572,27 @@ class TestGetAssetsUi:
         assert last_asset_event["id"] == latest_event_id
         assert last_asset_event["timestamp"] == "2024-01-02T00:00:00Z"
 
+    def test_last_asset_event_breaks_timestamp_tie_by_highest_id(self, test_client, session):
+        asset = AssetModel(name="tied_timestamp", uri="s3://bucket/tied_timestamp", group="asset")
+        session.add(asset)
+        session.add(AssetActive.for_asset(asset))
+        session.flush()
+
+        tied_timestamp = pendulum.datetime(2024, 1, 1)
+        lower_id_event = AssetEvent(asset_id=asset.id, timestamp=tied_timestamp)
+        higher_id_event = AssetEvent(asset_id=asset.id, timestamp=tied_timestamp)
+        session.add_all([lower_id_event, higher_id_event])
+        session.flush()
+        higher_id_event_id = higher_id_event.id
+        session.commit()
+
+        assert higher_id_event_id > lower_id_event.id
+
+        response = test_client.get("/assets")
+        assert response.status_code == 200
+        last_asset_event = response.json()["assets"][0]["last_asset_event"]
+        assert last_asset_event["id"] == higher_id_event_id
+
     def test_sort_by_group(self, test_client, session):
         billing = AssetModel(name="billing_asset", uri="s3://bucket/billing_sort", group="billing")
         marketing = AssetModel(name="marketing_asset", uri="s3://bucket/marketing_sort", group="marketing")

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_assets.py
@@ -549,6 +549,29 @@ class TestGetAssetsUi:
         assert response.status_code == 200
         assert [a["name"] for a in response.json()["assets"]] == ["newer", "older"]
 
+    def test_last_asset_event_uses_latest_timestamp_not_highest_id(self, test_client, session):
+        asset = AssetModel(name="out_of_order", uri="s3://bucket/out_of_order", group="asset")
+        session.add(asset)
+        session.add(AssetActive.for_asset(asset))
+        session.flush()
+
+        base = pendulum.datetime(2024, 1, 1)
+        latest_event = AssetEvent(asset_id=asset.id, timestamp=base.add(days=1))
+        highest_id_event = AssetEvent(asset_id=asset.id, timestamp=base)
+        session.add_all([latest_event, highest_id_event])
+        session.flush()
+        latest_event_id = latest_event.id
+        highest_id_event_id = highest_id_event.id
+        session.commit()
+
+        assert highest_id_event_id > latest_event_id
+
+        response = test_client.get("/assets")
+        assert response.status_code == 200
+        last_asset_event = response.json()["assets"][0]["last_asset_event"]
+        assert last_asset_event["id"] == latest_event_id
+        assert last_asset_event["timestamp"] == "2024-01-02T00:00:00Z"
+
     def test_sort_by_group(self, test_client, session):
         billing = AssetModel(name="billing_asset", uri="s3://bucket/billing_sort", group="billing")
         marketing = AssetModel(name="marketing_asset", uri="s3://bucket/marketing_sort", group="marketing")


### PR DESCRIPTION
`generate_assets_with_last_event_query()` picked the latest `AssetEvent` per asset using `MAX(id)`. Under concurrent writes to the same asset,the order rows arrive at the database doesn't reliably match the order their timestamps were computed, so a row can get a lower id while carrying a *later* timestamp. `MAX(id)` then surfaces a stale event as "latest," which `/ui/assets` displays, sorts, and filters by. Concurrent writes to the same asset are a known hotspot here (#62501, #69977). 

`public/assets.py` already resolves the equivalent query correctly, grouping by  `MAX(timestamp)` first and using `MAX(id)` only to break exact ties. This mirrors that approach, keeping `AssetEvent` joined directly in the outer query so the existing `last_asset_event_timestamp` sort/filter parameters keep working unchanged.


(Note added 2026-08-06, per feedback from @steveahnahn)
This change also fixes the default sort order (`last_asset_event_timestamp desc`), not just the displayed value — the sort was previously fed by a stale "last event" the same way the display was.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Claude Code

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=ea35697 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @takayoshi-makabe** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Merge conflicts**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/10_working_with_git.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
