### PR TITLE
Remove the unreachable 404 from the create Variable endpoint

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/variables.py
@@ -174,14 +174,7 @@ def post_variable(
 
     Variable.set(**post_body.model_dump(), session=session)
 
-    variable = session.scalar(select(Variable).where(Variable.key == post_body.key).limit(1))
-    if variable is None:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND,
-            f"Variable with key: `{post_body.key}` was not found",
-        )
-
-    return variable
+    return session.scalars(select(Variable).where(Variable.key == post_body.key)).one()
 
 
 @variables_router.patch(


### PR DESCRIPTION
### Sumarry

Split out of the [#71011](https://github.com/apache/airflow/pull/71011) review.

Remove the unreachable 404 from the create Variable endpoint

### The branch cannot be reached

```python
Variable.set(**post_body.model_dump(), session=session)

variable = session.scalar(select(Variable).where(Variable.key == post_body.key).limit(1))
if variable is None:
    raise HTTPException(status.HTTP_404_NOT_FOUND, ...)
```

`Variable.set()` upserts the row through the same session the read-back then queries, so the
read cannot come up empty. The status is also wrong on its own terms: a `404` on a create
endpoint tells a caller the variable they just created was not found.

That left the endpoint with a choice between publishing a response it can never return and
leaving its OpenAPI spec incomplete — which is what surfaced during #71011.

### Why it could not simply be deleted

It was added in [#56813](https://github.com/apache/airflow/pull/56813) as part of the
SQLAlchemy 2 typing cleanup. SQLAlchemy types the method as returning an optional:

```python
@overload
def scalar(self, statement: TypedReturnsRows[Tuple[_T]], ...) -> Optional[_T]: ...
```

So `variable` is `Variable | None`, and returning it fails:

```
error: Incompatible return value type (got "Variable | None", expected "VariableResponse")  [return-value]
```

The `raise` is what fixes that — it never returns, so mypy narrows the value to `Variable`
below it. Dropping the branch on its own puts the original error back.

### The change

```python
return session.scalars(select(Variable).where(Variable.key == post_body.key)).one()
```

`ScalarResult.one()` is typed `-> _R`, not `-> Optional[_R]`, because its contract already is
"exactly one row, or raise". The invariant moves into the query instead of being asserted by
control flow, so nothing has to narrow a type and no HTTP status is spent doing it. If the
invariant were ever violated, `NoResultFound` surfaces as a `500`, which is the honest answer
for a write that silently did not happen.

`.limit(1)` goes with it: `Variable.key` is `unique=True`, so `.one()` is already exact and
the limit would only contradict it.

### Behaviour

Unchanged — the removed branch was unreachable. No spec change either: the `404` was never
declared in `responses=`, so the generated OpenAPI spec and UI client are untouched.

<!-- pr-triage-fold: triaged=2026-08-13T12:55:40Z head=e911207 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @ColtenOuO** · by `@potiuk` · 2026-08-13 12:55 UTC
>
> Helpful heads-up from the maintainers — please address before this PR can be reviewed:
> - :x: **Other failing CI checks**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
> - :x: **Provider tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/12_provider_distributions.rst).
> - :x: **Unit tests**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/09_testing.rst).
> - :x: **Image build**. See [docs](https://github.com/apache/airflow/blob/main/contributing-docs/08_static_code_checks.rst).
>
> Full list of what we check: [Pull Request quality criteria](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-quality-criteria).
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
