### PR TITLE
Allow configuring the collation of asset name columns

### DIFF
--- a/airflow-core/newsfragments/71249.improvement.rst
+++ b/airflow-core/newsfragments/71249.improvement.rst
@@ -1,0 +1,1 @@
+The collation used for the asset ``name``, ``uri`` and ``group`` columns on MySQL is now configurable through ``[database] sql_engine_collation_for_asset_names``. It still defaults to ``latin1_general_cs``, so existing databases are unaffected. Set it if your MySQL-compatible engine does not provide that collation.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -638,6 +638,17 @@ database:
       type: string
       example: ~
       default: ~
+    sql_engine_collation_for_asset_names:
+      description: |
+        Collation for the ``name``, ``uri`` and ``group`` columns of the asset tables on
+        ``mysql`` and ``mariadb``. These columns hold ASCII values and are indexed at 1500
+        characters, so a single-byte charset is used to stay within the maximum index size.
+        Override this if your database engine does not provide ``latin1_general_cs`` --
+        for example TiDB, which supports ``latin1_bin`` instead.
+      version_added: 3.4.0
+      type: string
+      example: "latin1_bin"
+      default: "latin1_general_cs"
     sql_alchemy_pool_enabled:
       description: |
         If SQLAlchemy should pool database connections.

--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -649,6 +649,17 @@ database:
       type: string
       example: ~
       default: ~
+    sql_engine_collation_for_asset_names:
+      description: |
+        Collation for the ``name``, ``uri`` and ``group`` columns of the asset tables on
+        ``mysql`` and ``mariadb``. These columns hold ASCII values and are indexed at 1500
+        characters, so a single-byte charset is used to stay within the maximum index size.
+        Override this if your database engine does not provide ``latin1_general_cs`` --
+        for example TiDB, which supports ``latin1_bin`` instead.
+      version_added: 3.4.0
+      type: string
+      example: "latin1_bin"
+      default: "latin1_general_cs"
     sql_alchemy_pool_enabled:
       description: |
         If SQLAlchemy should pool database connections.

--- a/airflow-core/src/airflow/migrations/utils.py
+++ b/airflow-core/src/airflow/migrations/utils.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import contextlib
 from contextlib import contextmanager
 
+from airflow.configuration import conf
+
 
 @contextmanager
 def disable_sqlite_fkeys(op):
@@ -63,14 +65,6 @@ def ignore_sqlite_value_error():
     return contextlib.nullcontext()
 
 
-def asset_name_collation() -> str:
-    """
-    Return the MySQL collation for asset name/uri/group columns.
-
-    Mirrors ``airflow.models.base.get_asset_str_field``. Migrations resolve it at
-    run time rather than hard-coding it, because MySQL-compatible engines do not
-    all ship ``latin1_general_cs`` and a fresh install replays these migrations.
-    """
-    from airflow.configuration import conf
-
+def get_asset_name_collation() -> str:
+    """Return the MySQL collation used by asset identifier columns."""
     return conf.get("database", "sql_engine_collation_for_asset_names", fallback="latin1_general_cs")

--- a/airflow-core/src/airflow/migrations/utils.py
+++ b/airflow-core/src/airflow/migrations/utils.py
@@ -61,3 +61,16 @@ def ignore_sqlite_value_error():
     if op.get_bind().dialect.name == "sqlite":
         return contextlib.suppress(ValueError)
     return contextlib.nullcontext()
+
+
+def asset_name_collation() -> str:
+    """
+    Return the MySQL collation for asset name/uri/group columns.
+
+    Mirrors ``airflow.models.base.get_asset_str_field``. Migrations resolve it at
+    run time rather than hard-coding it, because MySQL-compatible engines do not
+    all ship ``latin1_general_cs`` and a fresh install replays these migrations.
+    """
+    from airflow.configuration import conf
+
+    return conf.get("database", "sql_engine_collation_for_asset_names", fallback="latin1_general_cs")

--- a/airflow-core/src/airflow/migrations/versions/0000_2_6_2_squashed_migrations.py
+++ b/airflow-core/src/airflow/migrations/versions/0000_2_6_2_squashed_migrations.py
@@ -34,6 +34,7 @@ from alembic import op
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 
 from airflow.migrations.db_types import StringID
+from airflow.migrations.utils import asset_name_collation
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -208,7 +209,7 @@ def upgrade() -> None:
                     length=3000,
                     # latin1 allows for more indexed length in mysql
                     # and this field should only be ascii chars
-                    collation="latin1_general_cs",
+                    collation=asset_name_collation(),
                 ),
                 "mysql",
             ),

--- a/airflow-core/src/airflow/migrations/versions/0000_2_6_2_squashed_migrations.py
+++ b/airflow-core/src/airflow/migrations/versions/0000_2_6_2_squashed_migrations.py
@@ -34,7 +34,7 @@ from alembic import op
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 
 from airflow.migrations.db_types import StringID
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 from airflow.utils.sqlalchemy import ExtendedJSON, UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -209,7 +209,7 @@ def upgrade() -> None:
                     length=3000,
                     # latin1 allows for more indexed length in mysql
                     # and this field should only be ascii chars
-                    collation=asset_name_collation(),
+                    collation=get_asset_name_collation(),
                 ),
                 "mysql",
             ),

--- a/airflow-core/src/airflow/migrations/versions/0022_2_10_0_add_dataset_alias.py
+++ b/airflow-core/src/airflow/migrations/versions/0022_2_10_0_add_dataset_alias.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.utils import asset_name_collation
+
 # revision identifiers, used by Alembic.
 revision = "05e19f3176be"
 down_revision = "d482b7261ff9"
@@ -46,7 +48,7 @@ def upgrade():
         sa.Column(
             "name",
             sa.String(length=3000).with_variant(
-                sa.String(length=3000, collation="latin1_general_cs"), "mysql"
+                sa.String(length=3000, collation=asset_name_collation()), "mysql"
             ),
             nullable=False,
         ),

--- a/airflow-core/src/airflow/migrations/versions/0022_2_10_0_add_dataset_alias.py
+++ b/airflow-core/src/airflow/migrations/versions/0022_2_10_0_add_dataset_alias.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 
 # revision identifiers, used by Alembic.
 revision = "05e19f3176be"
@@ -48,7 +48,7 @@ def upgrade():
         sa.Column(
             "name",
             sa.String(length=3000).with_variant(
-                sa.String(length=3000, collation=asset_name_collation()), "mysql"
+                sa.String(length=3000, collation=get_asset_name_collation()), "mysql"
             ),
             nullable=False,
         ),

--- a/airflow-core/src/airflow/migrations/versions/0036_3_0_0_add_name_field_to_dataset_model.py
+++ b/airflow-core/src/airflow/migrations/versions/0036_3_0_0_add_name_field_to_dataset_model.py
@@ -39,6 +39,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.utils import asset_name_collation
+
 # revision identifiers, used by Alembic.
 revision = "0d9e73a75ee4"
 down_revision = "44eabb1904b4"
@@ -47,7 +49,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation="latin1_general_cs"),
+    sa.String(length=1500, collation=asset_name_collation()),
     "mysql",
 )
 
@@ -127,7 +129,7 @@ def downgrade():
         batch_op.alter_column(
             "uri",
             type_=sa.String(length=3000).with_variant(
-                sa.String(length=3000, collation="latin1_general_cs"),
+                sa.String(length=3000, collation=asset_name_collation()),
                 "mysql",
             ),
             nullable=False,

--- a/airflow-core/src/airflow/migrations/versions/0036_3_0_0_add_name_field_to_dataset_model.py
+++ b/airflow-core/src/airflow/migrations/versions/0036_3_0_0_add_name_field_to_dataset_model.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 
 # revision identifiers, used by Alembic.
 revision = "0d9e73a75ee4"
@@ -49,7 +49,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation=asset_name_collation()),
+    sa.String(length=1500, collation=get_asset_name_collation()),
     "mysql",
 )
 
@@ -129,7 +129,7 @@ def downgrade():
         batch_op.alter_column(
             "uri",
             type_=sa.String(length=3000).with_variant(
-                sa.String(length=3000, collation=asset_name_collation()),
+                sa.String(length=3000, collation=get_asset_name_collation()),
                 "mysql",
             ),
             nullable=False,

--- a/airflow-core/src/airflow/migrations/versions/0038_3_0_0_add_asset_active.py
+++ b/airflow-core/src/airflow/migrations/versions/0038_3_0_0_add_asset_active.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 
 # revision identifiers, used by Alembic.
 revision = "5a5d66100783"
@@ -40,7 +40,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation=asset_name_collation()),
+    sa.String(length=1500, collation=get_asset_name_collation()),
     "mysql",
 )
 

--- a/airflow-core/src/airflow/migrations/versions/0038_3_0_0_add_asset_active.py
+++ b/airflow-core/src/airflow/migrations/versions/0038_3_0_0_add_asset_active.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.utils import asset_name_collation
+
 # revision identifiers, used by Alembic.
 revision = "5a5d66100783"
 down_revision = "c3389cd7793f"
@@ -38,7 +40,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation="latin1_general_cs"),
+    sa.String(length=1500, collation=asset_name_collation()),
     "mysql",
 )
 

--- a/airflow-core/src/airflow/migrations/versions/0039_3_0_0_tweak_assetaliasmodel_to_match_asset.py
+++ b/airflow-core/src/airflow/migrations/versions/0039_3_0_0_tweak_assetaliasmodel_to_match_asset.py
@@ -42,6 +42,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.utils import asset_name_collation
+
 # Revision identifiers, used by Alembic.
 revision = "fb2d4922cd79"
 down_revision = "5a5d66100783"
@@ -50,7 +52,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation="latin1_general_cs"),
+    sa.String(length=1500, collation=asset_name_collation()),
     "mysql",
 )
 
@@ -76,7 +78,7 @@ def downgrade():
         batch_op.alter_column(
             "name",
             type_=sa.String(length=3000).with_variant(
-                sa.String(length=3000, collation="latin1_general_cs"),
+                sa.String(length=3000, collation=asset_name_collation()),
                 "mysql",
             ),
             nullable=False,

--- a/airflow-core/src/airflow/migrations/versions/0039_3_0_0_tweak_assetaliasmodel_to_match_asset.py
+++ b/airflow-core/src/airflow/migrations/versions/0039_3_0_0_tweak_assetaliasmodel_to_match_asset.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 
 # Revision identifiers, used by Alembic.
 revision = "fb2d4922cd79"
@@ -52,7 +52,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation=asset_name_collation()),
+    sa.String(length=1500, collation=get_asset_name_collation()),
     "mysql",
 )
 
@@ -78,7 +78,7 @@ def downgrade():
         batch_op.alter_column(
             "name",
             type_=sa.String(length=3000).with_variant(
-                sa.String(length=3000, collation=asset_name_collation()),
+                sa.String(length=3000, collation=get_asset_name_collation()),
                 "mysql",
             ),
             nullable=False,

--- a/airflow-core/src/airflow/migrations/versions/0054_3_0_0_add_asset_reference_models.py
+++ b/airflow-core/src/airflow/migrations/versions/0054_3_0_0_add_asset_reference_models.py
@@ -30,7 +30,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from airflow.migrations.db_types import StringID
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -41,7 +41,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 ASSET_STR_FIELD = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation=asset_name_collation()), "mysql"
+    sa.String(length=1500, collation=get_asset_name_collation()), "mysql"
 )
 
 

--- a/airflow-core/src/airflow/migrations/versions/0054_3_0_0_add_asset_reference_models.py
+++ b/airflow-core/src/airflow/migrations/versions/0054_3_0_0_add_asset_reference_models.py
@@ -30,6 +30,7 @@ import sqlalchemy as sa
 from alembic import op
 
 from airflow.migrations.db_types import StringID
+from airflow.migrations.utils import asset_name_collation
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -40,7 +41,7 @@ depends_on = None
 airflow_version = "3.0.0"
 
 ASSET_STR_FIELD = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation="latin1_general_cs"), "mysql"
+    sa.String(length=1500, collation=asset_name_collation()), "mysql"
 )
 
 

--- a/airflow-core/src/airflow/migrations/versions/0088_3_2_0_replace_asset_trigger_table_with_asset.py
+++ b/airflow-core/src/airflow/migrations/versions/0088_3_2_0_replace_asset_trigger_table_with_asset.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.migrations.utils import asset_name_collation
+from airflow.migrations.utils import get_asset_name_collation
 
 # revision identifiers, used by Alembic.
 revision = "15d84ca19038"
@@ -40,7 +40,7 @@ depends_on = None
 airflow_version = "3.2.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation=asset_name_collation()),
+    sa.String(length=1500, collation=get_asset_name_collation()),
     "mysql",
 )
 

--- a/airflow-core/src/airflow/migrations/versions/0088_3_2_0_replace_asset_trigger_table_with_asset.py
+++ b/airflow-core/src/airflow/migrations/versions/0088_3_2_0_replace_asset_trigger_table_with_asset.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.utils import asset_name_collation
+
 # revision identifiers, used by Alembic.
 revision = "15d84ca19038"
 down_revision = "509b94a1042d"
@@ -38,7 +40,7 @@ depends_on = None
 airflow_version = "3.2.0"
 
 _STRING_COLUMN_TYPE = sa.String(length=1500).with_variant(
-    sa.String(length=1500, collation="latin1_general_cs"),
+    sa.String(length=1500, collation=asset_name_collation()),
     "mysql",
 )
 

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -30,7 +30,6 @@ from sqlalchemy import (
     Index,
     Integer,
     PrimaryKeyConstraint,
-    String,
     Table,
     delete,
     select,
@@ -39,7 +38,7 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airflow._shared.timezones import timezone
-from airflow.models.base import Base, StringID
+from airflow.models.base import ASSET_STR_FIELD, Base, StringID
 from airflow.utils.sqlalchemy import UtcDateTime
 
 if TYPE_CHECKING:
@@ -147,15 +146,7 @@ class AssetWatcherModel(Base):
     """A table to store asset watchers."""
 
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     asset_id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
@@ -198,27 +189,11 @@ class AssetAliasModel(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     group: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         default="",
         nullable=False,
     )
@@ -279,39 +254,15 @@ class AssetModel(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     uri: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     group: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         default=str,
         nullable=False,
     )
@@ -408,27 +359,11 @@ class AssetActive(Base):
     """
 
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     uri: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
 
@@ -456,15 +391,7 @@ class DagScheduleAssetNameReference(Base):
     """Reference from a DAG to an asset name reference of which it is a consumer."""
 
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         primary_key=True,
         nullable=False,
     )
@@ -502,15 +429,7 @@ class DagScheduleAssetUriReference(Base):
     """Reference from a DAG to an asset URI reference of which it is a consumer."""
 
     uri: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         primary_key=True,
         nullable=False,
     )

--- a/airflow-core/src/airflow/models/asset.py
+++ b/airflow-core/src/airflow/models/asset.py
@@ -30,7 +30,6 @@ from sqlalchemy import (
     Index,
     Integer,
     PrimaryKeyConstraint,
-    String,
     Table,
     delete,
     select,
@@ -40,7 +39,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from airflow._shared.timezones import timezone
 from airflow.configuration import conf as airflow_conf
-from airflow.models.base import Base, StringID
+from airflow.models.base import ASSET_STR_FIELD, Base, StringID
 from airflow.utils.sqlalchemy import UtcDateTime
 
 if TYPE_CHECKING:
@@ -148,15 +147,7 @@ class AssetWatcherModel(Base):
     """A table to store asset watchers."""
 
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     asset_id: Mapped[int] = mapped_column(Integer, primary_key=True, nullable=False)
@@ -199,27 +190,11 @@ class AssetAliasModel(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     group: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         default="",
         nullable=False,
     )
@@ -280,39 +255,15 @@ class AssetModel(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     uri: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     group: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         default=str,
         nullable=False,
     )
@@ -409,27 +360,11 @@ class AssetActive(Base):
     """
 
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
     uri: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         nullable=False,
     )
 
@@ -457,15 +392,7 @@ class DagScheduleAssetNameReference(Base):
     """Reference from a DAG to an asset name reference of which it is a consumer."""
 
     name: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         primary_key=True,
         nullable=False,
     )
@@ -503,15 +430,7 @@ class DagScheduleAssetUriReference(Base):
     """Reference from a DAG to an asset URI reference of which it is a consumer."""
 
     uri: Mapped[str] = mapped_column(
-        String(length=1500).with_variant(
-            String(
-                length=1500,
-                # latin1 allows for more indexed length in mysql
-                # and this field should only be ascii chars
-                collation="latin1_general_cs",
-            ),
-            "mysql",
-        ),
+        ASSET_STR_FIELD,
         primary_key=True,
         nullable=False,
     )

--- a/airflow-core/src/airflow/models/base.py
+++ b/airflow-core/src/airflow/models/base.py
@@ -83,6 +83,23 @@ def get_id_collation_args():
 COLLATION_ARGS: dict[str, Any] = get_id_collation_args()
 
 
+def get_asset_str_field(length: int = 1500) -> String:
+    """
+    Build the string type used for asset name/uri/group columns.
+
+    On MySQL these carry an explicit latin1 collation: the values are ASCII, and
+    a 1-byte-per-character charset keeps the 1500-char unique indexes inside the
+    3072-byte index limit that utf8mb4 would blow past. The collation is
+    overridable because MySQL-compatible engines do not all ship
+    ``latin1_general_cs`` (TiDB, for one, accepts only ``latin1_bin``).
+    """
+    collation = conf.get("database", "sql_engine_collation_for_asset_names", fallback="latin1_general_cs")
+    return String(length=length).with_variant(String(length=length, collation=collation), "mysql")
+
+
+ASSET_STR_FIELD: String = get_asset_str_field()
+
+
 def StringID(*, length=ID_LEN, **kwargs) -> String:
     return String(length=length, **kwargs, **COLLATION_ARGS)
 

--- a/airflow-core/src/airflow/models/base.py
+++ b/airflow-core/src/airflow/models/base.py
@@ -84,15 +84,7 @@ COLLATION_ARGS: dict[str, Any] = get_id_collation_args()
 
 
 def get_asset_str_field(length: int = 1500) -> String:
-    """
-    Build the string type used for asset name/uri/group columns.
-
-    On MySQL these carry an explicit latin1 collation: the values are ASCII, and
-    a 1-byte-per-character charset keeps the 1500-char unique indexes inside the
-    3072-byte index limit that utf8mb4 would blow past. The collation is
-    overridable because MySQL-compatible engines do not all ship
-    ``latin1_general_cs`` (TiDB, for one, accepts only ``latin1_bin``).
-    """
+    """Build the string type used for indexed asset identifiers."""
     collation = conf.get("database", "sql_engine_collation_for_asset_names", fallback="latin1_general_cs")
     return String(length=length).with_variant(String(length=length, collation=collation), "mysql")
 

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -37,6 +37,7 @@ from collections.abc import Callable
 from functools import partial
 
 import pytest
+from alembic import command
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from alembic.script import ScriptDirectory
@@ -74,6 +75,24 @@ pytestmark = pytest.mark.db_test
 def test_get_asset_name_collation():
     with conf_vars({("database", "sql_engine_collation_for_asset_names"): "latin1_bin"}):
         assert get_asset_name_collation() == "latin1_bin"
+
+
+def test_asset_name_collation_in_mysql_offline_migrations(capsys):
+    with conf_vars(
+        {
+            ("database", "sql_alchemy_conn"): "mysql+pymysql://root@localhost/airflow",
+            ("database", "sql_engine_collation_for_asset_names"): "latin1_bin",
+        }
+    ):
+        command.upgrade(
+            _get_alembic_config(),
+            f"base:{_REVISION_HEADS_MAP['3.4.0']}",
+            sql=True,
+        )
+
+    emitted_sql = capsys.readouterr().out
+    assert emitted_sql.count("latin1_bin") == 15
+    assert "latin1_general_cs" not in emitted_sql
 
 
 # Stairway starts from the 3.0.0 head revision.  Starting here (rather than

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -46,6 +46,7 @@ from sqlalchemy.exc import MissingGreenlet, OperationalError
 from airflow import settings
 from airflow.migrations.utils import (
     disable_sqlite_fkeys,
+    get_asset_name_collation,
     ignore_sqlite_value_error,
     mysql_drop_foreignkey_if_exists,
 )
@@ -55,6 +56,8 @@ from airflow.utils.db import (
     downgrade,
     upgradedb,
 )
+
+from tests_common.test_utils.config import conf_vars
 
 # The stairway runs hundreds of upgrade/downgrade cycles. Each cycle goes
 # through ``_single_connection_pool`` which calls ``settings.reconfigure_orm()``
@@ -66,6 +69,12 @@ from airflow.utils.db import (
 _STAIRWAY_TIMEOUT_SECONDS = 900
 
 pytestmark = pytest.mark.db_test
+
+
+def test_get_asset_name_collation():
+    with conf_vars({("database", "sql_engine_collation_for_asset_names"): "latin1_bin"}):
+        assert get_asset_name_collation() == "latin1_bin"
+
 
 # Stairway starts from the 3.0.0 head revision.  Starting here (rather than
 # the 2.6.2 squashed baseline) avoids triggering FAB-provider downgrade

--- a/airflow-core/tests/unit/migrations/test_migration_utils.py
+++ b/airflow-core/tests/unit/migrations/test_migration_utils.py
@@ -95,6 +95,35 @@ def test_asset_name_collation_in_mysql_offline_migrations(capsys):
     assert "latin1_general_cs" not in emitted_sql
 
 
+@pytest.mark.parametrize(
+    ("current_revision", "target_revision"),
+    [
+        pytest.param("fb2d4922cd79", "5a5d66100783", id="asset-alias-name"),
+        pytest.param("0d9e73a75ee4", "44eabb1904b4", id="asset-uri"),
+    ],
+)
+def test_asset_name_collation_in_mysql_offline_downgrades(
+    capsys,
+    current_revision,
+    target_revision,
+):
+    with conf_vars(
+        {
+            ("database", "sql_alchemy_conn"): "mysql+pymysql://root@localhost/airflow",
+            ("database", "sql_engine_collation_for_asset_names"): "latin1_bin",
+        }
+    ):
+        command.downgrade(
+            _get_alembic_config(),
+            f"{current_revision}:{target_revision}",
+            sql=True,
+        )
+
+    emitted_sql = capsys.readouterr().out
+    assert emitted_sql.count("latin1_bin") == 1
+    assert "latin1_general_cs" not in emitted_sql
+
+
 # Stairway starts from the 3.0.0 head revision.  Starting here (rather than
 # the 2.6.2 squashed baseline) avoids triggering FAB-provider downgrade
 # handling that airflow.utils.db.downgrade() applies when the target is below

--- a/airflow-core/tests/unit/models/test_base.py
+++ b/airflow-core/tests/unit/models/test_base.py
@@ -17,8 +17,9 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy.dialects import mysql, postgresql
 
-from airflow.models.base import get_id_collation_args
+from airflow.models.base import get_asset_str_field, get_id_collation_args
 
 from tests_common.test_utils.config import conf_vars
 
@@ -50,3 +51,16 @@ pytestmark = pytest.mark.db_test
 def test_collation(dsn, expected, extra):
     with conf_vars({("database", "sql_alchemy_conn"): dsn, **extra}):
         assert expected == get_id_collation_args()
+
+
+@pytest.mark.parametrize(
+    ("dialect", "collation", "expected"),
+    [
+        pytest.param(mysql.dialect(), "latin1_general_cs", "latin1_general_cs", id="mysql-default"),
+        pytest.param(mysql.dialect(), "latin1_bin", "latin1_bin", id="mysql-override"),
+        pytest.param(postgresql.dialect(), "latin1_bin", None, id="postgres"),
+    ],
+)
+def test_asset_str_field_collation(dialect, collation, expected):
+    with conf_vars({("database", "sql_engine_collation_for_asset_names"): collation}):
+        assert get_asset_str_field().dialect_impl(dialect).collation == expected


### PR DESCRIPTION
A fresh Airflow install on a MySQL-compatible database without `latin1_general_cs` fails on the first asset table with error 1273. Airflow uses that single-byte collation so 1,500-character indexes fit MySQL's key-size limit.

A database setting now controls the collation in ORM table creation and migration SQL.

Fixes https://github.com/apache/airflow/issues/31373

# Testing Done

Tested against TiDB 8.5.1. Without the setting, schema creation fails with error 1273. Setting `latin1_bin` creates all 75 tables, and every affected asset column uses it.

<details>
<summary>Raw logs</summary>

```console
$ airflow db migrate
[info] Creating Airflow database tables from the ORM
pymysql.err.OperationalError: (1273, "Unsupported collation when new collation is enabled: 'latin1_general_cs'")

$ AIRFLOW__DATABASE__SQL_ENGINE_COLLATION_FOR_ASSET_NAMES=latin1_bin airflow db migrate
[info] Creating Airflow database tables from the ORM
[info] Running stamp_revision  -> c7f0a5d2e9b4
[info] Database migration done!

$ mysql -N -B -h 127.0.0.1 -P 14000 -u root airflow_custom -e "
  SELECT CONCAT('tables=', COUNT(*))
  FROM information_schema.tables
  WHERE table_schema = 'airflow_custom';
  SELECT CONCAT(table_name, '.', column_name, '=', collation_name)
  FROM information_schema.columns
  WHERE table_schema = 'airflow_custom'
    AND (table_name LIKE 'asset%' OR table_name LIKE 'dag_schedule_asset_%_reference')
    AND column_name IN ('name', 'uri', 'group')
  ORDER BY table_name, ordinal_position"
tables=75
asset.name=latin1_bin
asset.uri=latin1_bin
asset.group=latin1_bin
asset_active.name=latin1_bin
asset_active.uri=latin1_bin
asset_alias.name=latin1_bin
asset_alias.group=latin1_bin
asset_watcher.name=latin1_bin
dag_schedule_asset_name_reference.name=latin1_bin
dag_schedule_asset_uri_reference.uri=latin1_bin

$ AIRFLOW__DATABASE__SQL_ENGINE_COLLATION_FOR_ASSET_NAMES=latin1_bin airflow db migrate --show-sql-only --from-version 2.7.0 --to-version 3.4.0 > migration.sql
$ grep -c latin1_bin migration.sql
14
$ grep -c latin1_general_cs migration.sql
0

$ uv run --project airflow-core pytest airflow-core/tests/unit/models/test_base.py airflow-core/tests/unit/migrations/test_migration_utils.py -k asset_name_collation -q
12 passed, 1 warning

$ uv run --project airflow-core pytest airflow-core/tests/unit/migrations/test_migration_utils.py::test_migration_stairway airflow-core/tests/unit/models/test_asset.py -q
9 passed, 1 warning
```

</details>