### PR TITLE
Fix scheduler crash pickling in-cluster pod_override onto executor queue

### DIFF
--- a/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/providers/cncf/kubernetes/src/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -334,6 +334,15 @@ class KubernetesExecutor(BaseExecutor):
 
         try:
             kube_executor_config = PodGenerator.from_obj(executor_config)
+            if kube_executor_config is not None:
+                # Round-trip through a fresh Configuration rather than queuing the pod_override
+                # as constructed by user code. In-cluster, kubernetes-client 36.x's default
+                # Configuration carries a refresh_api_key_hook local closure that pickle cannot
+                # serialize; queuing this object as-is crashes the scheduler (not just the task)
+                # when task_queue.put() pickles it. See PodGenerator.deserialize_model_dict.
+                kube_executor_config = PodGenerator.deserialize_model_dict(
+                    PodGenerator.serialize_pod(kube_executor_config)
+                )
         except Exception:
             self.log.error("Invalid executor_config for %s. Executor_config: %s", key, executor_config)
             self.fail(key=key, info="Invalid executor_config passed")

--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/executors/test_kubernetes_executor.py
@@ -2367,6 +2367,65 @@ class TestKubernetesExecutor:
         finally:
             executor.end()
 
+    @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
+    @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")
+    def test_execute_async_pod_override_is_picklable_in_cluster(
+        self, mock_get_kube_client, mock_kubernetes_job_watcher
+    ):
+        """A pod_override built under an in-cluster Configuration must still be picklable.
+
+        kubernetes-client 36.x's default Configuration carries a ``refresh_api_key_hook``
+        local closure when running in-cluster (set by ``InClusterConfigLoader``). Any
+        ``V1Pod``/nested model built without an explicit ``local_vars_configuration``
+        inherits that closure via ``Configuration.get_default_copy()`` and becomes
+        unpicklable -- crashing the scheduler (not just the task) when execute_async's
+        ``task_queue.put()`` tries to pickle it.
+        """
+        import pickle
+
+        from kubernetes.client.configuration import Configuration
+
+        def _unpicklable_refresh_hook(client_configuration):
+            pass
+
+        original_default = Configuration.get_default_copy()
+        bad_config = Configuration()
+        bad_config.refresh_api_key_hook = _unpicklable_refresh_hook
+        Configuration.set_default(bad_config)
+        try:
+            pod_override = k8s.V1Pod(
+                spec=k8s.V1PodSpec(
+                    containers=[
+                        k8s.V1Container(
+                            name="base",
+                            resources=k8s.V1ResourceRequirements(requests={"cpu": "100m", "memory": "384Mi"}),
+                        )
+                    ]
+                ),
+            )
+            # Sanity check the reproduction: an unprotected pod_override must not be
+            # picklable under this Configuration, otherwise this test proves nothing.
+            with pytest.raises(AttributeError, match="local object"):
+                pickle.dumps(pod_override)
+
+            executor = self.kubernetes_executor
+            executor.start()
+            try:
+                key = TaskInstanceKey("dag", "task", "run_id", 1, -1)
+                executor.execute_async(
+                    key=key,
+                    queue=None,
+                    command=["airflow", "tasks", "run", "true", "some_parameter"],
+                    executor_config={"pod_override": pod_override},
+                )
+                stored_config = executor.pod_launch_attempts[key].job.kube_executor_config
+                # Must not raise: this is what task_queue.put() does internally.
+                pickle.dumps(stored_config)
+            finally:
+                executor.end()
+        finally:
+            Configuration.set_default(original_default)
+
     @pytest.mark.db_test
     @mock.patch("airflow.providers.cncf.kubernetes.executors.kubernetes_executor_utils.KubernetesJobWatcher")
     @mock.patch("airflow.providers.cncf.kubernetes.kube_client.get_kube_client")


### PR DESCRIPTION
## Summary

Fixes #68827.

In-cluster, kubernetes-client 36.x's default `Configuration` (set by `InClusterConfigLoader`) carries a `refresh_api_key_hook` local closure. Every openapi-generated model's `__init__` calls `Configuration.get_default_copy()` when `local_vars_configuration` isn't explicitly passed:

```python
def __init__(self, ..., local_vars_configuration=None):
    if local_vars_configuration is None:
        local_vars_configuration = Configuration.get_default_copy()
    self.local_vars_configuration = local_vars_configuration
```

A task's `pod_override` (a `V1Pod` built by user DAG code, which never passes `local_vars_configuration`) therefore inherits that closure in-cluster. `execute_async` embeds it in a `KubernetesJob` and puts it on `self.task_queue`, a `multiprocessing.Manager().JoinableQueue()` -- the manager pickles the object to send it over IPC, and `pickle` can't serialize a closure. This crashes the **scheduler process itself**, not just the task, and since the task gets re-queued on restart, it loops.

The fix wires up protection that already exists in this codebase but wasn't used at this call site: `PodGenerator.deserialize_model_dict` builds `V1Pod` objects against a fresh, empty `Configuration()` specifically so neither the pod nor any nested model captures the process-global in-cluster default -- its docstring says as much verbatim. `execute_async` never routed `pod_override` through it before constructing `KubernetesJob`. This PR rounds it through `PodGenerator.serialize_pod` + `deserialize_model_dict` right after `PodGenerator.from_obj`, so the queued object is always built from a fresh `Configuration`.

**Scope note:** the linked issue also mentions the same fix would help `OAuth2.py`-style curl callers elsewhere and suggests a broader `CURLOPT_PROTOCOLS` pass -- not applicable here, that's from a different (Appwrite) advisory I worked on separately. This PR only touches the `execute_async` → `task_queue.put()` path described in #68827.

## Test plan

- [x] Reproduced the exact crash locally: constructed a `Configuration` with an unpicklable `refresh_api_key_hook` (mirroring `InClusterConfigLoader`), set it as the process default, built a `V1Pod` the way user code would, and confirmed `pickle.dumps()` fails with `AttributeError: Can't get local object ...` -- then confirmed `PodGenerator.serialize_pod` + `deserialize_model_dict` produces a pod that pickles/unpickles cleanly with the pod spec intact.
- [x] Added `test_execute_async_pod_override_is_picklable_in_cluster`, which reproduces the same in-cluster `Configuration` and calls the *real* `execute_async` → `task_queue.put()` path (the actual production `multiprocessing.Manager` IPC pickling, not a synthetic `pickle.dumps()` check).
- [x] Verified the new test actually catches the bug: reverted the source fix and confirmed the test fails at `self.task_queue.put(job)` with the exact same `AttributeError`; re-applied the fix and confirmed it passes.
- [x] Ran the full `test_kubernetes_executor.py` file: **177 passed, 1 skipped** (pre-existing, version-gated skip unrelated to this change) -- no regressions.
- [x] `ruff check` and `ruff format --check` pass on both changed files.