### PR TITLE
Log retried task failures as warnings, not errors

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1660,9 +1660,9 @@ def _run_task_and_map_outcome(
         error = e
     except (AirflowTaskTimeout, AirflowException, AirflowRuntimeError) as e:
         # We should allow retries if the task has defined it.
-        log.exception("Task failed with exception")
         log.info("::group::Post Execute")
         msg, state = _handle_current_task_failed(ti, e, log, context)
+        _log_task_failure(log, state, e)
         error = e
     except AirflowTaskTerminated as e:
         # External state updates are already handled with `ti_heartbeat` and will be
@@ -1685,9 +1685,9 @@ def _run_task_and_map_outcome(
         msg, state = _handle_current_task_failed(ti, e, log, context)
         error = e
     except BaseException as e:
-        log.exception("Task failed with exception")
         log.info("::group::Post Execute")
         msg, state = _handle_current_task_failed(ti, e, log, context)
+        _log_task_failure(log, state, e)
         error = e
 
     return state, msg, error
@@ -1791,6 +1791,23 @@ def _handle_current_task_success(
     return msg, TaskInstanceState.SUCCESS
 
 
+def _log_task_failure(log: Logger, state: TaskInstanceState, exception: BaseException) -> None:
+    """
+    Log a task failure at the severity matching its outcome.
+
+    A failure that will be retried is logged as a warning so error-tracking tools
+    (e.g. Sentry) aren't paged for transient failures; only the final, non-retried
+    attempt is logged as an error. ``exception`` is passed explicitly (rather than
+    relying on ``exc_info=True``) since this is called after the except block that
+    caught it has already done other work, and in ``_handle_handler_failure``'s case,
+    from outside an except block entirely.
+    """
+    if state == TaskInstanceState.UP_FOR_RETRY:
+        log.warning("Task failed with exception, will be retried", exc_info=exception)
+    else:
+        log.exception("Task failed with exception")
+
+
 def _evaluate_retry_policy(
     ti: RuntimeTaskInstance,
     exception: BaseException,
@@ -1838,11 +1855,12 @@ def _handle_handler_failure(
     through the retry-count check, so an exception that means "do not retry" still means
     that when it surfaces from a handler.
     """
-    log.exception("Task failed with exception")
     if isinstance(exception, (AirflowFailException, AirflowSensorTimeout, AirflowTaskTerminated)):
+        log.exception("Task failed with exception")
         return _terminal_failure(ti), TaskInstanceState.FAILED, exception
     try:
         msg, state = _handle_current_task_failed(ti, exception, log, context)
+        _log_task_failure(log, state, exception)
     except Exception:
         # The failure path itself failed. Re-entering it would just fail again and
         # escape, losing the callbacks this whole function exists to preserve, so fail

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5172,6 +5172,7 @@ class TestTaskRunnerCallsCallbacks:
             "expected_state",
             "expected_results",
             "extra_exceptions",
+            "expected_warning_call",
         ),
         [
             pytest.param(
@@ -5181,6 +5182,7 @@ class TestTaskRunnerCallsCallbacks:
                 TaskInstanceState.SUCCESS,
                 ["on-execute 1", "on-execute 3", "execute success", "on-success 1", "on-success 3"],
                 [],
+                None,
                 id="success",
             ),
             pytest.param(
@@ -5190,6 +5192,7 @@ class TestTaskRunnerCallsCallbacks:
                 TaskInstanceState.SKIPPED,
                 ["on-execute 1", "on-execute 3", "execute skipped", "on-skipped 1", "on-skipped 3"],
                 [],
+                None,
                 id="skipped",
             ),
             pytest.param(
@@ -5199,6 +5202,7 @@ class TestTaskRunnerCallsCallbacks:
                 TaskInstanceState.FAILED,
                 ["on-execute 1", "on-execute 3", "execute failure", "on-failure 1", "on-failure 3"],
                 [(1, mock.call("Task failed with exception"))],
+                None,
                 id="failure",
             ),
             pytest.param(
@@ -5207,7 +5211,10 @@ class TestTaskRunnerCallsCallbacks:
                 True,
                 TaskInstanceState.UP_FOR_RETRY,
                 ["on-execute 1", "on-execute 3", "execute failure", "on-retry 1", "on-retry 3"],
-                [(1, mock.call("Task failed with exception"))],
+                # A failure that will be retried is logged as a warning, not an exception -- see
+                # `expected_warning_call` below.
+                [],
+                mock.call("Task failed with exception, will be retried", exc_info=mock.ANY),
                 id="retry",
             ),
         ],
@@ -5221,6 +5228,7 @@ class TestTaskRunnerCallsCallbacks:
         expected_state,
         expected_results,
         extra_exceptions,
+        expected_warning_call,
     ):
         collected_results = []
 
@@ -5281,6 +5289,9 @@ class TestTaskRunnerCallsCallbacks:
         for index, calls in extra_exceptions:
             expected_exception_logs.insert(index, calls)
         assert log.exception.mock_calls == expected_exception_logs
+
+        if expected_warning_call is not None:
+            assert expected_warning_call in log.warning.mock_calls
 
 
 class TestTriggerDagRunOperator:


### PR DESCRIPTION
## Summary

`_run_task_and_map_outcome` in the Task SDK's `task_runner.py` logged every task failure via `log.exception` (ERROR level, with traceback) unconditionally -- even when the failure was about to be retried automatically. For a DAG with many task instances hitting transient errors, this means error-tracking integrations (Sentry, etc.) get paged on every retry attempt, not just the final, terminal failure.

The retry-vs-fail decision is already computed by `_handle_current_task_failed` (via `ti._ti_context_from_server.should_retry` and any custom retry policy) immediately after the log call used to happen. This moves the log call after that decision and adds `_log_task_failure`, which:
- logs at `WARNING` (with the exception attached via `exc_info=`) when the outcome is `UP_FOR_RETRY`
- logs at `ERROR` via `log.exception` for the final, non-retried failure

`AirflowFailException`, `AirflowSensorTimeout`, and `AirflowTaskTerminated` are untouched -- those are already documented in this file as never eligible for retry, so they keep unconditional `log.exception`.

Closes: #32246

## Test plan

- [x] Updated `test_task_runner_not_fail_on_failed_callback`'s `retry` case (`task-sdk/tests/task_sdk/execution_time/test_task_runner.py`) to assert the new `log.warning` call instead of expecting `log.exception` for the retry-eligible path; the `failure` (non-retry) case still asserts `log.exception`, unchanged.
- [x] Reviewed all other tests referencing `"Task failed with exception"` / `UP_FOR_RETRY` in this file and confirmed none assert on retry-path `log.exception` calls other than the one updated.
- [x] `ruff check` and `ruff format --check` pass on both changed files.

Note: I wasn't able to run the full suite in this environment (`task-sdk`'s tests require `apache-airflow-core` installed, which isn't published for this pre-release version, and building it locally needs Docker/breeze which wasn't available here). The change was verified via careful manual trace of the exact control flow instead -- happy to have CI/a maintainer double check.