### PR TITLE
Keep API error details when a response declares a JSON charset

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -112,7 +112,8 @@ class ServerResponseError(httpx.HTTPStatusError):
         if response.status_code < 400:
             return None
 
-        if response.headers.get("content-type") != "application/json":
+        media_type = response.headers.get("content-type", "").partition(";")[0].strip().lower()
+        if media_type != "application/json":
             return None
 
         # httpx runs response event hooks before it reads the body, so the body has to be

--- a/airflow-ctl/tests/airflow_ctl/api/test_client.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_client.py
@@ -124,6 +124,24 @@ class TestClient:
         assert err.value.args == ("Client error message: {'detail': 'Not found'}",)
 
     @pytest.mark.parametrize(
+        "content_type",
+        [
+            pytest.param("application/json; charset=utf-8", id="charset-parameter"),
+            pytest.param("application/json ; charset=utf-8", id="space-before-parameter"),
+            pytest.param("Application/JSON", id="uppercase-media-type"),
+        ],
+    )
+    def test_error_parsing_normalizes_json_media_type(self, content_type):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Not found"}, headers={"content-type": content_type})
+
+        client = Client(base_url="", token="", mounts={"'http://": httpx.MockTransport(handle_request)})
+
+        with pytest.raises(ServerResponseError) as err:
+            client.get("http://error")
+        assert err.value.args == ("Client error message: {'detail': 'Not found'}",)
+
+    @pytest.mark.parametrize(
         ("status_code", "expected_message"),
         [
             pytest.param(404, "Client error message: {'detail': 'boom'}", id="client-error"),

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -1331,7 +1331,9 @@ class ServerResponseError(httpx.HTTPStatusError):
         if not (400 <= response.status_code < 600):
             return None
 
-        if response.headers.get("content-type") != "application/json":
+        # Servers and proxies may send parameters such as ``; charset=utf-8`` along with the media type.
+        media_type = response.headers.get("content-type", "").partition(";")[0].strip().lower()
+        if media_type != "application/json":
             return None
 
         detail: list[RemoteValidationError] | dict[str, Any] | None = None

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -174,6 +174,24 @@ class TestClient:
         assert err.value.args == ("Not found",)
         assert err.value.detail is None
 
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            pytest.param("application/json; charset=utf-8", id="charset-parameter"),
+            pytest.param("application/json ; charset=utf-8", id="space-before-parameter"),
+            pytest.param("Application/JSON", id="uppercase-media-type"),
+        ],
+    )
+    def test_error_parsing_normalizes_json_media_type(self, content_type):
+        responses = [
+            httpx.Response(404, json={"detail": "Not found"}, headers={"content-type": content_type})
+        ]
+        client = make_client_w_responses(responses)
+
+        with pytest.raises(ServerResponseError) as err:
+            client.get("http://error")
+        assert err.value.args == ("Not found",)
+
     def test_server_response_error_pickling(self):
         responses = [httpx.Response(404, json={"detail": {"message": "Invalid input"}})]
         client = make_client_w_responses(responses)


### PR DESCRIPTION
## Summary

Both API clients treated a response as a parseable error only when `Content-Type` was exactly `application/json`, so any media type carrying parameters — `application/json; charset=utf-8`, as proxies and gateways routinely emit on the errors they generate themselves — skipped error parsing and fell through to `raise_for_status()`. That loses the server's `detail`, and it raises a plain `httpx.HTTPStatusError`, so the `except ServerResponseError` branches in the supervisor and in the CLI commands stop matching.

Airflow's own API server is unaffected — Starlette appends a charset only to `text/*` responses — so this surfaces only where something between client and API server rewrites the header. Parameters are now stripped and the media type case folded; `application/problem+json` remains unaccepted.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)