### PR TITLE
Stop Dependabot from raising Go SDK PRs against v3-3-test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -371,26 +371,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
-  - package-ecosystem: "gomod"
-    cooldown:
-      # Longer than other ecosystems: distributed Go releases are not pre-scanned by a
-      # central registry, so we give any malicious release more time to be flagged.
-      default-days: 14
-    directory: "/go-sdk"
-    schedule:
-      interval: "weekly"
-    target-branch: v3-3-test
-    groups:
-      3-3-go-sdk-dependency-updates:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
   - package-ecosystem: "uv"
     cooldown:
       default-days: 4
@@ -422,6 +402,20 @@ updates:
     open-pull-requests-limit: 0
     groups:
       go-sdk-security-updates:
+        patterns:
+          - "*"
+        applies-to: security-updates
+
+  - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 14
+    directory: "/go-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: v3-3-test
+    open-pull-requests-limit: 0
+    groups:
+      3-3-go-sdk-security-updates:
         patterns:
           - "*"
         applies-to: security-updates


### PR DESCRIPTION
- related: https://github.com/apache/airflow/pull/71020#pullrequestreview-4872489614
- related: #70914, #70915

## Why

Dependabot opened #71020 bumping a Go SDK dependency against `v3-3-test`. In review, jason810496 flagged that we shouldn't raise any Dependabot PRs for the Go SDK against release-test branches at all, since the Go SDK only ever releases from `main`.

## What

- Rework the `gomod`/`/go-sdk` Dependabot block targeting `v3-3-test` to match the default-branch block's security-only pattern (`open-pull-requests-limit: 0`, security-updates-only group), instead of raising routine version-update PRs.

Once this merges, #71020 should be closed manually — this config change doesn't retroactively close a PR Dependabot already opened.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Sonnet 5)

Generated-by: Claude Code (Sonnet 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
