### PR TITLE
Spark: Promote private SparkSubmitHook attributes used by strategy backends to public interface

### DIFF
--- a/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -335,6 +335,44 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         # (and re-hit any configured Secrets Backend) on every iteration.
         self._yarn_rm_base_url: str | None = None
 
+    @property
+    def conf(self) -> dict[str, Any]:
+        """Spark configuration properties dictionary."""
+        return self._conf
+
+    @property
+    def kubernetes_driver_pod(self) -> str | None:
+        """Kubernetes driver pod name captured from submission or explicit setter."""
+        return self._kubernetes_driver_pod
+
+    @kubernetes_driver_pod.setter
+    def kubernetes_driver_pod(self, value: str | None) -> None:
+        self._kubernetes_driver_pod = value
+
+    @property
+    def yarn_application_id(self) -> str | None:
+        """YARN application ID captured from submission log output."""
+        return self._yarn_application_id
+
+    @property
+    def driver_id(self) -> str | None:
+        """Spark standalone driver ID."""
+        return self._driver_id
+
+    @driver_id.setter
+    def driver_id(self, value: str | None) -> None:
+        self._driver_id = value
+
+    @property
+    def driver_status(self) -> str | None:
+        """Spark standalone driver status."""
+        return self._driver_status
+
+    @property
+    def connection(self) -> dict[str, Any]:
+        """Resolved Spark connection extra metadata dictionary."""
+        return self._connection
+
     def _resolve_should_track_driver_status(self) -> bool:
         """
         Check if we should track the driver status.
@@ -722,7 +760,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             func = getattr(kerberos, "get_kerberos_principle")
         return func(principal)
 
-    def _run_post_submit_commands(self) -> None:
+    def run_post_submit_commands(self) -> None:
         """
         Run any post-submit shell commands configured on this hook.
 
@@ -758,6 +796,9 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 self.log.warning("Post-submit command timed out (30s): %s", cmd)
             except Exception as exc:
                 self.log.warning("Post-submit command raised an exception: %s. Error: %s", cmd, exc)
+
+    def _run_post_submit_commands(self) -> None:
+        self.run_post_submit_commands()
 
     def submit(self, application: str = "", **kwargs: Any) -> str | None:
         """
@@ -895,7 +936,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
             self._last_submit_log_lines.append(line)
             self.log.info(line)
 
-    def _start_yarn_application_status_tracking(self, application_id: str) -> None:
+    def start_yarn_application_status_tracking(self, application_id: str) -> None:
         """
         Poll the YARN ResourceManager REST API until the application reaches a terminal state.
 
@@ -1061,7 +1102,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 f"{application_id}: {resp.text[:200]}"
             ) from exc
 
-    def _kill_yarn_application(self, application_id: str) -> None:
+    def kill_yarn_application(self, application_id: str) -> None:
         """PUT ``/ws/v1/cluster/apps/{id}/state`` to kill the application (best-effort)."""
         try:
             url = f"{self._get_yarn_rm_base_url()}/ws/v1/cluster/apps/{application_id}/state"
@@ -1111,7 +1152,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         if valid_response and not driver_found:
             self._driver_status = "UNKNOWN"
 
-    def _start_driver_status_tracking(self) -> None:
+    def start_driver_status_tracking(self) -> None:
         """
         Poll the driver based on self._driver_id to get the status.
 
@@ -1175,7 +1216,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                         f"returncode = {returncode}"
                     )
 
-    def _poll_k8s_driver_via_api(self) -> str | None:
+    def poll_k8s_driver_via_api(self) -> str | None:
         """
         Poll the K8s driver pod phase until it reaches a terminal state.
 

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -152,7 +152,7 @@ class _YarnSparkSubmitBackend(_SparkSubmitDeploymentBackend):
     def submit_job(self, context: Context) -> str | None:
         if self.hook._conf.get("spark.yarn.submit.waitAppCompletion", "").strip().lower() == "true":
             raise ValueError(
-                "spark.yarn.submit.waitAppCompletion=true cannot be set for cluster mode as it conflicts"
+                "spark.yarn.submit.waitAppCompletion=true cannot be set for cluster mode as it conflicts "
                 "with the need to exit spark-submit immediately to persist the application ID for tracking. "
                 "Either remove the explicit conf or set durable=False."
             )

--- a/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/operators/spark_submit.py
@@ -96,10 +96,10 @@ class _KubernetesSparkSubmitBackend(_SparkSubmitDeploymentBackend):
     """Logic for tracking Spark driver pods in Kubernetes."""
 
     def submit_job(self, context: Context) -> str | None:
-        self.hook._conf[_K8S_WAIT_APP_COMPLETION_CONF] = "false"
+        self.hook.conf[_K8S_WAIT_APP_COMPLETION_CONF] = "false"
         self.hook.submit(self.operator.application)
-        pod_name = self.hook._kubernetes_driver_pod
-        namespace = self.hook._connection["namespace"]
+        pod_name = self.hook.kubernetes_driver_pod
+        namespace = self.hook.connection["namespace"]
         if not pod_name:
             raise RuntimeError("spark-submit did not capture a K8s driver pod name")
         external_id = f"{namespace}:{pod_name}"
@@ -133,8 +133,8 @@ class _KubernetesSparkSubmitBackend(_SparkSubmitDeploymentBackend):
     def poll_until_complete(self, external_id: str, context: Context) -> None:
         if external_id is not None:
             _, pod_name = self.operator._parse_k8s_external_id(external_id)
-            self.hook._kubernetes_driver_pod = pod_name
-        terminal_phase = self.hook._poll_k8s_driver_via_api()
+            self.hook.kubernetes_driver_pod = pod_name
+        terminal_phase = self.hook.poll_k8s_driver_via_api()
         # Cache only when the pod actually reached Succeeded, the 404/vanished path
         # returns None for cases like: pod deleted by on_kill or garbage collected after failure)
         # and must not be cached, otherwise a retry would see "Succeeded" and skip resubmission.
@@ -150,15 +150,15 @@ class _YarnSparkSubmitBackend(_SparkSubmitDeploymentBackend):
     """Logic for tracking Spark applications in YARN cluster mode."""
 
     def submit_job(self, context: Context) -> str | None:
-        if self.hook._conf.get("spark.yarn.submit.waitAppCompletion", "").strip().lower() == "true":
+        if self.hook.conf.get("spark.yarn.submit.waitAppCompletion", "").strip().lower() == "true":
             raise ValueError(
                 "spark.yarn.submit.waitAppCompletion=true cannot be set for cluster mode as it conflicts "
                 "with the need to exit spark-submit immediately to persist the application ID for tracking. "
                 "Either remove the explicit conf or set durable=False."
             )
-        self.hook._conf["spark.yarn.submit.waitAppCompletion"] = "false"
+        self.hook.conf["spark.yarn.submit.waitAppCompletion"] = "false"
         self.hook.submit(self.operator.application)
-        app_id = self.hook._yarn_application_id
+        app_id = self.hook.yarn_application_id
         if not app_id:
             raise RuntimeError("spark-submit did not produce a YARN application ID")
         self.operator.log.info("YARN application submitted: %s", app_id)
@@ -176,15 +176,15 @@ class _YarnSparkSubmitBackend(_SparkSubmitDeploymentBackend):
 
     def poll_until_complete(self, external_id: str, context: Context) -> None:
         try:
-            self.hook._start_yarn_application_status_tracking(external_id)
+            self.hook.start_yarn_application_status_tracking(external_id)
         finally:
-            self.hook._run_post_submit_commands()
+            self.hook.run_post_submit_commands()
 
     def on_kill(self) -> None:
-        if self.hook._yarn_application_id:
+        if self.hook.yarn_application_id:
             # spark-submit has already exited (waitAppCompletion=false), so the hook's
             # CLI-based kill has nothing to terminate. Kill the YARN app via REST API instead.
-            self.hook._kill_yarn_application(self.hook._yarn_application_id)
+            self.hook.kill_yarn_application(self.hook.yarn_application_id)
         else:
             self.hook.on_kill()
 
@@ -200,12 +200,12 @@ class _StandaloneSparkSubmitBackend(_SparkSubmitDeploymentBackend):
         return driver_id
 
     def get_job_status(self, external_id: str, context: Context) -> str:
-        scheme = self.hook._connection.get("rest_scheme", "http")
-        rest_port = self.hook._connection.get("rest_port", 6066)
+        scheme = self.hook.connection.get("rest_scheme", "http")
+        rest_port = self.hook.connection.get("rest_port", 6066)
         # HA master URLs can look like spark://m1:7077,m2:7077 — try each host in order.
         # The master URL port (e.g. 7077) is the RPC port — not the REST API port.
         # Use rest-port connection extra to override spark.master.rest.port (default 6066).
-        master_urls = self.hook._connection["master"].replace("spark://", "").split(",")
+        master_urls = self.hook.connection["master"].replace("spark://", "").split(",")
         last_exc: Exception = RuntimeError("No Spark masters to query")
         for m in master_urls:
             host = m.strip().split(":")[0]
@@ -230,14 +230,14 @@ class _StandaloneSparkSubmitBackend(_SparkSubmitDeploymentBackend):
 
     def poll_until_complete(self, external_id: str, context: Context) -> None:
         self.operator.log.info("Polling driver %s until completion", external_id)
-        self.hook._driver_id = external_id
+        self.hook.driver_id = external_id
         try:
-            self.hook._start_driver_status_tracking()
-            if self.hook._driver_status != "FINISHED":
-                raise RuntimeError(f"Driver {external_id} exited with status {self.hook._driver_status}")
+            self.hook.start_driver_status_tracking()
+            if self.hook.driver_status != "FINISHED":
+                raise RuntimeError(f"Driver {external_id} exited with status {self.hook.driver_status}")
         finally:
             # post-submit commands must fire whether the job succeeded or failed.
-            self.hook._run_post_submit_commands()
+            self.hook.run_post_submit_commands()
 
     def on_kill(self) -> None:
         self.hook.on_kill()

--- a/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/hooks/test_spark_submit.py
@@ -88,6 +88,20 @@ class TestSparkSubmitHook:
                 extra='{"queue": "root.etl", "deploy-mode": "cluster"}',
             )
         )
+
+    def test_public_properties_and_methods(self):
+        hook = SparkSubmitHook(conn_id="spark_yarn_cluster", conf={"spark.app.name": "test"})
+        assert hook.conf == {"spark.app.name": "test"}
+        assert hook.yarn_application_id is None
+        assert hook.driver_id is None
+        assert hook.driver_status is None
+        assert isinstance(hook.connection, dict)
+
+        hook.kubernetes_driver_pod = "my-driver-pod"
+        assert hook.kubernetes_driver_pod == "my-driver-pod"
+
+        hook.driver_id = "driver-12345"
+        assert hook.driver_id == "driver-12345"
         create_connection_without_db(
             Connection(
                 conn_id="spark_k8s_cluster",

--- a/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
+++ b/providers/apache/spark/tests/unit/apache/spark/operators/test_spark_submit.py
@@ -819,7 +819,10 @@ class TestSparkSubmitOperatorResumable:
         hook._conf = {"spark.yarn.submit.waitAppCompletion": "true"}
         operator._hook = hook
 
-        with pytest.raises(ValueError, match="waitAppCompletion=true"):
+        with pytest.raises(
+            ValueError,
+            match=r"spark\.yarn\.submit\.waitAppCompletion=true cannot be set for cluster mode as it conflicts with the need",
+        ):
             operator.submit_job(context={})
 
     def test_yarn_poll_tolerates_transient_resourcemanager_failures(self):


### PR DESCRIPTION
### Description

During the refactoring of `SparkSubmitOperator` into backend strategy classes (`_KubernetesSparkSubmitBackend`, `_YarnSparkSubmitBackend`, `_StandaloneSparkSubmitBackend`), the strategy backends reached directly into internal/private attributes and methods of `SparkSubmitHook`:

- `hook._conf`
- `hook._kubernetes_driver_pod`
- `hook._yarn_application_id`
- `hook._driver_id` / `hook._driver_status`
- `hook._connection`
- `hook._poll_k8s_driver_via_api()`
- `hook._start_yarn_application_status_tracking()`
- `hook._kill_yarn_application()`
- `hook._start_driver_status_tracking()`
- `hook._run_post_submit_commands()`

Reaching into private `_` members across class boundaries breaks object encapsulation.

This PR promotes these key internal attributes and methods on `SparkSubmitHook` to clean public interface members:

- **Public Properties:** `@property def conf`, `@property def kubernetes_driver_pod` (with setter), `@property def yarn_application_id`, `@property def driver_id` (with setter), `@property def driver_status`, `@property def connection`.
- **Public Methods:** `poll_k8s_driver_via_api()`, `start_yarn_application_status_tracking()`, `kill_yarn_application()`, `start_driver_status_tracking()`, `run_post_submit_commands()`.

The strategy backend classes in `spark_submit.py` have been updated to use these clean public hook interfaces, and a unit test has been added to `test_spark_submit.py`.

### Related Context

Follow-up thought from PR #68679 review.

### fixes: #71058 