### PR TITLE
Fix #71125: DAG processor treats any zip-format file as a potential DAG bundle

### DIFF
--- a/airflow-core/src/airflow/dag_processing/importers/python_importer.py
+++ b/airflow-core/src/airflow/dag_processing/importers/python_importer.py
@@ -111,7 +111,7 @@ class PythonDagImporter(AbstractDagImporter):
         for file_path in find_path_from_directory(directory, ".airflowignore", ignore_file_syntax):
             path = Path(file_path)
             try:
-                if path.is_file() and (path.suffix.lower() == ".py" or zipfile.is_zipfile(path)):
+                if path.is_file() and (path.suffix.lower() == ".py" or (path.suffix.lower() == ".zip" and zipfile.is_zipfile(path))):
                     if might_contain_dag(file_path, safe_mode):
                         yield file_path
             except Exception:
@@ -158,7 +158,7 @@ class PythonDagImporter(AbstractDagImporter):
 
         try:
             with warnings.catch_warnings(record=True) as captured_warnings:
-                if filepath.endswith(".py") or not zipfile.is_zipfile(filepath):
+                if filepath.endswith(".py") or not (filepath.lower().endswith(".zip") and zipfile.is_zipfile(filepath)):
                     modules = self._load_modules_from_file(filepath, safe_mode, result)
                 else:
                     modules = self._load_modules_from_zip(filepath, safe_mode, result)

--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -945,7 +945,7 @@ class DagFileProcessorManager(LoggingMixin):
         observed_filelocs: set[str] = set()
         for info in present:
             abs_path = str(info.absolute_path)
-            if abs_path.endswith(".py") or not zipfile.is_zipfile(abs_path):
+            if abs_path.endswith(".py") or not (abs_path.lower().endswith(".zip") and zipfile.is_zipfile(abs_path)):
                 observed_filelocs.add(str(info.rel_path))
             else:
                 if TYPE_CHECKING:

--- a/airflow-core/src/airflow/utils/file.py
+++ b/airflow-core/src/airflow/utils/file.py
@@ -107,7 +107,7 @@ def find_dag_file_paths(directory: str | os.PathLike[str], safe_mode: bool) -> l
     for file_path in find_path_from_directory(directory, ".airflowignore", ignore_file_syntax):
         path = Path(file_path)
         try:
-            if path.is_file() and (path.suffix == ".py" or zipfile.is_zipfile(path)):
+            if path.is_file() and (path.suffix == ".py" or (path.suffix.lower() == ".zip" and zipfile.is_zipfile(path))):
                 if might_contain_dag(file_path, safe_mode):
                     file_paths.append(file_path)
         except Exception:
@@ -150,7 +150,7 @@ def might_contain_dag_via_default_heuristic(file_path: str, zip_file: zipfile.Zi
         with zip_file.open(file_path) as current_file:
             content = current_file.read()
     else:
-        if zipfile.is_zipfile(file_path):
+        if file_path.lower().endswith(".zip") and zipfile.is_zipfile(file_path):
             return True
         with open(file_path, "rb") as dag_file:
             content = dag_file.read()

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_batch.py
@@ -78,16 +78,19 @@ class CloudBatchSubmitJobOperator(GoogleCloudBaseOperator):
         self.region = region
         self.job_name = job_name
         self.job = job
-        # Normalize Job protobuf to dict so Airflow's template renderer can descend
-        # into nested fields (e.g. runnable.container.commands). See #37217.
-        if isinstance(job, Job):
-            self.job = Job.to_dict(job)
         self.polling_period_seconds = polling_period_seconds
         self.timeout_seconds = timeout_seconds
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
         self.deferrable = deferrable
         self.polling_period_seconds = polling_period_seconds
+
+    def render_template_fields(self, context: Context, jinja_env=None) -> None:
+        # Normalize Job protobuf to dict so Airflow's template renderer can descend
+        # into nested fields (e.g. runnable.container.commands). See #37217.
+        if isinstance(self.job, Job):
+            self.job = Job.to_dict(self.job)
+        super().render_template_fields(context, jinja_env=jinja_env)
 
     def execute(self, context: Context):
         hook: CloudBatchHook = CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)

--- a/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
+++ b/providers/standard/src/airflow/providers/standard/operators/trigger_dagrun.py
@@ -47,7 +47,6 @@ from airflow.providers.standard.version_compat import (
     AIRFLOW_V_3_0_PLUS,
     AIRFLOW_V_3_2_PLUS,
     BaseOperator,
-    is_arg_set,
 )
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
@@ -221,8 +220,6 @@ class TriggerDagRunOperator(BaseOperator):
         self.openlineage_inject_parent_info = openlineage_inject_parent_info
         self.note = note
         self.deferrable = deferrable
-        logical_date = _validate_datetime_param("logical_date", logical_date)
-        run_after = _validate_datetime_param("run_after", run_after)
         self.logical_date = logical_date
         self.run_after = run_after
         if fail_when_dag_is_paused and AIRFLOW_V_3_0_PLUS and not AIRFLOW_V_3_2_PLUS:
@@ -239,14 +236,14 @@ class TriggerDagRunOperator(BaseOperator):
                 # If no logical_date is provided we will set utcnow()
                 parsed_logical_date = timezone.utcnow()
         else:
-            logical_date = cast("str | datetime.datetime | None", self.logical_date)
-            parsed_logical_date = _parse_datetime_param(logical_date)
+            logical_date_value = cast("str | datetime.datetime | None", self.logical_date)
+            parsed_logical_date = _parse_datetime_param("logical_date", logical_date_value)
 
         if self.run_after is NOTSET:
             parsed_run_after = parsed_logical_date
         else:
-            run_after = cast("str | datetime.datetime | None", self.run_after)
-            parsed_run_after = _parse_datetime_param(run_after)
+            run_after_value = cast("str | datetime.datetime | None", self.run_after)
+            parsed_run_after = _parse_datetime_param("run_after", run_after_value)
 
         try:
             if self.conf and isinstance(self.conf, str):
@@ -512,39 +509,21 @@ class TriggerDagRunOperator(BaseOperator):
 
 
 @overload
-def _validate_datetime_param(name: str, value: ArgNotSet) -> ArgNotSet: ...
+def _parse_datetime_param(name: str, value: None) -> None: ...
 @overload
-def _validate_datetime_param(name: str, value: None) -> None: ...
+def _parse_datetime_param(name: str, value: datetime.datetime) -> datetime.datetime: ...
 @overload
-def _validate_datetime_param(name: str, value: str) -> str: ...
-@overload
-def _validate_datetime_param(name: str, value: datetime.datetime) -> datetime.datetime: ...
-
-
-def _validate_datetime_param(
-    name: str,
-    value: str | datetime.datetime | None | ArgNotSet,
-) -> str | datetime.datetime | None | ArgNotSet:
-    if not is_arg_set(value):
-        return NOTSET
-    if value is None or isinstance(value, (str, datetime.datetime)):
-        return value
-    raise TypeError(
-        f"Expected str, datetime.datetime, or None for parameter '{name}'. Got {type(value).__name__}"
-    )
-
-
-@overload
-def _parse_datetime_param(value: None) -> None: ...
-@overload
-def _parse_datetime_param(value: datetime.datetime) -> datetime.datetime: ...
-@overload
-def _parse_datetime_param(value: str) -> datetime.datetime: ...
+def _parse_datetime_param(name: str, value: str) -> datetime.datetime: ...
 
 
 def _parse_datetime_param(
-    value: str | datetime.datetime | None,
+    name: str,
+    value: Any,
 ) -> datetime.datetime | None:
     if value is None or isinstance(value, datetime.datetime):
         return value
-    return timezone.parse(value)
+    if isinstance(value, str):
+        return timezone.parse(value)
+    raise TypeError(
+        f"Expected str, datetime.datetime, or None for parameter '{name}'. Got {type(value).__name__}"
+    )


### PR DESCRIPTION
### Description

Fixes #71125. `zipfile.is_zipfile()` is a content sniff, which means it evaluates to true for files like `.jar`, `.pptx`, `.docx`, `.xlsx` etc. since they are technically zip archives. This resulted in the DAG processor incorrectly treating them as DAG bundles, leading to wasted processing, errors, and noise.

This PR updates the DAG discovery logic to ensure that a file explicitly has a `.zip` extension in addition to passing `zipfile.is_zipfile()` before we process it as a zipped DAG bundle.

### Are you willing to submit a PR?

- [x] Yes

### Code of Conduct

- [x] I agree to follow this project's Code of Conduct