### PR TITLE
Skip maxed out queued DagRun candidates

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2840,46 +2840,95 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         # Team name should be added before listeners are called in notify_dagrun_state_changed()
         self._stamp_team_names(dag_runs, session)
 
+        dag_run_keys_at_limit: set[tuple[str, int | None]] = set()
+
+        def _mark_dag_run_key_at_limit(
+            dag_run_key: tuple[str, int | None],
+            *,
+            active_runs: int,
+            max_active_runs: int,
+            dag_id: str,
+            run_id: str,
+            backfill_id: int | None,
+        ) -> None:
+            if dag_run_key in dag_run_keys_at_limit:
+                return
+
+            dag_run_keys_at_limit.add(dag_run_key)
+            if backfill_id is not None:
+                self.log.info(
+                    "backfill max_active_runs reached; skipping remaining queued dag runs for this "
+                    "scheduler pass; active_runs=%s max_active_runs=%s dag_id=%s run_id=%s backfill_id=%s",
+                    active_runs,
+                    max_active_runs,
+                    dag_id,
+                    run_id,
+                    backfill_id,
+                )
+            else:
+                self.log.info(
+                    "dag max_active_runs reached; skipping remaining queued dag runs for this scheduler pass; "
+                    "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
+                    active_runs,
+                    max_active_runs,
+                    dag_id,
+                    run_id,
+                )
+
         for dag_run in dag_runs:
             dag_id = dag_run.dag_id
             run_id = dag_run.run_id
             backfill_id = dag_run.backfill_id
+            dag_run_key = (dag_id, backfill_id)
+            if dag_run_key in dag_run_keys_at_limit:
+                continue
+
             dag = dag_run.dag = cached_get_dag(dag_run)
             if not dag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
                 continue
-            active_runs = active_runs_of_dags[(dag_id, backfill_id)]
+            active_runs = active_runs_of_dags[dag_run_key]
+            max_active_runs: int | None = None
             if backfill_id is not None:
                 if backfill_id not in locked_backfills:
                     # Another scheduler has this backfill locked, skip this run
                     continue
                 backfill = dag_run.backfill
-                if active_runs >= backfill.max_active_runs:
-                    # todo: delete all "candidate dag runs" from list for this dag right now
-                    self.log.info(
-                        "dag cannot be started due to backfill max_active_runs constraint; "
-                        "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
-                        active_runs,
-                        backfill.max_active_runs,
-                        dag_id,
-                        run_id,
+                max_active_runs = backfill.max_active_runs
+                if active_runs >= max_active_runs:
+                    _mark_dag_run_key_at_limit(
+                        dag_run_key,
+                        active_runs=active_runs,
+                        max_active_runs=max_active_runs,
+                        dag_id=dag_id,
+                        run_id=run_id,
+                        backfill_id=backfill_id,
                     )
                     continue
             elif dag_run.max_active_runs:
                 # Using dag_run.max_active_runs which links to DagModel to ensure we are checking
                 # against the most recent changes on the dag and not using stale serialized dag
-                if active_runs >= dag_run.max_active_runs:
-                    # todo: delete all candidate dag runs for this dag from list right now
-                    self.log.info(
-                        "dag cannot be started due to dag max_active_runs constraint; "
-                        "active_runs=%s max_active_runs=%s dag_id=%s run_id=%s",
-                        active_runs,
-                        dag_run.max_active_runs,
-                        dag_run.dag_id,
-                        dag_run.run_id,
+                max_active_runs = dag_run.max_active_runs
+                if active_runs >= max_active_runs:
+                    _mark_dag_run_key_at_limit(
+                        dag_run_key,
+                        active_runs=active_runs,
+                        max_active_runs=max_active_runs,
+                        dag_id=dag_id,
+                        run_id=run_id,
+                        backfill_id=backfill_id,
                     )
                     continue
-            active_runs_of_dags[(dag_run.dag_id, backfill_id)] += 1
+            active_runs_of_dags[dag_run_key] += 1
+            if max_active_runs is not None and active_runs_of_dags[dag_run_key] >= max_active_runs:
+                _mark_dag_run_key_at_limit(
+                    dag_run_key,
+                    active_runs=active_runs_of_dags[dag_run_key],
+                    max_active_runs=max_active_runs,
+                    dag_id=dag_id,
+                    run_id=run_id,
+                    backfill_id=backfill_id,
+                )
             _update_state(dag, dag_run)
             dag_run.notify_dagrun_state_changed(msg="started")
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10726,6 +10726,88 @@ class TestSchedulerJob:
         session.refresh(ti)
         assert ti.state != State.NONE
 
+    def test_start_queued_dagruns_skips_remaining_candidates_once_max_active_runs_reached(
+        self, dag_maker, session
+    ):
+        with dag_maker(
+            "test_skip_candidates_once_max_active_runs_reached",
+            start_date=DEFAULT_DATE,
+            schedule=timedelta(hours=1),
+            max_active_runs=2,
+            catchup=True,
+            session=session,
+        ):
+            EmptyOperator(task_id="task")
+
+        running_dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=State.RUNNING)
+        queued_dr = dag_maker.create_dagrun_after(
+            running_dr, run_type=DagRunType.SCHEDULED, state=State.QUEUED
+        )
+        queued_drs = [queued_dr]
+        for _ in range(2):
+            queued_dr = dag_maker.create_dagrun_after(
+                queued_dr, run_type=DagRunType.SCHEDULED, state=State.QUEUED
+            )
+            queued_drs.append(queued_dr)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        with mock.patch.object(
+            self.job_runner.scheduler_dag_bag,
+            "get_dag_for_run",
+            wraps=self.job_runner.scheduler_dag_bag.get_dag_for_run,
+        ) as mock_get_dag:
+            self.job_runner._start_queued_dagruns(session)
+
+        session.flush()
+        assert mock_get_dag.call_count == 1
+        assert session.get(DagRun, queued_drs[0].id).state == State.RUNNING
+        assert {session.get(DagRun, dr.id).state for dr in queued_drs[1:]} == {State.QUEUED}
+
+    def test_start_queued_dagruns_skips_remaining_backfill_candidates_once_limit_reached(
+        self, dag_maker, session
+    ):
+        dag_id = "test_skip_backfill_candidates_once_limit_reached"
+        with dag_maker(
+            dag_id=dag_id,
+            start_date=DEFAULT_DATE,
+            schedule=timedelta(days=1),
+            catchup=True,
+            session=session,
+        ):
+            EmptyOperator(task_id="task")
+
+        _create_backfill(
+            dag_id=dag_id,
+            from_date=pendulum.parse("2021-01-01"),
+            to_date=pendulum.parse("2021-01-03"),
+            max_active_runs=1,
+            reverse=False,
+            triggering_user_name="test_user",
+            dag_run_conf={},
+        )
+        queued_drs = session.scalars(
+            select(DagRun)
+            .where(DagRun.dag_id == dag_id, DagRun.run_type == DagRunType.BACKFILL_JOB)
+            .order_by(DagRun.run_after)
+        ).all()
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        with mock.patch.object(
+            self.job_runner.scheduler_dag_bag,
+            "get_dag_for_run",
+            wraps=self.job_runner.scheduler_dag_bag.get_dag_for_run,
+        ) as mock_get_dag:
+            self.job_runner._start_queued_dagruns(session)
+
+        session.flush()
+        assert mock_get_dag.call_count == 1
+        assert session.get(DagRun, queued_drs[0].id).state == State.RUNNING
+        assert {session.get(DagRun, dr.id).state for dr in queued_drs[1:]} == {State.QUEUED}
+
 
 @pytest.mark.need_serialized_dag
 def test_schedule_dag_run_with_upstream_skip(dag_maker, session):


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why:
When `_start_queued_dagruns()` processes queued DagRun candidates, one candidate can fill the remaining `max_active_runs` capacity for a Dag or backfill. The scheduler already knows later candidates for the same `(dag_id, backfill_id)` cannot start in the same pass, but it still loaded the serialized Dag and re-checked the same limit for each one.

## Solution:
Remember `(dag_id, backfill_id)` keys that reach their active run limit during the scheduler pass. Later queued DagRun candidates for the same key are skipped immediately, avoiding repeated serialized Dag loads and duplicate limit checks while preserving the existing `max_active_runs` behavior.


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)




* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
