### PR TITLE
Fix airflow-ctl 0.1 branch image build by realigning core versions

### DIFF
--- a/airflow-core/pyproject.toml
+++ b/airflow-core/pyproject.toml
@@ -64,7 +64,7 @@ classifiers = [
 ]
 
 # Version is defined in src/airflow/__init__.py and it is automatically synchronized by prek hook
-version = "3.3.0"
+version = "3.2.1"
 
 dependencies = [
     "a2wsgi>=1.10.8",
@@ -149,7 +149,7 @@ dependencies = [
     "typing-extensions>=4.14.1",
     "universal-pathlib>=0.3.8",
     "uuid6>=2024.7.10",
-    "apache-airflow-task-sdk<1.4.0,>=1.3.0",
+    "apache-airflow-task-sdk==1.2.1",
     "apache-airflow-ctl<0.1.6,>=0.1.5",
     # pre-installed providers
     "apache-airflow-providers-common-compat>=1.7.4",
@@ -248,7 +248,6 @@ exclude = [
 "../shared/secrets_backend/src/airflow_shared/secrets_backend" = "src/airflow/_shared/secrets_backend"
 "../shared/secrets_masker/src/airflow_shared/secrets_masker" = "src/airflow/_shared/secrets_masker"
 "../shared/serialization/src/airflow_shared/serialization" = "src/airflow/_shared/serialization"
-"../shared/state/src/airflow_shared/state" = "src/airflow/_shared/state"
 "../shared/timezones/src/airflow_shared/timezones" = "src/airflow/_shared/timezones"
 "../shared/listeners/src/airflow_shared/listeners" = "src/airflow/_shared/listeners"
 "../shared/plugins_manager/src/airflow_shared/plugins_manager" = "src/airflow/_shared/plugins_manager"
@@ -337,7 +336,6 @@ shared_distributions = [
     "apache-airflow-shared-secrets-backend",
     "apache-airflow-shared-secrets-masker",
     "apache-airflow-shared-serialization",
-    "apache-airflow-shared-state",
     "apache-airflow-shared-timezones",
     "apache-airflow-shared-plugins-manager",
     "apache-airflow-shared-providers-discovery",

--- a/uv.lock
+++ b/uv.lock
@@ -101,9 +101,9 @@ apache-airflow-providers-mongo = false
 apache-airflow-providers-apprise = false
 apache-airflow-providers-apache-impala = false
 apache-airflow-ctl = false
-apache-airflow-providers-zendesk = false
 apache-airflow-providers-github = false
 apache-airflow-providers-snowflake = false
+apache-airflow-providers-zendesk = false
 apache-airflow-providers-presto = false
 apache-airflow-providers-airbyte = false
 apache-airflow-providers-apache-hive = false
@@ -1735,6 +1735,7 @@ dependencies = [
     { name = "a2wsgi" },
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "apache-airflow-ctl" },
     { name = "apache-airflow-providers-common-compat" },
     { name = "apache-airflow-providers-common-io" },
     { name = "apache-airflow-providers-common-sql" },
@@ -1744,6 +1745,7 @@ dependencies = [
     { name = "argcomplete" },
     { name = "asgiref" },
     { name = "attrs" },
+    { name = "cachetools" },
     { name = "cadwyn" },
     { name = "colorlog" },
     { name = "cron-descriptor" },
@@ -1846,9 +1848,13 @@ dev = [
     { name = "apache-airflow-providers-fab" },
     { name = "apache-airflow-providers-ftp" },
     { name = "apache-airflow-providers-git" },
+    { name = "apache-airflow-task-sdk" },
 ]
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
+]
+mypy = [
+    { name = "apache-airflow-devel-common", extra = ["mypy"] },
 ]
 
 [package.metadata]
@@ -1857,6 +1863,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0,<0.22.0" },
     { name = "alembic", specifier = ">=1.13.1,<2.0" },
     { name = "apache-airflow-core", extras = ["graphviz", "gunicorn", "kerberos", "otel", "statsd"], marker = "extra == 'all'", editable = "airflow-core" },
+    { name = "apache-airflow-ctl", editable = "airflow-ctl" },
     { name = "apache-airflow-providers-common-compat", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-io", editable = "providers/common/io" },
     { name = "apache-airflow-providers-common-sql", editable = "providers/common/sql" },
@@ -1867,6 +1874,7 @@ requires-dist = [
     { name = "asgiref", marker = "python_full_version < '3.14'", specifier = ">=2.3.0" },
     { name = "asgiref", marker = "python_full_version >= '3.14'", specifier = ">=3.11.1" },
     { name = "attrs", specifier = ">=22.1.0,!=25.2.0" },
+    { name = "cachetools", specifier = ">=6.0.0" },
     { name = "cadwyn", specifier = ">=6.0.4" },
     { name = "colorlog", specifier = ">=6.8.2" },
     { name = "cron-descriptor", specifier = ">=1.2.24" },
@@ -1921,7 +1929,7 @@ requires-dist = [
     { name = "rich-argparse", specifier = ">=1.0.0" },
     { name = "setproctitle", specifier = ">=1.3.3" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.48" },
-    { name = "starlette", specifier = ">=0.45.0,<1" },
+    { name = "starlette", specifier = ">=0.45.0" },
     { name = "statsd", marker = "extra == 'statsd'", specifier = ">=3.3.0" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "svcs", specifier = ">=25.1.0" },
@@ -1948,8 +1956,10 @@ dev = [
     { name = "apache-airflow-providers-fab", editable = "providers/fab" },
     { name = "apache-airflow-providers-ftp", editable = "providers/ftp" },
     { name = "apache-airflow-providers-git", editable = "providers/git" },
+    { name = "apache-airflow-task-sdk", editable = "task-sdk" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
+mypy = [{ name = "apache-airflow-devel-common", extras = ["mypy"], editable = "devel-common" }]
 
 [[package]]
 name = "apache-airflow-ctl"
@@ -1987,6 +1997,9 @@ dev = [
 docs = [
     { name = "apache-airflow-devel-common", extra = ["docs"] },
 ]
+mypy = [
+    { name = "apache-airflow-devel-common", extra = ["mypy"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2017,6 +2030,7 @@ dev = [
     { name = "apache-airflow-devel-common", editable = "devel-common" },
 ]
 docs = [{ name = "apache-airflow-devel-common", extras = ["docs"], editable = "devel-common" }]
+mypy = [{ name = "apache-airflow-devel-common", extras = ["mypy"], editable = "devel-common" }]
 
 [[package]]
 name = "apache-airflow-ctl-tests"


### PR DESCRIPTION
The "airflow-ctl 0.1.5: test to stable" sync (#67294) copied main's `airflow-core/pyproject.toml` metadata onto this branch without the matching sources. Three leftovers stayed behind:

- the distribution version became `3.3.0` while `airflow-core/src/airflow/__init__.py` stayed `3.2.1`
- the Task SDK requirement became `>=1.3.0,<1.4.0` while task-sdk on this branch is `1.2.1`
- a force-include and a `shared_distributions` entry appeared for `apache-airflow-shared-state`, which has no `shared/state` folder here

Once CI actually started running on this branch (#70724), the CI image build failed `pip check` on the resulting triangle:

```
apache-airflow 3.2.1 has requirement apache-airflow-core==3.2.1,
  but you have apache-airflow-core 3.3.0
apache-airflow-core 3.3.0 has requirement
  apache-airflow-task-sdk<1.4.0,>=1.3.0, but you have 1.2.1
apache-airflow-task-sdk 1.2.1 has requirement
  apache-airflow-core<3.3.0,>=3.2.0, but you have 3.3.0
```

This realigns the metadata with the sources that are on the branch — which is what `check-version-consistency` and `check-shared-distributions-usage` already expect — and refreshes `uv.lock`, which had drifted from the same sync.

Split out of #70724 so that PR stays workflow-only.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5

Generated-by: Claude Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)