### PR TITLE
Allow opentelemetry-exporter-prometheus pre-release in candidate constraints resolution

### DIFF
--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -530,9 +530,17 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
     #   resolver might choose to downgrade gremlinpython to an older version,
     #   which in turn might downgrade tinkerpop provider. Having gremlinpython>=3.8.0 ensures
     #   that the resolver will not downgrade the provider.
+    # * opentelemetry-exporter-prometheus>=0.47b0 — this package only ever publishes beta versions
+    #   (airflow-core requires ``>=0.47b0`` and released constraints already pin a beta, e.g.
+    #   ``==0.65b0``). For a release candidate the resolution runs with ``--prerelease explicit``,
+    #   which permits a pre-release only for a package some requirement marks as such and drops the
+    #   if-necessary fallback; without this entry the package cannot resolve and generation fails
+    #   with "No solution found". Keeping it here (rather than the provider pre-release list) marks
+    #   it as an always-allowed pre-release across every resolution, matching how it already ships.
     additional_constraints_for_highest_resolution: list[str] = [
         "pyarrow>=22.0.0; python_version >= '3.14'",
         "gremlinpython>=3.8.0",
+        "opentelemetry-exporter-prometheus>=0.47b0",
     ]
 
     # Constraints cut for a release candidate have to pin the candidates themselves - the providers


### PR DESCRIPTION
Follow-up fix to #71040 (candidate constraints resolution).

**Problem:** the RC constraints path runs `uv pip install ... --prerelease explicit`, which allows a pre-release only for packages an explicit requirement marks as such (the provider `>=0.0.0rc0` bounds) and **drops the if-necessary fallback**. airflow-core requires `opentelemetry-exporter-prometheus>=0.47b0` — a package that **only ever publishes betas** (3.3.0's shipped constraints already pin `opentelemetry-exporter-prometheus==0.65b0`). With no explicit pre-release mark it can no longer resolve, and candidate constraint generation fails:

```
× No solution found when resolving dependencies:
  apache-airflow-core[all] depends on opentelemetry-exporter-prometheus>=0.47b0,
  but only opentelemetry-exporter-prometheus<0.47b0 is available (as a non-pre-release)
```
(seen in the `Release constraints` workflow_dispatch run on v3-3-test).

**Fix (per @potiuk's feedback):** add it to the build-side `additional_constraints_for_highest_resolution` list in `run_generate_constraints.py` — the list the failure message itself points at — rather than the provider-only pre-release list. This marks it as an always-allowed pre-release across every resolution, keeps `--prerelease explicit` so no *unknown* third-party beta can sneak in, and only re-allows a beta airflow already requires and ships.

**Validation:** please re-run the `Release constraints` workflow on the target branch to confirm green (the full `airflow[all]` resolution can't be exercised locally). If a second always-beta dep surfaces after this clears, it takes the same one-line list entry.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — targeted fix to the candidate constraints pre-release allow-list.