### PR TITLE
Fix stale flag name in Airflow translations agent skill

### DIFF
--- a/.agents/skills/airflow-translations/SKILL.md
+++ b/.agents/skills/airflow-translations/SKILL.md
@@ -122,11 +122,12 @@ If there are **missing** keys, scaffold them with `TODO: translate:` stubs:
 breeze ui check-translation-completeness --language <locale> --add-missing
 ```
 
-If there are **extra** keys (present in the locale but not in English), remove
-them:
+If there are **unused** keys — keys that are not required, meaning they are
+absent from the English locale or are plural suffixes this language does not
+need — remove them:
 
 ```bash
-breeze ui check-translation-completeness --language <locale> --remove-extra
+breeze ui check-translation-completeness --language <locale> --remove-unused
 ```
 
 Now translate the `TODO: translate:` entries following the locale-specific
@@ -138,7 +139,8 @@ guideline, then continue to **Validation** below.
 
 After completing translations, run these checks:
 
-Check completeness. The output should show 0 missing, 0 extra, and 0 TODOs:
+Check completeness. The output table should show 0 missing, 0 TODOs, 0 unused,
+and 100% coverage:
 
 ```bash
 breeze ui check-translation-completeness --language <locale>


### PR DESCRIPTION
### Sumarry

The `airflow-translations` agent skill still documents `--remove-extra` for `breeze ui check-translation-completeness`. 

That option was renamed to `--remove-unused` in #62983

The same PR merged the separate "extra" and "unused" concepts into a single **unused** category (keys that are not required — absent from the English locale, or plural suffixes the language does not need), and the summary table now reports Missing / Coverage / TODOs / Unused with no Extra column. This updates both the command and the surrounding wording to match.

### Notes

#62983 updated `airflow-core/src/airflow/ui/public/i18n/README.md` and `dev/breeze/doc/10_ui_tasks.rst` but missed the skill file.
