### PR TITLE
Add vatsrahul1001 to the release-constraints workflow allowlist

### DIFF
--- a/.github/workflows/release-constraints.yml
+++ b/.github/workflows/release-constraints.yml
@@ -61,6 +61,7 @@ jobs:
       "pierrejeambrun",
       "potiuk",
       "utkarsharma2",
+      "vatsrahul1001",
       "vincbeck",
       ]'), github.event.sender.login)
     outputs:


### PR DESCRIPTION
The `Release constraints` workflow (added in #71040) gates its `build-info` job on an actor allowlist. It seeded that list with the standard committer set but omitted `vatsrahul1001`, who is already on the allowlist of the sibling release workflows (`publish-docs-to-s3.yml`, `release_dockerhub_image.yml`, `update-constraints-on-push.yml`).


##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions) — one-line allowlist addition.