### PR TITLE
Fix tag-providers --dry-run failing to find the push remote

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1502,6 +1502,9 @@ def tag_providers(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 text=True,
+                # Read-only lookup, so run it even in dry-run mode: a dry run returns empty
+                # stdout for every remote, which would make the search below find nothing.
+                dry_run_override=False,
             )
             if "apache/airflow.git" in result.stdout:
                 found_remote = remote

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -1513,6 +1513,9 @@ def tag_providers(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 text=True,
+                # Read-only lookup, so run it even in dry-run mode: a dry run returns empty
+                # stdout for every remote, which would make the search below find nothing.
+                dry_run_override=False,
             )
             if "apache/airflow.git" in result.stdout:
                 found_remote = remote

--- a/dev/breeze/tests/test_release_management_commands.py
+++ b/dev/breeze/tests/test_release_management_commands.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -36,6 +37,7 @@ from airflow_breeze.commands.release_management_commands import (
     is_package_in_dist,
 )
 from airflow_breeze.global_constants import DEFAULT_PYTHON_MAJOR_MINOR_VERSION
+from airflow_breeze.utils import shared_options
 
 
 @pytest.mark.parametrize(
@@ -386,3 +388,29 @@ def test_prepare_provider_distributions_skip_git_fetch(
 
     assert exc_info.value.code == 0
     assert len(fetches) == expected_fetches
+
+
+def test_tag_providers_detects_push_remote_in_dry_run(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def fake_run_command(cmd, **kwargs):
+        commands.append(cmd)
+        if cmd[:4] == ["git", "remote", "get-url", "--push"]:
+            if shared_options.get_dry_run(kwargs.get("dry_run_override")):
+                return SimpleNamespace(returncode=0, stdout="")
+            if cmd[-1] == "upstream":
+                return SimpleNamespace(returncode=0, stdout="https://github.com/apache/airflow.git\n")
+            raise subprocess.CalledProcessError(2, cmd)
+        return SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(release_management_commands, "run_command", fake_run_command)
+    monkeypatch.setattr(release_management_commands, "AIRFLOW_DIST_PATH", tmp_path)
+    (tmp_path / "apache_airflow_providers_amazon-9.29.0-py3-none-any.whl").touch()
+
+    shared_options.set_dry_run(True)
+    try:
+        release_management_commands.tag_providers.callback(clean_tags=False, release_date="2026-08-06")
+    finally:
+        shared_options.set_dry_run(False)
+
+    assert ["git", "push", "upstream", "providers-amazon/9.29.0"] in commands

--- a/dev/breeze/tests/test_release_management_commands.py
+++ b/dev/breeze/tests/test_release_management_commands.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -35,6 +36,7 @@ from airflow_breeze.commands.release_management_commands import (
     is_package_in_dist,
 )
 from airflow_breeze.global_constants import DEFAULT_PYTHON_MAJOR_MINOR_VERSION
+from airflow_breeze.utils import shared_options
 
 
 @pytest.mark.parametrize(
@@ -309,3 +311,29 @@ def test_get_package_version_possibly_from_stable_txt_for_java_sdk(
 )
 def test_issue_match_in_body(body: str, expected: list[int]):
     assert [int(m.group(1)) for m in ISSUE_MATCH_IN_BODY.finditer(body)] == expected
+
+
+def test_tag_providers_detects_push_remote_in_dry_run(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def fake_run_command(cmd, **kwargs):
+        commands.append(cmd)
+        if cmd[:4] == ["git", "remote", "get-url", "--push"]:
+            if shared_options.get_dry_run(kwargs.get("dry_run_override")):
+                return SimpleNamespace(returncode=0, stdout="")
+            if cmd[-1] == "upstream":
+                return SimpleNamespace(returncode=0, stdout="https://github.com/apache/airflow.git\n")
+            raise subprocess.CalledProcessError(2, cmd)
+        return SimpleNamespace(returncode=0, stdout="")
+
+    monkeypatch.setattr(release_management_commands, "run_command", fake_run_command)
+    monkeypatch.setattr(release_management_commands, "AIRFLOW_DIST_PATH", tmp_path)
+    (tmp_path / "apache_airflow_providers_amazon-9.29.0-py3-none-any.whl").touch()
+
+    shared_options.set_dry_run(True)
+    try:
+        release_management_commands.tag_providers.callback(clean_tags=False, release_date="2026-08-06")
+    finally:
+        shared_options.set_dry_run(False)
+
+    assert ["git", "push", "upstream", "providers-amazon/9.29.0"] in commands


### PR DESCRIPTION
`breeze release-management tag-providers --dry-run` always aborted with:

```
ValueError: Could not find the remote configured to push to apache/airflow
```

A dry run short-circuits every `run_command`, returning an empty stdout, so
the `git remote get-url --push` lookup that picks the apache/airflow remote
found nothing for all three candidate names (`upstream`, `origin`, `apache`).

The lookup is read-only, so it now runs even in dry-run mode. That makes
`--dry-run` usable for previewing the tags a provider wave will create,
which is precisely when a release manager wants to check them.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
