### PR TITLE
Fix misspelled variable in CI migration test DB manager export

### DIFF
--- a/.github/actions/migration_tests/action.yml
+++ b/.github/actions/migration_tests/action.yml
@@ -39,7 +39,7 @@ runs:
           --use-airflow-version "${MIN_AIRFLOW_VERSION}" \
           ${AIRFLOW_EXTRAS} \
           --answer y &&
-        breeze shell "export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=${DB_MANGERS}
+        breeze shell "export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=${DB_MANAGERS}
                     ${AIRFLOW_3_CMD}" --no-db-cleanup
       env:
         COMPOSE_PROJECT_NAME: "docker-compose"
@@ -73,7 +73,7 @@ runs:
           --use-airflow-version "${MIN_AIRFLOW_VERSION}" \
           ${AIRFLOW_EXTRAS} \
           --answer y &&
-        breeze shell "export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=${DB_MANGERS}
+        breeze shell "export AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=${DB_MANAGERS}
              ${AIRFLOW_3_CMD}" --no-db-cleanup
       env:
         COMPOSE_PROJECT_NAME: "docker-compose"


### PR DESCRIPTION
### Sumarry

Two steps in `.github/actions/migration_tests/action.yml` reference `${DB_MANGERS}`
while the surrounding `env:` block defines `DB_MANAGERS`. The variable is undefined,
so the export resolves to `AIRFLOW__DATABASE__EXTERNAL_DB_MANAGERS=` (empty). The
other two steps in the same file spell it correctly.

Nothing fails: GitHub's default `shell: bash` runs without `-u`, `export X=` on its
own line is valid, and the migration commands on the next line run normally — so the
steps have stayed green since the typo was introduced in #50343.

**Current impact: none.** 

Since #62308, `RunDBManager` starts from DB managers
auto-discovered via `provider.yaml`, and the FAB provider declares its own, so the
empty config is simply skipped. This is a cleanup: it removes a silent failure that
would come back if discovery were ever not in play, and stops the file contradicting
itself.
