### PR TITLE
Serve logs from scheduler if any executor is LocalExecutor

### DIFF
--- a/airflow-core/src/airflow/cli/commands/scheduler_command.py
+++ b/airflow-core/src/airflow/cli/commands/scheduler_command.py
@@ -79,8 +79,11 @@ def _serve_logs(skip_serve_logs: bool = False):
 
     sub_proc = None
     if skip_serve_logs is False:
-        executor_class, _ = ExecutorLoader.import_default_executor_cls()
-        if executor_class.serve_logs:
+        executor_classes = [
+            ExecutorLoader.import_executor_cls(executor_name)[0]
+            for executor_name in (ExecutorLoader.get_executor_names())
+        ]
+        if any(executor_class.serve_logs for executor_class in executor_classes):
             sub_proc = Process(target=serve_logs)
             sub_proc.start()
     try:

--- a/airflow-core/tests/unit/cli/commands/test_scheduler_command.py
+++ b/airflow-core/tests/unit/cli/commands/test_scheduler_command.py
@@ -44,6 +44,8 @@ class TestSchedulerCommand:
             ("CeleryExecutor", False),
             ("LocalExecutor", True),
             ("KubernetesExecutor", False),
+            ("LocalExecutor,KubernetesExecutor", True),
+            ("KubernetesExecutor,LocalExecutor", True),
         ],
     )
     @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJobRunner")


### PR DESCRIPTION
This change causes the scheduler to start the local log server if the `LocalExecutor` is anywhere in the list of configured executors; previously, scheduler would start the log server only if `LocalExecutor` was the default (first) executor.

In my org, we set up multiple executors on Airflow 2 with the `core.executor` config set to `KubernetesExecutor,LocalExecutor`. We put the `KubernetesExecutor` first as a fail-safe - in the event a task runs without specifying an executor, we want it to run in an isolated pod so it doesn't threaten resources on the scheduler or its locally-running tasks.

After we upgraded to Airflow 3, we noticed:
* Task logs would not display in the UI for running local tasks (logs would display as expected for finished local tasks, and running and finished k8s tasks)
* Logs in the api-server would show a corresponding `Connection refused` error trying to connect to the scheduler on port 8793
* The scheduler was not actually listening on 8793, i.e. the local log server had not been started

I examined the code and found that `scheduler_command` launches the log server only if `LocalExecutor` is the default executor (i.e., the first executor listed in the configuration). 

This PR solves the issue by examining all configured executor types instead of only the default when deciding whether to launch the log server.

I've added two test cases to the existing parameterized `TestSchedulerCommand.test_serve_logs_on_scheduler()` method: 
* `"LocalExecutor,KubernetesExecutor"` passes before and after this fix, showing that the log server is launched when the local executor is the default in a multiple-executor setup
* `"KubernetesExecutor,LocalExecutor"` fails before this fix and passes after it, showing that the log server is launched when the local executor is non-default in a multiple-executor setup
---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---
