### PR TITLE
fix(calendar): localize cron start_time to timetable timezone before computing planned runs

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/services/ui/calendar.py
@@ -28,6 +28,7 @@ from sqlalchemy.engine import Row
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from airflow._shared.timezones import timezone
+from airflow._shared.timezones.timezone import convert_to_utc, make_aware, make_naive
 from airflow.api_fastapi.common.parameters import RangeFilter
 from airflow.api_fastapi.core_api.datamodels.ui.calendar import (
     CalendarDeadlineCollectionResponse,
@@ -215,21 +216,35 @@ class CalendarService:
         """Calculate planned runs for cron-based timetables."""
         dates: dict[datetime, int] = collections.Counter()
 
+        timetable = cast("CronMixin", dag.timetable)
+        tz = timetable._timezone
+
+        # Localize start_time into the timetable's own timezone before
+        # constructing croniter, matching the pattern used by
+        # CronMixin._get_next().  Without this, the cron expression is
+        # matched against UTC wall-clock, which produces wrong scheduled
+        # times for DAGs with a non-UTC default_timezone.
+        local_start = make_naive(last_data_interval.end, tz)
+
         dates_iter: Iterator[datetime | None] = croniter(
-            cast("CronMixin", dag.timetable)._expression,
-            start_time=last_data_interval.end,
+            timetable._expression,
+            start_time=local_start,
             ret_type=datetime,
         )
 
         for dt in dates_iter:
-            if dt is None or dt.year != year:
+            if dt is None:
                 break
-            if dag.end_date and dt > dag.end_date:
+            # Convert back to UTC-aware for comparison and storage.
+            dt_utc = convert_to_utc(make_aware(dt, tz))
+            if dt_utc.year != year:
                 break
-            if not self._is_date_in_range(dt, date_filter):
+            if dag.end_date and dt_utc > dag.end_date:
+                break
+            if not self._is_date_in_range(dt_utc, date_filter):
                 continue
 
-            dates[self._truncate_datetime_for_granularity(dt, granularity)] += 1
+            dates[self._truncate_datetime_for_granularity(dt_utc, granularity)] += 1
 
         return [
             CalendarTimeRangeResponse(date=dt, state="planned", count=count) for dt, count in dates.items()


### PR DESCRIPTION
Closes #71234

## Problem

Calendar view's planned/future runs for cron-based timetables are computed
in UTC wall-clock instead of the DAG's configured timezone.  When a DAG
uses a non-UTC `default_timezone` (e.g. `Asia/Seoul`, UTC+9) with a cron
schedule like `"0 8 * * *"`, the planned runs appear at 17:00 instead of
08:00 — exactly a UTC-vs-local offset.

The root cause is in `CalendarService._calculate_cron_planned_runs()`:
`croniter` receives `last_data_interval.end` (a UTC-aware datetime) as
`start_time` and reads its timezone — UTC — so the cron expression is
matched against UTC wall-clock.  The real scheduler (`CronMixin._get_next`)
correctly localizes the start time to the timetable's own timezone before
calling croniter.

## Fix

1. Add imports for `convert_to_utc`, `make_aware`, `make_naive` from
   `airflow._shared.timezones.timezone` (same utilities used by
   `CronMixin._get_next`).

2. In `_calculate_cron_planned_runs`:
   - Extract the timetable's `_timezone` from the `CronMixin` cast.
   - Localize `start_time` to that timezone via `make_naive()` before
     constructing `croniter`.
   - Convert each result back to UTC via `convert_to_utc(make_aware(...))`.

This matches the exact pattern used by `CronMixin._get_next()` in
`airflow/timetables/_cron.py`.

## Testing

All 19 existing calendar tests continue to pass.  The fix was verified
locally by the issue reporter with an additional regression test for a
non-UTC cron timetable (20/20 passing).

## Related

- #71234 (original issue report with full reproduction steps)
- #67477 (fixed frontend layer; this completes the fix at the backend)
- #67717 (same pattern, fixed in `airflow dags clear`)
- #63631 (added timezone-aware `next_dagrun_info_v2` path for non-cron timetables)