### PR TITLE
fix(config): Mark three unused config.yml options as deprecated

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1142,6 +1142,9 @@ logging:
         A comma separated list of keywords related to errors whose presence should display the line in red
         color in UI
       version_added: 2.10.0
+      version_deprecated: 3.4.0
+      deprecation_reason: |
+        This parameter is no longer used.
       type: string
       example: ~
       default: "error,exception"
@@ -1150,6 +1153,9 @@ logging:
         A comma separated list of keywords related to warning whose presence should display the line in yellow
         color in UI
       version_added: 2.10.0
+      version_deprecated: 3.4.0
+      deprecation_reason: |
+        This parameter is no longer used.
       type: string
       example: ~
       default: "warn"
@@ -2742,6 +2748,9 @@ scheduler:
         in the DB with a logical_date earlier than it., i.e. no manual marking
         success will be needed for a newly added task to be scheduled.
       version_added: 2.3.0
+      version_deprecated: 3.4.0
+      deprecation_reason: |
+        This parameter is no longer used.
       type: boolean
       example: ~
       default: "True"


### PR DESCRIPTION
## Description

Three options in `config.yml` are never read anywhere in the repository — not in Python, not in the React UI, not in the Helm chart, not in the docs:

| config.yml | option | added | references outside config.yml |
|---|---|---|---|
| line 1140 | `[logging] color_log_error_keywords` | 2.10.0 | **0** |
| line 1148 | `[logging] color_log_warning_keywords` | 2.10.0 | **0** |
| line 2737 | `[scheduler] ignore_first_depends_on_past_by_default` | 2.3.0 | **0** |

None of the three carried `version_deprecated` or `deprecation_reason`, so they were presented as current settings in `config.yml` (which drives both the generated `airflow.cfg` and the [configuration reference](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html)). Someone reading the docs sets one of these and nothing happens, with no warning.

## Fix

Add `version_deprecated: 3.4.0` and `deprecation_reason: This parameter is no longer used.` to all three options, following the existing pattern used by e.g. `[traces] otel_debug_traces_on`.

Closes #71259