### PR TITLE
Remove duplicate otel_* options from [metrics] section

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1294,48 +1294,6 @@ metrics:
       type: boolean
       example: ~
       default: "False"
-    otel_on:
-      description: |
-        Enables sending metrics to OpenTelemetry.
-      version_added: 2.6.0
-      type: boolean
-      example: ~
-      default: "False"
-    otel_host:
-      description: |
-        Specifies the hostname or IP address of the OpenTelemetry Collector to which Airflow sends
-        metrics and traces.
-      version_added: 2.6.0
-      version_deprecated: 3.2.0
-      deprecation_reason: |
-        According to the OpenTelemetry specification, configuration is expected to happen through
-        the standard OpenTelemetry environment variables rather than project-specific settings.
-
-        This option has been deprecated to ensure consistent behavior across different environments
-        and deployments that use OpenTelemetry.
-
-        OpenTelemetry should be configured exclusively using the standard OpenTelemetry environment variables
-        such as 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_EXPORTER_OTLP_PROTOCOL', 'OTEL_SERVICE_NAME', etc.
-      type: string
-      example: ~
-      default: "localhost"
-    otel_port:
-      description: |
-        Specifies the port of the OpenTelemetry Collector that is listening to.
-      version_added: 2.6.0
-      version_deprecated: 3.2.0
-      deprecation_reason: |
-        According to the OpenTelemetry specification, configuration is expected to happen through
-        the standard OpenTelemetry environment variables rather than project-specific settings.
-
-        This option has been deprecated to ensure consistent behavior across different environments
-        and deployments that use OpenTelemetry.
-
-        OpenTelemetry should be configured exclusively using the standard OpenTelemetry environment variables
-        such as 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_EXPORTER_OTLP_PROTOCOL', 'OTEL_SERVICE_NAME', etc.
-      type: integer
-      example: ~
-      default: "8889"
     otel_prefix:
       description: |
         The prefix for the Airflow metrics.
@@ -1361,23 +1319,6 @@ metrics:
       type: integer
       example: ~
       default: "60000"
-    otel_debugging_on:
-      description: |
-        If ``True``, all metrics are also emitted to the console. Defaults to ``False``.
-      version_added: 2.7.0
-      version_deprecated: 3.2.0
-      deprecation_reason: |
-        According to the OpenTelemetry specification, configuration is expected to happen through
-        the standard OpenTelemetry environment variables rather than project-specific settings.
-
-        This option has been deprecated to ensure consistent behavior across different environments
-        and deployments that use OpenTelemetry.
-
-        OpenTelemetry should be configured exclusively using the standard OpenTelemetry environment variables
-        such as 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_EXPORTER_OTLP_PROTOCOL', 'OTEL_SERVICE_NAME', etc.
-      type: boolean
-      example: ~
-      default: "False"
     otel_service:
       description: |
         The default service name of traces.
@@ -1395,26 +1336,6 @@ metrics:
       type: string
       example: ~
       default: "Airflow"
-    otel_ssl_active:
-      description: |
-        If ``True``, SSL will be enabled. Defaults to ``False``.
-        To establish an HTTPS connection to the OpenTelemetry collector,
-        you need to configure the SSL certificate and key within the OpenTelemetry collector's
-        ``config.yml`` file.
-      version_added: 2.7.0
-      version_deprecated: 3.2.0
-      deprecation_reason: |
-        According to the OpenTelemetry specification, configuration is expected to happen through
-        the standard OpenTelemetry environment variables rather than project-specific settings.
-
-        This option has been deprecated to ensure consistent behavior across different environments
-        and deployments that use OpenTelemetry.
-
-        OpenTelemetry should be configured exclusively using the standard OpenTelemetry environment variables
-        such as 'OTEL_EXPORTER_OTLP_ENDPOINT', 'OTEL_EXPORTER_OTLP_PROTOCOL', 'OTEL_SERVICE_NAME', etc.
-      type: boolean
-      example: ~
-      default: "False"
 traces:
   description: |
     Distributed traces integration settings.


### PR DESCRIPTION
## Summary

Fixes #43366 — Five `otel_*` configuration options (`otel_on`, `otel_host`, `otel_port`, `otel_debugging_on`, `otel_ssl_active`) appear **twice** in the Configuration Reference documentation: once under `[metrics]` and once under `[traces]`.

These options were moved from `[metrics]` to `[traces]` in commit ccf12026b44685f2d9917cd313676784e63c81af, but the original copies in `[metrics]` were not removed.

## Changes

**File:** `airflow-core/src/airflow/config_templates/config.yml`

Removed the 5 duplicate option blocks (79 lines) from the `[metrics]` section. The canonical versions remain intact in the `[traces]` section.

The following options were **kept** in `[metrics]` (not duplicated in traces):
- `otel_prefix` — metrics-specific prefix
- `otel_interval_milliseconds` — send interval for metrics
- `otel_service` — also present in both sections (left as-is since not mentioned in the issue)

## Verification

After this change, searching for each of the 5 removed options in config.yml returns exactly **1 result** (the `[traces]` version) instead of 2.