### PR TITLE
Fix Java Beam SDK example to target Java 11

### DIFF
--- a/providers/google/tests/system/google/cloud/dataflow/resources/non_python_src/java_streaming_src/README.MD
+++ b/providers/google/tests/system/google/cloud/dataflow/resources/non_python_src/java_streaming_src/README.MD
@@ -1,6 +1,6 @@
 # Dataflow Java Streaming
 
-This project is a streaming example running with latest Apache Beam Java SDK (v.2.63),
+This project is a streaming example running with latest Apache Beam Java SDK (v.2.75),
 as there is no "official" streaming example yet https://beam.apache.org/get-started/wordcount-example/.
 
 Sample logic to direct streaming data from input Pub/Sub source to the output PubSub topic to work
@@ -11,7 +11,7 @@ That used for Java dataflow streaming system tests.
 
 ## Requirements
 
-- **Java 17**: Ensure you have Java 17 installed and configured on your system.
+- **Java 11 or higher**: Ensure you have Java installed and configured on your system
 - **Maven**: Make sure Maven is installed and configured on your system.
 - Maven is used for dependency management and building the project.
 

--- a/providers/google/tests/system/google/cloud/dataflow/resources/non_python_src/java_streaming_src/pom.xml
+++ b/providers/google/tests/system/google/cloud/dataflow/resources/non_python_src/java_streaming_src/pom.xml
@@ -26,16 +26,15 @@
     <version>v-0.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <beam.version>2.63.0</beam.version>
-        <slf4j.version>2.0.16</slf4j.version>
-        <google.cloud.version>1.113.0</google.cloud.version>
+        <beam.version>2.75.0</beam.version>
+        <slf4j.version>2.0.18</slf4j.version>
+        <google.cloud.version>1.152.0</google.cloud.version>
         <secretmanager.version>2.45.0</secretmanager.version>
         <iamcredentials.version>2.45.0</iamcredentials.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
 
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     </properties>
     <dependencies>
         <!--        Beam Dependencies-->


### PR DESCRIPTION
We use Java 11 in a breeze container. Java is backwards compatible and it also works with the more recent releases.
Also updated dependencies. JAR file in the GCS has already been updated.