### PR TITLE
Fix airflowctl date parameters rejecting every input value

### DIFF
--- a/airflow-ctl/src/airflowctl/ctl/cli_config.py
+++ b/airflow-ctl/src/airflowctl/ctl/cli_config.py
@@ -205,6 +205,14 @@ def json_dict_type(val: str | dict[str, Any]) -> dict[str, Any]:
     return parsed
 
 
+def iso_date_type(val: str) -> datetime.date:
+    """Parse ISO 8601 date argument."""
+    try:
+        return datetime.date.fromisoformat(val)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"invalid ISO 8601 date: {val!r}") from e
+
+
 def _load_help_texts_yaml() -> dict[str, dict[str, str]]:
     """Load the help texts yaml for the auto-generated commands."""
     help_texts_path = Path(__file__).parent / "help_texts.yaml"
@@ -636,7 +644,7 @@ class CommandFactory:
             "dict": json_dict_type,
             "tuple": tuple,
             "set": set,
-            "datetime.date": datetime.date,
+            "datetime.date": iso_date_type,
             "datetime.datetime": datetime.datetime,
             "dict[str, typing.Any]": json_dict_type,
         }

--- a/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
+++ b/airflow-ctl/tests/airflow_ctl/ctl/test_cli_config.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 from argparse import BooleanOptionalAction
 from pathlib import Path
 from textwrap import dedent
@@ -34,6 +35,7 @@ from airflowctl.ctl.cli_config import (
     CommandFactory,
     GroupCommand,
     add_auth_token_to_all_commands,
+    iso_date_type,
     json_dict_type,
     merge_commands,
     safe_call_command,
@@ -363,6 +365,40 @@ class TestCommandFactory:
         """Valid JSON that is not an object raises an ArgumentTypeError."""
         with pytest.raises(argparse.ArgumentTypeError, match="expected JSON object"):
             json_dict_type(value)
+
+    def test_command_factory_parses_date_datamodel_fields(self):
+        """Date datamodel fields should parse ISO 8601 date CLI values."""
+        command_factory = CommandFactory()
+        dagrun_list_args = []
+        for generated_group_command in command_factory.group_commands:
+            if generated_group_command.name != "dagrun":
+                continue
+            for sub_command in generated_group_command.subcommands:
+                if sub_command.name == "list":
+                    dagrun_list_args = list(sub_command.args)
+                    break
+
+        partition_date_arg = next(arg for arg in dagrun_list_args if arg.flags == ("--partition-date-gte",))
+        parsed_partition_date = partition_date_arg.kwargs["type"]("2026-07-01")
+
+        assert parsed_partition_date == datetime.date(2026, 7, 1)
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("2026-07-01", datetime.date(2026, 7, 1)), ("20260701", datetime.date(2026, 7, 1))],
+    )
+    def test_iso_date_type_parses_iso_date(self, value, expected):
+        """An ISO 8601 date string is parsed into a date."""
+        assert iso_date_type(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", "2026-7-1", "01/07/2026", "2026-07-01T00:00:00", "yesterday"],
+    )
+    def test_iso_date_type_rejects_invalid_date(self, value):
+        """A value that is not an ISO 8601 date raises an ArgumentTypeError."""
+        with pytest.raises(argparse.ArgumentTypeError, match="invalid ISO 8601 date"):
+            iso_date_type(value)
 
     def test_command_factory_required_primitive_param_is_positional(self, tmp_path):
         """Required primitive parameters (no default, not Optional) become positional arguments.


### PR DESCRIPTION
`_python_type_from_string` maps OpenAPI parameter annotations to the argparse `type=` callable used by auto-generated commands. `datetime.date` was mapped to the class itself, but argparse calls that callable with the raw string from the command line and `date.__init__` expects three integers, so every value was rejected:

```
$ airflowctl dagrun list --partition-date-gte 2026-07-01
argument --partition-date-gte: invalid date value: '2026-07-01'
```

The message reads as a complaint about the format, but no input can succeed.

`_is_primitive_type` accepts `datetime.date`, and `DagRunOperations.list` declares `partition_date_gte` and `partition_date_lte` as `datetime.date | None`, so this affects the shipped CLI. The hand-written commands in `dag_command.py` already parse these values with `date.fromisoformat`; the generated path had no equivalent.

This adds `iso_date_type` alongside the existing `json_dict_type` and wires it into the mapping, so a valid value is parsed into a `date` and an invalid one reports the format that is actually expected.

`datetime.datetime` has the same root cause but is left untouched here, since #70249 and #70250 are already open against it. The remaining constructor entries (`bytes`, `list`, `tuple`, `set`) are not reachable today, as no operation is annotated with them.

related: #70232

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
