### PR TITLE
Stop airflowctl update commands from clearing fields left unset

### DIFF
--- a/airflow-ctl/src/airflowctl/api/operations.py
+++ b/airflow-ctl/src/airflowctl/api/operations.py
@@ -430,7 +430,7 @@ class ConnectionsOperations(BaseOperations):
         """Update a connection."""
         self.response = self.client.patch(
             f"connections/{connection.connection_id}",
-            json=connection.model_dump(mode="json", by_alias=True),
+            json=connection.model_dump(mode="json", by_alias=True, exclude_none=True),
         )
         return ConnectionResponse.model_validate_json(self.response.content)
 
@@ -652,7 +652,9 @@ class PoolsOperations(BaseOperations):
 
     def update(self, pool_body: PoolPatchBody) -> PoolResponse | ServerResponseError:
         """Update a pool."""
-        self.response = self.client.patch(f"pools/{pool_body.pool}", json=pool_body.model_dump(mode="json"))
+        self.response = self.client.patch(
+            f"pools/{pool_body.pool}", json=pool_body.model_dump(mode="json", exclude_none=True)
+        )
         return PoolResponse.model_validate_json(self.response.content)
 
 
@@ -766,7 +768,9 @@ class VariablesOperations(BaseOperations):
 
     def update(self, variable: VariableBody) -> VariableResponse | ServerResponseError:
         """Update a variable."""
-        self.response = self.client.patch(f"variables/{variable.key}", json=variable.model_dump(mode="json"))
+        self.response = self.client.patch(
+            f"variables/{variable.key}", json=variable.model_dump(mode="json", exclude_none=True)
+        )
         return VariableResponse.model_validate_json(self.response.content)
 
 

--- a/airflow-ctl/tests/airflow_ctl/api/test_operations.py
+++ b/airflow-ctl/tests/airflow_ctl/api/test_operations.py
@@ -877,16 +877,33 @@ class TestConnectionsOperations:
             assert request_body == {
                 "connection_id": self.connection_id,
                 "conn_type": self.conn_type,
-                "description": None,
-                "host": None,
-                "login": None,
                 "schema": self.schema_,
-                "port": None,
-                "password": None,
-                "extra": None,
-                "team_name": None,
             }
             assert "schema_" not in request_body
+            return httpx.Response(
+                200, json=json.loads(self.connection_response.model_dump_json(by_alias=True))
+            )
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.connections.update(connection=connection)
+        assert response == self.connection_response
+
+    def test_update_omits_unset_fields_from_request_body(self):
+        # The API treats every key present in a PATCH body as an intentional value, so sending
+        # unset fields as null clears the stored login, port, schema and description.
+        connection = ConnectionBody(
+            connection_id=self.connection_id,
+            conn_type=self.conn_type,
+            host="new-host",
+        )
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == f"/api/v2/connections/{self.connection_id}"
+            assert json.loads(request.content.decode()) == {
+                "connection_id": self.connection_id,
+                "conn_type": self.conn_type,
+                "host": "new-host",
+            }
             return httpx.Response(
                 200, json=json.loads(self.connection_response.model_dump_json(by_alias=True))
             )
@@ -1709,6 +1726,19 @@ class TestPoolsOperations:
         response = client.pools.update(pool_body=self.pool_patch_body)
         assert response == self.pool_response
 
+    def test_update_omits_unset_fields_from_request_body(self):
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == f"/api/v2/pools/{self.pool_name}"
+            assert json.loads(request.content.decode()) == {
+                "pool": self.pool_name,
+                "description": "description",
+            }
+            return httpx.Response(200, json=json.loads(self.pool_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.pools.update(pool_body=self.pool_patch_body)
+        assert response == self.pool_response
+
 
 class TestProvidersOperations:
     provider_response = ProviderResponse(
@@ -1976,6 +2006,18 @@ class TestVariablesOperations:
 
         client = make_api_client(transport=httpx.MockTransport(handle_request))
         response = client.variables.update(variable=self.variable)
+        assert response == self.variable_response
+
+    def test_update_omits_unset_fields_from_request_body(self):
+        variable = VariableBody.model_validate({"key": self.key, "value": "new-value"})
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == f"/api/v2/variables/{self.key}"
+            assert json.loads(request.content.decode()) == {"key": self.key, "value": "new-value"}
+            return httpx.Response(200, json=json.loads(self.variable_response.model_dump_json()))
+
+        client = make_api_client(transport=httpx.MockTransport(handle_request))
+        response = client.variables.update(variable=variable)
         assert response == self.variable_response
 
 


### PR DESCRIPTION
`airflowctl connections update --connection-id pg_prod --conn-type postgres --host db2.example.com`
erases that connection's login, port, schema and description.

The API applies every key present in a PATCH body, so a field the user never typed arrives as `null`
and is stored as one. argparse fills an omitted flag with `None`, and the generated command builds
the whole datamodel from those values, so by the time the body is serialized the client can no longer
distinguish "not supplied" from "set to null".

The `create` methods in `operations.py` already pass `exclude_none=True`; the `update` methods did
not. This is the same omission reported in #70327 for `dags trigger`, where it shows up as a request
older API servers reject rather than as lost data.

### Reproduction

Against a real Airflow 3.4.0 API server on SQLite (no Docker):

```
$ airflowctl connections update --connection-id pg_prod --conn-type postgres --host db2.example.com

before  {"connection_id":"pg_prod","conn_type":"postgres","description":"primary warehouse",
         "host":"db1.example.com","login":"airflow","schema":"analytics","port":5432}
after   {"connection_id":"pg_prod","conn_type":"postgres","description":null,
         "host":"db2.example.com","login":null,"schema":null,"port":null}
```

```
$ airflowctl variables update --key api_endpoint --value https://staging.example.com

before  {"key":"api_endpoint","value":"https://prod.example.com","description":"prod endpoint - owned by data team"}
after   {"key":"api_endpoint","value":"https://staging.example.com","description":null}
```

```
$ airflowctl pools update --pool etl_pool --slots 42

before  {"name":"etl_pool","slots":5,"description":"ETL workers - do not delete"}
after   {"name":"etl_pool","slots":42,"description":null}
```

With this change, each of those commands sends only the fields the user passed, and the untouched
fields keep their stored values.

### Scope

`PoolsOperations.update` still sends `include_deferred: false`, because `False` is not `None`. That
has a different cause — `_get_bool_arg_default` in `ctl/cli_config.py` returns `False` for every
datamodel outside its one-entry allowlist instead of the field's declared default — and is left for a
separate PR.

Also deliberately unchanged:

- `DagsOperations.update` — `DAGPatchBody` has a single required `bool` field, so `exclude_none` would
  be a no-op with nothing to test.
- The `bulk` methods — they PATCH a collection endpoint with a body of actions, where a `null` inside
  an action may be meaningful. Different semantics.
- `ConnectionsOperations.test` — POST, not PATCH; it does not mutate stored state.
- `default_pool` remains un-updatable through `airflowctl` (`Only slots and included_deferred can be
  modified on Default Pool`). The server only permits it when `update_mask` is sent, and the client
  never sends one. Separate fix.

`test_update_uses_schema_alias_in_request_body` asserted the old body including its `null` keys; its
expectation is updated. Its subject — that the `schema` alias is used rather than `schema_` — is
unchanged and still asserted.

related: #70327

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)

