### PR TITLE
Fix execution_timeout not interrupting a hung virtualenv subprocess

### DIFF
--- a/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
+++ b/providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py
@@ -145,7 +145,7 @@ def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str
     log = logging.getLogger(__name__)
 
     log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
-    with subprocess.Popen(
+    proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
@@ -153,7 +153,8 @@ def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str
         close_fds=False,
         cwd=cwd,
         env=env,
-    ) as proc:
+    )
+    try:
         log.info("Output:")
         if proc.stdout:
             with proc.stdout:
@@ -161,6 +162,15 @@ def _execute_in_subprocess(cmd: list[str], cwd: str | None = None, env: dict[str
                     log.info("%s", line.decode().rstrip())
 
         exit_code = proc.wait()
+    except BaseException:
+        # e.g. AirflowTaskTimeout delivered via SIGALRM while blocked on the read/wait above.
+        # subprocess.Popen used as a context manager only closes pipes on exit and then calls
+        # proc.wait() again -- which blocks until the child exits on its own, silently absorbing
+        # the timeout for however long the child keeps running (indefinitely, if it's blocked on
+        # something like an open network connection). Kill it explicitly instead.
+        proc.kill()
+        proc.wait()
+        raise
     if exit_code != 0:
         raise subprocess.CalledProcessError(exit_code, cmd)
 

--- a/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
+++ b/providers/standard/tests/unit/standard/utils/test_python_virtualenv.py
@@ -17,16 +17,97 @@
 # under the License.
 from __future__ import annotations
 
+import os
+import signal
+import subprocess
+import time
 from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
 import pytest
 
-from airflow.providers.standard.utils.python_virtualenv import _generate_pip_conf, _use_uv, prepare_virtualenv
+from airflow.providers.standard.utils.python_virtualenv import (
+    _execute_in_subprocess,
+    _generate_pip_conf,
+    _use_uv,
+    prepare_virtualenv,
+)
 
 from tests_common.test_utils.config import conf_vars
 from tests_common.test_utils.version_compat import remove_task_decorator
+
+
+class TestExecuteInSubprocess:
+    """
+    Regression tests for a signal-based timeout (e.g. AirflowTaskTimeout via SIGALRM)
+    interrupting _execute_in_subprocess while the child is still running.
+
+    ``with subprocess.Popen(...) as proc`` only closes pipes on exit and calls
+    ``proc.wait()`` again -- it does not kill the child. If the child is blocked on
+    something long-running (e.g. an open network connection), that silently absorbs
+    the timeout: the exception isn't actually delivered to the caller until the child
+    exits on its own, however long that takes.
+    """
+
+    def test_signal_interrupt_kills_child_promptly(self):
+        class _Interrupted(Exception):
+            pass
+
+        def _handler(signum, frame):
+            raise _Interrupted
+
+        original_handler = signal.signal(signal.SIGALRM, _handler)
+        signal.setitimer(signal.ITIMER_REAL, 1)
+        start = time.monotonic()
+        try:
+            with pytest.raises(_Interrupted):
+                _execute_in_subprocess(["python3", "-c", "import time; time.sleep(30)"])
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, original_handler)
+
+        # The exception must propagate promptly (bounded by the 1s alarm), not after
+        # waiting out the child's full 30s runtime.
+        assert time.monotonic() - start < 10
+
+    def test_signal_interrupt_does_not_orphan_child(self):
+        class _Interrupted(Exception):
+            pass
+
+        def _handler(signum, frame):
+            raise _Interrupted
+
+        pids: list[int] = []
+        real_popen = subprocess.Popen
+
+        def _spy_popen(*args, **kwargs):
+            proc = real_popen(*args, **kwargs)
+            pids.append(proc.pid)
+            return proc
+
+        original_handler = signal.signal(signal.SIGALRM, _handler)
+        signal.setitimer(signal.ITIMER_REAL, 1)
+        try:
+            with mock.patch("subprocess.Popen", side_effect=_spy_popen):
+                with pytest.raises(_Interrupted):
+                    _execute_in_subprocess(["python3", "-c", "import time; time.sleep(30)"])
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, original_handler)
+
+        # Give the kill a moment to take effect, then confirm the child is gone.
+        time.sleep(0.5)
+        with pytest.raises(ProcessLookupError):
+            os.kill(pids[0], 0)
+
+    def test_normal_execution_still_succeeds(self):
+        # Baseline: unaffected by the exception-handling change on the happy path.
+        _execute_in_subprocess(["python3", "-c", "print('hello')"])
+
+    def test_nonzero_exit_still_raises_called_process_error(self):
+        with pytest.raises(subprocess.CalledProcessError):
+            _execute_in_subprocess(["python3", "-c", "import sys; sys.exit(3)"])
 
 
 class TestPrepareVirtualenv:


### PR DESCRIPTION
## Summary

Fixes #57712.

`@task.virtualenv` / `@task.external_python` run the user's callable in a subprocess via `_execute_in_subprocess` (`providers/standard/src/airflow/providers/standard/utils/python_virtualenv.py`):

```python
with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, ...) as proc:
    for line in iter(proc.stdout.readline, b""):
        log.info(...)
    exit_code = proc.wait()
```

`execution_timeout` is enforced by `TimeoutPosix` (`task-sdk/.../timeout.py`), which sets a `SIGALRM` that raises `AirflowTaskTimeout` from inside whatever's currently running -- here, that's the blocking `readline()`/`wait()` call above.

The bug: `subprocess.Popen.__exit__` only closes the pipes and calls `proc.wait()` **again** on its way out -- it does not kill the child. If the child is still running when the exception fires (e.g. blocked on an open HTTP connection, per the linked issue's repro), that second `wait()` blocks until the child exits **on its own**, silently absorbing the timeout for however long that takes. This matches the reported symptom exactly: "shows in the logs as timeout, but the task keeps in running state" -- the log line comes from the signal handler firing correctly, but the task doesn't actually finish timing out until the child process happens to exit.

I verified this precisely with a standalone repro before touching any code (`with subprocess.Popen(...)`, `SIGALRM` at 1s, child `sleep(8)`): the exception was only actually caught after the full 8 seconds, not the 1 second the alarm was set for.

## Fix

Catch the exception around the read/wait, explicitly `proc.kill()` + `proc.wait()` to reap the child, then re-raise:

```python
try:
    ...
    exit_code = proc.wait()
except BaseException:
    proc.kill()
    proc.wait()
    raise
```

## Test plan

- [x] Reproduced standalone against the actual (pre-fix) `_execute_in_subprocess`: caught the timeout exception only after the full child runtime (8s), not the 1s alarm.
- [x] Re-verified against the fixed version: exception caught at ~1.0s, and confirmed via a `subprocess.Popen` spy that the child process is actually dead (not orphaned) ~0.5s after.
- [x] Added `TestExecuteInSubprocess` with 4 tests: prompt interruption timing, no orphaned child process, happy-path success, and non-zero exit still raises `CalledProcessError` as before.
- [x] Verified the new timing test actually catches the regression: reverted the source fix, ran it, and confirmed it fails (`32.31s` vs the asserted `< 10s`) with the exact same log line from the report ("Executing cmd... Output:" followed by the full sleep duration before the assertion fires); re-applied the fix and confirmed it passes.
- [x] Ran the full test file: `pytest tests/unit/standard/utils/test_python_virtualenv.py` -- **23 passed**.
- [x] `ruff check` and `ruff format --check` pass on both changed files.