### PR TITLE
Fix Airflow JWT getting cleared in KeycloakAuthManager /login_callback route

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/middleware.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/middleware.py
@@ -78,8 +78,6 @@ class KeycloakJWTMiddleware(BaseHTTPMiddleware):
                 user = new_user or current_user
             except (
                 AuthManagerRefreshTokenExpiredException,
-                ExpiredSignatureError,
-                InvalidTokenError,
                 HTTPException,
             ):
                 new_token = ""
@@ -234,13 +232,17 @@ class KeycloakJWTMiddleware(BaseHTTPMiddleware):
         access_token = request.cookies.get(COOKIE_NAME_ACCESS_TOKEN)
         refresh_token = request.cookies.get(COOKIE_NAME_REFRESH_TOKEN)
         if not jwt_token:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED, detail="User is not logged into Airflow."
-            )
+            # User is not logged into Airflow
+            return None, None
         if not access_token:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="User is not logged into Keycloak."
             )
         auth_manager = cast("KeycloakAuthManager", get_auth_manager())
-        user = await auth_manager.get_user_from_token(jwt_token, access_token, refresh_token)
+        try:
+            user = await auth_manager.get_user_from_token(jwt_token, access_token, refresh_token)
+        except ExpiredSignatureError:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token Expired")
+        except InvalidTokenError:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid JWT token")
         return get_auth_manager().refresh_user(user=user), user

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/test_middleware.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/test_middleware.py
@@ -239,7 +239,7 @@ class TestKeycloakJWTMiddleware:
             COOKIE_NAME_REFRESH_TOKEN: "refresh_token",
         }
 
-        await middleware.dispatch(mock_request, call_next)
+        response = await middleware.dispatch(mock_request, call_next)
 
         auth_manager.get_user_from_token.assert_not_called()
         auth_manager.refresh_user.assert_not_called()
@@ -258,6 +258,7 @@ class TestKeycloakJWTMiddleware:
             assert not hasattr(mock_request.state, "user_authenticated_via")
 
         call_next.assert_awaited_once_with(mock_request)
+        response.set_cookie.assert_not_called()
 
     @patch("airflow.providers.keycloak.auth_manager.middleware.get_auth_manager")
     @pytest.mark.asyncio


### PR DESCRIPTION
Fix Airflow JWT getting cleared in KeycloakAuthManager /login_callback route
---

related: #70800

In the /login_callback route the request has no `_token` property because the `/login_callback` route is going to set `_token` in the response. The `KeycloakJWTMiddleware` was incorrectly raising a 401 status and clearing the `_token` cookie, preventing logins. Gracefully handle this scenario by returning `None, None` for the user.

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
- [X] No
