### PR TITLE
Fix google provider install failure on Python 3.14

### DIFF
--- a/providers/google/README.rst
+++ b/providers/google/README.rst
@@ -77,7 +77,8 @@ PIP package                                 Version required
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-genai``                            ``>=2.8.0``
-``google-cloud-aiplatform[evaluation]``     ``>=1.155.0``
+``google-cloud-aiplatform[evaluation]``     ``>=1.155.0; python_version < "3.14"``
+``google-cloud-aiplatform``                 ``>=1.155.0; python_version >= "3.14"``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
 ``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``ray[default]``                            ``>=2.55.0; python_version >= "3.14" and python_version < "3.15"``

--- a/providers/google/docs/index.rst
+++ b/providers/google/docs/index.rst
@@ -130,7 +130,8 @@ PIP package                                 Version required
 ``google-auth``                             ``>=2.29.0``
 ``google-auth-httplib2``                    ``>=0.0.1``
 ``google-genai``                            ``>=2.8.0``
-``google-cloud-aiplatform[evaluation]``     ``>=1.155.0``
+``google-cloud-aiplatform[evaluation]``     ``>=1.155.0; python_version < "3.14"``
+``google-cloud-aiplatform``                 ``>=1.155.0; python_version >= "3.14"``
 ``ray[default]``                            ``>=2.42.0; python_version < "3.13"``
 ``ray[default]``                            ``>=2.49.0; python_version >= "3.13" and python_version < "3.14"``
 ``ray[default]``                            ``>=2.55.0; python_version >= "3.14" and python_version < "3.15"``

--- a/providers/google/pyproject.toml
+++ b/providers/google/pyproject.toml
@@ -84,7 +84,13 @@ dependencies = [
     # google-cloud-aiplatform doesn't install ray for python 3.12 (issue: https://github.com/googleapis/python-aiplatform/issues/5252).
     # Temporarily lock in ray 2.42.0 which is compatible with python 3.12 until linked issue is solved.
     # Remove the ray dependency as well as google-cloud-bigquery-storage once linked issue is fixed
-    "google-cloud-aiplatform[evaluation]>=1.155.0",
+    # google-cloud-aiplatform[evaluation] pulls litellm, which cannot be installed on Python 3.14:
+    # aiplatform caps the evaluation extra at litellm<1.86.0, and no litellm in that range works on
+    # 3.14 (1.95.0+ does, but that is above the cap). Install the evaluation extra only below 3.14
+    # until google-cloud-aiplatform raises its litellm ceiling to a 3.14-capable version.
+    # tracked at https://github.com/apache/airflow/issues/71268
+    "google-cloud-aiplatform[evaluation]>=1.155.0;python_version<'3.14'",
+    "google-cloud-aiplatform>=1.155.0;python_version>='3.14'",
     "ray[default]>=2.42.0;python_version<'3.13'",
     "ray[default]>=2.49.0;python_version>='3.13' and python_version <'3.14'",
     "ray[default]>=2.55.0;python_version>='3.14' and python_version <'3.15'",


### PR DESCRIPTION
Gate `google-cloud-aiplatform[evaluation]` to Python < 3.14, falling back to plain `google-cloud-aiplatform` on 3.14.

`apache-airflow-providers-google` is currently uninstallable on Python 3.14: the `evaluation` extra pulls `litellm`, but `google-cloud-aiplatform` (latest 1.163.0) caps the extra at `litellm<1.86.0`, and no litellm in that range works on 3.14 (1.95.0+ does, but it is above the cap). `pip install apache-airflow-providers-google` therefore fails with `ResolutionImpossible` on 3.14, even though the provider advertises `requires_python >=3.10`.

This gates the evaluation extra to `python_version < '3.14'` so 3.14 installs the base aiplatform without the litellm-bearing extra. Everything else is unaffected. Removal of the workaround (once aiplatform raises its litellm ceiling to a 3.14-capable version) is tracked in #71268.

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 4.8)

Generated-by: Claude Code (Opus 4.8) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)