### PR TITLE
Optimize scheduler backfill completion updates

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2458,30 +2458,34 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
         self.log.debug("checking for completed backfills.")
         unfinished_states = (DagRunState.RUNNING, DagRunState.QUEUED)
         now = timezone.utcnow()
-        # todo: AIP-78 simplify this function to an update statement
         initializing_cutoff = now - timedelta(minutes=2)
-        query = select(Backfill).where(
-            Backfill.completed_at.is_(None),
-            # Guard: backfill must have at least one association,
-            # otherwise it is still being set up (see #61375).
-            # Allow cleanup of orphaned backfills older than 2 minutes
-            # that failed during initialization and never got any associations.
-            or_(
-                exists(select(BackfillDagRun.id).where(BackfillDagRun.backfill_id == Backfill.id)),
-                Backfill.created_at < initializing_cutoff,
-            ),
-            ~exists(
-                select(DagRun.id).where(
-                    and_(DagRun.backfill_id == Backfill.id, DagRun.state.in_(unfinished_states))
+        result = cast(
+            "CursorResult",
+            session.execute(
+                update(Backfill)
+                .where(
+                    Backfill.completed_at.is_(None),
+                    # Guard: backfill must have at least one association,
+                    # otherwise it is still being set up (see #61375).
+                    # Allow cleanup of orphaned backfills older than 2 minutes
+                    # that failed during initialization and never got any associations.
+                    or_(
+                        exists(select(BackfillDagRun.id).where(BackfillDagRun.backfill_id == Backfill.id)),
+                        Backfill.created_at < initializing_cutoff,
+                    ),
+                    ~exists(
+                        select(DagRun.id).where(
+                            and_(DagRun.backfill_id == Backfill.id, DagRun.state.in_(unfinished_states))
+                        )
+                    ),
                 )
+                .values(completed_at=now)
+                .execution_options(synchronize_session=False)
             ),
         )
-        backfills = list(session.scalars(query))
-        if not backfills:
-            return
-        self.log.info("marking %s backfills as complete", len(backfills))
-        for b in backfills:
-            b.completed_at = now
+        updated_count = max(result.rowcount or 0, 0)
+        if updated_count > 0:
+            self.log.info("marking %s backfills as complete", updated_count)
 
     def _create_dag_runs(self, dag_models: Collection[DagModel], session: Session) -> None:
         """Create a DAG run and update the dag_model to control if/when the next DAGRun should be created."""

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10862,6 +10862,54 @@ def test_mark_backfills_completed(dag_maker, session):
     assert b.completed_at.timestamp() > 0
 
 
+def test_mark_backfills_complete_uses_single_update_statement(dag_maker, session):
+    clear_db_backfills()
+    dag_id = "test_backfill_single_update"
+    with dag_maker(serialized=True, dag_id=dag_id, schedule="@daily"):
+        BashOperator(task_id="hi", bash_command="echo hi")
+    b = Backfill(
+        dag_id=dag_id,
+        from_date=pendulum.parse("2021-01-01"),
+        to_date=pendulum.parse("2021-01-03"),
+        max_active_runs=10,
+        dag_run_conf={},
+        reprocess_behavior=ReprocessBehavior.NONE,
+    )
+    session.add(b)
+    session.commit()
+    backfill_id = b.id
+    dr = DagRun(
+        dag_id=dag_id,
+        run_id="backfill__2021-01-01T00:00:00+00:00",
+        run_type=DagRunType.BACKFILL_JOB,
+        logical_date=pendulum.parse("2021-01-01"),
+        data_interval=(pendulum.parse("2021-01-01"), pendulum.parse("2021-01-02")),
+        run_after=pendulum.parse("2021-01-02"),
+        state=DagRunState.SUCCESS,
+        backfill_id=backfill_id,
+    )
+    session.add(dr)
+    session.flush()
+    session.add(
+        BackfillDagRun(
+            backfill_id=backfill_id,
+            dag_run_id=dr.id,
+            logical_date=pendulum.parse("2021-01-01"),
+            sort_ordinal=1,
+        )
+    )
+    session.commit()
+    session.expunge_all()
+    runner = SchedulerJobRunner(
+        job=Job(job_type=SchedulerJobRunner.job_type), executors=[MockExecutor(do_update=False)]
+    )
+    with assert_queries_count(1, session=session):
+        runner._mark_backfills_complete(session=session)
+    session.expire_all()
+    b = session.get(Backfill, backfill_id)
+    assert b.completed_at is not None
+
+
 def test_mark_backfills_complete_skips_initializing_backfill(dag_maker, session):
     clear_db_backfills()
     dag_id = "test_backfill_race_lifecycle"


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->
## Why:

The scheduler checks whether backfills are complete as part of its regular loop. The previous implementation loaded every matching `Backfill` row into the ORM session and then updated each object in Python, even though the completion condition can be expressed entirely in SQL.

Using a bulk update keeps this scheduler path lighter while preserving the existing AIP-78 backfill lifecycle guards.

## Solution:

Update `_mark_backfills_complete()` to issue a single bulk `UPDATE` for backfills that are ready to complete.

The existing guards are preserved:
- initializing backfills without associations are skipped
- orphaned backfills older than the cutoff can still be completed
- backfills with queued or running Dag runs stay active

Add a regression test that verifies the completion path uses a single update statement.



##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
