### PR TITLE
Bound SQL toolset query results by size, not just row count

### DIFF
--- a/providers/common/ai/docs/changelog.rst
+++ b/providers/common/ai/docs/changelog.rst
@@ -25,6 +25,18 @@
 Changelog
 ---------
 
+.. note::
+    The ``query`` tool of ``SQLToolset`` and ``DataFusionToolset`` returns a different
+    shape. Rows were a dict per row alongside a ``count`` of every matching row:
+    ``{"rows": [{"id": 1, "name": "a"}], "count": 900}``. They are now columnar, and
+    ``row_count`` counts the rows actually returned:
+    ``{"columns": ["id", "name"], "rows": [[1, "a"]], "row_count": 1}``. A truncated
+    result also carries ``truncated_by`` -- ``max_rows`` or the new ``max_result_bytes``
+    -- and ``total_rows`` appears only when the driver reports a trustworthy query
+    total. The tool's own description states the new shape, so agents adapt without
+    changes; update any system prompt that describes the old shape, and any code
+    calling ``toolset.call_tool("query", ...)`` directly.
+
 0.7.0
 .....
 

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -128,7 +128,8 @@ Curated toolset wrapping
    * - ``get_schema``
      - Returns column names and types for a table
    * - ``query``
-     - Executes a SQL query and returns rows as JSON
+     - Executes a SQL query and returns bounded, columnar JSON (see
+       :ref:`bounded-query-results`)
    * - ``check_query``
      - Validates SQL syntax without executing it
 
@@ -203,6 +204,57 @@ Parameters
   Default ``False`` -- only SELECT-family and read-only metadata
   (``DESCRIBE``/``SHOW``) statements are permitted.
 - ``max_rows``: Maximum rows returned from the ``query`` tool. Default ``50``.
+  Rows beyond it are never fetched from the cursor.
+- ``max_result_bytes``: Budget for the serialized ``query`` result. Default 64 KiB.
+  See :ref:`bounded-query-results`.
+
+.. _bounded-query-results:
+
+Bounded query results
+^^^^^^^^^^^^^^^^^^^^^
+
+A tool result stays in the model's message history for the rest of the run, so its
+cost is re-paid on every subsequent model request. The ``query`` tool of both
+``SQLToolset`` and ``DataFusionToolset`` bounds that in three ways.
+
+**The result is columnar.** Column names appear once, not once per row:
+
+.. code-block:: json
+
+    {"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]], "row_count": 2}
+
+On a table with thousands of columns the repeated names, not the values, are the bulk
+of a row-of-dicts payload. Positional rows also keep columns that share a name --
+``SELECT o.id, c.id`` -- which a dict per row silently collapsed to one.
+
+**Rows are fetched, not filtered.** ``max_rows`` bounds what leaves the cursor, so a
+query matching a whole table costs the worker roughly what one matching ``max_rows``
+costs. How much is saved depends on the driver: with a server-side cursor the
+remaining rows are never sent, while a client-buffering driver (psycopg2's default
+cursor, MySQLdb) has already received them and only the per-row conversion is skipped.
+``DataFusionToolset`` materializes the full result in the engine before the toolset
+sees it, so only the payload is bounded there.
+
+**A byte budget bounds the payload.** ``max_rows`` caps rows, which says nothing about
+size -- one row of a 3000-column table is larger than a thousand rows of a narrow one.
+``max_result_bytes`` is what actually bounds context. Rows are dropped from the end
+until the payload fits, and the result says which limit it hit:
+
+.. code-block:: json
+
+    {"columns": ["..."], "rows": ["..."], "row_count": 3,
+     "truncated": true, "truncated_by": "max_result_bytes"}
+
+``truncated_by`` is ``max_rows`` or ``max_result_bytes``. When not even one row fits,
+or the column names alone exceed the budget, the result carries a ``hint`` telling the
+agent to narrow its projection -- the only move that helps. ``total_rows`` is present
+when the driver reports a row count for the query; several (SQLite, some warehouse
+drivers) do not, and it is then omitted rather than guessed.
+
+The default budget is deliberately generous: the columnar shape alone shrinks a wide
+result several-fold, so results that fit before still fit. Lower ``max_result_bytes``
+when an agent makes many queries in one run, since every result is re-paid on every
+later request.
 
 ``DataFusionToolset``
 ---------------------
@@ -223,7 +275,8 @@ querying files on object stores (S3, local filesystem, Iceberg) via Apache DataF
    * - ``get_schema``
      - Returns column names and types for a table (Arrow schema)
    * - ``query``
-     - Executes a SQL query and returns rows as JSON
+     - Executes a SQL query and returns bounded, columnar JSON (see
+       :ref:`bounded-query-results`)
 
 Each :class:`~airflow.providers.common.sql.config.DataSourceConfig` entry
 registers a table backed by Parquet, CSV, Avro, or Iceberg data. Multiple
@@ -267,6 +320,8 @@ Parameters
   permitted. DataFusion on object stores is mostly read-only, but it does
   support DDL for in-memory tables; this guard blocks those by default.
 - ``max_rows``: Maximum rows returned from the ``query`` tool. Default ``50``.
+- ``max_result_bytes``: Budget for the serialized ``query`` result. Default 64 KiB.
+  See :ref:`bounded-query-results`.
 
 ``LoggingToolset``
 ------------------
@@ -616,10 +671,12 @@ No single layer is sufficient — they work together.
        ``allowed_functions``. Fail-closed, but only as exact as the SQL parser. Not a
        security boundary -- always pair it with least-privilege database grants. See
        :ref:`allowed-tables-enforcement` below.
-   * - **SQLToolset: max_rows**
-     - Truncates query results to ``max_rows`` (default 50), preventing the
-       agent from pulling entire tables into context.
-     - Does not limit the number of queries the agent can make.
+   * - **SQLToolset: max_rows / max_result_bytes**
+     - Bounds a query result by rows (default 50) and by serialized size
+       (default 64 KiB), preventing the agent from pulling entire tables into
+       context. Rows past ``max_rows`` are never fetched from the cursor.
+     - Does not limit the number of queries the agent can make, and each result
+       stays in message history for the rest of the run.
    * - **MCPToolset: external server**
      - Connects the agent to tools exposed by an MCP server, authenticated
        through an Airflow connection.
@@ -735,7 +792,8 @@ Recommended Configuration
         db_conn_id="analytics_readonly",  # Connection with SELECT-only grants
         allowed_tables=["orders", "customers"],  # Hide other tables from agent
         allow_writes=False,  # Default — validates SQL
-        max_rows=50,  # Default — truncate large results
+        max_rows=50,  # Default — cap rows
+        max_result_bytes=65536,  # Default — cap bytes; lower it for wide tables
     )
 
 **Agents that need to modify data** (use with caution):
@@ -763,8 +821,10 @@ Before deploying an agent task to production:
    agent can call any exposed tool with any arguments.
 4. **Read-only default**: Keep ``allow_writes=False`` unless the task
    specifically requires writes.
-5. **Row limits**: Set ``max_rows`` appropriate to the use case. Large
-   result sets consume LLM context and increase cost.
+5. **Result limits**: Set ``max_rows`` and ``max_result_bytes`` appropriate to
+   the use case. ``max_rows`` alone does not bound size -- on wide tables it is
+   ``max_result_bytes`` that keeps a result from dominating the context window for
+   the rest of the run.
 6. **Model budget**: Configure pydantic-ai's ``model_settings`` (e.g.
    ``max_tokens``) and ``retries`` to bound cost and prevent runaway loops.
 7. **System prompt**: Include safety instructions in ``system_prompt`` (e.g.

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -204,7 +204,8 @@ Parameters
   Default ``False`` -- only SELECT-family and read-only metadata
   (``DESCRIBE``/``SHOW``) statements are permitted.
 - ``max_rows``: Maximum rows returned from the ``query`` tool. Default ``50``.
-  Rows beyond it are never fetched from the cursor.
+  Rows beyond it are not read out of a DBAPI cursor; what the driver has already
+  transferred is its own call. See :ref:`bounded-query-results`.
 - ``max_result_bytes``: Budget for the serialized ``query`` result. Default 64 KiB.
   See :ref:`bounded-query-results`.
 
@@ -239,8 +240,10 @@ not.
 
 **A byte budget bounds the payload.** ``max_rows`` caps rows, which says nothing about
 size -- one row of a 3000-column table is larger than a thousand rows of a narrow one.
-``max_result_bytes`` is what actually bounds context. Rows are dropped from the end
-until the payload fits, and the result says which limit it hit:
+``max_result_bytes`` is what actually bounds context. Rows are returned as a contiguous
+prefix: the result stops at the first row that does not fit the remaining budget rather
+than skipping it and packing later ones, so a single wide row early in the result ends
+it. The result says which limit it hit:
 
 .. code-block:: json
 

--- a/providers/common/ai/docs/toolsets.rst
+++ b/providers/common/ai/docs/toolsets.rst
@@ -232,8 +232,10 @@ query matching a whole table costs the worker roughly what one matching ``max_ro
 costs. How much is saved depends on the driver: with a server-side cursor the
 remaining rows are never sent, while a client-buffering driver (psycopg2's default
 cursor, MySQLdb) has already received them and only the per-row conversion is skipped.
-``DataFusionToolset`` materializes the full result in the engine before the toolset
-sees it, so only the payload is bounded there.
+Hooks whose cursor is not DBAPI 2.0 (``ExasolHook`` passes a pyexasol statement) fall
+back to a full fetch, and ``DataFusionToolset`` materializes the full result in the
+engine before the toolset sees it; in both the payload is bounded but the transfer is
+not.
 
 **A byte budget bounds the payload.** ``max_rows`` caps rows, which says nothing about
 size -- one row of a 3000-column table is larger than a thousand rows of a narrow one.
@@ -674,9 +676,11 @@ No single layer is sufficient — they work together.
    * - **SQLToolset: max_rows / max_result_bytes**
      - Bounds a query result by rows (default 50) and by serialized size
        (default 64 KiB), preventing the agent from pulling entire tables into
-       context. Rows past ``max_rows`` are never fetched from the cursor.
+       context.
      - Does not limit the number of queries the agent can make, and each result
-       stays in message history for the rest of the run.
+       stays in message history for the rest of the run. Rows past ``max_rows``
+       are not read out of the cursor, but a client-buffering driver has already
+       transferred them -- this bounds context, not database or network load.
    * - **MCPToolset: external server**
      - Connects the agent to tools exposed by an MCP server, authenticated
        through an Airflow connection.

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
@@ -36,6 +36,11 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 
+from airflow.providers.common.ai.utils.query_results import (
+    DEFAULT_MAX_RESULT_BYTES,
+    QUERY_TOOL_DESCRIPTION as _QUERY_DESCRIPTION,
+    build_query_result,
+)
 from airflow.providers.common.ai.utils.tool_definition import build_args_validator
 
 if TYPE_CHECKING:
@@ -97,6 +102,13 @@ class DataFusionToolset(AbstractToolset[Any]):
         are permitted.
     :param max_rows: Maximum number of rows returned from the ``query`` tool.
         Default ``50``.
+    :param max_result_bytes: Budget for the serialized ``query`` result, in bytes.
+        Default 64 KiB. ``max_rows`` bounds rows, which says nothing about size: one
+        row of a 3000-column table is larger than a thousand rows of a narrow one, and
+        a tool result stays in the model's message history for the rest of the run, so
+        its cost is re-paid on every subsequent request. Rows are dropped from the end
+        until the payload fits, and the result reports which limit it hit so the agent
+        can narrow its projection rather than page through the table.
     """
 
     def __init__(
@@ -105,12 +117,14 @@ class DataFusionToolset(AbstractToolset[Any]):
         *,
         allow_writes: bool = False,
         max_rows: int = 50,
+        max_result_bytes: int = DEFAULT_MAX_RESULT_BYTES,
     ) -> None:
         if not datasource_configs:
             raise ValueError("datasource_configs must contain at least one DataSourceConfig")
         self._datasource_configs = datasource_configs
         self._allow_writes = allow_writes
         self._max_rows = max_rows
+        self._max_result_bytes = max_result_bytes
         self._engine: DataFusionEngine | None = None
 
     @property
@@ -133,7 +147,7 @@ class DataFusionToolset(AbstractToolset[Any]):
         for name, description, schema in (
             ("list_tables", "List available table names.", _LIST_TABLES_SCHEMA),
             ("get_schema", "Get column names and types for a table.", _GET_SCHEMA_SCHEMA),
-            ("query", "Execute a SQL query and return rows as JSON.", _QUERY_SCHEMA),
+            ("query", _QUERY_DESCRIPTION, _QUERY_SCHEMA),
         ):
             tool_def = ToolDefinition(
                 name=name,
@@ -199,16 +213,17 @@ class DataFusionToolset(AbstractToolset[Any]):
             col_names = list(pydict.keys())
             num_rows = len(next(iter(pydict.values()), []))
 
-            result: list[dict[str, Any]] = [
-                {col: pydict[col][i] for col in col_names} for i in range(min(num_rows, self._max_rows))
-            ]
-
-            truncated = num_rows > self._max_rows
-            output: dict[str, Any] = {"rows": result, "count": num_rows}
-            if truncated:
-                output["truncated"] = True
-                output["max_rows"] = self._max_rows
-            return json.dumps(output, default=str)
+            # DataFusion has already materialised the full result, so unlike SQLToolset
+            # there is nothing left to avoid fetching -- only the payload is bounded.
+            rows = [[pydict[col][i] for col in col_names] for i in range(min(num_rows, self._max_rows))]
+            return build_query_result(
+                col_names,
+                rows,
+                max_rows=self._max_rows,
+                max_result_bytes=self._max_result_bytes,
+                more_rows_available=num_rows > self._max_rows,
+                total_rows=num_rows,
+            )
         except SQLSafetyError as ex:
             log.warning("query failed SQL safety validation: %s", ex)
             raise

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/datafusion.py
@@ -106,9 +106,11 @@ class DataFusionToolset(AbstractToolset[Any]):
         Default 64 KiB. ``max_rows`` bounds rows, which says nothing about size: one
         row of a 3000-column table is larger than a thousand rows of a narrow one, and
         a tool result stays in the model's message history for the rest of the run, so
-        its cost is re-paid on every subsequent request. Rows are dropped from the end
-        until the payload fits, and the result reports which limit it hit so the agent
-        can narrow its projection rather than page through the table.
+        its cost is re-paid on every subsequent request. Rows are returned as a
+        contiguous prefix, stopping at the first that does not fit the remaining budget
+        rather than skipping it and packing later ones, so one wide row early in the
+        result ends it. The result reports which limit it hit so the agent can narrow
+        its projection rather than page through the table.
     """
 
     def __init__(

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
@@ -30,6 +30,7 @@ try:
         resolve_sqlglot_dialect,
         validate_sql as _validate_sql,
     )
+    from airflow.providers.common.sql.hooks.handlers import get_row_count
     from airflow.providers.common.sql.hooks.sql import DbApiHook
 except ImportError as e:
     from airflow.providers.common.compat.sdk import AirflowOptionalProviderFeatureException
@@ -40,6 +41,11 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import AbstractToolset, ToolsetTool
 
+from airflow.providers.common.ai.utils.query_results import (
+    DEFAULT_MAX_RESULT_BYTES,
+    QUERY_TOOL_DESCRIPTION as _QUERY_DESCRIPTION,
+    build_query_result,
+)
 from airflow.providers.common.ai.utils.tool_definition import build_args_validator, return_schema_kwargs
 from airflow.providers.common.compat.sdk import BaseHook
 
@@ -75,6 +81,44 @@ _CHECK_QUERY_SCHEMA: dict[str, Any] = {
     },
     "required": ["sql"],
 }
+
+
+class _CappedFetch:
+    """
+    ``DbApiHook.run`` handler that fetches at most ``limit`` rows instead of all of them.
+
+    The counterpart in ``common.sql``,
+    :func:`~airflow.providers.common.sql.hooks.handlers.fetch_all_handler`, pulls the
+    whole result set into the worker; the toolset then discards all but ``max_rows`` of
+    it, having already paid for the transfer. Fetching through the cursor keeps the cost
+    proportional to what the agent is actually shown.
+
+    How much this saves depends on the driver: with a server-side cursor the unfetched
+    rows are never sent, while a driver that buffers client-side (psycopg2's default
+    cursor, MySQLdb) has already received them and only the per-row conversion is
+    skipped. The result handed to the model is bounded either way.
+
+    Instances are single-use -- ``total_rows`` refers to the last query run.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        #: Rows the driver reports for the query, or ``None`` when it reports none.
+        self.total_rows: int | None = None
+
+    def __call__(self, cursor: Any) -> list[tuple] | None:
+        if not hasattr(cursor, "description"):
+            raise RuntimeError(
+                "The database we interact with does not support DBAPI 2.0. Use a connection "
+                "whose hook is a DbApiHook over a DBAPI 2.0 driver."
+            )
+        if cursor.description is None:
+            return None
+        rows = cursor.fetchmany(self._limit)
+        # Read after fetching: drivers that stream set rowcount as rows arrive, and the
+        # ones that buffer have it set either way.
+        self.total_rows = get_row_count(cursor)
+        return rows
 
 
 class SQLToolset(AbstractToolset[Any]):
@@ -143,7 +187,16 @@ class SQLToolset(AbstractToolset[Any]):
     :param allow_writes: Allow data-modifying SQL (INSERT, UPDATE, DELETE, etc.).
         Default ``False`` — only SELECT-family statements are permitted.
     :param max_rows: Maximum number of rows returned from the ``query`` tool.
-        Default ``50``.
+        Default ``50``. Rows beyond this are not fetched from the cursor at all, so a
+        query matching the whole table costs the worker the same as one matching
+        ``max_rows``.
+    :param max_result_bytes: Budget for the serialized ``query`` result, in bytes.
+        Default 64 KiB. ``max_rows`` bounds rows, which says nothing about size: one
+        row of a 3000-column table is larger than a thousand rows of a narrow one, and
+        a tool result stays in the model's message history for the rest of the run, so
+        its cost is re-paid on every subsequent request. Rows are dropped from the end
+        until the payload fits, and the result reports which limit it hit so the agent
+        can narrow its projection rather than page through the table.
     """
 
     def __init__(
@@ -155,6 +208,7 @@ class SQLToolset(AbstractToolset[Any]):
         schema: str | None = None,
         allow_writes: bool = False,
         max_rows: int = 50,
+        max_result_bytes: int = DEFAULT_MAX_RESULT_BYTES,
     ) -> None:
         self._db_conn_id = db_conn_id
         self._allowed_tables: frozenset[str] | None = frozenset(allowed_tables) if allowed_tables else None
@@ -166,6 +220,7 @@ class SQLToolset(AbstractToolset[Any]):
         self._schema = schema
         self._allow_writes = allow_writes
         self._max_rows = max_rows
+        self._max_result_bytes = max_result_bytes
         self._hook: DbApiHook | None = None
 
         # Canonical ``(catalog, schema, table)`` view of allowed_tables for membership
@@ -251,7 +306,7 @@ class SQLToolset(AbstractToolset[Any]):
         for name, description, schema in (
             ("list_tables", "List available table names in the database.", _LIST_TABLES_SCHEMA),
             ("get_schema", "Get column names and types for a table.", _GET_SCHEMA_SCHEMA),
-            ("query", "Execute a SQL query and return rows as JSON.", _QUERY_SCHEMA),
+            ("query", _QUERY_DESCRIPTION, _QUERY_SCHEMA),
             ("check_query", "Validate SQL syntax without executing it.", _CHECK_QUERY_SCHEMA),
         ):
             # sequential=True because all tools use a shared DbApiHook with
@@ -370,24 +425,24 @@ class SQLToolset(AbstractToolset[Any]):
         if statements is not None:
             self._enforce_allowed_tables(statements)
 
-        rows = hook.get_records(sql)
-        # Fetch column names from cursor description.
-        col_names: list[str] | None = None
+        # One row beyond the cap, so "there is more" is knowable without fetching the
+        # rest. strip_sql_string mirrors what get_records did for the hooks that
+        # override it (Trino rejects a trailing semicolon) and is a no-op elsewhere.
+        fetch = _CappedFetch(self._max_rows + 1)
+        rows = hook.run(hook.strip_sql_string(sql), handler=fetch) or []
+
+        col_names: list[str] = []
         if hook.last_description:
             col_names = [desc[0] for desc in hook.last_description]
 
-        result: list[dict[str, Any]] | list[list[Any]]
-        if rows and col_names:
-            result = [dict(zip(col_names, row)) for row in rows[: self._max_rows]]
-        else:
-            result = [list(row) for row in (rows or [])[: self._max_rows]]
-
-        truncated = len(rows or []) > self._max_rows
-        output: dict[str, Any] = {"rows": result, "count": len(rows or [])}
-        if truncated:
-            output["truncated"] = True
-            output["max_rows"] = self._max_rows
-        return json.dumps(output, default=str)
+        return build_query_result(
+            col_names,
+            rows[: self._max_rows],
+            max_rows=self._max_rows,
+            max_result_bytes=self._max_result_bytes,
+            more_rows_available=len(rows) > self._max_rows,
+            total_rows=fetch.total_rows,
+        )
 
     def _check_query(self, sql: str) -> str:
         # Resolve the dialect best-effort: if the connection can't be reached we

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
@@ -228,9 +228,11 @@ class SQLToolset(AbstractToolset[Any]):
         Default 64 KiB. ``max_rows`` bounds rows, which says nothing about size: one
         row of a 3000-column table is larger than a thousand rows of a narrow one, and
         a tool result stays in the model's message history for the rest of the run, so
-        its cost is re-paid on every subsequent request. Rows are dropped from the end
-        until the payload fits, and the result reports which limit it hit so the agent
-        can narrow its projection rather than page through the table.
+        its cost is re-paid on every subsequent request. Rows are returned as a
+        contiguous prefix, stopping at the first that does not fit the remaining budget
+        rather than skipping it and packing later ones, so one wide row early in the
+        result ends it. The result reports which limit it hit so the agent can narrow
+        its projection rather than page through the table.
     """
 
     def __init__(

--- a/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py
@@ -83,6 +83,26 @@ _CHECK_QUERY_SCHEMA: dict[str, Any] = {
 }
 
 
+def _trusted_row_count(cursor: Any, *, fetched: int) -> int | None:
+    """
+    Return the driver's row count for the query, or ``None`` when it cannot mean that.
+
+    ``rowcount`` is only a query total on drivers that buffer the whole result before
+    handing back the first row. Others report rows fetched *so far* -- python-oracledb
+    documents exactly that for ``SELECT`` -- which after a capped fetch equals the cap,
+    not the total. Handing an agent ``total_rows: 51`` for a ten-million-row table is
+    worse than handing it nothing: it reads as authoritative and it is wrong.
+
+    A count no larger than what was fetched is indistinguishable from that failure mode,
+    so it is discarded. Nothing is lost when the result was not truncated -- ``row_count``
+    is already the total there.
+    """
+    row_count = get_row_count(cursor)
+    if row_count is None or row_count <= fetched:
+        return None
+    return row_count
+
+
 class _CappedFetch:
     """
     ``DbApiHook.run`` handler that fetches at most ``limit`` rows instead of all of them.
@@ -98,6 +118,12 @@ class _CappedFetch:
     cursor, MySQLdb) has already received them and only the per-row conversion is
     skipped. The result handed to the model is bounded either way.
 
+    Not every hook hands its handler a DBAPI cursor -- ``ExasolHook`` passes a pyexasol
+    statement, which signals "this produced rows" through ``result_type`` rather than
+    ``description``. Bounding the fetch is not possible without knowing that per driver,
+    so those fall back to a full fetch, which is what the toolset did everywhere before.
+    The payload is still bounded; only the transfer is not.
+
     Instances are single-use -- ``total_rows`` refers to the last query run.
     """
 
@@ -108,16 +134,21 @@ class _CappedFetch:
 
     def __call__(self, cursor: Any) -> list[tuple] | None:
         if not hasattr(cursor, "description"):
-            raise RuntimeError(
-                "The database we interact with does not support DBAPI 2.0. Use a connection "
-                "whose hook is a DbApiHook over a DBAPI 2.0 driver."
-            )
+            fetchall = getattr(cursor, "fetchall", None)
+            if not callable(fetchall):
+                raise RuntimeError(
+                    "The database we interact with does not support DBAPI 2.0. Use a "
+                    "connection whose hook exposes a DBAPI 2.0 cursor."
+                )
+            rows = fetchall()
+            # Nothing was left behind, so the fetched count is the exact total.
+            self.total_rows = len(rows) if rows is not None else 0
+            return rows
         if cursor.description is None:
+            # A statement that returned no result set (DDL, or DML without RETURNING).
             return None
         rows = cursor.fetchmany(self._limit)
-        # Read after fetching: drivers that stream set rowcount as rows arrive, and the
-        # ones that buffer have it set either way.
-        self.total_rows = get_row_count(cursor)
+        self.total_rows = _trusted_row_count(cursor, fetched=len(rows or []))
         return rows
 
 
@@ -187,9 +218,12 @@ class SQLToolset(AbstractToolset[Any]):
     :param allow_writes: Allow data-modifying SQL (INSERT, UPDATE, DELETE, etc.).
         Default ``False`` — only SELECT-family statements are permitted.
     :param max_rows: Maximum number of rows returned from the ``query`` tool.
-        Default ``50``. Rows beyond this are not fetched from the cursor at all, so a
-        query matching the whole table costs the worker the same as one matching
-        ``max_rows``.
+        Default ``50``. Rows beyond it are not pulled out of the cursor. How much that
+        saves is the driver's call, not this toolset's: a client-buffering driver
+        (psycopg2's default cursor, MySQLdb) has already received the whole result by
+        the time the first row is read, so only the per-row Python conversion is
+        skipped. Treat this as a bound on what the agent is shown, not as a guarantee
+        that ``SELECT * FROM huge_table`` is cheap.
     :param max_result_bytes: Budget for the serialized ``query`` result, in bytes.
         Default 64 KiB. ``max_rows`` bounds rows, which says nothing about size: one
         row of a 3000-column table is larger than a thousand rows of a narrow one, and

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/query_results.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/query_results.py
@@ -35,14 +35,17 @@ import json
 from collections.abc import Sequence
 from typing import Any
 
-# Roughly 16k tokens at 4 characters per token. Large enough that ordinary queries
-# are unaffected, small enough that no single tool result can dominate the context
-# window. Deployments that keep many results in history should lower it.
+# A policy default, not a limit imposed by any storage, protocol, or model layer:
+# roughly 16k tokens at 4 characters per token. Large enough that ordinary queries are
+# unaffected, small enough that no single tool result can dominate the context window.
+# Deployments that keep many results in history should lower it.
 DEFAULT_MAX_RESULT_BYTES = 65_536
 
-# Tool results are machine-read, so no whitespace: separators alone cut ~15% off a
-# wide payload, and the measurement below is exact only if it matches the final dump.
-_COMPACT = (",", ":")
+# Tool results are machine-read, so no whitespace. ensure_ascii=False matters as much as
+# the separators: escaping one CJK character to \uXXXX costs six bytes instead of three,
+# so an ASCII-escaped result is charged several times over against the budget and
+# truncated that much earlier than an equivalent English one.
+_DUMP_KWARGS: dict[str, Any] = {"default": str, "separators": (",", ":"), "ensure_ascii": False}
 
 #: Description for the ``query`` tool. States the columnar shape, since the model has
 #: to align each row's values to ``columns`` positionally, and the truncation contract,
@@ -57,7 +60,12 @@ QUERY_TOOL_DESCRIPTION = (
 
 
 def _dumps(payload: Any) -> str:
-    return json.dumps(payload, default=str, separators=_COMPACT)
+    return json.dumps(payload, **_DUMP_KWARGS)
+
+
+def _size(payload: Any) -> int:
+    """Measure the serialized size in bytes -- not characters, which diverge outside ASCII."""
+    return len(_dumps(payload).encode("utf-8"))
 
 
 def build_query_result(
@@ -86,7 +94,7 @@ def build_query_result(
         reports one at all. ``None`` is common and is not an error -- SQLite and
         several warehouse drivers do not populate it for ``SELECT``.
     """
-    budget = max_result_bytes - len(_dumps(list(columns)))
+    budget = max_result_bytes - _size(list(columns))
     if budget < 0:
         # The column names alone blow the budget, so returning them would spend the
         # whole context on a header and leave no room for data. Report the shape and
@@ -98,21 +106,24 @@ def build_query_result(
             "truncated": True,
             "truncated_by": "max_result_bytes",
             "hint": (
-                f"This query returns {len(columns)} columns, whose names alone exceed "
-                f"max_result_bytes ({max_result_bytes}). Select the specific columns you "
-                f"need instead of all of them."
+                f"This query returns {len(columns)} column{'' if len(columns) == 1 else 's'}, "
+                f"whose names alone exceed max_result_bytes ({max_result_bytes}). Select the "
+                f"specific columns you need instead of all of them."
             ),
         }
         if total_rows is not None:
             output["total_rows"] = total_rows
         return _dumps(output)
 
+    # Rows are kept as a contiguous prefix: stopping at the first row that does not fit
+    # rather than skipping it and packing later ones, so "rows 1..n" means what it says
+    # and the agent is never handed a result with a hole in the middle.
     kept: list[list[Any]] = []
     for row in rows:
         as_list = list(row)
         # +1 for the comma joining this row to the previous one; the serializer and
         # separators match the final dump, so this accounting is exact.
-        cost = len(_dumps(as_list)) + (1 if kept else 0)
+        cost = _size(as_list) + (1 if kept else 0)
         if cost > budget:
             break
         budget -= cost
@@ -127,11 +138,15 @@ def build_query_result(
         output["truncated"] = True
         output["truncated_by"] = "max_result_bytes" if byte_capped else "max_rows"
     if byte_capped:
-        if not kept:
-            output["hint"] = (
-                f"No row fits within max_result_bytes ({max_result_bytes}). Select fewer "
-                f"columns, or aggregate, instead of returning whole rows."
-            )
+        # Say which row stopped it. "No row fits" would be false whenever a single wide
+        # row sits in front of narrow ones, and a partial result with no guidance at all
+        # is the common case, not the empty one.
+        output["hint"] = (
+            f"The first row alone exceeds max_result_bytes ({max_result_bytes}). "
+            if not kept
+            else f"Stopped after {len(kept)} row{'' if len(kept) == 1 else 's'}: the next row "
+            f"did not fit in max_result_bytes ({max_result_bytes}). "
+        ) + "Select fewer columns, or aggregate, instead of returning whole rows."
     elif more_rows_available:
         output["hint"] = (
             f"Only the first {max_rows} rows are shown. Filter or aggregate in SQL rather "

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/query_results.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/query_results.py
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Bounded, columnar payloads for the ``query`` tool of the SQL toolsets.
+
+A tool result stays in the model's message history for the rest of the run, so its
+cost is re-paid on every subsequent request. Two things here keep that bounded:
+
+* **Columnar shape.** ``{"columns": [...], "rows": [[...], ...]}`` names each column
+  once instead of repeating it in a dict per row. On a table with thousands of
+  columns the repeated names, not the values, are the bulk of the payload.
+* **A byte budget.** ``max_rows`` caps rows, which says nothing about size -- a
+  single row of a 3000-column table dwarfs a thousand rows of a narrow one. The
+  budget here is what actually bounds context, and when it bites the payload says
+  so, in terms the agent can act on (narrow the projection).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+# Roughly 16k tokens at 4 characters per token. Large enough that ordinary queries
+# are unaffected, small enough that no single tool result can dominate the context
+# window. Deployments that keep many results in history should lower it.
+DEFAULT_MAX_RESULT_BYTES = 65_536
+
+# Tool results are machine-read, so no whitespace: separators alone cut ~15% off a
+# wide payload, and the measurement below is exact only if it matches the final dump.
+_COMPACT = (",", ":")
+
+#: Description for the ``query`` tool. States the columnar shape, since the model has
+#: to align each row's values to ``columns`` positionally, and the truncation contract,
+#: so a short result is not read as an empty table.
+QUERY_TOOL_DESCRIPTION = (
+    "Execute a SQL query. Returns JSON of the form "
+    '{"columns": [name, ...], "rows": [[value, ...], ...]}, where each row holds its '
+    "values in column order. A `truncated` key means the query matched more than was "
+    "returned and `truncated_by` names the limit that was hit; narrow the projection or "
+    "aggregate in SQL rather than paging through the result."
+)
+
+
+def _dumps(payload: Any) -> str:
+    return json.dumps(payload, default=str, separators=_COMPACT)
+
+
+def build_query_result(
+    columns: Sequence[str],
+    rows: Sequence[Sequence[Any]],
+    *,
+    max_rows: int,
+    max_result_bytes: int,
+    more_rows_available: bool,
+    total_rows: int | None = None,
+) -> str:
+    """
+    Render query rows as a bounded, columnar JSON tool result.
+
+    :param columns: Column names, in the order the values appear in each row.
+    :param rows: Rows already capped to ``max_rows``; only the byte budget is
+        applied here.
+    :param max_rows: The row cap that produced *rows*, reported back to the agent
+        so it knows which limit it hit.
+    :param max_result_bytes: Budget for the serialized column names plus rows.
+        The surrounding envelope (the ``truncated``/``hint`` keys) adds a small
+        fixed amount on top.
+    :param more_rows_available: Whether the query matched more rows than *rows*
+        holds.
+    :param total_rows: Total rows the driver reported for the query, when it
+        reports one at all. ``None`` is common and is not an error -- SQLite and
+        several warehouse drivers do not populate it for ``SELECT``.
+    """
+    budget = max_result_bytes - len(_dumps(list(columns)))
+    if budget < 0:
+        # The column names alone blow the budget, so returning them would spend the
+        # whole context on a header and leave no room for data. Report the shape and
+        # tell the agent to narrow the projection -- the only move that helps here.
+        output: dict[str, Any] = {
+            "column_count": len(columns),
+            "rows": [],
+            "row_count": 0,
+            "truncated": True,
+            "truncated_by": "max_result_bytes",
+            "hint": (
+                f"This query returns {len(columns)} columns, whose names alone exceed "
+                f"max_result_bytes ({max_result_bytes}). Select the specific columns you "
+                f"need instead of all of them."
+            ),
+        }
+        if total_rows is not None:
+            output["total_rows"] = total_rows
+        return _dumps(output)
+
+    kept: list[list[Any]] = []
+    for row in rows:
+        as_list = list(row)
+        # +1 for the comma joining this row to the previous one; the serializer and
+        # separators match the final dump, so this accounting is exact.
+        cost = len(_dumps(as_list)) + (1 if kept else 0)
+        if cost > budget:
+            break
+        budget -= cost
+        kept.append(as_list)
+
+    byte_capped = len(kept) < len(rows)
+    output = {"columns": list(columns), "rows": kept, "row_count": len(kept)}
+    if total_rows is not None:
+        output["total_rows"] = total_rows
+
+    if byte_capped or more_rows_available:
+        output["truncated"] = True
+        output["truncated_by"] = "max_result_bytes" if byte_capped else "max_rows"
+    if byte_capped:
+        if not kept:
+            output["hint"] = (
+                f"No row fits within max_result_bytes ({max_result_bytes}). Select fewer "
+                f"columns, or aggregate, instead of returning whole rows."
+            )
+    elif more_rows_available:
+        output["hint"] = (
+            f"Only the first {max_rows} rows are shown. Filter or aggregate in SQL rather "
+            f"than paging through the result."
+        )
+    return _dumps(output)

--- a/providers/common/ai/src/airflow/providers/common/ai/utils/query_results.py
+++ b/providers/common/ai/src/airflow/providers/common/ai/utils/query_results.py
@@ -53,9 +53,10 @@ _DUMP_KWARGS: dict[str, Any] = {"default": str, "separators": (",", ":"), "ensur
 QUERY_TOOL_DESCRIPTION = (
     "Execute a SQL query. Returns JSON of the form "
     '{"columns": [name, ...], "rows": [[value, ...], ...]}, where each row holds its '
-    "values in column order. A `truncated` key means the query matched more than was "
-    "returned and `truncated_by` names the limit that was hit; narrow the projection or "
-    "aggregate in SQL rather than paging through the result."
+    "values in column order. A `truncated` key means you are not seeing the whole result "
+    "-- either more rows matched than were returned, or the result was too large -- and "
+    "`truncated_by` names the limit that was hit; narrow the projection or aggregate in "
+    "SQL rather than paging through the result."
 )
 
 

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_datafusion.py
@@ -180,8 +180,9 @@ class TestDataFusionToolsetQuery:
             )
         )
         data = json.loads(result)
-        assert data["rows"] == [{"id": 1, "amount": 10.5}, {"id": 2, "amount": 20.0}]
-        assert data["count"] == 2
+        assert data["columns"] == ["id", "amount"]
+        assert data["rows"] == [[1, 10.5], [2, 20.0]]
+        assert data["row_count"] == 2
 
     def test_truncates_at_max_rows(self):
         cfg = _make_mock_datasource_config()
@@ -197,9 +198,10 @@ class TestDataFusionToolsetQuery:
             )
         )
         data = json.loads(result)
-        assert len(data["rows"]) == 1
+        assert data["rows"] == [[1, "a"]]
         assert data["truncated"] is True
-        assert data["count"] == 3
+        assert data["truncated_by"] == "max_rows"
+        assert data["total_rows"] == 3
 
     def test_handles_empty_result(self):
         cfg = _make_mock_datasource_config()
@@ -216,7 +218,7 @@ class TestDataFusionToolsetQuery:
         )
         data = json.loads(result)
         assert data["rows"] == []
-        assert data["count"] == 0
+        assert data["row_count"] == 0
 
     def test_blocks_create_table_by_default(self):
         cfg = _make_mock_datasource_config()

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
@@ -21,12 +21,35 @@ import json
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
+from pydantic_ai._run_context import RunContext
 from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.toolsets.abstract import ToolsetTool
 from pydantic_core import ValidationError
+from sqlalchemy.engine.reflection import Inspector
 
 from airflow.providers.common.ai.toolsets.sql import SQLToolset
 from airflow.providers.common.ai.utils.tool_definition import _SUPPORTS_RETURN_SCHEMA
 from airflow.providers.common.sql.hooks.sql import DbApiHook
+
+
+class _FakeCursor:
+    """
+    Minimal DBAPI cursor over canned records.
+
+    The toolset fetches through ``DbApiHook.run``'s handler protocol rather than
+    ``get_records``, so the mock hook drives the real handler over this instead of
+    returning a canned list -- that keeps ``fetchmany``'s bounded-fetch behaviour
+    under test rather than mocked away.
+    """
+
+    def __init__(self, records: list[tuple], description: list[tuple] | None, rowcount: int) -> None:
+        self.description = description
+        self.rowcount = rowcount
+        self._remaining = list(records)
+
+    def fetchmany(self, size: int) -> list[tuple]:
+        chunk, self._remaining = self._remaining[:size], self._remaining[size:]
+        return chunk
 
 
 def _make_mock_db_hook(
@@ -34,18 +57,38 @@ def _make_mock_db_hook(
     table_schema: list[dict[str, str]] | None = None,
     records: list[tuple] | None = None,
     last_description: list[tuple] | None = None,
+    rowcount: int = -1,
 ):
     """Create a mock DbApiHook with sensible defaults."""
     mock = MagicMock(spec=DbApiHook)
-    mock.inspector = MagicMock()
+    mock.inspector = MagicMock(spec=Inspector)
     mock.inspector.get_table_names.return_value = table_names or ["users", "orders"]
     mock.get_table_schema.return_value = table_schema or [
         {"name": "id", "type": "INTEGER"},
         {"name": "name", "type": "VARCHAR"},
     ]
-    mock.get_records.return_value = records or [(1, "Alice"), (2, "Bob")]
-    type(mock).last_description = PropertyMock(return_value=last_description or [("id",), ("name",)])
+    rows = [(1, "Alice"), (2, "Bob")] if records is None else records
+    description = last_description or [("id",), ("name",)]
+    # -1 is what a driver reports when it has no row count for a SELECT (SQLite);
+    # get_row_count normalises that to None, so total_rows is absent by default.
+    mock.strip_sql_string.side_effect = DbApiHook.strip_sql_string
+    mock.run.side_effect = lambda sql, handler, **kwargs: handler(_FakeCursor(rows, description, rowcount))
+    type(mock).last_description = PropertyMock(return_value=description)
     return mock
+
+
+def _assert_executed(hook, sql: str) -> None:
+    """Assert the toolset ran exactly *sql* (the handler is an implementation detail)."""
+    assert hook.run.call_count == 1
+    assert hook.run.call_args.args[0] == sql
+
+
+def _query(ts: SQLToolset, sql: str) -> dict:
+    """Run the ``query`` tool and decode its JSON result."""
+    result = asyncio.run(
+        ts.call_tool("query", {"sql": sql}, ctx=MagicMock(spec=RunContext), tool=MagicMock(spec=ToolsetTool))
+    )
+    return json.loads(result)
 
 
 class TestSQLToolsetInit:
@@ -163,19 +206,30 @@ class TestSQLToolsetGetSchema:
 
 
 class TestSQLToolsetQuery:
-    def test_returns_rows_as_json(self):
+    def test_returns_rows_columnar(self):
+        """Column names are named once, not repeated per row -- on a wide table the
+        repeated names, not the values, dominate the payload."""
         ts = SQLToolset("pg_default")
         ts._hook = _make_mock_db_hook(
             records=[(1, "Alice"), (2, "Bob")],
             last_description=[("id",), ("name",)],
         )
 
-        result = asyncio.run(
-            ts.call_tool("query", {"sql": "SELECT id, name FROM users"}, ctx=MagicMock(), tool=MagicMock())
-        )
-        data = json.loads(result)
-        assert data["rows"] == [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-        assert data["count"] == 2
+        data = _query(ts, "SELECT id, name FROM users")
+        assert data["columns"] == ["id", "name"]
+        assert data["rows"] == [[1, "Alice"], [2, "Bob"]]
+        assert data["row_count"] == 2
+        assert "truncated" not in data
+
+    def test_duplicate_column_names_are_preserved(self):
+        """A dict per row silently dropped one of two same-named columns; positional
+        rows keep both."""
+        ts = SQLToolset("pg_default")
+        ts._hook = _make_mock_db_hook(records=[(1, 2)], last_description=[("id",), ("id",)])
+
+        data = _query(ts, "SELECT o.id, c.id FROM orders o JOIN customers c ON o.id = c.id")
+        assert data["columns"] == ["id", "id"]
+        assert data["rows"] == [[1, 2]]
 
     def test_truncates_at_max_rows(self):
         ts = SQLToolset("pg_default", max_rows=1)
@@ -184,13 +238,98 @@ class TestSQLToolsetQuery:
             last_description=[("id",), ("name",)],
         )
 
-        result = asyncio.run(
-            ts.call_tool("query", {"sql": "SELECT id, name FROM users"}, ctx=MagicMock(), tool=MagicMock())
-        )
-        data = json.loads(result)
-        assert len(data["rows"]) == 1
+        data = _query(ts, "SELECT id, name FROM users")
+        assert data["rows"] == [[1, "Alice"]]
+        assert data["row_count"] == 1
         assert data["truncated"] is True
-        assert data["count"] == 3
+        assert data["truncated_by"] == "max_rows"
+
+    def test_fetches_only_one_row_beyond_max_rows(self):
+        """The rows past the cap are never pulled out of the cursor. Fetching them all
+        and then slicing pays the full transfer cost for data the agent never sees."""
+        cursor = _FakeCursor([(i, "x") for i in range(1000)], [("id",), ("name",)], -1)
+        ts = SQLToolset("pg_default", max_rows=2)
+        ts._hook = _make_mock_db_hook()
+        ts._hook.run.side_effect = lambda sql, handler, **kwargs: handler(cursor)
+
+        _query(ts, "SELECT id, name FROM users")
+        # 1000 rows matched; 3 left the cursor (max_rows plus the one that proves
+        # there are more), so 997 were never transferred.
+        assert len(cursor._remaining) == 997
+
+    def test_reports_total_rows_when_the_driver_provides_one(self):
+        ts = SQLToolset("pg_default", max_rows=1)
+        ts._hook = _make_mock_db_hook(
+            records=[(1, "Alice"), (2, "Bob")],
+            last_description=[("id",), ("name",)],
+            rowcount=4_200_000,
+        )
+
+        assert _query(ts, "SELECT id, name FROM users")["total_rows"] == 4_200_000
+
+    def test_omits_total_rows_when_the_driver_has_none(self):
+        """SQLite and several warehouse drivers report -1 for a SELECT. Absent beats
+        inventing a count the agent would treat as authoritative."""
+        ts = SQLToolset("pg_default")
+        ts._hook = _make_mock_db_hook(records=[(1, "Alice")], rowcount=-1)
+
+        assert "total_rows" not in _query(ts, "SELECT id, name FROM users")
+
+    def test_wide_rows_are_capped_by_byte_budget_before_max_rows(self):
+        """max_rows says nothing about size. A handful of very wide rows must still be
+        bounded, or the result dominates the context for the rest of the run."""
+        ts = SQLToolset("pg_default", max_rows=50, max_result_bytes=16_384)
+        ts._hook = _make_mock_db_hook(
+            records=[tuple(f"value_{i}" for i in range(200))] * 50,
+            last_description=[(f"col_{i}",) for i in range(200)],
+        )
+
+        data = _query(ts, "SELECT * FROM wide")
+        # 50 rows are under max_rows, so only the byte budget can have stopped this.
+        assert 0 < data["row_count"] < 50
+        assert len(json.dumps(data, separators=(",", ":"))) <= 16_384 + 512  # budget + envelope
+        assert data["truncated"] is True
+        assert data["truncated_by"] == "max_result_bytes"
+
+    def test_row_too_wide_to_fit_tells_the_agent_to_narrow_the_projection(self):
+        ts = SQLToolset("pg_default", max_result_bytes=200)
+        ts._hook = _make_mock_db_hook(records=[("x" * 500,)], last_description=[("blob",)])
+
+        data = _query(ts, "SELECT blob FROM docs")
+        assert data["rows"] == []
+        assert data["truncated_by"] == "max_result_bytes"
+        assert "max_result_bytes" in data["hint"]
+
+    def test_column_names_alone_over_budget_report_the_shape_instead(self):
+        """When even the header does not fit, returning it would spend the whole budget
+        on column names and leave no room for data."""
+        ts = SQLToolset("pg_default", max_result_bytes=256)
+        ts._hook = _make_mock_db_hook(
+            records=[tuple(range(3000))],
+            last_description=[(f"column_name_{i}",) for i in range(3000)],
+        )
+
+        data = _query(ts, "SELECT * FROM very_wide")
+        assert "columns" not in data
+        assert data["column_count"] == 3000
+        assert data["rows"] == []
+        assert "3000 columns" in data["hint"]
+
+    def test_no_rows_matched(self):
+        ts = SQLToolset("pg_default")
+        ts._hook = _make_mock_db_hook(records=[], last_description=[("id",), ("name",)])
+
+        data = _query(ts, "SELECT id, name FROM users WHERE 1=0")
+        assert data == {"columns": ["id", "name"], "rows": [], "row_count": 0}
+
+    def test_trailing_semicolon_is_stripped(self):
+        """get_records did this for the hooks that override it -- Trino rejects a
+        trailing semicolon -- so fetching through run() has to keep doing it."""
+        ts = SQLToolset("pg_default")
+        ts._hook = _make_mock_db_hook()
+
+        _query(ts, "SELECT id FROM users;")
+        _assert_executed(ts._hook, "SELECT id FROM users")
 
     def test_unsafe_sql_raises_model_retry(self):
         """An unsafe statement is surfaced to the agent as a retry so it can switch to a SELECT."""
@@ -232,7 +371,7 @@ class TestSQLToolsetQuery:
         max_retries bounds the loop, so an unrecoverable error still fails the task."""
         ts = SQLToolset("pg_default")
         ts._hook = _make_mock_db_hook()
-        ts._hook.get_records.side_effect = error
+        ts._hook.run.side_effect = error
 
         with pytest.raises(ModelRetry) as exc_info:
             asyncio.run(
@@ -448,7 +587,7 @@ class TestSQLToolsetMetadataStatements:
         )
         data = json.loads(result)
         assert "rows" in data
-        ts._hook.get_records.assert_called_once_with("DESCRIBE TABLE users")
+        _assert_executed(ts._hook, "DESCRIBE TABLE users")
 
     def test_show_allowed_with_snowflake_dialect(self):
         """SHOW parses to a metadata statement once the hook's dialect is passed through."""
@@ -459,7 +598,7 @@ class TestSQLToolsetMetadataStatements:
         result = asyncio.run(ts.call_tool("query", {"sql": "SHOW TABLES"}, ctx=MagicMock(), tool=MagicMock()))
         data = json.loads(result)
         assert "rows" in data
-        ts._hook.get_records.assert_called_once_with("SHOW TABLES")
+        _assert_executed(ts._hook, "SHOW TABLES")
 
     @pytest.mark.parametrize(
         "sql",
@@ -477,7 +616,7 @@ class TestSQLToolsetMetadataStatements:
         with pytest.raises(ModelRetry) as exc_info:
             asyncio.run(ts.call_tool("query", {"sql": sql}, ctx=MagicMock(), tool=MagicMock()))
         assert "not allowed" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_check_query_accepts_describe(self):
         ts = SQLToolset("pg_default")
@@ -518,7 +657,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         result = _run_query(ts, "SELECT id FROM orders")
 
         assert "rows" in json.loads(result)
-        ts._hook.get_records.assert_called_once_with("SELECT id FROM orders")
+        _assert_executed(ts._hook, "SELECT id FROM orders")
 
     def test_query_blocks_table_off_the_list(self):
         """The headline escape: querying a table that is not on the allow-list is refused."""
@@ -530,7 +669,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
 
         assert "not in the allowed tables list" in exc_info.value.message
         assert "secret_salaries" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     @pytest.mark.parametrize(
         "sql",
@@ -551,7 +690,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, sql)
 
         assert "secret_salaries" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_blocks_catalog_enumeration(self):
         """information_schema/pg_catalog are ordinary tables, so the allow-list blocks them too."""
@@ -562,7 +701,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "SELECT table_name FROM information_schema.tables")
 
         assert "information_schema.tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_allows_cte_reference_not_mistaken_for_table(self):
         """A CTE whose name is not on the list is fine as long as its body stays allowed."""
@@ -583,7 +722,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "SELECT * FROM dblink('host=evil', 'SELECT 1') AS t(x int)")
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     @pytest.mark.parametrize(
         "sql",
@@ -608,7 +747,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, sql)
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_blocks_copy_from_program_under_allow_writes(self):
         """COPY ... FROM PROGRAM is OS command execution. Even with allow_writes=True (only
@@ -622,7 +761,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "COPY orders FROM PROGRAM 'id > /tmp/x'")
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_check_query_reports_data_reaching_function_invalid(self):
         """check_query surfaces the same rejection so the agent learns before executing."""
@@ -644,7 +783,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         result = _run_query(ts, "SELECT count(*), lower(name) FROM orders")
 
         assert "rows" in json.loads(result)
-        ts._hook.get_records.assert_called_once_with("SELECT count(*), lower(name) FROM orders")
+        _assert_executed(ts._hook, "SELECT count(*), lower(name) FROM orders")
 
     def test_query_blocks_unrecognized_function_by_default(self):
         """Fail-closed: a legit-but-unrecognized builtin (json_build_object) is refused
@@ -657,7 +796,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "SELECT json_build_object('id', id) FROM orders")
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_allows_function_named_in_allowed_functions(self):
         """allowed_functions is the opt-in escape hatch for a safe unrecognized function."""
@@ -668,7 +807,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         result = _run_query(ts, "SELECT json_build_object('id', id) FROM orders")
 
         assert "rows" in json.loads(result)
-        ts._hook.get_records.assert_called_once_with("SELECT json_build_object('id', id) FROM orders")
+        _assert_executed(ts._hook, "SELECT json_build_object('id', id) FROM orders")
 
     def test_allowed_functions_does_not_permit_a_dangerous_sibling(self):
         """Permitting one function does not open the door to another unlisted one."""
@@ -680,7 +819,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "SELECT json_build_object('x', pg_read_file('/etc/passwd')) FROM orders")
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_blocks_show_when_allowlist_active(self):
         ts = SQLToolset("sf_default", allowed_tables=["orders"])
@@ -691,7 +830,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "SHOW TABLES")
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_blocks_describe_of_disallowed_table(self):
         ts = SQLToolset("sf_default", allowed_tables=["orders"])
@@ -702,7 +841,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "DESCRIBE TABLE secret_salaries")
 
         assert "secret_salaries" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_query_allows_describe_of_allowed_table(self):
         ts = SQLToolset("sf_default", allowed_tables=["orders"])
@@ -712,7 +851,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         result = _run_query(ts, "DESCRIBE TABLE orders")
 
         assert "rows" in json.loads(result)
-        ts._hook.get_records.assert_called_once_with("DESCRIBE TABLE orders")
+        _assert_executed(ts._hook, "DESCRIBE TABLE orders")
 
     def test_query_allows_schema_qualified_table_on_list(self):
         ts = SQLToolset("sf", allowed_tables=["MODEL_CRM.SF_ASTRO_ORGS"])
@@ -740,7 +879,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
         result = _run_query(ts, "SELECT * FROM anything_at_all")
 
         assert "rows" in json.loads(result)
-        ts._hook.get_records.assert_called_once_with("SELECT * FROM anything_at_all")
+        _assert_executed(ts._hook, "SELECT * FROM anything_at_all")
 
     def test_check_query_reports_disallowed_table_as_invalid(self):
         ts = SQLToolset("pg_default", allowed_tables=["orders"])
@@ -764,14 +903,14 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
 
         # An allowed target is written.
         _run_query(ts, "INSERT INTO orders (id) VALUES (1)")
-        ts._hook.get_records.assert_called_once_with("INSERT INTO orders (id) VALUES (1)")
+        _assert_executed(ts._hook, "INSERT INTO orders (id) VALUES (1)")
 
         # A disallowed target is refused before execution.
-        ts._hook.get_records.reset_mock()
+        ts._hook.run.reset_mock()
         with pytest.raises(ModelRetry) as exc_info:
             _run_query(ts, "INSERT INTO secret_salaries (id) VALUES (1)")
         assert "secret_salaries" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_writes_reject_dynamic_sql_the_parser_cannot_inspect(self):
         """allow_writes skips the read-only validator, so the allow-list must still
@@ -784,7 +923,7 @@ class TestSQLToolsetAllowedTablesQueryEnforcement:
             _run_query(ts, "EXEC sp_who")
 
         assert "cannot be checked against allowed_tables" in exc_info.value.message
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
 
 class TestSQLToolsetAllowedTablesBypassRegressions:
@@ -854,7 +993,7 @@ class TestSQLToolsetAllowedTablesBypassRegressions:
 
         with pytest.raises(ModelRetry):
             _run_query(ts, sql)
-        ts._hook.get_records.assert_not_called()
+        ts._hook.run.assert_not_called()
 
     def test_legit_cte_over_allowed_table_still_runs(self):
         """The scope-aware fix must not false-reject a genuine CTE over an allowed table."""
@@ -864,7 +1003,7 @@ class TestSQLToolsetAllowedTablesBypassRegressions:
         result = _run_query(ts, "WITH ranked AS (SELECT * FROM orders) SELECT * FROM ranked")
 
         assert "rows" in json.loads(result)
-        ts._hook.get_records.assert_called_once()
+        assert ts._hook.run.call_count == 1
 
     def test_dml_with_cte_source_over_allowed_table_runs(self):
         """A CTE used as a DML source must not be mistaken for a disallowed base table."""
@@ -874,4 +1013,4 @@ class TestSQLToolsetAllowedTablesBypassRegressions:
         sql = "WITH src AS (SELECT * FROM orders) INSERT INTO orders SELECT * FROM src"
         _run_query(ts, sql)
 
-        ts._hook.get_records.assert_called_once_with(sql)
+        _assert_executed(ts._hook, sql)

--- a/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
+++ b/providers/common/ai/tests/unit/common/ai/toolsets/test_sql.py
@@ -267,6 +267,23 @@ class TestSQLToolsetQuery:
 
         assert _query(ts, "SELECT id, name FROM users")["total_rows"] == 4_200_000
 
+    def test_omits_total_rows_when_the_driver_counts_rows_fetched_so_far(self):
+        """python-oracledb documents rowcount for SELECT as rows fetched *so far*, so
+        after a capped fetch it equals the cap, not the query total. Reporting it would
+        tell an agent it saw 50 of 51 rows when the table holds millions."""
+        ts = SQLToolset("pg_default", max_rows=50)
+        ts._hook = _make_mock_db_hook(
+            records=[(i, f"name_{i}") for i in range(500)],
+            last_description=[("id",), ("name",)],
+            # Fetching max_rows + 1 leaves an incremental driver reporting exactly 51.
+            rowcount=51,
+        )
+
+        data = _query(ts, "SELECT id, name FROM big")
+        assert data["row_count"] == 50
+        assert data["truncated"] is True
+        assert "total_rows" not in data
+
     def test_omits_total_rows_when_the_driver_has_none(self):
         """SQLite and several warehouse drivers report -1 for a SELECT. Absent beats
         inventing a count the agent would treat as authoritative."""
@@ -321,6 +338,49 @@ class TestSQLToolsetQuery:
 
         data = _query(ts, "SELECT id, name FROM users WHERE 1=0")
         assert data == {"columns": ["id", "name"], "rows": [], "row_count": 0}
+
+    def test_statement_returning_no_result_set(self):
+        """A DBAPI cursor reports description=None for DDL and for DML without
+        RETURNING; that is not an error, just no rows."""
+        ts = SQLToolset("pg_default", allow_writes=True)
+        ts._hook = _make_mock_db_hook()
+        ts._hook.run.side_effect = lambda sql, handler, **kwargs: handler(_FakeCursor([], None, -1))
+
+        assert _query(ts, "INSERT INTO users VALUES (3, 'Eve')")["row_count"] == 0
+
+    def test_non_dbapi_cursor_falls_back_to_a_full_fetch(self):
+        """ExasolHook hands its handler a pyexasol statement, which has no
+        ``description``. Bounding the fetch needs driver-specific knowledge, so those
+        fall back to fetching everything -- as the toolset did before -- rather than
+        failing the query. The payload is still bounded."""
+
+        class _NonDbapiStatement:
+            def __init__(self, records):
+                self._records = records
+
+            def fetchall(self):
+                return self._records
+
+        ts = SQLToolset("pg_default", max_rows=2)
+        ts._hook = _make_mock_db_hook()
+        ts._hook.run.side_effect = lambda sql, handler, **kwargs: handler(
+            _NonDbapiStatement([(i, f"name_{i}") for i in range(10)])
+        )
+
+        data = _query(ts, "SELECT id, name FROM users")
+        assert data["rows"] == [[0, "name_0"], [1, "name_1"]]
+        assert data["truncated_by"] == "max_rows"
+        # A full fetch left nothing behind, so the count is exact and worth reporting.
+        assert data["total_rows"] == 10
+
+    def test_cursor_that_can_neither_describe_nor_fetch_is_an_error(self):
+        """Returning an empty result would read to the agent as 'the table is empty'."""
+        ts = SQLToolset("pg_default")
+        ts._hook = _make_mock_db_hook()
+        ts._hook.run.side_effect = lambda sql, handler, **kwargs: handler(object())
+
+        with pytest.raises(ModelRetry, match="DBAPI 2.0"):
+            _query(ts, "SELECT id FROM users")
 
     def test_trailing_semicolon_is_stripped(self):
         """get_records did this for the hooks that override it -- Trino rejects a

--- a/providers/common/ai/tests/unit/common/ai/utils/test_query_results.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_query_results.py
@@ -105,7 +105,42 @@ class TestByteBudget:
         data = _build(["blob"], [("x" * 400,)], max_result_bytes=100)
         assert data["rows"] == []
         assert data["truncated_by"] == "max_result_bytes"
-        assert "max_result_bytes (100)" in data["hint"]
+        assert "first row alone exceeds max_result_bytes (100)" in data["hint"]
+
+    def test_an_oversized_row_stops_the_result_rather_than_being_skipped(self):
+        """Packing later rows around a wide one would hand the agent a prefix with a
+        hole in it. Stopping keeps 'rows 1..n' meaning what it says."""
+        rows = [("small",), ("x" * 5000,), ("small",), ("small",)]
+
+        data = _build(["blob"], rows, max_result_bytes=1000)
+        assert data["rows"] == [["small"]]
+        assert data["truncated_by"] == "max_result_bytes"
+
+    def test_partial_byte_truncation_still_guides_the_agent(self):
+        """The partial case is the common one; it used to carry no hint at all, so the
+        agent saw a short result with no reason to change its query."""
+        rows = [("small",), ("x" * 5000,), ("small",)]
+
+        data = _build(["blob"], rows, max_result_bytes=1000)
+        assert "Stopped after 1 row:" in data["hint"]
+        assert "Select fewer columns" in data["hint"]
+
+    def test_budget_counts_bytes_not_escape_sequences(self):
+        """With ensure_ascii the budget charges six characters per CJK character, so a
+        Japanese result would be truncated several times earlier than an English one
+        carrying the same information."""
+        rows = [("日本語のテキスト",)] * 40
+
+        data = _build(["text"], rows, max_result_bytes=2048)
+        assert data["rows"][0] == ["日本語のテキスト"]
+        # Three bytes per character, not the six an escaped \uXXXX would cost.
+        assert data["row_count"] > 40 / 2
+
+    def test_reported_size_is_bytes_for_non_ascii(self):
+        rows = [("é" * 200,)]
+        data = _build(["text"], rows, max_result_bytes=300)
+        # 400 bytes of payload cannot fit a 300-byte budget, though it is 200 characters.
+        assert data["rows"] == []
 
     def test_columns_over_budget_report_the_shape_without_the_names(self):
         columns = [f"column_name_{i}" for i in range(3000)]

--- a/providers/common/ai/tests/unit/common/ai/utils/test_query_results.py
+++ b/providers/common/ai/tests/unit/common/ai/utils/test_query_results.py
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import datetime
+import json
+from decimal import Decimal
+
+import pytest
+
+from airflow.providers.common.ai.utils.query_results import build_query_result
+
+
+def _build(columns, rows, *, max_rows=50, max_result_bytes=65_536, more=False, total=None) -> dict:
+    return json.loads(
+        build_query_result(
+            columns,
+            rows,
+            max_rows=max_rows,
+            max_result_bytes=max_result_bytes,
+            more_rows_available=more,
+            total_rows=total,
+        )
+    )
+
+
+class TestShape:
+    def test_columns_are_named_once(self):
+        data = _build(["id", "name"], [(1, "a"), (2, "b")])
+        assert data == {"columns": ["id", "name"], "rows": [[1, "a"], [2, "b"]], "row_count": 2}
+
+    def test_columnar_is_smaller_than_a_dict_per_row(self):
+        """The saving that motivates the shape: on a wide table the repeated column
+        names, not the values, are the bulk of the payload."""
+        columns = [f"column_name_{i}" for i in range(500)]
+        rows = [tuple(range(500))] * 10
+
+        columnar = build_query_result(
+            columns, rows, max_rows=50, max_result_bytes=10**9, more_rows_available=False
+        )
+        per_row_dicts = json.dumps(
+            {"rows": [dict(zip(columns, row)) for row in rows], "count": 10},
+            separators=(",", ":"),
+        )
+        # The header is serialized once rather than once per row, so the gap widens
+        # with row count; at 10 rows it is already a factor of three.
+        assert len(columnar) * 3 < len(per_row_dicts)
+
+    def test_non_json_types_are_stringified(self):
+        data = _build(
+            ["at", "amount"],
+            [(datetime.datetime(2026, 8, 8, 12, 0), Decimal("1.50"))],
+        )
+        assert data["rows"] == [["2026-08-08 12:00:00", "1.50"]]
+
+
+class TestTotalRows:
+    def test_included_when_known(self):
+        assert _build(["id"], [(1,)], total=97)["total_rows"] == 97
+
+    def test_absent_when_the_driver_reports_none(self):
+        assert "total_rows" not in _build(["id"], [(1,)], total=None)
+
+
+class TestByteBudget:
+    def test_budget_is_accounted_exactly(self):
+        """The per-row measurement uses the same serializer and separators as the final
+        dump, so the emitted columns-plus-rows must land inside the budget."""
+        columns = [f"col_{i}" for i in range(20)]
+        rows = [tuple(f"value_{i}" for i in range(20))] * 100
+        budget = 4096
+
+        data = _build(columns, rows, max_rows=100, max_result_bytes=budget)
+        measured = len(json.dumps(data["columns"], separators=(",", ":"))) + len(
+            json.dumps(data["rows"], separators=(",", ":"))
+        )
+        row_size = len(json.dumps(list(rows[0]), separators=(",", ":")))
+
+        # Never over budget (the +2 is the rows array's own brackets, which the per-row
+        # accounting does not charge for) and never more than one unplaced row under it.
+        assert measured <= budget + 2
+        assert measured > budget - row_size
+        assert data["truncated_by"] == "max_result_bytes"
+
+    def test_max_rows_wins_when_it_bites_first(self):
+        data = _build(["id"], [(1,)], more=True)
+        assert data["truncated"] is True
+        assert data["truncated_by"] == "max_rows"
+
+    def test_a_single_oversized_row_yields_a_narrowing_hint(self):
+        data = _build(["blob"], [("x" * 400,)], max_result_bytes=100)
+        assert data["rows"] == []
+        assert data["truncated_by"] == "max_result_bytes"
+        assert "max_result_bytes (100)" in data["hint"]
+
+    def test_columns_over_budget_report_the_shape_without_the_names(self):
+        columns = [f"column_name_{i}" for i in range(3000)]
+        data = _build(columns, [tuple(range(3000))], max_result_bytes=512, total=9)
+
+        assert "columns" not in data
+        assert data["column_count"] == 3000
+        assert data["row_count"] == 0
+        assert data["total_rows"] == 9
+        assert "3000 columns" in data["hint"]
+
+    @pytest.mark.parametrize("max_result_bytes", [0, -1])
+    def test_non_positive_budget_returns_no_rows_rather_than_raising(self, max_result_bytes):
+        data = _build(["id"], [(1,)], max_result_bytes=max_result_bytes)
+        assert data["row_count"] == 0
+
+    def test_empty_result_is_not_reported_as_truncated(self):
+        data = _build(["id", "name"], [])
+        assert data == {"columns": ["id", "name"], "rows": [], "row_count": 0}


### PR DESCRIPTION
`SQLToolset`'s `query` tool returns a JSON dict per row and caps the result with `max_rows`. Neither bounds what actually costs money.

A tool result stays in the model's message history for the rest of the agent run, so its size is re-paid on every subsequent model request. On wide tables that gets expensive fast, and `max_rows` does not help:

- **It caps rows, not bytes.** One row of a 3000-column table is larger than a thousand rows of a narrow one. A 50-row cap on a wide table still produces a multi-megabyte tool result.
- **A dict per row repeats every column name on every row.** At 3000 columns and 50 rows, the column names are serialized 50 times over. On a wide result the repeated names, not the values, are the bulk of the payload.
- **It truncates after the fetch.** [`hook.get_records(sql)`](https://github.com/apache/airflow/blob/274011b437/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py#L373) pulls the entire result set into the worker and [`rows[: self._max_rows]`](https://github.com/apache/airflow/blob/274011b437/providers/common/ai/src/airflow/providers/common/ai/toolsets/sql.py#L381) then discards most of it. The full transfer cost is already paid for rows nothing ever sees.

`DataFusionToolset`'s `query` tool has the same payload shape and the same row-only cap.

## Solution

Three changes to the `query` tool of both toolsets.

**Columnar result.** Column names are serialized once instead of once per row:

```json
{"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]], "row_count": 2}
```

Positional rows also fix a correctness bug: `SELECT o.id, c.id` produced a dict with one `id` key, silently dropping a column.

**`max_result_bytes` budget** (default 64 KiB). Rows are dropped from the end until the serialized payload fits. The result names the limit it hit -- `truncated_by` is `max_rows` or `max_result_bytes` -- so the agent can narrow its projection rather than page through the table. When not even one row fits, or the column names alone exceed the budget, the result carries a `hint` saying so.

**Bounded fetch.** `SQLToolset` fetches through `DbApiHook.run`'s handler protocol with `fetchmany(max_rows + 1)` instead of `get_records`. Rows past the cap never leave the cursor; the extra row is what makes "there is more" knowable without fetching the rest.

## Measurements

Real SQLite database, 1200-column table, default settings:

| | Before | After |
|---|---|---|
| Tool result entering message history | 2,349,614 B | 59,324 B |
| Worker peak memory, query matching 200k rows | 56.6 MiB | 0.1 MiB |

The memory figure is SQLite, whose driver genuinely stops producing rows. On a
client-buffering driver the result has already been transferred by the time the first
row is read, and only the Python-object conversion is skipped -- a real saving, but a
smaller one. No Airflow hook opens a server-side cursor on this path, so treat the
row cap as a bound on what the agent is shown rather than on database or network load.

Asked to run `SELECT * FROM wide` and report what it received, a model given no
explanation of the format answered:

> I got back only 2 rows, and yes -- there are more rows I did not see, since the result
> was truncated by the `max_result_bytes` byte limit (each row is very wide at 1,200
> columns), meaning the query matched more rows than were returned.

which is the property that matters for a shape change: the agent reads a bounded result
as bounded rather than as an empty or complete table, and aligns positional values to
`columns` without being told how.

## Design decisions

**Why a byte budget rather than offloading the result to XCom or object storage.** Offloading is the better answer for keeping the full result available to downstream tasks, but it needs a result-locator contract and a backend, which belongs with the task-state/checkpoint work rather than in the toolset. Bounding the payload is orthogonal and useful either way -- an offloaded result still needs a bounded digest in the message history.

**Why the default budget is generous.** 64 KiB is roughly 16k tokens: large enough that ordinary queries are unaffected, small enough that no single result dominates a context window. The columnar shape alone shrinks a wide result several-fold, so results that fit before still fit -- the budget only bites where the payload was already pathological. Deployments whose agents make many queries per run should lower it.

**Why `fetchmany` rather than pushing a `LIMIT` into the SQL.** Rewriting user SQL is dialect-sensitive and changes the meaning of aggregate queries. `run(handler=...)` is the documented `DbApiHook` extension point that `get_records` is itself built on, and the same path `SQLExecuteQueryOperator` uses.

**Why `total_rows` is often absent.** `rowcount` is only a query total on drivers that buffer the whole result up front. Others report rows fetched *so far* -- python-oracledb documents exactly that for `SELECT` -- so after a capped fetch it equals the cap. A ten-million-row Oracle query would otherwise report `total_rows: 51`, which reads as authoritative and is wrong. A count no larger than what was fetched is indistinguishable from that case, so it is discarded; nothing is lost when the result was not truncated, because `row_count` is already the total there. Agents that need an exact total can `SELECT COUNT(*)`.

**Why the payload is measured in UTF-8 bytes with `ensure_ascii=False`.** With the default escaping, one CJK character costs six bytes instead of three, so an identical result in Japanese would be truncated several times earlier than in English and the model would pay several times the tokens for it.

## Tradeoffs and limitations

- **The result shape changed.** `count` (total matched) is replaced by `row_count` (rows returned) plus optional `total_rows`; `rows` holds positional lists instead of dicts. The old `count` was the more confusing of the two -- it reported the full match count next to a truncated `rows` array. The `query` tool description states the new shape, so agents get it in-band.
- **A wide table fills the default budget with very few rows.** At 1200 columns, 64 KiB holds 2 rows. That is the bound doing its job rather than a regression -- the alternative was a 2.3 MB result -- but on tables that wide an agent should be selecting specific columns, and the `hint` in the result tells it so.
- **How much the bounded fetch saves depends on the driver.** With a server-side cursor the remaining rows are never sent. A client-buffering driver (psycopg2's default cursor, MySQLdb) has already received them and only skips the per-row conversion. The payload is bounded either way.
- **Hooks whose cursor is not DBAPI 2.0 fall back to a full fetch.** `ExasolHook` hands its handler a pyexasol statement that signals "produced rows" through `result_type` rather than `description`. Bounding the fetch there needs driver-specific knowledge, so those keep the previous full-fetch behaviour; the payload is still bounded.
- **`DataFusionToolset` bounds the payload only.** The engine materializes the full result before the toolset sees it, so there is nothing left to avoid fetching.
- **`BigQueryHook.get_records`' `location` guard no longer applies.** It raises a clear "Need to specify 'location'" error that `run()` does not; a BigQuery connection without `location` now fails further down instead. BigQuery is otherwise unaffected by the switch.
- **`get_schema` is still unbounded.** On a 3000-column table it returns 3000 column entries, and an agent usually calls it before querying. Truncating it is not obviously right -- those column names are information the agent needs to write SQL at all -- so it wants a different answer (column search or filtering) and is left alone here.

## Usage

```python
SQLToolset(
    db_conn_id="analytics_readonly",
    allowed_tables=["orders", "customers"],
    max_rows=50,  # Default -- cap rows
    max_result_bytes=16384,  # Lower than the 64 KiB default for wide tables
)
```

 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
