### PR TITLE
Fix executor validation error referencing non-existent [core] executors

### DIFF
--- a/airflow-core/src/airflow/dag_processing/dagbag.py
+++ b/airflow-core/src/airflow/dag_processing/dagbag.py
@@ -151,12 +151,12 @@ def _validate_executor_fields(dag: DAG, bundle_name: str | None = None) -> None:
                     f"Task '{task.task_id}' specifies executor '{task.executor}', which is not available "
                     f"for team '{dag_team_name}' (the team associated with DAG '{dag.dag_id}') or as a global executor. "
                     f"Make sure '{task.executor}' is configured for team '{dag_team_name}' or globally in your "
-                    "[core] executors configuration, or update the task's executor to use one of the "
+                    "[core] executor configuration, or update the task's executor to use one of the "
                     f"configured executors for team '{dag_team_name}' or available global executors."
                 )
             raise UnknownExecutorException(
                 f"Task '{task.task_id}' specifies executor '{task.executor}', which is not available. "
-                "Make sure it is listed in your [core] executors configuration, or update the task's "
+                "Make sure it is listed in your [core] executor configuration, or update the task's "
                 "executor to use one of the configured executors."
             )
 

--- a/airflow-core/tests/unit/dag_processing/test_dagbag.py
+++ b/airflow-core/tests/unit/dag_processing/test_dagbag.py
@@ -185,7 +185,7 @@ class TestValidateExecutorFields:
                     "Task 'task1' specifies executor 'invalid.executor', which is not available "
                     "for team 'test_team' (the team associated with DAG 'test-dag') or as a global executor. "
                     "Make sure 'invalid.executor' is configured for team 'test_team' or globally in your "
-                    "[core] executors configuration, or update the task's executor to use one of the "
+                    "[core] executor configuration, or update the task's executor to use one of the "
                     "configured executors for team 'test_team' or available global executors."
                 ),
             ):
@@ -204,7 +204,7 @@ class TestValidateExecutorFields:
                 UnknownExecutorException,
                 match=re.escape(
                     "Task 'task1' specifies executor 'invalid.executor', which is not available. "
-                    "Make sure it is listed in your [core] executors configuration, or update the task's "
+                    "Make sure it is listed in your [core] executor configuration, or update the task's "
                     "executor to use one of the configured executors."
                 ),
             ):
@@ -258,7 +258,7 @@ class TestValidateExecutorFields:
                     "Task 'task1' specifies executor 'unknown.executor', which is not available "
                     "for team 'test_team' (the team associated with DAG 'test-dag') or as a global executor. "
                     "Make sure 'unknown.executor' is configured for team 'test_team' or globally in your "
-                    "[core] executors configuration, or update the task's executor to use one of the "
+                    "[core] executor configuration, or update the task's executor to use one of the "
                     "configured executors for team 'test_team' or available global executors."
                 ),
             ):
@@ -330,7 +330,7 @@ def test_validate_executor_field_executor_not_configured():
         UnknownExecutorException,
         match=re.escape(
             "Task 't1' specifies executor 'test.custom.executor', which is not available. "
-            "Make sure it is listed in your [core] executors configuration, or update the task's "
+            "Make sure it is listed in your [core] executor configuration, or update the task's "
             "executor to use one of the configured executors."
         ),
     ):


### PR DESCRIPTION
## Summary

`_validate_executor_fields` (`airflow-core/src/airflow/dag_processing/dagbag.py`) raises `UnknownExecutorException` when a task's `executor=` isn't available, and tells the user to check their `"[core] executors configuration"`. That config key does not exist:

```python
executor_config = conf.get_mandatory_value("core", "executor")
```

(`airflow-core/src/airflow/executors/executor_loader.py`) -- Airflow has a single `[core] executor` key, documented in `config.yml` as accepting a comma-separated list to configure multiple executors. The plural `"executors"` only appears in this error message text; grepping the whole tree, it does not exist as an actual config option anywhere.

This is exactly the kind of message a user hits when trying to run a task with an explicit `executor=` that isn't in their configured list (e.g. from a Helm chart deployment), and the message sends them looking for a setting (`[core] executors`) that isn't there instead of telling them to make `[core] executor` a comma-separated list.

Fix: both branches of the message (with and without a team name) now say `[core] executor`.

## Test plan

- [x] Confirmed via `conf.get_mandatory_value("core", "executor")` that this is the only config key involved -- no plural variant exists in `config.yml` or anywhere else in the codebase.
- [x] Updated the 4 matching assertions in `airflow-core/tests/unit/dag_processing/test_dagbag.py`.
- [x] Ran the full test suite for this: `pytest tests/unit/dag_processing/test_dagbag.py -k executor` -- **12 passed**.
- [x] Ran the full `test_dagbag.py` file (72 tests) to confirm no other breakage -- passes aside from 4 pre-existing errors unrelated to this change (missing `airflow_shared` module in an unrelated fixture, present before this change too).
- [x] `ruff check` and `ruff format --check` pass on both changed files.