### PR TITLE
Extract supervisor heartbeat logic into a standalone Heartbeater

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -175,7 +175,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.connection import Connection
     from airflow.sdk.types import RuntimeTaskInstanceProtocol as RuntimeTI
 
-__all__ = ["ActivitySubprocess", "WatchedSubprocess", "supervise", "supervise_task"]
+__all__ = ["ActivitySubprocess", "Heartbeater", "WatchedSubprocess", "supervise", "supervise_task"]
 
 log: FilteringBoundLogger = structlog.get_logger(logger_name="supervisor")
 
@@ -1359,6 +1359,115 @@ def _remote_logging_conn(client: Client):
 
 
 @attrs.define(kw_only=True)
+class Heartbeater:
+    """
+    Send periodic task-instance heartbeats and track their success/failure state.
+
+    Standalone from :class:`ActivitySubprocess` so a caller can heartbeat outside a
+    subprocess's lifetime (e.g. a coordinator materializing a Dag bundle before the
+    task subprocess exists). The server rejects a heartbeat whose pid differs from
+    the one registered at task start as "running elsewhere", so the pid is fixed at
+    construction for the task instance's lifetime rather than read from a process
+    handle. Reactions to fatal heartbeat outcomes (killing the process, recording a
+    terminal state) are injected as callbacks.
+    """
+
+    client: Client
+    """The HTTP client to use for communication with the API server."""
+
+    ti_id: UUID
+    """ID of the task instance to heartbeat."""
+
+    pid: int
+    """The pid registered with the server at task start; presented on every heartbeat."""
+
+    on_server_terminated: Callable[[Any], None]
+    """Called with the response detail when the server says the task should no longer run."""
+
+    on_fatal_failures: Callable[[], None] | None = None
+    """Called when consecutive heartbeat failures reach ``MAX_FAILED_HEARTBEATS``.
+
+    ``None`` disables the cap: failures are logged and retried indefinitely, for
+    callers that have no process to kill (e.g. heartbeating before the task
+    subprocess exists).
+    """
+
+    _last_successful_heartbeat: float = attrs.field(default=0, init=False)
+    _last_heartbeat_attempt: float = attrs.field(default=0, init=False)
+
+    # After the failure of a heartbeat, we'll increment this counter. If it reaches `MAX_FAILED_HEARTBEATS`, we
+    # will kill the process. This is to handle temporary network issues etc. ensuring that the process
+    # does not hang around forever.
+    failed_heartbeats: int = attrs.field(default=0, init=False)
+
+    def record_successful_heartbeat(self) -> None:
+        """Record an out-of-band beat the server already counted (e.g. the task-start API call)."""
+        self._last_successful_heartbeat = time.monotonic()
+
+    def compute_max_wait_time(self) -> float:
+        """How long the monitor loop may block in ``select`` before the next heartbeat is due."""
+        last_heartbeat_ago = time.monotonic() - self._last_successful_heartbeat
+        return max(
+            0,  # Make sure this value is never negative,
+            min(
+                # Ensure we heartbeat _at most_ 75% through the task instance heartbeat timeout time
+                HEARTBEAT_TIMEOUT - last_heartbeat_ago * 0.75,
+                MIN_HEARTBEAT_INTERVAL,
+            ),
+        )
+
+    def send_heartbeat_if_needed(self) -> None:
+        """Send a heartbeat to the client if heartbeat interval has passed."""
+        # Respect the minimum interval between heartbeat attempts
+        if (time.monotonic() - self._last_heartbeat_attempt) < MIN_HEARTBEAT_INTERVAL:
+            return
+
+        self.send_heartbeat()
+
+    def send_heartbeat(self) -> None:
+        """Send a heartbeat unconditionally; pacing is the caller's responsibility."""
+        self._last_heartbeat_attempt = time.monotonic()
+        try:
+            self.client.task_instances.heartbeat(self.ti_id, pid=self.pid)
+            # Update the last heartbeat time on success
+            self._last_successful_heartbeat = time.monotonic()
+
+            # Reset the counter on success
+            self.failed_heartbeats = 0
+        except ServerResponseError as e:
+            if e.response.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.GONE, HTTPStatus.CONFLICT}:
+                log.error(
+                    "Server indicated the task shouldn't be running anymore",
+                    detail=e.detail,
+                    status_code=e.response.status_code,
+                    ti_id=self.ti_id,
+                )
+                self.on_server_terminated(e.detail)
+            else:
+                # If we get any other error, we'll just log it and try again next time
+                self._handle_heartbeat_failures(e)
+        except Exception as e:
+            self._handle_heartbeat_failures(e)
+
+    def _handle_heartbeat_failures(self, exc: Exception) -> None:
+        """Increment the failed heartbeats counter and kill the process if too many failures."""
+        self.failed_heartbeats += 1
+        log.warning(
+            "Failed to send heartbeat. Will be retried",
+            failed_heartbeats=self.failed_heartbeats,
+            ti_id=self.ti_id,
+            max_retries=MAX_FAILED_HEARTBEATS,
+            exc_info=exc,
+        )
+        # If we've failed to heartbeat too many times, kill the process
+        if self.on_fatal_failures is not None and self.failed_heartbeats >= MAX_FAILED_HEARTBEATS:
+            log.error(
+                "Too many failed heartbeats; terminating process", failed_heartbeats=self.failed_heartbeats
+            )
+            self.on_fatal_failures()
+
+
+@attrs.define(kw_only=True)
 class ActivitySubprocess(WatchedSubprocess):
     client: Client
     """The HTTP client to use for communication with the API server."""
@@ -1378,16 +1487,11 @@ class ActivitySubprocess(WatchedSubprocess):
         SucceedTask | RetryTask | DeferTask | RescheduleTask | AwaitInputTask | None
     ) = attrs.field(default=None, init=False)
 
-    _last_successful_heartbeat: float = attrs.field(default=0, init=False)
-    _last_heartbeat_attempt: float = attrs.field(default=0, init=False)
+    heartbeater: Heartbeater = attrs.field(init=False)
+    """Sends periodic heartbeats for this task instance while the subprocess runs."""
 
     _should_retry: bool = attrs.field(default=False, init=False)
     """Whether the task should retry or not as decided by the API server."""
-
-    # After the failure of a heartbeat, we'll increment this counter. If it reaches `MAX_FAILED_HEARTBEATS`, we
-    # will kill theprocess. This is to handle temporary network issues etc. ensuring that the process
-    # does not hang around forever.
-    failed_heartbeats: int = attrs.field(default=0, init=False)
 
     _task_end_time_monotonic: float | None = attrs.field(default=None, init=False)
     _rendered_map_index: str | None = attrs.field(default=None, init=False)
@@ -1395,6 +1499,27 @@ class ActivitySubprocess(WatchedSubprocess):
     decoder: ClassVar[TypeAdapter[ToSupervisor]] = TypeAdapter(ToSupervisor)
 
     ti: RuntimeTI | None = None
+
+    def __attrs_post_init__(self) -> None:
+        self.heartbeater = Heartbeater(
+            client=self.client,
+            ti_id=self.id,
+            pid=self._process.pid,
+            on_server_terminated=self._on_heartbeat_server_terminated,
+            on_fatal_failures=self._kill_on_heartbeat_failure,
+        )
+
+    def _on_heartbeat_server_terminated(self, detail: Any) -> None:
+        self.process_log.error(
+            "Server indicated the task shouldn't be running anymore. Terminating process",
+            detail=detail,
+        )
+        self.kill(signal.SIGTERM, force=True)
+        self.process_log.error("Task killed!")
+        self._terminal_state = SERVER_TERMINATED
+
+    def _kill_on_heartbeat_failure(self) -> None:
+        self.kill(signal.SIGTERM, force=True)
 
     @classmethod
     def start(  # type: ignore[override]
@@ -1448,7 +1573,8 @@ class ActivitySubprocess(WatchedSubprocess):
             # tell us "no, stop!" for any reason)
             ti_context = self.client.task_instances.start(ti.id, self.pid, datetime.now(tz=timezone.utc))
             self._should_retry = ti_context.should_retry
-            self._last_successful_heartbeat = time.monotonic()
+            # The start call above updated last_heartbeat_at on the server.
+            self.heartbeater.record_successful_heartbeat()
         except Exception:
             # On any error kill that subprocess!
             self.kill(signal.SIGKILL)
@@ -1610,17 +1736,9 @@ class ActivitySubprocess(WatchedSubprocess):
         - Sends heartbeats to ensure the process is alive and checks if the subprocess has exited.
         """
         while self._exit_code is None or self._open_sockets:
-            last_heartbeat_ago = time.monotonic() - self._last_successful_heartbeat
             # Monitor the task to see if it's done. Wait in a syscall (`select`) for as long as possible
             # so we notice the subprocess finishing as quick as we can.
-            max_wait_time = max(
-                0,  # Make sure this value is never negative,
-                min(
-                    # Ensure we heartbeat _at most_ 75% through the task instance heartbeat timeout time
-                    HEARTBEAT_TIMEOUT - last_heartbeat_ago * 0.75,
-                    MIN_HEARTBEAT_INTERVAL,
-                ),
-            )
+            max_wait_time = self.heartbeater.compute_max_wait_time()
             # Block until events are ready or the timeout is reached
             # This listens for activity (e.g., subprocess output) on registered file objects
             alive = self._service_subprocess(max_wait_time=max_wait_time) is None
@@ -1666,60 +1784,12 @@ class ActivitySubprocess(WatchedSubprocess):
 
     def _send_heartbeat_if_needed(self):
         """Send a heartbeat to the client if heartbeat interval has passed."""
-        # Respect the minimum interval between heartbeat attempts
-        if (time.monotonic() - self._last_heartbeat_attempt) < MIN_HEARTBEAT_INTERVAL:
-            return
-
         if self._terminal_state:
             # If the task has finished, and we are in "overtime" (running OL listeners etc) we shouldn't
             # heartbeat
             return
 
-        self._last_heartbeat_attempt = time.monotonic()
-        try:
-            self.client.task_instances.heartbeat(self.id, pid=self._process.pid)
-            # Update the last heartbeat time on success
-            self._last_successful_heartbeat = time.monotonic()
-
-            # Reset the counter on success
-            self.failed_heartbeats = 0
-        except ServerResponseError as e:
-            if e.response.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.GONE, HTTPStatus.CONFLICT}:
-                log.error(
-                    "Server indicated the task shouldn't be running anymore",
-                    detail=e.detail,
-                    status_code=e.response.status_code,
-                    ti_id=self.id,
-                )
-                self.process_log.error(
-                    "Server indicated the task shouldn't be running anymore. Terminating process",
-                    detail=e.detail,
-                )
-                self.kill(signal.SIGTERM, force=True)
-                self.process_log.error("Task killed!")
-                self._terminal_state = SERVER_TERMINATED
-            else:
-                # If we get any other error, we'll just log it and try again next time
-                self._handle_heartbeat_failures(e)
-        except Exception as e:
-            self._handle_heartbeat_failures(e)
-
-    def _handle_heartbeat_failures(self, exc: Exception):
-        """Increment the failed heartbeats counter and kill the process if too many failures."""
-        self.failed_heartbeats += 1
-        log.warning(
-            "Failed to send heartbeat. Will be retried",
-            failed_heartbeats=self.failed_heartbeats,
-            ti_id=self.id,
-            max_retries=MAX_FAILED_HEARTBEATS,
-            exc_info=exc,
-        )
-        # If we've failed to heartbeat too many times, kill the process
-        if self.failed_heartbeats >= MAX_FAILED_HEARTBEATS:
-            log.error(
-                "Too many failed heartbeats; terminating process", failed_heartbeats=self.failed_heartbeats
-            )
-            self.kill(signal.SIGTERM, force=True)
+        self.heartbeater.send_heartbeat_if_needed()
 
     @property
     def final_state(self):

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -1041,7 +1041,7 @@ class TestWatchedSubprocess:
             # Simulate sending heartbeats and ensure the process gets killed after max retries
             for i in range(1, max_failed_heartbeats):
                 proc._send_heartbeat_if_needed()
-                assert proc.failed_heartbeats == i  # Increment happens after failure
+                assert proc.heartbeater.failed_heartbeats == i  # Increment happens after failure
                 mock_client_heartbeat.assert_called_with(TI_ID, pid=mock_process.pid)
 
                 # Ensure the retry log is present
@@ -1066,7 +1066,7 @@ class TestWatchedSubprocess:
         # On the final failure, the process should be killed
         proc._send_heartbeat_if_needed()
 
-        assert proc.failed_heartbeats == max_failed_heartbeats
+        assert proc.heartbeater.failed_heartbeats == max_failed_heartbeats
         mock_kill.assert_called_once_with(signal.SIGTERM, force=True)
         mock_client_heartbeat.assert_called_with(TI_ID, pid=mock_process.pid)
         assert {
@@ -1603,7 +1603,7 @@ class TestWatchedSubprocessKill:
 
         # Set up a scenario where the last successful heartbeat was a long time ago
         # This will cause the heartbeat calculation to result in a negative value
-        mock_process._last_successful_heartbeat = time.time() - 100  # 100 seconds ago
+        watched_subprocess.heartbeater._last_successful_heartbeat = time.time() - 100  # 100 seconds ago
 
         # Mock process to still be alive (not exited)
         mock_process.wait.side_effect = psutil.TimeoutExpired(pid=12345, seconds=0)
@@ -1646,7 +1646,7 @@ class TestWatchedSubprocessKill:
         monkeypatch.setattr("airflow.sdk.execution_time.supervisor.HEARTBEAT_TIMEOUT", heartbeat_timeout)
         monkeypatch.setattr("airflow.sdk.execution_time.supervisor.MIN_HEARTBEAT_INTERVAL", min_interval)
 
-        watched_subprocess._last_successful_heartbeat = time.time() - heartbeat_ago
+        watched_subprocess.heartbeater._last_successful_heartbeat = time.time() - heartbeat_ago
         mock_process.wait.side_effect = psutil.TimeoutExpired(pid=12345, seconds=0)
 
         # Call the method and verify timeout is never less than our minimum


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/70805 (the `dag_bundle_name` materialization step this heartbeat refactor is preparing to support during coordinator startup)
- next: https://github.com/apache/airflow/pull/71075

## Why

A planned follow-up will let subprocess coordinators heartbeat while materializing a Dag bundle, before the task subprocess exists. That requires the heartbeat state to live outside `ActivitySubprocess`, especially the pid presented to the server: it must stay identical for the whole task instance lifetime, otherwise the server rejects the heartbeat with 409 `running_elsewhere` and the task is killed. This PR is the purely mechanical foundation with no behavior change.

## What

- Add a `Heartbeater` class in `supervisor.py` owning the heartbeat state (`_last_successful_heartbeat`, `_last_heartbeat_attempt`, `failed_heartbeats`) and a fixed `pid`, with the moved methods:
  - `send_heartbeat_if_needed()` and `_handle_heartbeat_failures()` (moved from `ActivitySubprocess`)
  - `send_heartbeat()`: the ungated primitive `send_heartbeat_if_needed()` wraps, for callers that own their own pacing (the coordinator startup thread in the follow-up)
  - `compute_max_wait_time()` (the select-timeout formula moved from `_monitor_subprocess`)
  - `record_successful_heartbeat()` (the task-start call already counts as a beat on the server)
- Rewire `ActivitySubprocess` to compose a `Heartbeater`, injecting its reactions as callbacks:
  - `on_server_terminated`: terminate the process and record `SERVER_TERMINATED`
  - `on_fatal_failures`: kill the process after `MAX_FAILED_HEARTBEATS`; optional (`None` disables the cap and retries indefinitely, for callers with no process to kill)
  - `_send_heartbeat_if_needed` stays as a thin wrapper keeping the overtime guard
- Constants (`HEARTBEAT_TIMEOUT`, `MIN_HEARTBEAT_INTERVAL`, `MAX_FAILED_HEARTBEATS`) stay module level, so existing config handling and test monkeypatching are unaffected
- Export `Heartbeater` in the module `__all__`
- Update `test_supervisor.py` references to the moved attributes; the behavior tests (`test_regular_heartbeat`, `test_no_heartbeat_in_overtime`, `test_state_conflict_on_heartbeat`) pass unchanged

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes, with help of Claude Code Opus 5 following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

