### PR TITLE
Flush scheduled DagRun creation state promptly

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -2616,6 +2616,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     session=session,
                     active_non_backfill_runs=active_runs_of_dags[dag_model.dag_id],
                 )
+                session.flush()
 
             # Exceptions like ValueError, ParamValidationError, etc. are raised by
             # DagModel.create_dagrun() when dag is misconfigured. The scheduler should not
@@ -2627,9 +2628,6 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                 #  session needs rollback. you need either to make smaller transactions and
                 #  commit after every dag run or use savepoints.
                 #  https://github.com/apache/airflow/issues/59120
-
-            # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
-            #  memory for larger dags? or expunge_all()
 
     def _create_dag_runs_asset_triggered(
         self,

--- a/airflow-core/tests/unit/jobs/test_scheduler_job.py
+++ b/airflow-core/tests/unit/jobs/test_scheduler_job.py
@@ -4116,6 +4116,44 @@ class TestSchedulerJob:
         assert session.scalar(select(func.count(DagRun.state)).where(DagRun.state == State.QUEUED)) == 0
         assert orm_dag.next_dagrun_create_after is not None
 
+    def test_create_dag_runs_flushes_without_retaining_per_task_objects(self, dag_maker, session):
+        dag_count = 5
+        task_count = 20
+        dag_ids = []
+        for dag_index in range(dag_count):
+            dag_id = f"test_create_dag_runs_flushes_without_retaining_per_task_objects_{dag_index}"
+            with dag_maker(dag_id=dag_id, session=session):
+                for task_index in range(task_count):
+                    EmptyOperator(task_id=f"task_{task_index}")
+            dag_ids.append(dag_id)
+
+        scheduler_job = Job()
+        self.job_runner = SchedulerJobRunner(job=scheduler_job, executors=[self.null_exec])
+
+        orm_dags = list(session.scalars(select(DagModel).where(DagModel.dag_id.in_(dag_ids))))
+        assert len(orm_dags) == dag_count
+        session.flush()
+        assert not session.new
+        assert not session.dirty
+
+        self.job_runner._create_dag_runs(orm_dags, session)
+
+        identity_map_counts = Counter(type(obj) for obj in session.identity_map.values())
+        assert not session.new
+        assert not session.dirty
+        assert identity_map_counts[DagRun] == 0
+        assert identity_map_counts[TaskInstance] == 0
+        assert (
+            session.scalar(select(func.count()).select_from(DagRun).where(DagRun.dag_id.in_(dag_ids)))
+            == dag_count
+        )
+        assert (
+            session.scalar(
+                select(func.count()).select_from(TaskInstance).where(TaskInstance.dag_id.in_(dag_ids))
+            )
+            == dag_count * task_count
+        )
+
     def test_runs_are_created_after_max_active_runs_was_reached(self, dag_maker, session):
         """
         Test that when creating runs once max_active_runs is reached the runs does not stick


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: https://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

## Why

`SchedulerJobRunner._create_dag_runs()` had a TODO asking whether the scheduler should call `session.flush()` or `session.expunge_all()` while creating scheduled DagRuns.

The concern behind the TODO is that the scheduler may iterate over multiple Dags, create scheduled DagRuns, update `DagModel` scheduling fields, and create task instance rows in the same SQLAlchemy session. For larger Dags or larger batches of Dags, leaving ORM state pending until the outer transaction boundary can make it harder to reason about session growth and memory behavior.

This PR resolves that TODO by flushing after each successful scheduled DagRun creation and related `DagModel` scheduling-state update.

## Why `flush()` Instead of `expunge_all()`

The narrower operation is enough for the state observed in this path.

`session.flush()` writes pending ORM changes to the database transaction while keeping objects attached to the session. That directly addresses the observed pending/dirty scheduler state after creating a scheduled DagRun and updating the corresponding `DagModel`.

`session.expunge_all()` does something broader: it detaches every ORM object from the session. That can reduce identity-map retention, but it also carries more behavioral risk because later scheduler code may still expect ORM objects to be attached, refreshable, or tracked by the session.

To decide whether `expunge_all()` was needed, this path was checked for retained ORM objects after DagRun creation. If creating larger Dags left one tracked `DagRun` or `TaskInstance` object per created row, `flush()` would not address that memory growth because it does not clear the session identity map.

A local pressure check with 20 Dags and 500 tasks per Dag created 10,000 TaskInstance rows. After `_create_dag_runs()` returned, the observed session state was:

```text
session.new: 0
session.dirty: 0
identity_map: Counter({'DagModel': 20, 'DagVersion': 1, 'SerializedDagModel': 1, 'DagCode': 1})
```
<img width="728" height="122" alt="螢幕擷取畫面 2026-08-08 204423" src="https://github.com/user-attachments/assets/d154a3f9-27fd-441c-9072-ee57cf6a32d9" />


##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- `[X]` Yes (please specify the tool below)


Generated-by: [Codex] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)


---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
