### PR TITLE
Isolate scheduled DagRun creation failures with savepoints

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -123,6 +123,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.retries import MAX_DB_RETRIES, retry_db_transaction, run_with_db_retries
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.sqlalchemy import (
+    create_savepoint,
     get_dialect_name,
     is_lock_not_available_error,
     prohibit_commit,
@@ -2583,7 +2584,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
 
             new_active_runs = active_runs_of_dags[dag_model.dag_id] + 1
             try:
-                with session.begin_nested():
+                with create_savepoint(session):
                     next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
                     if TYPE_CHECKING:
                         assert next_info is not None

--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2581,39 +2581,41 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 )
                 continue
 
+            new_active_runs = active_runs_of_dags[dag_model.dag_id] + 1
             try:
-                next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
-                if TYPE_CHECKING:
-                    assert next_info is not None
-                data_interval = next_info.data_interval
-                logical_date = next_info.logical_date
-                partition_key = next_info.partition_key
-                run_after = next_info.run_after
-                created_run = serdag.create_dagrun(
-                    run_id=serdag.timetable.generate_run_id(
-                        run_type=DagRunType.SCHEDULED,
-                        run_after=run_after,
+                with session.begin_nested():
+                    next_info = serdag.timetable.next_run_info_from_dag_model(dag_model=dag_model)
+                    if TYPE_CHECKING:
+                        assert next_info is not None
+                    data_interval = next_info.data_interval
+                    logical_date = next_info.logical_date
+                    partition_key = next_info.partition_key
+                    run_after = next_info.run_after
+                    created_run = serdag.create_dagrun(
+                        run_id=serdag.timetable.generate_run_id(
+                            run_type=DagRunType.SCHEDULED,
+                            run_after=run_after,
+                            data_interval=data_interval,
+                            partition_key=partition_key,
+                        ),
+                        logical_date=logical_date,
                         data_interval=data_interval,
+                        run_after=run_after,
+                        run_type=DagRunType.SCHEDULED,
+                        triggered_by=DagRunTriggeredByType.TIMETABLE,
+                        state=DagRunState.QUEUED,
+                        creating_job_id=self.job.id,
+                        session=session,
                         partition_key=partition_key,
-                    ),
-                    logical_date=logical_date,
-                    data_interval=data_interval,
-                    run_after=run_after,
-                    run_type=DagRunType.SCHEDULED,
-                    triggered_by=DagRunTriggeredByType.TIMETABLE,
-                    state=DagRunState.QUEUED,
-                    creating_job_id=self.job.id,
-                    session=session,
-                    partition_key=partition_key,
-                    partition_date=next_info.partition_date,
-                )
-                active_runs_of_dags[dag_model.dag_id] += 1
-                dag_model.calculate_dagrun_date_fields(dag=serdag, reference_run=created_run)
-                self._set_exceeds_max_active_runs(
-                    dag_model=dag_model,
-                    session=session,
-                    active_non_backfill_runs=active_runs_of_dags[dag_model.dag_id],
-                )
+                        partition_date=next_info.partition_date,
+                    )
+                    dag_model.calculate_dagrun_date_fields(dag=serdag, reference_run=created_run)
+                    self._set_exceeds_max_active_runs(
+                        dag_model=dag_model,
+                        session=session,
+                        active_non_backfill_runs=new_active_runs,
+                    )
+                active_runs_of_dags[dag_model.dag_id] = new_active_runs
 
             # Exceptions like ValueError, ParamValidationError, etc. are raised by
             # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
@@ -2621,10 +2623,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
             # and continue to the next serdag.
             except Exception:
                 self.log.exception("Failed creating DagRun", dag_id=dag_model.dag_id)
-                # todo: if you get a database error here, continuing does not work because
-                #  session needs rollback. you need either to make smaller transactions and
-                #  commit after every dag run or use savepoints.
-                #  https://github.com/apache/airflow/issues/59120
 
             # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
             #  memory for larger dags? or expunge_all()

--- a/airflow-core/src/airflow/utils/sqlalchemy.py
+++ b/airflow-core/src/airflow/utils/sqlalchemy.py
@@ -627,6 +627,29 @@ def with_db_lock_timeout(session: Session, lock_timeout: int = 30) -> Generator[
             session.execute(text(f"SET SESSION innodb_lock_wait_timeout = {old_mysql_timeout}"))
 
 
+_EXPECTED_SAVEPOINT_COMMIT = "_airflow_expected_savepoint_commit"
+
+
+@contextlib.contextmanager
+def create_savepoint(session: Session) -> Generator[None, None, None]:
+    savepoint = session.begin_nested()
+    try:
+        yield
+    except Exception:
+        savepoint.rollback()
+        raise
+    else:
+        session.info[_EXPECTED_SAVEPOINT_COMMIT] = session.info.get(_EXPECTED_SAVEPOINT_COMMIT, 0) + 1
+        try:
+            savepoint.commit()
+        finally:
+            remaining = session.info[_EXPECTED_SAVEPOINT_COMMIT] - 1
+            if remaining:
+                session.info[_EXPECTED_SAVEPOINT_COMMIT] = remaining
+            else:
+                session.info.pop(_EXPECTED_SAVEPOINT_COMMIT, None)
+
+
 class CommitProhibitorGuard:
     """Context manager class that powers prohibit_commit."""
 
@@ -635,9 +658,12 @@ class CommitProhibitorGuard:
     def __init__(self, session: Session):
         self.session = session
 
-    def _validate_commit(self, _):
+    def _validate_commit(self, session):
         if self.expected_commit:
             self.expected_commit = False
+            return
+        # This session-wide marker is set only around the synchronous savepoint release.
+        if session.info.get(_EXPECTED_SAVEPOINT_COMMIT) and session.in_nested_transaction():
             return
         raise RuntimeError("UNEXPECTED COMMIT - THIS WILL BREAK HA LOCKS!")
 

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -5658,6 +5658,43 @@ class TestSchedulerJob:
         assert dr.start_date is None
         assert dr.creating_job_id == scheduler_job.id
 
+    def test_create_dag_runs_continues_after_db_error(self, dag_maker, session):
+        with dag_maker(dag_id="test_create_dag_runs_bad_flush", schedule="@daily"):
+            EmptyOperator(task_id="dummy")
+        bad_dag_model = dag_maker.dag_model
+
+        with dag_maker(dag_id="test_create_dag_runs_good_after_bad", schedule="@daily"):
+            EmptyOperator(task_id="dummy")
+        good_dag_model = dag_maker.dag_model
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+        original_create_dagrun = SerializedDAG.create_dagrun
+
+        def create_dagrun(serialized_dag, **kwargs):
+            if serialized_dag.dag_id == bad_dag_model.dag_id:
+                session.add(
+                    DagRun(
+                        dag_id=None,
+                        run_id="scheduled__bad_flush",
+                        logical_date=DEFAULT_DATE,
+                        run_after=timezone.utcnow(),
+                        run_type=DagRunType.SCHEDULED,
+                        triggered_by=DagRunTriggeredByType.TIMETABLE,
+                        state=DagRunState.QUEUED,
+                    )
+                )
+                session.flush()
+                pytest.fail("Expected invalid DagRun to fail during flush")
+            return original_create_dagrun(serialized_dag, **kwargs)
+
+        with patch.object(SerializedDAG, "create_dagrun", autospec=True, side_effect=create_dagrun):
+            self.job_runner._create_dag_runs([bad_dag_model, good_dag_model], session)
+
+        session.flush()
+        assert session.scalar(select(func.count()).where(DagRun.dag_id == bad_dag_model.dag_id)) == 0
+        assert session.scalar(select(func.count()).where(DagRun.dag_id == good_dag_model.dag_id)) == 1
+
     @pytest.mark.need_serialized_dag
     def test_create_dag_runs_assets(self, session, dag_maker):
         """

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -10922,8 +10922,8 @@ class TestSchedulerJobQueriesCount:
     @pytest.mark.parametrize(
         ("expected_query_count", "dag_count", "task_count"),
         [
-            (21, 1, 1),  # One DAG with one task per DAG file.
-            (21, 1, 5),  # One DAG with five tasks per DAG file.
+            (25, 1, 1),  # One DAG with one task per DAG file.
+            (25, 1, 5),  # One DAG with five tasks per DAG file.
             (148, 10, 10),  # 10 DAGs with 10 tasks per DAG file.
         ],
     )
@@ -10992,33 +10992,33 @@ class TestSchedulerJobQueriesCount:
             # One DAG with one task per DAG file.
             ([10, 10, 10, 10], 1, 1, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 1, 1, "1d", "None", "linear"),
-            ([24, 14, 14, 14], 1, 1, "1d", "@once", "no_structure"),
-            ([24, 14, 14, 14], 1, 1, "1d", "@once", "linear"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "no_structure"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "linear"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "binary_tree"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "star"),
-            ([24, 26, 29, 32], 1, 1, "1d", "30m", "grid"),
+            ([26, 14, 14, 14], 1, 1, "1d", "@once", "no_structure"),
+            ([26, 14, 14, 14], 1, 1, "1d", "@once", "linear"),
+            ([26, 28, 31, 34], 1, 1, "1d", "30m", "no_structure"),
+            ([26, 28, 31, 34], 1, 1, "1d", "30m", "linear"),
+            ([26, 28, 31, 34], 1, 1, "1d", "30m", "binary_tree"),
+            ([26, 28, 31, 34], 1, 1, "1d", "30m", "star"),
+            ([26, 28, 31, 34], 1, 1, "1d", "30m", "grid"),
             # One DAG with five tasks per DAG file.
             ([10, 10, 10, 10], 1, 5, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 1, 5, "1d", "None", "linear"),
-            ([24, 14, 14, 14], 1, 5, "1d", "@once", "no_structure"),
-            ([25, 15, 15, 15], 1, 5, "1d", "@once", "linear"),
-            ([24, 26, 29, 32], 1, 5, "1d", "30m", "no_structure"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "linear"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "binary_tree"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "star"),
-            ([25, 28, 32, 36], 1, 5, "1d", "30m", "grid"),
+            ([26, 14, 14, 14], 1, 5, "1d", "@once", "no_structure"),
+            ([27, 15, 15, 15], 1, 5, "1d", "@once", "linear"),
+            ([26, 28, 31, 34], 1, 5, "1d", "30m", "no_structure"),
+            ([27, 30, 34, 38], 1, 5, "1d", "30m", "linear"),
+            ([27, 30, 34, 38], 1, 5, "1d", "30m", "binary_tree"),
+            ([27, 30, 34, 38], 1, 5, "1d", "30m", "star"),
+            ([27, 30, 34, 38], 1, 5, "1d", "30m", "grid"),
             # 10 DAGs with 10 tasks per DAG file.
             ([10, 10, 10, 10], 10, 10, "1d", "None", "no_structure"),
             ([10, 10, 10, 10], 10, 10, "1d", "None", "linear"),
-            ([218, 69, 69, 69], 10, 10, "1d", "@once", "no_structure"),
-            ([228, 84, 84, 84], 10, 10, "1d", "@once", "linear"),
-            ([217, 119, 119, 119], 10, 10, "1d", "30m", "no_structure"),
-            ([2227, 145, 145, 145], 10, 10, "1d", "30m", "linear"),
-            ([227, 139, 139, 139], 10, 10, "1d", "30m", "binary_tree"),
-            ([227, 139, 139, 139], 10, 10, "1d", "30m", "star"),
-            ([227, 259, 259, 259], 10, 10, "1d", "30m", "grid"),
+            ([238, 69, 69, 69], 10, 10, "1d", "@once", "no_structure"),
+            ([248, 84, 84, 84], 10, 10, "1d", "@once", "linear"),
+            ([237, 139, 139, 139], 10, 10, "1d", "30m", "no_structure"),
+            ([2247, 165, 165, 165], 10, 10, "1d", "30m", "linear"),
+            ([247, 159, 159, 159], 10, 10, "1d", "30m", "binary_tree"),
+            ([247, 159, 159, 159], 10, 10, "1d", "30m", "star"),
+            ([247, 279, 279, 279], 10, 10, "1d", "30m", "grid"),
         ],
     )
     def test_process_dags_queries_count(

--- a/airflow-core/tests/unit/utils/test_sqlalchemy.py
+++ b/airflow-core/tests/unit/utils/test_sqlalchemy.py
@@ -36,6 +36,7 @@ from airflow.settings import Session
 from airflow.utils.sqlalchemy import (
     ExecutorConfigType,
     apply_regex_query_timeout,
+    create_savepoint,
     ensure_pod_is_valid_after_unpickling,
     get_dialect_name,
     prohibit_commit,
@@ -191,6 +192,16 @@ class TestSqlAlchemyUtils:
             guard.commit()
 
             # Check the expected_commit is reset
+            self.session.execute(text("SELECT 1"))
+            with pytest.raises(RuntimeError, match="UNEXPECTED COMMIT"):
+                self.session.commit()
+
+    def test_prohibit_commit_allows_savepoint_release(self):
+        with prohibit_commit(self.session):
+            self.session.execute(text("SELECT 1"))
+            with create_savepoint(self.session):
+                self.session.execute(text("SELECT 1"))
+
             self.session.execute(text("SELECT 1"))
             with pytest.raises(RuntimeError, match="UNEXPECTED COMMIT"):
                 self.session.commit()


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->





<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

## Why

`SchedulerJobRunner._create_dag_runs` catches exceptions while creating scheduled DagRuns and then continues with the next Dag. This does not work reliably when the failure is caused by a database error, because the SQLAlchemy session can be left in a failed transaction state.

When that happens, one failing DagRun creation attempt can prevent the scheduler from creating DagRuns for other healthy Dags in the same batch.

## Solution

Wrap each scheduled DagRun creation attempt in a nested transaction/savepoint. If a database-level failure happens for one Dag, only that DagRun creation attempt is rolled back and the outer scheduler transaction remains usable.

The in-memory active run counter is updated only after the savepoint succeeds, keeping scheduler state aligned with the database transaction outcome.

A regression test covers a flush-time database failure for one Dag and verifies that another Dag in the same batch still creates its DagRun successfully.

relates: #59120

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
