### PR TITLE
Fix release dry-run fails with a non-existing workflow

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/gh_workflow_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/gh_workflow_utils.py
@@ -26,6 +26,7 @@ from shutil import which
 from airflow_breeze.global_constants import MIN_GH_VERSION
 from airflow_breeze.utils.console import console_print
 from airflow_breeze.utils.github import run_gh_command
+from airflow_breeze.utils.shared_options import get_dry_run
 
 
 def tigger_workflow(workflow_name: str, repo: str, branch: str = "main", **kwargs):
@@ -55,6 +56,11 @@ def tigger_workflow(workflow_name: str, repo: str, branch: str = "main", **kwarg
     if result.returncode != 0:
         console_print(f"[red]Error running workflow: {result.stderr}[/red]")
         sys.exit(1)
+
+    if get_dry_run():
+        # A dry run dispatches nothing, so `gh run list` comes back empty.
+        console_print(f"[info]Dry run: not looking up or monitoring a run of {workflow_name}.")
+        return
 
     # Wait for a few seconds to start the workflow run
     time.sleep(5)
@@ -203,6 +209,9 @@ def trigger_workflow_and_monitor(
         branch=branch,
         **workflow_fields,
     )
+
+    if get_dry_run():
+        return
 
     workflow_run_id = get_workflow_run_id(
         workflow_name=workflow_name,

--- a/dev/breeze/tests/test_gh_workflow_utils.py
+++ b/dev/breeze/tests/test_gh_workflow_utils.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest import mock
+
+from airflow_breeze.utils.gh_workflow_utils import trigger_workflow_and_monitor
+from airflow_breeze.utils.shared_options import set_dry_run
+
+
+@mock.patch("airflow_breeze.utils.gh_workflow_utils.monitor_workflow_run")
+@mock.patch("airflow_breeze.utils.gh_workflow_utils.make_sure_gh_is_installed")
+def test_trigger_workflow_and_monitor_stops_after_the_dispatch_in_dry_run(_, mock_monitor):
+    """A dry run dispatches nothing, so the empty `gh run list` must not read as a missing run."""
+    set_dry_run(True)
+    try:
+        trigger_workflow_and_monitor(
+            workflow_name="release-constraints.yml",
+            repo="apache/airflow",
+            version="3.2.0rc1",
+            ref="v3-2-stable",
+        )
+    finally:
+        set_dry_run(False)
+
+    mock_monitor.assert_not_called()


### PR DESCRIPTION
## Why

- `Basic tests / Test Airflow release commands` has failed on every canary run of `main` on both AMD and ARM.
  - https://github.com/apache/airflow/actions/runs/30920541612/job/92029887148
  - https://github.com/apache/airflow/actions/runs/30946105312/job/92116499405
- Until #71040, the constraints step of `start-rc-process` was `tag_and_push_constraints()`: a local `git checkout`, `git tag` and `git push` through `run_command()`. A dry run prints those and moves on.
- #71040 replaced it with `generate_and_push_constraints()` → `publish_constraints()` → `trigger_workflow_and_monitor()`, which dispatches the `release-constraints` workflow and then has to locate the run it created and poll it to completion.
- `run_gh_command()` short-circuits a dry run: it returns a synthetic success with empty output.
- `get_workflow_run_id()` then goes looking for the run. The `run_gh_command()` short-circuits `gh run list` in the same way. The `get_workflow_run_id()` gets an empty string and exits 1 with "No workflow runs found."

## How

- `trigger_workflow_and_monitor()` returns right after the dispatch in a dry run.

## Verification

- `uv run --project dev/breeze --frozen --no-sync pytest dev/breeze/tests/test_gh_workflow_utils.py dev/breeze/tests/test_release_constraints.py dev/breeze/tests/test_workflow_commands.py -v`
- `env CI=true GITHUB_REPOSITORY=apache/airflow breeze release-management start-rc-process --version 3.2.0rc1 --previous-version 3.1.0 --task-sdk-version 1.1.0rc1 --sync-branch v3-2-test --answer yes --dry-run`

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
