### PR TITLE
Retry transient database errors in the metastore secrets backend

### DIFF
--- a/airflow-core/src/airflow/secrets/metastore.py
+++ b/airflow-core/src/airflow/secrets/metastore.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import or_, select
 
 from airflow.secrets import BaseSecretsBackend
+from airflow.utils.retries import retry_db_transaction
 from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ class MetastoreBackend(BaseSecretsBackend):
     """Retrieves Connection object and Variable from airflow metastore database."""
 
     @provide_session
+    @retry_db_transaction
     def get_connection(
         self, conn_id: str, team_name: str | None = None, *, session: Session = NEW_SESSION
     ) -> Connection | None:
@@ -62,6 +64,7 @@ class MetastoreBackend(BaseSecretsBackend):
         return conn
 
     @provide_session
+    @retry_db_transaction
     def get_variable(
         self, key: str, team_name: str | None = None, *, session: Session = NEW_SESSION
     ) -> str | None:

--- a/airflow-core/tests/unit/always/test_secrets_metastore.py
+++ b/airflow-core/tests/unit/always/test_secrets_metastore.py
@@ -17,7 +17,10 @@
 # under the License.
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from airflow.models.connection import Connection
 from airflow.models.variable import Variable
@@ -27,6 +30,18 @@ from airflow.utils.session import create_session
 from tests_common.test_utils.db import clear_db_connections, clear_db_variables
 
 pytestmark = pytest.mark.db_test
+
+
+def _flaky_once(real_scalar, calls):
+    """Wrap ``session.scalar`` so the first call raises a transient DBAPI error."""
+
+    def scalar(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise OperationalError("SELECT 1", {}, Exception("server closed the connection unexpectedly"))
+        return real_scalar(*args, **kwargs)
+
+    return scalar
 
 
 class TestMetastoreBackendSessionSafety:
@@ -108,3 +123,45 @@ class TestMetastoreBackendSessionSafety:
         # Attributes should still be accessible
         assert conn.conn_id == "test_conn"
         assert conn.host == "localhost"
+
+
+class TestMetastoreBackendTransientDBErrors:
+    """A transient DB error must be retried, not reported as a missing secret.
+
+    Both ``Connection.get_connection_from_secrets`` and ``Variable.get_variable_from_secrets``
+    swallow every exception from a backend and fall through to the next one, so without a
+    retry a momentary DB blip is indistinguishable from "the secret does not exist".
+    """
+
+    def setup_method(self) -> None:
+        clear_db_connections()
+        clear_db_variables()
+
+    def teardown_method(self) -> None:
+        clear_db_connections()
+        clear_db_variables()
+
+    def test_get_connection_retries_transient_db_error(self):
+        with create_session() as session:
+            session.add(Connection(conn_id="target_conn", conn_type="mysql", host="localhost"))
+            session.commit()
+
+        with create_session() as session:
+            calls: list[int] = []
+            with mock.patch.object(session, "scalar", side_effect=_flaky_once(session.scalar, calls)):
+                conn = MetastoreBackend().get_connection("target_conn", session=session)
+
+        assert len(calls) == 2
+        assert conn is not None
+        assert conn.conn_id == "target_conn"
+
+    def test_get_variable_retries_transient_db_error(self):
+        Variable.set(key="test_key", value="test_value")
+
+        with create_session() as session:
+            calls: list[int] = []
+            with mock.patch.object(session, "scalar", side_effect=_flaky_once(session.scalar, calls)):
+                value = MetastoreBackend().get_variable("test_key", session=session)
+
+        assert len(calls) == 2
+        assert value == "test_value"


### PR DESCRIPTION
`MetastoreBackend` reads connections and variables from the metadata database with no retry. Every caller that wraps it (`Connection.get_connection_from_secrets`, `Variable.get_variable_from_secrets`, and the Task SDK's server-context lookup) catches `Exception`, logs it at debug level, and falls through to the next backend. A transient database failure therefore reaches the caller as *the secret does not exist*.

## Why it matters

The Execution API answers **404** for a connection or variable that is present in the database. 404 is permanent, so the Task SDK does not retry and the task fails with `The conn_id 'x' isn't defined`. The real cause is visible only at debug level.

Two amplifiers. Under `[secrets] use_cache = True` the resulting `None` is cached for `cache_ttl_seconds` (see [`variable.py:498`](https://github.com/apache/airflow/blob/2c9d91ef34/airflow-core/src/airflow/models/variable.py#L498), which notes "we save None as well"), so one blip poisons the key. The triggerer, Dag processor, and callback supervisor call this backend in-process, so deferred tasks hit the same bogus not-found.

`pool_pre_ping` does not cover this. It recycles a *stale* pooled connection, but the failure here lands on the reconnect itself.

## The fix

Apply the existing `retry_db_transaction` under `@provide_session`, so retries run within one session with a rollback between attempts. That is the stacking already used in [`renderedtifields.py:241`](https://github.com/apache/airflow/blob/2c9d91ef34/airflow-core/src/airflow/models/renderedtifields.py#L241), [`dagwarning.py:78`](https://github.com/apache/airflow/blob/2c9d91ef34/airflow-core/src/airflow/models/dagwarning.py#L78), and [`manager.py:701`](https://github.com/apache/airflow/blob/2c9d91ef34/airflow-core/src/airflow/dag_processing/manager.py#L701). Both lookups are reads, the budget is the existing `[database] max_db_retries`, and a missing secret still returns `None` on the first attempt.

## Testing Done

Real Postgres, real psycopg2, real TCP-level failure. Airflow connects through a local forwarder; `blip()` drops the open connections and refuses exactly the next connection attempt, then serves normally. One failover-shaped blip, so the outcome is deterministic rather than a race against the backoff.

### Setup

```bash
docker run -d --name af-e2e-pg -e POSTGRES_PASSWORD=airflow \
    -e POSTGRES_USER=airflow -e POSTGRES_DB=airflow -p 55432:5432 postgres:16

export AIRFLOW_HOME=/tmp/af-e2e-metastore
export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@127.0.0.1:55433/airflow

python repro.py --setup    # airflow db migrate, then seed e2e_conn and e2e_var
python repro.py
```

<details><summary><code>repro.py</code></summary>

```python
from __future__ import annotations

import socket
import subprocess
import sys
import threading
import time

UPSTREAM = ("127.0.0.1", 55432)
LISTEN = ("127.0.0.1", 55433)


class Forwarder:
    """TCP forwarder to the database that can drop and refuse connections on demand."""

    def __init__(self):
        self.refuse_next = 0
        self.live: list[socket.socket] = []
        self._sock = socket.socket()
        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
        self._sock.bind(LISTEN)
        self._sock.listen(64)
        threading.Thread(target=self._serve, daemon=True).start()

    def _serve(self):
        while True:
            client, _ = self._sock.accept()
            if self.refuse_next > 0:
                self.refuse_next -= 1
                client.close()
                continue
            upstream = socket.create_connection(UPSTREAM)
            self.live += [client, upstream]
            for a, b in ((client, upstream), (upstream, client)):
                threading.Thread(target=self._pipe, args=(a, b), daemon=True).start()

    @staticmethod
    def _pipe(src, dst):
        try:
            while chunk := src.recv(65536):
                dst.sendall(chunk)
        except OSError:
            pass
        finally:
            src.close()
            dst.close()

    def blip(self, attempts: int = 1) -> None:
        """Drop open connections and refuse the next `attempts` connection attempts."""
        for sock in self.live:
            try:
                sock.close()
            except OSError:
                pass
        self.live = []
        self.refuse_next = attempts


def setup():
    for cmd in (
        ["airflow", "db", "migrate"],
        ["airflow", "connections", "add", "e2e_conn", "--conn-type", "mysql", "--conn-host", "db.example.com"],
        ["airflow", "variables", "set", "e2e_var", "e2e_value"],
    ):
        subprocess.run(cmd, check=True)


def main():
    forwarder = Forwarder()

    from airflow.exceptions import AirflowNotFoundException
    from airflow.models.connection import Connection
    from airflow.models.variable import Variable

    Connection.get_connection_from_secrets("e2e_conn")
    Variable.get_variable_from_secrets("e2e_var")
    print("baseline: connection 'e2e_conn' and variable 'e2e_var' both resolve")

    print("\none refused connection attempt, then look up the connection:")
    forwarder.blip()
    try:
        conn = Connection.get_connection_from_secrets("e2e_conn")
        print(f"  -> OK: conn_id={conn.conn_id} host={conn.host}")
    except AirflowNotFoundException as e:
        print(f"  -> SPURIOUS NOT-FOUND: AirflowNotFoundException: {e}")

    print("\none refused connection attempt, then look up the variable:")
    forwarder.blip()
    value = Variable.get_variable_from_secrets("e2e_var")
    if value is None:
        print("  -> SPURIOUS NOT-FOUND: None (Variable.get raises KeyError -> HTTP 404)")
    else:
        print(f"  -> OK: {value!r}")

    time.sleep(0.2)


if __name__ == "__main__":
    if "--setup" in sys.argv:
        Forwarder()
        time.sleep(0.2)
        setup()
    else:
        main()
```

</details>

### Before, on `origin/main`

```console
$ git checkout origin/main -- airflow-core/src/airflow/secrets/metastore.py
$ python repro.py
baseline: connection 'e2e_conn' and variable 'e2e_var' both resolve

one refused connection attempt, then look up the connection:
  -> SPURIOUS NOT-FOUND: AirflowNotFoundException: The conn_id `e2e_conn` isn't defined

one refused connection attempt, then look up the variable:
  -> SPURIOUS NOT-FOUND: None (Variable.get raises KeyError -> HTTP 404)
```

<details><summary>The swallowed driver error (debug level)</summary>

```
Unable to retrieve connection from secrets backend (MetastoreBackend). Checking subsequent secrets backend.
Traceback (most recent call last):
  File "sqlalchemy/pool/base.py", line 896, in __connect
    self.dbapi_connection = connection = pool._invoke_creator(self)
  File "sqlalchemy/engine/default.py", line 630, in connect
    return self.loaded_dbapi.connect(*cargs, **cparams)
  File "psycopg2/__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: connection to server at "127.0.0.1", port 55433 failed: server closed the connection unexpectedly
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at "127.0.0.1", port 55433 failed: server closed the connection unexpectedly
```

</details>

### After, on this branch

```console
$ git checkout HEAD -- airflow-core/src/airflow/secrets/metastore.py
$ python repro.py
baseline: connection 'e2e_conn' and variable 'e2e_var' both resolve

one refused connection attempt, then look up the connection:
  -> OK: conn_id=e2e_conn host=db.example.com

one refused connection attempt, then look up the variable:
  -> OK: 'e2e_value'
```

Three consecutive runs each way:

```console
### PRE-FIX (origin/main) — 3 consecutive runs ###
  -> SPURIOUS NOT-FOUND: AirflowNotFoundException: The conn_id `e2e_conn` isn't defined
  -> SPURIOUS NOT-FOUND: None (Variable.get raises KeyError -> HTTP 404)
  --
  -> SPURIOUS NOT-FOUND: AirflowNotFoundException: The conn_id `e2e_conn` isn't defined
  -> SPURIOUS NOT-FOUND: None (Variable.get raises KeyError -> HTTP 404)
  --
  -> SPURIOUS NOT-FOUND: AirflowNotFoundException: The conn_id `e2e_conn` isn't defined
  -> SPURIOUS NOT-FOUND: None (Variable.get raises KeyError -> HTTP 404)
  --

### POST-FIX (this PR) — 3 consecutive runs ###
  -> OK: conn_id=e2e_conn host=db.example.com
  -> OK: 'e2e_value'
  --
  -> OK: conn_id=e2e_conn host=db.example.com
  -> OK: 'e2e_value'
  --
  -> OK: conn_id=e2e_conn host=db.example.com
  -> OK: 'e2e_value'
  --
```

Regression tests in `airflow-core/tests/unit/always/test_secrets_metastore.py` drive a real session against a real database and fail on unpatched source.

