### PR TITLE
Flag airflow-ctl release-branch sync PRs for backport-to-v0-1-test attention

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -381,13 +381,18 @@ labelPRBasedOnFilePath:
       - ^main$
 
   # Apply to PRs touching airflow-ctl code so the release manager notices when a
-  # fix should land on the airflow-ctl/v0-1-test maintenance branch.
-  # Scoped to PRs targeting `main` only.
+  # fix should land on the airflow-ctl/v0-1-test maintenance branch. Also covers
+  # PRs opened directly against the release branches themselves (e.g. the
+  # main->v0-1-test and v0-1-test->v0-1-stable sync PRs) — those are exactly
+  # where branch-specific paths like .pre-commit-config.yaml have drifted
+  # silently in the past (see #71096).
   backport-to-airflow-ctl/v0-1-test:
     paths:
       - airflow-ctl/**/*
     targetBranchFilter:
       - ^main$
+      - ^airflow-ctl/v0-1-test$
+      - ^airflow-ctl/v0-1-stable$
 
   kind:documentation:
     - airflow-core/docs/**/*


### PR DESCRIPTION
The `backport-to-airflow-ctl/v0-1-test` label only fired for PRs targeting main. The `main->v0-1-test` and `v0-1-test->v0-1-stable` sync PRs target the release branches directly, so they never got flagged even though that is exactly where branch-specific paths (e.g. `airflow-ctl/.pre-commit-config.yaml` pointing at a script that only exists on one branch) have silently drifted before, causing #71096.

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
