### PR TITLE
Document config-backed enum Dag Params

### DIFF
--- a/airflow-core/docs/core-concepts/params.rst
+++ b/airflow-core/docs/core-concepts/params.rst
@@ -253,6 +253,11 @@ The following features are supported in the Trigger UI Form:
             * ``format="multiline"``: Generate a multi-line textarea
             * | ``enum=["a", "b", "c"]``: Generates a
               | drop-down select list for scalar values.
+              | If the choices come from an external config file,
+              | read that file while the Dag is parsed and pass the
+              | resulting list to ``enum``; the trigger form reads
+              | the serialized Dag Params and does not call dynamic
+              | choice providers when the form opens.
               | As of JSON validation, a value must be
               | selected or the field must be marked as
               | optional explicit. See also details inside

--- a/airflow-core/newsfragments/71180.improvement.rst
+++ b/airflow-core/newsfragments/71180.improvement.rst
@@ -1,0 +1,1 @@
+Documented how to populate enum Dag Params from external config files for the trigger Dag form.

--- a/airflow-core/newsfragments/71180.improvement.rst
+++ b/airflow-core/newsfragments/71180.improvement.rst
@@ -1,1 +1,0 @@
-Documented how to populate enum Dag Params from external config files for the trigger Dag form.

--- a/airflow-core/src/airflow/example_dags/example_params_ui_interfaces.ini
+++ b/airflow-core/src/airflow/example_dags/example_params_ui_interfaces.ini
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[InterfaceA]
+TYPE = Script
+
+[InterfaceB]
+TYPE = EBICS
+
+[InterfaceC]
+TYPE = Script

--- a/airflow-core/src/airflow/example_dags/example_params_ui_tutorial.py
+++ b/airflow-core/src/airflow/example_dags/example_params_ui_tutorial.py
@@ -23,11 +23,22 @@ to the DAG and which are used to render a trigger form.
 
 from __future__ import annotations
 
+import configparser
 import datetime
 import json
 from pathlib import Path
 
 from airflow.sdk import DAG, Param, task
+
+
+def _get_script_interfaces_from_config() -> list[str]:
+    config = configparser.ConfigParser()
+    config.read(Path(__file__).with_name("example_params_ui_interfaces.ini"))
+
+    return [section for section in config.sections() if config[section].get("TYPE") == "Script"]
+
+
+SCRIPT_INTERFACES = _get_script_interfaces_from_config()
 
 with DAG(
     dag_id=Path(__file__).stem,
@@ -74,6 +85,19 @@ with DAG(
             description="You can use JSON schema enum's to generate drop down selection boxes.",
             enum=[f"value {i}" for i in range(16, 64)],
             section="Typed parameters with Param object",
+        ),
+        "script_interface": Param(
+            SCRIPT_INTERFACES[0],
+            description="Choices are generated from example_params_ui_interfaces.ini at Dag parse time.",
+            schema={
+                "type": "string",
+                "title": "Script interface",
+                "enum": SCRIPT_INTERFACES,
+                "values_display": {
+                    name: name.replace("Interface", "Interface ") for name in SCRIPT_INTERFACES
+                },
+                "section": "Typed parameters with Param object",
+            },
         ),
         # [END section_1]
         # Boolean as proper parameter with description


### PR DESCRIPTION
## Why

Dag authors sometimes need the choices for an enum Param to come from deployment-local
configuration rather than being hard-coded in the Dag file. Airflow already supports this —
the trigger form reads the serialized Param schema, so any list computed while the Dag is
parsed shows up as a dropdown — but nothing in the docs or the examples shows the pattern,
so it isn't obvious that it works.

## What

Documents and demonstrates building an enum Param's choices from an external config file:

- `params.rst` notes that choices can be read from a config file at parse time, and that the
  trigger form uses the serialized Params rather than calling any dynamic choice provider
  when the form opens.
- `example_params_ui_tutorial.py` gains a `script_interface` Param whose choices come from a
  colocated INI file, filtered to the sections with `TYPE = Script`.
- `example_params_ui_interfaces.ini` is the accompanying config file.

No behavior change: enum Params still render as dropdowns, and no new schema fields or UI
code are added.

## Scope

An earlier revision of this PR proposed an `x-airflow-ui.widget = "radio"` schema hint so
enum Params could render as radio buttons. That was dropped after review — the naming and
the expansion story for `x-airflow-ui` need to be settled first, and a radio has no way to
clear the selection for an optional Param. The dropdown already covers the "selector instead
of free text" ask in #56632, so this PR keeps to the documentation half.

related: #56632

## Screenshot

Trigger Dag form showing the `Script interface` Param rendering as a dropdown with the
choices read from the INI file (`Interface A`, `Interface C` — `InterfaceB` is filtered out
because its `TYPE` is not `Script`):

<img width="750" height="598" alt="螢幕擷取畫面 2026-08-07 223941" src="https://github.com/user-attachments/assets/97871884-5ed2-4e48-b869-8a012e8a45b9" />


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
