### PR TITLE
Surface keyring failures instead of silently dropping the token

### DIFF
--- a/airflow-ctl/src/airflowctl/api/client.py
+++ b/airflow-ctl/src/airflowctl/api/client.py
@@ -244,9 +244,10 @@ class Credentials:
                 "Use `airflowctl auth login --skip-keyring ...` to dismiss this error."
             ) from e
         except TypeError as e:
-            # This happens when the token is None, which is not allowed by keyring
-            if self.api_token is None and self.client_kind == ClientKind.CLI:
+            # keyring rejects a None password; any other TypeError is a real backend failure
+            if self.api_token is None:
                 raise AirflowCtlCredentialNotFoundException("No API token found. Please login first.") from e
+            raise
 
     def load(self) -> Credentials:
         """Load the credentials from keyring and URL from disk file."""

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -216,6 +216,25 @@ class TestCredentials:
         with pytest.raises(AirflowCtlKeyringException, match="Keyring backend is not available"):
             Credentials(client_kind=cli_client).save()
 
+    @pytest.mark.parametrize("client_kind", [ClientKind.AUTH, ClientKind.NO_AUTH, None])
+    @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_SAVE_NO_TOKEN"})
+    @patch("airflowctl.api.client.keyring")
+    def test_save_without_token_raises_for_non_cli_client_kinds(self, mock_keyring, client_kind):
+        mock_keyring.set_password.side_effect = TypeError("password must be a string")
+
+        with pytest.raises(AirflowCtlCredentialNotFoundException, match="No API token found"):
+            Credentials(api_url="http://localhost:8080", client_kind=client_kind).save()
+
+    @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_SAVE_TYPE_ERROR"})
+    @patch("airflowctl.api.client.keyring")
+    def test_save_reraises_type_error_unrelated_to_missing_token(self, mock_keyring):
+        mock_keyring.set_password.side_effect = TypeError("keyring backend blew up")
+
+        with pytest.raises(TypeError, match="keyring backend blew up"):
+            Credentials(
+                api_url="http://localhost:8080", api_token="TEST_TOKEN", client_kind=ClientKind.CLI
+            ).save()
+
     @patch.dict(os.environ, {"AIRFLOW_CLI_ENVIRONMENT": "TEST_SAVE_SKIP_KEYRING"})
     @patch("airflowctl.api.client.keyring")
     def test_save_no_keyring_backend_skip_keyring(self, mock_keyring):


### PR DESCRIPTION
## Summary

`airflowctl auth login` could report success while the token never reached the keyring. `Credentials.save()` writes the API url config before storing the token, and when keyring rejected the token the `TypeError` handler only raised for `ClientKind.CLI` — a kind neither call site passes. Every other case, including a genuine keyring backend failure, returned as though the save had worked, leaving the user with a config file and no credentials.

## Behavior change

A missing token now fails for every client kind, and a `TypeError` unrelated to a missing token propagates instead of being discarded. An unavailable keyring backend still reports the keyring error first, as before.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)