### PR TITLE
Guard StackdriverRemoteLogIO's transport.send() against errors

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -219,7 +219,14 @@ class StackdriverRemoteLogIO(LoggingMixin):
                 if map_index := event.get("map_index"):
                     labels["map_index"] = str(map_index)
 
-            _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
+            try:
+                _transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
+            except Exception:
+                # Cloud Logging unavailable / IAM glitch / gRPC error. This processor runs for
+                # every supervised component (scheduler, dag-processor, triggerer, workers), so
+                # letting this propagate would crash the whole process on a logging
+                # misconfiguration. Log delivery is best-effort; degrade gracefully instead.
+                _logger.warning("Failed to send log entry to Cloud Logging", exc_info=True)
             return event
 
         return (proc,)

--- a/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
+++ b/providers/google/tests/unit/google/cloud/log/test_stackdriver_task_handler.py
@@ -370,6 +370,35 @@ class TestStackdriverRemoteLogIO:
     @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="airflow.sdk.log only exists in Airflow 3+")
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
     @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.gcp_logging.Client")
+    def test_processors_survives_transport_send_failure(self, mock_client, mock_get_creds_and_project_id):
+        """A Cloud Logging IAM/gRPC error must not propagate out of the log processor.
+
+        This processor runs for every supervised component (scheduler, dag-processor,
+        triggerer, workers); letting a transport error propagate would crash the whole
+        process on a logging misconfiguration.
+        """
+        mock_get_creds_and_project_id.return_value = ("creds", "project_id")
+
+        mock_transport_type = mock.MagicMock()
+        mock_transport_type.return_value.send.side_effect = Exception("IAM permission denied")
+        with mock.patch("airflow.sdk.log.relative_path_from_logger", return_value="dag/task/1.log"):
+            io = StackdriverRemoteLogIO(
+                base_log_folder=self.local_log_location,
+                gcp_log_name="airflow",
+                transport_type=mock_transport_type,
+            )
+            proc = io.processors[0]
+
+            event = {"event": "hello world", "logger_name": "airflow.task"}
+            # Must not raise, despite transport.send() failing.
+            result = proc(mock.MagicMock(), "info", event)
+
+        assert result is event
+        mock_transport_type.return_value.send.assert_called_once()
+
+    @pytest.mark.skipif(not AIRFLOW_V_3_0_PLUS, reason="airflow.sdk.log only exists in Airflow 3+")
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.get_credentials_and_project_id")
+    @mock.patch("airflow.providers.google.cloud.log.stackdriver_task_handler.gcp_logging.Client")
     def test_processors_skips_non_task_logger(self, mock_client, mock_get_creds_and_project_id):
         mock_get_creds_and_project_id.return_value = ("creds", "project_id")
 


### PR DESCRIPTION
## Summary

Fixes one of three bugs reported in #68240 (the one I could verify is still present and fix with high confidence -- see scope note below).

`StackdriverRemoteLogIO.processors`' `proc` closure calls `_transport.send(...)` with no error handling:

```python
_transport.send(record, str(msg.get("event", "")), resource=self.resource, labels=labels)
return event
```

This processor is installed for **every supervised component** (scheduler, dag-processor, triggerer, workers) whenever `REMOTE_TASK_LOG` routes through Stackdriver. Any IAM permission error, gRPC connectivity failure, or quota exception from Cloud Logging propagates straight out of the structlog processor and takes down the whole process -- reported as a dag-processor pod stuck in `CrashLoopBackOff` on every log emit when its Kubernetes Service Account lacked the `logging.logEntries.create` IAM binding.

The *read* path already has exactly this guard, a few lines down in the same file, with a comment explaining the rationale:
```python
try:
    messages, end_of_log, next_page_token = self.io.read_logs(log_filter, next_page_token, all_pages)
except Exception:
    # Cloud Logging unavailable / IAM glitch / gRPC error. Without a guard, the
    # exception used to propagate up as HTTP 500 from the log viewer. ...
    _logger.exception(...)
```
The *write* path was simply missing the equivalent. This PR adds it, reusing the same `_logger` (already defined in this file specifically for handler-internal failures) and logging a warning instead of raising, since log delivery here is best-effort.

**Scope note:** the linked issue reports three bugs. I traced the other two (empty labels when `record.task_instance` is unset in supervisor context, and `read()` filtering on `logical_date`) against current `main` and found the code has moved on since the report -- there's now a fallback in `proc()` that reads labels from the event dict when no `task_instance` is present (see `test_processors_fallback_to_event_labels`), and `read()`'s `ti: RuntimeTI` already exposes `logical_date` locally without a DB round-trip. I wasn't confident those two are still bugs as described, so this PR only covers the third (`transport.send()` unguarded), which I could verify precisely.

## Test plan

- [x] Added `test_processors_survives_transport_send_failure`: mocks `transport.send()` to raise, asserts the processor doesn't propagate the exception.
- [x] Verified the test actually catches the bug: reverted the source fix and confirmed the new test fails with `Exception: IAM permission denied` propagating out of `proc()`; re-applied the fix and confirmed it passes.
- [x] Ran the full file: `pytest tests/unit/google/cloud/log/test_stackdriver_task_handler.py` -- **33 passed**.
- [x] `ruff check` and `ruff format --check` pass on both changed files.