### PR TITLE
Validate provider metadata list entries instead of ignoring them

### DIFF
--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -576,6 +576,7 @@
                         "type": "string"
                     }
                 },
+                "additionalProperties": false,
                 "required": [
                     "name",
                     "class-name"
@@ -708,6 +709,7 @@
                         "type": "string"
                     }
                 },
+                "additionalProperties": false,
                 "required": [
                     "name",
                     "plugin-class"

--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -565,12 +565,21 @@
             "type": "array",
             "description": "Decorators to use with the TaskFlow API. Can be accessed by users via '@task.<name>'",
             "items": {
-                "name": {
-                    "type": "string"
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "Name the decorator is exposed under, following '@task.'",
+                        "type": "string"
+                    },
+                    "class-name": {
+                        "description": "Class name that implements the decorator",
+                        "type": "string"
+                    }
                 },
-                "path": {
-                    "type": "string"
-                }
+                "required": [
+                    "name",
+                    "class-name"
+                ]
             }
         },
         "secrets-backends": {
@@ -688,24 +697,28 @@
             "type": "array",
             "description": "Plugins exposed by the provider",
             "items": {
-                "name": {
-                    "type": "string"
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "Name of the plugin",
+                        "type": "string"
+                    },
+                    "plugin-class": {
+                        "description": "Class name that implements the plugin",
+                        "type": "string"
+                    }
                 },
-                "plugin-class": {
-                    "type": "string"
-                }
+                "required": [
+                    "name",
+                    "plugin-class"
+                ]
             }
         },
         "queues": {
             "type": "array",
-            "description": "Message Queues exposed by the provider",
+            "description": "Message queue provider class names",
             "items": {
-                "name": {
-                    "type": "string"
-                },
-                "message-queue-class": {
-                    "type": "string"
-                }
+                "type": "string"
             }
         },
         "source-date-epoch": {

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -442,11 +442,7 @@
                         "description": "Class name that implements the decorator",
                         "type": "string"
                     }
-                },
-                "required": [
-                    "name",
-                    "class-name"
-                ]
+                }
             }
         },
         "plugins": {
@@ -463,19 +459,12 @@
                         "type": "string",
                         "description": "Class to instantiate the plugin"
                     }
-                },
-                "required": [
-                    "name",
-                    "plugin-class"
-                ]
+                }
             }
         },
         "queues": {
             "type": "array",
-            "description": "Message queue provider class names",
-            "items": {
-                "type": "string"
-            }
+            "description": "Message queue provider class names"
         }
     },
     "definitions": {

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -432,38 +432,49 @@
             "type": "array",
             "description": "Apply custom decorators to the TaskFlow API. Can be accessed by users via '@task.<name>'",
             "items": {
-                "name": {
-                    "type": "string"
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "Name the decorator is exposed under, following '@task.'",
+                        "type": "string"
+                    },
+                    "class-name": {
+                        "description": "Class name that implements the decorator",
+                        "type": "string"
+                    }
                 },
-                "path": {
-                    "type": "string"
-                }
+                "required": [
+                    "name",
+                    "class-name"
+                ]
             }
         },
         "plugins": {
             "type": "array",
             "description": "Plugins provided by the provider",
             "items": {
-                "name": {
-                    "type": "string",
-                    "description": "Name of the plugin"
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the plugin"
+                    },
+                    "plugin-class": {
+                        "type": "string",
+                        "description": "Class to instantiate the plugin"
+                    }
                 },
-                "plugin-class": {
-                    "type": "string",
-                    "description": "Class to instantiate the plugin"
-                }
+                "required": [
+                    "name",
+                    "plugin-class"
+                ]
             }
         },
         "queues": {
             "type": "array",
-            "description": "Message Queues exposed by the provider",
+            "description": "Message queue provider class names",
             "items": {
-                "name": {
-                    "type": "string"
-                },
-                "message-queue-class": {
-                    "type": "string"
-                }
+                "type": "string"
             }
         }
     },

--- a/providers-summary-docs/howto/create-custom-providers.rst
+++ b/providers-summary-docs/howto/create-custom-providers.rst
@@ -114,7 +114,7 @@ Exposing customized functionality to the Airflow's core:
 * ``sensors`` - this field should contain the list of all the sensor class names that the
   provider provides. See :doc:`apache-airflow:core-concepts/sensors` for description of the sensors.
 
-* ``task-decorators`` - this field should contain the list of dictionaries of name/path where the decorators
+* ``task-decorators`` - this field should contain the list of dictionaries of name/class-name where the decorators
   are available. See :doc:`apache-airflow:howto/create-custom-decorator` for description of how to add
   custom decorators.
 


### PR DESCRIPTION
## Why
https://github.com/apache/airflow/pull/70190#discussion_r3682598659

The items blocks for `queues, plugins and task-decorators` listed their field names directly under items, where they are not JSON Schema keywords, so the blocks were inert and any shape passed. A provider author following what those blocks appeared to document — a dict for queues, or a path key for a decorator — got no error and was quietly dropped by the consumers instead.

## What
Pinning each section to the shape the provider.yaml files and generated payloads actually use turns that into a failure at authoring time. The custom-provider howto named the same nonexistent path field.



 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
