### PR TITLE
Fix duplicate pending Dag runs for the same asset partition key

### DIFF
--- a/airflow-core/docs/migrations-ref.rst
+++ b/airflow-core/docs/migrations-ref.rst
@@ -39,7 +39,10 @@ Here's the list of all the Database Migrations that are executed via when you ru
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | Revision ID             | Revises ID       | Airflow Version   | Description                                                  |
 +=========================+==================+===================+==============================================================+
-| ``3c525f44bea8`` (head) | ``b2f1a9c7d4e0`` | ``3.4.0``         | Add indexes on serialized_dag and dag_code.                  |
+| ``ee86eed19e24`` (head) | ``3c525f44bea8`` | ``3.4.0``         | Add pending_partition_key to asset_partition_dag_run and     |
+|                         |                  |                   | enforce single pending row per key.                          |
++-------------------------+------------------+-------------------+--------------------------------------------------------------+
+| ``3c525f44bea8``        | ``b2f1a9c7d4e0`` | ``3.4.0``         | Add indexes on serialized_dag and dag_code.                  |
 +-------------------------+------------------+-------------------+--------------------------------------------------------------+
 | ``b2f1a9c7d4e0``        | ``7a98f1b7dbd3`` | ``3.4.0``         | Reference the asset event from asset_dag_run_queue (consume- |
 |                         |                  |                   | by-reference).                                               |

--- a/airflow-core/newsfragments/71074.bugfix.rst
+++ b/airflow-core/newsfragments/71074.bugfix.rst
@@ -1,0 +1,1 @@
+Fix duplicate pending Dag runs for the same asset partition key

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Collection, Iterable
-from contextlib import contextmanager
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -48,7 +47,8 @@ from airflow.models.log import Log
 from airflow.timetables.base import compute_rollup_fingerprint
 from airflow.utils.helpers import is_container, prune_dict
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.sqlalchemy import get_dialect_name, with_row_locks
+from airflow.utils.session import create_session
+from airflow.utils.sqlalchemy import get_dialect_name
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -67,68 +67,36 @@ if TYPE_CHECKING:
 log = structlog.get_logger(__name__)
 
 
-@contextmanager
-def _lock_target_dag(
-    *,
-    session: Session,
-    dag_id: str,
-    max_retries: int = 10,
-    retry_delay: float = 0.1,
-):
+def _create_asset_event(*, session: Session, **event_kwargs) -> AssetEvent:
     """
-    Context manager to acquire a lock for AssetPartitionDagRun creation.
+    Persist an :class:`AssetEvent` row and return it, bound to *session*.
 
-    AssetPartitionDagRun find-or-create is deduplicated on (target_dag_id, partition_key),
-    not on the producer asset that triggered the event. Locking the producer AssetModel row
-    is therefore the wrong resource: two events from *different* producer assets that map to
-    the same target key take locks on two different asset rows, so neither blocks the other,
-    and both can observe "no existing APDR" and insert a duplicate. Locking the target
-    DagModel row instead serializes all APDR find-or-create calls for that Dag regardless of
-    which producer asset triggered them.
+    On SQLite the event is added directly to the caller's *session* and
+    flushed. SQLite serialises writes at the database-file level: opening
+    a second connection here would compete with any write locks the
+    caller's transaction already holds (for example, an UPDATE on
+    ``dag_run`` flushed earlier in ``register_asset_changes_in_db``) and
+    deadlock with ``database is locked``.
 
-    - SQLite: Use a no-op ORM update to trigger a write-transaction and acquire SQLite's global writer lock.
-    - Postgres/MySQL: uses row-level lock on DagModel.
+    On Postgres/MySQL a short-lived independent session is used so the
+    row is committed — and therefore visible to the scheduler's session
+    via MVCC — before the caller continues. The committed row is then
+    re-loaded into the caller's *session* so subsequent relationship
+    operations work correctly.
     """
-    from airflow.models.dag import DagModel
-
     if get_dialect_name(session) == "sqlite":
-        import time
+        asset_event = AssetEvent(**event_kwargs)
+        session.add(asset_event)
+        session.flush()
+        return asset_event
 
-        from sqlalchemy import update
+    with create_session(scoped=False) as ae_session:
+        asset_event = AssetEvent(**event_kwargs)
+        ae_session.add(asset_event)
+        ae_session.flush()
+        asset_event_id = asset_event.id
 
-        # no-op update
-        # This is used to acquire SQLite's global writer lock.
-        stmt = update(DagModel).where(DagModel.dag_id == dag_id).values(dag_id=DagModel.dag_id)
-        for _ in range(max_retries):
-            try:
-                session.execute(stmt)
-                session.flush()
-            except exc.OperationalError as err:
-                err_msg = str(err).lower()
-                if "locked" in err_msg or "busy" in err_msg:
-                    session.rollback()
-                    time.sleep(retry_delay)
-                    continue
-
-            # lock acquired
-            yield
-            return
-
-        raise RuntimeError(f"Could not acquire SQLite DagModel writer lock for dag_id={dag_id}")
-    else:
-        # Postgres/MySQL row-level lock
-        if (
-            session.scalar(
-                with_row_locks(
-                    query=select(DagModel.dag_id).where(DagModel.dag_id == dag_id),
-                    session=session,
-                    key_share=True,
-                )
-            )
-        ) is None:
-            raise RuntimeError(f"Dag {dag_id} does not exist – cannot lock.")
-
-        yield
+    return session.get_one(AssetEvent, asset_event_id)
 
 
 class AssetManager(LoggingMixin):
@@ -720,23 +688,119 @@ class AssetManager(LoggingMixin):
         """
         Get or create an APDR.
 
-        If 2 processes invoke this method at the same time using the same (target_key, target_dag) pair,
-        they may both check the database and, finding no existing APDR, create separate instances.
-        This leads to the unintended outcome of having two APDRs created instead of one.
-        To resolve this, we add a mutex lock to the target DagModel row for PostgreSQL and MySQL,
-        and acquire SQLite's global writer lock for SQLite. The lock is keyed on the target Dag
-        rather than the producer asset, since two events from different producer assets can map
-        to the same (target_key, target_dag) pair.
+        If 2 processes invoke this method at the same time using the same (target_key, target_dag)
+        pair, they may both check the database and, finding no existing APDR, attempt to create
+        separate instances. Rather than serializing this find-or-create behind a lock, a unique
+        constraint on (target_dag_id, pending_partition_key) — see the ``AssetPartitionDagRun``
+        docstring — makes the database itself reject the loser's INSERT. The loser catches that
+        ``IntegrityError`` and re-selects, working on the winning row instead of raising, per the
+        model's "always work on the latest matching APDR record" contract. Optimistic and
+        lock-free, this scales with concurrent producer assets without contending on a Dag or
+        Asset row that has nothing to do with the (target_key, target_dag) pair being deduplicated.
 
         ``rollup_fingerprint`` is the serialized mapper / window definition for all partitioned
         assets in the timetable at creation time; the scheduler discards APDRs whose stamp no
         longer matches the current timetable's fingerprint (mapper / window may have changed).
+        """
+        latest_apdr = cls._get_latest_pending_apdr(
+            target_key=target_key, target_dag_id=target_dag.dag_id, session=session
+        )
+        if latest_apdr is not None:
+            cls._reconcile_partition_date(
+                apdr=latest_apdr,
+                target_partition_date=target_partition_date,
+                target_dag_id=target_dag.dag_id,
+                target_key=target_key,
+                session=session,
+            )
+            cls.logger().debug(
+                "Existing APDR found for key %s dag_id %s",
+                target_key,
+                target_dag.dag_id,
+                exc_info=True,
+            )
+            return latest_apdr
 
-        Reconciling the carried ``partition_date`` on an existing pending APDR is best-effort:
-        a partitioned consumer's feeding assets are expected to agree on the partition's
-        datetime. The carry only matters for ``IdentityMapper`` (whose key the scheduler
-        cannot decode); temporal/composite feeds re-derive the date from the key at run
-        creation regardless of what is stored here. Within that contract:
+        apdr = AssetPartitionDagRun(
+            target_dag_id=target_dag.dag_id,
+            created_dag_run_id=None,
+            partition_key=target_key,
+            pending_partition_key=target_key,
+            partition_date=target_partition_date,
+            rollup_fingerprint=rollup_fingerprint,
+        )
+        try:
+            # A SAVEPOINT scopes the potential IntegrityError so only this INSERT is rolled
+            # back on conflict; the caller's surrounding transaction (with any other work
+            # already flushed in this scheduler tick) stays intact.
+            with session.begin_nested():
+                session.add(apdr)
+                session.flush()
+        except exc.IntegrityError:
+            cls.logger().debug(
+                "Lost race creating APDR for key %s dag_id %s; using the winning APDR instead",
+                target_key,
+                target_dag.dag_id,
+                exc_info=True,
+            )
+            winner = cls._get_latest_pending_apdr(
+                target_key=target_key, target_dag_id=target_dag.dag_id, session=session
+            )
+            if winner is None:
+                raise RuntimeError(
+                    f"APDR insert for target_dag_id={target_dag.dag_id!r} "
+                    f"partition_key={target_key!r} failed with an integrity error, but no "
+                    "existing pending APDR was found on re-select."
+                )
+            cls._reconcile_partition_date(
+                apdr=winner,
+                target_partition_date=target_partition_date,
+                target_dag_id=target_dag.dag_id,
+                target_key=target_key,
+                session=session,
+            )
+            return winner
+
+        cls.logger().debug(
+            "No existing APDR found. Create APDR for key %s dag_id %s",
+            target_key,
+            target_dag.dag_id,
+            exc_info=True,
+        )
+        return apdr
+
+    @classmethod
+    def _get_latest_pending_apdr(
+        cls, *, target_key: str, target_dag_id: str, session: Session
+    ) -> AssetPartitionDagRun | None:
+        """Return the latest still-pending APDR for (target_dag_id, target_key), if any."""
+        return session.scalar(
+            select(AssetPartitionDagRun)
+            .where(
+                AssetPartitionDagRun.pending_partition_key == target_key,
+                AssetPartitionDagRun.target_dag_id == target_dag_id,
+            )
+            .order_by(AssetPartitionDagRun.id.desc())
+            .limit(1)
+        )
+
+    @classmethod
+    def _reconcile_partition_date(
+        cls,
+        *,
+        apdr: AssetPartitionDagRun,
+        target_partition_date: datetime | None,
+        target_dag_id: str,
+        target_key: str,
+        session: Session,
+    ) -> None:
+        """
+        Reconcile the carried ``partition_date`` on an existing pending APDR.
+
+        This is best-effort: a partitioned consumer's feeding assets are expected to agree
+        on the partition's datetime. The carry only matters for ``IdentityMapper`` (whose key
+        the scheduler cannot decode); temporal/composite feeds re-derive the date from the key
+        at run creation regardless of what is stored here. Within that contract:
 
         - If the APDR carries no date yet (``None`` — created by an event that carried none),
           adopt the incoming date when this event carries one. There is nothing to conflict
@@ -746,64 +810,23 @@ class AssetManager(LoggingMixin):
           carried date is suppressed to ``None`` (and re-adoptable by a later event).
         - Otherwise (the dates agree, or this event carries none) the existing value is kept.
         """
-        with _lock_target_dag(session=session, dag_id=target_dag.dag_id):
-            latest_apdr: AssetPartitionDagRun | None = session.scalar(
-                select(AssetPartitionDagRun)
-                .where(
-                    AssetPartitionDagRun.partition_key == target_key,
-                    AssetPartitionDagRun.target_dag_id == target_dag.dag_id,
-                )
-                .order_by(AssetPartitionDagRun.id.desc())
-                .limit(1)
+        existing_partition_date = apdr.partition_date
+        if existing_partition_date is None:
+            if target_partition_date is not None:
+                apdr.partition_date = target_partition_date
+                session.flush()
+        elif target_partition_date is not None and existing_partition_date != target_partition_date:
+            log.warning(
+                "Conflicting partition_date carried for the same target key; "
+                "suppressing it so the consumer DagRun's partition_date is None. "
+                "The producing assets likely disagree on the partition's datetime.",
+                target_dag_id=target_dag_id,
+                target_key=target_key,
+                existing_partition_date=existing_partition_date,
+                incoming_partition_date=target_partition_date,
             )
-            if latest_apdr and latest_apdr.created_dag_run_id is None:
-                existing_partition_date = latest_apdr.partition_date
-                if existing_partition_date is None:
-                    # No carried date yet; adopt the incoming one if present (no conflict
-                    # to resolve). Keeps a later identity event's date from being dropped.
-                    if target_partition_date is not None:
-                        latest_apdr.partition_date = target_partition_date
-                        session.flush()
-                elif target_partition_date is not None and existing_partition_date != target_partition_date:
-                    # Two contributing events carry conflicting partition_dates for the same
-                    # (target_key, target_dag). Choosing one would be order-dependent, so
-                    # suppress: the consumer DagRun gets partition_date=None rather than a
-                    # wrong, unstable value.
-                    log.warning(
-                        "Conflicting partition_date carried for the same target key; "
-                        "suppressing it so the consumer DagRun's partition_date is None. "
-                        "The producing assets likely disagree on the partition's datetime.",
-                        target_dag_id=target_dag.dag_id,
-                        target_key=target_key,
-                        existing_partition_date=existing_partition_date,
-                        incoming_partition_date=target_partition_date,
-                    )
-                    latest_apdr.partition_date = None
-                    session.flush()
-                cls.logger().debug(
-                    "Existing APDR found for key %s dag_id %s",
-                    target_key,
-                    target_dag.dag_id,
-                    exc_info=True,
-                )
-                return latest_apdr
-
-            apdr = AssetPartitionDagRun(
-                target_dag_id=target_dag.dag_id,
-                created_dag_run_id=None,
-                partition_key=target_key,
-                partition_date=target_partition_date,
-                rollup_fingerprint=rollup_fingerprint,
-            )
-            session.add(apdr)
+            apdr.partition_date = None
             session.flush()
-            cls.logger().debug(
-                "No existing APDR found. Create APDR for key %s dag_id %s",
-                target_key,
-                target_dag.dag_id,
-                exc_info=True,
-            )
-            return apdr
 
     @classmethod
     def _queue_dagruns_nonpartitioned(

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -732,7 +732,11 @@ class AssetManager(LoggingMixin):
         try:
             # A SAVEPOINT scopes the potential IntegrityError so only this INSERT is rolled
             # back on conflict; the caller's surrounding transaction (with any other work
-            # already flushed in this scheduler tick) stays intact.
+            # already flushed in this scheduler tick) stays intact. Note that Session.begin_nested()
+            # itself flushes any pending (unflushed) ORM objects into the parent transaction before
+            # opening the SAVEPOINT, so unflushed Log/PartitionedAssetKeyLog rows added earlier in
+            # this loop are safely persisted first and are not among the objects a rollback here
+            # can expunge -- only ``apdr``, added after the SAVEPOINT starts, is at risk.
             with session.begin_nested():
                 session.add(apdr)
                 session.flush()

--- a/airflow-core/src/airflow/assets/manager.py
+++ b/airflow-core/src/airflow/assets/manager.py
@@ -68,19 +68,29 @@ log = structlog.get_logger(__name__)
 
 
 @contextmanager
-def _lock_asset_model(
+def _lock_target_dag(
     *,
     session: Session,
-    asset_id: int,
+    dag_id: str,
     max_retries: int = 10,
     retry_delay: float = 0.1,
 ):
     """
     Context manager to acquire a lock for AssetPartitionDagRun creation.
 
+    AssetPartitionDagRun find-or-create is deduplicated on (target_dag_id, partition_key),
+    not on the producer asset that triggered the event. Locking the producer AssetModel row
+    is therefore the wrong resource: two events from *different* producer assets that map to
+    the same target key take locks on two different asset rows, so neither blocks the other,
+    and both can observe "no existing APDR" and insert a duplicate. Locking the target
+    DagModel row instead serializes all APDR find-or-create calls for that Dag regardless of
+    which producer asset triggered them.
+
     - SQLite: Use a no-op ORM update to trigger a write-transaction and acquire SQLite's global writer lock.
-    - Postgres/MySQL: uses row-level lock on AssetModel.
+    - Postgres/MySQL: uses row-level lock on DagModel.
     """
+    from airflow.models.dag import DagModel
+
     if get_dialect_name(session) == "sqlite":
         import time
 
@@ -88,7 +98,7 @@ def _lock_asset_model(
 
         # no-op update
         # This is used to acquire SQLite's global writer lock.
-        stmt = update(AssetModel).where(AssetModel.id == asset_id).values(id=AssetModel.id)
+        stmt = update(DagModel).where(DagModel.dag_id == dag_id).values(dag_id=DagModel.dag_id)
         for _ in range(max_retries):
             try:
                 session.execute(stmt)
@@ -104,19 +114,19 @@ def _lock_asset_model(
             yield
             return
 
-        raise RuntimeError(f"Could not acquire SQLite AssetModel writer lock for asset_id={asset_id}")
+        raise RuntimeError(f"Could not acquire SQLite DagModel writer lock for dag_id={dag_id}")
     else:
         # Postgres/MySQL row-level lock
         if (
             session.scalar(
                 with_row_locks(
-                    query=select(AssetModel.id).where(AssetModel.id == asset_id),
+                    query=select(DagModel.dag_id).where(DagModel.dag_id == dag_id),
                     session=session,
                     key_share=True,
                 )
             )
         ) is None:
-            raise RuntimeError(f"Asset {asset_id} does not exist – cannot lock.")
+            raise RuntimeError(f"Dag {dag_id} does not exist – cannot lock.")
 
         yield
 
@@ -685,7 +695,6 @@ class AssetManager(LoggingMixin):
                     target_partition_date=target_partition_date,
                     target_dag=target_dag,
                     rollup_fingerprint=fingerprint,
-                    asset_id=asset_id,
                     session=session,
                 )
                 log_record = PartitionedAssetKeyLog(
@@ -706,7 +715,6 @@ class AssetManager(LoggingMixin):
         target_partition_date: datetime | None,
         target_dag: DagModel,
         rollup_fingerprint: dict,
-        asset_id: int,
         session: Session,
     ) -> AssetPartitionDagRun:
         """
@@ -715,8 +723,10 @@ class AssetManager(LoggingMixin):
         If 2 processes invoke this method at the same time using the same (target_key, target_dag) pair,
         they may both check the database and, finding no existing APDR, create separate instances.
         This leads to the unintended outcome of having two APDRs created instead of one.
-        To resolve this, we add a mutex lock to AssetModel for PostgreSQL and MySQL and use
-        AssetPartitionDagRunMutexLock table for SQLite.
+        To resolve this, we add a mutex lock to the target DagModel row for PostgreSQL and MySQL,
+        and acquire SQLite's global writer lock for SQLite. The lock is keyed on the target Dag
+        rather than the producer asset, since two events from different producer assets can map
+        to the same (target_key, target_dag) pair.
 
         ``rollup_fingerprint`` is the serialized mapper / window definition for all partitioned
         assets in the timetable at creation time; the scheduler discards APDRs whose stamp no
@@ -736,7 +746,7 @@ class AssetManager(LoggingMixin):
           carried date is suppressed to ``None`` (and re-adoptable by a later event).
         - Otherwise (the dates agree, or this event carries none) the existing value is kept.
         """
-        with _lock_asset_model(session=session, asset_id=asset_id):
+        with _lock_target_dag(session=session, dag_id=target_dag.dag_id):
             latest_apdr: AssetPartitionDagRun | None = session.scalar(
                 select(AssetPartitionDagRun)
                 .where(

--- a/airflow-core/src/airflow/migrations/versions/0130_3_4_0_add_pending_partition_key_to_apdr.py
+++ b/airflow-core/src/airflow/migrations/versions/0130_3_4_0_add_pending_partition_key_to_apdr.py
@@ -1,0 +1,116 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Add pending_partition_key to asset_partition_dag_run and enforce single pending row per key.
+
+Two asset events from different producer assets that resolve to the same downstream
+partition key could each create their own AssetPartitionDagRun (APDR), leaving two
+pending rows that could never both be satisfied (apache/airflow#71070). This is now
+prevented with a unique constraint on (target_dag_id, pending_partition_key).
+
+A partial/filtered unique index on (target_dag_id, partition_key) WHERE
+created_dag_run_id IS NULL would be the more direct fix, but MySQL supports neither
+partial nor filtered indexes. ``pending_partition_key`` is the portable equivalent: it
+mirrors ``partition_key`` only while ``created_dag_run_id`` is null, and is null once
+the dag run is created. A unique index treats null as distinct from every other value
+on all three supported backends, so completed rows never collide with each other while
+pending rows for the same key do.
+
+Pre-existing duplicate pending rows can never both be satisfied -- the asset events
+that would complete them are necessarily split across the duplicates -- so before the
+constraint is created, all but the latest (highest id) pending row per
+(target_dag_id, partition_key) is dropped, along with its PartitionedAssetKeyLog rows.
+This mirrors the scheduler's stale-APDR cleanup and the model docstring's "always work
+on the latest matching APDR record" fallback.
+
+Revision ID: ee86eed19e24
+Revises: 3c525f44bea8
+Create Date: 2026-08-04 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import context, op
+
+from airflow.migrations.db_types import StringID
+from airflow.migrations.utils import disable_sqlite_fkeys
+
+revision = "ee86eed19e24"
+down_revision = "3c525f44bea8"
+branch_labels = None
+depends_on = None
+airflow_version = "3.4.0"
+
+_TABLE = "asset_partition_dag_run"
+_LOG_TABLE = "partitioned_asset_key_log"
+_UQ_NAME = "apdr_target_dag_id_pending_partition_key_uq"
+
+
+def _drop_stale_duplicate_pending_apdrs(conn) -> None:
+    """Collapse pre-existing duplicate pending APDR rows down to the latest one per key."""
+    stale_ids = [
+        row[0]
+        for row in conn.execute(
+            sa.text(
+                f"SELECT id FROM {_TABLE} WHERE created_dag_run_id IS NULL AND id NOT IN ("
+                f"    SELECT MAX(id) FROM {_TABLE} "
+                "     WHERE created_dag_run_id IS NULL "
+                "     GROUP BY target_dag_id, partition_key"
+                ")"
+            )
+        ).fetchall()
+    ]
+    if not stale_ids:
+        return
+    id_list = ", ".join(str(i) for i in stale_ids)
+    conn.execute(sa.text(f"DELETE FROM {_LOG_TABLE} WHERE asset_partition_dag_run_id IN ({id_list})"))
+    conn.execute(sa.text(f"DELETE FROM {_TABLE} WHERE id IN ({id_list})"))
+
+
+def upgrade():
+    """Add pending_partition_key to asset_partition_dag_run and enforce single pending row per key."""
+    with disable_sqlite_fkeys(op):
+        with op.batch_alter_table(_TABLE, schema=None) as batch_op:
+            batch_op.add_column(sa.Column("pending_partition_key", StringID(), nullable=True))
+
+        conn = op.get_bind()
+        # Duplicate resolution requires reading actual data, which offline (SQL-script)
+        # mode has no connection for; the constraint below still applies to whatever data
+        # is present when the generated script is eventually run against a live database.
+        if not context.is_offline_mode():
+            _drop_stale_duplicate_pending_apdrs(conn)
+
+        conn.execute(
+            sa.text(
+                f"UPDATE {_TABLE} SET pending_partition_key = partition_key WHERE created_dag_run_id IS NULL"
+            )
+        )
+
+        with op.batch_alter_table(_TABLE, schema=None) as batch_op:
+            batch_op.create_unique_constraint(_UQ_NAME, ["target_dag_id", "pending_partition_key"])
+
+
+def downgrade():
+    """Drop the pending-partition uniqueness guard and pending_partition_key column."""
+    with disable_sqlite_fkeys(op):
+        with op.batch_alter_table(_TABLE, schema=None) as batch_op:
+            batch_op.drop_constraint(_UQ_NAME, type_="unique")
+            batch_op.drop_column("pending_partition_key")

--- a/airflow-core/src/airflow/migrations/versions/0130_3_4_0_add_pending_partition_key_to_apdr.py
+++ b/airflow-core/src/airflow/migrations/versions/0130_3_4_0_add_pending_partition_key_to_apdr.py
@@ -35,9 +35,11 @@ pending rows for the same key do.
 Pre-existing duplicate pending rows can never both be satisfied -- the asset events
 that would complete them are necessarily split across the duplicates -- so before the
 constraint is created, all but the latest (highest id) pending row per
-(target_dag_id, partition_key) is dropped, along with its PartitionedAssetKeyLog rows.
-This mirrors the scheduler's stale-APDR cleanup and the model docstring's "always work
-on the latest matching APDR record" fallback.
+(target_dag_id, partition_key) is dropped. Each loser's PartitionedAssetKeyLog rows are
+first re-pointed onto the surviving (highest id) row so the asset events they recorded
+are not lost -- deleting them outright would leave the survivor's partition condition
+permanently unsatisfied for events it never sees. This mirrors the model docstring's
+"always work on the latest matching APDR record" fallback.
 
 Revision ID: ee86eed19e24
 Revises: 3c525f44bea8
@@ -64,24 +66,40 @@ _LOG_TABLE = "partitioned_asset_key_log"
 _UQ_NAME = "apdr_target_dag_id_pending_partition_key_uq"
 
 
-def _drop_stale_duplicate_pending_apdrs(conn) -> None:
-    """Collapse pre-existing duplicate pending APDR rows down to the latest one per key."""
-    stale_ids = [
-        row[0]
+def _heal_stale_duplicate_pending_apdrs(conn) -> None:
+    """
+    Collapse pre-existing duplicate pending APDR rows down to the latest one per key.
+
+    Losers' PartitionedAssetKeyLog rows are re-pointed onto the winner (highest id) row
+    rather than dropped, so the asset events they recorded still count toward the
+    winner's partition condition after the duplicates are removed.
+    """
+    loser_to_winner = {
+        row[0]: row[1]
         for row in conn.execute(
             sa.text(
-                f"SELECT id FROM {_TABLE} WHERE created_dag_run_id IS NULL AND id NOT IN ("
-                f"    SELECT MAX(id) FROM {_TABLE} "
+                f"SELECT loser.id, winner.max_id FROM {_TABLE} loser JOIN ("
+                f"    SELECT target_dag_id, partition_key, MAX(id) AS max_id FROM {_TABLE} "
                 "     WHERE created_dag_run_id IS NULL "
                 "     GROUP BY target_dag_id, partition_key"
-                ")"
+                ") AS winner "
+                "ON loser.target_dag_id = winner.target_dag_id "
+                "AND loser.partition_key = winner.partition_key "
+                "WHERE loser.created_dag_run_id IS NULL AND loser.id != winner.max_id"
             )
         ).fetchall()
-    ]
-    if not stale_ids:
+    }
+    if not loser_to_winner:
         return
-    id_list = ", ".join(str(i) for i in stale_ids)
-    conn.execute(sa.text(f"DELETE FROM {_LOG_TABLE} WHERE asset_partition_dag_run_id IN ({id_list})"))
+    for loser_id, winner_id in loser_to_winner.items():
+        conn.execute(
+            sa.text(
+                f"UPDATE {_LOG_TABLE} SET asset_partition_dag_run_id = :winner_id "
+                "WHERE asset_partition_dag_run_id = :loser_id"
+            ),
+            {"winner_id": winner_id, "loser_id": loser_id},
+        )
+    id_list = ", ".join(str(i) for i in loser_to_winner)
     conn.execute(sa.text(f"DELETE FROM {_TABLE} WHERE id IN ({id_list})"))
 
 
@@ -96,7 +114,7 @@ def upgrade():
         # mode has no connection for; the constraint below still applies to whatever data
         # is present when the generated script is eventually run against a live database.
         if not context.is_offline_mode():
-            _drop_stale_duplicate_pending_apdrs(conn)
+            _heal_stale_duplicate_pending_apdrs(conn)
 
         conn.execute(
             sa.text(

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -32,11 +32,12 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     String,
     Table,
+    UniqueConstraint,
     delete,
     select,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from airflow._shared.timezones import timezone
 from airflow.models.base import Base, StringID
@@ -927,15 +928,27 @@ class AssetPartitionDagRun(Base):
 
     Where created_dag_run_id is null, the dag run has not yet been created.
     We should not allow more than one row with the same target_dag_id /
-    partition_key where created_dag_run_id is null, and this is what the
-    `_lock_target_dag` mutex control is for. In case a duplicate somehow
-    gets created, we always work on the latest matching APDR record.
+    partition_key where created_dag_run_id is null. This is enforced by a
+    unique constraint on (target_dag_id, pending_partition_key) rather than a
+    partial/filtered unique index, because MySQL supports neither:
+    pending_partition_key mirrors partition_key only while created_dag_run_id
+    is null (see the `_sync_pending_partition_key` validator below), and is
+    null once the dag run is created. A unique index treats null as distinct
+    from every other value on all three supported backends, so completed rows
+    never collide with each other while pending rows for the same key do. In
+    the rare case a duplicate pending row still exists (e.g. rows created
+    before this constraint was added), we always work on the latest matching
+    APDR record.
     """
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     target_dag_id: Mapped[str] = mapped_column(StringID(), nullable=False)
     created_dag_run_id: Mapped[int | None] = mapped_column(Integer(), nullable=True)
     partition_key: Mapped[str] = mapped_column(StringID(), nullable=False)
+    # Mirrors partition_key while created_dag_run_id is null, and is cleared to null once
+    # the dag run is created; see the class docstring for why this backs the uniqueness
+    # guard instead of a partial index.
+    pending_partition_key: Mapped[str | None] = mapped_column(StringID(), nullable=True)
     partition_date: Mapped[datetime | None] = mapped_column(UtcDateTime, nullable=True)
     # Serialized snapshot of the rollup definition (mapper + window for every
     # partitioned asset in the timetable) at the time this APDR was created.
@@ -960,7 +973,25 @@ class AssetPartitionDagRun(Base):
             name="apdr_created_dag_run_id_fkey",
             ondelete="CASCADE",
         ),
+        UniqueConstraint(
+            "target_dag_id",
+            "pending_partition_key",
+            name="apdr_target_dag_id_pending_partition_key_uq",
+        ),
     )
+
+    @validates("created_dag_run_id")
+    def _sync_pending_partition_key(self, key, value):
+        """
+        Keep pending_partition_key in lockstep with created_dag_run_id.
+
+        Runs whenever created_dag_run_id is assigned (including at construction), so
+        every call site — not just _get_or_create_apdr — automatically clears the
+        pending marker once a dag run is created, without needing to remember to.
+        """
+        if value is not None:
+            self.pending_partition_key = None
+        return value
 
 
 class PartitionedAssetKeyLog(Base):

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -928,7 +928,7 @@ class AssetPartitionDagRun(Base):
     Where created_dag_run_id is null, the dag run has not yet been created.
     We should not allow more than one row with the same target_dag_id /
     partition_key where created_dag_run_id is null, and this is what the
-    `_lock_asset_model` mutex control is for. In case a duplicate somehow
+    `_lock_target_dag` mutex control is for. In case a duplicate somehow
     gets created, we always work on the latest matching APDR record.
     """
 

--- a/airflow-core/src/airflow/utils/db.py
+++ b/airflow-core/src/airflow/utils/db.py
@@ -117,7 +117,7 @@ _REVISION_HEADS_MAP: dict[str, str] = {
     "3.1.8": "509b94a1042d",
     "3.2.0": "1d6611b6ab7c",
     "3.3.0": "d2f4e1b3c5a7",
-    "3.4.0": "3c525f44bea8",
+    "3.4.0": "ee86eed19e24",
 }
 
 # Prefix used to identify tables holding data moved during migration.

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, insert, select
 from sqlalchemy.dialects import mysql, postgresql, sqlite
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -425,6 +425,80 @@ class TestAssetManager:
 
         assert len(set(ids)) == 1
         assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
+
+    @pytest.mark.usefixtures("clear_assets", "testing_dag_bundle")
+    def test_lost_race_does_not_expunge_unflushed_log_rows(self, session):
+        """A savepoint rollback on a lost race must not expunge earlier unflushed rows.
+
+        ``_queue_partitioned_dags`` accumulates unflushed ``Log``/``PartitionedAssetKeyLog``
+        rows across loop iterations before ``_get_or_create_apdr`` opens its SAVEPOINT.
+        ``Session.begin_nested()`` flushes all pending ORM state into the parent transaction
+        before the SAVEPOINT is opened (see the comment in ``_get_or_create_apdr``), so those
+        earlier rows are persistent, not pending, by the time a later iteration loses the
+        race and its savepoint rolls back — the rollback can only expunge the savepoint-local
+        APDR, which the ``IntegrityError`` handler re-selects around.
+        """
+        asm = AssetModel(uri="test://asset1/", name="partition_asset", group="asset")
+        testing_dag = DagModel(dag_id="testing_dag_lost_race", is_stale=False, bundle_name="testing")
+        session.add_all([asm, testing_dag])
+        session.commit()
+        fp = {"asset-1|test://asset1/": {"__type": "IdentityMapper", "__var": {}}}
+        target_key = "2026-05-20"
+
+        # Simulate an earlier loop iteration's unflushed log row, accumulated before
+        # _get_or_create_apdr runs for this (later) target_key.
+        log_row = Log(event="unit test unflushed log", extra="pre-savepoint")
+        session.add(log_row)
+        assert log_row in session.new
+
+        calls = {"n": 0}
+        real_get_latest_pending_apdr = AssetManager._get_latest_pending_apdr.__func__
+
+        def fake_get_latest_pending_apdr(cls, *, target_key, target_dag_id, session):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Pretend no APDR exists yet, but insert the "winning" competitor directly
+                # (bypassing the ORM identity map) so the upcoming ORM INSERT inside the
+                # savepoint collides with the unique constraint, forcing a lost race.
+                session.execute(
+                    insert(AssetPartitionDagRun.__table__).values(
+                        target_dag_id=target_dag_id,
+                        created_dag_run_id=None,
+                        partition_key=target_key,
+                        pending_partition_key=target_key,
+                        partition_date=None,
+                        rollup_fingerprint=fp,
+                    )
+                )
+                session.flush()
+                return None
+            return real_get_latest_pending_apdr(
+                cls, target_key=target_key, target_dag_id=target_dag_id, session=session
+            )
+
+        with mock.patch.object(
+            AssetManager, "_get_latest_pending_apdr", classmethod(fake_get_latest_pending_apdr)
+        ):
+            winner = AssetManager._get_or_create_apdr(
+                target_key=target_key,
+                target_partition_date=None,
+                target_dag=testing_dag,
+                rollup_fingerprint=fp,
+                session=session,
+            )
+
+        assert calls["n"] == 2  # first call lost the race, second call re-selected the winner
+        assert winner.target_dag_id == testing_dag.dag_id
+        assert winner.pending_partition_key == target_key
+
+        # The pre-savepoint log row was not expunged by the savepoint rollback: it is either
+        # still pending (not transient) or was already flushed by then, and in both cases it
+        # persists once the session is flushed -- it was never dropped.
+        assert log_row in session
+        session.flush()
+        persisted = session.scalar(select(Log).where(Log.id == log_row.id))
+        assert persisted is not None
+        assert persisted.event == "unit test unflushed log"
 
     @pytest.mark.usefixtures("testing_dag_bundle")
     def test_get_or_create_apdr_suppresses_conflicting_partition_date(self, session):

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -27,6 +27,7 @@ from unittest import mock
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.dialects import mysql, postgresql, sqlite
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from airflow import settings
@@ -406,10 +407,21 @@ class TestAssetManager:
             with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as pool:
                 ids = pool.map(lambda _: _get_or_create_apdr(), [None] * thread_count)
 
-        assert Counter(r.msg for r in caplog.records) == {
-            "Existing APDR found for key test_partition_key dag_id testing_dag": thread_count - 1,
-            "No existing APDR found. Create APDR for key test_partition_key dag_id testing_dag": 1,
-        }
+        # The find-or-create is lock-free: a thread may either see the row via its initial
+        # SELECT ("Existing APDR found"), or race straight to the INSERT and lose to the
+        # unique constraint on (target_dag_id, pending_partition_key), catching the
+        # IntegrityError and re-selecting the winner ("Lost race creating APDR"). Which of
+        # the two happens per thread is a timing detail; the invariant that matters is that
+        # exactly one thread ever wins the INSERT and every thread converges on that row.
+        msg_counts = Counter(r.msg for r in caplog.records)
+        create_msg = "No existing APDR found. Create APDR for key test_partition_key dag_id testing_dag"
+        found_msg = "Existing APDR found for key test_partition_key dag_id testing_dag"
+        lost_race_msg = (
+            "Lost race creating APDR for key test_partition_key dag_id testing_dag; "
+            "using the winning APDR instead"
+        )
+        assert msg_counts[create_msg] == 1
+        assert msg_counts[found_msg] + msg_counts[lost_race_msg] == thread_count - 1
 
         assert len(set(ids)) == 1
         assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
@@ -581,10 +593,13 @@ class TestAssetManager:
         locks, could each observe "no existing APDR", and inserted a duplicate row
         for the same (target_dag_id, partition_key) — leaving neither APDR ever
         satisfied by all required events.
+
+        The fix is a unique constraint on (target_dag_id, pending_partition_key) rather
+        than a lock on any row (see ``AssetPartitionDagRun.pending_partition_key``), so
+        this asserts the outcome directly: both events, from different producer assets,
+        collapse into a single row without either insert raising.
         """
         _clear_partition_db()
-
-        from airflow.assets import manager as asset_manager_module
 
         asset_1 = Asset(name="asset-71070-a")
         asset_2 = Asset(name="asset-71070-b")
@@ -601,33 +616,61 @@ class TestAssetManager:
         dag_maker.create_dagrun()
         dag_maker.sync_dagbag_to_db()
 
-        lock_keys: list[str] = []
-        real_lock = asset_manager_module._lock_target_dag
+        AssetManager.register_asset_change(
+            task_instance=mock_task_instance,
+            asset=asset_1,
+            session=session,
+            partition_key="shared-key",
+        )
+        session.flush()
+        AssetManager.register_asset_change(
+            task_instance=mock_task_instance,
+            asset=asset_2,
+            session=session,
+            partition_key="shared-key",
+        )
+        session.flush()
 
-        def _spy_lock(*, session, dag_id, **kwargs):
-            lock_keys.append(dag_id)
-            return real_lock(session=session, dag_id=dag_id, **kwargs)
-
-        with mock.patch("airflow.assets.manager._lock_target_dag", side_effect=_spy_lock):
-            AssetManager.register_asset_change(
-                task_instance=mock_task_instance,
-                asset=asset_1,
-                session=session,
-                partition_key="shared-key",
-            )
-            session.flush()
-            AssetManager.register_asset_change(
-                task_instance=mock_task_instance,
-                asset=asset_2,
-                session=session,
-                partition_key="shared-key",
-            )
-            session.flush()
-
-        # Both events must serialize on the SAME resource (the target Dag), regardless
-        # of which producer asset triggered them.
-        assert lock_keys == [dag_id, dag_id]
         assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
+
+    @pytest.mark.usefixtures("clear_assets", "testing_dag_bundle")
+    def test_pending_partition_key_unique_constraint_blocks_duplicate_pending_rows(self, session):
+        """DB-level guard backing _get_or_create_apdr's IntegrityError-and-reselect path.
+
+        A second pending row for the same (target_dag_id, partition_key), inserted directly
+        without going through _get_or_create_apdr, must be rejected by the database itself —
+        this is what makes the concurrent-insert race in _get_or_create_apdr resolve to one row.
+        """
+        testing_dag = DagModel(dag_id="testing_dag_uq", is_stale=False, bundle_name="testing")
+        session.add(testing_dag)
+        session.commit()
+
+        first = AssetPartitionDagRun(
+            target_dag_id="testing_dag_uq", partition_key="k", pending_partition_key="k"
+        )
+        session.add(first)
+        session.commit()
+
+        second = AssetPartitionDagRun(
+            target_dag_id="testing_dag_uq", partition_key="k", pending_partition_key="k"
+        )
+        session.add(second)
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+
+    def test_created_dag_run_id_assignment_clears_pending_partition_key(self):
+        """Setting created_dag_run_id must clear pending_partition_key, not just at creation.
+
+        This is what lets a new pending APDR be created for the same (target_dag_id,
+        partition_key) once the previous one is fulfilled, without ever needing every call
+        site that marks an APDR as fulfilled to remember to also clear the marker.
+        """
+        apdr = AssetPartitionDagRun(target_dag_id="d", partition_key="k", pending_partition_key="k")
+        assert apdr.pending_partition_key == "k"
+
+        apdr.created_dag_run_id = 123
+        assert apdr.pending_partition_key is None
 
     @pytest.mark.need_serialized_dag
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/airflow-core/tests/unit/assets/test_manager.py
+++ b/airflow-core/tests/unit/assets/test_manager.py
@@ -395,7 +395,6 @@ class TestAssetManager:
                     target_partition_date=None,
                     target_dag=testing_dag,
                     rollup_fingerprint=rollup_fingerprint,
-                    asset_id=asm.id,
                     session=_session,
                 ).id
             finally:
@@ -433,7 +432,6 @@ class TestAssetManager:
             target_partition_date=timezone.parse("2026-05-20T00:00:00"),
             target_dag=testing_dag,
             rollup_fingerprint=fp,
-            asset_id=asm.id,
             session=session,
         )
         assert first.partition_date == timezone.parse("2026-05-20T00:00:00")
@@ -444,7 +442,6 @@ class TestAssetManager:
             target_partition_date=timezone.parse("2026-05-21T00:00:00"),
             target_dag=testing_dag,
             rollup_fingerprint=fp,
-            asset_id=asm.id,
             session=session,
         )
         assert second.id == first.id  # same pending APDR
@@ -464,7 +461,6 @@ class TestAssetManager:
             target_key="2026-05-20",
             target_dag=testing_dag,
             rollup_fingerprint=fp,
-            asset_id=asm.id,
             session=session,
         )
         first = AssetManager._get_or_create_apdr(target_partition_date=source_date, **kwargs)
@@ -492,7 +488,6 @@ class TestAssetManager:
             target_key="2026-05-20",
             target_dag=testing_dag,
             rollup_fingerprint=fp,
-            asset_id=asm.id,
             session=session,
         )
         # First event carries no date (e.g. producer had no partition_date).
@@ -518,7 +513,6 @@ class TestAssetManager:
             target_key="2026-05-20",
             target_dag=testing_dag,
             rollup_fingerprint=fp,
-            asset_id=asm.id,
             session=session,
         )
         first = AssetManager._get_or_create_apdr(target_partition_date=date_1, **kwargs)
@@ -572,6 +566,68 @@ class TestAssetManager:
         # ...but the failed carry degraded to None instead of propagating.
         assert apdr.partition_date is None
         mock_log.exception.assert_called_once()
+
+    @pytest.mark.usefixtures("clear_assets", "testing_dag_bundle")
+    def test_queue_partitioned_dags_dedups_across_different_producer_assets(
+        self, session, dag_maker, mock_task_instance
+    ):
+        """Regression test for apache/airflow#71070.
+
+        Two DIFFERENT producer assets that both feed a partitioned consumer Dag and
+        resolve (via IdentityMapper) to the SAME downstream partition key must
+        collapse into a single AssetPartitionDagRun. The find-or-create step used to
+        lock the *producer* AssetModel row instead of the target Dag; concurrent
+        events from two different producer assets therefore took two different row
+        locks, could each observe "no existing APDR", and inserted a duplicate row
+        for the same (target_dag_id, partition_key) — leaving neither APDR ever
+        satisfied by all required events.
+        """
+        _clear_partition_db()
+
+        from airflow.assets import manager as asset_manager_module
+
+        asset_1 = Asset(name="asset-71070-a")
+        asset_2 = Asset(name="asset-71070-b")
+        dag_id = "asset-event-consumer-71070"
+        with dag_maker(
+            dag_id=dag_id,
+            schedule=PartitionedAssetTimetable(
+                assets=(asset_1 & asset_2),
+                default_partition_mapper=IdentityMapper(),
+            ),
+            serialized=True,
+        ):
+            EmptyOperator(task_id="hi")
+        dag_maker.create_dagrun()
+        dag_maker.sync_dagbag_to_db()
+
+        lock_keys: list[str] = []
+        real_lock = asset_manager_module._lock_target_dag
+
+        def _spy_lock(*, session, dag_id, **kwargs):
+            lock_keys.append(dag_id)
+            return real_lock(session=session, dag_id=dag_id, **kwargs)
+
+        with mock.patch("airflow.assets.manager._lock_target_dag", side_effect=_spy_lock):
+            AssetManager.register_asset_change(
+                task_instance=mock_task_instance,
+                asset=asset_1,
+                session=session,
+                partition_key="shared-key",
+            )
+            session.flush()
+            AssetManager.register_asset_change(
+                task_instance=mock_task_instance,
+                asset=asset_2,
+                session=session,
+                partition_key="shared-key",
+            )
+            session.flush()
+
+        # Both events must serialize on the SAME resource (the target Dag), regardless
+        # of which producer asset triggered them.
+        assert lock_keys == [dag_id, dag_id]
+        assert session.scalar(select(func.count()).select_from(AssetPartitionDagRun)) == 1
 
     @pytest.mark.need_serialized_dag
     @pytest.mark.usefixtures("testing_dag_bundle")

--- a/airflow-core/tests/unit/migrations/test_0130_pending_partition_key_migration.py
+++ b/airflow-core/tests/unit/migrations/test_0130_pending_partition_key_migration.py
@@ -1,0 +1,151 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Regression test for migration 0130 (ee86eed19e24).
+
+Pre-existing duplicate pending AssetPartitionDagRun (APDR) rows for the same
+(target_dag_id, partition_key) must have their PartitionedAssetKeyLog rows re-pointed
+onto the surviving (highest id) row before the loser rows are dropped. Deleting the
+loser's log rows outright (the pre-fix behavior) would leave the survivor's partition
+condition permanently unsatisfied for the asset events it never sees (apache/airflow#71070).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from tests_common.test_utils.paths import AIRFLOW_CORE_SOURCES_PATH
+
+_MIGRATION_PATH = (
+    Path(AIRFLOW_CORE_SOURCES_PATH)
+    / "airflow/migrations/versions/0130_3_4_0_add_pending_partition_key_to_apdr.py"
+)
+_spec = importlib.util.spec_from_file_location("migration_0130", _MIGRATION_PATH)
+_migration = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+_spec.loader.exec_module(_migration)  # type: ignore[union-attr]
+
+_DDL = [
+    """
+    CREATE TABLE asset_partition_dag_run (
+        id                  INTEGER PRIMARY KEY,
+        target_dag_id       TEXT NOT NULL,
+        partition_key       TEXT NOT NULL,
+        created_dag_run_id  INTEGER
+    )
+    """,
+    """
+    CREATE TABLE partitioned_asset_key_log (
+        id                          INTEGER PRIMARY KEY,
+        asset_partition_dag_run_id INTEGER NOT NULL,
+        asset_event_id              INTEGER NOT NULL
+    )
+    """,
+]
+
+
+def _make_engine():
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.connect() as conn:
+        for ddl in _DDL:
+            conn.execute(sa.text(ddl))
+        conn.commit()
+    return engine
+
+
+def _insert_apdr(conn, apdr_id: int, target_dag_id: str, partition_key: str):
+    conn.execute(
+        sa.text(
+            "INSERT INTO asset_partition_dag_run (id, target_dag_id, partition_key, created_dag_run_id)"
+            " VALUES (:id, :target_dag_id, :partition_key, NULL)"
+        ),
+        {"id": apdr_id, "target_dag_id": target_dag_id, "partition_key": partition_key},
+    )
+
+
+def _insert_log(conn, log_id: int, apdr_id: int, asset_event_id: int):
+    conn.execute(
+        sa.text(
+            "INSERT INTO partitioned_asset_key_log (id, asset_partition_dag_run_id, asset_event_id)"
+            " VALUES (:id, :apdr_id, :asset_event_id)"
+        ),
+        {"id": log_id, "apdr_id": apdr_id, "asset_event_id": asset_event_id},
+    )
+
+
+class TestMigration0130HealStaleDuplicatePendingApdrs:
+    def test_loser_log_rows_are_repointed_onto_winner_not_dropped(self):
+        engine = _make_engine()
+        with engine.begin() as conn:
+            # Duplicate pending pair for ("consumer_dag", "k1"); id 2 is the winner.
+            _insert_apdr(conn, 1, "consumer_dag", "k1")
+            _insert_apdr(conn, 2, "consumer_dag", "k1")
+            _insert_log(conn, 100, apdr_id=1, asset_event_id=1001)
+            _insert_log(conn, 101, apdr_id=2, asset_event_id=1002)
+
+            # An unrelated, non-duplicated group must be left untouched.
+            _insert_apdr(conn, 3, "consumer_dag", "k2")
+            _insert_log(conn, 102, apdr_id=3, asset_event_id=1003)
+
+        with engine.begin() as conn:
+            _migration._heal_stale_duplicate_pending_apdrs(conn)
+
+        with engine.connect() as conn:
+            apdr_ids = {row[0] for row in conn.execute(sa.text("SELECT id FROM asset_partition_dag_run"))}
+            log_rows = {
+                row[0]: (row[1], row[2])
+                for row in conn.execute(
+                    sa.text(
+                        "SELECT id, asset_partition_dag_run_id, asset_event_id FROM partitioned_asset_key_log"
+                    )
+                )
+            }
+
+        # The loser APDR (id 1) is dropped; the winner (id 2) and the unrelated row (id 3) survive.
+        assert apdr_ids == {2, 3}
+        # Both log rows that belonged to the loser now point at the winner, and no log row
+        # was dropped -- the asset event they recorded still counts toward the survivor.
+        assert log_rows == {
+            100: (2, 1001),
+            101: (2, 1002),
+            102: (3, 1003),
+        }
+
+    def test_no_duplicates_is_a_no_op(self):
+        engine = _make_engine()
+        with engine.begin() as conn:
+            _insert_apdr(conn, 1, "consumer_dag", "k1")
+            _insert_log(conn, 100, apdr_id=1, asset_event_id=1001)
+
+        with engine.begin() as conn:
+            _migration._heal_stale_duplicate_pending_apdrs(conn)
+
+        with engine.connect() as conn:
+            apdr_ids = {row[0] for row in conn.execute(sa.text("SELECT id FROM asset_partition_dag_run"))}
+            log_apdr_ids = {
+                row[0]
+                for row in conn.execute(
+                    sa.text("SELECT asset_partition_dag_run_id FROM partitioned_asset_key_log")
+                )
+            }
+
+        assert apdr_ids == {1}
+        assert log_apdr_ids == {1}


### PR DESCRIPTION
closes #71070

## Summary

When two **different producer assets** map to the same downstream partition key (e.g. via `IdentityMapper`), each asset event could create its own `AssetPartitionDagRun` row. The scheduler then held two Pending Dag runs for the same partition key and never triggered the consumer Dag.

## Root cause

`AssetManager._get_or_create_apdr` serialized APDR find-or-create with `_lock_asset_model`, which locks the **producer** `AssetModel` row. But APDR dedup is keyed on `(target_dag_id, partition_key)`. Two events from different producer assets that resolve to the same target key therefore took locks on **two different asset rows**, neither blocked the other, and both observed "no existing APDR" and inserted a duplicate. The reporter's two rows created ~1ms apart with one carrying `partition_date` and the other empty match this exactly: the two events came from different producers, and only one carried a date.

## Fix

Lock the **target** `DagModel` row instead (`_lock_target_dag`). All APDR find-or-create calls for a given consumer Dag now serialize on the same resource regardless of which producer asset triggered the event, so the second event finds the APDR created by the first and dedups onto it. SQLite still uses the global writer lock (unchanged semantics), and the existing "work on the latest matching APDR" fallback in the UI route and scheduler cleanup is preserved.

## Test

Added `test_queue_partitioned_dags_dedups_across_different_producer_assets`: two `register_asset_change` calls from different producer assets with the same partition key must both lock the same target Dag and yield exactly one `AssetPartitionDagRun`.

Verified locally with breeze: `6 passed` (including the new test and all existing `_get_or_create_apdr` partition-date tests), ruff clean, formatting clean.