### PR TITLE
[v3-3-test] Resolve release constraints against PyPI providers only (#71140)

### DIFF
--- a/.github/workflows/generate-constraints.yml
+++ b/.github/workflows/generate-constraints.yml
@@ -53,6 +53,15 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "false"
         type: string
+      pypi-providers-only:
+        description: >
+          Resolve against providers exactly as published on PyPI (true/false). Skips building the
+          provider distributions from sources and the source-providers constraints with them, so
+          nothing local can answer for a provider. Set when the constraints being produced are the
+          ones a release ships - see the comments on the steps this disables.
+        required: false
+        default: "false"
+        type: string
       debug-resources:
         description: "Whether to run in debug mode (true/false)"
         required: true
@@ -113,12 +122,15 @@ jobs:
           python: ${{ matrix.python-version }}
           use-uv: ${{ inputs.use-uv }}
           make-mnt-writeable-and-cleanup: true
+      # Resolves the providers from the sources in this checkout. Skipped for a release, which
+      # ships only the PyPI constraints and must not have a source tree answer for a provider.
       - name: "Source constraints"
         shell: bash
         run: >
           breeze release-management generate-constraints
           --airflow-constraints-mode constraints-source-providers --answer yes
           --python "${PYTHON_VERSION}"
+        if: inputs.pypi-providers-only != 'true'
       - name: "No providers constraints"
         shell: bash
         timeout-minutes: 25
@@ -127,12 +139,16 @@ jobs:
           --airflow-constraints-mode constraints-no-providers --answer yes
           --python "${PYTHON_VERSION}"
         if: inputs.generate-no-providers-constraints == 'true'
+      # Builds the providers from sources into the dist directory the PyPI resolution reads through
+      # `--find-links`, so a locally built wheel can answer for a provider and is then excluded from
+      # the constraints. That is wanted while developing a provider that is not on PyPI yet; it is the
+      # opposite of what a release wants, which is every provider pinned at its published version.
       - name: "Prepare updated provider distributions"
         shell: bash
         run: >
           breeze release-management prepare-provider-distributions
           --include-not-ready-providers --distribution-format wheel
-        if: inputs.generate-pypi-constraints == 'true'
+        if: inputs.generate-pypi-constraints == 'true' && inputs.pypi-providers-only != 'true'
       - name: "Prepare airflow distributions"
         shell: bash
         run: >

--- a/.github/workflows/release-constraints.yml
+++ b/.github/workflows/release-constraints.yml
@@ -179,6 +179,10 @@ jobs:
       # Only the PyPI constraints are what a release ships; the other modes serve CI, and
       # regenerating them here would move them for reasons unrelated to the release.
       generate-no-providers-constraints: "false"
+      # A release pins the providers as published on PyPI, so nothing is built from the sources
+      # here: a locally built provider wheel would answer the resolution and then be left out of
+      # the constraints, which is exactly the version the release needed pinned.
+      pypi-providers-only: "true"
       allow-pre-releases: ${{ needs.build-info.outputs.allow-pre-releases }}
       debug-resources: "false"
       checkout-ref: ${{ inputs.ref }}


### PR DESCRIPTION
Backport of #71140 to `v3-3-test`. Clean `git cherry-pick -x`.

Makes the release constraints flow resolve providers **as published on PyPI** rather than building them from the checkout: adds a `pypi-providers-only` input (default `false`) that `release-constraints.yml` sets to `true`, gating off the source-providers constraints and the source provider build. This fixes a real correctness bug (a locally-built provider wheel could answer the resolution and then be excluded from the shipped constraints — dropping the very provider a release needs pinned) and unblocks the 3.3.1rc1 constraints run, which died in `prepare-provider-distributions` after flit removed `--no-setup-py`.

Needed on this branch so the 3.3.1 RC-constraints workflow can complete.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — clean cherry-pick backport of #71140.