### PR TITLE
Fix Dataflow sensors losing their XCom value when not deferred

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/dataflow.py
@@ -219,7 +219,7 @@ class DataflowJobMetricsSensor(BaseSensorOperator):
         self.deferrable = deferrable
         self.poll_interval = poll_interval
 
-    def poke(self, context: Context) -> bool:
+    def poke(self, context: Context) -> PokeReturnValue | bool:
         if self.fail_on_terminal_state:
             job = self.hook.get_job(
                 job_id=self.job_id,
@@ -236,26 +236,35 @@ class DataflowJobMetricsSensor(BaseSensorOperator):
             project_id=self.project_id,
             location=self.location,
         )
-        return result["metrics"] if self.callback is None else self.callback(result["metrics"])
+        result = result["metrics"] if self.callback is None else self.callback(result["metrics"])
+
+        if isinstance(result, PokeReturnValue):
+            return result
+
+        if bool(result):
+            return PokeReturnValue(
+                is_done=True,
+                xcom_value=result,
+            )
+        return False
 
     def execute(self, context: Context) -> Any:
         """Airflow runs this method on the worker and defers using the trigger."""
         if not self.deferrable:
-            super().execute(context)
-        else:
-            self.defer(
-                timeout=self.execution_timeout,
-                trigger=DataflowJobMetricsTrigger(
-                    job_id=self.job_id,
-                    project_id=self.project_id,
-                    location=self.location,
-                    gcp_conn_id=self.gcp_conn_id,
-                    poll_sleep=self.poll_interval,
-                    impersonation_chain=self.impersonation_chain,
-                    fail_on_terminal_state=self.fail_on_terminal_state,
-                ),
-                method_name="execute_complete",
-            )
+            return super().execute(context)
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=DataflowJobMetricsTrigger(
+                job_id=self.job_id,
+                project_id=self.project_id,
+                location=self.location,
+                gcp_conn_id=self.gcp_conn_id,
+                poll_sleep=self.poll_interval,
+                impersonation_chain=self.impersonation_chain,
+                fail_on_terminal_state=self.fail_on_terminal_state,
+            ),
+            method_name="execute_complete",
+        )
 
     def execute_complete(self, context: Context, event: dict[str, str | list]) -> Any:
         """
@@ -372,21 +381,20 @@ class DataflowJobMessagesSensor(BaseSensorOperator):
     def execute(self, context: Context) -> Any:
         """Airflow runs this method on the worker and defers using the trigger."""
         if not self.deferrable:
-            super().execute(context)
-        else:
-            self.defer(
-                timeout=self.execution_timeout,
-                trigger=DataflowJobMessagesTrigger(
-                    job_id=self.job_id,
-                    project_id=self.project_id,
-                    location=self.location,
-                    gcp_conn_id=self.gcp_conn_id,
-                    poll_sleep=self.poll_interval,
-                    impersonation_chain=self.impersonation_chain,
-                    fail_on_terminal_state=self.fail_on_terminal_state,
-                ),
-                method_name="execute_complete",
-            )
+            return super().execute(context)
+        self.defer(
+            timeout=self.execution_timeout,
+            trigger=DataflowJobMessagesTrigger(
+                job_id=self.job_id,
+                project_id=self.project_id,
+                location=self.location,
+                gcp_conn_id=self.gcp_conn_id,
+                poll_sleep=self.poll_interval,
+                impersonation_chain=self.impersonation_chain,
+                fail_on_terminal_state=self.fail_on_terminal_state,
+            ),
+            method_name="execute_complete",
+        )
 
     def execute_complete(self, context: Context, event: dict[str, str | list]) -> Any:
         """
@@ -502,20 +510,19 @@ class DataflowJobAutoScalingEventsSensor(BaseSensorOperator):
     def execute(self, context: Context) -> Any:
         """Airflow runs this method on the worker and defers using the trigger."""
         if not self.deferrable:
-            super().execute(context)
-        else:
-            self.defer(
-                trigger=DataflowJobAutoScalingEventTrigger(
-                    job_id=self.job_id,
-                    project_id=self.project_id,
-                    location=self.location,
-                    gcp_conn_id=self.gcp_conn_id,
-                    poll_sleep=self.poll_interval,
-                    impersonation_chain=self.impersonation_chain,
-                    fail_on_terminal_state=self.fail_on_terminal_state,
-                ),
-                method_name="execute_complete",
-            )
+            return super().execute(context)
+        self.defer(
+            trigger=DataflowJobAutoScalingEventTrigger(
+                job_id=self.job_id,
+                project_id=self.project_id,
+                location=self.location,
+                gcp_conn_id=self.gcp_conn_id,
+                poll_sleep=self.poll_interval,
+                impersonation_chain=self.impersonation_chain,
+                fail_on_terminal_state=self.fail_on_terminal_state,
+            ),
+            method_name="execute_complete",
+        )
 
     def execute_complete(self, context: Context, event: dict[str, str | list]) -> Any:
         """

--- a/providers/google/tests/unit/google/cloud/sensors/test_dataflow.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_dataflow.py
@@ -200,7 +200,7 @@ class TestDataflowJobMetricsSensor:
         mock_get_job.return_value = {"id": TEST_JOB_ID, "currentState": job_current_state}
         results = task.poke(mock.MagicMock())
 
-        assert callback.return_value == results
+        assert callback.return_value == results.xcom_value
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
@@ -243,6 +243,23 @@ class TestDataflowJobMetricsSensor:
         )
         mock_fetch_job_messages_by_id.assert_not_called()
         callback.assert_not_called()
+
+    @mock.patch("airflow.providers.google.cloud.sensors.dataflow.DataflowHook")
+    def test_execute_returns_xcom_value_in_non_deferrable_mode(self, mock_hook):
+        """Deferrable mode returns the metrics through execute_complete; poke mode must match it."""
+        callback = mock.MagicMock()
+        task = DataflowJobMetricsSensor(
+            task_id=TEST_TASK_ID,
+            job_id=TEST_JOB_ID,
+            callback=callback,
+            fail_on_terminal_state=False,
+            location=TEST_LOCATION,
+            project_id=TEST_PROJECT_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
+
+        assert task.execute(mock.MagicMock()) == callback.return_value
 
     @mock.patch("airflow.providers.google.cloud.hooks.dataflow.AsyncDataflowHook")
     def test_execute_enters_deferred_state(self, mock_hook):
@@ -422,6 +439,23 @@ class TestDataflowJobMessagesSensor:
         mock_fetch_job_messages_by_id.assert_not_called()
         callback.assert_not_called()
 
+    @mock.patch("airflow.providers.google.cloud.sensors.dataflow.DataflowHook")
+    def test_execute_returns_xcom_value_in_non_deferrable_mode(self, mock_hook):
+        """Deferrable mode returns the messages through execute_complete; poke mode must match it."""
+        callback = mock.MagicMock()
+        task = DataflowJobMessagesSensor(
+            task_id=TEST_TASK_ID,
+            job_id=TEST_JOB_ID,
+            callback=callback,
+            fail_on_terminal_state=False,
+            location=TEST_LOCATION,
+            project_id=TEST_PROJECT_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
+
+        assert task.execute(mock.MagicMock()) == callback.return_value
+
     @mock.patch("airflow.providers.google.cloud.hooks.dataflow.AsyncDataflowHook")
     def test_execute_enters_deferred_state(self, mock_hook):
         """
@@ -597,6 +631,23 @@ class TestDataflowJobAutoScalingEventsSensor:
         )
         mock_fetch_job_autoscaling_events_by_id.assert_not_called()
         callback.assert_not_called()
+
+    @mock.patch("airflow.providers.google.cloud.sensors.dataflow.DataflowHook")
+    def test_execute_returns_xcom_value_in_non_deferrable_mode(self, mock_hook):
+        """Deferrable mode returns the events through execute_complete; poke mode must match it."""
+        callback = mock.MagicMock()
+        task = DataflowJobAutoScalingEventsSensor(
+            task_id=TEST_TASK_ID,
+            job_id=TEST_JOB_ID,
+            callback=callback,
+            fail_on_terminal_state=False,
+            location=TEST_LOCATION,
+            project_id=TEST_PROJECT_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+        )
+
+        assert task.execute(mock.MagicMock()) == callback.return_value
 
     @mock.patch("airflow.providers.google.cloud.hooks.dataflow.AsyncDataflowHook")
     def test_execute_enters_deferred_state(self, mock_hook):


### PR DESCRIPTION
### Why

- `DataflowJobMessagesSensor`, `DataflowJobAutoScalingEventsSensor` and `DataflowJobMetricsSensor` return their payload to XCom when deferred, but drop it in poke mode. `deferrable` defaults to `False`, so the default path is the broken one.
- The payload travels through a chain, and these sensors break it at the last step:

  ```
  poke()                          →  PokeReturnValue(is_done=True, xcom_value=X)
  BaseSensorOperator.execute()    →  picks X out and returns it
  subclass execute()              →  must return it upwards        ← dropped here
  task runner                     →  pushes it as the return_value XCom
  ```

### How

- Return `super().execute(context)` from the three sensors' `execute()` overrides.
- Wrap `DataflowJobMetricsSensor.poke()`'s result in `PokeReturnValue`, the same way #53115 did for the other two. 


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
