### PR TITLE
Fix __getattr__ in helpers.py throwing AttributeError for dotted module paths

### DIFF
--- a/airflow-core/src/airflow/utils/helpers.py
+++ b/airflow-core/src/airflow/utils/helpers.py
@@ -313,6 +313,7 @@ def __getattr__(name: str):
     except KeyError:
         raise AttributeError(f"module '{__name__}' has no attribute '{name}'") from None
 
+    import importlib
     import warnings
 
     warnings.warn(
@@ -320,4 +321,4 @@ def __getattr__(name: str):
         DeprecationWarning,
         stacklevel=2,
     )
-    return getattr(__import__(modpath), name)
+    return getattr(importlib.import_module(modpath), name)


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

### Description

This PR fixes a bug in `airflow.utils.helpers.__getattr__` where the dynamic loading of deprecated functions (like `render_template_as_native`) was failing for dotted module paths (e.g. `airflow.sdk.definitions.context`). 

When passing a dotted path to `__import__` without the `fromlist` argument, it incorrectly returned the root package `airflow` instead of the target leaf module. This caused an `AttributeError` when the code subsequently tried to `getattr` the deprecated function directly on the root `airflow` module. 

The fix replaces `__import__(modpath)` with `importlib.import_module(modpath)`, which correctly returns the leaf module, allowing the compatibility shim and `DeprecationWarning` to function as intended.

* closes: #71198

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Antigravity IDE following the guidelines at https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions
