### PR TITLE
Only refuse team-scoped-looking env var ids when multi_team is on

### DIFF
--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import os
 
+from airflow.configuration import conf
 from airflow.secrets import BaseSecretsBackend
 
 CONN_ENV_PREFIX = "AIRFLOW_CONN_"
@@ -34,10 +35,20 @@ TEAM_SEP = "___"
 class EnvironmentVariablesBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from environment variable."""
 
+    @staticmethod
+    def _names_a_team_namespace(secret_id: str) -> bool:
+        """
+        Whether ``secret_id`` spells out a team scoped secret name.
+
+        Only checked in multi-team mode: ``team_name`` is never non-``None`` otherwise, so no
+        team scoped variable can exist to collide with.
+        """
+        if not conf.getboolean("core", "multi_team", fallback=False):
+            return False
+        return TEAM_SEP in secret_id
+
     def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
-        if TEAM_SEP in conn_id:
-            # An id containing the separator could collide with another team's namespace
-            # even on the scoped lookup below, so it must be refused before either runs.
+        if self._names_a_team_namespace(conn_id):
             return None
 
         if team_name and (
@@ -56,8 +67,7 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         :param team_name: Team name associated to the task trying to access the variable (if any)
         :return: Variable Value
         """
-        if TEAM_SEP in key:
-            # Same collision risk as get_conn_value, see its code comment.
+        if self._names_a_team_namespace(key):
             return None
 
         if team_name and (

--- a/airflow-core/tests/unit/always/test_secrets.py
+++ b/airflow-core/tests/unit/always/test_secrets.py
@@ -122,6 +122,7 @@ class TestConnectionsFromSecrets:
         assert conn.get_uri() == "mysql://airflow:airflow@host:5432/airflow"
 
     @pytest.mark.db_test
+    @conf_vars({("core", "multi_team"): "True"})
     @mock.patch.dict(
         "os.environ",
         {
@@ -218,6 +219,7 @@ class TestVariableFromSecrets:
         mock_secret_get.return_value = "a_secret_value"
         assert Variable.get(key="not_myvar") == "a_secret_value"
 
+    @conf_vars({("core", "multi_team"): "True"})
     @mock.patch.dict(
         "os.environ",
         {

--- a/airflow-core/tests/unit/always/test_secrets_environment_variables.py
+++ b/airflow-core/tests/unit/always/test_secrets_environment_variables.py
@@ -26,6 +26,8 @@ from airflow.secrets.environment_variables import (
     EnvironmentVariablesBackend,
 )
 
+from tests_common.test_utils.config import conf_vars
+
 # A team specific secret is stored as ``<PREFIX>_<TEAM_NAME>___<SECRET_ID>``. Team names may contain
 # underscores (they are validated against ``^[a-zA-Z0-9_-]{3,50}$``), so both shapes are exercised.
 TEAM_NAMES = ["team_a", "teama"]
@@ -56,6 +58,11 @@ def lookup(env_prefix: str, method: str, secret_id: str, team_name: str | None) 
 
 class TestEnvironmentVariablesBackendTeamScope:
     """A team specific secret must only be resolvable for the team it is stored for."""
+
+    @pytest.fixture(autouse=True)
+    def _multi_team_enabled(self):
+        with conf_vars({("core", "multi_team"): "True"}):
+            yield
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
@@ -186,3 +193,15 @@ class TestEnvironmentVariablesBackendTeamScope:
         monkeypatch.delenv(env_prefix + SECRET_ID.upper(), raising=False)
 
         assert lookup(env_prefix, method, SECRET_ID, team_name) is None
+
+
+class TestEnvironmentVariablesBackendMultiTeamDisabled:
+    """No team scoped variable can exist without multi-team mode, so there is no ambiguity
+    to refuse -- an ordinary id containing the separator must resolve normally."""
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    def test_ambiguous_id_resolves_when_multi_team_is_disabled(self, monkeypatch, env_prefix, method):
+        secret_id = f"prod{TEAM_SEP}{SECRET_ID}"
+        monkeypatch.setenv(env_prefix + secret_id.upper(), GLOBAL_VALUE)
+
+        assert lookup(env_prefix, method, secret_id, None) == GLOBAL_VALUE


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

Same issue as https://github.com/apache/airflow/pull/71078 but for core airflow env backend.

## Summary

- `EnvironmentVariablesBackend` refuses to resolve any connection or variable id containing the team separator (`___`), to avoid colliding with a team-scoped environment variable name.
- That refusal ran unconditionally, even when `[core] multi_team` is off -- the default. Without multi-team mode, no team-scoped variable can be defined, so the refusal had no ambiguity to guard against and only produced false positives on ordinary ids.

Gating with the multi team config to guard it.

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
