### PR TITLE
Refuse separator-bearing env secret ids only in multi-team mode

### DIFF
--- a/airflow-core/src/airflow/secrets/environment_variables.py
+++ b/airflow-core/src/airflow/secrets/environment_variables.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import os
 
+from airflow.configuration import conf
 from airflow.secrets import BaseSecretsBackend
 
 CONN_ENV_PREFIX = "AIRFLOW_CONN_"
@@ -35,9 +36,7 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from environment variable."""
 
     def get_conn_value(self, conn_id: str, team_name: str | None = None) -> str | None:
-        if TEAM_SEP in conn_id:
-            # An id containing the separator could collide with another team's namespace
-            # even on the scoped lookup below, so it must be refused before either runs.
+        if self._names_a_team_namespace(conn_id):
             return None
 
         if team_name and (
@@ -56,8 +55,7 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         :param team_name: Team name associated to the task trying to access the variable (if any)
         :return: Variable Value
         """
-        if TEAM_SEP in key:
-            # Same collision risk as get_conn_value, see its code comment.
+        if self._names_a_team_namespace(key):
             return None
 
         if team_name and (
@@ -67,3 +65,21 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
             return team_var
 
         return os.environ.get(VAR_ENV_PREFIX + key.upper())
+
+    @staticmethod
+    def _names_a_team_namespace(secret_id: str) -> bool:
+        """
+        Whether ``secret_id`` could resolve into some team's namespace.
+
+        A team specific secret lives under ``<PREFIX>_<TEAM_NAME>___<SECRET_ID>``. An id carrying
+        the separator can build that name for a team other than the caller's -- on the team scoped
+        lookup as much as on the team agnostic one, since a team name may itself contain the
+        separator -- and nothing in the string says which reading was meant. Such an id is refused
+        in every scope rather than resolved to one of its readings.
+
+        Only checked in multi-team mode: ``team_name`` is never non-``None`` otherwise, so no team
+        scoped secret can be read and an id carrying the separator has only one meaning.
+        """
+        if not conf.getboolean("core", "multi_team"):
+            return False
+        return TEAM_SEP in secret_id

--- a/airflow-core/tests/unit/always/test_secrets.py
+++ b/airflow-core/tests/unit/always/test_secrets.py
@@ -122,6 +122,7 @@ class TestConnectionsFromSecrets:
         assert conn.get_uri() == "mysql://airflow:airflow@host:5432/airflow"
 
     @pytest.mark.db_test
+    @conf_vars({("core", "multi_team"): "True"})
     @mock.patch.dict(
         "os.environ",
         {
@@ -218,6 +219,7 @@ class TestVariableFromSecrets:
         mock_secret_get.return_value = "a_secret_value"
         assert Variable.get(key="not_myvar") == "a_secret_value"
 
+    @conf_vars({("core", "multi_team"): "True"})
     @mock.patch.dict(
         "os.environ",
         {

--- a/airflow-core/tests/unit/always/test_secrets_environment_variables.py
+++ b/airflow-core/tests/unit/always/test_secrets_environment_variables.py
@@ -26,6 +26,11 @@ from airflow.secrets.environment_variables import (
     EnvironmentVariablesBackend,
 )
 
+from tests_common.test_utils.config import conf_vars
+
+# The team scoping rules only apply in multi-team mode -- see ``_names_a_team_namespace``.
+multi_team_enabled = conf_vars({("core", "multi_team"): "True"})
+
 # A team specific secret is stored as ``<PREFIX>_<TEAM_NAME>___<SECRET_ID>``. Team names may contain
 # underscores (they are validated against ``^[a-zA-Z0-9_-]{3,50}$``), so both shapes are exercised.
 TEAM_NAMES = ["team_a", "teama"]
@@ -59,6 +64,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    @multi_team_enabled
     def test_team_scoped_secret_is_not_resolved_without_a_team_scope(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -68,6 +74,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    @multi_team_enabled
     def test_team_scoped_secret_is_not_resolved_for_another_team(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -77,6 +84,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    @multi_team_enabled
     def test_team_scoped_secret_is_resolved_for_its_own_team(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -86,6 +94,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    @multi_team_enabled
     def test_id_spelling_out_a_team_namespace_is_never_resolved(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -100,6 +109,7 @@ class TestEnvironmentVariablesBackendTeamScope:
         assert lookup(env_prefix, method, team_scoped_id(team_name), team_name) is None
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @multi_team_enabled
     def test_team_whose_name_extends_the_callers_is_not_readable(self, monkeypatch, env_prefix, method):
         """A team name may contain the ``___`` separator, so one team's namespace can start with another's.
 
@@ -119,6 +129,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    @multi_team_enabled
     def test_team_scoped_secret_wins_over_the_team_agnostic_one(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -130,6 +141,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])
+    @multi_team_enabled
     def test_team_agnostic_secret_is_resolved_for_any_team_scope(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -138,6 +150,7 @@ class TestEnvironmentVariablesBackendTeamScope:
         assert lookup(env_prefix, method, SECRET_ID, team_name) == GLOBAL_VALUE
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    @multi_team_enabled
     def test_a_bare_id_containing_the_separator_is_not_resolved(self, monkeypatch, env_prefix, method):
         """The scoped lookup can build another team's variable name from a *bare* id.
 
@@ -153,6 +166,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])
+    @multi_team_enabled
     def test_an_id_containing_the_separator_is_refused_in_every_scope(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -167,6 +181,7 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", TEAM_NAMES)
+    @multi_team_enabled
     def test_the_owning_team_cannot_reach_a_separator_bearing_id_either(
         self, monkeypatch, env_prefix, method, team_name
     ):
@@ -182,7 +197,24 @@ class TestEnvironmentVariablesBackendTeamScope:
 
     @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
     @pytest.mark.parametrize("team_name", [None, *TEAM_NAMES])
+    @multi_team_enabled
     def test_unset_secret_is_not_resolved(self, monkeypatch, env_prefix, method, team_name):
         monkeypatch.delenv(env_prefix + SECRET_ID.upper(), raising=False)
 
         assert lookup(env_prefix, method, SECRET_ID, team_name) is None
+
+
+class TestEnvironmentVariablesBackendWithoutMultiTeam:
+    """Without multi-team mode there is no team namespace for an id to be confused with."""
+
+    @pytest.mark.parametrize(("env_prefix", "method"), LOOKUPS)
+    def test_an_id_containing_the_separator_is_resolved(self, monkeypatch, env_prefix, method):
+        """An ordinary id that happens to carry the separator is a plain secret, not an ambiguity.
+
+        No team scoped secret can be read while multi-team is off, so the id has one reading and
+        refusing it only makes a set secret look missing.
+        """
+        secret_id = f"prod{TEAM_SEP}dbconn"
+        monkeypatch.setenv(env_prefix + secret_id.upper(), GLOBAL_VALUE)
+
+        assert lookup(env_prefix, method, secret_id, None) == GLOBAL_VALUE


### PR DESCRIPTION
Another follow-up after @amoghrajesh's #71078, which fixed this same regression in the AWS, Key Vault, Google Secret Manager and Lockbox secrets backends. The core `EnvironmentVariablesBackend` carries it too, and was not covered there — cc @vatsrahul1001 @amoghrajesh.

The backend refuses any connection or variable id carrying the team namespace separator, because such an id cannot be attributed to a team unambiguously — a team name may itself contain the separator, so `_a___b___c` reads as team `a` with id `b___c` just as well as team `a___b` with id `c`.

That refusal fires unconditionally, including in deployments that never enabled multi-team mode. There, an ordinary connection or variable id that happens to contain `___` is silently reported as missing — no exception, and nothing distinguishes it from a secret that was never set.

No team scoped secret can be read while multi-team is off: the lookups are only ever handed a `team_name` in that mode. So the id has a single meaning there and nothing needs refusing. Same gate as #71078, applied at the same place in the logic.

### What this changes for the tests

The existing team-scoping tests all assert the refusal, so they now run with multi-team enabled. Two of them (`test_connection_env_var_do_not_access_team_specific` and `test_variable_env_var_do_not_access_team_specific`) would otherwise fail, because `AIRFLOW_CONN__TEAM___TEST_MYSQL` legitimately resolves as an ordinary connection named `_team___test_mysql` once multi-team is off — that is the intended trade, and the same one #71078 makes on the provider side.

### Test plan

- [x] New `TestEnvironmentVariablesBackendWithoutMultiTeam` — verified against unmodified code: it **fails** with `assert None == 'team-agnostic-value'`, the reported symptom exactly
- [x] `test_secrets.py`, `test_secrets_environment_variables.py`, `test_secrets_backends.py` — 72 passed
- [x] Full `airflow-core/tests/unit/always` — 2008 passed; the one failure (`example_mysql_to_gcs.py`) is a missing `mysqlclient` on the host and reproduces on unmodified `main`
- [x] `ruff` / `ruff format` / static checks clean

No newsfragment: #70736 is milestoned 3.3.1 and unreleased, so the regression never reached users.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
