### PR TITLE
Fix broken translation guide links in the i18n README

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/README.md
+++ b/airflow-core/src/airflow/ui/public/i18n/README.md
@@ -83,7 +83,7 @@ A new locale may be added when all of the following are true:
 
 The PR for a new locale should include:
 
-- A locale-specific translation guide file at `.github/skills/airflow-translations/locales/<locale>.md`
+- A locale-specific translation guide file at `.agents/skills/airflow-translations/locales/<locale>.md`
 - Locale files under `airflow-core/src/airflow/ui/public/i18n/locales/<locale>`.
 - Updates to `airflow-core/src/airflow/ui/src/i18n/config.ts`.
 - Updates to `dev/breeze/src/airflow_breeze/commands/ui_commands.py`.
@@ -210,22 +210,22 @@ primarily intended for LLM-assisted translation work, but can also be used by hu
 
 | Locale Code | Language                | Guideline File                  |
 | ----------- | ----------------------- | ------------------------------- |
-| `ar`        | Arabic                  | [.github/skills/airflow-translations/locales/ar.md](../../../../../../.github/skills/airflow-translations/locales/ar.md)  |
-| `ca`        | Catalan                 | [.github/skills/airflow-translations/locales/ca.md](../../../../../../.github/skills/airflow-translations/locales/ca.md)  |
-| `de`        | German                  | [.github/skills/airflow-translations/locales/de.md](../../../../../../.github/skills/airflow-translations/locales/de.md)  |
-| `el`        | Greek                   | [.github/skills/airflow-translations/locales/el.md](../../../../../../.github/skills/airflow-translations/locales/el.md)  |
-| `es`        | Spanish                 | [.github/skills/airflow-translations/locales/es.md](../../../../../../.github/skills/airflow-translations/locales/es.md)  |
-| `fr`        | French                  | [.github/skills/airflow-translations/locales/fr.md](../../../../../../.github/skills/airflow-translations/locales/fr.md)  |
-| `he`        | Hebrew                  | [.github/skills/airflow-translations/locales/he.md](../../../../../../.github/skills/airflow-translations/locales/he.md)  |
-| `hi`        | Hindi                   | [.github/skills/airflow-translations/locales/hi.md](../../../../../../.github/skills/airflow-translations/locales/hi.md)  |
-| `hu`        | Hungarian               | [.github/skills/airflow-translations/locales/hu.md](../../../../../../.github/skills/airflow-translations/locales/hu.md)  |
-| `it`        | Italian                 | [.github/skills/airflow-translations/locales/it.md](../../../../../../.github/skills/airflow-translations/locales/it.md)  |
-| `ja`        | Japanese                | [.github/skills/airflow-translations/locales/ja.md](../../../../../../.github/skills/airflow-translations/locales/ja.md)  |
-| `ko`        | Korean                  | [.github/skills/airflow-translations/locales/ko.md](../../../../../../.github/skills/airflow-translations/locales/ko.md)  |
-| `nl`        | Dutch                   | [.github/skills/airflow-translations/locales/nl.md](../../../../../../.github/skills/airflow-translations/locales/nl.md)  |
-| `pl`        | Polish                  | [.github/skills/airflow-translations/locales/pl.md](../../../../../../.github/skills/airflow-translations/locales/pl.md)  |
-| `pt`        | Portuguese              | [.github/skills/airflow-translations/locales/pt.md](../../../../../../.github/skills/airflow-translations/locales/pt.md)  |
-| `th`        | Thai                    | [.github/skills/airflow-translations/locales/th.md](../../../../../../.github/skills/airflow-translations/locales/th.md)  |
-| `tr`        | Turkish                 | [.github/skills/airflow-translations/locales/tr.md](../../../../../../.github/skills/airflow-translations/locales/tr.md)  |
-| `zh-CN`     | Simplified Chinese      | [.github/skills/airflow-translations/locales/zh-CN.md](../../../../../../.github/skills/airflow-translations/locales/zh-CN.md) |
-| `zh-TW`     | Traditional Chinese     | [.github/skills/airflow-translations/locales/zh-TW.md](../../../../../../.github/skills/airflow-translations/locales/zh-TW.md) |
+| `ar`        | Arabic                  | [.agents/skills/airflow-translations/locales/ar.md](../../../../../../.agents/skills/airflow-translations/locales/ar.md)  |
+| `ca`        | Catalan                 | [.agents/skills/airflow-translations/locales/ca.md](../../../../../../.agents/skills/airflow-translations/locales/ca.md)  |
+| `de`        | German                  | [.agents/skills/airflow-translations/locales/de.md](../../../../../../.agents/skills/airflow-translations/locales/de.md)  |
+| `el`        | Greek                   | [.agents/skills/airflow-translations/locales/el.md](../../../../../../.agents/skills/airflow-translations/locales/el.md)  |
+| `es`        | Spanish                 | [.agents/skills/airflow-translations/locales/es.md](../../../../../../.agents/skills/airflow-translations/locales/es.md)  |
+| `fr`        | French                  | [.agents/skills/airflow-translations/locales/fr.md](../../../../../../.agents/skills/airflow-translations/locales/fr.md)  |
+| `he`        | Hebrew                  | [.agents/skills/airflow-translations/locales/he.md](../../../../../../.agents/skills/airflow-translations/locales/he.md)  |
+| `hi`        | Hindi                   | [.agents/skills/airflow-translations/locales/hi.md](../../../../../../.agents/skills/airflow-translations/locales/hi.md)  |
+| `hu`        | Hungarian               | [.agents/skills/airflow-translations/locales/hu.md](../../../../../../.agents/skills/airflow-translations/locales/hu.md)  |
+| `it`        | Italian                 | [.agents/skills/airflow-translations/locales/it.md](../../../../../../.agents/skills/airflow-translations/locales/it.md)  |
+| `ja`        | Japanese                | [.agents/skills/airflow-translations/locales/ja.md](../../../../../../.agents/skills/airflow-translations/locales/ja.md)  |
+| `ko`        | Korean                  | [.agents/skills/airflow-translations/locales/ko.md](../../../../../../.agents/skills/airflow-translations/locales/ko.md)  |
+| `nl`        | Dutch                   | [.agents/skills/airflow-translations/locales/nl.md](../../../../../../.agents/skills/airflow-translations/locales/nl.md)  |
+| `pl`        | Polish                  | [.agents/skills/airflow-translations/locales/pl.md](../../../../../../.agents/skills/airflow-translations/locales/pl.md)  |
+| `pt`        | Portuguese              | [.agents/skills/airflow-translations/locales/pt.md](../../../../../../.agents/skills/airflow-translations/locales/pt.md)  |
+| `th`        | Thai                    | [.agents/skills/airflow-translations/locales/th.md](../../../../../../.agents/skills/airflow-translations/locales/th.md)  |
+| `tr`        | Turkish                 | [.agents/skills/airflow-translations/locales/tr.md](../../../../../../.agents/skills/airflow-translations/locales/tr.md)  |
+| `zh-CN`     | Simplified Chinese      | [.agents/skills/airflow-translations/locales/zh-CN.md](../../../../../../.agents/skills/airflow-translations/locales/zh-CN.md) |
+| `zh-TW`     | Traditional Chinese     | [.agents/skills/airflow-translations/locales/zh-TW.md](../../../../../../.agents/skills/airflow-translations/locales/zh-TW.md) |


### PR DESCRIPTION
The locale guideline table in `airflow-core/src/airflow/ui/public/i18n/README.md` links to `.github/skills/airflow-translations/locales/<locale>.md`. All twenty of those links return 404 on GitHub.

`.github/skills/airflow-translations` is a symlink to `../../.agents/skills/airflow-translations`. Git stores it as a symlink blob rather than a tree, and GitHub does not traverse it when resolving a path, so anything *through* it is unreachable in the web UI.

This is verifiable against the API on `main`:

```
GET /repos/apache/airflow/contents/.github/skills/airflow-translations
  -> type=symlink, target=../../.agents/skills/airflow-translations

GET /repos/apache/airflow/contents/.github/skills/airflow-translations/locales/ar.md
  -> 404 Not Found

GET /repos/apache/airflow/contents/.agents/skills/airflow-translations/locales/ar.md
  -> type=file, size=6597
```

So the fix is to point the table at `.agents/skills/airflow-translations/locales/`, where the files actually are. Both the link target and the visible text are updated, so the table keeps naming the location it sends you to.

The prose above the table ("The PR for a new locale should include: A locale-specific translation guide file at ...") named the same unreachable path. Since a new guide cannot be added under a symlink anyway — it has to be created in `.agents/skills/airflow-translations/locales/` — that line is updated too. It is one line, in the same file and the same section, describing the same location.

Note `.agents/skills/airflow-translations/SKILL.md` already carries an equivalent table and links correctly, as `[locales/ar.md](locales/ar.md)`, because it sits next to the directory. Only the copy of the table in the i18n README was affected.

### What was not touched

`README.md` at the repo root links to `.github/skills/magpie-setup/` — that is a link *to* the symlink rather than through it, and the surrounding text deliberately describes that path as the committed framework artefact. It behaves differently and looked like a separate call, so I left it alone.

### Testing

- Every link in the changed file was re-resolved against a clone of `main`; none now resolves through a symlinked path component, and none is missing.
- `.github` and `.agents` are both seven characters, so the markdown table alignment is byte-for-byte unchanged.
- File hygiene checked for the `trailing-whitespace`, `end-of-file-fixer` and `mixed-line-ending` hooks: no trailing whitespace, no CRLF, trailing newline present. The change is a like-for-like string swap inside existing links and inline code, so `markdownlint` sees no structural change.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

I ran the link sweep and drafted this description with the tool, and I reviewed the result before opening: the symlink behaviour was confirmed against the GitHub API rather than assumed, the replacement path was confirmed to serve, and the one related link I chose not to change is called out above.
