### PR TITLE
Move CloudBatchSubmitJobOperator job normalization out of __init__

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -78,16 +78,19 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         self.region = region
         self.job_name = job_name
         self.job = job
-        # Normalize Job protobuf to dict so Airflow's template renderer can descend
-        # into nested fields (e.g. runnable.container.commands). See #37217.
-        if isinstance(job, Job):
-            self.job = Job.to_dict(job)
         self.polling_period_seconds = polling_period_seconds
         self.timeout_seconds = timeout_seconds
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
         self.deferrable = deferrable
         self.polling_period_seconds = polling_period_seconds
+
+    def prepare_template(self) -> None:
+        # Normalize Job protobuf to dict so Airflow's template renderer can descend
+        # into nested fields (e.g. runnable.container.commands) before rendering runs.
+        # See #37217.
+        if isinstance(self.job, Job):
+            self.job = Job.to_dict(self.job)
 
     def execute(self, context: Context):
         hook: CloudBatchHook = CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_batch.py
@@ -48,6 +48,7 @@ class TestCloudBatchSubmitJobOperator:
         operator = CloudBatchSubmitJobOperator(
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, job=JOB
         )
+        operator.prepare_template()
 
         completed_job = operator.execute(context=mock.MagicMock())
 
@@ -118,6 +119,18 @@ def _job_dict_with_template() -> dict:
 class TestCloudBatchSubmitJobOperatorTemplating:
     def test_template_fields_includes_job(self):
         assert "job" in CloudBatchSubmitJobOperator.template_fields
+
+    def test_protobuf_job_is_normalized_by_prepare_template_not_init(self):
+        job = batch_v1.Job.from_json(json.dumps(_job_dict_with_template()))
+        operator = CloudBatchSubmitJobOperator(
+            task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, job=job
+        )
+
+        assert isinstance(operator.job, batch_v1.Job)
+
+        operator.prepare_template()
+
+        assert isinstance(operator.job, dict)
 
     @pytest.mark.db_test
     @pytest.mark.parametrize(

--- a/scripts/ci/prek/validate_operators_init_exemptions.txt
+++ b/scripts/ci/prek/validate_operators_init_exemptions.txt
@@ -9,7 +9,6 @@ providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneS
 providers/amazon/src/airflow/providers/amazon/aws/operators/neptune.py::NeptuneStopDbClusterOperator
 providers/amazon/src/airflow/providers/amazon/aws/transfers/gcs_to_s3.py::GCSToS3Operator
 providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/operators/pod.py::KubernetesPodOperator
-providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py::CloudBatchSubmitJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_build.py::CloudBuildCreateBuildOperator
 providers/google/src/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py::CloudDataTransferServiceCreateJobOperator
 providers/google/src/airflow/providers/google/cloud/operators/dataproc.py::DataprocCreateClusterOperator


### PR DESCRIPTION
Moves `CloudBatchSubmitJobOperator`'s `Job` protobuf → dict normalization out of
`__init__`, as part of the exemption-list burn-down tracked in #70296.

Template fields are rendered after the constructor runs, so reading a template
field's value inside `__init__` operates on the un-rendered Jinja expression
rather than the real value. The `job` protobuf-to-dict conversion — added for
#37217 so the renderer can descend into nested fields such as a runnable's
container commands — is exactly that pattern.

The conversion has to run *before* Jinja rendering, not after: moving it to
`execute()` would silently stop nested Jinja expressions inside a `Job`
protobuf from ever being rendered. It now lives in `prepare_template()`, the
hook Airflow runs after construction but before rendering, matching the pattern
`CloudBuildCreateBuildOperator` already uses in this provider.

`CloudBatchSubmitJobOperator`'s entry is removed from
`validate_operators_init_exemptions.txt`.

The existing rendering test already covers both a `dict` and a protobuf `Job`
input; a new test asserts the normalization happens in `prepare_template()`
rather than the constructor.

related: #70296

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5 and Opus 5)

Generated-by: Claude Code (Sonnet 5 and Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
