### PR TITLE
Improve confirmation output when connections are added via cli

### DIFF
--- a/airflow-core/src/airflow/cli/commands/connection_command.py
+++ b/airflow-core/src/airflow/cli/commands/connection_command.py
@@ -29,6 +29,7 @@ from urllib.parse import urlsplit, urlunsplit
 from sqlalchemy import select
 from sqlalchemy.orm import exc
 
+from airflow._shared.secrets_masker import redact
 from airflow.cli.simple_table import AirflowConsole
 from airflow.cli.utils import (
     SENSITIVE_PLACEHOLDER,
@@ -365,22 +366,19 @@ def connections_add(args):
     with create_session() as session:
         if not session.scalar(select(Connection).where(Connection.conn_id == new_conn.conn_id).limit(1)):
             session.add(new_conn)
-            msg = "Successfully added `conn_id`={conn_id} : {uri}"
-            msg = msg.format(
-                conn_id=new_conn.conn_id,
-                uri=args.conn_uri
-                or urlunsplit(
-                    (
-                        new_conn.conn_type,
-                        f"{new_conn.login or ''}:{'******' if new_conn.password else ''}"
-                        f"@{new_conn.host or ''}:{new_conn.port or ''}",
-                        new_conn.schema or "",
-                        "",
-                        "",
-                    )
-                ),
+            print(f"Successfully added `conn_id`={new_conn.conn_id}")
+            AirflowConsole().print_as(
+                data=[new_conn],
+                output="table",
+                mapper=lambda conn: {
+                    "conn_id": conn.conn_id,
+                    "conn_type": conn.conn_type,
+                    "host": conn.host,
+                    "login": conn.login,
+                    "port": conn.port,
+                    "extra": redact(conn.extra_dejson),
+                },
             )
-            print(msg)
         else:
             msg = f"A connection with `conn_id`={new_conn.conn_id} already exists."
             raise SystemExit(msg)

--- a/airflow-core/tests/unit/cli/commands/test_connection_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_connection_command.py
@@ -481,7 +481,7 @@ class TestCliAddConnections:
                     "new0-json",
                     f"--conn-json={TEST_JSON}",
                 ],
-                "Successfully added `conn_id`=new0-json : postgres://airflow:******@host:5432/airflow",
+                "Successfully added `conn_id`=new0-json",
                 {
                     "conn_type": "postgres",
                     "description": "new0-json description",
@@ -503,7 +503,7 @@ class TestCliAddConnections:
                     f"--conn-uri={TEST_URL}",
                     "--conn-description=new0 description",
                 ],
-                "Successfully added `conn_id`=new0 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new0",
                 {
                     "conn_type": "postgres",
                     "description": "new0 description",
@@ -525,7 +525,7 @@ class TestCliAddConnections:
                     f"--conn-uri={TEST_URL}",
                     "--conn-description=new1 description",
                 ],
-                "Successfully added `conn_id`=new1 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new1",
                 {
                     "conn_type": "postgres",
                     "description": "new1 description",
@@ -548,7 +548,7 @@ class TestCliAddConnections:
                     "--conn-extra",
                     '{"extra": "yes"}',
                 ],
-                "Successfully added `conn_id`=new2 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new2",
                 {
                     "conn_type": "postgres",
                     "description": None,
@@ -573,7 +573,7 @@ class TestCliAddConnections:
                     "--conn-description",
                     "new3 description",
                 ],
-                "Successfully added `conn_id`=new3 : postgresql://airflow:airflow@host:5432/airflow",
+                "Successfully added `conn_id`=new3",
                 {
                     "conn_type": "postgres",
                     "description": "new3 description",
@@ -600,7 +600,7 @@ class TestCliAddConnections:
                     "--conn-schema=airflow",
                     "--conn-description=  new4 description  ",
                 ],
-                "Successfully added `conn_id`=new4 : hive_metastore://airflow:******@host:9083/airflow",
+                "Successfully added `conn_id`=new4",
                 {
                     "conn_type": "hive_metastore",
                     "description": "  new4 description  ",
@@ -626,7 +626,7 @@ class TestCliAddConnections:
                     '{"extra": "yes"}',
                     "--conn-description=new5 description",
                 ],
-                "Successfully added `conn_id`=new5 : google_cloud_platform://:@:",
+                "Successfully added `conn_id`=new5",
                 {
                     "conn_type": "google_cloud_platform",
                     "description": "new5 description",
@@ -642,7 +642,7 @@ class TestCliAddConnections:
             ),
             pytest.param(
                 ["connections", "add", "new6", "--conn-uri", "aws://?region_name=foo-bar-1"],
-                "Successfully added `conn_id`=new6 : aws://?region_name=foo-bar-1",
+                "Successfully added `conn_id`=new6",
                 {
                     "conn_type": "aws",
                     "description": None,
@@ -658,7 +658,7 @@ class TestCliAddConnections:
             ),
             pytest.param(
                 ["connections", "add", "new7", "--conn-uri", "aws://@/?region_name=foo-bar-1"],
-                "Successfully added `conn_id`=new7 : aws://@/?region_name=foo-bar-1",
+                "Successfully added `conn_id`=new7",
                 {
                     "conn_type": "aws",
                     "description": None,


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

## Why and What?
The success message reconstructed a URI from login/host/port even when those fields were never set, producing a misleading `aws://:@:` and never showing what was actually stored in `extra`. Replace it with a table (reusing the CLI's existing table renderer) that shows the fields that were actually set, with `extra` passed through the shared secrets masker so sensitive keys are redacted per-key instead of the confirmation omitting `extra` entirely.

## Testing

To test, created this script:
```shell
#!/usr/bin/env bash
# Demo script for the new `airflow connections add` confirmation output.
# Run via breeze from the repo root:
#   breeze run bash dev/demo_connections_add.sh
set -euo pipefail

CONN_IDS=(
  demo_aws_extra_only
  demo_aws_with_secret
  demo_postgres_uri
  demo_generic_discrete
  demo_generic_json
)

cleanup() {
  for conn_id in "${CONN_IDS[@]}"; do
    airflow connections delete "$conn_id" >/dev/null 2>&1 || true
  done
}
trap cleanup EXIT

cleanup

echo "=== 1. Extra-only AWS connection (no host/login/password) ==="
airflow connections add demo_aws_extra_only \
  --conn-type aws \
  --conn-extra '{"region_name": "us-east-1"}'

echo
echo "=== 2. AWS connection with a sensitive key in extra (gets redacted) ==="
airflow connections add demo_aws_with_secret \
  --conn-type aws \
  --conn-extra '{"region_name": "us-east-1", "aws_secret_access_key": "supersecretvalue"}'

echo
echo "=== 3. Postgres connection via --conn-uri ==="
airflow connections add demo_postgres_uri \
  --conn-uri 'postgresql://airflow:airflow@localhost:5432/airflow'

echo
echo "=== 4. Generic connection via discrete flags ==="
airflow connections add demo_generic_discrete \
  --conn-type generic \
  --conn-host example.com \
  --conn-login myuser \
  --conn-port 443

echo
echo "=== 5. Connection via --conn-json with nested extra ==="
airflow connections add demo_generic_json \
  --conn-json '{"conn_type": "generic", "host": "example.com", "extra": {"api_key": "shouldberedacted", "region": "eu-west-1"}}'

```

Output:

```shell
[Breeze:3.10.20] root@4f2541c6e55f:/opt/airflow$  bash dev/demo_connections_add.sh
=== 1. Extra-only AWS connection (no host/login/password) ===
Successfully added `conn_id`=demo_aws_extra_only
conn_id             | conn_type | host | login | port | extra
====================+===========+======+=======+======+=============================
demo_aws_extra_only | aws       | None | None  | None | {'region_name': 'us-east-1'}


=== 2. AWS connection with a sensitive key in extra (gets redacted) ===
Successfully added `conn_id`=demo_aws_with_secret
conn_id              | conn_type | host | login | port | extra
=====================+===========+======+=======+======+=============================================================
demo_aws_with_secret | aws       | None | None  | None | {'region_name': 'us-east-1', 'aws_secret_access_key': '***'}


=== 3. Postgres connection via --conn-uri ===
Successfully added `conn_id`=demo_postgres_uri
conn_id           | conn_type | host      | login   | port | extra
==================+===========+===========+=========+======+======
demo_postgres_uri | postgres  | localhost | airflow | 5432 | {}


=== 4. Generic connection via discrete flags ===
Successfully added `conn_id`=demo_generic_discrete
conn_id               | conn_type | host        | login  | port | extra
======================+===========+=============+========+======+======
demo_generic_discrete | generic   | example.com | myuser | 443  | {}


=== 5. Connection via --conn-json with nested extra ===
Successfully added `conn_id`=demo_generic_json
conn_id           | conn_type | host        | login | port | extra
==================+===========+=============+=======+======+==========================================
demo_generic_json | generic   | example.com | None  | None | {'api_key': '***', 'region': 'eu-west-1'}

```




---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
