### PR TITLE
Add tdsodbc to RUNTIME_APT_DEPS so libtdsodbc.so is available for Syb…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,7 @@ pkgconf \
 sasl2-bin \
 sqlite3 \
 sudo \
+tdsodbc \
 tk-dev \
 unixodbc \
 unixodbc-dev \
@@ -248,6 +249,7 @@ rsync \
 sasl2-bin \
 sqlite3 \
 sudo \
+tdsodbc \
 unixodbc \
 wget\
 "

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -133,6 +133,7 @@ pkgconf \
 sasl2-bin \
 sqlite3 \
 sudo \
+tdsodbc \
 tk-dev \
 unixodbc \
 unixodbc-dev \
@@ -188,6 +189,7 @@ rsync \
 sasl2-bin \
 sqlite3 \
 sudo \
+tdsodbc \
 unixodbc \
 wget\
 "

--- a/docker-stack-docs/changelog.rst
+++ b/docker-stack-docs/changelog.rst
@@ -34,6 +34,12 @@ the Airflow team.
        any Airflow version from the ``Airflow 2`` line. There is no guarantee that it will work, but if it does,
        then you can use latest features from that image to build images for previous Airflow versions.
 
+Airflow 3.4.0
+~~~~~~~~~~~~~
+
+  * The ``tdsodbc`` package was added to the image so that the FreeTDS ODBC driver
+    (``libtdsodbc.so``) is available for connecting to Sybase/TDS databases via ODBC.
+
 Airflow 3.1.4
 ~~~~~~~~~~~~~
 

--- a/scripts/docker/install_os_dependencies.sh
+++ b/scripts/docker/install_os_dependencies.sh
@@ -101,6 +101,7 @@ pkgconf \
 sasl2-bin \
 sqlite3 \
 sudo \
+tdsodbc \
 tk-dev \
 unixodbc \
 unixodbc-dev \
@@ -156,6 +157,7 @@ rsync \
 sasl2-bin \
 sqlite3 \
 sudo \
+tdsodbc \
 unixodbc \
 wget\
 "


### PR DESCRIPTION
**Summary**
Users connecting to Sybase databases via ODBC + FreeTDS find that
libtdsodbc.so is missing from the Airflow image, even though freetds-bin
and unixodbc are both already present.

**Root cause**
On Debian, the FreeTDS ODBC driver ships in a separate package, tdsodbc,
which freetds-bin does not pull in (freetds-bin only provides tsql/libct).
RUNTIME_APT_DEPS lists freetds-bin and unixodbc but not tdsodbc, so the
.so file that gets registered with unixodbc is never installed.

**Fix**
Added tdsodbc to RUNTIME_APT_DEPS, and to the dev-deps list for local
source builds.

closes: #71205

Was generative AI tooling used ?

- [X] Yes - Claude

Generated-by: Claude following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)