### PR TITLE
Render triggerer exception dicts as a stack trace

### DIFF
--- a/airflow-core/newsfragments/71286.bugfix.rst
+++ b/airflow-core/newsfragments/71286.bugfix.rst
@@ -1,0 +1,1 @@
+Exceptions logged by the triggerer about itself now appear as a stack trace rather than as the raw list of dicts ``structlog`` serialises them to. Per-trigger records written to the task log keep the structured payload, which is what the log view in the UI renders from.

--- a/airflow-core/src/airflow/jobs/triggerer_job_runner.py
+++ b/airflow-core/src/airflow/jobs/triggerer_job_runner.py
@@ -46,6 +46,7 @@ from pydantic import BaseModel, Field, TypeAdapter
 from sqlalchemy import func, select
 from structlog.contextvars import bind_contextvars as bind_log_contextvars
 
+from airflow._shared.logging.tracebacks import format_exception_dicts
 from airflow._shared.module_loading import import_string
 from airflow._shared.observability.metrics import stats
 from airflow._shared.timezones import timezone
@@ -1051,8 +1052,14 @@ class TriggerRunnerSupervisor(WatchedSubprocess):
                 log = fallback_log
 
             if exc := event.pop("exception", None):
-                # TODO: convert the dict back to a pretty stack trace
-                event["error_detail"] = exc
+                if log is fallback_log:
+                    # The triggerer's own log is read as plain text, where structlog's list of
+                    # exception dicts is unreadable. Per-trigger records instead go to the task
+                    # log, whose readers render the structured payload themselves, so those keep
+                    # it as it arrived.
+                    event["error_detail"] = format_exception_dicts(exc) or exc
+                else:
+                    event["error_detail"] = exc
             if lvl_name := NAME_TO_LEVEL.get(event.pop("level")):
                 log.log(lvl_name, event.pop("event", None), **event)
 

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.test.tsx
@@ -112,6 +112,18 @@ describe("renderStructuredLog — already rendered error_detail", () => {
     expect(container.textContent).toBe(`0Trigger failed\n${traceback}`);
   });
 
+  it("adds no blank line when error_detail is an empty string", () => {
+    const result = renderStructuredLog({
+      index: 0,
+      logLink: "",
+      logMessage: { error_detail: "", event: "Trigger failed" },
+      renderingMode: "text",
+      translate: translate as never,
+    });
+
+    expect(result).toBe("Trigger failed");
+  });
+
   it("does not throw on an error_detail that is neither a list nor a string", () => {
     const result = renderStructuredLog({
       index: 0,

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.test.tsx
@@ -83,29 +83,9 @@ describe("renderStructuredLog — already rendered error_detail", () => {
     "RuntimeError: outer",
   ].join("\n");
 
-  const logMessage = {
-    error_detail: traceback,
-    event: "Trigger failed",
-    level: "error",
-    timestamp: "2026-07-22T09:15:20Z",
-  };
+  const logMessage = { error_detail: traceback, event: "Trigger failed" };
 
-  it("jsx mode: renders a string error_detail instead of throwing", () => {
-    const result = renderStructuredLog({
-      index: 0,
-      logLink: "",
-      logMessage,
-      renderingMode: "jsx",
-      translate: translate as never,
-    });
-
-    render(<Wrapper>{result}</Wrapper>);
-
-    expect(screen.getByText(/RuntimeError: outer/u)).toBeInTheDocument();
-    expect(screen.getByText("Trigger failed")).toBeInTheDocument();
-  });
-
-  it("text mode: keeps the traceback verbatim", () => {
+  it("text mode: puts the traceback on its own line rather than against the event", () => {
     const result = renderStructuredLog({
       index: 0,
       logLink: "",
@@ -114,7 +94,34 @@ describe("renderStructuredLog — already rendered error_detail", () => {
       translate: translate as never,
     });
 
-    expect(result).toContain(traceback);
+    expect(result).toBe(`Trigger failed\n${traceback}`);
+  });
+
+  it("jsx mode: puts the traceback on its own line rather than against the event", () => {
+    const result = renderStructuredLog({
+      index: 0,
+      logLink: "",
+      logMessage,
+      renderingMode: "jsx",
+      translate: translate as never,
+    });
+
+    const { container } = render(<Wrapper>{result}</Wrapper>);
+
+    // The leading "0" is the line-number gutter link, which carries the index.
+    expect(container.textContent).toBe(`0Trigger failed\n${traceback}`);
+  });
+
+  it("does not throw on an error_detail that is neither a list nor a string", () => {
+    const result = renderStructuredLog({
+      index: 0,
+      logLink: "",
+      logMessage: { error_detail: { unexpected: true }, event: "Trigger failed" },
+      renderingMode: "text",
+      translate: translate as never,
+    });
+
+    expect(result).toBe('Trigger failed\n{"unexpected":true}');
   });
 });
 

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.test.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.test.tsx
@@ -76,6 +76,48 @@ describe("renderStructuredLog — traceback frame highlighting", () => {
   });
 });
 
+describe("renderStructuredLog — already rendered error_detail", () => {
+  const traceback = [
+    "Traceback (most recent call last):",
+    '  File "/dags/t.py", line 12, in run',
+    "RuntimeError: outer",
+  ].join("\n");
+
+  const logMessage = {
+    error_detail: traceback,
+    event: "Trigger failed",
+    level: "error",
+    timestamp: "2026-07-22T09:15:20Z",
+  };
+
+  it("jsx mode: renders a string error_detail instead of throwing", () => {
+    const result = renderStructuredLog({
+      index: 0,
+      logLink: "",
+      logMessage,
+      renderingMode: "jsx",
+      translate: translate as never,
+    });
+
+    render(<Wrapper>{result}</Wrapper>);
+
+    expect(screen.getByText(/RuntimeError: outer/u)).toBeInTheDocument();
+    expect(screen.getByText("Trigger failed")).toBeInTheDocument();
+  });
+
+  it("text mode: keeps the traceback verbatim", () => {
+    const result = renderStructuredLog({
+      index: 0,
+      logLink: "",
+      logMessage,
+      renderingMode: "text",
+      translate: translate as never,
+    });
+
+    expect(result).toContain(traceback);
+  });
+});
+
 describe("renderStructuredLog — TI context field stripping", () => {
   it("does not render TI context fields as per-line structured attributes", () => {
     const result = renderStructuredLog({

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -248,7 +248,11 @@ const renderStructuredLogImpl = ({
   const { error_detail: errorDetail, ...reStructured } = structured;
   let details;
 
-  if (errorDetail !== undefined) {
+  if (typeof errorDetail === "string") {
+    // Some producers render the traceback themselves instead of sending the frames. Both the
+    // text branch and the jsx wrapper below keep whitespace, so it lays out as it arrived.
+    details = errorDetail;
+  } else if (errorDetail !== undefined) {
     details = (errorDetail as Array<ErrorDetail>).map((error) => {
       const errorLines = error.frames.map((frame) => {
         if (renderingMode === "text") {

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -248,11 +248,7 @@ const renderStructuredLogImpl = ({
   const { error_detail: errorDetail, ...reStructured } = structured;
   let details;
 
-  if (typeof errorDetail === "string") {
-    // Some producers render the traceback themselves instead of sending the frames. Both the
-    // text branch and the jsx wrapper below keep whitespace, so it lays out as it arrived.
-    details = errorDetail;
-  } else if (errorDetail !== undefined) {
+  if (Array.isArray(errorDetail)) {
     details = (errorDetail as Array<ErrorDetail>).map((error) => {
       const errorLines = error.frames.map((frame) => {
         if (renderingMode === "text") {
@@ -293,6 +289,14 @@ const renderStructuredLogImpl = ({
         </chakra.details>
       );
     });
+  } else if (errorDetail !== undefined) {
+    // Some producers render the traceback themselves instead of sending the frames. Break the
+    // line first so it does not run into the event text, and let the whitespace through: both
+    // the text branch and the jsx wrapper below preserve it. Anything that is neither shape is
+    // stringified rather than rendered, so an unexpected value cannot take the log view down.
+    const rendered = typeof errorDetail === "string" ? errorDetail : JSON.stringify(errorDetail);
+
+    details = `\n${rendered}`;
   }
 
   elements.push(

--- a/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/renderStructuredLog.tsx
@@ -296,7 +296,8 @@ const renderStructuredLogImpl = ({
     // stringified rather than rendered, so an unexpected value cannot take the log view down.
     const rendered = typeof errorDetail === "string" ? errorDetail : JSON.stringify(errorDetail);
 
-    details = `\n${rendered}`;
+    // An empty detail would otherwise contribute nothing but the line break.
+    details = rendered === "" ? undefined : `\n${rendered}`;
   }
 
   elements.push(

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -439,6 +439,9 @@ def test_process_log_messages_renders_exceptions_from_the_triggerer_itself(
 ):
     """The triggerer's own log is read as text, so the exception dicts become a stack trace."""
     supervisor = supervisor_builder()
+    # Priming the generator calls configure_logging(), which reconfigures structlog globally
+    # and would replace the capture cap_structlog installed. Keep the patch.
+    mocker.patch("airflow.sdk.log.configure_logging")
     mocker.patch("airflow.sdk.log.logging_processors")
 
     gen = supervisor._process_log_messages_from_subprocess()
@@ -492,6 +495,8 @@ def test_process_log_messages_keeps_an_unrecognised_exception_payload(
 ):
     """A payload that is not transformer output is passed through rather than dropped."""
     supervisor = supervisor_builder()
+    # Same reason as the test above: priming reconfigures structlog and drops the capture.
+    mocker.patch("airflow.sdk.log.configure_logging")
     mocker.patch("airflow.sdk.log.logging_processors")
     payload = {"not": "a transformer payload"}
 

--- a/airflow-core/tests/unit/jobs/test_triggerer_job.py
+++ b/airflow-core/tests/unit/jobs/test_triggerer_job.py
@@ -410,6 +410,98 @@ def test_process_log_messages_configures_logging_matching_json_logs(supervisor_b
     configure_logging.assert_called_once_with(json_output=json_logs)
 
 
+EXCEPTION_PAYLOAD = [
+    {
+        "exc_type": "RuntimeError",
+        "exc_value": "outer",
+        "exc_notes": [],
+        "syntax_error": None,
+        "is_cause": False,
+        "frames": [{"filename": "/dags/t.py", "lineno": 12, "name": "run"}],
+        "is_group": False,
+        "exceptions": [],
+    },
+    {
+        "exc_type": "ValueError",
+        "exc_value": "inner",
+        "exc_notes": [],
+        "syntax_error": None,
+        "is_cause": True,
+        "frames": [{"filename": "/dags/t.py", "lineno": 7, "name": "boom"}],
+        "is_group": False,
+        "exceptions": [],
+    },
+]
+
+
+def test_process_log_messages_renders_exceptions_from_the_triggerer_itself(
+    supervisor_builder, mocker, cap_structlog
+):
+    """The triggerer's own log is read as text, so the exception dicts become a stack trace."""
+    supervisor = supervisor_builder()
+    mocker.patch("airflow.sdk.log.logging_processors")
+
+    gen = supervisor._process_log_messages_from_subprocess()
+    next(gen)
+    gen.send(
+        msgspec.json.encode({"event": "Trigger failed", "level": "error", "exception": EXCEPTION_PAYLOAD})
+    )
+
+    assert {
+        "event": "Trigger failed",
+        "log_level": "error",
+        "error_detail": (
+            "Traceback (most recent call last):\n"
+            '  File "/dags/t.py", line 7, in boom\n'
+            "ValueError: inner\n"
+            "\n"
+            "The above exception was the direct cause of the following exception:\n"
+            "\n"
+            "Traceback (most recent call last):\n"
+            '  File "/dags/t.py", line 12, in run\n'
+            "RuntimeError: outer"
+        ),
+    } in cap_structlog
+
+
+def test_process_log_messages_leaves_task_log_exceptions_structured(supervisor_builder, mocker):
+    """Per-trigger records go to the task log, whose readers render the payload themselves."""
+    supervisor = supervisor_builder()
+    mocker.patch("airflow.sdk.log.logging_processors")
+    trigger_log = mocker.MagicMock()
+    supervisor.logger_cache[7] = mocker.MagicMock(return_value=trigger_log)
+
+    gen = supervisor._process_log_messages_from_subprocess()
+    next(gen)
+    gen.send(
+        msgspec.json.encode(
+            {
+                "event": "Trigger failed",
+                "level": "error",
+                "trigger_id": 7,
+                "exception": EXCEPTION_PAYLOAD,
+            }
+        )
+    )
+
+    assert trigger_log.log.call_args.kwargs["error_detail"] == EXCEPTION_PAYLOAD
+
+
+def test_process_log_messages_keeps_an_unrecognised_exception_payload(
+    supervisor_builder, mocker, cap_structlog
+):
+    """A payload that is not transformer output is passed through rather than dropped."""
+    supervisor = supervisor_builder()
+    mocker.patch("airflow.sdk.log.logging_processors")
+    payload = {"not": "a transformer payload"}
+
+    gen = supervisor._process_log_messages_from_subprocess()
+    next(gen)
+    gen.send(msgspec.json.encode({"event": "Trigger failed", "level": "error", "exception": payload}))
+
+    assert {"event": "Trigger failed", "log_level": "error", "error_detail": payload} in cap_structlog
+
+
 def test_client_delegates_to_make_client_and_caches_result(supervisor_builder, mocker):
     """``supervisor.client`` delegates to ``make_client`` (the subclass-override hook)
     and caches the result across accesses."""

--- a/shared/logging/src/airflow_shared/logging/tracebacks.py
+++ b/shared/logging/src/airflow_shared/logging/tracebacks.py
@@ -99,9 +99,15 @@ def _format_stack(stack: Any, depth: int) -> list[str]:
         # over ``exc_value``, which repeats them.
         summary = syntax_error.get("msg", summary)
 
-    lines.append(f"{stack.get('exc_type')}: {summary}")
+    lines.append(_exception_line(stack.get("exc_type"), summary))
     lines.extend(_as_list(stack.get("exc_notes")))
     return _prefixed(lines, depth)
+
+
+def _exception_line(exc_type: Any, summary: Any) -> str:
+    """Render the ``Type: message`` line, dropping the separator when there is no message."""
+    # `raise ValueError()` carries an empty `exc_value`, and CPython prints the bare type name.
+    return f"{exc_type}: {summary}" if summary else f"{exc_type}"
 
 
 def _as_list(value: Any) -> list[Any]:
@@ -126,7 +132,7 @@ def _format_group(stack: Any, depth: int) -> list[str]:
         header.append(_GROUP_HEADER)
         for frame in frames:
             header.extend(_format_frame(frame))
-    header.append(f"{stack.get('exc_type')}: {stack.get('exc_value')}")
+    header.append(_exception_line(stack.get("exc_type"), stack.get("exc_value")))
     header.extend(_as_list(stack.get("exc_notes")))
 
     lines = _prefixed(header, group_depth)
@@ -160,17 +166,20 @@ def _ends_in_group(children: list[Any]) -> bool:
 def _format_syntax_error(syntax_error: Any) -> list[str]:
     """Render the offending source line of a :exc:`SyntaxError` with a caret beneath it."""
     lines = [f'  File "{syntax_error.get("filename")}", line {syntax_error.get("lineno")}']
-    source = (syntax_error.get("line") or "").rstrip()
+    source = (syntax_error.get("line") or "").rstrip("\n")
     if not source.strip():
         return lines
 
-    stripped = source.lstrip()
+    # Match CPython, which strips only spaces, newlines and form feeds so that tab-indented
+    # source keeps its tabs, and pads the caret with the whitespace it kept so it lines up.
+    stripped = source.lstrip(" \n\f")
     lines.append(f"    {stripped}")
     offset = syntax_error.get("offset")
     if isinstance(offset, int):
         column = offset - 1 - (len(source) - len(stripped))
         if 0 <= column < len(stripped):
-            lines.append(f"    {' ' * column}^")
+            padding = "".join(char if char.isspace() else " " for char in stripped[:column])
+            lines.append(f"    {padding}^")
     return lines
 
 

--- a/shared/logging/src/airflow_shared/logging/tracebacks.py
+++ b/shared/logging/src/airflow_shared/logging/tracebacks.py
@@ -28,9 +28,11 @@ _CONTEXT_MESSAGE = "During handling of the above exception, another exception oc
 _GROUP_HEADER = "Exception Group Traceback (most recent call last):"
 _SEPARATOR_DASHES = 16
 _CLOSING_DASHES = 36
-# Groups can nest arbitrarily deep. CPython's own traceback module stops at 15 levels and so
-# do we, both to keep the output readable and to bound recursion on a hostile payload.
-_MAX_GROUP_DEPTH = 15
+# Both limits and their wording are CPython's, from `TracebackException.max_group_width` and
+# `max_group_depth`. Matching them keeps the output familiar and bounds recursion and length
+# on a hostile payload.
+_MAX_GROUP_WIDTH = 15
+_MAX_GROUP_DEPTH = 10
 
 
 class _MalformedPayload(Exception):
@@ -83,6 +85,8 @@ def _prefixed(lines: list[str], depth: int) -> list[str]:
 def _format_stack(stack: Any, depth: int) -> list[str]:
     """Render a single exception together with its stack frames."""
     if stack.get("is_group") and stack.get("exceptions"):
+        if (depth or 1) > _MAX_GROUP_DEPTH:
+            return _prefixed([f"... (max_group_depth is {_MAX_GROUP_DEPTH})"], depth)
         return _format_group(stack, depth)
 
     lines: list[str] = []
@@ -141,31 +145,52 @@ def _format_group(stack: Any, depth: int) -> list[str]:
         lines[0] = f"{indent}+ {_GROUP_HEADER}"
 
     children = _as_list(stack.get("exceptions"))
-    if group_depth >= _MAX_GROUP_DEPTH:
-        return [*lines, f"{child_indent}+ ... ({len(children)} more nested sub-exceptions)"]
+    shown = children[:_MAX_GROUP_WIDTH]
 
-    for position, child in enumerate(children):
-        divider = f"{'-' * _SEPARATOR_DASHES} {position + 1} {'-' * _SEPARATOR_DASHES}"
+    for position, child in enumerate(shown):
+        divider = _divider(str(position + 1))
         lines.append(f"{indent}+-+{divider}" if position == 0 else f"{child_indent}+{divider}")
         lines.extend(_format_chain(_as_list(child), group_depth + 1))
 
-    # The last sub-exception draws the closing line itself when it is a group of its own.
-    if not _ends_in_group(children):
+    dropped = len(children) - len(shown)
+    if dropped:
+        plural = "s" if dropped > 1 else ""
+        lines.append(f"{child_indent}+{_divider('...')}")
+        lines.extend(_prefixed([f"and {dropped} more exception{plural}"], group_depth + 1))
+
+    # A sub-exception that is itself a group draws the closing line at its own level, so the
+    # one place we must not draw it is directly after such a group. A group deep enough to be
+    # replaced by the depth notice never gets that far, and neither does the dropped count.
+    if dropped or not _ends_in_rendered_group(shown, group_depth + 1):
         lines.append(f"{child_indent}+{'-' * _CLOSING_DASHES}")
     return lines
 
 
-def _ends_in_group(children: list[Any]) -> bool:
-    """Tell whether the last sub-exception rendered is itself an exception group."""
+def _divider(title: str) -> str:
+    """Build the numbered rule that separates one sub-exception from the next."""
+    return f"{'-' * _SEPARATOR_DASHES} {title} {'-' * _SEPARATOR_DASHES}"
+
+
+def _ends_in_rendered_group(children: list[Any], child_depth: int) -> bool:
+    """Tell whether the last sub-exception is a group that was rendered rather than elided."""
     if not children or not isinstance(children[-1], list) or not children[-1]:
         return False
     last = children[-1][0]
-    return bool(isinstance(last, dict) and last.get("is_group") and last.get("exceptions"))
+    if not (isinstance(last, dict) and last.get("is_group") and last.get("exceptions")):
+        return False
+    return child_depth <= _MAX_GROUP_DEPTH
 
 
 def _format_syntax_error(syntax_error: Any) -> list[str]:
     """Render the offending source line of a :exc:`SyntaxError` with a caret beneath it."""
-    lines = [f'  File "{syntax_error.get("filename")}", line {syntax_error.get("lineno")}']
+    # CPython prints the location only when the exception carries a line number, so a
+    # `raise SyntaxError("bad")` written by hand gets none. structlog stores `lineno or 0`,
+    # which turns that absence into a zero, and no real syntax error is reported on line 0.
+    # Printing the header regardless would invent a position that does not exist.
+    lines = []
+    if lineno := syntax_error.get("lineno"):
+        lines.append(f'  File "{syntax_error.get("filename")}", line {lineno}')
+
     # structlog stores `exc_value.text or ""`, so an exception with no source text arrives as
     # an empty string. Anything else is printed, including a line that is only indentation,
     # which is exactly what `expected an indented block` reports.

--- a/shared/logging/src/airflow_shared/logging/tracebacks.py
+++ b/shared/logging/src/airflow_shared/logging/tracebacks.py
@@ -1,0 +1,189 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Render :class:`structlog.tracebacks.ExceptionDictTransformer` output as text."""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["format_exception_dicts"]
+
+_CAUSE_MESSAGE = "The above exception was the direct cause of the following exception:"
+_CONTEXT_MESSAGE = "During handling of the above exception, another exception occurred:"
+_GROUP_HEADER = "Exception Group Traceback (most recent call last):"
+_SEPARATOR_DASHES = 16
+_CLOSING_DASHES = 36
+# Groups can nest arbitrarily deep. CPython's own traceback module stops at 15 levels and so
+# do we, both to keep the output readable and to bound recursion on a hostile payload.
+_MAX_GROUP_DEPTH = 15
+
+
+class _MalformedPayload(Exception):
+    """Raised internally when the payload does not match the transformer's schema."""
+
+
+def format_exception_dicts(exc_dicts: Any) -> str | None:
+    """
+    Render structlog's dict representation of an exception back into a traceback.
+
+    The payload reaches us as JSON from a separate process, so anything at all may turn up
+    here. Rather than risk taking down the log pipeline, an unusable payload renders as
+    ``None`` and lets the caller keep whatever it already had.
+
+    :param exc_dicts: the value produced by
+        :class:`structlog.tracebacks.ExceptionDictTransformer`.
+    :return: a multi-line string, or ``None`` if the payload could not be rendered.
+    """
+    if not isinstance(exc_dicts, list) or not exc_dicts:
+        return None
+    if not all(isinstance(entry, dict) and entry.get("exc_type") for entry in exc_dicts):
+        return None
+    try:
+        return "\n".join(_format_chain(exc_dicts, depth=0))
+    except Exception:
+        # Losing the stack trace is annoying. Losing the log line it belongs to is worse.
+        return None
+
+
+def _format_chain(chain: list[Any], depth: int) -> list[str]:
+    """Render one exception chain, innermost cause first, at the given group nesting depth."""
+    lines: list[str] = []
+    ordered = list(reversed(chain))
+    for position, stack in enumerate(ordered):
+        lines.extend(_format_stack(stack, depth))
+        if position < len(ordered) - 1:
+            banner = _CAUSE_MESSAGE if stack.get("is_cause") else _CONTEXT_MESSAGE
+            lines += _prefixed(["", banner, ""], depth)
+    return lines
+
+
+def _prefixed(lines: list[str], depth: int) -> list[str]:
+    """Apply the margin that marks lines as belonging to an enclosing exception group."""
+    if not depth:
+        return lines
+    margin = "  " * depth + "| "
+    return [margin + line for line in lines]
+
+
+def _format_stack(stack: Any, depth: int) -> list[str]:
+    """Render a single exception together with its stack frames."""
+    if stack.get("is_group") and stack.get("exceptions"):
+        return _format_group(stack, depth)
+
+    lines: list[str] = []
+    frames = _as_list(stack.get("frames"))
+    if frames:
+        lines.append("Traceback (most recent call last):")
+        for frame in frames:
+            lines.extend(_format_frame(frame))
+
+    summary = stack.get("exc_value")
+    if syntax_error := stack.get("syntax_error"):
+        lines.extend(_format_syntax_error(syntax_error))
+        # The file and line are already on the preceding lines, so prefer the bare message
+        # over ``exc_value``, which repeats them.
+        summary = syntax_error.get("msg", summary)
+
+    lines.append(f"{stack.get('exc_type')}: {summary}")
+    lines.extend(_as_list(stack.get("exc_notes")))
+    return _prefixed(lines, depth)
+
+
+def _as_list(value: Any) -> list[Any]:
+    """Return an empty or list value unchanged, and reject anything else."""
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise _MalformedPayload(type(value).__name__)
+    return value
+
+
+def _format_group(stack: Any, depth: int) -> list[str]:
+    """Render an :exc:`ExceptionGroup` and its sub-exceptions as indented, numbered blocks."""
+    # A group at the top level still draws its own margin, so it renders one level in.
+    group_depth = depth or 1
+    indent = "  " * group_depth
+    child_indent = "  " * (group_depth + 1)
+
+    header: list[str] = []
+    frames = _as_list(stack.get("frames"))
+    if frames:
+        header.append(_GROUP_HEADER)
+        for frame in frames:
+            header.extend(_format_frame(frame))
+    header.append(f"{stack.get('exc_type')}: {stack.get('exc_value')}")
+    header.extend(_as_list(stack.get("exc_notes")))
+
+    lines = _prefixed(header, group_depth)
+    if frames and depth == 0:
+        # CPython marks the outermost group header with a `+` rather than the usual `|`.
+        lines[0] = f"{indent}+ {_GROUP_HEADER}"
+
+    children = _as_list(stack.get("exceptions"))
+    if group_depth >= _MAX_GROUP_DEPTH:
+        return [*lines, f"{child_indent}+ ... ({len(children)} more nested sub-exceptions)"]
+
+    for position, child in enumerate(children):
+        divider = f"{'-' * _SEPARATOR_DASHES} {position + 1} {'-' * _SEPARATOR_DASHES}"
+        lines.append(f"{indent}+-+{divider}" if position == 0 else f"{child_indent}+{divider}")
+        lines.extend(_format_chain(_as_list(child), group_depth + 1))
+
+    # The last sub-exception draws the closing line itself when it is a group of its own.
+    if not _ends_in_group(children):
+        lines.append(f"{child_indent}+{'-' * _CLOSING_DASHES}")
+    return lines
+
+
+def _ends_in_group(children: list[Any]) -> bool:
+    """Tell whether the last sub-exception rendered is itself an exception group."""
+    if not children or not isinstance(children[-1], list) or not children[-1]:
+        return False
+    last = children[-1][0]
+    return bool(isinstance(last, dict) and last.get("is_group") and last.get("exceptions"))
+
+
+def _format_syntax_error(syntax_error: Any) -> list[str]:
+    """Render the offending source line of a :exc:`SyntaxError` with a caret beneath it."""
+    lines = [f'  File "{syntax_error.get("filename")}", line {syntax_error.get("lineno")}']
+    source = (syntax_error.get("line") or "").rstrip()
+    if not source.strip():
+        return lines
+
+    stripped = source.lstrip()
+    lines.append(f"    {stripped}")
+    offset = syntax_error.get("offset")
+    if isinstance(offset, int):
+        column = offset - 1 - (len(source) - len(stripped))
+        if 0 <= column < len(stripped):
+            lines.append(f"    {' ' * column}^")
+    return lines
+
+
+def _format_frame(frame: Any) -> list[str]:
+    """Render one stack frame, including the source line when structlog captured it."""
+    filename = frame.get("filename")
+    lineno = frame.get("lineno")
+    name = frame.get("name")
+    # structlog replaces the middle of an over-long traceback with a placeholder frame that
+    # carries only a count, so rendering it as a `File "", line -1` entry would be nonsense.
+    if not filename and lineno == -1:
+        return [f"  [{name}]"]
+    lines = [f'  File "{filename}", line {lineno}, in {name}']
+    if source := frame.get("line"):
+        lines.append(f"    {source.strip()}")
+    return lines

--- a/shared/logging/src/airflow_shared/logging/tracebacks.py
+++ b/shared/logging/src/airflow_shared/logging/tracebacks.py
@@ -166,8 +166,11 @@ def _ends_in_group(children: list[Any]) -> bool:
 def _format_syntax_error(syntax_error: Any) -> list[str]:
     """Render the offending source line of a :exc:`SyntaxError` with a caret beneath it."""
     lines = [f'  File "{syntax_error.get("filename")}", line {syntax_error.get("lineno")}']
+    # structlog stores `exc_value.text or ""`, so an exception with no source text arrives as
+    # an empty string. Anything else is printed, including a line that is only indentation,
+    # which is exactly what `expected an indented block` reports.
     source = (syntax_error.get("line") or "").rstrip("\n")
-    if not source.strip():
+    if not source:
         return lines
 
     # Match CPython, which strips only spaces, newlines and form feeds so that tab-indented
@@ -177,7 +180,9 @@ def _format_syntax_error(syntax_error: Any) -> list[str]:
     offset = syntax_error.get("offset")
     if isinstance(offset, int):
         column = offset - 1 - (len(source) - len(stripped))
-        if 0 <= column < len(stripped):
+        # `<=` rather than `<`: the commonest syntax errors point at the column just past the
+        # last character, so the caret legitimately sits one beyond the end of the line.
+        if 0 <= column <= len(stripped):
             padding = "".join(char if char.isspace() else " " for char in stripped[:column])
             lines.append(f"    {padding}^")
     return lines

--- a/shared/logging/tests/logging/test_tracebacks.py
+++ b/shared/logging/tests/logging/test_tracebacks.py
@@ -214,7 +214,69 @@ class TestFormatExceptionDicts:
             '  File "tabs.py", line 1\n    \t x = 1 +\n    \t^\nIndentationError: unexpected indent'
         )
 
-    def test_syntax_error_with_out_of_range_offset_drops_the_caret(self):
+    def test_syntax_error_points_one_past_the_end_of_the_line(self):
+        payload = [
+            stack(
+                "SyntaxError",
+                "expected ':'",
+                syntax_error={
+                    "offset": 8,
+                    "filename": "q.py",
+                    "line": "if True\n",
+                    "lineno": 1,
+                    "msg": "expected ':'",
+                },
+            )
+        ]
+
+        # The commonest syntax errors of all (`expected ':'`, a dangling `=`) point at the
+        # column just past the last character, so the caret sits one beyond the line.
+        assert format_exception_dicts(payload) == (
+            "  File \"q.py\", line 1\n    if True\n           ^\nSyntaxError: expected ':'"
+        )
+
+    def test_syntax_error_keeps_a_source_line_that_is_only_whitespace(self):
+        payload = [
+            stack(
+                "IndentationError",
+                "expected an indented block after function definition on line 1",
+                syntax_error={
+                    "offset": 2,
+                    "filename": "q.py",
+                    "line": "\t\n",
+                    "lineno": 2,
+                    "msg": "expected an indented block after function definition on line 1",
+                },
+            )
+        ]
+
+        # `expected an indented block` reports a line with nothing on it but indentation.
+        # CPython still prints the line and the caret, so dropping it loses the position.
+        assert format_exception_dicts(payload) == (
+            '  File "q.py", line 2\n    \t\n    \t^\n'
+            "IndentationError: expected an indented block after function definition on line 1"
+        )
+
+    def test_syntax_error_without_a_source_line_prints_only_the_location(self):
+        payload = [
+            stack(
+                "SyntaxError",
+                "bad",
+                syntax_error={
+                    "offset": 1,
+                    "filename": "b.py",
+                    "line": "",
+                    "lineno": 2,
+                    "msg": "invalid syntax",
+                },
+            )
+        ]
+
+        # structlog stores `exc_value.text or ""`, so a SyntaxError that carries no source text
+        # arrives as an empty string. CPython prints no source line in that case either.
+        assert format_exception_dicts(payload) == '  File "b.py", line 2\nSyntaxError: invalid syntax'
+
+    def test_syntax_error_offset_beyond_the_line_drops_only_the_caret(self):
         payload = [
             stack(
                 "SyntaxError",
@@ -229,6 +291,8 @@ class TestFormatExceptionDicts:
             )
         ]
 
+        # An offset past one-beyond-the-end cannot be placed, so the source line is kept and
+        # only the caret is dropped. This guards a corrupt offset, not an end-of-line one.
         assert format_exception_dicts(payload) == (
             '  File "b.py", line 2\n    x = 1\nSyntaxError: invalid syntax'
         )
@@ -436,6 +500,12 @@ class TestAgainstRealTransformerOutput:
                 id="nested-exception-group",
             ),
             pytest.param("    compile('def f(:', 'bad.py', 'exec')", id="syntax-error"),
+            pytest.param("    compile('if True', 'bad.py', 'exec')", id="syntax-error-at-end-of-line"),
+            pytest.param("    compile('x = ', 'bad.py', 'exec')", id="syntax-error-trailing-operator"),
+            pytest.param(
+                "    compile('def f():\\n\\t\\n', 'bad.py', 'exec')",
+                id="syntax-error-whitespace-only-line",
+            ),
             pytest.param("    raise ValueError()", id="no-message"),
             pytest.param(
                 "    try:\n        raise OSError('a')\n"

--- a/shared/logging/tests/logging/test_tracebacks.py
+++ b/shared/logging/tests/logging/test_tracebacks.py
@@ -214,6 +214,27 @@ class TestFormatExceptionDicts:
             '  File "tabs.py", line 1\n    \t x = 1 +\n    \t^\nIndentationError: unexpected indent'
         )
 
+    def test_syntax_error_raised_by_hand_invents_no_location(self):
+        # `raise SyntaxError("bad")` carries no position at all. structlog stores
+        # `lineno or 0` and `filename or "?"`, so the absence arrives as 0 and "?".
+        # CPython prints no File line when there is no lineno, and neither do we: printing
+        # one would put a location in the log that does not exist.
+        payload = [
+            stack(
+                "SyntaxError",
+                "bad",
+                syntax_error={
+                    "offset": 0,
+                    "filename": "?",
+                    "line": "",
+                    "lineno": 0,
+                    "msg": "bad",
+                },
+            )
+        ]
+
+        assert format_exception_dicts(payload) == "SyntaxError: bad"
+
     def test_syntax_error_points_one_past_the_end_of_the_line(self):
         payload = [
             stack(
@@ -438,8 +459,54 @@ class TestMalformedPayloads:
         rendered = format_exception_dicts([payload])
 
         assert rendered is not None
-        assert "more nested sub-exceptions)" in rendered
+        # CPython's own limit, and its own wording. Ten groups are rendered, then the rest of
+        # the nest is replaced by one line and the block is closed.
+        assert rendered.splitlines()[-2:] == [
+            f"{'  ' * 11}| ... (max_group_depth is 10)",
+            f"{'  ' * 11}+{'-' * 36}",
+        ]
+        assert rendered.count("ExceptionGroup: level") == 10
         assert "ValueError: innermost" not in rendered
+
+    def test_group_wider_than_the_limit_reports_how_many_were_dropped(self):
+        payload = [
+            stack(
+                "ExceptionGroup",
+                "g (20 sub-exceptions)",
+                [("<string>", 4, "<module>")],
+                is_group=True,
+                exceptions=[[stack("ValueError", str(i))] for i in range(20)],
+            )
+        ]
+
+        rendered = format_exception_dicts(payload)
+
+        assert rendered is not None
+        # CPython prints the first fifteen, then a `...` divider and a count of the rest.
+        assert "    | ValueError: 14" in rendered
+        assert "    | ValueError: 15" not in rendered
+        assert rendered.splitlines()[-3:] == [
+            f"    +{'-' * 16} ... {'-' * 16}",
+            "    | and 5 more exceptions",
+            f"    +{'-' * 36}",
+        ]
+
+    def test_group_one_over_the_limit_uses_the_singular(self):
+        payload = [
+            stack(
+                "ExceptionGroup",
+                "g (16 sub-exceptions)",
+                [("<string>", 4, "<module>")],
+                is_group=True,
+                exceptions=[[stack("ValueError", str(i))] for i in range(16)],
+            )
+        ]
+
+        rendered = format_exception_dicts(payload)
+
+        assert rendered is not None
+        assert "    | and 1 more exception" in rendered
+        assert "more exceptions" not in rendered
 
 
 # Compiling from a name that is not on disk keeps `linecache` from finding source, so CPython
@@ -500,6 +567,22 @@ class TestAgainstRealTransformerOutput:
                 id="nested-exception-group",
             ),
             pytest.param("    compile('def f(:', 'bad.py', 'exec')", id="syntax-error"),
+            pytest.param("    raise SyntaxError('bad')", id="manually-raised-syntax-error"),
+            pytest.param(
+                "    raise ExceptionGroup('g', [SyntaxError('bad'), ValueError('v')])",
+                id="group-containing-a-syntax-error",
+            ),
+            pytest.param(
+                "    raise ExceptionGroup('g', [ValueError(str(i)) for i in range(20)])",
+                id="group-wider-than-the-limit",
+            ),
+            pytest.param(
+                "    e = ValueError('innermost')\n"
+                "    for i in range(20):\n"
+                "        e = ExceptionGroup(f'L{i}', [e])\n"
+                "    raise e",
+                id="group-deeper-than-the-limit",
+            ),
             pytest.param("    compile('if True', 'bad.py', 'exec')", id="syntax-error-at-end-of-line"),
             pytest.param("    compile('x = ', 'bad.py', 'exec')", id="syntax-error-trailing-operator"),
             pytest.param(

--- a/shared/logging/tests/logging/test_tracebacks.py
+++ b/shared/logging/tests/logging/test_tracebacks.py
@@ -97,6 +97,29 @@ class TestFormatExceptionDicts:
     def test_exception_without_frames_omits_the_traceback_header(self):
         assert format_exception_dicts([stack("ValueError", "first")]) == "ValueError: first"
 
+    def test_exception_raised_without_a_message_drops_the_colon(self):
+        assert format_exception_dicts([stack("ValueError", "")]) == "ValueError"
+
+    def test_exception_group_without_a_message_drops_the_colon(self):
+        payload = [
+            stack(
+                "ExceptionGroup",
+                "",
+                [("<string>", 4, "<module>")],
+                is_group=True,
+                exceptions=[[stack("ValueError", "first")]],
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "  + Exception Group Traceback (most recent call last):\n"
+            '  |   File "<string>", line 4, in <module>\n'
+            "  | ExceptionGroup\n"
+            "  +-+---------------- 1 ----------------\n"
+            "    | ValueError: first\n"
+            "    +------------------------------------"
+        )
+
     def test_frame_source_line_is_indented_under_its_file_line(self):
         payload = [stack("ValueError", "boom")]
         payload[0]["frames"] = [
@@ -168,6 +191,27 @@ class TestFormatExceptionDicts:
 
         assert format_exception_dicts(payload) == (
             '  File "b.py", line 2\n    x ==== 1\n        ^\nSyntaxError: invalid syntax'
+        )
+
+    def test_syntax_error_keeps_tab_indentation_so_the_caret_still_lines_up(self):
+        payload = [
+            stack(
+                "IndentationError",
+                "unexpected indent",
+                syntax_error={
+                    "offset": 4,
+                    "filename": "tabs.py",
+                    "line": "  \t x = 1 +\n",
+                    "lineno": 1,
+                    "msg": "unexpected indent",
+                },
+            )
+        ]
+
+        # CPython strips only spaces, newlines and form feeds, and pads the caret with the
+        # whitespace it kept, so a tab in the source stays a tab in the caret line.
+        assert format_exception_dicts(payload) == (
+            '  File "tabs.py", line 1\n    \t x = 1 +\n    \t^\nIndentationError: unexpected indent'
         )
 
     def test_syntax_error_with_out_of_range_offset_drops_the_caret(self):
@@ -392,6 +436,12 @@ class TestAgainstRealTransformerOutput:
                 id="nested-exception-group",
             ),
             pytest.param("    compile('def f(:', 'bad.py', 'exec')", id="syntax-error"),
+            pytest.param("    raise ValueError()", id="no-message"),
+            pytest.param(
+                "    try:\n        raise OSError('a')\n"
+                "    except OSError as e:\n        raise RuntimeError() from e",
+                id="no-message-in-chain",
+            ),
         ],
     )
     def test_output_matches_cpython_traceback(self, body):
@@ -419,3 +469,14 @@ class TestAgainstRealTransformerOutput:
         assert "    x ==== 1\n        ^\n" in rendered
         # CPython would underline the whole operator, but `end_offset` is not in the payload.
         assert "^^" in namespace["stdlib"]
+
+    def test_non_builtin_exception_loses_its_module_because_structlog_drops_it(self):
+        namespace = run_in_synthetic_module("    import socket\n    raise socket.gaierror('dns')")
+
+        rendered = format_exception_dicts(namespace["dicts"])
+
+        # CPython qualifies any exception outside `builtins`, but structlog records only the
+        # bare class name, so the module cannot be recovered here. Airflow's own exceptions
+        # are all non-builtin, so this applies to most real triggerer tracebacks.
+        assert rendered.endswith("gaierror: dns")
+        assert "socket.gaierror: dns" in namespace["stdlib"]

--- a/shared/logging/tests/logging/test_tracebacks.py
+++ b/shared/logging/tests/logging/test_tracebacks.py
@@ -1,0 +1,421 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow_shared.logging.tracebacks import format_exception_dicts
+
+
+def stack(exc_type, exc_value, frames=(), **overrides):
+    """Build one entry of an ``ExceptionDictTransformer`` payload."""
+    return {
+        "exc_type": exc_type,
+        "exc_value": exc_value,
+        "exc_notes": [],
+        "syntax_error": None,
+        "is_cause": False,
+        "frames": [{"filename": f, "lineno": n, "name": fn} for f, n, fn in frames],
+        "is_group": False,
+        "exceptions": [],
+        **overrides,
+    }
+
+
+def corrupt(**overrides):
+    """Build a payload entry whose shape is valid except for the overridden keys."""
+    return {**stack("ValueError", "boom"), **overrides}
+
+
+class TestFormatExceptionDicts:
+    def test_single_exception_renders_like_a_python_traceback(self):
+        payload = [stack("ValueError", "boom", [("/app/dags/my_dag.py", 12, "run")])]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "/app/dags/my_dag.py", line 12, in run\n'
+            "ValueError: boom"
+        )
+
+    def test_cause_chain_is_ordered_innermost_first_with_direct_cause_banner(self):
+        payload = [
+            stack("RuntimeError", "outer", [("<string>", 12, "<module>")]),
+            stack(
+                "ValueError",
+                "inner boom",
+                [("<string>", 10, "<module>"), ("<string>", 7, "boom")],
+                is_cause=True,
+            ),
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "<string>", line 10, in <module>\n'
+            '  File "<string>", line 7, in boom\n'
+            "ValueError: inner boom\n"
+            "\n"
+            "The above exception was the direct cause of the following exception:\n"
+            "\n"
+            "Traceback (most recent call last):\n"
+            '  File "<string>", line 12, in <module>\n'
+            "RuntimeError: outer"
+        )
+
+    def test_notes_are_appended_after_the_exception_line(self):
+        payload = [
+            stack(
+                "RuntimeError",
+                "noted",
+                [("<string>", 3, "<module>")],
+                exc_notes=["note one", "note two"],
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "<string>", line 3, in <module>\n'
+            "RuntimeError: noted\n"
+            "note one\n"
+            "note two"
+        )
+
+    def test_exception_without_frames_omits_the_traceback_header(self):
+        assert format_exception_dicts([stack("ValueError", "first")]) == "ValueError: first"
+
+    def test_frame_source_line_is_indented_under_its_file_line(self):
+        payload = [stack("ValueError", "boom")]
+        payload[0]["frames"] = [
+            {"filename": "/app/x.py", "lineno": 4, "name": "run", "line": "    raise ValueError('boom')"}
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "/app/x.py", line 4, in run\n'
+            "    raise ValueError('boom')\n"
+            "ValueError: boom"
+        )
+
+    def test_truncated_frame_sentinel_renders_as_a_note_not_a_bogus_file_line(self):
+        payload = [stack("RecursionError", "too deep")]
+        payload[0]["frames"] = [
+            {"filename": "/app/x.py", "lineno": 4, "name": "run"},
+            {"filename": "", "lineno": -1, "name": "Skipped frames: 12"},
+            {"filename": "/app/x.py", "lineno": 4, "name": "run"},
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "/app/x.py", line 4, in run\n'
+            "  [Skipped frames: 12]\n"
+            '  File "/app/x.py", line 4, in run\n'
+            "RecursionError: too deep"
+        )
+
+    def test_syntax_error_renders_offending_line_with_a_caret(self):
+        payload = [
+            stack(
+                "SyntaxError",
+                "invalid syntax (badfile.py, line 1)",
+                [("<string>", 4, "<module>")],
+                syntax_error={
+                    "offset": 7,
+                    "filename": "badfile.py",
+                    "line": "def f(:\n",
+                    "lineno": 1,
+                    "msg": "invalid syntax",
+                },
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "<string>", line 4, in <module>\n'
+            '  File "badfile.py", line 1\n'
+            "    def f(:\n"
+            "          ^\n"
+            "SyntaxError: invalid syntax"
+        )
+
+    def test_syntax_error_caret_accounts_for_stripped_indentation(self):
+        payload = [
+            stack(
+                "SyntaxError",
+                "invalid syntax (b.py, line 2)",
+                syntax_error={
+                    "offset": 11,
+                    "filename": "b.py",
+                    "line": "      x ==== 1\n",
+                    "lineno": 2,
+                    "msg": "invalid syntax",
+                },
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            '  File "b.py", line 2\n    x ==== 1\n        ^\nSyntaxError: invalid syntax'
+        )
+
+    def test_syntax_error_with_out_of_range_offset_drops_the_caret(self):
+        payload = [
+            stack(
+                "SyntaxError",
+                "bad",
+                syntax_error={
+                    "offset": 999,
+                    "filename": "b.py",
+                    "line": "x = 1\n",
+                    "lineno": 2,
+                    "msg": "invalid syntax",
+                },
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            '  File "b.py", line 2\n    x = 1\nSyntaxError: invalid syntax'
+        )
+
+    def test_exception_group_renders_numbered_sub_exception_blocks(self):
+        payload = [
+            stack(
+                "ExceptionGroup",
+                "group boom (2 sub-exceptions)",
+                [("<string>", 4, "<module>")],
+                is_group=True,
+                exceptions=[
+                    [stack("ValueError", "first")],
+                    [stack("KeyError", "'second'")],
+                ],
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "  + Exception Group Traceback (most recent call last):\n"
+            '  |   File "<string>", line 4, in <module>\n'
+            "  | ExceptionGroup: group boom (2 sub-exceptions)\n"
+            "  +-+---------------- 1 ----------------\n"
+            "    | ValueError: first\n"
+            "    +---------------- 2 ----------------\n"
+            "    | KeyError: 'second'\n"
+            "    +------------------------------------"
+        )
+
+    def test_nested_exception_group_indents_and_keeps_inner_cause_chains(self):
+        payload = [
+            stack(
+                "ExceptionGroup",
+                "outer group (2 sub-exceptions)",
+                [("<string>", 14, "<module>")],
+                is_group=True,
+                exceptions=[
+                    [
+                        stack(
+                            "TypeError", "wrapped", [("<string>", 10, "<module>"), ("<string>", 7, "inner")]
+                        ),
+                        stack("ValueError", "root cause", [("<string>", 5, "inner")], is_cause=True),
+                    ],
+                    [
+                        stack(
+                            "ExceptionGroup",
+                            "nested group (1 sub-exception)",
+                            [("<string>", 12, "<module>")],
+                            is_group=True,
+                            exceptions=[[stack("OSError", "io fail")]],
+                        )
+                    ],
+                ],
+            )
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "  + Exception Group Traceback (most recent call last):\n"
+            '  |   File "<string>", line 14, in <module>\n'
+            "  | ExceptionGroup: outer group (2 sub-exceptions)\n"
+            "  +-+---------------- 1 ----------------\n"
+            "    | Traceback (most recent call last):\n"
+            '    |   File "<string>", line 5, in inner\n'
+            "    | ValueError: root cause\n"
+            "    | \n"
+            "    | The above exception was the direct cause of the following exception:\n"
+            "    | \n"
+            "    | Traceback (most recent call last):\n"
+            '    |   File "<string>", line 10, in <module>\n'
+            '    |   File "<string>", line 7, in inner\n'
+            "    | TypeError: wrapped\n"
+            "    +---------------- 2 ----------------\n"
+            "    | Exception Group Traceback (most recent call last):\n"
+            '    |   File "<string>", line 12, in <module>\n'
+            "    | ExceptionGroup: nested group (1 sub-exception)\n"
+            "    +-+---------------- 1 ----------------\n"
+            "      | OSError: io fail\n"
+            "      +------------------------------------"
+        )
+
+    def test_context_chain_uses_during_handling_banner(self):
+        payload = [
+            stack("RuntimeError", "outer", [("<string>", 12, "<module>")]),
+            stack("ValueError", "inner boom", [("<string>", 7, "boom")], is_cause=False),
+        ]
+
+        assert format_exception_dicts(payload) == (
+            "Traceback (most recent call last):\n"
+            '  File "<string>", line 7, in boom\n'
+            "ValueError: inner boom\n"
+            "\n"
+            "During handling of the above exception, another exception occurred:\n"
+            "\n"
+            "Traceback (most recent call last):\n"
+            '  File "<string>", line 12, in <module>\n'
+            "RuntimeError: outer"
+        )
+
+
+class TestMalformedPayloads:
+    """A worker sends these dicts over as JSON, so the renderer must never take the log line down."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            {},
+            "boom",
+            42,
+            [],
+            {"exc_type": "ValueError"},
+            [None],
+            ["ValueError: boom"],
+            [{"exc_value": "no type here"}],
+            [corrupt(frames="not a list")],
+            [corrupt(frames=["not a frame"])],
+            [corrupt(frames=[{"filename": "x.py"}, None])],
+            [corrupt(syntax_error="not a dict")],
+            [corrupt(exc_notes="not a list")],
+            [corrupt(is_group=True, exceptions=["not a chain"])],
+            [corrupt(is_group=True, exceptions=[[None]])],
+        ],
+    )
+    def test_unusable_payload_falls_back_instead_of_raising(self, payload):
+        assert format_exception_dicts(payload) is None
+
+    def test_entry_missing_optional_keys_still_renders(self):
+        assert format_exception_dicts([{"exc_type": "ValueError", "exc_value": "boom"}]) == (
+            "ValueError: boom"
+        )
+
+    def test_deeply_nested_groups_are_truncated_rather_than_recursing(self):
+        payload = stack("ValueError", "innermost")
+        for level in range(40):
+            payload = stack(
+                "ExceptionGroup",
+                f"level {level} (1 sub-exception)",
+                [("<string>", 1, "<module>")],
+                is_group=True,
+                exceptions=[[payload]],
+            )
+
+        rendered = format_exception_dicts([payload])
+
+        assert rendered is not None
+        assert "more nested sub-exceptions)" in rendered
+        assert "ValueError: innermost" not in rendered
+
+
+# Compiling from a name that is not on disk keeps `linecache` from finding source, so CPython
+# omits the source lines that structlog never captures. What is left is directly comparable.
+_HARNESS = """
+import traceback
+from structlog.tracebacks import ExceptionDictTransformer
+try:
+{body}
+except BaseException as exc:
+    info = (type(exc), exc, exc.__traceback__)
+    stdlib = "".join(traceback.format_exception(*info))
+    dicts = ExceptionDictTransformer(use_rich=False, show_locals=False)(info)
+"""
+
+
+def run_in_synthetic_module(body: str) -> dict:
+    namespace: dict = {}
+    exec(compile(_HARNESS.format(body=body), "<synthetic-dag>", "exec"), namespace)
+    return namespace
+
+
+class TestAgainstRealTransformerOutput:
+    """Round-trip real structlog payloads and compare against CPython's own renderer."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param(
+                "    try:\n"
+                "        raise ValueError('inner')\n"
+                "    except ValueError as e:\n"
+                "        raise RuntimeError('outer') from e",
+                id="cause-chain",
+            ),
+            pytest.param(
+                "    try:\n"
+                "        raise ValueError('inner')\n"
+                "    except ValueError:\n"
+                "        raise RuntimeError('outer')",
+                id="context-chain",
+            ),
+            pytest.param(
+                "    e = RuntimeError('noted')\n"
+                "    e.add_note('note one')\n"
+                "    e.add_note('note two')\n"
+                "    raise e",
+                id="notes",
+            ),
+            pytest.param(
+                "    raise ExceptionGroup('boom', [ValueError('first'), KeyError('second')])",
+                id="exception-group",
+            ),
+            pytest.param(
+                "    raise ExceptionGroup(\n"
+                "        'outer', [ValueError('a'), ExceptionGroup('inner', [OSError('io')])]\n"
+                "    )",
+                id="nested-exception-group",
+            ),
+            pytest.param("    compile('def f(:', 'bad.py', 'exec')", id="syntax-error"),
+        ],
+    )
+    def test_output_matches_cpython_traceback(self, body):
+        namespace = run_in_synthetic_module(body)
+
+        assert format_exception_dicts(namespace["dicts"]) + "\n" == namespace["stdlib"]
+
+    def test_over_long_traceback_reports_the_frames_structlog_dropped(self):
+        namespace = run_in_synthetic_module("    def r(n):\n        return r(n + 1)\n    r(0)")
+
+        rendered = format_exception_dicts(namespace["dicts"])
+
+        assert rendered is not None
+        # structlog keeps the first and last 25 frames and replaces the rest with a counter,
+        # so this can never match CPython, which instead collapses repeats as it walks.
+        assert len([line for line in rendered.splitlines() if line.startswith('  File "')]) == 50
+        assert any(line.startswith("  [Skipped frames: ") for line in rendered.splitlines())
+        assert rendered.endswith("RecursionError: maximum recursion depth exceeded")
+
+    def test_caret_is_single_because_structlog_drops_the_end_offset(self):
+        namespace = run_in_synthetic_module("    compile('x ==== 1', 'bad.py', 'exec')")
+
+        rendered = format_exception_dicts(namespace["dicts"])
+
+        assert "    x ==== 1\n        ^\n" in rendered
+        # CPython would underline the whole operator, but `end_offset` is not in the payload.
+        assert "^^" in namespace["stdlib"]

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2409,11 +2409,13 @@ def process_log_messages_from_subprocess(
             event["timestamp"] = msgspec.json.decode(f'"{ts}"', type=datetime)
 
         if exc := event.pop("exception", None):
-            # Left structured on purpose. These records go to the task log, whose log view in the
-            # UI renders the frames itself, so handing it a string would cost it that. Picking a
-            # format per destination is not open to us here either: the loop below sends this one
-            # event to every target logger, and those can be the task log and stdout at the same
-            # time, so there is only ever a single payload to decide about.
+            # Left structured on purpose. Every WatchedSubprocess shares this relay, so where a
+            # record lands depends on the caller: the task log when a task runs, the DAG
+            # processor's own log file when a file is parsed. The task log is read by the log
+            # view in the UI, which renders the frames itself and would lose that if handed a
+            # string. Picking a format per destination is not open to us in any case, because
+            # the loop below gives this one event to every target logger, and there can be more
+            # than one of those at a time.
             event["error_detail"] = exc
 
         if level := NAME_TO_LEVEL.get(event.pop("level")):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2409,11 +2409,11 @@ def process_log_messages_from_subprocess(
             event["timestamp"] = msgspec.json.decode(f'"{ts}"', type=datetime)
 
         if exc := event.pop("exception", None):
-            # Left structured on purpose. These records go to the task log, and its readers (the
-            # UI's log view, and the Elasticsearch and OpenSearch handlers) render the frames
-            # themselves, so handing them a string would cost them that. Choosing a format per
-            # destination is not open to us either: `_get_target_loggers` fans this single event
-            # out to both the task log and stdout, so there is only one payload to decide about.
+            # Left structured on purpose. These records go to the task log, whose log view in the
+            # UI renders the frames itself, so handing it a string would cost it that. Picking a
+            # format per destination is not open to us here either: the loop below sends this one
+            # event to every target logger, and those can be the task log and stdout at the same
+            # time, so there is only ever a single payload to decide about.
             event["error_detail"] = exc
 
         if level := NAME_TO_LEVEL.get(event.pop("level")):

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -2409,7 +2409,11 @@ def process_log_messages_from_subprocess(
             event["timestamp"] = msgspec.json.decode(f'"{ts}"', type=datetime)
 
         if exc := event.pop("exception", None):
-            # TODO: convert the dict back to a pretty stack trace
+            # Left structured on purpose. These records go to the task log, and its readers (the
+            # UI's log view, and the Elasticsearch and OpenSearch handlers) render the frames
+            # themselves, so handing them a string would cost them that. Choosing a format per
+            # destination is not open to us either: `_get_target_loggers` fans this single event
+            # out to both the task log and stdout, so there is only one payload to decide about.
             event["error_detail"] = exc
 
         if level := NAME_TO_LEVEL.get(event.pop("level")):


### PR DESCRIPTION
closes: #69572

## What the problem is

The triggerer relays log lines from its subprocess. structlog serialises exceptions into a list of dicts so they survive the JSON hop, and the relay dropped that list straight onto the log record:

```python
if exc := event.pop("exception", None):
    # TODO: convert the dict back to a pretty stack trace
    event["error_detail"] = exc
```

In the triggerer's own log that comes out as a wall of nested JSON rather than a stack trace.

## What this changes

A new pure function `format_exception_dicts()` in the shared logging package turns `ExceptionDictTransformer` output back into a traceback. It covers `__cause__` and `__context__` chains, exception notes, `SyntaxError` with its caret, and exception groups including nested ones.

The tests check the output by comparison against CPython rather than against hand-written fixtures: they raise a real exception, run it through the real transformer, and diff the two renderings. To make that diff meaningful the test bodies are compiled from a name that is not on disk, which stops `linecache` from supplying source lines that structlog never captures either.

Under that condition the two agree byte for byte across every shape I could think to try: cause and context chains, notes, exception groups flat and nested and past both of CPython's elision limits, syntax errors from `compile` and raised by hand, and a syntax error inside a group.

Real tracebacks are not byte-identical, and cannot be. structlog's `Frame` carries only `filename`, `lineno` and `name`, so for a DAG that does exist on disk CPython additionally prints the source line and, since 3.11, the `~~~^^^` anchors under the failing subexpression. Neither can be reconstructed from the payload. What this produces is the same traceback minus those two, which is still an enormous improvement on a wall of JSON.

Where CPython elides, this elides the same way and says the same thing: at most 15 sub-exceptions per group before `and N more exceptions`, and at most 10 levels of nesting before `... (max_group_depth is 10)`. Those are `max_group_width` and `max_group_depth` from `TracebackException`.

The triggerer then uses it for the records that go to its own log.

## Why the task log keeps the structured payload

`error_detail` is not a free-form field. The live reader is the UI:

- `renderStructuredLog.tsx` gives each exception a collapsible `<details>`, marks user code frames apart from library frames with `isUserCodeFrame`, and runs the frame labels through i18n. All of that needs the frames, not a finished string.

There is also a `_format_error_detail` in each of the elasticsearch and opensearch task handlers that walks the list and renders it to text. Those show the same intent, but in fairness neither is reachable today: see below.

So the split is by destination. Records written to `{log_path}.trigger.{id}.log`, which is a task log and therefore what the log view reads, keep the list exactly as it arrived. Records going to the triggerer's own stream get the rendered trace, because a person reads that one as text.

The check is `log is fallback_log` rather than a test on `trigger_id`, which matters: `get_logger()` falls back to the triggerer's own logger when a trigger has no cached factory, for instance once `logger_cache.pop` has run at the end of a trigger's life. Keying off the destination gets those late records right too.

## The other two readers

`renderStructuredLog.tsx` mapped over `error_detail` unconditionally, so anything that was not an array would have thrown. It now keys the structured path off `Array.isArray` and renders anything else as text on a line of its own. **This is not fixing a live crash.** Nothing in the tree hands the log view a non-array today, and the triggerer records changed here go to the triggerer's own stream rather than to a task log, so they never reach it either. The guard is there so the field has a single honest contract and so that a future producer cannot take the log view down.

`supervisor.py` had the same TODO and the same two lines. It keeps the structured payload, and the TODO is replaced by a comment saying why. Every `WatchedSubprocess` shares that relay, so the destination follows the caller: the task log when a task runs, and the DAG processor's own log file when `DagFileProcessorProcess` parses a file, since it inherits `_register_pipe_readers` unchanged and its `process_log` is built with `logger_name="processor"`. The task log is the one the UI log view renders frames from. Either way there is no per-destination choice to make, because the loop that follows gives the one event to every target logger and there can be more than one at a time.

While tracing the readers I found that both copies of `_format_error_detail` are unreachable: each is called only from its own unit tests, and the live `_build_log_fields` forwards `error_detail` untouched. That looks worth a look on its own, but it has nothing to do with this issue, so both are left exactly as they are.

## Known gaps

Three, and all three are the same story: the payload does not carry what CPython prints from, so no renderer sitting where this one sits could produce it. Each has a test pinning the behaviour and saying why.

- No source lines, and no `~~~^^^` anchors under the failing subexpression. structlog's `Frame` records `filename`, `lineno` and `name` only. This is the one that shows up on every real traceback.
- Exceptions outside `builtins` lose their module: `socket.gaierror` renders as `gaierror`. structlog records the bare class name and nothing else. This one is worth knowing about because `airflow.exceptions.*` are all non-builtin, so it applies to most real triggerer tracebacks.
- `SyntaxError` gets a single caret. CPython underlines the whole offending token using `end_offset`, which structlog's `SyntaxError_` does not carry.

Separately, one thing that is a choice rather than a limit: repeated frames are not collapsed into `[Previous line repeated N more times]`. CPython collapses as it walks the live traceback; structlog has already truncated at `max_frames` and left a placeholder by the time we see it, so this renders that placeholder as `[Skipped frames: N]`. Different wording for a different thing, deliberately.

## Testing

`format_exception_dicts` is a pure function, so it is covered by unit tests in `shared/logging/tests/logging/test_tracebacks.py`: 57 tests over the chain, group, note, syntax-error and elision paths, plus the round trips against CPython.

The payload arrives as JSON from another process, so a good part of the suite is about surviving whatever turns up. Anything unrecognisable renders as `None` and the caller keeps the raw payload, on the grounds that a missing stack trace costs less than a log pipeline that raises.

Two tests in `airflow-core/tests/unit/jobs/test_triggerer_job.py` cover the destination split. Four in `renderStructuredLog.test.tsx` cover the non-array branch, asserting the whole rendered output in both rendering modes so that a traceback running into the event text is caught.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
