### PR TITLE
Refresh the image cache on canary pushes, not only on the schedule

### DIFF
--- a/.github/workflows/additional-ci-image-checks.yml
+++ b/.github/workflows/additional-ci-image-checks.yml
@@ -83,13 +83,23 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: read
 jobs:
-  # Push early BuildX cache to GitHub Registry in Apache repository, This cache does not wait for all the
-  # tests to complete - it is run very early in the build process for "main" merges in order to refresh
-  # cache using the current constraints. This will speed up cache refresh in cases when pyproject.toml
-  # changes or in case of Dockerfile changes. Failure in this step is not a problem (at most it will
-  # delay cache refresh. It does not attempt to upgrade to newer dependencies.
+  # Push early BuildX cache to GitHub Registry in Apache repository. This cache does not wait for all the
+  # tests to complete - it is run very early in the build process in order to refresh cache using the
+  # current constraints. This will speed up cache refresh in cases when pyproject.toml changes or in case
+  # of Dockerfile changes. Failure in this step is not a problem (at most it will delay cache refresh).
+  # It does not attempt to upgrade to newer dependencies.
   # We only push CI cache as PROD cache usually does not gain as much from fresh cache because
   # it uses prepared airflow and provider distributions that invalidate the cache anyway most of the time
+  #
+  # Runs on `push` as well, not only on the scheduled canary. Release branches (`v*-*-test`) are built
+  # by `push` only, and their other refresh path -- the Regular cache push in `finalize-tests.yml` -- sits
+  # behind the whole test matrix. A branch that is red therefore never refreshes its cache at all, and the
+  # staler the cache gets the slower it is to turn green again. `main` is unaffected either way: it is not
+  # built on push, so it keeps refreshing through the scheduled canary.
+  #
+  # Pull requests stay excluded -- `canary-run` is also true for a PR carrying the `canary` label, and
+  # pushing cache from an unmerged branch is not something a label should authorise. This is the same
+  # condition the Regular cache push uses.
   push-early-buildx-cache-to-github-registry:
     name: Push Early Image Cache
     uses: ./.github/workflows/push-image-cache.yml
@@ -111,9 +121,7 @@ jobs:
       include-success-outputs: ${{ inputs.include-success-outputs }}
       docker-cache: ${{ inputs.docker-cache }}
       disable-airflow-repo-cache: ${{ inputs.disable-airflow-repo-cache }}
-    if: >
-      inputs.canary-run == 'true' &&
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: inputs.canary-run == 'true' && github.event_name != 'pull_request'
 
   # Check that after earlier cache push, breeze command will build quickly
   # This build is a bit slow from in-the scratch builds, so we should run it only in


### PR DESCRIPTION
The early cache push was gated to `schedule` and `workflow_dispatch`, so it never ran for a merge into a release branch. Those branches are built by `push` only, and their other refresh path — the Regular cache push in `finalize-tests.yml` — sits behind the whole test matrix. A branch whose CI is failing therefore never refreshes its image cache at all, and the staler the cache gets the slower every build on it becomes, which makes it harder to get green again.

`v3-3-test` has been in exactly that state: its last successful canary push run was 2026-07-28, so its registry cache is eight days old, and every build against it — including release-constraints runs — pays for it.

`main` is unaffected either way. It is not built on push, so it keeps refreshing through the scheduled canary.

Pull requests stay excluded. `canary-run` is also true for a PR carrying the `canary` label, and pushing cache from an unmerged branch is not something a label should authorise — so the condition matches the one the Regular cache push already uses.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
