### PR TITLE
fix(keycloak): add missing Dag resource to Op-team permission

### DIFF
--- a/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
+++ b/providers/keycloak/src/airflow/providers/keycloak/auth_manager/cli/commands.py
@@ -480,6 +480,7 @@ def _get_permissions_to_create(
                         "type": "resource-based",
                         "resources": [
                             f"{KeycloakResource.CONNECTION.value}:{team}",
+                            f"{KeycloakResource.DAG.value}:{team}",
                             f"{KeycloakResource.POOL.value}:{team}",
                             f"{KeycloakResource.VARIABLE.value}:{team}",
                         ],
@@ -828,6 +829,7 @@ def _attach_team_permissions(
         policy_name=_team_role_policy_name(team, "Op"),
         resource_names=[
             f"{KeycloakResource.CONNECTION.value}:{team}",
+            f"{KeycloakResource.DAG.value}:{team}",
             f"{KeycloakResource.POOL.value}:{team}",
             f"{KeycloakResource.VARIABLE.value}:{team}",
         ],

--- a/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
+++ b/providers/keycloak/tests/unit/keycloak/auth_manager/cli/test_commands.py
@@ -426,6 +426,17 @@ class TestCommands:
             },
             skip_exists=True,
         )
+        client.create_client_authz_resource_based_permission.assert_any_call(
+            client_id="test-id",
+            payload={
+                "name": "Op-team-a",
+                "type": "scope",
+                "logic": "POSITIVE",
+                "decisionStrategy": "UNANIMOUS",
+                "resources": ["r1", "r2", "r3", "r4"],  # Dag:team-a, Connection:team-a, Pool:team-a, Variable:team-a
+            },
+            skip_exists=True,
+        )
 
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._attach_policy_to_resource_permission")
     @patch("airflow.providers.keycloak.auth_manager.cli.commands._attach_policy_to_scope_permission")
@@ -606,6 +617,7 @@ class TestCommands:
             policy_name="Allow-Op-team-a",
             resource_names=[
                 "Connection:team-a",
+                "Dag:team-a",
                 "Pool:team-a",
                 "Variable:team-a",
             ],


### PR DESCRIPTION
fix(keycloak): add missing Dag resource to Op-team permission

The Op-{team} permission created by the create-team command was missing
the Dag:{team} resource. This caused users with the Op role to not
receive the expected permission for the team's DAG resource.

The fix adds Dag:{team} to the Op-{team} permission resources in two
places:
1. _get_permissions_to_create() — the initial permission creation
2. _attach_team_permissions() — the policy attachment for create-team

Fixes #71319