### PR TITLE
Add startup probe for Kerberos worker sidecars

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -175,6 +175,15 @@ spec:
       {{- end }}
       args: ["kerberos"]
       resources: {{- toYaml .Values.workers.kubernetes.kerberosSidecar.resources | nindent 8 }}
+      {{- if .Values.workers.kubernetes.kerberosSidecar.startupProbe.enabled }}
+      startupProbe:
+        exec:
+          command: ["klist", "-s"]
+        timeoutSeconds: {{ .Values.workers.kubernetes.kerberosSidecar.startupProbe.timeoutSeconds }}
+        initialDelaySeconds: {{ .Values.workers.kubernetes.kerberosSidecar.startupProbe.initialDelaySeconds }}
+        periodSeconds: {{ .Values.workers.kubernetes.kerberosSidecar.startupProbe.periodSeconds }}
+        failureThreshold: {{ .Values.workers.kubernetes.kerberosSidecar.startupProbe.failureThreshold }}
+      {{- end }}
       volumeMounts:
         - name: logs
           mountPath: {{ template "airflow_logs" . }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -403,6 +403,15 @@ spec:
           {{- end }}
           args: ["kerberos"]
           resources: {{- toYaml .Values.workers.celery.kerberosSidecar.resources | nindent 12 }}
+          {{- if .Values.workers.celery.kerberosSidecar.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command: ["klist", "-s"]
+            timeoutSeconds: {{ .Values.workers.celery.kerberosSidecar.startupProbe.timeoutSeconds }}
+            initialDelaySeconds: {{ .Values.workers.celery.kerberosSidecar.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.workers.celery.kerberosSidecar.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.workers.celery.kerberosSidecar.startupProbe.failureThreshold }}
+          {{- end }}
           volumeMounts:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}

--- a/chart/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/chart/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -1343,6 +1343,52 @@ class TestPodTemplateFile:
             "allowPrivilegeEscalation": False
         }
 
+    @pytest.mark.parametrize(
+        ("override", "expected"),
+        [
+            (
+                {},
+                {
+                    "exec": {"command": ["klist", "-s"]},
+                    "timeoutSeconds": 5,
+                    "initialDelaySeconds": 0,
+                    "periodSeconds": 10,
+                    "failureThreshold": 6,
+                },
+            ),
+            (
+                {
+                    "timeoutSeconds": 11,
+                    "initialDelaySeconds": 12,
+                    "periodSeconds": 13,
+                    "failureThreshold": 14,
+                },
+                {
+                    "exec": {"command": ["klist", "-s"]},
+                    "timeoutSeconds": 11,
+                    "initialDelaySeconds": 12,
+                    "periodSeconds": 13,
+                    "failureThreshold": 14,
+                },
+            ),
+            ({"enabled": False}, None),
+        ],
+        ids=["default", "custom", "disabled"],
+    )
+    def test_kerberos_sidecar_startup_probe(self, override, expected):
+        docs = render_chart(
+            values={
+                "workers": {"kubernetes": {"kerberosSidecar": {"enabled": True, "startupProbe": override}}}
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert (
+            jmespath.search("spec.containers[?name=='worker-kerberos'] | [0].startupProbe", docs[0])
+            == expected
+        )
+
     def test_kerberos_init_container_default(self):
         docs = render_chart(
             show_only=["templates/pod-template-file.yaml"],

--- a/chart/tests/helm_tests/airflow_aux/test_pod_template_file.py
+++ b/chart/tests/helm_tests/airflow_aux/test_pod_template_file.py
@@ -22,7 +22,7 @@ from shutil import copyfile, copytree
 
 import jmespath
 import pytest
-from chart_utils.helm_template_generator import render_chart
+from chart_utils.helm_template_generator import HelmFailedError, render_chart
 
 
 @pytest.fixture(scope="class")
@@ -1388,6 +1388,28 @@ class TestPodTemplateFile:
             jmespath.search("spec.containers[?name=='worker-kerberos'] | [0].startupProbe", docs[0])
             == expected
         )
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"timeoutSeconds": 0},
+            {"initialDelaySeconds": -1},
+            {"periodSeconds": 0},
+            {"failureThreshold": 0},
+        ],
+        ids=["timeout", "initial-delay", "period", "failure-threshold"],
+    )
+    def test_kerberos_sidecar_startup_probe_rejects_invalid_values(self, override):
+        with pytest.raises(HelmFailedError):
+            render_chart(
+                values={
+                    "workers": {
+                        "kubernetes": {"kerberosSidecar": {"enabled": True, "startupProbe": override}}
+                    }
+                },
+                show_only=["templates/pod-template-file.yaml"],
+                chart_dir=self.temp_chart_dir,
+            )
 
     def test_kerberos_init_container_default(self):
         docs = render_chart(

--- a/chart/tests/helm_tests/security/test_kerberos.py
+++ b/chart/tests/helm_tests/security/test_kerberos.py
@@ -20,7 +20,7 @@ import json
 
 import jmespath
 import pytest
-from chart_utils.helm_template_generator import render_chart
+from chart_utils.helm_template_generator import HelmFailedError, render_chart
 
 
 class TestKerberos:
@@ -202,3 +202,23 @@ class TestKerberos:
             )
             == expected
         )
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"timeoutSeconds": 0},
+            {"initialDelaySeconds": -1},
+            {"periodSeconds": 0},
+            {"failureThreshold": 0},
+        ],
+        ids=["timeout", "initial-delay", "period", "failure-threshold"],
+    )
+    def test_kerberos_sidecar_startup_probe_rejects_invalid_values(self, override):
+        with pytest.raises(HelmFailedError):
+            render_chart(
+                values={
+                    "executor": "CeleryExecutor",
+                    "workers": {"celery": {"kerberosSidecar": {"enabled": True, "startupProbe": override}}},
+                },
+                show_only=["templates/workers/worker-deployment.yaml"],
+            )

--- a/chart/tests/helm_tests/security/test_kerberos.py
+++ b/chart/tests/helm_tests/security/test_kerberos.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 
 import jmespath
+import pytest
 from chart_utils.helm_template_generator import render_chart
 
 
@@ -153,3 +154,51 @@ class TestKerberos:
         )
 
         assert len(docs) == 0
+
+    @pytest.mark.parametrize(
+        ("override", "expected"),
+        [
+            (
+                {},
+                {
+                    "exec": {"command": ["klist", "-s"]},
+                    "timeoutSeconds": 5,
+                    "initialDelaySeconds": 0,
+                    "periodSeconds": 10,
+                    "failureThreshold": 6,
+                },
+            ),
+            (
+                {
+                    "timeoutSeconds": 11,
+                    "initialDelaySeconds": 12,
+                    "periodSeconds": 13,
+                    "failureThreshold": 14,
+                },
+                {
+                    "exec": {"command": ["klist", "-s"]},
+                    "timeoutSeconds": 11,
+                    "initialDelaySeconds": 12,
+                    "periodSeconds": 13,
+                    "failureThreshold": 14,
+                },
+            ),
+            ({"enabled": False}, None),
+        ],
+        ids=["default", "custom", "disabled"],
+    )
+    def test_kerberos_sidecar_startup_probe(self, override, expected):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {"celery": {"kerberosSidecar": {"enabled": True, "startupProbe": override}}},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert (
+            jmespath.search(
+                "spec.template.spec.containers[?name=='worker-kerberos'] | [0].startupProbe", docs[0]
+            )
+            == expected
+        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2124,22 +2124,26 @@
                                         "timeoutSeconds": {
                                             "description": "Number of seconds after which the probe times out.",
                                             "type": "integer",
-                                            "default": 5
+                                            "default": 5,
+                                            "minimum": 1
                                         },
                                         "initialDelaySeconds": {
                                             "description": "Number of seconds after the container has started before the startup probe is initiated.",
                                             "type": "integer",
-                                            "default": 0
+                                            "default": 0,
+                                            "minimum": 0
                                         },
                                         "periodSeconds": {
                                             "description": "How often (in seconds) to perform the probe.",
                                             "type": "integer",
-                                            "default": 10
+                                            "default": 10,
+                                            "minimum": 1
                                         },
                                         "failureThreshold": {
                                             "description": "Number of consecutive failures required for the startup probe to fail.",
                                             "type": "integer",
-                                            "default": 6
+                                            "default": 6,
+                                            "minimum": 1
                                         }
                                     }
                                 },
@@ -2904,22 +2908,26 @@
                                         "timeoutSeconds": {
                                             "description": "Number of seconds after which the probe times out.",
                                             "type": "integer",
-                                            "default": 5
+                                            "default": 5,
+                                            "minimum": 1
                                         },
                                         "initialDelaySeconds": {
                                             "description": "Number of seconds after the container has started before the startup probe is initiated.",
                                             "type": "integer",
-                                            "default": 0
+                                            "default": 0,
+                                            "minimum": 0
                                         },
                                         "periodSeconds": {
                                             "description": "How often (in seconds) to perform the probe.",
                                             "type": "integer",
-                                            "default": 10
+                                            "default": 10,
+                                            "minimum": 1
                                         },
                                         "failureThreshold": {
                                             "description": "Number of consecutive failures required for the startup probe to fail.",
                                             "type": "integer",
-                                            "default": 6
+                                            "default": 6,
+                                            "minimum": 1
                                         }
                                     }
                                 },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2111,6 +2111,38 @@
                                     "type": "boolean",
                                     "default": false
                                 },
+                                "startupProbe": {
+                                    "description": "Startup probe for the Kerberos worker sidecar (runs `klist -s`).",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "Enable the Kerberos sidecar startup probe. Disable for custom images without `klist`.",
+                                            "type": "boolean",
+                                            "default": true
+                                        },
+                                        "timeoutSeconds": {
+                                            "description": "Number of seconds after which the probe times out.",
+                                            "type": "integer",
+                                            "default": 5
+                                        },
+                                        "initialDelaySeconds": {
+                                            "description": "Number of seconds after the container has started before the startup probe is initiated.",
+                                            "type": "integer",
+                                            "default": 0
+                                        },
+                                        "periodSeconds": {
+                                            "description": "How often (in seconds) to perform the probe.",
+                                            "type": "integer",
+                                            "default": 10
+                                        },
+                                        "failureThreshold": {
+                                            "description": "Number of consecutive failures required for the startup probe to fail.",
+                                            "type": "integer",
+                                            "default": 6
+                                        }
+                                    }
+                                },
                                 "resources": {
                                     "description": "Resources on kerberos sidecar.",
                                     "type": "object",
@@ -2858,6 +2890,38 @@
                                     "description": "Enable Kerberos sidecar.",
                                     "type": "boolean",
                                     "default": false
+                                },
+                                "startupProbe": {
+                                    "description": "Startup probe for the Kerberos worker sidecar (runs `klist -s`).",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "description": "Enable the Kerberos sidecar startup probe. Disable for custom images without `klist`.",
+                                            "type": "boolean",
+                                            "default": true
+                                        },
+                                        "timeoutSeconds": {
+                                            "description": "Number of seconds after which the probe times out.",
+                                            "type": "integer",
+                                            "default": 5
+                                        },
+                                        "initialDelaySeconds": {
+                                            "description": "Number of seconds after the container has started before the startup probe is initiated.",
+                                            "type": "integer",
+                                            "default": 0
+                                        },
+                                        "periodSeconds": {
+                                            "description": "How often (in seconds) to perform the probe.",
+                                            "type": "integer",
+                                            "default": 10
+                                        },
+                                        "failureThreshold": {
+                                            "description": "Number of consecutive failures required for the startup probe to fail.",
+                                            "type": "integer",
+                                            "default": 6
+                                        }
+                                    }
                                 },
                                 "resources": {
                                     "description": "Resources on kerberos sidecar.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -839,6 +839,15 @@ workers:
       # Container level lifecycle hooks
       containerLifecycleHooks: {}
 
+      # Startup probe for the kerberos sidecar: `klist -s` succeeds once the credential
+      # cache holds a valid, unexpired ticket. Disable for custom images without `klist`.
+      startupProbe:
+        enabled: true
+        timeoutSeconds: 5
+        initialDelaySeconds: 0
+        periodSeconds: 10
+        failureThreshold: 6
+
     # Kerberos init container configuration for Airflow Celery workers
     # If not set, the values from `workers.kerberosInitContainer` section will be used.
     kerberosInitContainer:
@@ -1085,6 +1094,15 @@ workers:
 
       # Container level lifecycle hooks
       containerLifecycleHooks: {}
+
+      # Startup probe for the kerberos sidecar: `klist -s` succeeds once the credential
+      # cache holds a valid, unexpired ticket. Disable for custom images without `klist`.
+      startupProbe:
+        enabled: true
+        timeoutSeconds: 5
+        initialDelaySeconds: 0
+        periodSeconds: 10
+        failureThreshold: 6
 
     # Kerberos init container configuration for pods created with pod-template-file
     # If not set, the values from `workers.kerberosInitContainer` section will be used.


### PR DESCRIPTION
related: #35154

## Summary

Add a configurable `klist -s` startup probe to Kerberos worker sidecars as a prerequisite for adopting native Kubernetes sidecars.

| File | Purpose and design principle |
| --- | --- |
| `chart/values.yaml` | Defines default-enabled probe settings for Celery and Kubernetes workers. The approximately 60-second failure window allows time to obtain the initial Kerberos credentials. |
| `chart/values.schema.json` | Validates the new settings and intentionally exposes only enablement and timing controls. The probe type and command remain fixed to preserve its Kerberos-specific semantics. |
| `chart/templates/workers/worker-deployment.yaml` | Renders the `klist -s` exec probe for the Celery worker Kerberos sidecar. Users of custom images without `klist` can disable it. |
| `chart/files/pod-template-file.kubernetes-helm-yaml` | Applies the same probe contract to the KubernetesExecutor worker pod template. |
| `chart/tests/helm_tests/security/test_kerberos.py` | Verifies the Celery worker probe's default, customized, and disabled rendering. |
| `chart/tests/helm_tests/airflow_aux/test_pod_template_file.py` | Verifies the same three cases for the KubernetesExecutor pod template. |

<br>

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (please specify the tool below)

Generated-by: [GPT 5.6-sol] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

