### PR TITLE
Update provider metadata after the 2026-08-06 providers release

### DIFF
--- a/generated/provider_metadata.json
+++ b/generated/provider_metadata.json
@@ -175,6 +175,10 @@
         "6.0.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "6.0.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:12Z"
         }
     },
     "akeyless": {
@@ -371,6 +375,10 @@
         "3.3.9": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-22T21:14:32Z"
+        },
+        "3.4.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:12Z"
         }
     },
     "amazon": {
@@ -769,6 +777,10 @@
         "9.33.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "9.34.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:13Z"
         }
     },
     "anthropic": {
@@ -779,6 +791,10 @@
         "0.2.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "0.2.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:14Z"
         }
     },
     "apache.beam": {
@@ -1771,6 +1787,10 @@
         "4.12.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-22T21:14:32Z"
+        },
+        "4.12.2": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:15Z"
         }
     },
     "apache.hive": {
@@ -2049,6 +2069,10 @@
         "9.6.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "9.6.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:16Z"
         }
     },
     "apache.iceberg": {
@@ -2359,6 +2383,10 @@
         "1.15.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "1.15.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:17Z"
         }
     },
     "apache.kylin": {
@@ -2687,6 +2715,10 @@
         "4.5.7": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-22T21:14:32Z"
+        },
+        "4.6.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:18Z"
         }
     },
     "apache.pig": {
@@ -3213,6 +3245,10 @@
         "6.3.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "6.3.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:19Z"
         }
     },
     "apache.tinkerpop": {
@@ -3475,6 +3511,10 @@
         "2.9.5": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-07T10:04:12Z"
+        },
+        "2.9.6": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:20Z"
         }
     },
     "asana": {
@@ -3977,6 +4017,10 @@
         "3.23.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "3.23.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:21Z"
         }
     },
     "clickhousedb": {
@@ -4625,6 +4669,10 @@
         "1.6.6": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-07T10:04:16Z"
+        },
+        "1.6.7": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:22Z"
         }
     },
     "common.ai": {
@@ -4655,6 +4703,10 @@
         "0.6.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:24Z"
+        },
+        "0.7.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:23Z"
         }
     },
     "common.compat": {
@@ -4777,6 +4829,10 @@
         "1.17.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "1.18.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:24Z"
         }
     },
     "common.io": {
@@ -5203,6 +5259,10 @@
         "2.0.3": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "2.1.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:25Z"
         }
     },
     "databricks": {
@@ -5517,6 +5577,10 @@
         "7.18.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "7.18.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:26Z"
         }
     },
     "datadog": {
@@ -5881,6 +5945,10 @@
         "4.9.2": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-22T21:14:32Z"
+        },
+        "4.9.3": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:27Z"
         }
     },
     "dingding": {
@@ -6411,6 +6479,10 @@
         "4.5.8": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "4.5.9": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:28Z"
         }
     },
     "edge3": {
@@ -6525,6 +6597,10 @@
         "4.2.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "4.3.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:29Z"
         }
     },
     "elasticsearch": {
@@ -6795,6 +6871,10 @@
         "6.8.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "6.9.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:30Z"
         }
     },
     "exasol": {
@@ -7009,6 +7089,10 @@
         "4.10.4": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:25Z"
+        },
+        "4.10.5": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:31Z"
         }
     },
     "fab": {
@@ -7211,6 +7295,10 @@
         "3.7.3": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "3.8.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:32Z"
         }
     },
     "facebook": {
@@ -7613,6 +7701,10 @@
         "0.4.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:25Z"
+        },
+        "0.4.2": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:33Z"
         }
     },
     "github": {
@@ -8457,6 +8549,10 @@
         "4.7.2": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "4.8.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:34Z"
         }
     },
     "http": {
@@ -8853,6 +8949,10 @@
         "3.12.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:25Z"
+        },
+        "3.12.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:35Z"
         }
     },
     "influxdb": {
@@ -9817,6 +9917,10 @@
         "14.0.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "14.1.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:36Z"
         }
     },
     "microsoft.mssql": {
@@ -10897,6 +11001,10 @@
         "3.12.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:24Z"
+        },
+        "3.12.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:37Z"
         }
     },
     "odbc": {
@@ -11173,6 +11281,10 @@
         "1.8.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "1.8.2": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:38Z"
         }
     },
     "openfaas": {
@@ -11517,6 +11629,10 @@
         "2.19.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:24Z"
+        },
+        "2.20.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:39Z"
         }
     },
     "opensearch": {
@@ -11647,6 +11763,10 @@
         "1.11.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "1.12.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:40Z"
         }
     },
     "opsgenie": {
@@ -12335,6 +12455,10 @@
         "3.13.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-07T10:04:52Z"
+        },
+        "3.13.2": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:41Z"
         }
     },
     "pgvector": {
@@ -12769,6 +12893,10 @@
         "7.0.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "7.0.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:42Z"
         }
     },
     "presto": {
@@ -12983,6 +13111,10 @@
         "5.12.0": {
             "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "5.12.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:43Z"
         }
     },
     "qdrant": {
@@ -13409,6 +13541,10 @@
         "5.14.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-07T10:04:57Z"
+        },
+        "5.14.2": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:44Z"
         }
     },
     "samba": {
@@ -14065,6 +14201,10 @@
         "6.0.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "6.0.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:45Z"
         }
     },
     "singularity": {
@@ -14579,6 +14719,10 @@
         "3.0.2": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:25Z"
+        },
+        "3.0.3": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:46Z"
         }
     },
     "snowflake": {
@@ -14913,6 +15057,10 @@
         "6.15.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "6.16.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:47Z"
         }
     },
     "sqlite": {
@@ -15317,6 +15465,10 @@
         "6.0.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "6.0.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:48Z"
         }
     },
     "standard": {
@@ -15463,6 +15615,10 @@
         "1.16.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-10T16:30:24Z"
+        },
+        "1.17.0": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:49Z"
         }
     },
     "tableau": {
@@ -15787,6 +15943,10 @@
         "4.9.5": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-06-07T10:05:08Z"
+        },
+        "4.9.6": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:50Z"
         }
     },
     "teradata": {
@@ -15905,6 +16065,10 @@
         "3.6.1": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "3.6.2": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:51Z"
         }
     },
     "trino": {
@@ -16135,6 +16299,10 @@
         "6.6.0": {
             "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-23T12:35:14Z"
+        },
+        "6.6.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:52Z"
         }
     },
     "vertica": {
@@ -16429,6 +16597,10 @@
         "3.4.0": {
             "associated_airflow_version": "3.3.0",
             "date_released": "2026-07-28T06:43:08Z"
+        },
+        "3.4.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:53Z"
         }
     },
     "yandex": {
@@ -16591,6 +16763,10 @@
         "4.5.0": {
             "associated_airflow_version": "3.2.2",
             "date_released": "2026-05-11T15:47:09Z"
+        },
+        "4.5.1": {
+            "associated_airflow_version": "3.3.0",
+            "date_released": "2026-08-08T06:51:54Z"
         }
     },
     "ydb": {


### PR DESCRIPTION
Regenerated `generated/provider_metadata.json` after the 2026-08-06 providers
release (44 providers published to PyPI and `dist/release`).

Produced by `breeze release-management generate-providers-metadata
--refresh-constraints-and-airflow-releases`; the diff is 176 added lines
covering exactly the 44 released versions.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)