### PR TITLE
Fix Calendar view computing cron planned runs in UTC instead of the Dag's timezone

### DIFF
--- a/airflow-core/newsfragments/71243.bugfix.rst
+++ b/airflow-core/newsfragments/71243.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the Calendar view computing planned runs for cron-scheduled Dags in UTC instead of the Dag's configured timezone.

--- a/airflow-core/newsfragments/71243.bugfix.rst
+++ b/airflow-core/newsfragments/71243.bugfix.rst
@@ -1,1 +1,0 @@
-Fix the Calendar view computing planned runs for cron-scheduled Dags in UTC instead of the Dag's configured timezone.

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
@@ -17,14 +17,12 @@
 from __future__ import annotations
 
 import collections
-import itertools
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from typing import Literal, cast
 
 import sqlalchemy as sa
 import structlog
-from croniter.croniter import croniter
 from sqlalchemy.engine import Row
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
@@ -216,17 +214,17 @@ class CalendarService:
         """Calculate planned runs for cron-based timetables."""
         dates: dict[datetime, int] = collections.Counter()
 
-        dates_iter: Iterator[datetime | None] = croniter(
-            cast("CronMixin", dag.timetable)._expression,
-            start_time=last_data_interval.end,
-            ret_type=datetime,
-        )
+        cron_timetable = cast("CronMixin", dag.timetable)
+        dt = last_data_interval.end
 
-        # Cap the iteration like _calculate_timetable_planned_runs does; a high-frequency
-        # expression (e.g. "* * * * *", or a seconds-resolution cron) would otherwise take
-        # hundreds of thousands of steps before hitting the year boundary.
-        for dt in itertools.islice(dates_iter, self.MAX_PLANNED_RUNS):
-            if dt is None or dt.year != year:
+        # Step with CronMixin._get_next so planned instants match the scheduler exactly,
+        # including its DST gap/fold handling. Cap the iteration like
+        # _calculate_timetable_planned_runs does; a high-frequency expression (e.g.
+        # "* * * * *", or a seconds-resolution cron) would otherwise take hundreds of
+        # thousands of steps before hitting the year boundary.
+        for _ in range(self.MAX_PLANNED_RUNS):
+            dt = cron_timetable._get_next(dt)
+            if dt.year != year:
                 break
             if dag.end_date and dt > dag.end_date:
                 break

--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
@@ -28,6 +28,7 @@ from sqlalchemy.engine import Row
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from airflow._shared.timezones import timezone
+from airflow._shared.timezones.timezone import convert_to_utc, make_aware, make_naive
 from airflow.api_fastapi.common.parameters import RangeFilter
 from airflow.api_fastapi.core_api.datamodels.ui.calendar import (
     CalendarDeadlineCollectionResponse,
@@ -215,14 +216,19 @@ class CalendarService:
         """Calculate planned runs for cron-based timetables."""
         dates: dict[datetime, int] = collections.Counter()
 
+        cron_timetable = cast("CronMixin", dag.timetable)
+        tz = cron_timetable._timezone
         dates_iter: Iterator[datetime | None] = croniter(
-            cast("CronMixin", dag.timetable)._expression,
-            start_time=last_data_interval.end,
+            cron_timetable._expression,
+            start_time=make_naive(last_data_interval.end, tz),
             ret_type=datetime,
         )
 
-        for dt in dates_iter:
-            if dt is None or dt.year != year:
+        for naive_dt in dates_iter:
+            if naive_dt is None:
+                break
+            dt = convert_to_utc(make_aware(naive_dt, tz))
+            if dt.year != year:
                 break
             if dag.end_date and dt > dag.end_date:
                 break

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
@@ -27,7 +27,7 @@ from airflow._shared.timezones import timezone
 from airflow.api_fastapi.core_api.services.ui.calendar import CalendarService
 from airflow.models.deadline import Deadline
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.sdk import CronPartitionTimetable
+from airflow.sdk import CronPartitionTimetable, CronTriggerTimetable
 from airflow.sdk.definitions.callback import AsyncCallback
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState
@@ -189,6 +189,125 @@ class TestCalendar:
         body = response.json()
 
         assert body == result
+
+
+class TestCalendarCronNonUTCTimezone:
+    """Planned runs for a cron timetable must be computed in the timetable's own timezone, not UTC."""
+
+    DAG_NAME = "test_dag_non_utc_tz"
+
+    @pytest.fixture(autouse=True)
+    @provide_session
+    def setup_dag_runs(self, dag_maker, *, session: Session = NEW_SESSION) -> None:
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            self.DAG_NAME,
+            schedule=CronTriggerTimetable("0 8 * * *", timezone="Asia/Seoul"),
+            start_date=datetime(2025, 1, 1),
+            catchup=True,
+            serialized=True,
+            session=session,
+        ):
+            EmptyOperator(task_id="test_task1")
+        dag_maker.create_dagrun(
+            run_id="run_1",
+            state=DagRunState.SUCCESS,
+            logical_date=pendulum.datetime(2025, 1, 1, 23, 0, 0, tz="UTC"),
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        session.commit()
+
+    def teardown_method(self) -> None:
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_planned_runs_use_timetable_timezone_not_utc(self, test_client):
+        response = test_client.get(f"/calendar/{self.DAG_NAME}", params={"granularity": "hourly"})
+        assert response.status_code == 200
+        body = response.json()
+
+        planned = [r for r in body["dag_runs"] if r["state"] == "planned"]
+        # Daily 08:00 Asia/Seoul is 23:00Z the previous day; the last run's data interval
+        # ends 2025-01-01T23:00Z, so planned runs are one per remaining day of 2025.
+        assert len(planned) == 364
+        assert min(r["date"] for r in planned) == "2025-01-02T23:00:00Z"
+        assert all(r["date"].endswith("T23:00:00Z") for r in planned), planned
+        assert all(r["count"] == 1 for r in planned)
+
+
+class CalendarEveryHourCronDstBase:
+    """Every-hour crons must plan exactly one run per UTC hour across a DST transition, like the scheduler."""
+
+    DAG_NAME: str
+    START_DATE: datetime
+    LAST_RUN_UTC: pendulum.DateTime
+    EXPECTED_HOURS: list[str]
+
+    @pytest.fixture(autouse=True)
+    @provide_session
+    def setup_dag_runs(self, dag_maker, *, session: Session = NEW_SESSION) -> None:
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            self.DAG_NAME,
+            schedule=CronTriggerTimetable("0 * * * *", timezone="Europe/Zurich"),
+            start_date=self.START_DATE,
+            catchup=True,
+            serialized=True,
+            session=session,
+        ):
+            EmptyOperator(task_id="test_task1")
+        dag_maker.create_dagrun(
+            run_id="run_1",
+            state=DagRunState.SUCCESS,
+            logical_date=self.LAST_RUN_UTC,
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        session.commit()
+
+    def teardown_method(self) -> None:
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_one_planned_run_per_utc_hour(self, test_client):
+        response = test_client.get(f"/calendar/{self.DAG_NAME}", params={"granularity": "hourly"})
+        assert response.status_code == 200
+
+        planned = {r["date"]: r["count"] for r in response.json()["dag_runs"] if r["state"] == "planned"}
+        assert {h: planned.get(h) for h in self.EXPECTED_HOURS} == dict.fromkeys(self.EXPECTED_HOURS, 1)
+
+
+class TestCalendarEveryHourCronDstFold(CalendarEveryHourCronDstBase):
+    """Fall-back (2025-10-26 03:00 CEST -> 02:00 CET): the repeated hour keeps its planned run."""
+
+    DAG_NAME = "test_dag_every_hour_dst_fold"
+    START_DATE = datetime(2025, 10, 1)
+    LAST_RUN_UTC = pendulum.datetime(2025, 10, 25, 22, 0, 0, tz="UTC")
+    EXPECTED_HOURS = [
+        "2025-10-25T23:00:00Z",
+        "2025-10-26T00:00:00Z",
+        "2025-10-26T01:00:00Z",
+        "2025-10-26T02:00:00Z",
+        "2025-10-26T03:00:00Z",
+    ]
+
+
+class TestCalendarEveryHourCronDstGap(CalendarEveryHourCronDstBase):
+    """Spring-forward (2026-03-29 02:00 CET -> 03:00 CEST): the skipped hour is not double-counted."""
+
+    DAG_NAME = "test_dag_every_hour_dst_gap"
+    START_DATE = datetime(2026, 3, 1)
+    LAST_RUN_UTC = pendulum.datetime(2026, 3, 28, 22, 0, 0, tz="UTC")
+    EXPECTED_HOURS = [
+        "2026-03-28T23:00:00Z",
+        "2026-03-29T00:00:00Z",
+        "2026-03-29T01:00:00Z",
+        "2026-03-29T02:00:00Z",
+        "2026-03-29T03:00:00Z",
+    ]
 
 
 class TestPartitionedCalendar:

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/ui/test_calendar.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 from airflow._shared.timezones import timezone
 from airflow.models.deadline import Deadline
 from airflow.providers.standard.operators.empty import EmptyOperator
-from airflow.sdk import CronPartitionTimetable
+from airflow.sdk import CronPartitionTimetable, CronTriggerTimetable
 from airflow.sdk.definitions.callback import AsyncCallback
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState
@@ -188,6 +188,49 @@ class TestCalendar:
         body = response.json()
 
         assert body == result
+
+
+class TestCalendarCronNonUTCTimezone:
+    """Planned runs for a cron timetable must be computed in the timetable's own timezone, not UTC."""
+
+    DAG_NAME = "test_dag_non_utc_tz"
+
+    @pytest.fixture(autouse=True)
+    @provide_session
+    def setup_dag_runs(self, dag_maker, *, session: Session = NEW_SESSION) -> None:
+        clear_db_runs()
+        clear_db_dags()
+        with dag_maker(
+            self.DAG_NAME,
+            schedule=CronTriggerTimetable("0 8 * * *", timezone="Asia/Seoul"),
+            start_date=datetime(2025, 1, 1),
+            catchup=True,
+            serialized=True,
+            session=session,
+        ):
+            EmptyOperator(task_id="test_task1")
+        dag_maker.create_dagrun(
+            run_id="run_1",
+            state=DagRunState.SUCCESS,
+            logical_date=pendulum.datetime(2025, 1, 1, 23, 0, 0, tz="UTC"),
+        )
+        dag_maker.sync_dagbag_to_db()
+
+        session.commit()
+
+    def teardown_method(self) -> None:
+        clear_db_runs()
+        clear_db_dags()
+
+    def test_planned_runs_use_timetable_timezone_not_utc(self, test_client):
+        response = test_client.get(f"/calendar/{self.DAG_NAME}", params={"granularity": "hourly"})
+        assert response.status_code == 200
+        body = response.json()
+
+        planned = [r for r in body["dag_runs"] if r["state"] == "planned"]
+        assert planned, "expected at least one planned run"
+
+        assert all(r["date"].endswith("T23:00:00Z") for r in planned), planned
 
 
 class TestPartitionedCalendar:


### PR DESCRIPTION
closes: #71234

`CalendarService._calculate_cron_planned_runs()` handed `croniter` a UTC-tagged `start_time` when computing "planned" (future, not-yet-executed) calendar cells for cron-based timetables. `croniter` matches cron fields against whatever wall-clock its `start_time` carries, so for a Dag on a non-UTC `default_timezone`, planned runs came out shifted by the UTC offset (e.g. a `08:00 Asia/Seoul` schedule showed planned cells at `17:00`).

This steps planned instants with `CronMixin._get_next()` instead of iterating a raw `croniter`, so the Calendar matches the scheduler exactly — including its `_covers_every_hour` DST gap/fold handling for every-hour crons. Historical (already-executed) runs were unaffected, since those come straight from already-correct `DagRun` rows.

Added regression tests in `test_calendar.py` for a non-UTC cron timetable and for DST gap/fold transitions of an every-hour cron.

Verified with `uv sync --package apache-airflow-core` + pytest on `test_calendar.py`: 23/23 passing (20 existing + 3 new).

Before/after (local demo, `schedule="0 8 * * *"`, `AIRFLOW__CORE__DEFAULT_TIMEZONE=Asia/Seoul`): planned cells moved from the 16:00–17:00 row to the 08:00 row, now matching the Success row above.
<img width="1080" height="700" alt="image" src="https://github.com/user-attachments/assets/a75e1808-d1e8-483f-a417-468c908d628a" />
<img width="1080" height="700" alt="image" src="https://github.com/user-attachments/assets/5047557e-9ff9-4284-bb0e-119104415764" />


---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes — Claude Code

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
