### PR TITLE
Clarify template-field validator guidance

### DIFF
--- a/scripts/ci/prek/validate_operators_init.py
+++ b/scripts/ci/prek/validate_operators_init.py
@@ -403,9 +403,11 @@ def _check_constructor_field_logic(
     if findings:
         console.print(
             f"{class_node.name}'s constructor applies logic to template fields. Template fields "
-            f"are rendered after the constructor runs, so validation or transformation here acts "
-            f"on the un-rendered Jinja expression and should move to execute() "
-            f"(see contributing-docs/05_pull_requests.rst):"
+            f"are rendered after the constructor runs, so value-dependent validation or transformation "
+            f"here acts on the un-rendered Jinja expression and should run in execute() or another method "
+            f"called after rendering. Checks that only ask whether an argument was passed belong in "
+            f"__init__ and should use explicit is None / is not None comparisons rather than truthiness. "
+            f"See https://github.com/apache/airflow/issues/70296#false-positives"
         )
         for lineno in sorted(findings):
             source = source_lines[lineno - 1].strip() if lineno <= len(source_lines) else ""

--- a/scripts/tests/ci/prek/test_validate_operators_init.py
+++ b/scripts/tests/ci/prek/test_validate_operators_init.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import pytest
 import validate_operators_init
+from rich.text import Text
 from validate_operators_init import (
     _check_constructor_field_logic,
     _check_constructor_template_fields,
@@ -130,6 +131,18 @@ class TestConstructorFieldLogic:
     )
     def test_flags_logic_but_not_sanctioned_patterns(self, ctor_body: str, expected: int):
         assert _logic_findings(_operator_code(ctor_body), ["foo"]) == expected
+
+    def test_failure_message_explains_provision_check_exception(self):
+        code = _operator_code("self._validate(foo)\nself.foo = foo")
+        with validate_operators_init.console.capture() as capture:
+            assert _logic_findings(code, ["foo"]) == 1
+
+        output = " ".join(Text.from_ansi(capture.get()).plain.split())
+        assert "value-dependent validation or transformation" in output
+        assert "whether an argument was passed" in output
+        assert "is None" in output
+        assert "is not None" in output
+        assert "https://github.com/apache/airflow/issues/70296#false-positives" in output
 
     def test_name_in_parameter_default_is_not_the_field(self):
         # A field named like a module (e.g. "conf") used in a parameter default evaluates at


### PR DESCRIPTION
Clarify the `validate-operators-init` diagnostic at the point where contributors encounter template-field constructor logic.

The burn-down distinguishes value-dependent validation or transformation, which must run after template rendering, from argument-provision checks, which belong in `__init__`. The current message only recommends moving logic to `execute()`, making the documented exception easy to miss. This change names both cases, links the issue's false-positive guidance, and adds regression coverage for the emitted diagnostic without changing validator semantics or the exemption list.

related: #70296

Testing:
- `uv run --frozen pytest scripts/tests/ci/prek/test_validate_operators_init.py -q` (49 passed)
- `uv run --frozen pytest scripts/tests/ci/prek -q` (845 passed)
- Applicable pre-commit hooks, including `mypy-scripts` (245 files) and `mypy-devel-common` (100 files)
- Manual-stage hooks
- `breeze ci selective-check --commit-ref HEAD`

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Codex (GPT-5)

Generated-by: Codex (GPT-5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---
Drafted-by: Codex (GPT-5) (no human review before posting)