### PR TITLE
Stop dag processor from warning on every file path normalized for stats

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -156,7 +156,7 @@ class DagFileInfo:
     @property
     def normalized_file_path_for_stats(self) -> str:
         """Return the relative file path normalized for use in stats tags."""
-        return normalize_name_for_stats(str(self.rel_path))
+        return normalize_name_for_stats(str(self.rel_path), log_warning=False)
 
 
 def _config_int_factory(section: str, key: str):

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3636,4 +3636,4 @@ def test_normalized_file_path_for_stats_does_not_warn(caplog):
         result = dag_file_info.normalized_file_path_for_stats
 
     assert result == "dags_test_test_dag.py"
-    assert caplog.records == []
+    assert caplog.entries == []

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -3620,3 +3620,20 @@ class TestMultiTeamMetrics:
         # Two bundles resolved in a single batched query; the repeat call is served from cache.
         mock_get_team_names.assert_called_once()
         assert manager._bundle_name_to_team_name == {"bundle_a": "team_alpha", "bundle_b": "team_alpha"}
+
+
+def test_normalized_file_path_for_stats_does_not_warn(caplog):
+    """
+    rel_path always contains "/" for any nested DAG file, so normalizing it for stats
+    always requires substitution -- this must not log a warning on every DAG file, every
+    processing cycle.
+    """
+    dag_file_info = DagFileInfo(
+        bundle_name="testing", bundle_path=TEST_DAGS_FOLDER, rel_path=Path("dags/test/test_dag.py")
+    )
+
+    with caplog.at_level(logging.WARNING, logger="airflow._shared.observability.metrics.stats"):
+        result = dag_file_info.normalized_file_path_for_stats
+
+    assert result == "dags_test_test_dag.py"
+    assert caplog.records == []


### PR DESCRIPTION
**Summary**
Right after the dag-processor starts, it repeatedly logs a warning like:
"Name 'dags/test/test_dag.py' contains invalid characters for stats
reporting. Reporting stats with normalized name 'dags_test_test_dag.py'."
This fires once per DAG file, on every processing cycle.

**Root cause**
DagFileInfo.normalized_file_path_for_stats calls normalize_name_for_stats()
without log_warning=False. A relative file path always contains "/" as a
directory separator, so normalization always requires substitution -- the
warning can never signal an actual problem, only expected, routine behavior.

**Fix**
Pass log_warning=False for this specific call. The other normalize_name_for_stats
call sites in the same file (bundle_name, file name stem) are left unchanged,
since those genuinely rarely contain invalid characters, so a warning there
still carries real diagnostic value.

**Testing**
Added a regression test asserting normalized_file_path_for_stats does not
emit a warning for a normal nested file path.

closes: #71084

Was generative AI tooling used ?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)