### PR TITLE
Fix OpenSearch remote logging crash if port is empty

### DIFF
--- a/airflow-core/src/airflow/config_templates/airflow_local_settings.py
+++ b/airflow-core/src/airflow/config_templates/airflow_local_settings.py
@@ -357,7 +357,10 @@ if REMOTE_LOGGING:
     elif OPENSEARCH_HOST:
         from airflow.providers.opensearch.log.os_task_handler import OpensearchRemoteLogIO
 
-        OPENSEARCH_PORT = conf.getint("opensearch", "PORT", fallback=9200)
+        # ``[opensearch] port`` declares an empty-string default, so the key is always present and
+        # ``conf.getint`` raises on ``int("")`` instead of falling back to 9200.
+        _opensearch_port = conf.get("opensearch", "PORT", fallback="")
+        OPENSEARCH_PORT = int(_opensearch_port) if _opensearch_port else 9200
         OPENSEARCH_USERNAME: str = conf.get_mandatory_value("opensearch", "USERNAME")
         OPENSEARCH_PASSWORD: str = conf.get_mandatory_value("opensearch", "PASSWORD")
         OPENSEARCH_WRITE_STDOUT: bool = conf.getboolean("opensearch", "WRITE_STDOUT")

--- a/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
+++ b/airflow-core/tests/unit/config_templates/test_airflow_local_settings.py
@@ -131,6 +131,34 @@ def test_mixed_kwargs_split_correctly(remote_base, remote_io_path, restore_local
         assert "backup_count" not in mock_remote_io.call_args.kwargs
 
 
+@pytest.mark.parametrize(
+    ("configured_port", "expected_port"),
+    [
+        pytest.param("", 9200, id="unset-falls-back-to-9200"),
+        pytest.param("9201", 9201, id="explicit-port-is-an-int"),
+    ],
+)
+def test_opensearch_port_resolution(configured_port, expected_port, restore_local_settings):
+    """``[opensearch] port`` defaults to an empty string, which must not blow up module import."""
+    remote_io_path = "airflow.providers.opensearch.log.os_task_handler.OpensearchRemoteLogIO"
+    pytest.importorskip(remote_io_path.rsplit(".", 1)[0])
+    with (
+        mock.patch(remote_io_path) as mock_remote_io,
+        conf_vars(
+            {
+                ("logging", "remote_logging"): "True",
+                ("logging", "remote_base_log_folder"): "",
+                ("elasticsearch", "host"): "",
+                ("opensearch", "host"): "https://opensearch.example.com:9202",
+                ("opensearch", "port"): configured_port,
+            }
+        ),
+    ):
+        importlib.reload(airflow_local_settings)
+
+        assert mock_remote_io.call_args.kwargs["port"] == expected_port
+
+
 def test_file_handler_params_introspected_correctly():
     """The introspected FileTaskHandler params include the expected kwargs."""
     init_params = set(inspect.signature(FileTaskHandler.__init__).parameters) - {"self", "base_log_folder"}


### PR DESCRIPTION
Followup PR for https://github.com/apache/airflow/pull/70295#discussion_r3701681474.

## Why

- `[opensearch] port` declares `default: ""` in `provider.yaml`, so the key always resolves and `conf.getint("opensearch", "PORT", fallback=9200)` never reaches its fallback. The default value `""` make it raise ValueError on `int("")`.

## How

- Read `[opensearch] port` as a string and convert explicitly, treating an empty value as "unset". An unset port still resolves to 9200.

## Verification

- `uv run --project providers/opensearch pytest airflow-core/tests/unit/config_templates/test_airflow_local_settings.py`
- `env -u AIRFLOW__OPENSEARCH__PORT AIRFLOW__LOGGING__REMOTE_LOGGING=True AIRFLOW__OPENSEARCH__HOST=https://opensearch.example.com uv run --project providers/opensearch airflow version`
  - This command fails on main branch, but pass in this PR.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes - Claude Code

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
