### PR TITLE
Fix unnecessary DAG file stats warning

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -156,7 +156,7 @@ class DagFileInfo:
     @property
     def normalized_file_path_for_stats(self) -> str:
         """Return the relative file path normalized for use in stats tags."""
-        return normalize_name_for_stats(str(self.rel_path))
+        return normalize_name_for_stats(str(self.rel_path), log_warning=False)
 
 
 def _config_int_factory(section: str, key: str):

--- a/airflow-core/tests/unit/dag_processing/test_manager.py
+++ b/airflow-core/tests/unit/dag_processing/test_manager.py
@@ -99,6 +99,13 @@ def _get_versioned_file_info(file: str | Path, bundle_version: str = "v1") -> Da
     )
 
 
+def test_normalized_file_path_for_stats_does_not_warn(caplog):
+    file_info = DagFileInfo(bundle_name="testing", rel_path=Path("folder/test_dag.py"))
+
+    assert file_info.normalized_file_path_for_stats == "folder_test_dag.py"
+    assert not caplog.records
+
+
 def mock_get_mtime(file: Path):
     f = str(file)
     m = re.match(pattern=r".*ss=(.+?)\.\w+", string=f)


### PR DESCRIPTION
Fixes the repeated warning emitted when expected DAG relative paths are normalized for metrics tags.

The path is intentionally normalized, so `DagFileInfo.normalized_file_path_for_stats` now disables the invalid-character warning while preserving the normalized tag. A regression test covers both the normalized value and absence of a warning.

closes: #71084

Testing:
- standalone regression for normalization and suppressed warning
- `python -m compileall -q airflow-core/src/airflow/dag_processing/manager.py airflow-core/tests/unit/dag_processing/test_manager.py`
- `git diff --check`

The repository's `uv run pytest ...` and Ruff commands could not reach collection on Windows because `pykerberos==1.2.4` requires the unavailable `gssapi/gssapi.h` header.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following the guidelines