### PR TITLE
Regenerate airflowctl datamodels from this branch's API spec

### DIFF
--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -49,27 +49,6 @@ class AssetAliasResponse(BaseModel):
     group: Annotated[str, Field(title="Group")]
 
 
-class AssetStateBody(BaseModel):
-    """
-    Request body for setting an asset state value.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    value: Annotated[str, Field(max_length=65535, title="Value")]
-
-
-class AssetStateResponse(BaseModel):
-    """
-    A single asset state key/value pair with metadata.
-    """
-
-    key: Annotated[str, Field(title="Key")]
-    value: Annotated[str, Field(title="Value")]
-    updated_at: Annotated[datetime, Field(title="Updated At")]
-
-
 class AssetWatcherResponse(BaseModel):
     """
     Asset watcher serializer for responses.
@@ -129,32 +108,6 @@ class BulkActionResponse(BaseModel):
     ] = []
 
 
-class BulkDAGRunBody(BaseModel):
-    """
-    Request body for bulk delete operations on Dag Runs.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    dag_run_id: Annotated[str, Field(title="Dag Run Id")]
-    dag_id: Annotated[str | None, Field(title="Dag Id")] = None
-
-
-class BulkDeleteActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["delete"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[str | BulkDAGRunBody],
-        Field(description="A list of entity id/key or entity objects to be deleted.", title="Entities"),
-    ]
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
-
-
 class BulkResponse(BaseModel):
     """
     Serializer for responses to bulk entity operations.
@@ -180,26 +133,6 @@ class BulkResponse(BaseModel):
 
 class Note(RootModel[str]):
     root: Annotated[str, Field(max_length=1000, title="Note")]
-
-
-class BulkUpdateActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["update"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[BulkDAGRunBody], Field(description="A list of entities to be updated.", title="Entities")
-    ]
-    update_mask: Annotated[
-        list[str] | None,
-        Field(
-            description="A list of field names to update for each entity.Only these fields will be applied from the request body to the database model.Any extra fields provided will be ignored.",
-            title="Update Mask",
-        ),
-    ] = None
-    action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
 class TaskIds(RootModel[list[Any]]):
@@ -235,12 +168,11 @@ class ClearTaskInstancesBody(BaseModel):
     run_on_latest_version: Annotated[
         bool | None,
         Field(
-            description="(Experimental) Run on the latest bundle version of the dag after clearing the task instances. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).",
+            description="(Experimental) Run on the latest bundle version of the dag after clearing the task instances.",
             title="Run On Latest Version",
         ),
-    ] = None
+    ] = False
     prevent_running_task: Annotated[bool | None, Field(title="Prevent Running Task")] = False
-    note: Annotated[Note | None, Field(title="Note")] = None
 
 
 class Value(RootModel[list[Any]]):
@@ -355,20 +287,23 @@ class DAGRunClearBody(BaseModel):
     )
     dry_run: Annotated[bool | None, Field(title="Dry Run")] = True
     only_failed: Annotated[bool | None, Field(title="Only Failed")] = False
-    only_new: Annotated[
-        bool | None,
-        Field(
-            description="Only queue newly added tasks in the latest Dag version without clearing existing tasks.",
-            title="Only New",
-        ),
-    ] = False
     run_on_latest_version: Annotated[
         bool | None,
         Field(
-            description="(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``False`` (the historical default for clear/rerun).",
+            description="(Experimental) Run on the latest bundle version of the Dag after clearing the Dag Run.",
             title="Run On Latest Version",
         ),
-    ] = None
+    ] = False
+
+
+class DAGRunPatchStates(str, Enum):
+    """
+    Enum for Dag Run states when updating a Dag Run.
+    """
+
+    QUEUED = "queued"
+    SUCCESS = "success"
+    FAILED = "failed"
 
 
 class DAGSourceResponse(BaseModel):
@@ -421,16 +356,6 @@ class DagRunAssetReference(BaseModel):
     partition_key: Annotated[str | None, Field(title="Partition Key")] = None
 
 
-class DagRunMutableStates(str, Enum):
-    """
-    Dag Run states from which the run may be mutated (patched, deleted).
-    """
-
-    QUEUED = "queued"
-    SUCCESS = "success"
-    FAILED = "failed"
-
-
 class DagRunState(str, Enum):
     """
     All possible states that a DagRun can be in.
@@ -469,7 +394,6 @@ class DagRunType(str, Enum):
     BACKFILL = "backfill"
     SCHEDULED = "scheduled"
     MANUAL = "manual"
-    OPERATOR_TRIGGERED = "operator_triggered"
     ASSET_TRIGGERED = "asset_triggered"
     ASSET_MATERIALIZATION = "asset_materialization"
 
@@ -712,15 +636,6 @@ class MaterializeAssetBody(BaseModel):
     conf: Annotated[dict[str, Any] | None, Field(title="Conf")] = None
     note: Annotated[str | None, Field(title="Note")] = None
     partition_key: Annotated[str | None, Field(title="Partition Key")] = None
-
-
-class NewTaskResponse(BaseModel):
-    """
-    Lightweight response for new tasks that don't have TaskInstances yet.
-    """
-
-    task_id: Annotated[str, Field(title="Task Id")]
-    task_display_name: Annotated[str, Field(title="Task Display Name")]
 
 
 class PluginImportErrorResponse(BaseModel):
@@ -973,28 +888,6 @@ class TaskOutletAssetReference(BaseModel):
     updated_at: Annotated[datetime, Field(title="Updated At")]
 
 
-class TaskStateBody(BaseModel):
-    """
-    Request body for setting a task state value.
-    """
-
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    value: Annotated[str, Field(max_length=65535, title="Value")]
-
-
-class TaskStateResponse(BaseModel):
-    """
-    A single task state key/value pair with metadata.
-    """
-
-    key: Annotated[str, Field(title="Key")]
-    value: Annotated[str, Field(title="Value")]
-    updated_at: Annotated[datetime, Field(title="Updated At")]
-    expires_at: Annotated[datetime | None, Field(title="Expires At")] = None
-
-
 class TimeDelta(BaseModel):
     """
     TimeDelta can be used to interact with datetime.timedelta objects.
@@ -1225,15 +1118,6 @@ class AssetResponse(BaseModel):
     last_asset_event: LastAssetEventResponse | None = None
 
 
-class AssetStateCollectionResponse(BaseModel):
-    """
-    All asset state entries for an asset.
-    """
-
-    asset_states: Annotated[list[AssetStateResponse], Field(title="Asset States")]
-    total_entries: Annotated[int, Field(title="Total Entries")]
-
-
 class BackfillPostBody(BaseModel):
     """
     Object used for create backfill request.
@@ -1246,16 +1130,10 @@ class BackfillPostBody(BaseModel):
     from_date: Annotated[datetime, Field(title="From Date")]
     to_date: Annotated[datetime, Field(title="To Date")]
     run_backwards: Annotated[bool | None, Field(title="Run Backwards")] = False
-    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")] = None
+    dag_run_conf: Annotated[dict[str, Any] | None, Field(title="Dag Run Conf")] = {}
     reprocess_behavior: ReprocessBehavior | None = "none"
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = 10
-    run_on_latest_version: Annotated[
-        bool | None,
-        Field(
-            description="Run on the latest bundle version of the Dag for each backfilled run. If not specified, falls back to the DAG-level ``rerun_with_latest_version`` parameter, then the ``[core] rerun_with_latest_version`` config option, and finally ``True`` (the historical default for backfills).",
-            title="Run On Latest Version",
-        ),
-    ] = None
+    run_on_latest_version: Annotated[bool | None, Field(title="Run On Latest Version")] = True
 
 
 class BackfillResponse(BaseModel):
@@ -1275,19 +1153,6 @@ class BackfillResponse(BaseModel):
     completed_at: Annotated[datetime | None, Field(title="Completed At")] = None
     updated_at: Annotated[datetime, Field(title="Updated At")]
     dag_display_name: Annotated[str, Field(title="Dag Display Name")]
-
-
-class BulkCreateActionBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    action: Annotated[
-        Literal["create"], Field(description="The action to be performed on the entities.", title="Action")
-    ]
-    entities: Annotated[
-        list[BulkDAGRunBody], Field(description="A list of entities to be created.", title="Entities")
-    ]
-    action_on_existence: BulkActionOnExistence | None = "fail"
 
 
 class BulkCreateActionConnectionBody(BaseModel):
@@ -1511,7 +1376,6 @@ class DAGDetailsResponse(BaseModel):
     timetable_summary: Annotated[str | None, Field(title="Timetable Summary")] = None
     timetable_description: Annotated[str | None, Field(title="Timetable Description")] = None
     timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")]
-    timetable_periodic: Annotated[bool, Field(title="Timetable Periodic")]
     tags: Annotated[list[DagTagResponse], Field(title="Tags")]
     max_active_tasks: Annotated[int, Field(title="Max Active Tasks")]
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = None
@@ -1541,13 +1405,9 @@ class DAGDetailsResponse(BaseModel):
     timezone: Annotated[str | None, Field(title="Timezone")] = None
     last_parsed: Annotated[datetime | None, Field(title="Last Parsed")] = None
     default_args: Annotated[dict[str, Any] | None, Field(title="Default Args")] = None
-    rerun_with_latest_version: Annotated[bool | None, Field(title="Rerun With Latest Version")] = None
     owner_links: Annotated[dict[str, str] | None, Field(title="Owner Links")] = None
     is_favorite: Annotated[bool | None, Field(title="Is Favorite")] = False
     active_runs_count: Annotated[int | None, Field(title="Active Runs Count")] = 0
-    is_backfillable: Annotated[
-        bool, Field(description="Whether this Dag's schedule supports backfilling.", title="Is Backfillable")
-    ]
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
     concurrency: Annotated[
         int,
@@ -1581,7 +1441,6 @@ class DAGResponse(BaseModel):
     timetable_summary: Annotated[str | None, Field(title="Timetable Summary")] = None
     timetable_description: Annotated[str | None, Field(title="Timetable Description")] = None
     timetable_partitioned: Annotated[bool, Field(title="Timetable Partitioned")]
-    timetable_periodic: Annotated[bool, Field(title="Timetable Periodic")]
     tags: Annotated[list[DagTagResponse], Field(title="Tags")]
     max_active_tasks: Annotated[int, Field(title="Max Active Tasks")]
     max_active_runs: Annotated[int | None, Field(title="Max Active Runs")] = None
@@ -1598,9 +1457,6 @@ class DAGResponse(BaseModel):
     next_dagrun_run_after: Annotated[datetime | None, Field(title="Next Dagrun Run After")] = None
     allowed_run_types: Annotated[list[DagRunType] | None, Field(title="Allowed Run Types")] = None
     owners: Annotated[list[str], Field(title="Owners")]
-    is_backfillable: Annotated[
-        bool, Field(description="Whether this Dag's schedule supports backfilling.", title="Is Backfillable")
-    ]
     file_token: Annotated[str, Field(description="Return file token.", title="File Token")]
 
 
@@ -1612,7 +1468,7 @@ class DAGRunPatchBody(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    state: DagRunMutableStates | None = None
+    state: DAGRunPatchStates | None = None
     note: Annotated[Note | None, Field(title="Note")] = None
 
 
@@ -1775,7 +1631,7 @@ class JobCollectionResponse(BaseModel):
 
 class PatchTaskInstanceBody(BaseModel):
     """
-    Request body for patching task instance state.
+    Request body for Clear Task Instances endpoint.
     """
 
     model_config = ConfigDict(
@@ -1972,15 +1828,6 @@ class TaskResponse(BaseModel):
     ]
 
 
-class TaskStateCollectionResponse(BaseModel):
-    """
-    All task state entries for a task instance.
-    """
-
-    task_states: Annotated[list[TaskStateResponse], Field(title="Task States")]
-    total_entries: Annotated[int, Field(title="Total Entries")]
-
-
 class VariableCollectionResponse(BaseModel):
     """
     Variable Collection serializer for responses.
@@ -2024,18 +1871,6 @@ class BackfillCollectionResponse(BaseModel):
 
     backfills: Annotated[list[BackfillResponse], Field(title="Backfills")]
     total_entries: Annotated[int, Field(title="Total Entries")]
-
-
-class BulkBodyBulkDAGRunBody(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    actions: Annotated[
-        list[
-            BulkCreateActionBulkDAGRunBody | BulkUpdateActionBulkDAGRunBody | BulkDeleteActionBulkDAGRunBody
-        ],
-        Field(title="Actions"),
-    ]
 
 
 class BulkBodyConnectionBody(BaseModel):
@@ -2097,15 +1932,6 @@ class BulkDeleteActionBulkTaskInstanceBody(BaseModel):
     action_on_non_existence: BulkActionNotOnExistence | None = "fail"
 
 
-class ClearTaskInstanceCollectionResponse(BaseModel):
-    """
-    Response for clear dag run dry run, which may contain new tasks without full TaskInstance data.
-    """
-
-    task_instances: Annotated[list[TaskInstanceResponse | NewTaskResponse], Field(title="Task Instances")]
-    total_entries: Annotated[int, Field(title="Total Entries")]
-
-
 class DAGCollectionResponse(BaseModel):
     """
     Dag Collection serializer for responses.
@@ -2117,38 +1943,11 @@ class DAGCollectionResponse(BaseModel):
 
 class DAGRunCollectionResponse(BaseModel):
     """
-    Dag Run collection response supporting both offset and cursor pagination.
-
-    A single flat model is used instead of a discriminated union
-    (``Annotated[Offset | Cursor, Field(discriminator=...)]``) because
-    the OpenAPI ``oneOf`` + ``discriminator`` construct is not handled
-    correctly by ``@hey-api/openapi-ts`` / ``@7nohe/openapi-react-query-codegen``:
-    return types degrade to ``unknown`` in JSDoc and can produce
-    incorrect TypeScript types (see hey-api/openapi-ts#1613, #3270).
+    Dag Run Collection serializer for responses.
     """
 
     dag_runs: Annotated[list[DAGRunResponse], Field(title="Dag Runs")]
-    total_entries: Annotated[
-        int | None,
-        Field(
-            description="Total number of matching items. Populated for offset pagination, ``null`` when using cursor pagination.",
-            title="Total Entries",
-        ),
-    ] = None
-    next_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the next page. Populated for cursor pagination, ``null`` when using offset pagination or when there is no next page.",
-            title="Next Cursor",
-        ),
-    ] = None
-    previous_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the previous page. Populated for cursor pagination, ``null`` when using offset pagination or when on the first page.",
-            title="Previous Cursor",
-        ),
-    ] = None
+    total_entries: Annotated[int, Field(title="Total Entries")]
 
 
 class DAGWarningCollectionResponse(BaseModel):
@@ -2240,38 +2039,11 @@ class TaskCollectionResponse(BaseModel):
 
 class TaskInstanceCollectionResponse(BaseModel):
     """
-    Task instance collection response supporting both offset and cursor pagination.
-
-    A single flat model is used instead of a discriminated union
-    (``Annotated[Offset | Cursor, Field(discriminator=...)]``) because
-    the OpenAPI ``oneOf`` + ``discriminator`` construct is not handled
-    correctly by ``@hey-api/openapi-ts`` / ``@7nohe/openapi-react-query-codegen``:
-    return types degrade to ``unknown`` in JSDoc and can produce
-    incorrect TypeScript types (see hey-api/openapi-ts#1613, #3270).
+    Task Instance Collection serializer for responses.
     """
 
     task_instances: Annotated[list[TaskInstanceResponse], Field(title="Task Instances")]
-    total_entries: Annotated[
-        int | None,
-        Field(
-            description="Total number of matching items. Populated for offset pagination, ``null`` when using cursor pagination.",
-            title="Total Entries",
-        ),
-    ] = None
-    next_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the next page. Populated for cursor pagination, ``null`` when using offset pagination or when there is no next page.",
-            title="Next Cursor",
-        ),
-    ] = None
-    previous_cursor: Annotated[
-        str | None,
-        Field(
-            description="Token pointing to the previous page. Populated for cursor pagination, ``null`` when using offset pagination or when on the first page.",
-            title="Previous Cursor",
-        ),
-    ] = None
+    total_entries: Annotated[int, Field(title="Total Entries")]
 
 
 class TaskInstanceHistoryCollectionResponse(BaseModel):


### PR DESCRIPTION
The test-to-stable sync (#67294) copied airflowctl's generated datamodels from main, so they describe Airflow 3.3's API while this branch ships core 3.2.1. Two consequences, both red once CI started running here (#70724):

- `generate-airflowctl-datamodels` regenerates from `../airflow-core/src/airflow/api_fastapi` and fails on any drift, so Static checks could never pass
- the models required `is_backfillable` and `timetable_periodic`, which #64644 added in 3.3.0, so every single-object Dag response failed validation against this branch's own PROD image:

```
ValidationError: 2 validation errors for DAGResponse
  is_backfillable      Field required
  timetable_periodic   Field required
```

This runs the hook to bring the models back in line with the spec on this branch. It drops 14 model classes that no airflowctl code or test references, plus the 3.3-only fields above.

Note `RELEASE_NOTES.rst` credits "Add ``is_backfillable`` property to DAG API responses (#64644)" to airflowctl 0.1.5, but #64644 touches only airflow-core — that line is sync noise, not a client feature.

Split out of #70724 so that PR stays workflow-only.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5

Generated-by: Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)