### PR TITLE
Resolve release constraints against PyPI providers only

### DIFF
--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -53,6 +53,15 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "false"
         type: string
+      pypi-providers-only:
+        description: >
+          Resolve against providers exactly as published on PyPI (true/false). Skips building the
+          provider distributions from sources and the source-providers constraints with them, so
+          nothing local can answer for a provider. Set when the constraints being produced are the
+          ones a release ships - see the comments on the steps this disables.
+        required: false
+        default: "false"
+        type: string
       debug-resources:
         description: "Whether to run in debug mode (true/false)"
         required: true
@@ -113,12 +122,15 @@ jobs:
           python: ${{ matrix.python-version }}
           use-uv: ${{ inputs.use-uv }}
           make-mnt-writeable-and-cleanup: true
+      # Resolves the providers from the sources in this checkout. Skipped for a release, which
+      # ships only the PyPI constraints and must not have a source tree answer for a provider.
       - name: "Source constraints"
         shell: bash
         run: >
           breeze release-management generate-constraints
           --airflow-constraints-mode constraints-source-providers --answer yes
           --python "${PYTHON_VERSION}"
+        if: inputs.pypi-providers-only != 'true'
       - name: "No providers constraints"
         shell: bash
         timeout-minutes: 25
@@ -127,12 +139,16 @@ jobs:
           --airflow-constraints-mode constraints-no-providers --answer yes
           --python "${PYTHON_VERSION}"
         if: inputs.generate-no-providers-constraints == 'true'
+      # Builds the providers from sources into the dist directory the PyPI resolution reads through
+      # `--find-links`, so a locally built wheel can answer for a provider and is then excluded from
+      # the constraints. That is wanted while developing a provider that is not on PyPI yet; it is the
+      # opposite of what a release wants, which is every provider pinned at its published version.
       - name: "Prepare updated provider distributions"
         shell: bash
         run: >
           breeze release-management prepare-provider-distributions
           --include-not-ready-providers --distribution-format wheel
-        if: inputs.generate-pypi-constraints == 'true'
+        if: inputs.generate-pypi-constraints == 'true' && inputs.pypi-providers-only != 'true'
       - name: "Prepare airflow distributions"
         shell: bash
         run: >

--- a/.github/workflows/release-constraints.yml
+++ b/.github/workflows/release-constraints.yml
@@ -179,6 +179,10 @@ jobs:
       # Only the PyPI constraints are what a release ships; the other modes serve CI, and
       # regenerating them here would move them for reasons unrelated to the release.
       generate-no-providers-constraints: "false"
+      # A release pins the providers as published on PyPI, so nothing is built from the sources
+      # here: a locally built provider wheel would answer the resolution and then be left out of
+      # the constraints, which is exactly the version the release needed pinned.
+      pypi-providers-only: "true"
       allow-pre-releases: ${{ needs.build-info.outputs.allow-pre-releases }}
       debug-resources: "false"
       checkout-ref: ${{ inputs.ref }}


### PR DESCRIPTION
`release-constraints.yml` produces the constraints a release ships, which pin every provider at the version published on PyPI. It was still building the providers from the sources in the checkout first.

That is wrong in two ways. The built wheels land in the dist directory that the PyPI resolution reads through `--find-links`, so a locally built wheel can answer for a provider — and `get_locally_build_distribution_specs()` then *excludes* anything answered locally from the constraints file. The provider the release most needed pinned is the one that ends up missing. It is the right behaviour while developing a provider that is not on PyPI yet; it is the opposite of what a release wants.

It also makes cutting constraints depend on the provider build toolchain working. That is what broke the 3.3.1rc1 run: `flit` removed `--no-setup-py`, `prepare-provider-distributions` failed on all five Python versions, and generation died before any resolution ran.

A new `pypi-providers-only` input on `generate-constraints.yml` (default `false`, so nothing else changes) skips both the source-providers constraints and the provider distribution build. `release-constraints.yml` sets it. Combined with the `generate-no-providers-constraints: "false"` already there, a release run now generates only the PyPI constraints.

The airflow and task-sdk distributions are still built — a release resolves `apache-airflow==<version>` before that version exists on PyPI, so those have to come from `--find-links`.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
