### PR TITLE
Allow opentelemetry-semantic-conventions pre-release in constraints resolution

### DIFF
--- a/scripts/in_container/run_generate_constraints.py
+++ b/scripts/in_container/run_generate_constraints.py
@@ -537,10 +537,21 @@ def generate_constraints_pypi_providers(config_params: ConfigParams) -> None:
     #   if-necessary fallback; without this entry the package cannot resolve and generation fails
     #   with "No solution found". Keeping it here (rather than the provider pre-release list) marks
     #   it as an always-allowed pre-release across every resolution, matching how it already ships.
+    # * opentelemetry-semantic-conventions>=0.48b0 — same story: a beta-only package, pulled in as a
+    #   hard dependency of opentelemetry-sdk (via opentelemetry-exporter-otlp and shared/observability),
+    #   so the ``--prerelease explicit`` resolution needs the same explicit mark. The floor only marks
+    #   it as a pre-release and must stay at the version paired with our ``opentelemetry-*>=1.27.0``
+    #   floor — opentelemetry-sdk exact-pins the semantic conventions version it ships with, so a
+    #   higher floor here would conflict with any sdk older than that pairing.
+    #
+    # These two are the only pre-releases in the constraints we tag, and removing the need for the
+    # exception is tracked at https://github.com/apache/airflow/issues/71176
+    #
     additional_constraints_for_highest_resolution: list[str] = [
         "pyarrow>=22.0.0; python_version >= '3.14'",
         "gremlinpython>=3.8.0",
         "opentelemetry-exporter-prometheus>=0.47b0",
+        "opentelemetry-semantic-conventions>=0.48b0",
     ]
 
     # Constraints cut for a release candidate have to pin the candidates themselves - the providers


### PR DESCRIPTION
`opentelemetry-semantic-conventions` has never published a final release — every one of its 61 PyPI versions is a `0.NNbM` beta — and it arrives as a hard dependency of `opentelemetry-sdk` (via `opentelemetry-exporter-otlp` and `shared/observability`).

Constraints cut for a release candidate resolve with `--prerelease explicit`, which permits a pre-release only where some requirement marks one and drops the if-necessary fallback. Without an explicit mark the package cannot resolve at all and generation fails with "No solution found" — the same situation `opentelemetry-exporter-prometheus` was in (#71110).

The floor is `>=0.48b0`, the version paired with our declared `opentelemetry-*>=1.27.0` floor, and it only serves to mark the package as a pre-release. `opentelemetry-sdk` exact-pins the semantic-conventions version it ships with, so a higher floor would conflict with any older sdk the resolution might land on.

These two OpenTelemetry packages are the only pre-releases in the constraints we tag. Getting rid of them — and of this hardcoded exception — is tracked in #71176, linked from the code at the exception site.

related: #71176

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)