### PR TITLE
Add terminationGracePeriodSeconds support for PgBouncer in Helm chart

### DIFF
--- a/chart/newsfragments/71237.significant.rst
+++ b/chart/newsfragments/71237.significant.rst
@@ -1,0 +1,5 @@
+PgBouncer Deployment now sets ``terminationGracePeriodSeconds`` (default ``120``)
+
+The PgBouncer Deployment previously relied on the Kubernetes default termination grace period of 30 seconds, which SIGKILLed the pod mid-drain: the chart's default preStop hook (``killall -INT pgbouncer && sleep 120``) needs up to 120 seconds to drain client connections, so on a node drain or eviction in-flight connections were cut after 30 seconds instead of being released.
+
+The new ``pgbouncer.terminationGracePeriodSeconds`` value defaults to ``120`` to match the preStop drain window. PgBouncer exits as soon as the last client connection is released, so the full 120 seconds is an upper bound, not a fixed wait. Set the value to ``30`` to restore the previous behaviour.

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -87,6 +87,7 @@ spec:
       {{- end }}
       tolerations: {{- toYaml $tolerations | nindent 8 }}
       topologySpreadConstraints: {{- toYaml $topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.pgbouncer.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "pgbouncer.serviceAccountName" . }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       securityContext: {{ $securityContext | nindent 8 }}

--- a/chart/tests/helm_tests/other/test_pgbouncer.py
+++ b/chart/tests/helm_tests/other/test_pgbouncer.py
@@ -453,6 +453,20 @@ class TestPgbouncer:
         assert "labels" in jmespath.search("spec.template.metadata", docs[0])
         assert jmespath.search("spec.template.metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    @pytest.mark.parametrize(
+        ("pgbouncer_values", "expected"),
+        [
+            ({"enabled": True}, 120),
+            ({"enabled": True, "terminationGracePeriodSeconds": 30}, 30),
+        ],
+    )
+    def test_pgbouncer_termination_grace_period_seconds(self, pgbouncer_values, expected):
+        docs = render_chart(
+            values={"pgbouncer": pgbouncer_values},
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+        assert expected == jmespath.search("spec.template.spec.terminationGracePeriodSeconds", docs[0])
+
 
 class TestPgbouncerConfig:
     """Tests PgBouncer config."""

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7873,6 +7873,13 @@
                         }
                     ]
                 },
+                "terminationGracePeriodSeconds": {
+                    "description": "Grace period for PgBouncer to finish after SIGTERM is sent from Kubernetes.",
+                    "type": "integer",
+                    "default": 120,
+                    "minimum": 0,
+                    "x-docsSection": "Kubernetes"
+                },
                 "securityContexts": {
                     "description": "Security context definition for the PgBouncer.",
                     "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -7801,6 +7801,12 @@
                         }
                     ]
                 },
+                "terminationGracePeriodSeconds": {
+                    "description": "Grace period for PgBouncer to finish after SIGTERM is sent from Kubernetes. The default matches the default preStop hook, which needs up to 120 seconds to drain client connections.",
+                    "type": "integer",
+                    "default": 120,
+                    "x-docsSection": "Kubernetes"
+                },
                 "securityContexts": {
                     "description": "Security context definition for the PgBouncer.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2936,6 +2936,12 @@ pgbouncer:
         # Allow existing queries clients to complete within 120 seconds
         command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
 
+  # Grace period for PgBouncer to finish after SIGTERM is sent from Kubernetes.
+  # Matches the default preStop hook above, which needs up to 120 seconds to
+  # drain client connections; with a shorter grace period the pod is killed
+  # mid-drain and in-flight connections are cut.
+  terminationGracePeriodSeconds: 120
+
   metricsExporterSidecar:
     resources: {}
     # limits:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2918,6 +2918,12 @@ pgbouncer:
         # Allow existing queries clients to complete within 120 seconds
         command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
 
+  # Grace period for PgBouncer to finish after SIGTERM is sent from Kubernetes.
+  # Matches the default preStop hook above, which needs up to 120 seconds to
+  # drain client connections; with a shorter grace period the pod is killed
+  # mid-drain and in-flight connections are cut.
+  terminationGracePeriodSeconds: 120
+
   metricsExporterSidecar:
     resources: {}
     # limits:


### PR DESCRIPTION
The chart ships a default PgBouncer preStop hook that drains client connections for up to 120 seconds (`killall -INT pgbouncer && sleep 120`), but the Deployment never sets `terminationGracePeriodSeconds`, so the Kubernetes default of 30s SIGKILLs the pod mid-drain on a node drain or eviction and cuts in-flight client connections.

Every other long-running component in the chart (scheduler, workers, triggerer, dag-processor, statsd, redis, otel collector) already exposes this value; PgBouncer was the only one missing it, despite holding the database connections of all the others.

This adds `pgbouncer.terminationGracePeriodSeconds`, defaulting to 120 to match the preStop drain window. PgBouncer exits as soon as the last client connection is released, so the value is an upper bound rather than a fixed wait. Deployments that prefer the previous behaviour can set it back to 30.

Covered by a parametrized test in `test_pgbouncer.py` (default and override).

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Claude Fable 5)

Generated-by: Claude Code (Claude Fable 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)