### PR TITLE
Fix airflow-ctl mypy static check on the 0.1 branch

### DIFF
--- a/airflow-ctl/.pre-commit-config.yaml
+++ b/airflow-ctl/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: mypy-airflow-ctl
         name: Run mypy for airflow-ctl
         language: python
-        entry: ../scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py airflow-ctl
+        entry: ../scripts/ci/prek/mypy_local_folder.py airflow-ctl
         pass_filenames: false
         files: ^.*\.py$
         require_serial: true


### PR DESCRIPTION
The same test-to-stable sync (#67294) repointed the `mypy-airflow-ctl` hook at `../scripts/ci/prek/run_mypy_full_dist_local_venv_or_breeze_in_ci.py`, which only exists on main. On this branch prek dies before mypy ever runs:

```
error: Failed to run hook `mypy-airflow-ctl`
  caused by: Run command `python hook` failed
  caused by: No such file or directory (os error 2)
```

Point it back at `mypy_local_folder.py`, which is what airflow-core, task-sdk, devel-common and dev/scripts all use on this branch.

Split out of #70724 so that PR stays workflow-only.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5

Generated-by: Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)