### PR TITLE
fix(sensors): only skip timeout-related exceptions on deferred sensor soft_fail

### DIFF
--- a/task-sdk/src/airflow/sdk/bases/sensor.py
+++ b/task-sdk/src/airflow/sdk/bases/sensor.py
@@ -258,9 +258,13 @@ class BaseSensorOperator(BaseOperator):
                 return super().resume_execution(next_method, next_kwargs, context)
             except TaskDeferralTimeout as e:
                 raise AirflowSensorTimeout(*e.args) from e
-        except (AirflowException, TaskDeferralError) as e:
+        except (AirflowSensorTimeout, AirflowTaskTimeout, AirflowFailException) as e:
             if self.soft_fail:
                 raise AirflowSkipException("Skipping due to soft_fail is set to True.") from e
+            if self.never_fail:
+                raise AirflowSkipException("Skipping due to never_fail is set to True.") from e
+            raise
+        except (AirflowException, TaskDeferralError) as e:
             if self.never_fail:
                 raise AirflowSkipException("Skipping due to never_fail is set to True.") from e
             raise

--- a/task-sdk/tests/task_sdk/bases/test_sensor.py
+++ b/task-sdk/tests/task_sdk/bases/test_sensor.py
@@ -691,7 +691,7 @@ class TestAsyncSensor:
     @pytest.mark.parametrize(
         ("soft_fail", "expected_exception"),
         [
-            (True, AirflowSkipException),
+            (True, AirflowException),
             (False, AirflowException),
         ],
     )


### PR DESCRIPTION
## Description

When `soft_fail=True`, deferred sensors currently skip on **all** exceptions, while non-deferred (`poke`/`reschedule` mode) sensors only skip on timeout-related exceptions (`AirflowSensorTimeout`, `AirflowTaskTimeout`, `AirflowFailException`) and let unexpected errors propagate.

This behavior gap means operators cannot distinguish between a sensor timeout (legitimate skip) and a sensor misconfiguration or unexpected error when using deferred mode with `soft_fail=True`.

## Fix

In `BaseSensorOperator.resume_execution()`, split the exception handling into two tiers matching the `execute()` method:

1. **Timeout-related exceptions** (`AirflowSensorTimeout`, `AirflowTaskTimeout`, `AirflowFailException`) → `soft_fail` and `never_fail` apply (skip)
2. **Other exceptions** (`AirflowException`, `TaskDeferralError`) → only `never_fail` applies (not `soft_fail`)

## Related issue

Closes #71255