### PR TITLE
fix: redact non-string scalar values when key name is sensitive (#71275)

### DIFF
--- a/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
+++ b/shared/secrets_masker/src/airflow_shared/secrets_masker/secrets_masker.py
@@ -344,7 +344,7 @@ class SecretsMasker(logging.Filter):
             return list(
                 self._redact_all(subval, depth + 1, max_depth, replacement=replacement) for subval in item
             )
-        return item
+        return replacement
 
     def _redact(
         self, item: Redactable, name: str | None, depth: int, max_depth: int, replacement: str = "***"


### PR DESCRIPTION
## Description

When a Variable's key name matches the sensitive-keyword list, `GET /api/v2/variables` correctly returns `***` for string values but returns non-string values (int, float, bool) in cleartext, leaking sensitive data.

### Root cause

`SecretsMasker._redact_all` is the fail-closed path used when a key name is judged sensitive, but it only replaces `str`, recurses into containers, and returns every other type unchanged:

```python
def _redact_all(self, item, depth, max_depth=MAX_RECURSION_DEPTH, *, replacement="***"):
    if depth > max_depth or isinstance(item, str):
        return replacement
    if isinstance(item, dict): ...
    if isinstance(item, (tuple, set)): ...
    if isinstance(item, list): ...
    return item          # <-- non-str scalars pass through unredacted
```

The comment at lines 353-355 states that key-name-based redaction "must fail closed at any nesting level". It fails closed on depth, but not on type.

### Fix

Change the final fall-through in `_redact_all` from `return item` to `return replacement`, so any non-container, non-str scalar (int, float, bool) is also redacted when the key name is sensitive.

Closes #71275