### PR TITLE
Mask Connection password in Task SDK

### DIFF
--- a/task-sdk/src/airflow/sdk/definitions/connection.py
+++ b/task-sdk/src/airflow/sdk/definitions/connection.py
@@ -153,6 +153,12 @@ class Connection:
         else:
             self.__dict__.update(attrs.asdict(self.from_uri(uri, conn_id=conn_id), recurse=False))
 
+        if self.password:
+            from airflow.sdk.log import mask_secret
+
+            mask_secret(self.password)
+            mask_secret(quote(self.password))
+
     def get_uri(self) -> str:
         """Generate and return connection in URI format."""
         from urllib.parse import parse_qsl

--- a/task-sdk/tests/task_sdk/definitions/test_connection.py
+++ b/task-sdk/tests/task_sdk/definitions/test_connection.py
@@ -234,6 +234,21 @@ class TestConnections:
         connection.extra = '{"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}'
         assert connection.extra_dejson == {"auth": {"type": "oauth"}, "headers": {"User-Agent": "Airflow"}}
 
+    def test_password_is_masked(self):
+        """Test that the password is masked, whether set via kwargs or a URI."""
+        from airflow.sdk._shared.secrets_masker import _secrets_masker
+
+        masker = _secrets_masker()
+        masker.reset_masker()
+
+        Connection(conn_id="test_conn", conn_type="azure", login="client_id", password="sp-secret")
+        assert masker.redact("sp-secret") == "***"
+
+        masker.reset_masker()
+
+        Connection.from_uri("azure://client_id:sp-secret@?tenantId=tenant", conn_id="test_conn")
+        assert masker.redact("sp-secret") == "***"
+
 
 class TestConnectionsFromSecrets:
     def test_get_connection_secrets_backend(self, mock_supervisor_comms, tmp_path):


### PR DESCRIPTION
## Summary

`airflow.sdk.definitions.connection.Connection` (the Task SDK connection model used inside a running task in Airflow 3.x) masks `extra` fields via `mask_secret()`, but never masked the top-level `password` field, unlike the core ORM `Connection`. This meant secrets such as an Azure service principal secret (which maps to `Connection.password`) leaked into task logs unmasked whenever the connection was resolved through the Task SDK — e.g. when sourced from an `AIRFLOW_CONN_*` environment variable URI.

This adds the same `mask_secret(self.password)` / `mask_secret(quote(self.password))` calls that the core `Connection` class already performs, covering both the direct-kwargs constructor and the `from_uri` path.

Closes: #38144

## Test plan

- [x] Added `test_password_is_masked` in `task-sdk/tests/task_sdk/definitions/test_connection.py`, covering both the kwargs constructor and `from_uri`.
- [x] Verified against a pre-fix checkout that the new assertions fail without the change (masking returns `False`) and pass with it.
- [x] `ruff check` and `ruff format --check` pass on the changed files.