### PR TITLE
Clarify that DAG.access_control is only read by the FAB auth manager

### DIFF
--- a/airflow-core/docs/security/deprecated_permissions.rst
+++ b/airflow-core/docs/security/deprecated_permissions.rst
@@ -73,8 +73,6 @@ the Dag argument.
     moves off the FAB auth manager and leaves ``access_control`` on its Dags stops enforcing those grants,
     and does so without raising an error.
 
-To migrate, move the grants into the policy source your auth manager consults, and make the per-Dag
-decision in ``is_authorized_dag``, which every auth manager implements. ``filter_authorized_dag_ids`` and
-``get_authorized_dag_ids`` answer list views over that same policy. Both have working default
-implementations built on ``is_authorized_dag``, so overriding them is a performance concern rather than a
-correctness one.
+To migrate, move the grants into the policy source your auth manager consults. The
+:doc:`/core-concepts/auth-manager/index` guide covers how a custom auth manager should express
+Dag-level access.

--- a/airflow-core/docs/security/deprecated_permissions.rst
+++ b/airflow-core/docs/security/deprecated_permissions.rst
@@ -51,10 +51,30 @@ replacement available from Airflow core:
 
 * ``airflow.security.permissions.ACTION_*`` --> ``airflow.api_fastapi.auth.managers.base_auth_manager.ResourceMethod``
 * ``airflow.security.permissions.RESOURCE_*`` --> ``airflow.api_fastapi.auth.managers.models.resource_details``
-* ``DAG.access_control`` --> Dag-level permissions should be handled by the chosen Auth Manager's ``filter_authorized_dag_ids`` method.
 
 If you maintain a custom :doc:`/core-concepts/auth-manager/index` which relies on the deprecated module, it is
 recommended you refer to the ``SimpleAuthManager``'s `source code <https://github.com/apache/airflow/blob/main/airflow-core/src/airflow/api_fastapi/auth/managers/simple/simple_auth_manager.py>`_
 as an example for how you might use the ``ResourceMethod`` and ``resource_details`` components.
 
 If you rely on custom role definitions based off the deprecated module, you should refer to the documentation of the auth manager your system uses.
+
+Migrating ``DAG.access_control``
+--------------------------------
+
+Unlike the components above, ``DAG.access_control`` has no drop-in replacement. It was an input to the
+FAB auth manager rather than an authorization mechanism of its own: at parse time its contents were
+expanded into that manager's permission tables, and authorization then read those tables rather than
+the Dag argument.
+
+.. warning::
+    Airflow only reads ``DAG.access_control`` when the configured auth manager is the
+    :doc:`apache-airflow-providers-fab:auth-manager/index`. Under any other auth manager the argument is
+    parsed and serialized but never consulted, so it neither grants nor denies access. A deployment that
+    moves off the FAB auth manager and leaves ``access_control`` on its Dags stops enforcing those grants,
+    and does so without raising an error.
+
+To migrate, move the grants into the policy source your auth manager consults, and make the per-Dag
+decision in ``is_authorized_dag``, which every auth manager implements. ``filter_authorized_dag_ids`` and
+``get_authorized_dag_ids`` answer list views over that same policy. Both have working default
+implementations built on ``is_authorized_dag``, so overriding them is a performance concern rather than a
+correctness one.

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -591,7 +591,9 @@ class DAG:
             self.default_args["end_date"] = timezone.convert_to_utc(end_date)
         if self.access_control is not None:
             warnings.warn(
-                "The airflow.security.permissions module is deprecated; please see https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html",
+                "DAG.access_control is deprecated and is only read when the configured auth manager is the "
+                "FAB auth manager; under any other auth manager it is ignored and grants no access. See "
+                "https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html",
                 RemovedInAirflow4Warning,
                 stacklevel=2,
             )

--- a/task-sdk/src/airflow/sdk/definitions/dag.py
+++ b/task-sdk/src/airflow/sdk/definitions/dag.py
@@ -392,6 +392,9 @@ class DAG:
         "{'role1': {'can_read'}, 'role2': {'can_read', 'can_edit', 'can_delete'}}"
         or it can specify the resource name if there is a DAGs Run resource, e.g.,
         "{'role1': {'DAG Runs': {'can_create'}}, 'role2': {'DAGs': {'can_read', 'can_edit', 'can_delete'}}"
+        Deprecated, and only read when the configured auth manager is the FAB auth manager. Under any
+        other auth manager this argument is ignored and grants no access. See
+        https://airflow.apache.org/docs/apache-airflow/stable/security/deprecated_permissions.html
     :param is_paused_upon_creation: Specifies if the dag is paused when created for the first time.
         If the dag exists already, this flag will be ignored. If this optional parameter
         is not specified, the global config setting will be used.

--- a/task-sdk/tests/task_sdk/definitions/test_dag.py
+++ b/task-sdk/tests/task_sdk/definitions/test_dag.py
@@ -185,9 +185,7 @@ class TestDag:
             if len(role_access_control_entry) > 0
             else role_access_control_entry
         )
-        with pytest.warns(
-            RemovedInAirflow4Warning, match=re.escape("The airflow.security.permissions module is deprecated")
-        ):
+        with pytest.warns(RemovedInAirflow4Warning, match=re.escape("DAG.access_control is deprecated")):
             _ = DAG("should-warn-dag", access_control=access_control, schedule=None, start_date=DEFAULT_DATE)
 
     def test_params_not_passed_is_empty_dict(self):


### PR DESCRIPTION
`DAG.access_control` was documented as if it moved to `filter_authorized_dag_ids`. That row is wrong in two ways.

First, it names the wrong method. FAB is the only auth manager whose Dag permissions come from `access_control`, and it overrides [`get_authorized_dag_ids`](https://github.com/apache/airflow/blob/299ca2c8580773b2d51b7988aacd582695940d58/providers/fab/src/airflow/providers/fab/auth_manager/fab_auth_manager.py#L579), not `filter_authorized_dag_ids`, which has a [default implementation](https://github.com/apache/airflow/blob/299ca2c8580773b2d51b7988aacd582695940d58/airflow-core/src/airflow/api_fastapi/auth/managers/base_auth_manager.py#L668-L695) whose docstring treats overriding it as a performance choice.

Second, the row reads like an import swap. It is not. `access_control` was an input to FAB's permission tables, not a generic authorization mechanism. Since [#48070](https://github.com/apache/airflow/pull/48070), core has only synced it when the auth manager is FAB ([`collection.py`](https://github.com/apache/airflow/blob/299ca2c8580773b2d51b7988aacd582695940d58/airflow-core/src/airflow/dag_processing/collection.py#L299-L300)). With any other auth manager, the argument is still accepted and still [serialized](https://github.com/apache/airflow/blob/299ca2c8580773b2d51b7988aacd582695940d58/airflow-core/src/airflow/serialization/serialized_objects.py#L2287-L2288), but nothing reads it. A deployment that moves off FAB and leaves `access_control` on its Dags silently stops enforcing those grants.

The [auth manager guide](https://github.com/apache/airflow/blob/299ca2c8580773b2d51b7988aacd582695940d58/airflow-core/docs/core-concepts/auth-manager/index.rst#L304) already says FAB is the only reader and names the right method. The migration list is where the [deprecation warning](https://github.com/apache/airflow/blob/299ca2c8580773b2d51b7988aacd582695940d58/task-sdk/src/airflow/sdk/definitions/dag.py#L589-L594) sends readers, so it should say the same thing.

The warning emitted when `access_control` is set also reused the deprecation message from the `airflow.security.permissions` module, even when callers never imported that module. It now names `DAG.access_control` and warns that non-FAB auth managers ignore it and grant no access.

related: #53716
