### PR TITLE
Keep not-ready providers out of the all extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,9 +191,6 @@ apache-airflow = "airflow.__main__:main"
 "common.compat" = [
     "apache-airflow-providers-common-compat>=1.2.1"
 ]
-"common.dataquality" = [
-    "apache-airflow-providers-common-dataquality>=0.1.0"
-]
 "common.io" = [
     "apache-airflow-providers-common-io>=1.4.2"
 ]
@@ -256,9 +253,6 @@ apache-airflow = "airflow.__main__:main"
 ]
 "http" = [
     "apache-airflow-providers-http>=4.13.2"
-]
-"ibm.mq" = [
-    "apache-airflow-providers-ibm-mq>=0.1.0; platform_machine !=\"aarch64\" and platform_machine !=\"arm64\""
 ]
 "imap" = [
     "apache-airflow-providers-imap>=3.8.0"
@@ -444,7 +438,6 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-cohere>=1.4.0",
     "apache-airflow-providers-common-ai>=0.1.0",
     "apache-airflow-providers-common-compat>=1.2.1",
-    "apache-airflow-providers-common-dataquality>=0.1.0",
     "apache-airflow-providers-common-io>=1.4.2",
     "apache-airflow-providers-common-messaging>=2.0.0", # Set from MIN_VERSION_OVERRIDE in update_airflow_pyproject_toml.py
     "apache-airflow-providers-common-sql>=1.18.0",
@@ -466,7 +459,6 @@ apache-airflow = "airflow.__main__:main"
     "apache-airflow-providers-grpc>=3.7.0",
     "apache-airflow-providers-hashicorp>=4.0.0",
     "apache-airflow-providers-http>=4.13.2",
-    "apache-airflow-providers-ibm-mq>=0.1.0; platform_machine !=\"aarch64\" and platform_machine !=\"arm64\"",
     "apache-airflow-providers-imap>=3.8.0",
     "apache-airflow-providers-influxdb>=2.8.0",
     "apache-airflow-providers-informatica>=0.1.1",

--- a/scripts/ci/prek/common_prek_utils.py
+++ b/scripts/ci/prek/common_prek_utils.py
@@ -591,19 +591,30 @@ def get_provider_base_dir_from_path(file_path: Path) -> Path | None:
     return None
 
 
-def get_all_provider_ids(exclude_suspended_providers: bool = False) -> list[str]:
+def get_all_provider_ids(
+    exclude_suspended_providers: bool = False, exclude_not_ready_providers: bool = False
+) -> list[str]:
     """
     Get all providers from the new provider structure
+
+    :param exclude_suspended_providers: skip providers whose state is ``suspended``
+    :param exclude_not_ready_providers: skip providers whose state is ``not-ready`` - those have
+        never been published, so anything describing what is installable must leave them out
     """
     all_provider_ids = []
+    excluded_states = set()
+    if exclude_suspended_providers:
+        excluded_states.add("suspended")
+    if exclude_not_ready_providers:
+        excluded_states.add("not-ready")
     for provider_file in AIRFLOW_PROVIDERS_ROOT_PATH.rglob("provider.yaml"):
         if provider_file.is_relative_to(AIRFLOW_PROVIDERS_ROOT_PATH / "src"):
             continue
-        if exclude_suspended_providers:
+        if excluded_states:
             import yaml
 
             provider_info = yaml.safe_load(provider_file.read_text())
-            if provider_info.get("state") == "suspended":
+            if provider_info.get("state") in excluded_states:
                 continue
         provider_id = get_provider_id_from_path(provider_file)
         if provider_id:

--- a/scripts/ci/prek/update_airflow_pyproject_toml.py
+++ b/scripts/ci/prek/update_airflow_pyproject_toml.py
@@ -269,9 +269,20 @@ if __name__ == "__main__":
             all_optional_dependencies.append(f'"{optional}" = [\n    "apache-airflow-core[{optional}]"\n]\n')
     optional_airflow_task_sdk_dependencies = get_optional_dependencies(AIRFLOW_TASK_SDK_PYPROJECT_TOML_FILE)
     all_optional_dependencies.append('"all-task-sdk" = [\n    "apache-airflow-task-sdk[all]"\n]\n')
+    # Two lists, because the sections below describe two different things.
+    #
+    # `all_providers` describes the source tree: mypy has to type-check a not-ready provider and uv
+    # has to keep it in the workspace, which is how CI installs it. Only suspended providers drop out.
+    #
+    # `released_providers` describes what is installable from PyPI. A not-ready provider has never
+    # been published, so naming it in an extra makes that extra unsatisfiable - there is no version
+    # of it to resolve to.
     all_providers = sorted(get_all_provider_ids(exclude_suspended_providers=True))
+    released_providers = sorted(
+        get_all_provider_ids(exclude_suspended_providers=True, exclude_not_ready_providers=True)
+    )
     all_provider_lines = []
-    for provider_id in all_providers:
+    for provider_id in released_providers:
         distribution_name = provider_distribution_name(provider_id)
         min_provider_version, comment = find_min_provider_version(provider_id)
         exclusion_marker = get_exclusion_marker(all_providers_dependencies.get(provider_id, {}))
@@ -288,10 +299,15 @@ if __name__ == "__main__":
             all_provider_lines.append(f'    "{distribution_name}",\n')
     all_optional_dependencies.append('"all" = [\n')
     optional_apache_airflow_dependencies = get_optional_dependencies(AIRFLOW_PYPROJECT_TOML_FILE)
+    # Filtered against every provider id rather than against `all_providers`: a provider left out of
+    # `all_providers` still has an extra named after it, and testing only against the included ones
+    # would sweep that extra in here instead of dropping it - which is how a not-ready provider would
+    # come back into `all` through the side door.
+    every_provider_id = set(get_all_provider_ids())
     all_local_extras = [
         extra
         for extra in sorted(optional_apache_airflow_dependencies)
-        if extra not in all_providers and not extra.startswith("all")
+        if extra not in every_provider_id and not extra.startswith("all")
     ]
     all_optional_dependencies.append(f'    "apache-airflow[{",".join(all_local_extras)}]",\n')
     all_optional_dependencies.append('    "apache-airflow-core[all]",\n')

--- a/uv.lock
+++ b/uv.lock
@@ -1032,7 +1032,6 @@ all = [
     { name = "apache-airflow-providers-cohere" },
     { name = "apache-airflow-providers-common-ai" },
     { name = "apache-airflow-providers-common-compat" },
-    { name = "apache-airflow-providers-common-dataquality" },
     { name = "apache-airflow-providers-common-io" },
     { name = "apache-airflow-providers-common-messaging" },
     { name = "apache-airflow-providers-common-sql", extra = ["pandas", "polars"] },
@@ -1054,7 +1053,6 @@ all = [
     { name = "apache-airflow-providers-grpc" },
     { name = "apache-airflow-providers-hashicorp" },
     { name = "apache-airflow-providers-http" },
-    { name = "apache-airflow-providers-ibm-mq", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "apache-airflow-providers-imap" },
     { name = "apache-airflow-providers-influxdb" },
     { name = "apache-airflow-providers-informatica" },
@@ -1217,9 +1215,6 @@ common-ai = [
 common-compat = [
     { name = "apache-airflow-providers-common-compat" },
 ]
-common-dataquality = [
-    { name = "apache-airflow-providers-common-dataquality" },
-]
 common-io = [
     { name = "apache-airflow-providers-common-io" },
 ]
@@ -1296,9 +1291,6 @@ hashicorp = [
 ]
 http = [
     { name = "apache-airflow-providers-http" },
-]
-ibm-mq = [
-    { name = "apache-airflow-providers-ibm-mq", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
 ]
 imap = [
     { name = "apache-airflow-providers-imap" },
@@ -1632,8 +1624,6 @@ requires-dist = [
     { name = "apache-airflow-providers-common-ai", marker = "extra == 'common-ai'", editable = "providers/common/ai" },
     { name = "apache-airflow-providers-common-compat", marker = "extra == 'all'", editable = "providers/common/compat" },
     { name = "apache-airflow-providers-common-compat", marker = "extra == 'common-compat'", editable = "providers/common/compat" },
-    { name = "apache-airflow-providers-common-dataquality", marker = "extra == 'all'", editable = "providers/common/dataquality" },
-    { name = "apache-airflow-providers-common-dataquality", marker = "extra == 'common-dataquality'", editable = "providers/common/dataquality" },
     { name = "apache-airflow-providers-common-io", marker = "extra == 'all'", editable = "providers/common/io" },
     { name = "apache-airflow-providers-common-io", marker = "extra == 'common-io'", editable = "providers/common/io" },
     { name = "apache-airflow-providers-common-messaging", marker = "extra == 'all'", editable = "providers/common/messaging" },
@@ -1680,8 +1670,6 @@ requires-dist = [
     { name = "apache-airflow-providers-hashicorp", marker = "extra == 'hashicorp'", editable = "providers/hashicorp" },
     { name = "apache-airflow-providers-http", marker = "extra == 'all'", editable = "providers/http" },
     { name = "apache-airflow-providers-http", marker = "extra == 'http'", editable = "providers/http" },
-    { name = "apache-airflow-providers-ibm-mq", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64' and extra == 'all'", editable = "providers/ibm/mq" },
-    { name = "apache-airflow-providers-ibm-mq", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64' and extra == 'ibm-mq'", editable = "providers/ibm/mq" },
     { name = "apache-airflow-providers-imap", marker = "extra == 'all'", editable = "providers/imap" },
     { name = "apache-airflow-providers-imap", marker = "extra == 'imap'", editable = "providers/imap" },
     { name = "apache-airflow-providers-influxdb", marker = "extra == 'all'", editable = "providers/influxdb" },
@@ -1792,7 +1780,7 @@ requires-dist = [
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.30.0" },
     { name = "uv", marker = "extra == 'uv'", specifier = ">=0.11.29" },
 ]
-provides-extras = ["all-core", "async", "graphviz", "gunicorn", "kerberos", "memray", "otel", "statsd", "all-task-sdk", "airbyte", "akeyless", "alibaba", "amazon", "anthropic", "apache-cassandra", "apache-drill", "apache-druid", "apache-flink", "apache-hdfs", "apache-hive", "apache-iceberg", "apache-impala", "apache-kafka", "apache-kylin", "apache-livy", "apache-pig", "apache-pinot", "apache-spark", "apache-tinkerpop", "apprise", "arangodb", "asana", "atlassian-jira", "celery", "clickhousedb", "cloudant", "cncf-kubernetes", "cohere", "common-ai", "common-compat", "common-dataquality", "common-io", "common-messaging", "common-sql", "databricks", "datadog", "dbt-cloud", "dingding", "discord", "docker", "edge3", "elasticsearch", "exasol", "fab", "facebook", "ftp", "git", "github", "google", "grpc", "hashicorp", "http", "ibm-mq", "imap", "influxdb", "informatica", "jdbc", "jenkins", "keycloak", "microsoft-azure", "microsoft-mssql", "microsoft-psrp", "microsoft-winrm", "mongo", "mysql", "neo4j", "odbc", "openai", "openfaas", "openlineage", "opensearch", "opsgenie", "oracle", "pagerduty", "papermill", "pgvector", "pinecone", "postgres", "presto", "qdrant", "redis", "salesforce", "samba", "segment", "sendgrid", "sftp", "singularity", "slack", "smtp", "snowflake", "sqlite", "ssh", "standard", "tableau", "telegram", "teradata", "trino", "vertica", "vespa", "weaviate", "yandex", "ydb", "zendesk", "all", "aiobotocore", "apache-atlas", "apache-webhdfs", "amazon-aws-auth", "cloudpickle", "github-enterprise", "google-auth", "ldap", "pandas", "polars", "rabbitmq", "sentry", "s3fs", "uv"]
+provides-extras = ["all-core", "async", "graphviz", "gunicorn", "kerberos", "memray", "otel", "statsd", "all-task-sdk", "airbyte", "akeyless", "alibaba", "amazon", "anthropic", "apache-cassandra", "apache-drill", "apache-druid", "apache-flink", "apache-hdfs", "apache-hive", "apache-iceberg", "apache-impala", "apache-kafka", "apache-kylin", "apache-livy", "apache-pig", "apache-pinot", "apache-spark", "apache-tinkerpop", "apprise", "arangodb", "asana", "atlassian-jira", "celery", "clickhousedb", "cloudant", "cncf-kubernetes", "cohere", "common-ai", "common-compat", "common-io", "common-messaging", "common-sql", "databricks", "datadog", "dbt-cloud", "dingding", "discord", "docker", "edge3", "elasticsearch", "exasol", "fab", "facebook", "ftp", "git", "github", "google", "grpc", "hashicorp", "http", "imap", "influxdb", "informatica", "jdbc", "jenkins", "keycloak", "microsoft-azure", "microsoft-mssql", "microsoft-psrp", "microsoft-winrm", "mongo", "mysql", "neo4j", "odbc", "openai", "openfaas", "openlineage", "opensearch", "opsgenie", "oracle", "pagerduty", "papermill", "pgvector", "pinecone", "postgres", "presto", "qdrant", "redis", "salesforce", "samba", "segment", "sendgrid", "sftp", "singularity", "slack", "smtp", "snowflake", "sqlite", "ssh", "standard", "tableau", "telegram", "teradata", "trino", "vertica", "vespa", "weaviate", "yandex", "ydb", "zendesk", "all", "aiobotocore", "apache-atlas", "apache-webhdfs", "amazon-aws-auth", "cloudpickle", "github-enterprise", "google-auth", "ldap", "pandas", "polars", "rabbitmq", "sentry", "s3fs", "uv"]
 
 [package.metadata.requires-dev]
 ci-image = [


### PR DESCRIPTION
The `all` extra of the `apache-airflow` meta-package was generated from every provider in the source tree that is not suspended, so it also named the not-ready ones. A not-ready provider has never been published, which makes the extra impossible to satisfy against PyPI: there is no version of `apache-airflow-providers-ibm-mq` to resolve to.

That is what broke constraints generation for 3.3.1rc1:

```
Because there are no versions of apache-airflow-providers-ibm-mq{...} and
apache-airflow[all]==3.3.0 depends on apache-airflow-providers-ibm-mq{...}>=0.1.0,
we can conclude that apache-airflow[all]==3.3.0 cannot be used.
```

`ibm.mq` and `common.dataquality` are both `state: not-ready`; `apache.beam` is `suspended` and was already excluded.

### Only the extras change

The generator now works from two lists, because the sections it writes describe two different things:

- `all_providers` (suspended excluded) still drives the **mypy paths**, the **uv workspace members** and `[tool.uv.sources]`. A not-ready provider lives in the source tree, so mypy has to type-check it and uv has to keep it in the workspace - which is how CI installs it via `uv sync --all-packages`.
- `released_providers` (suspended **and** not-ready excluded) drives the **extras**: the per-provider extras and the distributions listed in `all`.

The self-referencing entry inside `all` - `apache-airflow[async,pandas,...]` - needed fixing too. It was filtered against `all_providers`, i.e. against the *included* providers, so excluding a provider from that list moved its extra into the self-reference rather than dropping it, and `all` would still have reached the provider through the side door. It is now filtered against every provider id whatever its state.

Non-provider extras are untouched: `async`, `cloudpickle`, `graphviz`, `kerberos`, `ldap`, `pandas`, `polars`, `sentry`, `statsd` and the rest, plus `apache-airflow-core[all]`. Regenerating twice produces no further change.

### Effect on uv.lock

The two providers lose their `extra == 'all'` and per-provider extra edges, and drop out of `provides-extras`. Their `[[package]]` entries and workspace membership stay, so `uv sync --all-packages` still installs them. Relocked with the pinned `AIRFLOW_UV_VERSION` (0.11.29).

`[dependency-groups] dev` includes `apache-airflow[all]`, so that group alone no longer pulls the two in; the workspace sync that CI and breeze use does.

It also fixes `dev/get_devel_deps.sh`, which installs `apache-airflow[all]==<version>` from PyPI and would hit the same unsatisfiable resolution.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Opus 5 (1M context)

Generated-by: Claude Opus 5 (1M context) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
