### PR TITLE
[airflow-ctl/v0-1-test] Fix airflowctl list operations ignoring the requested offset (#70989)

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -215,7 +215,7 @@ class BaseOperations:
                 raw = fill_missing_fields(json.loads(content), data_model)
                 return data_model.model_validate(raw)  # type: ignore[union-attr]
 
-        self.response = self.client.get(path, params=shared_params)
+        self.response = self.client.get(path, params={**shared_params, "offset": offset})
         first_pass = safe_validate(self.response.content)
         total_entries = first_pass.total_entries  # type: ignore[attr-defined]
         if total_entries < limit:

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -244,6 +244,29 @@ class TestBaseOperations:
         for call in mock_client.get.call_args_list:
             assert call.kwargs["params"]["limit"] == 2
 
+    def test_execute_list_sends_offset_to_server(self):
+        """``offset`` must reach the server on the first request, not only on subsequent pages."""
+        rows = [{"name": name} for name in "abcdef"]
+
+        def paged(path, params):
+            # An absent ``offset`` is what the server would see as its own default of 0.
+            start = params.get("offset", 0)
+            return Mock(
+                content=json.dumps(
+                    {"hellos": rows[start : start + params["limit"]], "total_entries": len(rows)}
+                )
+            )
+
+        mock_client = Mock()
+        mock_client.get.side_effect = paged
+        base_operation = BaseOperations(client=mock_client)
+
+        response = base_operation.execute_list(
+            path="hello", data_model=HelloCollectionResponse, offset=2, limit=2
+        )
+
+        assert [hello.name for hello in response.hellos] == ["c", "d", "e", "f"]
+
     @pytest.mark.parametrize("limit", [0, -1])
     def test_execute_list_rejects_non_positive_limit(self, limit):
         mock_client = Mock()


### PR DESCRIPTION
Backport of #70989 to `airflow-ctl/v0-1-test`. Cherry-picked cleanly, no conflicts and no adaptation needed — `execute_list` on this branch is identical to main's pre-fix state.

`BaseOperations.execute_list` accepts an `offset` but never sent it on the first request, so paging started at the server default while the loop still resumed at `offset + limit` — a non-zero offset both returned the wrong first page and skipped the rows in between. `offset=100, limit=2` returned rows 0-1, then jumped to row 102.

Sending `offset=0` is equivalent to omitting it — the API's `QueryOffset` already defaults to `0`, so this is compatible.

(cherry picked from commit b5414588d3ef97512cbe0b3595e6fc9f042a5861)

Co-authored-by: rjgoyln <151457491+rjgoyln@users.noreply.github.com>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)