### PR TITLE
Remove groups claim from access tokens in Keycloak clients from the KeycloakAuthManager cli

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -222,7 +222,7 @@ def _create_group_membership_mapper(
         "config": {
             "full.path": "false",
             "id.token.claim": "false",
-            "access.token.claim": "true",
+            "access.token.claim": "false",
             "userinfo.token.claim": "false",
             "claim.name": "groups",
             "jsonType.label": "String",


### PR DESCRIPTION
related #61771

Remove groups claim from access tokens in Keycloak clients from the KeycloakAuthManager cli
---

With the KeycloakAuthManager the groups mapper in Keycloak is only used for evaluating RBAC policy enforcements on the server side, not the client side. In large organisations users can be members of hundreds or thousands of Keycloak groups, which significantly increases the size of the Keycloak `access_token` JWT, which risks going over the browser's 4KB cookie size limit. In the keycloak provider cli, we should set these group claims to be excluded from user refresh tokens _and_ access tokens to avoid overloading the browser cookies.

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)
- [X] No

---
