### PR TITLE
Fix ambiguous git refspec when pushing release-candidate constraints

### DIFF
--- a/.github/workflows/release-constraints.yml
+++ b/.github/workflows/release-constraints.yml
@@ -237,13 +237,15 @@ jobs:
       - name: "Push ${{ needs.build-info.outputs.target-branch }}"
         working-directory: "constraints"
         shell: bash
-        run: git push origin "${TARGET_BRANCH}"
+        # Qualify as refs/heads/ -- for a release candidate the branch and the tag share a name
+        # (both constraints-<VERSION>), so a bare refspec is ambiguous ("matches more than one").
+        run: git push origin "refs/heads/${TARGET_BRANCH}"
       - name: "Tag constraints-${{ inputs.version }}"
         working-directory: "constraints"
         shell: bash
         run: |
           git tag -a "constraints-${VERSION}" -m "Constraints for Apache Airflow ${VERSION}"
-          git push origin "constraints-${VERSION}"
+          git push origin "refs/tags/constraints-${VERSION}"
       - name: "Summary"
         shell: bash
         run: |


### PR DESCRIPTION
The `Publish and tag constraints` job in `release-constraints.yml` fails at the push step for a **release candidate** with:

```
error: src refspec constraints-3.1.3rc1 matches more than one
error: failed to push some refs to 'https://github.com/apache/airflow'
```

For a candidate the constraints **branch** and **tag** are both named `constraints-<VERSION>` (e.g. `constraints-3.1.3rc1`), and both pushes use the bare name:

```yaml
git push origin "${TARGET_BRANCH}"          # branch
git push origin "constraints-${VERSION}"    # tag
```

When a local ref matches *both* `refs/heads/constraints-<VERSION>` and `refs/tags/constraints-<VERSION>`, git can't disambiguate. This happens on a **re-run** (a prior run created the remote tag, the checkout fetched it, so the branch push at the top is ambiguous), and on a first run the tag push later is ambiguous once the branch also exists locally. Either way the RC constraints cut is blocked.

Fix: qualify both refspecs so the branch and tag pushes are unambiguous — `refs/heads/${TARGET_BRANCH}` and `refs/tags/constraints-${VERSION}`. The final-release path is unaffected (its branch `constraints-X-Y` differs from the tag `constraints-X.Y.Z`); this change is harmless there.

Verified locally: `yamllint` and `zizmor` pass on the workflow.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)