### PR TITLE
Log and audit when the partitioned Dag run per-tick cap is reached

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2267,11 +2267,12 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # loses. The `id` tiebreaker on `order_by` keeps LIMIT deterministic when
         # two APDRs share a `created_at` under bulk asset-event ingestion.
         # SQLite is single-writer and silently drops `FOR UPDATE`, which is fine.
-        # LIMIT cap + 1: a row beyond the cap is the cheapest way to tell "there is a real
-        # backlog" apart from "this batch is the entire backlog" without a separate COUNT
-        # query. Only the first `cap` rows are sliced off and processed below — the extra
-        # probe row is never touched.
-        rows = session.scalars(
+        # The fetch is capped at `cap` rows. When it comes back full, we can't tell from the
+        # fetch alone whether that's the entire backlog or just this tick's slice of a larger
+        # one, so we pay for a separate lock-free `count()` query in that case only — trading
+        # an occasional extra read for not locking rows this process won't claim, and for a
+        # real number to report in logs/audit instead of the capped fetch size.
+        pending_apdrs = session.scalars(
             with_row_locks(
                 select(AssetPartitionDagRun)
                 .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
@@ -2280,15 +2281,29 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     DagModel.is_stale.is_(False),
                 )
                 .order_by(AssetPartitionDagRun.created_at, AssetPartitionDagRun.id)
-                .limit(self._max_partition_dag_runs_per_loop + 1),
+                .limit(self._max_partition_dag_runs_per_loop),
                 of=AssetPartitionDagRun,
                 skip_locked=True,
                 key_share=False,
                 session=session,
             )
         ).all()
-        has_backlog = len(rows) > self._max_partition_dag_runs_per_loop
-        pending_apdrs = rows[: self._max_partition_dag_runs_per_loop]
+        if len(pending_apdrs) >= self._max_partition_dag_runs_per_loop:
+            backlog_total = (
+                session.scalar(
+                    select(func.count())
+                    .select_from(AssetPartitionDagRun)
+                    .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
+                    .where(
+                        AssetPartitionDagRun.created_dag_run_id.is_(None),
+                        DagModel.is_stale.is_(False),
+                    )
+                )
+                or 0
+            )
+        else:
+            backlog_total = len(pending_apdrs)
+        has_backlog = backlog_total > self._max_partition_dag_runs_per_loop
         if has_backlog:
             # Cap the dag_ids surfaced in logs/audit to the first 5 distinct target_dag_ids so a
             # backlog spanning many Dags doesn't blow up the log line / audit row.
@@ -2299,7 +2314,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
                 "will be evaluated over subsequent scheduler ticks",
                 cap=self._max_partition_dag_runs_per_loop,
-                pending_count=len(pending_apdrs),
+                backlog_total=backlog_total,
                 dag_ids=truncated_dag_ids,
             )
             # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
@@ -2327,7 +2342,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                                     f"runs this tick, reaching the internal per-tick cap of "
                                     f"{self._max_partition_dag_runs_per_loop}. This cap is a hardcoded "
                                     "scheduler safety limit, not a configurable setting; the remaining "
-                                    f"backlog will be evaluated over subsequent ticks. {dag_ids_note}"
+                                    f"backlog will be evaluated over subsequent ticks. A total of "
+                                    f"{backlog_total} partitioned Dag runs are currently eligible and "
+                                    f"pending across ticks. {dag_ids_note}"
                                 ),
                             )
                         )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -381,6 +381,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # Edge-triggers the "partition Dag run cap reached" audit Log row: True once that row
         # has been committed for the current backlog episode, reset to False once the backlog
         # drains below the cap.
+        # Process-local: each scheduler in an HA deployment writes at most one audit row per
+        # episode; cross-process de-duplication would need a per-tick DB read, defeating the
+        # point of edge-triggering.
         self._partition_cap_backlog_reported = False
         self._dag_id_to_team_name: dict[str, str | None] = {}
 
@@ -2329,7 +2332,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         if backlog_total > self._max_partition_dag_runs_per_loop:
             displayed_dag_ids = sorted_dag_ids[:MAX_PARTITION_CAP_BACKLOG_DAG_IDS_LOGGED]
             remaining_dag_id_count = len(sorted_dag_ids) - len(displayed_dag_ids)
-            self.log.warning(
+            log_cap_reached = self.log.debug if self._partition_cap_backlog_reported else self.log.warning
+            log_cap_reached(
                 (
                     "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
                     "will be evaluated over subsequent scheduler ticks"

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -370,7 +370,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self._multi_team = conf.getboolean("core", "multi_team")
         self._dag_tags_in_metrics = conf.getboolean("metrics", "dag_tags_in_metrics", fallback=False)
         self._max_partition_dag_runs_per_loop = MAX_PARTITION_DAG_RUNS_PER_LOOP
-        # Edge-triggers the "partition dag run cap reached" audit Log row: True once that row
+        # Edge-triggers the "partition Dag run cap reached" audit Log row: True once that row
         # has been committed for the current backlog episode, reset to False once the backlog
         # drains below the cap.
         self._partition_cap_backlog_reported = False
@@ -2304,12 +2304,26 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 or 0
             )
+            # Distinct dag_ids across the *whole* backlog, not just this tick's oldest-cap
+            # slice (`pending_apdrs`) — a Dag whose partitions haven't reached the front of
+            # the FIFO queue yet would otherwise be missing from the log/audit row until its
+            # turn comes up. Same WHERE clause as the count query above so the two never drift.
+            backlog_dag_ids = set(
+                session.scalars(
+                    select(AssetPartitionDagRun.target_dag_id)
+                    .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
+                    .where(
+                        AssetPartitionDagRun.created_dag_run_id.is_(None),
+                        DagModel.is_stale.is_(False),
+                    )
+                    .distinct()
+                )
+            )
         else:
             backlog_total = len(pending_apdrs)
             self._partition_cap_backlog_reported = False
 
         if backlog_total > self._max_partition_dag_runs_per_loop:
-            affected_dag_ids = {apdr.target_dag_id for apdr in pending_apdrs}
             self.log.warning(
                 (
                     "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
@@ -2317,7 +2331,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ),
                 cap=self._max_partition_dag_runs_per_loop,
                 backlog_total=backlog_total,
-                dag_ids=affected_dag_ids,
+                dag_ids=backlog_dag_ids,
             )
             # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
             # and writing a `Log` row that often would flood the audit table. Write it once per
@@ -2331,7 +2345,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Invariant: this must run before *session* makes any writes this tick, or the
                 # new connection's commit can lock-contend with it on SQLite.
                 try:
-                    dag_ids_note = f"Affected dag_ids: {', '.join(affected_dag_ids)}."
                     with create_session(scoped=False) as audit_session:
                         audit_session.add(
                             Log(
@@ -2342,7 +2355,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                                     f"{self._max_partition_dag_runs_per_loop}. The remaining backlog will "
                                     f"be evaluated over subsequent ticks. A total of {backlog_total} "
                                     f"partitioned Dag runs are currently eligible and pending across "
-                                    f"ticks. {dag_ids_note}"
+                                    f"ticks. Affected dag_ids: {', '.join(backlog_dag_ids)}."
                                 ),
                             )
                         )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2265,23 +2265,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         This matches the UI's progress view (``_fetch_active_assets_per_dag``).
         """
         # Cap per-tick work so the scheduler transaction stays bounded and other
-        # scheduling work isn't starved. Remaining APDRs drain across subsequent ticks.
-        # FIFO is intentional: the oldest pending APDR fires first. A persistently
-        # unsatisfiable APDR at the head (e.g. broken mapper, upstream that will
-        # never arrive) blocks newer ones until an operator removes it or fixes
-        # the underlying mapper. We surface the stuck state rather than silently
-        # rotating past it.
-        # `with_row_locks(skip_locked=True)` mirrors the sibling ADRQ claim path:
-        # in HA two schedulers can otherwise both grab the same satisfied APDR
-        # and race the `created_dag_run_id` UPDATE, orphaning whichever DagRun
-        # loses. The `id` tiebreaker on `order_by` keeps LIMIT deterministic when
-        # two APDRs share a `created_at` under bulk asset-event ingestion.
-        # SQLite is single-writer and silently drops `FOR UPDATE`, which is fine.
-        # The fetch is capped at `cap` rows. When it comes back full, we can't tell from the
-        # fetch alone whether that's the entire backlog or just this tick's slice of a larger
-        # one, so we pay for a separate lock-free `count()` query in that case only — trading
-        # an occasional extra read for not locking rows this process won't claim, and for a
-        # real number to report in logs/audit instead of the capped fetch size.
+        # scheduling work isn't starved; the remainder drains over subsequent ticks.
+        # FIFO is intentional: a persistently unsatisfiable APDR at the head (e.g.
+        # broken mapper, upstream that will never arrive) blocks newer ones until an
+        # operator removes it or fixes the mapper, surfacing the stuck state rather
+        # than silently rotating past it.
+        # `with_row_locks(skip_locked=True)` mirrors the sibling ADRQ claim path: in
+        # HA two schedulers can otherwise both grab the same satisfied APDR and race
+        # the `created_dag_run_id` UPDATE, orphaning whichever DagRun loses. The `id`
+        # tiebreaker on `order_by` keeps LIMIT deterministic when two APDRs share a
+        # `created_at` under bulk asset-event ingestion. SQLite is single-writer and
+        # silently drops `FOR UPDATE`, which is fine.
         pending_apdrs = session.scalars(
             with_row_locks(
                 select(AssetPartitionDagRun)
@@ -2302,7 +2296,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             return set()
 
         if len(pending_apdrs) >= self._max_partition_dag_runs_per_loop:
-            # Per-dag counts across the *whole* backlog, not just this tick's oldest-cap
+            # A full fetch alone can't tell us whether that's the entire backlog or just
+            # this tick's slice of a larger one, so we only pay for this query then.
+            # Per-Dag counts across the *whole* backlog, not just this tick's oldest-cap
             # slice (`pending_apdrs`) — a Dag whose partitions haven't reached the front of
             # the FIFO queue yet would otherwise be missing from the log/audit row until its
             # turn comes up.

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2288,6 +2288,9 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 session=session,
             )
         ).all()
+        if not pending_apdrs:
+            return set()
+
         if len(pending_apdrs) >= self._max_partition_dag_runs_per_loop:
             backlog_total = (
                 session.scalar(
@@ -2303,19 +2306,18 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             )
         else:
             backlog_total = len(pending_apdrs)
-        has_backlog = backlog_total > self._max_partition_dag_runs_per_loop
-        if has_backlog:
-            # Cap the dag_ids surfaced in logs/audit to the first 5 distinct target_dag_ids so a
-            # backlog spanning many Dags doesn't blow up the log line / audit row.
-            affected_dag_ids = list(dict.fromkeys(apdr.target_dag_id for apdr in pending_apdrs))
-            truncated_dag_ids = affected_dag_ids[:5]
-            extra_dag_id_count = len(affected_dag_ids) - len(truncated_dag_ids)
+            self._partition_cap_backlog_reported = False
+
+        if backlog_total > self._max_partition_dag_runs_per_loop:
+            affected_dag_ids = {apdr.target_dag_id for apdr in pending_apdrs}
             self.log.warning(
-                "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
-                "will be evaluated over subsequent scheduler ticks",
+                (
+                    "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+                    "will be evaluated over subsequent scheduler ticks"
+                ),
                 cap=self._max_partition_dag_runs_per_loop,
                 backlog_total=backlog_total,
-                dag_ids=truncated_dag_ids,
+                dag_ids=affected_dag_ids,
             )
             # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
             # and writing a `Log` row that often would flood the audit table. Write it once per
@@ -2329,35 +2331,29 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Invariant: this must run before *session* makes any writes this tick, or the
                 # new connection's commit can lock-contend with it on SQLite.
                 try:
-                    dag_ids_note = f"Affected dag_ids: {', '.join(truncated_dag_ids)}"
-                    if extra_dag_id_count > 0:
-                        dag_ids_note += f" (and {extra_dag_id_count} more)"
-                    dag_ids_note += "."
+                    dag_ids_note = f"Affected dag_ids: {', '.join(affected_dag_ids)}."
                     with create_session(scoped=False) as audit_session:
                         audit_session.add(
                             Log(
-                                event="partition dag run cap reached",
+                                event="partition Dag run cap reached",
                                 extra=(
                                     f"The scheduler evaluated {len(pending_apdrs)} pending partitioned Dag "
                                     f"runs this tick, reaching the internal per-tick cap of "
-                                    f"{self._max_partition_dag_runs_per_loop}. This cap is a hardcoded "
-                                    "scheduler safety limit, not a configurable setting; the remaining "
-                                    f"backlog will be evaluated over subsequent ticks. A total of "
-                                    f"{backlog_total} partitioned Dag runs are currently eligible and "
-                                    f"pending across ticks. {dag_ids_note}"
+                                    f"{self._max_partition_dag_runs_per_loop}. The remaining backlog will "
+                                    f"be evaluated over subsequent ticks. A total of {backlog_total} "
+                                    f"partitioned Dag runs are currently eligible and pending across "
+                                    f"ticks. {dag_ids_note}"
                                 ),
                             )
                         )
                 except (DBAPIError, exc.TimeoutError):
                     # Purely observational — must not fail or retry the tick's actual DagRun
                     # creation work. Leave the flag False so the next tick retries the write.
-                    self.log.warning("Failed to write the partition dag run cap audit Log row", exc_info=True)
+                    self.log.warning("Failed to write the partition Dag run cap audit Log row", exc_info=True)
                 else:
                     self._partition_cap_backlog_reported = True
         else:
             self._partition_cap_backlog_reported = False
-        if not pending_apdrs:
-            return set()
 
         # Pre-fetch all required serialized Dags in one query. The same map
         # serves the stale-version cleanup below and the downstream rollup

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2331,7 +2331,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                                 ),
                             )
                         )
-                except (OperationalError, exc.TimeoutError):
+                except (DBAPIError, exc.TimeoutError):
                     # Purely observational — must not fail or retry the tick's actual DagRun
                     # creation work. Leave the flag False so the next tick retries the write.
                     self.log.warning("Failed to write the partition dag run cap audit Log row", exc_info=True)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -41,7 +41,6 @@ from sqlalchemy import (
     case,
     cast as sql_cast,
     delete,
-    exc,
     exists,
     func,
     inspect,
@@ -51,7 +50,7 @@ from sqlalchemy import (
     tuple_,
     update,
 )
-from sqlalchemy.exc import DBAPIError, OperationalError
+from sqlalchemy.exc import DBAPIError, OperationalError, SQLAlchemyError
 from sqlalchemy.orm import joinedload, lazyload, load_only, make_transient, selectinload
 from sqlalchemy.sql import expression
 
@@ -2374,7 +2373,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                                 ),
                             )
                         )
-                except (DBAPIError, exc.TimeoutError):
+                except SQLAlchemyError:
                     # Purely observational — must not fail or retry the tick's actual DagRun
                     # creation work. Leave the flag False so the next tick retries the write.
                     self.log.warning("Failed to write the partition Dag run cap audit Log row", exc_info=True)

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -41,6 +41,7 @@ from sqlalchemy import (
     case,
     cast as sql_cast,
     delete,
+    exc,
     exists,
     func,
     inspect,
@@ -369,6 +370,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self._multi_team = conf.getboolean("core", "multi_team")
         self._dag_tags_in_metrics = conf.getboolean("metrics", "dag_tags_in_metrics", fallback=False)
         self._max_partition_dag_runs_per_loop = MAX_PARTITION_DAG_RUNS_PER_LOOP
+        # Edge-triggers the "partition dag run cap reached" audit Log row: True once that row
+        # has been committed for the current backlog episode, reset to False once the backlog
+        # drains below the cap.
+        self._partition_cap_backlog_reported = False
         self._dag_id_to_team_name: dict[str, str | None] = {}
 
         self.executors: list[BaseExecutor] = executors if executors else ExecutorLoader.init_executors()
@@ -2262,7 +2267,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # loses. The `id` tiebreaker on `order_by` keeps LIMIT deterministic when
         # two APDRs share a `created_at` under bulk asset-event ingestion.
         # SQLite is single-writer and silently drops `FOR UPDATE`, which is fine.
-        pending_apdrs = session.scalars(
+        # LIMIT cap + 1: a row beyond the cap is the cheapest way to tell "there is a real
+        # backlog" apart from "this batch is the entire backlog" without a separate COUNT
+        # query. Only the first `cap` rows are sliced off and processed below — the extra
+        # probe row is never touched.
+        rows = session.scalars(
             with_row_locks(
                 select(AssetPartitionDagRun)
                 .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
@@ -2271,13 +2280,55 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     DagModel.is_stale.is_(False),
                 )
                 .order_by(AssetPartitionDagRun.created_at, AssetPartitionDagRun.id)
-                .limit(self._max_partition_dag_runs_per_loop),
+                .limit(self._max_partition_dag_runs_per_loop + 1),
                 of=AssetPartitionDagRun,
                 skip_locked=True,
                 key_share=False,
                 session=session,
             )
         ).all()
+        has_backlog = len(rows) > self._max_partition_dag_runs_per_loop
+        pending_apdrs = rows[: self._max_partition_dag_runs_per_loop]
+        if has_backlog:
+            self.log.warning(
+                "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+                "will be evaluated over subsequent scheduler ticks",
+                cap=self._max_partition_dag_runs_per_loop,
+                pending_count=len(pending_apdrs),
+            )
+            # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
+            # and writing a `Log` row that often would flood the audit table. Write it once per
+            # backlog episode; `_partition_cap_backlog_reported` is cleared below once the
+            # backlog drains.
+            if not self._partition_cap_backlog_reported:
+                # A separate, independently-committed session is required here: the caller
+                # (`_create_dagruns_for_dags`) runs under `@retry_db_transaction`, which rolls
+                # back *session* on a `DBAPIError` — sharing that transaction would silently
+                # discard this audit row along with the rest of the tick's work.
+                # Invariant: this must run before *session* makes any writes this tick, or the
+                # new connection's commit can lock-contend with it on SQLite.
+                try:
+                    with create_session(scoped=False) as audit_session:
+                        audit_session.add(
+                            Log(
+                                event="partition dag run cap reached",
+                                extra=(
+                                    f"The scheduler evaluated {len(pending_apdrs)} pending partitioned Dag "
+                                    f"runs this tick, reaching the internal per-tick cap of "
+                                    f"{self._max_partition_dag_runs_per_loop}. This cap is a hardcoded "
+                                    "scheduler safety limit, not a configurable setting; the remaining "
+                                    "backlog will be evaluated over subsequent ticks."
+                                ),
+                            )
+                        )
+                except (OperationalError, exc.TimeoutError):
+                    # Purely observational — must not fail or retry the tick's actual DagRun
+                    # creation work. Leave the flag False so the next tick retries the write.
+                    self.log.warning("Failed to write the partition dag run cap audit Log row", exc_info=True)
+                else:
+                    self._partition_cap_backlog_reported = True
+        else:
+            self._partition_cap_backlog_reported = False
         if not pending_apdrs:
             return set()
 

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -175,6 +175,14 @@ deployment, so eviction costs a re-fetch only where that working set is genuinel
 # safety bound, not a behavioural knob operators need to tune.
 MAX_PARTITION_DAG_RUNS_PER_LOOP = 500
 
+# Caps how many dag_ids are rendered in the per-tick cap log/audit row. The
+# backlog's distinct dag_id count is unbounded, so writing it straight into a
+# log field/DB row without a cap risks an unbounded payload. 20 is enough for
+# an operator to diagnose which Dags are backlogged without letting the audit
+# row's payload size run away. Internal constant, not a user setting, for the
+# same reason as the constant above.
+MAX_PARTITION_CAP_BACKLOG_DAG_IDS_LOGGED = 20
+
 
 def _eager_load_dag_run_for_validation() -> tuple[LoaderOption, LoaderOption]:
     """
@@ -2292,38 +2300,35 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             return set()
 
         if len(pending_apdrs) >= self._max_partition_dag_runs_per_loop:
-            backlog_total = (
-                session.scalar(
-                    select(func.count())
+            # Per-dag counts across the *whole* backlog, not just this tick's oldest-cap
+            # slice (`pending_apdrs`) — a Dag whose partitions haven't reached the front of
+            # the FIFO queue yet would otherwise be missing from the log/audit row until its
+            # turn comes up.
+            backlogs_per_dag: dict[str, int] = {
+                dag_id: count
+                for dag_id, count in session.execute(
+                    select(AssetPartitionDagRun.target_dag_id, func.count())
                     .select_from(AssetPartitionDagRun)
                     .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
                     .where(
                         AssetPartitionDagRun.created_dag_run_id.is_(None),
                         DagModel.is_stale.is_(False),
                     )
+                    .group_by(AssetPartitionDagRun.target_dag_id)
                 )
-                or 0
-            )
-            # Distinct dag_ids across the *whole* backlog, not just this tick's oldest-cap
-            # slice (`pending_apdrs`) — a Dag whose partitions haven't reached the front of
-            # the FIFO queue yet would otherwise be missing from the log/audit row until its
-            # turn comes up. Same WHERE clause as the count query above so the two never drift.
-            backlog_dag_ids = set(
-                session.scalars(
-                    select(AssetPartitionDagRun.target_dag_id)
-                    .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
-                    .where(
-                        AssetPartitionDagRun.created_dag_run_id.is_(None),
-                        DagModel.is_stale.is_(False),
-                    )
-                    .distinct()
-                )
-            )
+            }
+            backlog_total = sum(backlogs_per_dag.values())
+            # No SQL-side ORDER BY: it would have no dag_id tie-break, and relying on dict
+            # insertion order mirroring DB row order across backends (SQLite in tests vs
+            # Postgres/MySQL in production) isn't a contract worth trusting — sort explicitly.
+            sorted_dag_ids = sorted(backlogs_per_dag, key=lambda dag_id: (-backlogs_per_dag[dag_id], dag_id))
         else:
             backlog_total = len(pending_apdrs)
             self._partition_cap_backlog_reported = False
 
         if backlog_total > self._max_partition_dag_runs_per_loop:
+            displayed_dag_ids = sorted_dag_ids[:MAX_PARTITION_CAP_BACKLOG_DAG_IDS_LOGGED]
+            remaining_dag_id_count = len(sorted_dag_ids) - len(displayed_dag_ids)
             self.log.warning(
                 (
                     "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
@@ -2331,7 +2336,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 ),
                 cap=self._max_partition_dag_runs_per_loop,
                 backlog_total=backlog_total,
-                dag_ids=backlog_dag_ids,
+                dag_ids=displayed_dag_ids,
             )
             # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
             # and writing a `Log` row that often would flood the audit table. Write it once per
@@ -2344,6 +2349,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # discard this audit row along with the rest of the tick's work.
                 # Invariant: this must run before *session* makes any writes this tick, or the
                 # new connection's commit can lock-contend with it on SQLite.
+                more_suffix = (
+                    f", and {remaining_dag_id_count} more with fewer pending runs"
+                    if remaining_dag_id_count
+                    else ""
+                )
                 try:
                     with create_session(scoped=False) as audit_session:
                         audit_session.add(
@@ -2355,7 +2365,8 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                                     f"{self._max_partition_dag_runs_per_loop}. The remaining backlog will "
                                     f"be evaluated over subsequent ticks. A total of {backlog_total} "
                                     f"partitioned Dag runs are currently eligible and pending across "
-                                    f"ticks. Affected dag_ids: {', '.join(backlog_dag_ids)}."
+                                    f"ticks. Affected dag_ids (highest pending count first): "
+                                    f"{', '.join(displayed_dag_ids)}{more_suffix}."
                                 ),
                             )
                         )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2290,11 +2290,17 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         has_backlog = len(rows) > self._max_partition_dag_runs_per_loop
         pending_apdrs = rows[: self._max_partition_dag_runs_per_loop]
         if has_backlog:
+            # Cap the dag_ids surfaced in logs/audit to the first 5 distinct target_dag_ids so a
+            # backlog spanning many Dags doesn't blow up the log line / audit row.
+            affected_dag_ids = list(dict.fromkeys(apdr.target_dag_id for apdr in pending_apdrs))
+            truncated_dag_ids = affected_dag_ids[:5]
+            extra_dag_id_count = len(affected_dag_ids) - len(truncated_dag_ids)
             self.log.warning(
                 "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
                 "will be evaluated over subsequent scheduler ticks",
                 cap=self._max_partition_dag_runs_per_loop,
                 pending_count=len(pending_apdrs),
+                dag_ids=truncated_dag_ids,
             )
             # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
             # and writing a `Log` row that often would flood the audit table. Write it once per
@@ -2308,6 +2314,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 # Invariant: this must run before *session* makes any writes this tick, or the
                 # new connection's commit can lock-contend with it on SQLite.
                 try:
+                    dag_ids_note = f"Affected dag_ids: {', '.join(truncated_dag_ids)}"
+                    if extra_dag_id_count > 0:
+                        dag_ids_note += f" (and {extra_dag_id_count} more)"
+                    dag_ids_note += "."
                     with create_session(scoped=False) as audit_session:
                         audit_session.add(
                             Log(
@@ -2317,7 +2327,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                                     f"runs this tick, reaching the internal per-tick cap of "
                                     f"{self._max_partition_dag_runs_per_loop}. This cap is a hardcoded "
                                     "scheduler safety limit, not a configurable setting; the remaining "
-                                    "backlog will be evaluated over subsequent ticks."
+                                    f"backlog will be evaluated over subsequent ticks. {dag_ids_note}"
                                 ),
                             )
                         )

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -41,6 +41,7 @@ from sqlalchemy import (
     case,
     cast as sql_cast,
     delete,
+    exc,
     exists,
     func,
     inspect,
@@ -357,6 +358,10 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self._multi_team = conf.getboolean("core", "multi_team")
         self._dag_tags_in_metrics = conf.getboolean("metrics", "dag_tags_in_metrics", fallback=False)
         self._max_partition_dag_runs_per_loop = MAX_PARTITION_DAG_RUNS_PER_LOOP
+        # Edge-triggers the "partition dag run cap reached" audit Log row: True once that row
+        # has been committed for the current backlog episode, reset to False once the backlog
+        # drains below the cap.
+        self._partition_cap_backlog_reported = False
         self._dag_id_to_team_name: dict[str, str | None] = {}
 
         self.executors: list[BaseExecutor] = executors if executors else ExecutorLoader.init_executors()
@@ -2238,7 +2243,11 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # loses. The `id` tiebreaker on `order_by` keeps LIMIT deterministic when
         # two APDRs share a `created_at` under bulk asset-event ingestion.
         # SQLite is single-writer and silently drops `FOR UPDATE`, which is fine.
-        pending_apdrs = session.scalars(
+        # LIMIT cap + 1: a row beyond the cap is the cheapest way to tell "there is a real
+        # backlog" apart from "this batch is the entire backlog" without a separate COUNT
+        # query. Only the first `cap` rows are sliced off and processed below — the extra
+        # probe row is never touched.
+        rows = session.scalars(
             with_row_locks(
                 select(AssetPartitionDagRun)
                 .join(DagModel, DagModel.dag_id == AssetPartitionDagRun.target_dag_id)
@@ -2247,13 +2256,55 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     DagModel.is_stale.is_(False),
                 )
                 .order_by(AssetPartitionDagRun.created_at, AssetPartitionDagRun.id)
-                .limit(self._max_partition_dag_runs_per_loop),
+                .limit(self._max_partition_dag_runs_per_loop + 1),
                 of=AssetPartitionDagRun,
                 skip_locked=True,
                 key_share=False,
                 session=session,
             )
         ).all()
+        has_backlog = len(rows) > self._max_partition_dag_runs_per_loop
+        pending_apdrs = rows[: self._max_partition_dag_runs_per_loop]
+        if has_backlog:
+            self.log.warning(
+                "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+                "will be evaluated over subsequent scheduler ticks",
+                cap=self._max_partition_dag_runs_per_loop,
+                pending_count=len(pending_apdrs),
+            )
+            # Edge-trigger the audit row: a persistent backlog re-hits this branch every tick,
+            # and writing a `Log` row that often would flood the audit table. Write it once per
+            # backlog episode; `_partition_cap_backlog_reported` is cleared below once the
+            # backlog drains.
+            if not self._partition_cap_backlog_reported:
+                # A separate, independently-committed session is required here: the caller
+                # (`_create_dagruns_for_dags`) runs under `@retry_db_transaction`, which rolls
+                # back *session* on a `DBAPIError` — sharing that transaction would silently
+                # discard this audit row along with the rest of the tick's work.
+                # Invariant: this must run before *session* makes any writes this tick, or the
+                # new connection's commit can lock-contend with it on SQLite.
+                try:
+                    with create_session(scoped=False) as audit_session:
+                        audit_session.add(
+                            Log(
+                                event="partition dag run cap reached",
+                                extra=(
+                                    f"The scheduler evaluated {len(pending_apdrs)} pending partitioned Dag "
+                                    f"runs this tick, reaching the internal per-tick cap of "
+                                    f"{self._max_partition_dag_runs_per_loop}. This cap is a hardcoded "
+                                    "scheduler safety limit, not a configurable setting; the remaining "
+                                    "backlog will be evaluated over subsequent ticks."
+                                ),
+                            )
+                        )
+                except (OperationalError, exc.TimeoutError):
+                    # Purely observational — must not fail or retry the tick's actual DagRun
+                    # creation work. Leave the flag False so the next tick retries the write.
+                    self.log.warning("Failed to write the partition dag run cap audit Log row", exc_info=True)
+                else:
+                    self._partition_cap_backlog_reported = True
+        else:
+            self._partition_cap_backlog_reported = False
         if not pending_apdrs:
             return set()
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12958,19 +12958,18 @@ def test_partition_cap_reporting(
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     dag_id = f"cap-consumer-{suffix}"
-    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition Dag run cap reached")).all()
     if expect_cap_hit:
         assert {
             "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
             "will be evaluated over subsequent scheduler ticks",
             "cap": cap,
             "backlog_total": 3,
-            "dag_ids": [dag_id],
+            "dag_ids": {dag_id},
         } in caplog
-        assert [row.event for row in audit_rows] == ["partition dag run cap reached"]
+        assert [row.event for row in audit_rows] == ["partition Dag run cap reached"]
         extra = audit_rows[0].extra
         assert extra is not None
-        # A single distinct dag_id never needs the "(and N more)" truncation note.
         assert f"Affected dag_ids: {dag_id}." in extra
     else:
         assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
@@ -13018,7 +13017,7 @@ def test_partition_cap_reporting_excludes_already_fired_decoy(dag_maker: DagMake
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
-    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition Dag run cap reached")).all()
     assert audit_rows == []
 
 
@@ -13074,18 +13073,18 @@ def test_partition_cap_reporting_excludes_stale_dag_decoy(dag_maker: DagMaker, s
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
-    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition Dag run cap reached")).all()
     assert audit_rows == []
 
 
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
-def test_partition_cap_reporting_truncates_dag_ids_over_five(dag_maker: DagMaker, session: Session, caplog):
+def test_partition_cap_reporting_lists_all_affected_dag_ids(dag_maker: DagMaker, session: Session, caplog):
     """
-    The log/audit ``dag_ids`` list is capped at 5 distinct dag_ids, with a count of the rest.
+    The log/audit ``dag_ids`` list surfaces every distinct affected dag_id, without truncation.
 
     Seven consumer Dags each get one satisfied APDR; with the cap at 6, `pending_apdrs` spans six
-    distinct dag_ids — one more than the 5-item list the log/audit messages surface.
+    distinct dag_ids — all of which must appear in both the log event and the audit row.
 
     Built inline rather than via :func:`_make_n_satisfied_apdrs` because that helper's producer
     dag_id numbering restarts at 1 on every call, colliding across these seven consumer Dags.
@@ -13121,7 +13120,9 @@ def test_partition_cap_reporting_truncates_dag_ids_over_five(dag_maker: DagMaker
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
-    expected_dag_ids = [f"cap-consumer-many-{i}" for i in range(1, 6)]
+    # affected_dag_ids is a set, so its iteration order (and thus the exact rendering in the log
+    # event and audit row) is arbitrary — assert membership, not a specific order.
+    expected_dag_ids = {f"cap-consumer-many-{i}" for i in range(1, 7)}
     assert {
         "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
         "will be evaluated over subsequent scheduler ticks",
@@ -13130,10 +13131,13 @@ def test_partition_cap_reporting_truncates_dag_ids_over_five(dag_maker: DagMaker
         "dag_ids": expected_dag_ids,
     } in caplog
 
-    audit_row = session.scalar(select(Log).where(Log.event == "partition dag run cap reached"))
+    audit_row = session.scalar(select(Log).where(Log.event == "partition Dag run cap reached"))
     assert audit_row is not None
     assert audit_row.extra is not None
-    assert f"Affected dag_ids: {', '.join(expected_dag_ids)} (and 1 more)." in audit_row.extra
+    note_match = re.search(r"Affected dag_ids: (.+)\.$", audit_row.extra)
+    assert note_match is not None
+    assert set(note_match.group(1).split(", ")) == expected_dag_ids
+    assert "and 1 more" not in audit_row.extra
 
 
 @pytest.mark.need_serialized_dag
@@ -13165,7 +13169,7 @@ def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: Dag
     runner._max_partition_dag_runs_per_loop = 2
 
     def _count_audit_log() -> int:
-        return session.scalar(select(func.count()).where(Log.event == "partition dag run cap reached")) or 0
+        return session.scalar(select(func.count()).where(Log.event == "partition Dag run cap reached")) or 0
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 1: 5 pending, cap 2
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 2: 3 pending, still over cap
@@ -13225,9 +13229,9 @@ def test_partition_cap_audit_row_survives_outer_rollback(dag_maker: DagMaker, se
 
     assert runner._partition_cap_backlog_reported is True
     audit_events = session.scalars(
-        select(Log.event).where(Log.event == "partition dag run cap reached")
+        select(Log.event).where(Log.event == "partition Dag run cap reached")
     ).all()
-    assert audit_events == ["partition dag run cap reached"]
+    assert audit_events == ["partition Dag run cap reached"]
 
 
 @pytest.mark.need_serialized_dag
@@ -13264,9 +13268,9 @@ def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker,
     with mock.patch("airflow.jobs.scheduler_job_runner.create_session", return_value=failing_session_cm):
         runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
-    assert "Failed to write the partition dag run cap audit Log row" in caplog
+    assert "Failed to write the partition Dag run cap audit Log row" in caplog
     assert runner._partition_cap_backlog_reported is False
-    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition Dag run cap reached")).all()
     assert audit_rows == []
 
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -40,7 +40,7 @@ import pytest
 import time_machine
 from sqlalchemy import delete, func, inspect, select, update
 from sqlalchemy.dialects import mysql
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, InvalidRequestError
 from sqlalchemy.orm import joinedload
 
 from airflow import settings
@@ -13387,12 +13387,26 @@ def test_partition_cap_audit_row_survives_outer_rollback(dag_maker: DagMaker, se
 
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
-def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker, session: Session, caplog):
+@pytest.mark.parametrize(
+    "audit_write_error",
+    [
+        pytest.param(IntegrityError("INSERT INTO log", {}, Exception("duplicate key")), id="dbapi_error"),
+        pytest.param(
+            # Not a DBAPIError: exercises the broader SQLAlchemyError catch, distinct from a
+            # DBAPI-layer failure.
+            InvalidRequestError("session already flushing"),
+            id="non_dbapi_sqlalchemy_error",
+        ),
+    ],
+)
+def test_partition_cap_audit_row_write_failure_is_swallowed(
+    dag_maker: DagMaker, session: Session, caplog, audit_write_error: Exception
+):
     """
-    A `DBAPIError` while writing the cap-reached audit row must not escape the tick.
+    A `SQLAlchemyError` while writing the cap-reached audit row must not escape the tick.
 
-    The audit write is purely observational, so any DBAPI-layer failure — not just
-    `OperationalError` — must be caught and logged, leaving `_partition_cap_backlog_reported`
+    The audit write is purely observational, so any SQLAlchemy-layer failure — not just a
+    `DBAPIError` — must be caught and logged, leaving `_partition_cap_backlog_reported`
     `False` so the next tick retries the write, and the cap-reached log stays at `warning`
     instead of being downgraded.
     """
@@ -13412,9 +13426,7 @@ def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker,
     runner._max_partition_dag_runs_per_loop = 1
 
     failing_session_cm = MagicMock()
-    failing_session_cm.__enter__.return_value.add.side_effect = IntegrityError(
-        "INSERT INTO log", {}, Exception("duplicate key")
-    )
+    failing_session_cm.__enter__.return_value.add.side_effect = audit_write_error
     failing_session_cm.__exit__.return_value = False
 
     with mock.patch("airflow.jobs.scheduler_job_runner.create_session", return_value=failing_session_cm):

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12957,20 +12957,82 @@ def test_partition_cap_reporting(
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
-    audit_events = session.scalars(
-        select(Log.event).where(Log.event == "partition dag run cap reached")
-    ).all()
+    dag_id = f"cap-consumer-{suffix}"
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
     if expect_cap_hit:
         assert {
             "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
             "will be evaluated over subsequent scheduler ticks",
             "cap": cap,
             "pending_count": cap,
+            "dag_ids": [dag_id],
         } in caplog
-        assert audit_events == ["partition dag run cap reached"]
+        assert [row.event for row in audit_rows] == ["partition dag run cap reached"]
+        extra = audit_rows[0].extra
+        assert extra is not None
+        # A single distinct dag_id never needs the "(and N more)" truncation note.
+        assert f"Affected dag_ids: {dag_id}." in extra
     else:
         assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
-        assert audit_events == []
+        assert audit_rows == []
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_reporting_truncates_dag_ids_over_five(dag_maker: DagMaker, session: Session, caplog):
+    """
+    The log/audit ``dag_ids`` list is capped at 5 distinct dag_ids, with a count of the rest.
+
+    Seven consumer Dags each get one satisfied APDR; with the cap at 6, `pending_apdrs` spans six
+    distinct dag_ids — one more than the 5-item list the log/audit messages surface.
+
+    Built inline rather than via :func:`_make_n_satisfied_apdrs` because that helper's producer
+    dag_id numbering restarts at 1 on every call, colliding across these seven consumer Dags.
+    """
+    apdrs = []
+    for i in range(1, 8):
+        asset = Asset(name=f"asset-cap-many-{i}")
+        with dag_maker(
+            dag_id=f"cap-consumer-many-{i}",
+            schedule=PartitionedAssetTimetable(assets=asset, default_partition_mapper=IdentityMapper()),
+            session=session,
+        ):
+            EmptyOperator(task_id="hi")
+        session.commit()
+        apdrs.append(
+            _produce_and_register_asset_event(
+                dag_id=f"asset-event-producer-many-{i}",
+                asset=asset,
+                partition_key=f"k{i}",
+                session=session,
+                dag_maker=dag_maker,
+            )
+        )
+    base = timezone.utcnow()
+    for i, apdr in enumerate(apdrs):
+        apdr.created_at = base + timedelta(seconds=i)
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 6
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    expected_dag_ids = [f"cap-consumer-many-{i}" for i in range(1, 6)]
+    assert {
+        "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+        "will be evaluated over subsequent scheduler ticks",
+        "cap": 6,
+        "pending_count": 6,
+        "dag_ids": expected_dag_ids,
+    } in caplog
+
+    audit_row = session.scalar(select(Log).where(Log.event == "partition dag run cap reached"))
+    assert audit_row is not None
+    assert audit_row.extra is not None
+    assert f"Affected dag_ids: {', '.join(expected_dag_ids)} (and 1 more)." in audit_row.extra
 
 
 @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12926,9 +12926,9 @@ def test_partition_cap_at_n_minus_one_leaves_one_pending(dag_maker: DagMaker, se
     [
         pytest.param(2, ["k1", "k2", "k3"], True, id="over-cap"),
         pytest.param(3, ["k1", "k2"], False, id="under-cap"),
-        # Regression guard for the ``LIMIT cap + 1`` probe: ``LIMIT cap`` alone cannot tell
-        # "exactly cap, nothing left" from "more than cap, backlog remains", and would wrongly
-        # claim a backlog here.
+        # Regression guard for the ``backlog_total > cap`` boundary: ``backlog_total == cap``
+        # must not be misreported as a backlog (that would be the "exactly cap, nothing left"
+        # case wrongly reported as "more than cap, backlog remains").
         pytest.param(3, ["k1", "k2", "k3"], False, id="exactly-cap"),
     ],
 )
@@ -12964,7 +12964,7 @@ def test_partition_cap_reporting(
             "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
             "will be evaluated over subsequent scheduler ticks",
             "cap": cap,
-            "pending_count": cap,
+            "backlog_total": 3,
             "dag_ids": [dag_id],
         } in caplog
         assert [row.event for row in audit_rows] == ["partition dag run cap reached"]
@@ -12975,6 +12975,107 @@ def test_partition_cap_reporting(
     else:
         assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
         assert audit_rows == []
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_reporting_excludes_already_fired_decoy(dag_maker: DagMaker, session: Session, caplog):
+    """
+    The ``backlog_total`` count query's ``WHERE`` clause must mirror the main query's.
+
+    ``exactly-cap`` in :func:`test_partition_cap_reporting` cannot catch a filter drift in the
+    count query (e.g. a dropped ``created_dag_run_id.is_(None)`` filter): every row in that
+    table at that point is a genuine, unfired, non-stale APDR, so a looser filter has nothing
+    extra to over-count. This test adds a decoy APDR that already fired
+    (``created_dag_run_id`` set) — a naive/unfiltered ``count()`` would wrongly include it.
+    """
+    cap = 3
+    asset = Asset(name="asset-cap-decoy")
+    _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-decoy",
+        asset=asset,
+        partition_keys=["k1", "k2", "k3"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+    decoy = _produce_and_register_asset_event(
+        dag_id="asset-event-producer-decoy",
+        asset=asset,
+        partition_key="decoy",
+        session=session,
+        dag_maker=dag_maker,
+    )
+    fired_dag_run_id = session.scalar(select(DagRun.id).order_by(DagRun.id.desc()).limit(1))
+    assert fired_dag_run_id is not None
+    decoy.created_dag_run_id = fired_dag_run_id
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = cap
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    assert audit_rows == []
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_reporting_excludes_stale_dag_decoy(dag_maker: DagMaker, session: Session, caplog):
+    """
+    The ``backlog_total`` count query's ``WHERE`` clause must mirror the main query's.
+
+    Mirrors :func:`test_partition_cap_reporting_excludes_already_fired_decoy` for the fetch
+    query's other predicate: ``DagModel.is_stale.is_(False)``. This test adds a decoy pending
+    APDR whose target Dag has since gone stale (removed from its Dag file) — a count query
+    missing that filter would wrongly include it, over-counting the backlog even though the
+    fetch query (unaffected by this specific drift) never selects it.
+    """
+    cap = 3
+    _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-stale-decoy",
+        asset=Asset(name="asset-cap-stale-decoy"),
+        partition_keys=["k1", "k2", "k3"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    stale_consumer_dag_id = "cap-consumer-stale-decoy-stale"
+    stale_asset = Asset(name="asset-cap-stale-decoy-stale")
+    with dag_maker(
+        dag_id=stale_consumer_dag_id,
+        schedule=PartitionedAssetTimetable(assets=stale_asset, default_partition_mapper=IdentityMapper()),
+        session=session,
+    ):
+        EmptyOperator(task_id="hi")
+    session.commit()
+
+    _produce_and_register_asset_event(
+        dag_id="asset-event-producer-stale-decoy",
+        asset=stale_asset,
+        partition_key="decoy",
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    dm = session.get(DagModel, stale_consumer_dag_id)
+    assert dm is not None
+    dm.is_stale = True
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = cap
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    assert audit_rows == []
 
 
 @pytest.mark.need_serialized_dag
@@ -13025,7 +13126,7 @@ def test_partition_cap_reporting_truncates_dag_ids_over_five(dag_maker: DagMaker
         "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
         "will be evaluated over subsequent scheduler ticks",
         "cap": 6,
-        "pending_count": 6,
+        "backlog_total": 7,
         "dag_ids": expected_dag_ids,
     } in caplog
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12849,6 +12849,40 @@ def _make_n_satisfied_apdrs(
     ]
 
 
+def _make_n_consumer_dags_each_with_one_pending_apdr(
+    *,
+    name_prefix: str,
+    n: int,
+    session: Session,
+    dag_maker: DagMaker,
+) -> None:
+    """
+    Build *n* distinct consumer Dags named ``cap-consumer-{name_prefix}-{i:02d}``, each with
+    exactly one pending, satisfied APDR.
+
+    Used (instead of :func:`_make_n_satisfied_apdrs`, which numbers its producer dag_id starting
+    at 1 on every call) when a test needs many distinct consumer Dags in one go: a single shared
+    producer dag_id counter, namespaced by ``name_prefix``, avoids the producer dag_id collisions
+    that calling :func:`_make_n_satisfied_apdrs` once per consumer Dag would cause.
+    """
+    for i in range(1, n + 1):
+        asset = Asset(name=f"asset-{name_prefix}-{i:02d}")
+        with dag_maker(
+            dag_id=f"cap-consumer-{name_prefix}-{i:02d}",
+            schedule=PartitionedAssetTimetable(assets=asset, default_partition_mapper=IdentityMapper()),
+            session=session,
+        ):
+            EmptyOperator(task_id="hi")
+        session.commit()
+        _produce_and_register_asset_event(
+            dag_id=f"asset-event-producer-{name_prefix}-{i:02d}",
+            asset=asset,
+            partition_key=f"k{i:02d}",
+            session=session,
+            dag_maker=dag_maker,
+        )
+
+
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows")
 def test_partition_cap_at_exactly_n_processes_all(dag_maker: DagMaker, session: Session):
@@ -12965,12 +12999,12 @@ def test_partition_cap_reporting(
             "will be evaluated over subsequent scheduler ticks",
             "cap": cap,
             "backlog_total": 3,
-            "dag_ids": {dag_id},
+            "dag_ids": [dag_id],
         } in caplog
         assert [row.event for row in audit_rows] == ["partition Dag run cap reached"]
         extra = audit_rows[0].extra
         assert extra is not None
-        assert f"Affected dag_ids: {dag_id}." in extra
+        assert f"Affected dag_ids (highest pending count first): {dag_id}." in extra
     else:
         assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
         assert audit_rows == []
@@ -13120,10 +13154,11 @@ def test_partition_cap_reporting_lists_all_affected_dag_ids(dag_maker: DagMaker,
     runner._max_partition_dag_runs_per_loop = 6
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
-    # backlog_dag_ids is a set, so its iteration order (and thus the exact rendering in the log
-    # event and audit row) is arbitrary — assert membership, not a specific order. All seven Dags
-    # are expected, including the seventh whose APDR is deferred past this tick's cap.
-    expected_dag_ids = {f"cap-consumer-many-{i}" for i in range(1, 8)}
+    # The dag_ids list is sorted by (-count, dag_id); all seven Dags tie on count (one pending
+    # APDR each), so the tie-break is dag_id ascending — a deterministic, reproducible order,
+    # not just membership. All seven Dags are expected, including the seventh whose APDR is
+    # deferred past this tick's cap.
+    expected_dag_ids = sorted(f"cap-consumer-many-{i}" for i in range(1, 8))
     assert {
         "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
         "will be evaluated over subsequent scheduler ticks",
@@ -13135,10 +13170,110 @@ def test_partition_cap_reporting_lists_all_affected_dag_ids(dag_maker: DagMaker,
     audit_row = session.scalar(select(Log).where(Log.event == "partition Dag run cap reached"))
     assert audit_row is not None
     assert audit_row.extra is not None
-    note_match = re.search(r"Affected dag_ids: (.+)\.$", audit_row.extra)
+    note_match = re.search(r"Affected dag_ids \(highest pending count first\): (.+)\.$", audit_row.extra)
     assert note_match is not None
-    assert set(note_match.group(1).split(", ")) == expected_dag_ids
+    assert note_match.group(1).split(", ") == expected_dag_ids
     assert "and 1 more" not in audit_row.extra
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_reporting_truncates_dag_id_list_beyond_max(
+    dag_maker: DagMaker, session: Session, caplog
+):
+    """
+    The log/audit ``dag_ids`` list is capped at ``MAX_PARTITION_CAP_BACKLOG_DAG_IDS_LOGGED``,
+    ordered by descending per-dag pending count with a dag_id tie-break — not alphabetically
+    truncated — and the audit row's prose notes how many dag_ids were dropped by the cap.
+
+    Built via :func:`_make_n_consumer_dags_each_with_one_pending_apdr` rather than
+    :func:`_make_n_satisfied_apdrs` because that helper's producer dag_id numbering restarts at 1
+    on every call, colliding across these 21 consumer Dags — same issue documented on
+    :func:`test_partition_cap_reporting_lists_all_affected_dag_ids`.
+    """
+    _make_n_consumer_dags_each_with_one_pending_apdr(
+        name_prefix="trunc-low", n=20, session=session, dag_maker=dag_maker
+    )
+
+    high_asset = Asset(name="asset-cap-trunc-high")
+    with dag_maker(
+        dag_id="cap-consumer-trunc-high",
+        schedule=PartitionedAssetTimetable(assets=high_asset, default_partition_mapper=IdentityMapper()),
+        session=session,
+    ):
+        EmptyOperator(task_id="hi")
+    session.commit()
+    for key in ["high-1", "high-2", "high-3"]:
+        _produce_and_register_asset_event(
+            dag_id=f"asset-event-producer-trunc-high-{key}",
+            asset=high_asset,
+            partition_key=key,
+            session=session,
+            dag_maker=dag_maker,
+        )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 5
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    expected_dag_ids = ["cap-consumer-trunc-high"] + [f"cap-consumer-trunc-low-{i:02d}" for i in range(1, 20)]
+    assert {
+        "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+        "will be evaluated over subsequent scheduler ticks",
+        "cap": 5,
+        "backlog_total": 23,
+        "dag_ids": expected_dag_ids,
+    } in caplog
+
+    audit_row = session.scalar(select(Log).where(Log.event == "partition Dag run cap reached"))
+    assert audit_row is not None
+    assert audit_row.extra is not None
+    assert "and 1 more" in audit_row.extra
+    for dag_id in expected_dag_ids:
+        assert dag_id in audit_row.extra
+    assert "cap-consumer-trunc-low-20" not in audit_row.extra
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_reporting_at_exactly_max_dag_ids_no_truncation(
+    dag_maker: DagMaker, session: Session, caplog
+):
+    """
+    Cap-boundary pair to :func:`test_partition_cap_reporting_truncates_dag_id_list_beyond_max`:
+    when the backlog's distinct dag_id count equals ``MAX_PARTITION_CAP_BACKLOG_DAG_IDS_LOGGED``
+    exactly, no dag_id is dropped and the "and N more" suffix is absent.
+
+    Built via :func:`_make_n_consumer_dags_each_with_one_pending_apdr` for the same producer
+    dag_id collision reason documented on the neighboring cap tests above.
+    """
+    _make_n_consumer_dags_each_with_one_pending_apdr(
+        name_prefix="atmax", n=20, session=session, dag_maker=dag_maker
+    )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 5
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    expected_dag_ids = sorted(f"cap-consumer-atmax-{i:02d}" for i in range(1, 21))
+    assert {
+        "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+        "will be evaluated over subsequent scheduler ticks",
+        "cap": 5,
+        "backlog_total": 20,
+        "dag_ids": expected_dag_ids,
+    } in caplog
+
+    audit_row = session.scalar(select(Log).where(Log.event == "partition Dag run cap reached"))
+    assert audit_row is not None
+    assert audit_row.extra is not None
+    assert "more" not in audit_row.extra
+    for dag_id in expected_dag_ids:
+        assert dag_id in audit_row.extra
 
 
 @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -13129,6 +13129,46 @@ def test_partition_cap_audit_row_survives_outer_rollback(dag_maker: DagMaker, se
     assert audit_events == ["partition dag run cap reached"]
 
 
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker, session: Session, caplog):
+    """
+    A `DBAPIError` while writing the cap-reached audit row must not escape the tick.
+
+    The audit write is purely observational, so any DBAPI-layer failure — not just
+    `OperationalError` — must be caught and logged, leaving `_partition_cap_backlog_reported`
+    `False` so the next tick retries the write.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-audit-failure",
+        asset=Asset(name="asset-cap-audit-failure"),
+        partition_keys=["k1", "k2", "k3"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 2
+
+    failing_session_cm = MagicMock()
+    failing_session_cm.__enter__.return_value.add.side_effect = IntegrityError(
+        "INSERT INTO log", {}, Exception("duplicate key")
+    )
+    failing_session_cm.__exit__.return_value = False
+
+    with mock.patch("airflow.jobs.scheduler_job_runner.create_session", return_value=failing_session_cm):
+        runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    assert "Failed to write the partition dag run cap audit Log row" in caplog
+    assert runner._partition_cap_backlog_reported is False
+    audit_rows = session.scalars(select(Log).where(Log.event == "partition dag run cap reached")).all()
+    assert audit_rows == []
+
+
 def _set_asset_active(*, name: str, uri: str, session: Session, active: bool) -> None:
     """Toggle ``AssetActive`` row for an asset to simulate orphan / reactivation."""
     row = session.scalar(select(AssetActive).where(AssetActive.name == name, AssetActive.uri == uri))

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -13278,7 +13278,9 @@ def test_partition_cap_reporting_at_exactly_max_dag_ids_no_truncation(
 
 @pytest.mark.need_serialized_dag
 @pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
-def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: DagMaker, session: Session):
+def test_partition_cap_backlog_audit_row_written_once_per_episode(
+    dag_maker: DagMaker, session: Session, caplog
+):
     """
     The cap-reached audit row is written once per backlog episode, not once per tick.
 
@@ -13303,16 +13305,29 @@ def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: Dag
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._max_partition_dag_runs_per_loop = 2
+    caplog.set_level("DEBUG", logger="airflow.jobs.scheduler_job_runner.SchedulerJobRunner")
 
     def _count_audit_log() -> int:
         return session.scalar(select(func.count()).where(Log.event == "partition Dag run cap reached")) or 0
 
+    def _cap_reached_levels() -> list[str]:
+        return [
+            e["log_level"]
+            for e in caplog
+            if e.get("event") == "Reached the per-tick cap on pending partitioned Dag runs; the remaining "
+            "backlog will be evaluated over subsequent scheduler ticks"
+        ]
+
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 1: 5 pending, cap 2
+    assert _cap_reached_levels() == ["warning"]
+
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 2: 3 pending, still over cap
     assert _count_audit_log() == 1, "backlog persisted across two ticks; audit row must only be written once"
+    assert _cap_reached_levels() == ["warning", "debug"]
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 3: 1 pending, drains below cap
     assert _count_audit_log() == 1, "draining below the cap must not write another audit row"
+    assert _cap_reached_levels() == ["warning", "debug"]
 
     # A fresh backlog episode for the same consumer: three more satisfied APDRs push
     # pending count back above the cap.
@@ -13333,6 +13348,7 @@ def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: Dag
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 4: new episode, 3 pending
     assert _count_audit_log() == 2, "a fresh backlog episode after draining should write a second audit row"
+    assert _cap_reached_levels() == ["warning", "debug", "warning"]
 
 
 @pytest.mark.need_serialized_dag
@@ -13377,7 +13393,8 @@ def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker,
 
     The audit write is purely observational, so any DBAPI-layer failure — not just
     `OperationalError` — must be caught and logged, leaving `_partition_cap_backlog_reported`
-    `False` so the next tick retries the write.
+    `False` so the next tick retries the write, and the cap-reached log stays at `warning`
+    instead of being downgraded.
     """
     _make_n_satisfied_apdrs(
         consumer_dag_id="cap-consumer-audit-failure",
@@ -13390,7 +13407,9 @@ def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker,
     runner = SchedulerJobRunner(
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
-    runner._max_partition_dag_runs_per_loop = 2
+    # cap=1 so the 3-item backlog still exceeds the cap on the second tick too (3 -> 2 -> 1
+    # remaining), keeping both ticks in the cap-reached branch.
+    runner._max_partition_dag_runs_per_loop = 1
 
     failing_session_cm = MagicMock()
     failing_session_cm.__enter__.return_value.add.side_effect = IntegrityError(
@@ -13400,11 +13419,20 @@ def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker,
 
     with mock.patch("airflow.jobs.scheduler_job_runner.create_session", return_value=failing_session_cm):
         runner._create_dagruns_for_partitioned_asset_dags(session=session)
+        runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     assert "Failed to write the partition Dag run cap audit Log row" in caplog
     assert runner._partition_cap_backlog_reported is False
     audit_rows = session.scalars(select(Log).where(Log.event == "partition Dag run cap reached")).all()
     assert audit_rows == []
+
+    cap_reached_levels = [
+        e["log_level"]
+        for e in caplog
+        if e.get("event") == "Reached the per-tick cap on pending partitioned Dag runs; the remaining "
+        "backlog will be evaluated over subsequent scheduler ticks"
+    ]
+    assert cap_reached_levels == ["warning", "warning"]
 
 
 def _set_asset_active(*, name: str, uri: str, session: Session, active: bool) -> None:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -40,6 +40,7 @@ import pytest
 import time_machine
 from sqlalchemy import delete, func, inspect, select, update
 from sqlalchemy.dialects import mysql
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from airflow import settings
@@ -12954,7 +12955,6 @@ def test_partition_cap_reporting(
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._max_partition_dag_runs_per_loop = cap
-
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     dag_id = f"cap-consumer-{suffix}"
@@ -13013,7 +13013,6 @@ def test_partition_cap_reporting_excludes_already_fired_decoy(dag_maker: DagMake
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._max_partition_dag_runs_per_loop = cap
-
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
@@ -13069,7 +13068,6 @@ def test_partition_cap_reporting_excludes_stale_dag_decoy(dag_maker: DagMaker, s
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._max_partition_dag_runs_per_loop = cap
-
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
     assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
@@ -13081,10 +13079,13 @@ def test_partition_cap_reporting_excludes_stale_dag_decoy(dag_maker: DagMaker, s
 @pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
 def test_partition_cap_reporting_lists_all_affected_dag_ids(dag_maker: DagMaker, session: Session, caplog):
     """
-    The log/audit ``dag_ids`` list surfaces every distinct affected dag_id, without truncation.
+    The log/audit ``dag_ids`` list surfaces every distinct dag_id in the backlog, not just this
+    tick's oldest-cap slice.
 
-    Seven consumer Dags each get one satisfied APDR; with the cap at 6, `pending_apdrs` spans six
-    distinct dag_ids — all of which must appear in both the log event and the audit row.
+    Seven consumer Dags each get one satisfied APDR; with the cap at 6, `pending_apdrs` (this
+    tick's oldest six) spans only six distinct dag_ids, but the seventh Dag's APDR is still part
+    of the backlog `count()` sees — its dag_id must appear in both the log event and the audit
+    row too, even though its Dag run won't be created until the next tick.
 
     Built inline rather than via :func:`_make_n_satisfied_apdrs` because that helper's producer
     dag_id numbering restarts at 1 on every call, colliding across these seven consumer Dags.
@@ -13117,12 +13118,12 @@ def test_partition_cap_reporting_lists_all_affected_dag_ids(dag_maker: DagMaker,
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._max_partition_dag_runs_per_loop = 6
-
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
 
-    # affected_dag_ids is a set, so its iteration order (and thus the exact rendering in the log
-    # event and audit row) is arbitrary — assert membership, not a specific order.
-    expected_dag_ids = {f"cap-consumer-many-{i}" for i in range(1, 7)}
+    # backlog_dag_ids is a set, so its iteration order (and thus the exact rendering in the log
+    # event and audit row) is arbitrary — assert membership, not a specific order. All seven Dags
+    # are expected, including the seventh whose APDR is deferred past this tick's cap.
+    expected_dag_ids = {f"cap-consumer-many-{i}" for i in range(1, 8)}
     assert {
         "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
         "will be evaluated over subsequent scheduler ticks",
@@ -13221,7 +13222,6 @@ def test_partition_cap_audit_row_survives_outer_rollback(dag_maker: DagMaker, se
         job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
     )
     runner._max_partition_dag_runs_per_loop = 2
-
     runner._create_dagruns_for_partitioned_asset_dags(session=session)
     assert runner._partition_cap_backlog_reported is True
 
@@ -13244,8 +13244,6 @@ def test_partition_cap_audit_row_write_failure_is_swallowed(dag_maker: DagMaker,
     `OperationalError` — must be caught and logged, leaving `_partition_cap_backlog_reported`
     `False` so the next tick retries the write.
     """
-    from sqlalchemy.exc import IntegrityError
-
     _make_n_satisfied_apdrs(
         consumer_dag_id="cap-consumer-audit-failure",
         asset=Asset(name="asset-cap-audit-failure"),

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -162,6 +162,7 @@ from tests_common.test_utils.db import (
     clear_db_deadline,
     clear_db_import_errors,
     clear_db_jobs,
+    clear_db_logs,
     clear_db_pakl,
     clear_db_pools,
     clear_db_runs,
@@ -11372,6 +11373,22 @@ def clear_asset_partition_rows() -> Iterator:
     clear_db_pakl()
 
 
+@pytest.fixture
+def clear_audit_log_rows() -> Iterator:
+    """
+    Isolate ``Log`` rows for tests that assert on audit entries.
+
+    The partition-cap audit row is written through an independent, self-committing session, so
+    it escapes the test session's rollback in both directions: leftovers from earlier tests
+    would be counted here, and rows written here would leak into later ones.
+    """
+    clear_db_logs()
+
+    yield
+
+    clear_db_logs()
+
+
 def _produce_and_register_asset_event(
     *,
     dag_id: str,
@@ -12900,6 +12917,154 @@ def test_partition_cap_at_n_minus_one_leaves_one_pending(dag_maker: DagMaker, se
     assert apdrs[1].created_dag_run_id is not None
     assert apdrs[2].created_dag_run_id is None
     assert partition_dags == {"cap-consumer-n-minus-one"}
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+@pytest.mark.parametrize(
+    ("cap", "partition_keys", "expect_cap_hit"),
+    [
+        pytest.param(2, ["k1", "k2", "k3"], True, id="over-cap"),
+        pytest.param(3, ["k1", "k2"], False, id="under-cap"),
+        # Regression guard for the ``LIMIT cap + 1`` probe: ``LIMIT cap`` alone cannot tell
+        # "exactly cap, nothing left" from "more than cap, backlog remains", and would wrongly
+        # claim a backlog here.
+        pytest.param(3, ["k1", "k2", "k3"], False, id="exactly-cap"),
+    ],
+)
+def test_partition_cap_reporting(
+    dag_maker: DagMaker,
+    session: Session,
+    caplog,
+    cap: int,
+    partition_keys: list[str],
+    expect_cap_hit: bool,
+):
+    """Only a pending count strictly above the cap reports a backlog, via log and audit `Log` row."""
+    suffix = f"{cap}-{len(partition_keys)}"
+    _make_n_satisfied_apdrs(
+        consumer_dag_id=f"cap-consumer-{suffix}",
+        asset=Asset(name=f"asset-cap-{suffix}"),
+        partition_keys=partition_keys,
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = cap
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    audit_events = session.scalars(
+        select(Log.event).where(Log.event == "partition dag run cap reached")
+    ).all()
+    if expect_cap_hit:
+        assert {
+            "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+            "will be evaluated over subsequent scheduler ticks",
+            "cap": cap,
+            "pending_count": cap,
+        } in caplog
+        assert audit_events == ["partition dag run cap reached"]
+    else:
+        assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
+        assert audit_events == []
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: DagMaker, session: Session):
+    """
+    The cap-reached audit row is written once per backlog episode, not once per tick.
+
+    A persistent backlog re-hits the cap on every tick; only the first tick of the episode
+    should write the audit row. Draining below the cap and then hitting it again starts a new
+    episode and writes a second row.
+    """
+    asset = Asset(name="asset-cap-episode")
+    apdrs = _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-episode",
+        asset=asset,
+        partition_keys=["k1", "k2", "k3", "k4", "k5"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+    base = timezone.utcnow()
+    for i, apdr in enumerate(apdrs):
+        apdr.created_at = base + timedelta(seconds=i)
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 2
+
+    def _count_audit_log() -> int:
+        return session.scalar(select(func.count()).where(Log.event == "partition dag run cap reached")) or 0
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 1: 5 pending, cap 2
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 2: 3 pending, still over cap
+    assert _count_audit_log() == 1, "backlog persisted across two ticks; audit row must only be written once"
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 3: 1 pending, drains below cap
+    assert _count_audit_log() == 1, "draining below the cap must not write another audit row"
+
+    # A fresh backlog episode for the same consumer: three more satisfied APDRs push
+    # pending count back above the cap.
+    new_apdrs = [
+        _produce_and_register_asset_event(
+            dag_id=f"asset-event-producer-episode-{i}",
+            asset=asset,
+            partition_key=key,
+            session=session,
+            dag_maker=dag_maker,
+        )
+        for i, key in enumerate(["k6", "k7", "k8"], start=1)
+    ]
+    base2 = timezone.utcnow()
+    for i, apdr in enumerate(new_apdrs):
+        apdr.created_at = base2 + timedelta(seconds=i)
+    session.commit()
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 4: new episode, 3 pending
+    assert _count_audit_log() == 2, "a fresh backlog episode after draining should write a second audit row"
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_audit_row_survives_outer_rollback(dag_maker: DagMaker, session: Session):
+    """
+    The audit `Log` row is committed in its own session, independent of the caller's.
+
+    Rolling back *session* afterwards — as `_create_dagruns_for_dags`'s `@retry_db_transaction`
+    would on a `DBAPIError` — must not undo the audit row, and the flag must stay ``True``: it
+    reflects a row that is already durably persisted, not in-flight work tied to *session*.
+    """
+    _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-rollback",
+        asset=Asset(name="asset-cap-rollback"),
+        partition_keys=["k1", "k2", "k3"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 2
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    assert runner._partition_cap_backlog_reported is True
+
+    session.rollback()
+
+    assert runner._partition_cap_backlog_reported is True
+    audit_events = session.scalars(
+        select(Log.event).where(Log.event == "partition dag run cap reached")
+    ).all()
+    assert audit_events == ["partition dag run cap reached"]
 
 
 def _set_asset_active(*, name: str, uri: str, session: Session, active: bool) -> None:

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -12693,15 +12693,15 @@ def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: Dag
     )
     runner._max_partition_dag_runs_per_loop = 2
 
-    def _audit_row_count() -> int:
+    def _count_audit_log() -> int:
         return session.scalar(select(func.count()).where(Log.event == "partition dag run cap reached")) or 0
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 1: 5 pending, cap 2
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 2: 3 pending, still over cap
-    assert _audit_row_count() == 1, "backlog persisted across two ticks; audit row must only be written once"
+    assert _count_audit_log() == 1, "backlog persisted across two ticks; audit row must only be written once"
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 3: 1 pending, drains below cap
-    assert _audit_row_count() == 1, "draining below the cap must not write another audit row"
+    assert _count_audit_log() == 1, "draining below the cap must not write another audit row"
 
     # A fresh backlog episode for the same consumer: three more satisfied APDRs push
     # pending count back above the cap.
@@ -12721,7 +12721,7 @@ def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: Dag
     session.commit()
 
     runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 4: new episode, 3 pending
-    assert _audit_row_count() == 2, "a fresh backlog episode after draining should write a second audit row"
+    assert _count_audit_log() == 2, "a fresh backlog episode after draining should write a second audit row"
 
 
 @pytest.mark.need_serialized_dag

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -162,6 +162,7 @@ from tests_common.test_utils.db import (
     clear_db_deadline,
     clear_db_import_errors,
     clear_db_jobs,
+    clear_db_logs,
     clear_db_pakl,
     clear_db_pools,
     clear_db_runs,
@@ -11064,6 +11065,22 @@ def clear_asset_partition_rows() -> Iterator:
     clear_db_pakl()
 
 
+@pytest.fixture
+def clear_audit_log_rows() -> Iterator:
+    """
+    Isolate ``Log`` rows for tests that assert on audit entries.
+
+    The partition-cap audit row is written through an independent, self-committing session, so
+    it escapes the test session's rollback in both directions: leftovers from earlier tests
+    would be counted here, and rows written here would leak into later ones.
+    """
+    clear_db_logs()
+
+    yield
+
+    clear_db_logs()
+
+
 def _produce_and_register_asset_event(
     *,
     dag_id: str,
@@ -12592,6 +12609,154 @@ def test_partition_cap_at_n_minus_one_leaves_one_pending(dag_maker: DagMaker, se
     assert apdrs[1].created_dag_run_id is not None
     assert apdrs[2].created_dag_run_id is None
     assert partition_dags == {"cap-consumer-n-minus-one"}
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+@pytest.mark.parametrize(
+    ("cap", "partition_keys", "expect_cap_hit"),
+    [
+        pytest.param(2, ["k1", "k2", "k3"], True, id="over-cap"),
+        pytest.param(3, ["k1", "k2"], False, id="under-cap"),
+        # Regression guard for the ``LIMIT cap + 1`` probe: ``LIMIT cap`` alone cannot tell
+        # "exactly cap, nothing left" from "more than cap, backlog remains", and would wrongly
+        # claim a backlog here.
+        pytest.param(3, ["k1", "k2", "k3"], False, id="exactly-cap"),
+    ],
+)
+def test_partition_cap_reporting(
+    dag_maker: DagMaker,
+    session: Session,
+    caplog,
+    cap: int,
+    partition_keys: list[str],
+    expect_cap_hit: bool,
+):
+    """Only a pending count strictly above the cap reports a backlog, via log and audit `Log` row."""
+    suffix = f"{cap}-{len(partition_keys)}"
+    _make_n_satisfied_apdrs(
+        consumer_dag_id=f"cap-consumer-{suffix}",
+        asset=Asset(name=f"asset-cap-{suffix}"),
+        partition_keys=partition_keys,
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = cap
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+
+    audit_events = session.scalars(
+        select(Log.event).where(Log.event == "partition dag run cap reached")
+    ).all()
+    if expect_cap_hit:
+        assert {
+            "event": "Reached the per-tick cap on pending partitioned Dag runs; the remaining backlog "
+            "will be evaluated over subsequent scheduler ticks",
+            "cap": cap,
+            "pending_count": cap,
+        } in caplog
+        assert audit_events == ["partition dag run cap reached"]
+    else:
+        assert "Reached the per-tick cap on pending partitioned Dag runs" not in caplog
+        assert audit_events == []
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_backlog_audit_row_written_once_per_episode(dag_maker: DagMaker, session: Session):
+    """
+    The cap-reached audit row is written once per backlog episode, not once per tick.
+
+    A persistent backlog re-hits the cap on every tick; only the first tick of the episode
+    should write the audit row. Draining below the cap and then hitting it again starts a new
+    episode and writes a second row.
+    """
+    asset = Asset(name="asset-cap-episode")
+    apdrs = _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-episode",
+        asset=asset,
+        partition_keys=["k1", "k2", "k3", "k4", "k5"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+    base = timezone.utcnow()
+    for i, apdr in enumerate(apdrs):
+        apdr.created_at = base + timedelta(seconds=i)
+    session.commit()
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 2
+
+    def _audit_row_count() -> int:
+        return session.scalar(select(func.count()).where(Log.event == "partition dag run cap reached")) or 0
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 1: 5 pending, cap 2
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 2: 3 pending, still over cap
+    assert _audit_row_count() == 1, "backlog persisted across two ticks; audit row must only be written once"
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 3: 1 pending, drains below cap
+    assert _audit_row_count() == 1, "draining below the cap must not write another audit row"
+
+    # A fresh backlog episode for the same consumer: three more satisfied APDRs push
+    # pending count back above the cap.
+    new_apdrs = [
+        _produce_and_register_asset_event(
+            dag_id=f"asset-event-producer-episode-{i}",
+            asset=asset,
+            partition_key=key,
+            session=session,
+            dag_maker=dag_maker,
+        )
+        for i, key in enumerate(["k6", "k7", "k8"], start=1)
+    ]
+    base2 = timezone.utcnow()
+    for i, apdr in enumerate(new_apdrs):
+        apdr.created_at = base2 + timedelta(seconds=i)
+    session.commit()
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)  # tick 4: new episode, 3 pending
+    assert _audit_row_count() == 2, "a fresh backlog episode after draining should write a second audit row"
+
+
+@pytest.mark.need_serialized_dag
+@pytest.mark.usefixtures("clear_asset_partition_rows", "clear_audit_log_rows")
+def test_partition_cap_audit_row_survives_outer_rollback(dag_maker: DagMaker, session: Session):
+    """
+    The audit `Log` row is committed in its own session, independent of the caller's.
+
+    Rolling back *session* afterwards — as `_create_dagruns_for_dags`'s `@retry_db_transaction`
+    would on a `DBAPIError` — must not undo the audit row, and the flag must stay ``True``: it
+    reflects a row that is already durably persisted, not in-flight work tied to *session*.
+    """
+    _make_n_satisfied_apdrs(
+        consumer_dag_id="cap-consumer-rollback",
+        asset=Asset(name="asset-cap-rollback"),
+        partition_keys=["k1", "k2", "k3"],
+        session=session,
+        dag_maker=dag_maker,
+    )
+
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    runner._max_partition_dag_runs_per_loop = 2
+
+    runner._create_dagruns_for_partitioned_asset_dags(session=session)
+    assert runner._partition_cap_backlog_reported is True
+
+    session.rollback()
+
+    assert runner._partition_cap_backlog_reported is True
+    audit_events = session.scalars(
+        select(Log.event).where(Log.event == "partition dag run cap reached")
+    ).all()
+    assert audit_events == ["partition dag run cap reached"]
 
 
 def _set_asset_active(*, name: str, uri: str, session: Session, active: bool) -> None:


### PR DESCRIPTION
## Why
It's not noticeable when the APDR cap is reached.  

## What
Emits a scheduler warning on every tick the cap is hit, plus a single `partition dag run cap reached` audit Log row per backlog episode.

The audit row is written through `create_session(scoped=False)` so the caller's `@retry_db_transaction` rollback cannot discard it; it must stay ahead of any other write in the tick or the extra connection can lock-contend on SQLite.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)


Generated-by: [Claude] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
