### PR TITLE
Spark: Fix missing space in YARN waitAppCompletion error message

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -152,7 +152,7 @@ class _YarnSparkSubmitBackend(_SparkSubmitDeploymentBackend):
     def submit_job(self, context: Context) -> str | None:
         if self.hook._conf.get("spark.yarn.submit.waitAppCompletion", "").strip().lower() == "true":
             raise ValueError(
-                "spark.yarn.submit.waitAppCompletion=true cannot be set for cluster mode as it conflicts"
+                "spark.yarn.submit.waitAppCompletion=true cannot be set for cluster mode as it conflicts "
                 "with the need to exit spark-submit immediately to persist the application ID for tracking. "
                 "Either remove the explicit conf or set durable=False."
             )

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -819,7 +819,10 @@ class TestSparkSubmitOperatorResumable:
         hook._conf = {"spark.yarn.submit.waitAppCompletion": "true"}
         operator._hook = hook
 
-        with pytest.raises(ValueError, match="waitAppCompletion=true"):
+        with pytest.raises(
+            ValueError,
+            match=r"spark\.yarn\.submit\.waitAppCompletion=true cannot be set for cluster mode as it conflicts with the need",
+        ):
             operator.submit_job(context={})
 
     def test_yarn_poll_tolerates_transient_resourcemanager_failures(self):


### PR DESCRIPTION
### Description
In `_YarnSparkSubmitBackend.submit_job` (airflow/providers/apache/spark/operators/spark_submit.py), implicit string literal concatenation across lines lacked a trailing space after "conflicts":

### "spark.yarn.submit.waitAppCompletion=true cannot be set for cluster mode as it conflicts" "with the need to exit spark-submit immediately to persist the application ID for tracking. "

This rendered as `"conflictswith"` in the exception message raised to users.

This PR adds the missing space so the error message correctly formats as `"conflicts with the need"`, and updates the corresponding unit test regex in `test_spark_submit.py` to assert the formatted string.

### Related Issues / Context
Follow-up to #68679.

### fixes: #71053 