### PR TITLE
Fix airflowctl dags state crash from an incomplete backport

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -632,6 +632,8 @@ class DagRunOperations(BaseOperations):
         logical_date_gte: datetime.datetime | None = None,
         logical_date_lte: datetime.datetime | None = None,
         order_by: str | None = None,
+        *,
+        suppress_error_log: bool = False,
     ) -> DAGRunCollectionResponse | ServerResponseError:
         """
         List dag runs (at most `limit` results).
@@ -645,6 +647,7 @@ class DagRunOperations(BaseOperations):
             logical_date_gte: Filter dag runs with a logical date greater than or equal to this value.
             logical_date_lte: Filter dag runs with a logical date less than or equal to this value.
             order_by: Order the results by the specified field.
+            suppress_error_log: Skip client-side error logging, for callers handling the error themselves.
         """
         # Use "~" for all DAGs if dag_id is not specified
         if not dag_id:
@@ -661,7 +664,11 @@ class DagRunOperations(BaseOperations):
         )
 
         try:
-            self.response = self.client.get(f"/dags/{dag_id}/dagRuns", params=params)
+            self.response = self.client.get(
+                f"/dags/{dag_id}/dagRuns",
+                params=params,
+                extensions={"airflowctl_suppress_error_log": suppress_error_log},
+            )
             return DAGRunCollectionResponse.model_validate_json(self.response.content)
         except ServerResponseError as e:
             raise e


### PR DESCRIPTION
The `dags state` backport (#69915, #70352) brought the caller and the tests but dropped `suppress_error_log` from `DagRunOperations.list()`, which main has. `dag_command.py:147` passes it, so the command raised:

```
TypeError: DagRunOperations.list() got an unexpected keyword argument 'suppress_error_log'
```

Restore the keyword-only parameter and forward it to the client as the `airflowctl_suppress_error_log` extension, matching the sibling `get()`.

The broken caller only exists on this test branch, so no released airflowctl is affected and no newsfragment is needed.

Split out of #70724 so that PR stays workflow-only.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5

Generated-by: Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)