### PR TITLE
Verify version_added against the version being released

### DIFF
--- a/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
+++ b/dev/breeze/src/airflow_breeze/prepare_providers/provider_documentation.py
@@ -32,6 +32,7 @@ from shutil import copyfile
 from time import time
 from typing import Any, NamedTuple
 
+import yaml
 from packaging.version import Version, parse
 from rich.syntax import Syntax
 
@@ -611,6 +612,61 @@ def bump_version(v: Version, index: int) -> Version:
     )
 
 
+def _get_config_options(provider_yaml_content: str) -> dict[str, str | None]:
+    provider_yaml = yaml.safe_load(provider_yaml_content)
+    return {
+        f"{section_name}.{option_name}": option.get("version_added")
+        for section_name, section in (provider_yaml.get("config") or {}).items()
+        for option_name, option in (section.get("options") or {}).items()
+    }
+
+
+def _verify_version_added_fields(provider_id: str, previous_version: str, new_version: str) -> None:
+    """
+    Fails the release preparation if a config option declares a ``version_added`` it never shipped in.
+
+    Contributors have to guess ``version_added`` while writing the change, and the guess goes stale
+    when a release is cut before the PR merges. Nothing revalidates it afterwards, so the wrong value
+    reaches the published configuration reference. This runs at release preparation because that is
+    the only point where the version actually being released is known.
+
+    :param provider_id: provider package
+    :param previous_version: version released before this one
+    :param new_version: version being released
+    """
+    provider_yaml_path = get_provider_yaml(provider_id)
+    previous_tag = get_version_tag(previous_version, provider_id)
+    relative_yaml_path = provider_yaml_path.relative_to(AIRFLOW_ROOT_PATH)
+    result = run_command(
+        ["git", "show", f"{previous_tag}:{relative_yaml_path}"],
+        cwd=AIRFLOW_ROOT_PATH,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        # The tag is missing for a first release, and the path differs for a provider that moved
+        # between releases. Neither is a reason to block a release.
+        return
+    released_options = _get_config_options(result.stdout)
+    wrong_options = {
+        option_name: version_added
+        for option_name, version_added in _get_config_options(provider_yaml_path.read_text()).items()
+        # A null is left alone because the schema types version_added as nullable.
+        if option_name not in released_options and version_added is not None and version_added != new_version
+    }
+    if not wrong_options:
+        return
+    console_print(
+        f"[error]Wrong version_added in {provider_yaml_path}.[/]\n"
+        f"[error]These options do not exist in {previous_version}, so they first ship in "
+        f"{new_version}:[/]"
+    )
+    for option_name, version_added in wrong_options.items():
+        console_print(f"[error]  {option_name}: has {version_added}, expected {new_version}[/]")
+    sys.exit(1)
+
+
 def _update_version_in_provider_yaml(
     provider_id: str, type_of_change: TypeOfChange, min_airflow_version_bump: bool = False
 ) -> tuple[bool, bool, str]:
@@ -648,6 +704,7 @@ def _update_version_in_provider_yaml(
     )
     provider_yaml_path.write_text(updated_provider_yaml_content)
     console_print(f"[special]Bumped version to {v}\n")
+    _verify_version_added_fields(provider_id, previous_version=version, new_version=str(v))
     return with_breaking_changes, maybe_with_new_features, original_provider_yaml_content
 
 

--- a/dev/breeze/tests/test_provider_documentation.py
+++ b/dev/breeze/tests/test_provider_documentation.py
@@ -21,6 +21,7 @@ import string
 from pathlib import Path
 
 import pytest
+import yaml
 
 from airflow_breeze.prepare_providers.provider_documentation import (
     NEEDS_LLM_CLASSIFICATION,
@@ -33,7 +34,9 @@ from airflow_breeze.prepare_providers.provider_documentation import (
     _find_insertion_index_for_version,
     _get_change_from_line,
     _get_changes_classified,
+    _get_config_options,
     _get_git_log_command,
+    _verify_version_added_fields,
     classification_result,
     classify_change_deterministically,
     get_most_impactful_change,
@@ -303,7 +306,7 @@ def test_classify_changes_automatically(
         for description in descriptions
     ]
 
-    for i in range(0, len(changes)):
+    for i in range(len(changes)):
         SHORT_HASH_TO_TYPE_DICT[changes[i].short_hash] = type_of_change[i]
 
     classified_changes = _get_changes_classified(
@@ -532,3 +535,59 @@ def test_classify_change_deterministically(files_class, subject, expected):
         classification, reason = classify_change_deterministically("amazon", _make_change(subject))
     assert classification == expected
     assert reason, "a non-empty reason must always be returned"
+
+
+def _provider_yaml_with(version_added: str | None, include_new_option: bool = True) -> str:
+    options: dict[str, dict] = {"worker_pods_creation_batch_size": {"version_added": "10.1.0"}}
+    if include_new_option:
+        options["async_pod_creation"] = {"version_added": version_added}
+    return yaml.dump({"config": {"kubernetes_executor": {"options": options}}})
+
+
+@pytest.mark.parametrize(
+    ("version_added", "git_returncode", "should_fail"),
+    [
+        pytest.param("10.21.0", 0, False, id="declares_the_version_being_released"),
+        pytest.param("10.20.0", 0, True, id="declares_a_version_it_never_shipped_in"),
+        pytest.param("10.22.0", 0, True, id="declares_a_version_that_does_not_exist_yet"),
+        pytest.param(None, 0, False, id="null_is_allowed_by_the_schema"),
+        pytest.param("10.20.0", 1, False, id="no_tag_to_compare_against"),
+    ],
+)
+def test_verify_version_added_fields(tmp_path, version_added, git_returncode, should_fail):
+    from unittest import mock
+
+    provider_yaml_path = tmp_path / "provider.yaml"
+    provider_yaml_path.write_text(_provider_yaml_with(version_added))
+    previous_release = _provider_yaml_with(None, include_new_option=False)
+
+    with (
+        mock.patch(
+            "airflow_breeze.prepare_providers.provider_documentation.get_provider_yaml",
+            return_value=provider_yaml_path,
+        ),
+        mock.patch(
+            "airflow_breeze.prepare_providers.provider_documentation.AIRFLOW_ROOT_PATH",
+            tmp_path,
+        ),
+        mock.patch(
+            "airflow_breeze.prepare_providers.provider_documentation.run_command",
+            return_value=mock.Mock(returncode=git_returncode, stdout=previous_release),
+        ),
+    ):
+        if should_fail:
+            with pytest.raises(SystemExit):
+                _verify_version_added_fields("cncf.kubernetes", "10.20.0", "10.21.0")
+        else:
+            _verify_version_added_fields("cncf.kubernetes", "10.20.0", "10.21.0")
+
+
+def test_get_config_options_reads_version_added():
+    assert _get_config_options(_provider_yaml_with("10.21.0")) == {
+        "kubernetes_executor.worker_pods_creation_batch_size": "10.1.0",
+        "kubernetes_executor.async_pod_creation": "10.21.0",
+    }
+
+
+def test_get_config_options_without_a_config_section():
+    assert _get_config_options(yaml.dump({"package-name": "apache-airflow-providers-cncf-kubernetes"})) == {}


### PR DESCRIPTION
A provider config option's `version_added` is a guess. The contributor has no way to know which release will carry the change, so they write the next version number. If a release is cut while the PR is in review the guess is wrong, and nothing revalidates it: the schema types the field as a nullable string, and no check compares it to anything.

It is not cosmetic. `conf_constants.py` drops options whose `version_added` is newer than the package being documented, so a wrong value defeats the filter that keeps new options off old version pages.

`cncf-kubernetes` 10.21.0rc1 ships two options declaring `version_added: 10.20.0`, corrected in https://github.com/apache/airflow/pull/71157. Running the same comparison over the last five releases of every provider found two more, from unrelated PRs: 13 `apache.kafka` options declaring 1.14.1, which was never released, and `openlineage.emission_policy` declaring 2.18.0 when it first appears in 2.19.0.

### Why release preparation, not a pre-commit hook

A PR-time check cannot catch this. Branches are not required to be up to date before merge, so it passes against a base that predates the release and never runs again. The `cncf-kubernetes` PR's last commit was 2026-07-22, the 10.20.0 release commit landed 2026-07-23, and it merged on 2026-07-29 without a rebase. A hook would have compared against `versions[0]: 10.19.0` and gone green.

Release preparation knows the version being released, and runs on the merged tree.

### What this does

In `_update_version_in_provider_yaml`, read the previous release's `provider.yaml` from its git tag and compare the config option sets. Anything new since that release must declare the version being prepared.

Only options introduced since the last release are examined, so a value that already shipped wrong is never re-flagged and no release is blocked retroactively. A null is left alone, since the schema permits it. A missing tag, which happens on a first release or when a provider's path moves, skips the check rather than failing it.

related: https://github.com/apache/airflow/pull/71157

### Testing

Driven through the real `_verify_version_added_fields`, against the real repository, with no mocks.

<details>
<summary>Raw logs</summary>

Red, on `main` as it stands today, preparing 10.21.0 from 10.20.0:

```
$ python /tmp/e2e_va.py
AIRFLOW_ROOT_PATH = /private/tmp/airflow-va-check
Wrong version_added in
/private/tmp/airflow-va-check/providers/cncf/kubernetes/provider.yaml.
These options do not exist in 10.20.0, so they first ship in 10.21.0:
  kubernetes_executor.async_pod_creation: has 10.20.0, expected 10.21.0
  kubernetes_executor.pod_creation_max_concurrency: has 10.20.0, expected
10.21.0
RESULT: breeze exited with code 1
exit=1
```

Green, with the fix from https://github.com/apache/airflow/pull/71157 applied:

```
$ git apply version_added_fix.patch
$ python /tmp/e2e_va.py
AIRFLOW_ROOT_PATH = /private/tmp/airflow-va-check
RESULT: passed (no wrong version_added)
RESULT: breeze exited with code 0
exit=0
```

The same comparison over the last five releases of every provider, to measure false positives:

```
provider/version pairs checked: 444   skipped (no tag/unreadable): 56
pairs flagged: 2

  apache.kafka: 1.14.0 -> 1.15.0
      kafka_event_producer.dag_run_events_enabled  version_added=1.14.1
      kafka_event_producer.task_instance_events_enabled  version_added=1.14.1
      kafka_event_producer.kafka_config_id  version_added=1.14.1
      kafka_event_producer.topic  version_added=1.14.1
      kafka_event_producer.source  version_added=1.14.1
      kafka_event_producer.dag_run_dag_id_allowlist  version_added=1.14.1
      kafka_event_producer.dag_run_dag_id_denylist  version_added=1.14.1
      kafka_event_producer.task_instance_dag_id_allowlist  version_added=1.14.1
      kafka_event_producer.task_instance_dag_id_denylist  version_added=1.14.1
      kafka_event_producer.task_instance_task_id_allowlist  version_added=1.14.1
      kafka_event_producer.task_instance_task_id_denylist  version_added=1.14.1
      kafka_event_producer.topic_check_timeout  version_added=1.14.1
      kafka_event_producer.topic_check_retry_interval  version_added=1.14.1
  openlineage: 2.18.1 -> 2.19.0
      openlineage.emission_policy  version_added=2.18.0
```

Both verified by hand. `providers-apache-kafka/1.14.1` does not exist and the versions list goes 1.14.0 to 1.15.0. `emission_policy` has zero occurrences in the 2.18.0 and 2.18.1 tags and one in 2.19.0.

A wrong value is reported once, at the release that introduces the option, and never again:

```
-- cncf.kubernetes: preparing 10.21.0 from 10.20.0 (option is new) --
   ERROR: kubernetes_executor.async_pod_creation has version_added: 10.20.0 but did not exist in 10.20.0; it first ships in 10.21.0
   ERROR: kubernetes_executor.pod_creation_max_concurrency has version_added: 10.20.0 but did not exist in 10.20.0; it first ships in 10.21.0
-- cncf.kubernetes: preparing 10.22.0 from 10.21.0rc1 (option already shipped) --
   OK: every option new since 10.21.0rc1 declares 10.22.0
```

Unit tests:

```
$ pytest tests/test_provider_documentation.py -q
67 passed in 0.22s
```

</details>

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
