### PR TITLE
Azure batch 15x migration

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -175,7 +175,9 @@ baseoperatorlink
 BaseView
 BaseXCom
 bashrc
+BatchClient
 batchGet
+BatchNodeState
 BatchServiceClient
 bc
 bcc

--- a/generated/known_airflow_exceptions.txt
+++ b/generated/known_airflow_exceptions.txt
@@ -351,7 +351,7 @@ providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_facto
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/data_lake.py::1
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py::3
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/wasb.py::2
-providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py::9
+providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py::8
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/container_instances.py::10
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/data_factory.py::1
 providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/msgraph.py::1

--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -41,7 +41,6 @@ Features
 
 * ``Implement bulk authorization methods in KeycloakAuthManager (#70647)``
 * ``Move keycloak JWT tokens to separate cookies (#70550)``
-* ``Add KeycloakJWTMiddleware to KeycloakAuthManager (#70800)``
 * ``Add IMPORT_ERRORS_ALL permission for import errors of files with no registered Dag (#69790)``
 
 .. Below changes are excluded from the changelog. Move them to

--- a/providers/keycloak/docs/changelog.rst
+++ b/providers/keycloak/docs/changelog.rst
@@ -41,6 +41,7 @@ Features
 
 * ``Implement bulk authorization methods in KeycloakAuthManager (#70647)``
 * ``Move keycloak JWT tokens to separate cookies (#70550)``
+* ``Add KeycloakJWTMiddleware to KeycloakAuthManager (#70800)``
 * ``Add IMPORT_ERRORS_ALL permission for import errors of files with no registered Dag (#69790)``
 
 .. Below changes are excluded from the changelog. Move them to

--- a/providers/microsoft/azure/README.rst
+++ b/providers/microsoft/azure/README.rst
@@ -57,7 +57,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.13.0``
 ``adlfs``                                   ``>=2023.10.0``
 ``aiohttp``                                 ``>=3.14.0``
-``azure-batch``                             ``<15.0.0,>=8.0.0``
+``azure-batch``                             ``>=15.0.0``
 ``azure-ai-projects``                       ``>=2.2.0``
 ``azure-cosmos``                            ``>=4.6.0``
 ``azure-mgmt-cosmosdb``                     ``>=3.0.0``

--- a/providers/microsoft/azure/docs/changelog.rst
+++ b/providers/microsoft/azure/docs/changelog.rst
@@ -33,25 +33,25 @@ Changelog
 
   The following changes were introduced:
 
-* Hooks
-  * ``AzureBatchHook.get_conn`` and ``AzureBatchHook.connection`` now return an ``azure.batch.BatchClient``
-    instead of an ``azure.batch.BatchServiceClient``.
-  * Shared key authentication now uses ``azure.core.credentials.AzureNamedKeyCredential`` instead of
-    ``azure.batch.batch_auth.SharedKeyCredentials``.
-  * Managed identity / workload identity authentication now uses
-    ``azure.identity.DefaultAzureCredential`` (via ``get_sync_default_azure_credential``) instead of
-    ``AzureIdentityCredentialAdapter``, since the track 2 client requires a credential implementing
-    ``get_token()``.
-  * ``AzureBatchHook.configure_pool`` no longer accepts the ``os_family`` and ``os_version`` parameters.
-    Cloud service configuration is not supported by the track 2 SDK; use a virtual machine configuration
-    (``vm_publisher``, ``vm_offer``, ``vm_sku``, ``vm_version`` or ``use_latest_image_and_sku``) instead.
-  * The Batch model classes were renamed by the SDK: ``PoolAddParameter`` is now ``BatchPoolCreateOptions``,
-    ``JobAddParameter`` is now ``BatchJobCreateOptions``, ``TaskAddParameter`` is now ``BatchTaskCreateOptions``,
-    and ``CloudTask`` is now ``BatchTask``.
+  * Hooks
+    * ``AzureBatchHook.get_conn`` and ``AzureBatchHook.connection`` now return an ``azure.batch.BatchClient``
+      instead of an ``azure.batch.BatchServiceClient``.
+    * Shared key authentication now uses ``azure.core.credentials.AzureNamedKeyCredential`` instead of
+      ``azure.batch.batch_auth.SharedKeyCredentials``.
+    * Managed identity / workload identity authentication now uses
+      ``azure.identity.DefaultAzureCredential`` (via ``get_sync_default_azure_credential``) instead of
+      ``AzureIdentityCredentialAdapter``, since the track 2 client requires a credential implementing
+      ``get_token()``.
+    * ``AzureBatchHook.configure_pool`` no longer accepts the ``os_family`` and ``os_version`` parameters.
+      Cloud service configuration is not supported by the track 2 SDK; use a virtual machine configuration
+      (``vm_publisher``, ``vm_offer``, ``vm_sku``, ``vm_version`` or ``use_latest_image_and_sku``) instead.
+    * The Batch model classes were renamed by the SDK: ``PoolAddParameter`` is now ``BatchPoolCreateOptions``,
+      ``JobAddParameter`` is now ``BatchJobCreateOptions``, ``TaskAddParameter`` is now ``BatchTaskCreateOptions``,
+      and ``CloudTask`` is now ``BatchTask``.
 
-* Operators
-  * ``AzureBatchOperator`` no longer accepts the ``os_family`` parameter. A ``vm_publisher`` must now be
-    provided to configure the pool's virtual machine image.
+  * Operators
+    * ``AzureBatchOperator`` no longer accepts the ``os_family`` parameter. A ``vm_publisher`` must now be
+      provided to configure the pool's virtual machine image.
 
 14.1.0
 ......

--- a/providers/microsoft/azure/docs/changelog.rst
+++ b/providers/microsoft/azure/docs/changelog.rst
@@ -34,6 +34,7 @@ Changelog
   The following changes were introduced:
 
   * Hooks
+
     * ``AzureBatchHook.get_conn`` and ``AzureBatchHook.connection`` now return an ``azure.batch.BatchClient``
       instead of an ``azure.batch.BatchServiceClient``.
     * Shared key authentication now uses ``azure.core.credentials.AzureNamedKeyCredential`` instead of
@@ -50,6 +51,7 @@ Changelog
       and ``CloudTask`` is now ``BatchTask``.
 
   * Operators
+
     * ``AzureBatchOperator`` no longer accepts the ``os_family`` parameter. A ``vm_publisher`` must now be
       provided to configure the pool's virtual machine image.
 

--- a/providers/microsoft/azure/docs/changelog.rst
+++ b/providers/microsoft/azure/docs/changelog.rst
@@ -27,6 +27,32 @@
 Changelog
 ---------
 
+.. warning::
+  The ``AzureBatchHook`` and ``AzureBatchOperator`` have been migrated to the ``azure-batch`` 15.x
+  SDK (track 2). This is a breaking change and requires ``azure-batch>=15.0.0``.
+
+  The following changes were introduced:
+
+* Hooks
+  * ``AzureBatchHook.get_conn`` and ``AzureBatchHook.connection`` now return an ``azure.batch.BatchClient``
+    instead of an ``azure.batch.BatchServiceClient``.
+  * Shared key authentication now uses ``azure.core.credentials.AzureNamedKeyCredential`` instead of
+    ``azure.batch.batch_auth.SharedKeyCredentials``.
+  * Managed identity / workload identity authentication now uses
+    ``azure.identity.DefaultAzureCredential`` (via ``get_sync_default_azure_credential``) instead of
+    ``AzureIdentityCredentialAdapter``, since the track 2 client requires a credential implementing
+    ``get_token()``.
+  * ``AzureBatchHook.configure_pool`` no longer accepts the ``os_family`` and ``os_version`` parameters.
+    Cloud service configuration is not supported by the track 2 SDK; use a virtual machine configuration
+    (``vm_publisher``, ``vm_offer``, ``vm_sku``, ``vm_version`` or ``use_latest_image_and_sku``) instead.
+  * The Batch model classes were renamed by the SDK: ``PoolAddParameter`` is now ``BatchPoolCreateOptions``,
+    ``JobAddParameter`` is now ``BatchJobCreateOptions``, ``TaskAddParameter`` is now ``BatchTaskCreateOptions``,
+    and ``CloudTask`` is now ``BatchTask``.
+
+* Operators
+  * ``AzureBatchOperator`` no longer accepts the ``os_family`` parameter. A ``vm_publisher`` must now be
+    provided to configure the pool's virtual machine image.
+
 14.1.0
 ......
 

--- a/providers/microsoft/azure/docs/index.rst
+++ b/providers/microsoft/azure/docs/index.rst
@@ -111,7 +111,7 @@ PIP package                                 Version required
 ``apache-airflow-providers-common-compat``  ``>=1.13.0``
 ``adlfs``                                   ``>=2023.10.0``
 ``aiohttp``                                 ``>=3.14.0``
-``azure-batch``                             ``<15.0.0,>=8.0.0``
+``azure-batch``                             ``>=15.0.0``
 ``azure-ai-projects``                       ``>=2.2.0``
 ``azure-cosmos``                            ``>=4.6.0``
 ``azure-mgmt-cosmosdb``                     ``>=3.0.0``

--- a/providers/microsoft/azure/pyproject.toml
+++ b/providers/microsoft/azure/pyproject.toml
@@ -63,9 +63,7 @@ dependencies = [
     "apache-airflow-providers-common-compat>=1.13.0",
     "adlfs>=2023.10.0",
     "aiohttp>=3.14.0",
-    # azure-batch 15.x is a full rewrite of the Azure SDK (track 2) that removes BatchServiceClient, batch_auth,
-    # and the other references in AzureBatchHook. Lifting the upper bound cap needs a full hook rewrite.
-    "azure-batch>=8.0.0,<15.0.0",
+    "azure-batch>=15.0.0",
     # 2.2.0 adds force deletion support for Hosted agents and agent versions.
     "azure-ai-projects>=2.2.0",
     "azure-cosmos>=4.6.0",

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/batch.py
@@ -22,17 +22,20 @@ from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
-from azure.batch import BatchServiceClient, batch_auth, models as batch_models
+from azure.batch import BatchClient, models as batch_models
+from azure.core.credentials import AzureNamedKeyCredential
+from azure.core.exceptions import ResourceExistsError
 
 from airflow.providers.common.compat.sdk import AirflowException, BaseHook, timezone
 from airflow.providers.microsoft.azure.utils import (
-    AzureIdentityCredentialAdapter,
     add_managed_identity_connection_widgets,
     get_field,
+    get_sync_default_azure_credential,
 )
 
 if TYPE_CHECKING:
-    from azure.batch.models import JobAddParameter, PoolAddParameter, TaskAddParameter
+    from azure.batch.models import BatchJobCreateOptions, BatchPoolCreateOptions, BatchTaskCreateOptions
+    from azure.identity import DefaultAzureCredential
 
 
 class AzureBatchHook(BaseHook):
@@ -84,11 +87,11 @@ class AzureBatchHook(BaseHook):
         )
 
     @cached_property
-    def connection(self) -> BatchServiceClient:
+    def connection(self) -> BatchClient:
         """Get the Batch client connection (cached)."""
         return self.get_conn()
 
-    def get_conn(self) -> BatchServiceClient:
+    def get_conn(self) -> BatchClient:
         """
         Get the Batch client connection.
 
@@ -100,20 +103,21 @@ class AzureBatchHook(BaseHook):
         if not batch_account_url:
             raise AirflowException("Batch Account URL parameter is missing.")
 
-        credentials: batch_auth.SharedKeyCredentials | AzureIdentityCredentialAdapter
-        if all([conn.login, conn.password]):
-            credentials = batch_auth.SharedKeyCredentials(conn.login, conn.password)
+        credential: AzureNamedKeyCredential | DefaultAzureCredential
+        if conn.login and conn.password:
+            credential = AzureNamedKeyCredential(conn.login, conn.password)
         else:
             managed_identity_client_id = conn.extra_dejson.get("managed_identity_client_id")
             workload_identity_tenant_id = conn.extra_dejson.get("workload_identity_tenant_id")
-            credentials = AzureIdentityCredentialAdapter(
-                None,
-                resource_id="https://batch.core.windows.net/.default",
+            credential = get_sync_default_azure_credential(
                 managed_identity_client_id=managed_identity_client_id,
                 workload_identity_tenant_id=workload_identity_tenant_id,
             )
 
-        batch_client = BatchServiceClient(credentials, batch_url=batch_account_url)
+        batch_client = BatchClient(
+            endpoint=batch_account_url,
+            credential=credential,
+        )
         return batch_client
 
     def configure_pool(
@@ -126,13 +130,11 @@ class AzureBatchHook(BaseHook):
         sku_starts_with: str | None = None,
         vm_sku: str | None = None,
         vm_version: str | None = None,
-        os_family: str | None = None,
-        os_version: str | None = None,
         display_name: str | None = None,
         target_dedicated_nodes: int | None = None,
         use_latest_image_and_sku: bool = False,
         **kwargs,
-    ) -> PoolAddParameter:
+    ) -> BatchPoolCreateOptions:
         """
         Configure a pool.
 
@@ -161,17 +163,13 @@ class AzureBatchHook(BaseHook):
 
         :param vm_node_agent_sku_id: The node agent sku id of the virtual machine
 
-        :param os_family: The Azure Guest OS family to be installed on the virtual machines in the Pool.
-
-        :param os_version: The OS family version
-
         """
         if use_latest_image_and_sku:
             self.log.info("Using latest verified virtual machine image with node agent sku")
             sku_to_use, image_ref_to_use = self._get_latest_verified_image_vm_and_sku(
                 publisher=vm_publisher, offer=vm_offer, sku_starts_with=sku_starts_with
             )
-            pool = batch_models.PoolAddParameter(
+            pool = batch_models.BatchPoolCreateOptions(
                 id=pool_id,
                 vm_size=vm_size,
                 display_name=display_name,
@@ -182,29 +180,14 @@ class AzureBatchHook(BaseHook):
                 **kwargs,
             )
 
-        elif os_family:
-            self.log.info(
-                "Using cloud service configuration to create pool, virtual machine configuration ignored"
-            )
-            pool = batch_models.PoolAddParameter(
-                id=pool_id,
-                vm_size=vm_size,
-                display_name=display_name,
-                cloud_service_configuration=batch_models.CloudServiceConfiguration(
-                    os_family=os_family, os_version=os_version
-                ),
-                target_dedicated_nodes=target_dedicated_nodes,
-                **kwargs,
-            )
-
         else:
             self.log.info("Using virtual machine configuration to create a pool")
-            pool = batch_models.PoolAddParameter(
+            pool = batch_models.BatchPoolCreateOptions(
                 id=pool_id,
                 vm_size=vm_size,
                 display_name=display_name,
                 virtual_machine_configuration=batch_models.VirtualMachineConfiguration(
-                    image_reference=batch_models.ImageReference(
+                    image_reference=batch_models.BatchVmImageReference(
                         publisher=vm_publisher,
                         offer=vm_offer,
                         sku=vm_sku,
@@ -217,7 +200,7 @@ class AzureBatchHook(BaseHook):
             )
         return pool
 
-    def create_pool(self, pool: PoolAddParameter) -> None:
+    def create_pool(self, pool: BatchPoolCreateOptions) -> None:
         """
         Create a pool if not already existing.
 
@@ -226,11 +209,9 @@ class AzureBatchHook(BaseHook):
         """
         try:
             self.log.info("Attempting to create a pool: %s", pool.id)
-            self.connection.pool.add(pool)
+            self.connection.create_pool(pool)
             self.log.info("Created pool: %s", pool.id)
-        except batch_models.BatchErrorException as err:
-            if not err.error or err.error.code != "PoolExists":
-                raise
+        except ResourceExistsError:
             self.log.info("Pool %s already exists", pool.id)
 
     def _get_latest_verified_image_vm_and_sku(
@@ -248,13 +229,18 @@ class AzureBatchHook(BaseHook):
             For example, UbuntuServer or WindowsServer.
         :param sku_starts_with: The start name of the sku to search
         """
-        options = batch_models.AccountListSupportedImagesOptions(filter="verificationType eq 'verified'")
-        images = self.connection.account.list_supported_images(account_list_supported_images_options=options)
+        images = self.connection.list_supported_images(filter="verificationType eq 'verified'")
         # pick the latest supported sku
         skus_to_use = [
             (image.node_agent_sku_id, image.image_reference)
             for image in images
-            if image.image_reference.publisher.lower() == publisher
+            if publisher is not None
+            and offer is not None
+            and sku_starts_with is not None
+            and image.image_reference.publisher is not None
+            and image.image_reference.offer is not None
+            and image.image_reference.sku is not None
+            and image.image_reference.publisher.lower() == publisher
             and image.image_reference.offer.lower() == offer
             and image.image_reference.sku.startswith(sku_starts_with)
         ]
@@ -268,17 +254,18 @@ class AzureBatchHook(BaseHook):
         Wait for all nodes in a pool to reach given states.
 
         :param pool_id: A string that identifies the pool
-        :param node_state: A set of batch_models.ComputeNodeState
+        :param node_state: A set of batch_models.BatchNodeState
         """
         self.log.info("waiting for all nodes in pool %s to reach one of: %s", pool_id, node_state)
         while True:
             # refresh pool to ensure that there is no resize error
-            pool = self.connection.pool.get(pool_id)
+            pool = self.connection.get_pool(pool_id)
             if pool.resize_errors is not None:
                 resize_errors = "\n".join(repr(e) for e in pool.resize_errors)
                 raise RuntimeError(f"resize error encountered for pool {pool.id}:\n{resize_errors}")
-            nodes = list(self.connection.compute_node.list(pool.id))
-            if len(nodes) >= pool.target_dedicated_nodes and all(node.state in node_state for node in nodes):
+            nodes = list(self.connection.list_nodes(pool.id))
+            target_nodes = pool.target_dedicated_nodes or 0
+            if len(nodes) >= target_nodes and all(node.state in node_state for node in nodes):
                 return nodes
             # Allow the timeout to be controlled by the AzureBatchOperator
             # specified timeout. This way we don't interrupt a startTask inside
@@ -291,7 +278,7 @@ class AzureBatchHook(BaseHook):
         pool_id: str,
         display_name: str | None = None,
         **kwargs,
-    ) -> JobAddParameter:
+    ) -> BatchJobCreateOptions:
         """
         Configure a job for use in the pool.
 
@@ -299,26 +286,24 @@ class AzureBatchHook(BaseHook):
         :param pool_id: A string that identifies the pool
         :param display_name: The display name for the job
         """
-        job = batch_models.JobAddParameter(
+        job = batch_models.BatchJobCreateOptions(
             id=job_id,
-            pool_info=batch_models.PoolInformation(pool_id=pool_id),
+            pool_info=batch_models.BatchPoolInfo(pool_id=pool_id),
             display_name=display_name,
             **kwargs,
         )
         return job
 
-    def create_job(self, job: JobAddParameter) -> None:
+    def create_job(self, job: BatchJobCreateOptions) -> None:
         """
         Create a job in the pool.
 
         :param job: The job object to create
         """
         try:
-            self.connection.job.add(job)
+            self.connection.create_job(job)
             self.log.info("Job %s created", job.id)
-        except batch_models.BatchErrorException as err:
-            if not err.error or err.error.code != "JobExists":
-                raise
+        except ResourceExistsError:
             self.log.info("Job %s already exists", job.id)
 
     def configure_task(
@@ -328,7 +313,7 @@ class AzureBatchHook(BaseHook):
         display_name: str | None = None,
         container_settings=None,
         **kwargs,
-    ) -> TaskAddParameter:
+    ) -> BatchTaskCreateOptions:
         """
         Create a task.
 
@@ -340,7 +325,7 @@ class AzureBatchHook(BaseHook):
             this must be set as well. If the Pool that will run this Task doesn't have
             containerConfiguration set, this must not be set.
         """
-        task = batch_models.TaskAddParameter(
+        task = batch_models.BatchTaskCreateOptions(
             id=task_id,
             command_line=command_line,
             display_name=display_name,
@@ -350,7 +335,7 @@ class AzureBatchHook(BaseHook):
         self.log.info("Task created: %s", task_id)
         return task
 
-    def add_single_task_to_job(self, job_id: str, task: TaskAddParameter) -> None:
+    def add_single_task_to_job(self, job_id: str, task: BatchTaskCreateOptions) -> None:
         """
         Add a single task to given job if it doesn't exist.
 
@@ -358,13 +343,11 @@ class AzureBatchHook(BaseHook):
         :param task: The task to add
         """
         try:
-            self.connection.task.add(job_id=job_id, task=task)
-        except batch_models.BatchErrorException as err:
-            if not err.error or err.error.code != "TaskExists":
-                raise
+            self.connection.create_task(job_id, task)
+        except ResourceExistsError:
             self.log.info("Task %s already exists", task.id)
 
-    def wait_for_job_tasks_to_complete(self, job_id: str, timeout: int) -> list[batch_models.CloudTask]:
+    def wait_for_job_tasks_to_complete(self, job_id: str, timeout: int) -> list[batch_models.BatchTask]:
         """
         Wait for tasks in a particular job to complete.
 
@@ -373,15 +356,16 @@ class AzureBatchHook(BaseHook):
         """
         timeout_time = timezone.utcnow() + timedelta(minutes=timeout)
         while timezone.utcnow() < timeout_time:
-            tasks = list(self.connection.task.list(job_id))
+            tasks = list(self.connection.list_tasks(job_id))
 
-            incomplete_tasks = [task for task in tasks if task.state != batch_models.TaskState.completed]
+            incomplete_tasks = [task for task in tasks if task.state != batch_models.BatchTaskState.COMPLETED]
             if not incomplete_tasks:
                 # detect if any task in job has failed
                 fail_tasks = [
                     task
                     for task in tasks
-                    if task.execution_info.result == batch_models.TaskExecutionResult.failure
+                    if task.execution_info is not None
+                    and task.execution_info.result == batch_models.BatchTaskExecutionResult.FAILURE
                 ]
                 return fail_tasks
             for task in incomplete_tasks:
@@ -392,12 +376,12 @@ class AzureBatchHook(BaseHook):
     def test_connection(self):
         """Test a configured Azure Batch connection."""
         try:
-            # Attempt to list existing  jobs under the configured Batch account and retrieve
+            # Attempt to list existing jobs under the configured Batch account and retrieve
             # the first in the returned iterator. The Azure Batch API does allow for creation of a
-            # BatchServiceClient with incorrect values but then will fail properly once items are
+            # BatchClient with incorrect values but then will fail properly once items are
             # retrieved using the client. We need to _actually_ try to retrieve an object to properly
             # test the connection.
-            next(self.get_conn().job.list(), None)
+            next(self.get_conn().list_jobs(), None)
         except Exception as e:
             return False, str(e)
         return True, "Successfully connected to Azure Batch."

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
@@ -88,8 +88,6 @@ class AzureBatchOperator(BaseOperator):
     :param vm_version: The version of the virtual machine
     :param vm_version: str | None
     :param vm_node_agent_sku_id: The node agent sku id of the virtual machine
-    :param os_family: The Azure Guest OS family to be installed on the virtual machines in the Pool.
-    :param os_version: The OS family version
     :param timeout: The amount of time to wait for the job to complete in minutes. Default is 25
     :param should_delete_job: Whether to delete job after execution. Default is False
     :param should_delete_pool: Whether to delete pool after execution of jobs. Default is False
@@ -122,16 +120,14 @@ class AzureBatchOperator(BaseOperator):
         sku_starts_with: str | None = None,
         vm_sku: str | None = None,
         vm_version: str | None = None,
-        os_family: str | None = None,
-        os_version: str | None = None,
         batch_pool_display_name: str | None = None,
         batch_job_display_name: str | None = None,
-        batch_job_manager_task: batch_models.JobManagerTask | None = None,
-        batch_job_preparation_task: batch_models.JobPreparationTask | None = None,
-        batch_job_release_task: batch_models.JobReleaseTask | None = None,
+        batch_job_manager_task: batch_models.BatchJobManagerTask | None = None,
+        batch_job_preparation_task: batch_models.BatchJobPreparationTask | None = None,
+        batch_job_release_task: batch_models.BatchJobReleaseTask | None = None,
         batch_task_display_name: str | None = None,
-        batch_task_container_settings: batch_models.TaskContainerSettings | None = None,
-        batch_start_task: batch_models.StartTask | None = None,
+        batch_task_container_settings: batch_models.BatchTaskContainerSettings | None = None,
+        batch_start_task: batch_models.BatchStartTask | None = None,
         batch_max_retries: int = 3,
         batch_task_resource_files: list[batch_models.ResourceFile] | None = None,
         batch_task_output_files: list[batch_models.OutputFile] | None = None,
@@ -179,8 +175,6 @@ class AzureBatchOperator(BaseOperator):
         self.vm_sku = vm_sku
         self.vm_version = vm_version
         self.vm_node_agent_sku_id = vm_node_agent_sku_id
-        self.os_family = os_family
-        self.os_version = os_version
         self.timeout = timeout
         self.should_delete_job = should_delete_job
         self.should_delete_pool = should_delete_pool
@@ -193,14 +187,8 @@ class AzureBatchOperator(BaseOperator):
         return AzureBatchHook(self.azure_batch_conn_id)
 
     def _check_inputs(self) -> Any:
-        if not self.os_family and not self.vm_publisher:
-            raise AirflowException("You must specify either vm_publisher or os_family")
-        if self.os_family and self.vm_publisher:
-            raise AirflowException(
-                "Cloud service configuration and virtual machine configuration "
-                "are mutually exclusive. You must specify either of os_family and"
-                " vm_publisher"
-            )
+        if not self.vm_publisher:
+            raise AirflowException("You must specify vm_publisher")
 
         if self.use_latest_image:
             if not self.vm_publisher or not self.vm_offer:
@@ -253,7 +241,6 @@ class AzureBatchOperator(BaseOperator):
 
     def execute(self, context: Context) -> None:
         self._check_inputs()
-        self.hook.connection.config.retry_policy = self.batch_max_retries
 
         pool = self.hook.configure_pool(
             pool_id=self.batch_pool_id,
@@ -267,8 +254,6 @@ class AzureBatchOperator(BaseOperator):
             vm_sku=self.vm_sku,
             vm_version=self.vm_version,
             vm_node_agent_sku_id=self.vm_node_agent_sku_id,
-            os_family=self.os_family,
-            os_version=self.os_version,
             target_low_priority_nodes=self.target_low_priority_nodes,
             enable_auto_scale=self.enable_auto_scale,
             auto_scale_formula=self.auto_scale_formula,
@@ -280,9 +265,9 @@ class AzureBatchOperator(BaseOperator):
         self.hook.wait_for_all_node_state(
             self.batch_pool_id,
             {
-                batch_models.ComputeNodeState.start_task_failed,
-                batch_models.ComputeNodeState.unusable,
-                batch_models.ComputeNodeState.idle,
+                batch_models.BatchNodeState.START_TASK_FAILED,
+                batch_models.BatchNodeState.UNUSABLE,
+                batch_models.BatchNodeState.IDLE,
             },
         )
         # Create job if not already exist
@@ -310,11 +295,11 @@ class AzureBatchOperator(BaseOperator):
 
         if self.deferrable:
             # Pre-deferral check (node readiness is already enforced by wait_for_all_node_state above)
-            pool = self.hook.connection.pool.get(self.batch_pool_id)
-            if pool.resize_errors:
-                raise RuntimeError(f"Pool resize errors: {pool.resize_errors}")
+            current_pool = self.hook.connection.get_pool(self.batch_pool_id)
+            if current_pool.resize_errors:
+                raise RuntimeError(f"Pool resize errors: {current_pool.resize_errors}")
 
-            nodes = list(self.hook.connection.compute_node.list(self.batch_pool_id))
+            nodes = list(self.hook.connection.list_nodes(self.batch_pool_id))
             self.log.debug("Deferral pre-check: %d nodes present in pool %s", len(nodes), self.batch_pool_id)
             end_time = time.time() + (self.timeout * 60)
 
@@ -380,10 +365,8 @@ class AzureBatchOperator(BaseOperator):
                 self.clean_up(pool_id=self.batch_pool_id)
 
     def on_kill(self) -> None:
-        response = self.hook.connection.job.terminate(
-            job_id=self.batch_job_id, terminate_reason="Job killed by user"
-        )
-        self.log.info("Azure Batch job (%s) terminated: %s", self.batch_job_id, response)
+        self.hook.connection.begin_terminate_job(self.batch_job_id)
+        self.log.info("Azure Batch job (%s) terminated", self.batch_job_id)
 
     def clean_up(self, pool_id: str | None = None, job_id: str | None = None) -> None:
         """
@@ -395,7 +378,7 @@ class AzureBatchOperator(BaseOperator):
         """
         if job_id:
             self.log.info("Deleting job: %s", job_id)
-            self.hook.connection.job.delete(job_id)
+            self.hook.connection.begin_delete_job(job_id)
         if pool_id:
             self.log.info("Deleting pool: %s", pool_id)
-            self.hook.connection.pool.delete(pool_id)
+            self.hook.connection.begin_delete_pool(pool_id)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/operators/batch.py
@@ -365,7 +365,7 @@ class AzureBatchOperator(BaseOperator):
                 self.clean_up(pool_id=self.batch_pool_id)
 
     def on_kill(self) -> None:
-        self.hook.connection.begin_terminate_job(self.batch_job_id)
+        self.hook.connection.begin_terminate_job(self.batch_job_id).result()
         self.log.info("Azure Batch job (%s) terminated", self.batch_job_id)
 
     def clean_up(self, pool_id: str | None = None, job_id: str | None = None) -> None:
@@ -378,7 +378,7 @@ class AzureBatchOperator(BaseOperator):
         """
         if job_id:
             self.log.info("Deleting job: %s", job_id)
-            self.hook.connection.begin_delete_job(job_id)
+            self.hook.connection.begin_delete_job(job_id).result()
         if pool_id:
             self.log.info("Deleting pool: %s", pool_id)
-            self.hook.connection.begin_delete_pool(pool_id)
+            self.hook.connection.begin_delete_pool(pool_id).result()

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/batch.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/triggers/batch.py
@@ -66,14 +66,14 @@ class AzureBatchTrigger(BaseTrigger):
 
     def _get_incomplete_tasks(
         self,
-        tasks: list[batch_models.CloudTask],
-    ) -> list[batch_models.CloudTask]:
+        tasks: list[batch_models.BatchTask],
+    ) -> list[batch_models.BatchTask]:
         """Return tasks that have not yet completed."""
-        return [task for task in tasks if task.state != batch_models.TaskState.completed]
+        return [task for task in tasks if task.state != batch_models.BatchTaskState.COMPLETED]
 
     def _build_trigger_event(
         self,
-        tasks: list[batch_models.CloudTask],
+        tasks: list[batch_models.BatchTask],
     ) -> TriggerEvent | None:
         """
         Convert Batch task states to TriggerEvent.
@@ -95,7 +95,8 @@ class AzureBatchTrigger(BaseTrigger):
         failed_tasks = [
             task.id
             for task in tasks
-            if task.execution_info and task.execution_info.result == batch_models.TaskExecutionResult.failure
+            if task.execution_info
+            and task.execution_info.result == batch_models.BatchTaskExecutionResult.FAILURE
         ]
 
         if failed_tasks:
@@ -124,7 +125,7 @@ class AzureBatchTrigger(BaseTrigger):
 
         try:
             while time.time() <= self.end_time:
-                tasks = await asyncio.to_thread(lambda: list(hook.connection.task.list(self.job_id)))
+                tasks = await asyncio.to_thread(lambda: list(hook.connection.list_tasks(self.job_id)))
 
                 event = self._build_trigger_event(tasks)
 
@@ -145,7 +146,7 @@ class AzureBatchTrigger(BaseTrigger):
 
             # Final check before timeout event in case job completed
             # during the last sleep interval.
-            tasks = await asyncio.to_thread(lambda: list(hook.connection.task.list(self.job_id)))
+            tasks = await asyncio.to_thread(lambda: list(hook.connection.list_tasks(self.job_id)))
 
             event = self._build_trigger_event(tasks)
 

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_batch.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_batch.py
@@ -21,7 +21,7 @@ from unittest import mock
 from unittest.mock import PropertyMock
 
 import pytest
-from azure.batch import BatchServiceClient, models as batch_models
+from azure.batch import BatchClient, models as batch_models
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook
@@ -32,7 +32,6 @@ MODULE = "airflow.providers.microsoft.azure.hooks.batch"
 class TestAzureBatchHook:
     @pytest.fixture(autouse=True)
     def setup_test_cases(self, create_mock_connections):
-        # set up the test variable
         self.test_vm_conn_id = "test_azure_batch_vm"
         self.test_cloud_conn_id = "test_azure_batch_cloud"
         self.test_account_name = "test_account_name"
@@ -42,132 +41,101 @@ class TestAzureBatchHook:
         self.test_vm_publisher = "test.vm.publisher"
         self.test_vm_offer = "test.vm.offer"
         self.test_vm_sku = "test-sku"
-        self.test_cloud_os_family = "test-family"
-        self.test_cloud_os_version = "test-version"
         self.test_node_agent_sku = "test-node-agent-sku"
 
         create_mock_connections(
-            # connect with vm configuration
             Connection(
                 conn_id=self.test_vm_conn_id,
-                conn_type="azure-batch",
+                conn_type="azure_batch",
+                login=self.test_account_name,
+                password=self.test_account_key,
                 extra={"account_url": self.test_account_url},
             ),
-            # connect with cloud service
             Connection(
                 conn_id=self.test_cloud_conn_id,
-                conn_type="azure-batch",
+                conn_type="azure_batch",
+                login=self.test_account_name,
+                password=self.test_account_key,
                 extra={"account_url": self.test_account_url},
             ),
         )
 
     def test_connection_and_client(self):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
-        assert isinstance(hook.get_conn(), BatchServiceClient)
+        assert isinstance(hook.get_conn(), BatchClient)
         conn = hook.connection
-        assert isinstance(conn, BatchServiceClient)
+        assert isinstance(conn, BatchClient)
         assert hook.connection is conn, "`connection` property should be cached"
 
-    @mock.patch(f"{MODULE}.batch_auth.SharedKeyCredentials")
-    @mock.patch(f"{MODULE}.AzureIdentityCredentialAdapter")
-    def test_fallback_to_azure_identity_credential_adppter_when_name_and_key_is_not_provided(
-        self, mock_azure_identity_credential_adapter, mock_shared_key_credentials
+    @mock.patch(f"{MODULE}.get_sync_default_azure_credential")
+    def test_fallback_to_default_azure_credential_when_name_and_key_is_not_provided(
+        self, mock_get_default_credential, create_mock_connections
     ):
-        self.test_account_name = None
-        self.test_account_key = None
-
-        hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
-        assert isinstance(hook.get_conn(), BatchServiceClient)
-        mock_azure_identity_credential_adapter.assert_called_with(
-            None,
-            resource_id="https://batch.core.windows.net/.default",
+        create_mock_connections(
+            Connection(
+                conn_id="test_no_key_conn",
+                conn_type="azure_batch",
+                extra={"account_url": self.test_account_url},
+            )
+        )
+        hook = AzureBatchHook(azure_batch_conn_id="test_no_key_conn")
+        hook.get_conn()
+        mock_get_default_credential.assert_called_with(
             managed_identity_client_id=None,
             workload_identity_tenant_id=None,
         )
-        assert not mock_shared_key_credentials.auth.called
-
-        self.test_account_name = "test_account_name"
-        self.test_account_key = "test_account_key"
 
     def test_configure_pool_with_vm_config(self):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
         pool = hook.configure_pool(
             pool_id="mypool",
             vm_size="test_vm_size",
-            vm_node_agent_sku_id=self.test_vm_sku,
+            vm_node_agent_sku_id=self.test_node_agent_sku,
             target_dedicated_nodes=1,
-            vm_publisher="test.vm.publisher",
-            vm_offer="test.vm.offer",
-            sku_starts_with="test-sku",
+            vm_publisher=self.test_vm_publisher,
+            vm_offer=self.test_vm_offer,
+            sku_starts_with=self.test_vm_sku,
+            vm_sku=self.test_vm_sku,
         )
-        assert isinstance(pool, batch_models.PoolAddParameter)
-
-    def test_configure_pool_with_cloud_config(self):
-        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-        pool = hook.configure_pool(
-            pool_id="mypool",
-            vm_size="test_vm_size",
-            vm_node_agent_sku_id=self.test_vm_sku,
-            target_dedicated_nodes=1,
-            vm_publisher="test.vm.publisher",
-            vm_offer="test.vm.offer",
-            sku_starts_with="test-sku",
-        )
-        assert isinstance(pool, batch_models.PoolAddParameter)
+        assert isinstance(pool, batch_models.BatchPoolCreateOptions)
+        assert pool.id == "mypool"
+        assert pool.vm_size == "test_vm_size"
 
     def test_configure_pool_with_latest_vm(self):
         with mock.patch(
-            "airflow.providers.microsoft.azure.hooks."
-            "batch.AzureBatchHook._get_latest_verified_image_vm_and_sku"
+            "airflow.providers.microsoft.azure.hooks.batch.AzureBatchHook._get_latest_verified_image_vm_and_sku"
         ) as mock_getvm:
-            hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-            getvm_instance = mock_getvm
-            getvm_instance.return_value = ["test-image", "test-sku"]
+            hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
+            mock_getvm.return_value = ("test-sku", mock.Mock())
             pool = hook.configure_pool(
                 pool_id="mypool",
                 vm_size="test_vm_size",
-                vm_node_agent_sku_id=self.test_vm_sku,
+                vm_node_agent_sku_id=self.test_node_agent_sku,
                 use_latest_image_and_sku=True,
-                vm_publisher="test.vm.publisher",
-                vm_offer="test.vm.offer",
-                sku_starts_with="test-sku",
+                vm_publisher=self.test_vm_publisher,
+                vm_offer=self.test_vm_offer,
+                sku_starts_with=self.test_vm_sku,
             )
-            assert isinstance(pool, batch_models.PoolAddParameter)
+            assert isinstance(pool, batch_models.BatchPoolCreateOptions)
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
-    def test_create_pool_with_vm_config(self, mock_batch):
+    @mock.patch(f"{MODULE}.BatchClient")
+    def test_create_pool(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
-        mock_instance = mock_batch.return_value.pool.add
         pool = hook.configure_pool(
             pool_id="mypool",
             vm_size="test_vm_size",
-            vm_node_agent_sku_id=self.test_vm_sku,
+            vm_node_agent_sku_id=self.test_node_agent_sku,
             target_dedicated_nodes=1,
-            vm_publisher="test.vm.publisher",
-            vm_offer="test.vm.offer",
-            sku_starts_with="test-sku",
+            vm_publisher=self.test_vm_publisher,
+            vm_offer=self.test_vm_offer,
+            sku_starts_with=self.test_vm_sku,
+            vm_sku=self.test_vm_sku,
         )
         hook.create_pool(pool=pool)
-        mock_instance.assert_called_once_with(pool)
-
-    @mock.patch(f"{MODULE}.BatchServiceClient")
-    def test_create_pool_with_cloud_config(self, mock_batch):
-        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-        mock_instance = mock_batch.return_value.pool.add
-        pool = hook.configure_pool(
-            pool_id="mypool",
-            vm_size="test_vm_size",
-            vm_node_agent_sku_id=self.test_vm_sku,
-            target_dedicated_nodes=1,
-            vm_publisher="test.vm.publisher",
-            vm_offer="test.vm.offer",
-            sku_starts_with="test-sku",
-        )
-        hook.create_pool(pool=pool)
-        mock_instance.assert_called_once_with(pool)
+        hook.connection.create_pool.assert_called_once_with(pool)
 
     @mock.patch(f"{MODULE}.time.sleep", return_value=None)
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_nodes_success_immediately(self, _mock_batch, mock_sleep):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
 
@@ -176,24 +144,24 @@ class TestAzureBatchHook:
         pool.target_dedicated_nodes = 2
         pool.resize_errors = None
 
-        node_idle_1 = mock.Mock(state=batch_models.ComputeNodeState.idle)
-        node_idle_2 = mock.Mock(state=batch_models.ComputeNodeState.idle)
+        node_idle_1 = mock.Mock(state=batch_models.BatchNodeState.IDLE)
+        node_idle_2 = mock.Mock(state=batch_models.BatchNodeState.IDLE)
 
-        hook.connection.pool.get.return_value = pool
-        hook.connection.compute_node.list.return_value = [node_idle_1, node_idle_2]
+        hook.connection.get_pool.return_value = pool
+        hook.connection.list_nodes.return_value = [node_idle_1, node_idle_2]
 
         nodes = hook.wait_for_all_node_state(
             pool_id="mypool",
-            node_state={batch_models.ComputeNodeState.idle},
+            node_state={batch_models.BatchNodeState.IDLE},
         )
 
         assert nodes == [node_idle_1, node_idle_2]
-        hook.connection.pool.get.assert_called_once_with("mypool")
-        hook.connection.compute_node.list.assert_called_once_with("mypool")
+        hook.connection.get_pool.assert_called_once_with("mypool")
+        hook.connection.list_nodes.assert_called_once_with("mypool")
         assert mock_sleep.call_count == 0
 
     @mock.patch(f"{MODULE}.time.sleep", return_value=None)
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_nodes_waits_for_node_count(self, _mock_batch, mock_sleep):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
 
@@ -202,29 +170,26 @@ class TestAzureBatchHook:
         pool.target_dedicated_nodes = 2
         pool.resize_errors = None
 
-        node_idle_1 = mock.Mock(state=batch_models.ComputeNodeState.idle)
-        node_idle_2 = mock.Mock(state=batch_models.ComputeNodeState.idle)
+        node_idle_1 = mock.Mock(state=batch_models.BatchNodeState.IDLE)
+        node_idle_2 = mock.Mock(state=batch_models.BatchNodeState.IDLE)
 
-        hook.connection.pool.get.return_value = pool
-
-        # First call must return only 1 node.
-        # Second call must return 2 nodes.
-        hook.connection.compute_node.list.side_effect = [
+        hook.connection.get_pool.return_value = pool
+        hook.connection.list_nodes.side_effect = [
             [node_idle_1],
             [node_idle_1, node_idle_2],
         ]
 
         nodes = hook.wait_for_all_node_state(
             pool_id="mypool",
-            node_state={batch_models.ComputeNodeState.idle},
+            node_state={batch_models.BatchNodeState.IDLE},
         )
 
         assert nodes == [node_idle_1, node_idle_2]
-        assert hook.connection.compute_node.list.call_count == 2
+        assert hook.connection.list_nodes.call_count == 2
         assert mock_sleep.call_count == 1
 
     @mock.patch(f"{MODULE}.time.sleep", return_value=None)
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_nodes_retries_until_ready(self, _mock_batch, mock_sleep):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
 
@@ -233,32 +198,28 @@ class TestAzureBatchHook:
         pool.target_dedicated_nodes = 2
         pool.resize_errors = None
 
-        node_starting_1 = mock.Mock(state=batch_models.ComputeNodeState.starting)
-        node_starting_2 = mock.Mock(state=batch_models.ComputeNodeState.starting)
+        node_starting_1 = mock.Mock(state=batch_models.BatchNodeState.STARTING)
+        node_starting_2 = mock.Mock(state=batch_models.BatchNodeState.STARTING)
+        node_idle_1 = mock.Mock(state=batch_models.BatchNodeState.IDLE)
+        node_idle_2 = mock.Mock(state=batch_models.BatchNodeState.IDLE)
 
-        node_idle_1 = mock.Mock(state=batch_models.ComputeNodeState.idle)
-        node_idle_2 = mock.Mock(state=batch_models.ComputeNodeState.idle)
-
-        hook.connection.pool.get.return_value = pool
-
-        # Nodes are not ready in the first poll.
-        # Nodes are ready in the second poll.
-        hook.connection.compute_node.list.side_effect = [
+        hook.connection.get_pool.return_value = pool
+        hook.connection.list_nodes.side_effect = [
             [node_starting_1, node_starting_2],
             [node_idle_1, node_idle_2],
         ]
 
         nodes = hook.wait_for_all_node_state(
             pool_id="mypool",
-            node_state={batch_models.ComputeNodeState.idle},
+            node_state={batch_models.BatchNodeState.IDLE},
         )
 
         assert nodes == [node_idle_1, node_idle_2]
-        assert hook.connection.compute_node.list.call_count == 2
+        assert hook.connection.list_nodes.call_count == 2
         assert mock_sleep.call_count == 1
 
     @mock.patch(f"{MODULE}.time.sleep", return_value=None)
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_nodes_resize_error(self, _mock_batch, mock_sleep):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
 
@@ -267,102 +228,85 @@ class TestAzureBatchHook:
         pool.target_dedicated_nodes = 2
         pool.resize_errors = ["resize failed"]
 
-        hook.connection.pool.get.return_value = pool
+        hook.connection.get_pool.return_value = pool
 
         with pytest.raises(RuntimeError, match="resize error encountered"):
             hook.wait_for_all_node_state(
                 pool_id="mypool",
-                node_state={batch_models.ComputeNodeState.idle},
+                node_state={batch_models.BatchNodeState.IDLE},
             )
         assert mock_sleep.call_count == 0
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_job_configuration_and_create_job(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
-        mock_instance = mock_batch.return_value.job.add
         job = hook.configure_job(job_id="myjob", pool_id="mypool")
         hook.create_job(job)
-        assert isinstance(job, batch_models.JobAddParameter)
-        mock_instance.assert_called_once_with(job)
+        assert isinstance(job, batch_models.BatchJobCreateOptions)
+        hook.connection.create_job.assert_called_once_with(job)
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_add_single_task_to_job(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_vm_conn_id)
-        mock_instance = mock_batch.return_value.task.add
         task = hook.configure_task(task_id="mytask", command_line="echo hello")
         hook.add_single_task_to_job(job_id="myjob", task=task)
-        assert isinstance(task, batch_models.TaskAddParameter)
-        mock_instance.assert_called_once_with(job_id="myjob", task=task)
+        assert isinstance(task, batch_models.BatchTaskCreateOptions)
+        hook.connection.create_task.assert_called_once_with("myjob", task)
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_task_to_complete_timeout(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
         with pytest.raises(TimeoutError):
             hook.wait_for_job_tasks_to_complete("myjob", -1)
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_task_to_complete_all_success(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-        hook.connection.task.list.return_value = iter(
-            [
-                batch_models.CloudTask(
-                    id="mytask_1",
-                    execution_info=batch_models.TaskExecutionInformation(
-                        retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.success
-                    ),
-                    state=batch_models.TaskState.completed,
-                ),
-                batch_models.CloudTask(
-                    id="mytask_2",
-                    execution_info=batch_models.TaskExecutionInformation(
-                        retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.success
-                    ),
-                    state=batch_models.TaskState.completed,
-                ),
-            ]
-        )
+
+        task1 = mock.Mock()
+        task1.state = batch_models.BatchTaskState.COMPLETED
+        task1.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
+
+        task2 = mock.Mock()
+        task2.state = batch_models.BatchTaskState.COMPLETED
+        task2.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
+
+        hook.connection.list_tasks.return_value = [task1, task2]
 
         results = hook.wait_for_job_tasks_to_complete("myjob", 60)
         assert results == []
-        hook.connection.task.list.assert_called_once_with("myjob")
+        hook.connection.list_tasks.assert_called_once_with("myjob")
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_wait_for_all_task_to_complete_failures(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-        tasks = [
-            batch_models.CloudTask(
-                id="mytask_1",
-                execution_info=batch_models.TaskExecutionInformation(
-                    retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.success
-                ),
-                state=batch_models.TaskState.completed,
-            ),
-            batch_models.CloudTask(
-                id="mytask_2",
-                execution_info=batch_models.TaskExecutionInformation(
-                    retry_count=0, requeue_count=0, result=batch_models.TaskExecutionResult.failure
-                ),
-                state=batch_models.TaskState.completed,
-            ),
-        ]
-        hook.connection.task.list.return_value = iter(tasks)
+
+        task1 = mock.Mock()
+        task1.state = batch_models.BatchTaskState.COMPLETED
+        task1.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
+
+        task2 = mock.Mock()
+        task2.state = batch_models.BatchTaskState.COMPLETED
+        task2.execution_info.result = batch_models.BatchTaskExecutionResult.FAILURE
+
+        hook.connection.list_tasks.return_value = [task1, task2]
 
         results = hook.wait_for_job_tasks_to_complete("myjob", 60)
-        assert results == [tasks[1]]
-        hook.connection.task.list.assert_called_once_with("myjob")
+        assert results == [task2]
+        hook.connection.list_tasks.assert_called_once_with("myjob")
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_connection_success(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-        hook.connection.job.return_value = {}
+        hook.connection.list_jobs.return_value = iter([])
         status, msg = hook.test_connection()
         assert status is True
         assert msg == "Successfully connected to Azure Batch."
 
-    @mock.patch(f"{MODULE}.BatchServiceClient")
+    @mock.patch(f"{MODULE}.BatchClient")
     def test_connection_failure(self, mock_batch):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
-        hook.connection.job.list = PropertyMock(side_effect=Exception("Authentication failed."))
+        hook.connection.list_jobs = PropertyMock(side_effect=Exception("Authentication failed."))
         status, msg = hook.test_connection()
         assert status is False
         assert msg == "Authentication failed."

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_batch.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_batch.py
@@ -41,22 +41,18 @@ FORMULA = """$curTime = time();
 
 
 @pytest.fixture
-def mocked_batch_service_client():
-    with mock.patch("airflow.providers.microsoft.azure.hooks.batch.BatchServiceClient") as m:
+def mocked_batch_client():
+    with mock.patch("airflow.providers.microsoft.azure.hooks.batch.BatchClient") as m:
         yield m
 
 
 class TestAzureBatchOperator:
-    # set up the test environment
     @pytest.fixture(autouse=True)
-    def setup_test_cases(self, mocked_batch_service_client, create_mock_connections):
-        # set up mocked Azure Batch client
-        self.batch_client = mock.MagicMock(name="FakeBatchServiceClient")
-        mocked_batch_service_client.return_value = self.batch_client
+    def setup_test_cases(self, mocked_batch_client, create_mock_connections):
+        self.batch_client = mock.MagicMock(name="FakeBatchClient")
+        mocked_batch_client.return_value = self.batch_client
 
-        # set up the test variable
         self.test_vm_conn_id = "test_azure_batch_vm2"
-        self.test_cloud_conn_id = "test_azure_batch_cloud2"
         self.test_account_name = "test_account_name"
         self.test_account_key = "test_account_key"
         self.test_account_url = "http://test-endpoint:29000"
@@ -64,21 +60,14 @@ class TestAzureBatchOperator:
         self.test_vm_publisher = "test.vm.publisher"
         self.test_vm_offer = "test.vm.offer"
         self.test_vm_sku = "test-sku"
-        self.test_cloud_os_family = "test-family"
-        self.test_cloud_os_version = "test-version"
         self.test_node_agent_sku = "test-node-agent-sku"
 
         create_mock_connections(
-            # connect with vm configuration
             Connection(
                 conn_id=self.test_vm_conn_id,
                 conn_type="azure_batch",
-                extra=json.dumps({"account_url": self.test_account_url}),
-            ),
-            # connect with cloud service
-            Connection(
-                conn_id=self.test_cloud_conn_id,
-                conn_type="azure_batch",
+                login=self.test_account_name,
+                password=self.test_account_key,
                 extra=json.dumps({"account_url": self.test_account_url}),
             ),
         )
@@ -99,28 +88,32 @@ class TestAzureBatchOperator:
             target_dedicated_nodes=1,
             timeout=2,
         )
-        self.operator2_pass = AzureBatchOperator(
+        self.operator_auto_scale = AzureBatchOperator(
             task_id=TASK_ID,
             batch_pool_id=BATCH_POOL_ID,
             batch_pool_vm_size=BATCH_VM_SIZE,
             batch_job_id=BATCH_JOB_ID,
             batch_task_id=BATCH_TASK_ID,
+            vm_publisher=self.test_vm_publisher,
+            vm_offer=self.test_vm_offer,
+            vm_sku=self.test_vm_sku,
             vm_node_agent_sku_id=self.test_node_agent_sku,
-            os_family="4",
             batch_task_command_line="echo hello",
             azure_batch_conn_id=self.test_vm_conn_id,
             enable_auto_scale=True,
             auto_scale_formula=FORMULA,
             timeout=2,
         )
-        self.operator2_no_formula = AzureBatchOperator(
+        self.operator_no_formula = AzureBatchOperator(
             task_id=TASK_ID,
             batch_pool_id=BATCH_POOL_ID,
             batch_pool_vm_size=BATCH_VM_SIZE,
             batch_job_id=BATCH_JOB_ID,
             batch_task_id=BATCH_TASK_ID,
+            vm_publisher=self.test_vm_publisher,
+            vm_offer=self.test_vm_offer,
+            vm_sku=self.test_vm_sku,
             vm_node_agent_sku_id=self.test_node_agent_sku,
-            os_family="4",
             batch_task_command_line="echo hello",
             azure_batch_conn_id=self.test_vm_conn_id,
             enable_auto_scale=True,
@@ -132,27 +125,12 @@ class TestAzureBatchOperator:
             batch_pool_vm_size=BATCH_VM_SIZE,
             batch_job_id=BATCH_JOB_ID,
             batch_task_id=BATCH_TASK_ID,
-            vm_node_agent_sku_id=self.test_node_agent_sku,
-            os_family="4",
-            batch_task_command_line="echo hello",
-            azure_batch_conn_id=self.test_vm_conn_id,
-            timeout=2,
-        )
-        self.operator_mutual_exclusive = AzureBatchOperator(
-            task_id=TASK_ID,
-            batch_pool_id=BATCH_POOL_ID,
-            batch_pool_vm_size=BATCH_VM_SIZE,
-            batch_job_id=BATCH_JOB_ID,
-            batch_task_id=BATCH_TASK_ID,
             vm_publisher=self.test_vm_publisher,
             vm_offer=self.test_vm_offer,
             vm_sku=self.test_vm_sku,
             vm_node_agent_sku_id=self.test_node_agent_sku,
-            os_family="5",
-            sku_starts_with=self.test_vm_sku,
             batch_task_command_line="echo hello",
             azure_batch_conn_id=self.test_vm_conn_id,
-            target_dedicated_nodes=1,
             timeout=2,
         )
         self.operator_invalid = AzureBatchOperator(
@@ -170,44 +148,38 @@ class TestAzureBatchOperator:
 
     @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
     def test_execute_without_failures(self, wait_mock):
-        wait_mock.return_value = True  # No wait
+        wait_mock.return_value = True
         self.operator.execute(None)
-        # test pool creation
-        self.batch_client.pool.add.assert_called()
-        self.batch_client.job.add.assert_called()
-        self.batch_client.task.add.assert_called()
+        self.batch_client.create_pool.assert_called()
+        self.batch_client.create_job.assert_called()
+        self.batch_client.create_task.assert_called()
 
     @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
-    def test_execute_without_failures_2(self, wait_mock):
-        wait_mock.return_value = True  # No wait
-        self.operator2_pass.execute(None)
-        # test pool creation
-        self.batch_client.pool.add.assert_called()
-        self.batch_client.job.add.assert_called()
-        self.batch_client.task.add.assert_called()
+    def test_execute_auto_scale(self, wait_mock):
+        wait_mock.return_value = True
+        self.operator_auto_scale.execute(None)
+        self.batch_client.create_pool.assert_called()
+        self.batch_client.create_job.assert_called()
+        self.batch_client.create_task.assert_called()
 
     @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
     def test_execute_with_failures(self, wait_mock):
-        wait_mock.return_value = True  # No wait
-        # Remove pool id
+        wait_mock.return_value = True
         self.operator.batch_pool_id = None
-
-        # test that it raises
         with pytest.raises(AirflowException):
             self.operator.execute(None)
 
     @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
     @mock.patch.object(AzureBatchOperator, "clean_up")
     def test_execute_with_cleaning(self, mock_clean, wait_mock):
-        wait_mock.return_value = True  # No wait
-        # Remove pool id
+        wait_mock.return_value = True
         self.operator.should_delete_job = True
         self.operator.execute(None)
         mock_clean.assert_called()
         mock_clean.assert_called_once_with(job_id=BATCH_JOB_ID)
 
     @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
-    def test_operator_fails(self, wait_mock):
+    def test_operator_fails_no_dedicated_nodes_or_autoscale(self, wait_mock):
         wait_mock.return_value = True
         with pytest.raises(AirflowException) as ctx:
             self.operator_fail.execute(None)
@@ -219,41 +191,30 @@ class TestAzureBatchOperator:
     def test_operator_fails_no_formula(self, wait_mock):
         wait_mock.return_value = True
         with pytest.raises(AirflowException) as ctx:
-            self.operator2_no_formula.execute(None)
+            self.operator_no_formula.execute(None)
         assert str(ctx.value) == "The auto_scale_formula is required when enable_auto_scale is set"
-
-    @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
-    def test_operator_fails_mutual_exclusive(self, wait_mock):
-        wait_mock.return_value = True
-        with pytest.raises(AirflowException) as ctx:
-            self.operator_mutual_exclusive.execute(None)
-        assert (
-            str(ctx.value) == "Cloud service configuration and virtual machine configuration "
-            "are mutually exclusive. You must specify either of os_family and"
-            " vm_publisher"
-        )
 
     @mock.patch.object(AzureBatchHook, "wait_for_all_node_state")
     def test_operator_fails_invalid_args(self, wait_mock):
         wait_mock.return_value = True
         with pytest.raises(AirflowException) as ctx:
             self.operator_invalid.execute(None)
-        assert str(ctx.value) == "You must specify either vm_publisher or os_family"
+        assert str(ctx.value) == "You must specify vm_publisher"
 
     def test_cleaning_works(self):
         self.operator.clean_up(job_id="myjob")
-        self.batch_client.job.delete.assert_called_once_with("myjob")
+        self.batch_client.begin_delete_job.assert_called_once_with("myjob")
         self.operator.clean_up("mypool")
-        self.batch_client.pool.delete.assert_called_once_with("mypool")
+        self.batch_client.begin_delete_pool.assert_called_once_with("mypool")
         self.operator.clean_up("mypool", "myjob")
-        self.batch_client.job.delete.assert_called_with("myjob")
-        self.batch_client.pool.delete.assert_called_with("mypool")
+        self.batch_client.begin_delete_job.assert_called_with("myjob")
+        self.batch_client.begin_delete_pool.assert_called_with("mypool")
 
 
 class TestAzureBatchOperatorDeferrable:
     @pytest.fixture(autouse=True)
     def setup_test_cases(self, mocked_batch_service_client, create_mock_connections):
-        self.batch_client = mock.MagicMock(name="FakeBatchServiceClient")
+        self.batch_client = mock.MagicMock(name="FakeBatchClient")
         mocked_batch_service_client.return_value = self.batch_client
 
         self.test_conn_id = "test_azure_batch"
@@ -275,7 +236,9 @@ class TestAzureBatchOperatorDeferrable:
             batch_task_id=BATCH_TASK_ID,
             batch_task_command_line="echo hello",
             vm_node_agent_sku_id="node-agent",
-            os_family="4",
+            vm_publisher="MicrosoftWindowsServer",
+            vm_offer="WindowsServer",
+            vm_sku="2019-Datacenter",
             target_dedicated_nodes=1,
             azure_batch_conn_id=self.test_conn_id,
             deferrable=True,
@@ -285,7 +248,7 @@ class TestAzureBatchOperatorDeferrable:
     def test_execute_defers(self, wait_mock):
 
         wait_mock.return_value = True
-        self.batch_client.pool.get.return_value.resize_errors = None
+        self.batch_client.get_pool.return_value.resize_errors = None
 
         with pytest.raises(TaskDeferred) as ctx:
             self.operator.execute(None)
@@ -297,9 +260,9 @@ class TestAzureBatchOperatorDeferrable:
         assert trigger.job_id == BATCH_JOB_ID
         assert trigger.azure_batch_conn_id == self.test_conn_id
 
-        self.batch_client.pool.add.assert_called()
-        self.batch_client.job.add.assert_called()
-        self.batch_client.task.add.assert_called()
+        self.batch_client.create_pool.assert_called()
+        self.batch_client.create_job.assert_called()
+        self.batch_client.create_task.assert_called()
 
     def test_execute_complete_success(self):
         with mock.patch.object(self.operator.log, "info") as mock_log:

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_batch.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/operators/test_batch.py
@@ -213,9 +213,9 @@ class TestAzureBatchOperator:
 
 class TestAzureBatchOperatorDeferrable:
     @pytest.fixture(autouse=True)
-    def setup_test_cases(self, mocked_batch_service_client, create_mock_connections):
+    def setup_test_cases(self, mocked_batch_client, create_mock_connections):
         self.batch_client = mock.MagicMock(name="FakeBatchClient")
-        mocked_batch_service_client.return_value = self.batch_client
+        mocked_batch_client.return_value = self.batch_client
 
         self.test_conn_id = "test_azure_batch"
         self.test_account_url = "http://test-endpoint:29000"

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_batch.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_batch.py
@@ -56,8 +56,8 @@ class TestAzureBatchTrigger:
     def test_build_trigger_event_success(self):
         completed_task = mock.MagicMock()
         completed_task.id = "task1"
-        completed_task.state = batch_models.TaskState.completed
-        completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+        completed_task.state = batch_models.BatchTaskState.COMPLETED
+        completed_task.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
 
         event = self.TRIGGER._build_trigger_event([completed_task])
 
@@ -72,8 +72,8 @@ class TestAzureBatchTrigger:
     def test_build_trigger_event_failure(self):
         failed_task = mock.MagicMock()
         failed_task.id = "task1"
-        failed_task.state = batch_models.TaskState.completed
-        failed_task.execution_info.result = batch_models.TaskExecutionResult.failure
+        failed_task.state = batch_models.BatchTaskState.COMPLETED
+        failed_task.execution_info.result = batch_models.BatchTaskExecutionResult.FAILURE
 
         event = self.TRIGGER._build_trigger_event([failed_task])
 
@@ -89,12 +89,12 @@ class TestAzureBatchTrigger:
     def test_build_trigger_event_mixed_states(self):
         completed_task = mock.MagicMock()
         completed_task.id = "task1"
-        completed_task.state = batch_models.TaskState.completed
-        completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+        completed_task.state = batch_models.BatchTaskState.COMPLETED
+        completed_task.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
 
         running_task = mock.MagicMock()
         running_task.id = "task2"
-        running_task.state = batch_models.TaskState.running
+        running_task.state = batch_models.BatchTaskState.RUNNING
 
         event = self.TRIGGER._build_trigger_event([completed_task, running_task])
 
@@ -121,12 +121,12 @@ class TestAzureBatchTrigger:
     ):
         running_task = mock.MagicMock()
         running_task.id = "task1"
-        running_task.state = batch_models.TaskState.running
+        running_task.state = batch_models.BatchTaskState.RUNNING
 
         completed_task = mock.MagicMock()
         completed_task.id = "task1"
-        completed_task.state = batch_models.TaskState.completed
-        completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+        completed_task.state = batch_models.BatchTaskState.COMPLETED
+        completed_task.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
 
         mock_to_thread.side_effect = [
             [running_task],
@@ -150,7 +150,7 @@ class TestAzureBatchTrigger:
     def test_build_trigger_event_non_terminal(self):
         running_task = mock.MagicMock()
         running_task.id = "task1"
-        running_task.state = batch_models.TaskState.running
+        running_task.state = batch_models.BatchTaskState.RUNNING
 
         event = self.TRIGGER._build_trigger_event([running_task])
 
@@ -161,8 +161,8 @@ class TestAzureBatchTrigger:
     async def test_trigger_run_success(self, mock_to_thread):
         completed_task = mock.MagicMock()
         completed_task.id = "task1"
-        completed_task.state = batch_models.TaskState.completed
-        completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+        completed_task.state = batch_models.BatchTaskState.COMPLETED
+        completed_task.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
 
         mock_to_thread.return_value = [completed_task]
 
@@ -182,8 +182,8 @@ class TestAzureBatchTrigger:
     async def test_trigger_run_failure(self, mock_to_thread):
         failed_task = mock.MagicMock()
         failed_task.id = "task1"
-        failed_task.state = batch_models.TaskState.completed
-        failed_task.execution_info.result = batch_models.TaskExecutionResult.failure
+        failed_task.state = batch_models.BatchTaskState.COMPLETED
+        failed_task.execution_info.result = batch_models.BatchTaskExecutionResult.FAILURE
 
         mock_to_thread.return_value = [failed_task]
 
@@ -243,8 +243,8 @@ class TestAzureBatchTrigger:
     ):
         completed_task = mock.MagicMock()
         completed_task.id = "task1"
-        completed_task.state = batch_models.TaskState.completed
-        completed_task.execution_info.result = batch_models.TaskExecutionResult.success
+        completed_task.state = batch_models.BatchTaskState.COMPLETED
+        completed_task.execution_info.result = batch_models.BatchTaskExecutionResult.SUCCESS
 
         mock_to_thread.return_value = [completed_task]
 
@@ -268,7 +268,7 @@ class TestAzureBatchTrigger:
     async def test_trigger_timeout(self, mock_to_thread, mock_time):
         running_task = mock.MagicMock()
         running_task.id = "task1"
-        running_task.state = batch_models.TaskState.running
+        running_task.state = batch_models.BatchTaskState.RUNNING
 
         mock_to_thread.return_value = [running_task]
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,9 +64,9 @@ apache-airflow-providers-apache-cassandra = false
 apache-airflow-providers-asana = false
 apache-airflow-providers-oracle = false
 apache-airflow-providers-mysql = false
-apache-airflow-providers-teradata = false
 apache-airflow-providers-alibaba = false
 apache-airflow-providers-microsoft-mssql = false
+apache-airflow-providers-teradata = false
 apache-airflow-providers-jdbc = false
 apache-airflow-helm-chart = false
 apache-airflow-providers-anthropic = false
@@ -9558,14 +9558,15 @@ name = "azure-batch"
 version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core", specifier = ">=1.37.0" },
-    { name = "isodate", specifier = ">=0.6.1" },
-    { name = "typing-extensions", specifier = ">=4.6.0" },
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/ec/9c38379dea2a4817a5c5b44282eff56476326cefa09da9e804809b397656/azure_batch-15.1.0.tar.gz", hash = "sha256:2f684d176b457b7213535e145180a914ed6844b2d1066fcc22ac88c3ac9e3fa5", size = 298104, upload-time = "2026-05-01T23:30:12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/ec/9c38379dea2a4817a5c5b44282eff56476326cefa09da9e804809b397656/azure_batch-15.1.0.tar.gz", hash = "sha256:2f684d176b457b7213535e145180a914ed6844b2d1066fcc22ac88c3ac9e3fa5", size = 298104, upload-time = "2026-05-01T23:30:12.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/35/358a421ebbb0d6fa929333dd71b94922d34445aa02d9d2fa7c0a277dcf53/azure_batch-15.1.0-py3-none-any.whl", hash = "sha256:6001232ba67a4051f4f1b35d434232757b78baa14e4964ec3bfb91afa1d10ed4", size = 260933, upload-time = "2026-05-01T23:30:14Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/358a421ebbb0d6fa929333dd71b94922d34445aa02d9d2fa7c0a277dcf53/azure_batch-15.1.0-py3-none-any.whl", hash = "sha256:6001232ba67a4051f4f1b35d434232757b78baa14e4964ec3bfb91afa1d10ed4", size = 260933, upload-time = "2026-05-01T23:30:14.604Z" },
 ]
+
 [[package]]
 name = "azure-common"
 version = "1.1.28"

--- a/uv.lock
+++ b/uv.lock
@@ -4223,7 +4223,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-clickhousedb"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "providers/clickhousedb" }
 dependencies = [
     { name = "apache-airflow" },
@@ -6231,7 +6231,7 @@ docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "d
 
 [[package]]
 name = "apache-airflow-providers-keycloak"
-version = "0.8.2"
+version = "0.9.0"
 source = { editable = "providers/keycloak" }
 dependencies = [
     { name = "apache-airflow" },
@@ -6358,7 +6358,7 @@ requires-dist = [
     { name = "apache-airflow-providers-oracle", marker = "extra == 'oracle'", editable = "providers/oracle" },
     { name = "apache-airflow-providers-sftp", marker = "extra == 'sftp'", editable = "providers/sftp" },
     { name = "azure-ai-projects", specifier = ">=2.2.0" },
-    { name = "azure-batch", specifier = ">=8.0.0,<15.0.0" },
+    { name = "azure-batch", specifier = ">=15.0.0" },
     { name = "azure-cosmos", specifier = ">=4.6.0" },
     { name = "azure-datalake-store", specifier = ">=0.0.45" },
     { name = "azure-identity", specifier = ">=1.3.1" },
@@ -9555,17 +9555,17 @@ wheels = [
 
 [[package]]
 name = "azure-batch"
-version = "14.2.0"
+version = "15.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-common" },
-    { name = "msrestazure" },
+    { name = "azure-core", specifier = ">=1.37.0" },
+    { name = "isodate", specifier = ">=0.6.1" },
+    { name = "typing-extensions", specifier = ">=4.6.0" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/3e/4611960f8ceb281285d764f32a0e88515fab4e1e32ff5d02bc77e55bbcb6/azure-batch-14.2.0.tar.gz", hash = "sha256:c79267d6c3d3fe14a16a422ab5bbfabcbd68ed0b58b6bbcdfa0c8345c4c78532", size = 243784, upload-time = "2024-03-27T20:05:11.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/ec/9c38379dea2a4817a5c5b44282eff56476326cefa09da9e804809b397656/azure_batch-15.1.0.tar.gz", hash = "sha256:2f684d176b457b7213535e145180a914ed6844b2d1066fcc22ac88c3ac9e3fa5", size = 298104, upload-time = "2026-05-01T23:30:12Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/15/42aa83f62dc47e00bed0e590d19252c24b94b8c3b740d9bce33ec867e785/azure_batch-14.2.0-py3-none-any.whl", hash = "sha256:115ccff0007852784ccf8fc12f5f3d415ed80513be306da7a8938ca82d948ee7", size = 243322, upload-time = "2024-03-27T20:05:13.803Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/358a421ebbb0d6fa929333dd71b94922d34445aa02d9d2fa7c0a277dcf53/azure_batch-15.1.0-py3-none-any.whl", hash = "sha256:6001232ba67a4051f4f1b35d434232757b78baa14e4964ec3bfb91afa1d10ed4", size = 260933, upload-time = "2026-05-01T23:30:14Z" },
 ]
-
 [[package]]
 name = "azure-common"
 version = "1.1.28"


### PR DESCRIPTION
closes: #66466
related: #67600

`azure-batch` 15.x is a ground-up rewrite of Azure's Python SDK (track 1 → track 2); `BatchServiceClient` and the old model classes are gone. #66452 capped `azure-batch<15.0.0` as a stopgap; #66466 tracks the real migration to lift it.

### The migration 

This PR carries forward @arieleli01212's work from [#67600](https://github.com/apache/airflow/pull/67600) as-is: `BatchServiceClient` → `BatchClient`, shared-key auth moved to `AzureNamedKeyCredential`, the renamed model classes (`PoolAddParameter` → `BatchPoolCreateOptions`, `CloudTask` → `BatchTask`, etc.), the move to the new flat client API, dropping `CloudServiceConfiguration`/`os_family`/`os_version`, and the matching test rewrites.

### What this PR adds on top

Two commits on top of his 16, kept separate:

**1. Rebase onto current `main`.** One real conflict, in `docs/changelog.rst` (an unrelated `14.0.0` entry had landed since). Resolved by keeping it and placing this migration's pending note above it.

**2. Fix for the identity-auth path**, addressing [@aaron-y-chen's open review comment](https://github.com/apache/airflow/pull/67600#pullrequestreview-4679686593)(https://github.com/apache/airflow/pull/67600#pullrequestreview-4679686593) on the `# type: ignore[arg-type]` next to the `BatchClient` credential. The identity-based branch of `get_conn()` built an `AzureIdentityCredentialAdapter`, which subclasses msrest's track-1 `BasicTokenAuthentication` and doesn't implement `get_token()` — what azure-core's `TokenCredential` protocol requires, and what `BatchClient` needs to authenticate. `AzureBaseHook.get_token()` in this provider already documents this and raises `AttributeError` for it. So this path passed every mocked test but would fail against a real account. Switched to `get_sync_default_azure_credential()`,  already used by `AzureBaseHook` and `asb.py` for this exact purpose, which returns a real `DefaultAzureCredential` that does implement `get_token()`. The `type: ignore` is removed; updated the matching test; added a changelog line.

### Testing

`pytest providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_batch.py` passes.

[@eladkal asked](https://github.com/apache/airflow/pull/67600#issuecomment-4850934389) whether this had been tested against a live account. Since the bug above only shows up once the SDK actually tries to authenticate, I validated it two ways:

**1. Credential check (no Azure account needed):**
```python
hasattr(AzureIdentityCredentialAdapter(None, resource_id="https://batch.core.windows.net/.default"), "get_token")  # False
hasattr(get_sync_default_azure_credential(), "get_token")  # True
```

**2. Live pool lifecycle against a real Azure Batch account** (Azure for Students, Sweden Central), identity-based auth via Azure CLI login, no shared key:
```python
from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook

hook = AzureBatchHook(azure_batch_conn_id="test_live_azure_batch")
client = hook.get_conn()

pool = hook.configure_pool(
    pool_id="claude-smoketest-pool",
    vm_publisher="canonical",
    vm_offer="0001-com-ubuntu-server-jammy",
    vm_sku="22_04-lts",
    vm_node_agent_sku_id="batch.node.ubuntu 22.04",
    vm_size="Standard_A1_v2",
    target_dedicated_nodes=0,
)
client.create_pool(pool)
pools = list(client.list_pools())
client.begin_delete_pool("claude-smoketest-pool").result()
```
Real HTTP round trips, no mocking:
```
DefaultAzureCredential acquired a token from AzureCliCredential
POST /pools → 201, pool created
GET /pools → 200, pool visible
DELETE /pools/claude-smoketest-pool → 202, then 404 on follow-up :  confirmed deleted
```
No `AttributeError`:  the exact failure mode of the pre-fix code. Test resources were deleted after validation.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Sonnet 5), reviewed and tested by the submitter.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=640895c action=comment -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @baha-bouali** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Image build**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
